### PR TITLE
tested Python 3.11, fixed OpenSSL 3.x issue, and more

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,3 +21,4 @@ ignore = E203, E501, W503
 # emit a warning for high McCabe complexity
 # See https://en.wikipedia.org/wiki/Cyclomatic_complexity
 # max-complexity = 10
+per-file-ignores = __init__.py:F401

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11-dev
+          python-version: 3.12-dev
       - name: Install requirements
         run: |
           pip install -U -r requirements-dev.txt

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.12-dev
+          python-version: 3.11-dev
       - name: Install requirements
         run: |
           pip install -U -r requirements-dev.txt

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -24,10 +24,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11-dev
+          python-version: 3.12-dev
       - name: Install requirements
         run: |
           pip install -U -r requirements-dev.txt
           pip install -U -r requirements.txt
-      - name: Run Tox
-        run: tox -e py
+      - name: Run Test # tox
+        # tox with 3.12-dev fails because of pylint
+        # in general, better to receive early failure notice only for tests
+        # run: tox -e py
+        run: pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # avoid early failure notice for windows
+        os: [ubuntu-latest, macos-latest]
         experimental: [true]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,13 @@ on:
       - dev
 
 jobs:
-
   test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
@@ -45,9 +44,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - name: Upload to coveralls.io
-      run: |
-        pip install coveralls
-        coveralls --finish
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload to coveralls.io
+        run: |
+          pip install coveralls
+          coveralls --finish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,123 @@
+# How to contribute to btclib
+
+Thank you for investing your time in contributing to our project.
+We are glad you are reading this, because we need volunteer developers
+to help this project come to fruition.
+
+If you haven't already:
+
+- see the [README](./README.md) file to get an overview of the project
+- read our [Code of Conduct](./CODE_OF_CONDUCT.md) to keep our community approachable and respectable
+- come find us on [Slack](https://bbt-training.slack.com/archives/C01CCJ85AES).
+
+In this guide you will get an overview of the contribution workflow from opening an issue, creating a PR, reviewing, and merging the PR.
+
+## New contributor guide
+
+Here are some resources to help you get started with open source contributions:
+
+- [Finding ways to contribute to open source on GitHub](https://docs.github.com/en/get-started/exploring-projects-on-github/finding-ways-to-contribute-to-open-source-on-github)
+- [Set up Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
+- [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow)
+- [Collaborating with pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests)
+
+## Getting started
+
+Development tools are required to develop and test btclib;
+they can be installed with:
+
+    python -m pip install --upgrade -r requirements-dev.txt
+
+Developers might also consider installing btclib in editable way:
+
+    python -m pip install --upgrade -e ./
+
+Finally, additional packages are needed to build the documentation:
+
+    python -m pip install --upgrade -r docs/requirements.txt
+
+As an annotated python project, btclib is very strict on code formatting
+([isort](https://pycqa.github.io/isort/),
+[black](https://github.com/psf/black),
+[pylint](https://pylint.pycqa.org/en/latest/),
+[bandit](https://github.com/PyCQA/bandit),
+[flake8](https://flake8.pycqa.org/en/latest/),
+and [check-manifest](https://pypi.org/project/check-manifest/))
+and proper type definition
+([mypy](https://mypy-lang.org/)):
+warnings are not tolerated and should be taken care of.
+This might be annoying at first, but enforcing formatting rules can be done
+easily once you're finished with coding or, even better, automatically
+taken care of while coding, especially if you properly setup your development environment.
+Type definition improves code readability and helps in spotting bugs.
+
+Moreover, [unit tests](https://github.com/pytest-dev/pytest/) must pass at any time with 100% [coverage](https://coverage.readthedocs.io/) of both the
+library and the test suite.
+
+These requirements are easily checked (and partially fixed) if you test
+the impact of your contribution with [tox](https://tox.wiki/).
+
+We also like the contribution of [sourcery](https://sourcery.ai/): you might too.
+
+Finally, even when it comes to mark-down (*.md files),
+please use [markdownlint](https://github.com/DavidAnson/markdownlint).
+
+\[To do: document how to do it in VS Code\]
+
+### Issues
+
+#### Create a new issue
+
+Did you find a bug?
+*Do not open up a GitHub issue if the bug is a security vulnerability*,
+and instead refer to our [security policy](README.md).
+
+For any other problem,
+[search](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests)
+first if an [issue](https://github.com/btclib-org/btclib/issues) (or a [fixing pull request](https://github.com/btclib-org/btclib/pulls), also known as a PR) already exists.
+If a related issue/PR does not exist,
+please open a new issue.
+
+#### Solve an issue
+
+Scan through our [existing issues](https://github.com/btclib-org/btclib/issues) to find one that interests you. As a general rule, we don’t assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
+
+### Make Changes
+
+Work locally on your fork of btclib,
+until you are satisfied. Ensure that tox has no issue
+with your modified codebase.
+
+### Commit your update
+
+Commit the changes to your fork once you are happy with them.
+
+### Pull Request
+
+When you're finished with the changes, create a pull request (PR).
+
+- Don't forget to
+[link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
+if you are solving one.
+- Enable the checkbox to
+[allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge.
+Once you submit your PR, team members will review your proposal.
+We may ask questions or request additional information.
+- We may ask for changes to be made before a PR can be merged, either using
+[suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request)
+or pull request comments.
+You can apply suggested changes directly through the UI.
+You can make any other changes in your fork, then commit them to your branch.
+- [Sourcery](https://sourcery.ai/) might suggest changes, please accept them.
+- As you update your PR and apply changes, mark each conversation as
+[resolved](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#resolving-conversations).
+- If you run into any merge issues, checkout this
+[git tutorial](https://github.com/skills/resolve-merge-conflicts)
+to help you resolve merge conflicts and other issues.
+
+### Your PR is merged
+
+Congratulations :tada::tada: The btclib team thanks you :sparkles:.
+
+Once your PR is merged, your contributions will be publicly visible on the
+[contributors page](https://github.com/btclib-org/btclib/graphs/contributors).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,13 @@ Notable changes to the codebase are documented here.
 Release names follow [*calendar versioning*](https://calver.org/):
 full year, short month, short day (YYYY-M-D)
 
+## v2022.12.31
+
+Major changes include:
+
+- added support for Python 3.11
+- fixed the OpenSSL 3.x RIPEMD160 issue in btclib/hashes.py
+
 ## v2022.7.20
 
 Major changes include:
@@ -12,22 +19,21 @@ Major changes include:
 - by default ssa, dsa and point multiplication are now sped up using btclib_libsecp256k1;
   this provides an 8 times speed up in benchmarks and 3 times in real world applications.
 
-
-## v2022.5.3 
+## v2022.5.3
 
 Major changes includes:
 
 - dropped python 3.6 support
 - added support for btclib_libsecp256k1
-- the hashes.fingerprint function, removed in the previous version, 
-  has been reinstated in the to_pub_key module 
-- encode_num and decode_num have been moved from 
+- the hashes.fingerprint function, removed in the previous version,
+  has been reinstated in the to_pub_key module
+- encode_num and decode_num have been moved from
 script.op_codes to utils
-- op_pushdata and op_str have been renamed to 
+- op_pushdata and op_str have been renamed to
   serialize_bytes_command and serialize_str_command
 - script.op_codes has been removed and its functions merged in script
 - script serialization is now more consistent: all integers, even small
-  ones, are now considered like bytes. To put small integers on the stack 
+  ones, are now considered like bytes. To put small integers on the stack
   OP_X must be used explicitly. Using integers directly will lead to larger
   scripts that will be likely to be rejected by the network as not standard
 - check_validity is now correctly propagated inside each function
@@ -108,7 +114,7 @@ Major changes includes:
   bip32.deserialize(xkey), now it is bip32.BIP32KeyData.deserialize(xkey)
 - bip32: added str_from_bip32_path and bytes_from_bip32_path
 - bip3: made bip32 index an int (not bytes) to avoid byteorder ambiguity.
-  Consequently, where previously it was xkey_dict["index"][0] < 0x80,
+  Consequently, where previously it was xkey_dict\["index"\][0] < 0x80,
   now it is xkey_dict.index < 0x80000000
 - bip32: local "./" derivation, opposed to absolute "m/" derivation,
   is not available anymore

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@ Major changes include:
 
 - added support for Python 3.11
 - fixed the OpenSSL 3.x RIPEMD160 issue in btclib/hashes.py
+- added CONTRIBUTING and SECURITY
 
 ## v2022.7.20
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@ Major changes include:
 - added support for Python 3.11
 - fixed the OpenSSL 3.x RIPEMD160 issue in btclib/hashes.py
 - added CONTRIBUTING and SECURITY
+- solved issue #73 [Re-import Tx subclasses into btclib.tx](https://github.com/btclib-org/btclib/issues/73)
 
 ## v2022.7.20
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017-2022 Ferdinando M. Ametrano and btclib contributors
+Copyright (c) 2017-2023 Ferdinando M. Ametrano and btclib contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -115,15 +115,7 @@ Windows Git bash shell:
     cd ../..
     python -m pip install --upgrade btclib
 
-Some development tools are required to develop and test btclib;
-they can be installed with:
+See [CONTRIBUTING](./CONTRIBUTING.md) if you are interested
+in btclib develoment.
 
-    python -m pip install --upgrade -r requirements-dev.txt
-
-Some additional packages are needed to build the documentation:
-
-    python -m pip install --upgrade -r docs/requirements.txt
-
-Developers might also consider installing btclib in editable way:
-
-    python -m pip install --upgrade -e ./
+See [SECURITY](./SECURITY.md) if you have found a security vulnerability.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Some additional packages are needed to build the documentation:
 
     python -m pip install --upgrade -r docs/requirements.txt
 
-
 Developers might also consider installing btclib in editable way:
 
     python -m pip install --upgrade -e ./

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,24 +8,24 @@
 
 4. Add every major change since the previous version to HISTORY.md, if it wasn't already added.
 
-5. Push to Github. Verify that the documentation builds without failing on [read the docs](https://readthedocs.org/projects/btclib/builds/).   
+5. Push to GitHub. Verify that the documentation builds without failing on [read the docs](https://readthedocs.org/projects/btclib/builds/).
   Also check that the [website](https://btclib.org) and the [documentation](https://btclib.readthedocs.io/en/latest/) are displayed correctly in a browser
 
 6. Build the package distribution files:
 
    ```rm -r btclib.egg-info/ build/ dist/ && python setup.py sdist bdist_wheel```
-   
+
 7. Push the package files to PyPi:
 
     ```twine upload dist/*```
 
-8. Create a new release on Github:
+8. Create a new release on GitHub:
 
-    Use the version as the title, and the history as the description. Also upload the files in the dist/ folder 
+    Use the version as the title, and the history as the description. Also upload the files in the dist/ folder
     as the release attachments
-    
+
 9. Prepare for a new generic version:
 
     Choose a new version without specifying the day (es. if the previous release was 2022.2.9, choose 2022.3)\
     Then set the version in btclib/__init__.py and docs/source/conf.py to this new version. \
-    Use this new version name in HISTORY.md, specifying that it is in development
+    Use this new version name in HISTORY.md, specifying that it is in developmen

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,31 +1,36 @@
 # Release
 
-1. Run tox to verify that we pass all the tests (at least on our local machine)
+01. Run tox to verify that you pass all the tests (at least on your local machine)
 
-2. Set appropriate version inside btclib/__init__.py and docs/source/conf.py
+01. Set appropriate version inside btclib/__init__.py and docs/source/conf.py
 
-3. Follow docs/README.rst and test that the documentation builds without problems
+01. Follow docs/README.rst and test that the documentation builds without problems
 
-4. Add every major change since the previous version to HISTORY.md, if it wasn't already added.
+01. Add every major changes since the previous version to HISTORY.md, if they were not already there.
 
-5. Push to GitHub. Verify that the documentation builds without failing on [read the docs](https://readthedocs.org/projects/btclib/builds/).
-  Also check that the [website](https://btclib.org) and the [documentation](https://btclib.readthedocs.io/en/latest/) are displayed correctly in a browser
+01. Push to GitHub.
 
-6. Build the package distribution files:
+    Verify that the documentation builds without failing on
+    [read the docs](https://readthedocs.org/projects/btclib/builds/).
 
-   ```rm -r btclib.egg-info/ build/ dist/ && python setup.py sdist bdist_wheel```
+    Also check that the [website](https://btclib.org) and the
+    [documentation](https://btclib.readthedocs.io/en/latest/) are displayed correctly in a browser.
 
-7. Push the package files to PyPi:
+01. Build the package distribution files:
+
+    ```rm -r btclib.egg-info/ build/ dist/ && python setup.py sdist bdist_wheel```
+
+01. Push the package files to PyPi:
 
     ```twine upload dist/*```
 
-8. Create a new release on GitHub:
+01. Create a new release on GitHub:
 
-    Use the version as the title, and the history as the description. Also upload the files in the dist/ folder
-    as the release attachments
+    Use the version as the title, and the history as the description.
+    Also upload the files in the dist/ folder as release attachments.
 
-9. Prepare for a new generic version:
+01. Prepare for a new generic version:
 
-    Choose a new version without specifying the day (es. if the previous release was 2022.2.9, choose 2022.3)\
-    Then set the version in btclib/__init__.py and docs/source/conf.py to this new version. \
-    Use this new version name in HISTORY.md, specifying that it is in developmen
+    Choose a new version without specifying the day (es. if the previous release was 2022.2.9, choose 2022.3).
+    Then set the version in btclib/__init__.py and docs/source/conf.py to this new version.
+    Use this new version name in HISTORY.md, specifying that it is in development.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security policy
+
+If you have found a security vulnerability,
+please do not open up a GitHub issue; instead,
+please provide responsible disclosure emailing _security at btclib dot org_.

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.
@@ -14,5 +14,5 @@ name = "btclib"
 __version__ = "2022.12.31"
 __author__ = "The btclib developers"
 __author_email__ = "devs@btclib.org"
-__copyright__ = "Copyright (C) 2017-2022 The btclib developers"
+__copyright__ = "Copyright (C) 2017-2023 The btclib developers"
 __license__ = "MIT License"

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -11,7 +11,7 @@
 "__init__ module for the btclib package."
 
 name = "btclib"
-__version__ = "2022.7.20"
+__version__ = "2022.12.31"
 __author__ = "The btclib developers"
 __author_email__ = "devs@btclib.org"
 __copyright__ = "Copyright (C) 2017-2022 The btclib developers"

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/amount.py
+++ b/btclib/amount.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/b32.py
+++ b/btclib/b32.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Copyright (C) 2019-2022 The btclib developers
+# Copyright (C) 2019-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/b58.py
+++ b/btclib/b58.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/base58.py
+++ b/btclib/base58.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/bech32.py
+++ b/btclib/bech32.py
@@ -18,7 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Copyright (C) 2019-2022 The btclib developers
+# Copyright (C) 2019-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/bip32/__init__.py
+++ b/btclib/bip32/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -17,7 +17,7 @@ A BIP 32 derivation path can be represented as:
 - bytes (multiples of 4-bytes index)
 """
 
-from typing import List, Sequence, Union
+from typing import List, Optional, Sequence, Union
 
 from btclib.alias import Octets
 from btclib.exceptions import BTClibValueError
@@ -97,7 +97,7 @@ def _str_from_bip32_path(der_path: BIP32DerPath, hardening: str = _HARDENING) ->
 
 def str_from_bip32_path(
     der_path: BIP32DerPath,
-    master_fingerprint: Octets = None,
+    master_fingerprint: Optional[Octets] = None,
     hardening: str = _HARDENING,
 ) -> str:
     result = _str_from_bip32_path(der_path, hardening)

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/bip32/slip132.py
+++ b/btclib/bip32/slip132.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/__init__.py
+++ b/btclib/ecc/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2019-2022 The btclib developers
+# Copyright (C) 2019-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/curve.py
+++ b/btclib/ecc/curve.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/curve_group.py
+++ b/btclib/ecc/curve_group.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/curve_group_2.py
+++ b/btclib/ecc/curve_group_2.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/curve_group_f.py
+++ b/btclib/ecc/curve_group_f.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/der.py
+++ b/btclib/ecc/der.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/libsecp256k1.py
+++ b/btclib/ecc/libsecp256k1.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/number_theory.py
+++ b/btclib/ecc/number_theory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/rfc6979.py
+++ b/btclib/ecc/rfc6979.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/sec_point.py
+++ b/btclib/ecc/sec_point.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/sign_to_contract.py
+++ b/btclib/ecc/sign_to_contract.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/hashes.py
+++ b/btclib/hashes.py
@@ -21,6 +21,17 @@ from btclib.utils import bytes_from_octets, int_from_bits
 
 H160_Net = Tuple[bytes, str]
 
+# see https://bugs.python.org/issue47101
+# With OpenSSL 3.x, hashlib still includes ripemd160
+# but it is not usable unless the legacy provider is loaded.
+try:
+    hashlib.new("ripemd160")
+except ValueError:  # pragma: no cover
+    import ctypes
+
+    ctypes.CDLL("libssl.so").OSSL_PROVIDER_load(None, b"legacy")
+    ctypes.CDLL("libssl.so").OSSL_PROVIDER_load(None, b"default")
+
 
 def ripemd160(octets: Octets) -> bytes:
     "Return the RIPEMD160(*) of the input octet sequence."

--- a/btclib/hashes.py
+++ b/btclib/hashes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/mnemonic/__init__.py
+++ b/btclib/mnemonic/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/mnemonic/bip39.py
+++ b/btclib/mnemonic/bip39.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/mnemonic/entropy.py
+++ b/btclib/mnemonic/entropy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/mnemonic/mnemonic.py
+++ b/btclib/mnemonic/mnemonic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -45,8 +45,7 @@ from btclib.psbt.psbt_utils import (
 )
 from btclib.script.sig_hash import assert_valid_hash_type
 from btclib.script.witness import Witness
-from btclib.tx.tx import Tx
-from btclib.tx.tx_out import TxOut
+from btclib.tx import Tx, TxOut
 from btclib.utils import bytes_from_octets
 
 PSBT_IN_NON_WITNESS_UTXO = b"\x00"

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/psbt/psbt_out.py
+++ b/btclib/psbt/psbt_out.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -20,7 +20,7 @@ from btclib import var_bytes, var_int
 from btclib.alias import BinaryData, Octets
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
-from btclib.tx.tx import Tx
+from btclib.tx import Tx
 from btclib.utils import bytes_from_octets, bytesio_from_binarydata
 
 

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/script/__init__.py
+++ b/btclib/script/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -31,8 +31,7 @@ from btclib.script.script_pub_key import (
     is_p2wsh,
     type_and_payload,
 )
-from btclib.tx.tx import Tx
-from btclib.tx.tx_out import TxOut
+from btclib.tx import Tx, TxOut
 from btclib.utils import bytes_from_octets
 
 DEFAULT = 0

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -1,6 +1,6 @@
 # !/usr/bin/env python3
 
-# Copyright (C) 2021-2022 The btclib developers
+# Copyright (C) 2021-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/script/witness.py
+++ b/btclib/script/witness.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/tx/__init__.py
+++ b/btclib/tx/__init__.py
@@ -9,3 +9,7 @@
 # or distributed except according to the terms contained in the LICENSE file.
 
 """btclib.tx submodule."""
+
+from btclib.tx.tx import Tx
+from btclib.tx.tx_in import OutPoint, TxIn
+from btclib.tx.tx_out import TxOut

--- a/btclib/tx/__init__.py
+++ b/btclib/tx/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/tx/block_header.py
+++ b/btclib/tx/block_header.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/tx/blocks.py
+++ b/btclib/tx/blocks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/tx/out_point.py
+++ b/btclib/tx/out_point.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/var_bytes.py
+++ b/btclib/var_bytes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/btclib/var_int.py
+++ b/btclib/var_int.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ copyright = "2017-2022 The btclib developers"
 author = "The btclib developers"
 
 # The full version, including alpha/beta/rc tags
-release = "2022.7.20"
+release = "2022.12.31"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, path.abspath("../../"))
 # -- Project information -----------------------------------------------------
 
 project = "btclib"
-copyright = "2017-2022 The btclib developers"
+copyright = "2017-2023 The btclib developers"
 author = "The btclib developers"
 
 # The full version, including alpha/beta/rc tags

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "Intended Audience :: Education",

--- a/tests/bip32/__init__.py
+++ b/tests/bip32/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/bip32/test_bip32.py
+++ b/tests/bip32/test_bip32.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/bip32/test_der_path.py
+++ b/tests/bip32/test_der_path.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/bip32/test_key_origin.py
+++ b/tests/bip32/test_key_origin.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/bip32/test_slip132.py
+++ b/tests/bip32/test_slip132.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/__init__.py
+++ b/tests/ecc/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_bms.py
+++ b/tests/ecc/test_bms.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2019-2022 The btclib developers
+# Copyright (C) 2019-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_borromean.py
+++ b/tests/ecc/test_borromean.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_curve.py
+++ b/tests/ecc/test_curve.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_curve_group.py
+++ b/tests/ecc/test_curve_group.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_curve_group_2.py
+++ b/tests/ecc/test_curve_group_2.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_curve_group_f.py
+++ b/tests/ecc/test_curve_group_f.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_der.py
+++ b/tests/ecc/test_der.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_dh.py
+++ b/tests/ecc/test_dh.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_dsa.py
+++ b/tests/ecc/test_dsa.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_number_theory.py
+++ b/tests/ecc/test_number_theory.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_pedersen.py
+++ b/tests/ecc/test_pedersen.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_rfc6979.py
+++ b/tests/ecc/test_rfc6979.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_sec_point.py
+++ b/tests/ecc/test_sec_point.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_sign_to_contract.py
+++ b/tests/ecc/test_sign_to_contract.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/ecc/test_ssa.py
+++ b/tests/ecc/test_ssa.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/mnemonic/__init__.py
+++ b/tests/mnemonic/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/mnemonic/test_bip39.py
+++ b/tests/mnemonic/test_bip39.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/mnemonic/test_electrum.py
+++ b/tests/mnemonic/test_electrum.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/mnemonic/test_entropy.py
+++ b/tests/mnemonic/test_entropy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/mnemonic/test_mnemonic.py
+++ b/tests/mnemonic/test_mnemonic.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/psbt/__init__.py
+++ b/tests/psbt/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/psbt/test_psbt.py
+++ b/tests/psbt/test_psbt.py
@@ -28,9 +28,7 @@ from btclib.psbt.psbt import (
 )
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.script.witness import Witness
-from btclib.tx.tx import Tx
-from btclib.tx.tx_in import OutPoint, TxIn
-from btclib.tx.tx_out import TxOut
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
 # first tests are part of the official BIP174 test vectors
 

--- a/tests/psbt/test_psbt.py
+++ b/tests/psbt/test_psbt.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/psbt/test_psbt_in.py
+++ b/tests/psbt/test_psbt_in.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/psbt/test_psbt_out.py
+++ b/tests/psbt/test_psbt_out.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/psbt/test_psbt_utils.py
+++ b/tests/psbt/test_psbt_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/script/__init__.py
+++ b/tests/script/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/script/test_script.py
+++ b/tests/script/test_script.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/script/test_script_pub_key.py
+++ b/tests/script/test_script_pub_key.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/script/test_sig_hash_legacy.py
+++ b/tests/script/test_sig_hash_legacy.py
@@ -19,9 +19,7 @@ from os import path
 from btclib.ecc import dsa
 from btclib.script import sig_hash
 from btclib.script.script import serialize
-from btclib.tx.tx import Tx
-from btclib.tx.tx_in import OutPoint, TxIn
-from btclib.tx.tx_out import TxOut
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
 
 # block 170

--- a/tests/script/test_sig_hash_legacy.py
+++ b/tests/script/test_sig_hash_legacy.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/script/test_sig_hash_segwitv0.py
+++ b/tests/script/test_sig_hash_segwitv0.py
@@ -15,8 +15,7 @@ test vector at https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
 
 from btclib.script import sig_hash
 from btclib.script.witness import Witness
-from btclib.tx.tx import Tx
-from btclib.tx.tx_out import TxOut
+from btclib.tx import Tx, TxOut
 
 
 def test_native_p2wpkh() -> None:

--- a/tests/script/test_sig_hash_segwitv0.py
+++ b/tests/script/test_sig_hash_segwitv0.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/script/test_sig_hash_taproot.py
+++ b/tests/script/test_sig_hash_taproot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/script/test_sig_hash_taproot.py
+++ b/tests/script/test_sig_hash_taproot.py
@@ -25,9 +25,7 @@ from btclib.script import sig_hash
 from btclib.script.script import parse, serialize
 from btclib.script.script_pub_key import is_p2tr, type_and_payload
 from btclib.script.witness import Witness
-from btclib.tx.tx import Tx
-from btclib.tx.tx_in import OutPoint, TxIn
-from btclib.tx.tx_out import TxOut
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
 
 def test_valid_taproot_key_path() -> None:

--- a/tests/script/test_taproot.py
+++ b/tests/script/test_taproot.py
@@ -27,7 +27,7 @@ from btclib.script.taproot import (
     output_pubkey,
 )
 from btclib.script.witness import Witness
-from btclib.tx.tx_out import TxOut
+from btclib.tx import TxOut
 
 
 def test_valid_script_path() -> None:

--- a/tests/script/test_taproot.py
+++ b/tests/script/test_taproot.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/script/test_witness.py
+++ b/tests/script/test_witness.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_amount.py
+++ b/tests/test_amount.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_b32.py
+++ b/tests/test_b32.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Copyright (C) 2019-2022 The btclib developers
+# Copyright (C) 2019-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_b58.py
+++ b/tests/test_b58.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_base58.py
+++ b/tests/test_base58.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_bech32.py
+++ b/tests/test_bech32.py
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Copyright (C) 2019-2022 The btclib developers
+# Copyright (C) 2019-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_hashes.py
+++ b/tests/test_hashes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_to_key.py
+++ b/tests/test_to_key.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_to_prv_key.py
+++ b/tests/test_to_prv_key.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_to_pub_key.py
+++ b/tests/test_to_pub_key.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/test_var_int.py
+++ b/tests/test_var_int.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2017-2022 The btclib developers
+# Copyright (C) 2017-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/tx/__init__.py
+++ b/tests/tx/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/tx/test_blocks.py
+++ b/tests/tx/test_blocks.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/tx/test_out_point.py
+++ b/tests/tx/test_out_point.py
@@ -16,8 +16,8 @@ from os import path
 import pytest
 
 from btclib.exceptions import BTClibValueError
+from btclib.tx import Tx
 from btclib.tx.out_point import OutPoint
-from btclib.tx.tx import Tx
 
 
 def test_out_point() -> None:

--- a/tests/tx/test_out_point.py
+++ b/tests/tx/test_out_point.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -188,7 +188,7 @@ def test_coinbase_block_1() -> None:
     )
     tx_in = TxIn.parse(coinbase_inp)
     assert tx_in.serialize().hex() == coinbase_inp
-    assert tx_in.prev_out.is_coinbase
+    assert tx_in.prev_out.is_coinbase()
 
     coinbase = "01000000" "01" + coinbase_inp + "01" + coinbase_out + "00000000"
     tx = Tx.parse(coinbase)

--- a/tests/tx/test_tx.py
+++ b/tests/tx/test_tx.py
@@ -17,9 +17,7 @@ import pytest
 
 from btclib.exceptions import BTClibValueError
 from btclib.script.witness import Witness
-from btclib.tx.tx import Tx
-from btclib.tx.tx_in import OutPoint, TxIn
-from btclib.tx.tx_out import TxOut
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
 
 def test_tx() -> None:

--- a/tests/tx/test_tx_in.py
+++ b/tests/tx/test_tx_in.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.

--- a/tests/tx/test_tx_in.py
+++ b/tests/tx/test_tx_in.py
@@ -17,8 +17,8 @@ import pytest
 
 from btclib.exceptions import BTClibValueError
 from btclib.script.witness import Witness
-from btclib.tx.tx import Tx
-from btclib.tx.tx_in import TX_IN_COMPARES_WITNESS, OutPoint, TxIn
+from btclib.tx import OutPoint, Tx, TxIn
+from btclib.tx.tx_in import TX_IN_COMPARES_WITNESS
 
 
 def test_tx_in() -> None:

--- a/tests/tx/test_tx_out.py
+++ b/tests/tx/test_tx_out.py
@@ -16,8 +16,7 @@ from os import path
 import pytest
 
 from btclib.exceptions import BTClibValueError
-from btclib.tx.tx import Tx
-from btclib.tx.tx_out import TxOut
+from btclib.tx import Tx, TxOut
 
 
 def test_tx_out() -> None:

--- a/tests/tx/test_tx_out.py
+++ b/tests/tx/test_tx_out.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# Copyright (C) 2020-2022 The btclib developers
+# Copyright (C) 2020-2023 The btclib developers
 #
 # This file is part of btclib. It is subject to the license terms in the
 # LICENSE file found in the top-level directory of this distribution.


### PR DESCRIPTION
I was unaware of @giacomocaironi PR https://github.com/btclib-org/btclib/pull/75 and basically reimplemented it. I advocate for the approval of this PR as it also
- fixes the failures of the experimental workflow, properly signalling test success
- has a more general handling of OpenSSL 3.x issue in btclib/hashes.py
- fixes issue#73 https://github.com/btclib-org/btclib/issues/73
- updates copyright years

The (test) bug fix in tests/tx/test_tx.py and the support of python 3.11 are also included.

I advocate for this to be our end-of-year release.