### PR TITLE
Name the derivation path as its module and its parameters do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1429,7 +1429,7 @@ edit.
   derivation path were a BIP32-specific notion rather than the one SLIP132
   and the PSBT key origins hand to this very module. No alias is kept, as
   the `btclib.ec` → `btclib.curves` rename kept none: an old spelling left
-  reachable is a second name for one object, kept true release after
+  reachable is a second name for one object, kept through release after
   release for the sake of code that one search and replace fixes once
   (issue #180)
 - `btclib.b58` no longer imports `btclib.script`: importing an address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1417,6 +1417,21 @@ edit.
   on the left and the bitcoin semantics on the right, importing rightwards
   only. `bech32.py` also stops citing `segwitaddress.py`, a file renamed to
   `b32.py` several releases ago (issue #148)
+- **`btclib.bip32.der_path`'s names drop the `bip32_` prefix**: the type
+  alias `BIP32DerPath` is `DerPath`, and `indexes_from_bip32_path`,
+  `str_from_bip32_path` and `bytes_from_bip32_path` are
+  `indexes_from_der_path`, `str_from_der_path` and `bytes_from_der_path`,
+  with `_indexes_from_bip32_path_str` and `_str_from_bip32_path` following
+  them. The module is `der_path.py` and every parameter it takes is already
+  called `der_path`, so the prefix was contradicted by the file it lives in
+  and by the signatures it exports; inside `btclib.bip32` it also says
+  nothing the import path does not, and `BIP32DerPath` reads as though a
+  derivation path were a BIP32-specific notion rather than the one SLIP132
+  and the PSBT key origins hand to this very module. No alias is kept, as
+  the `btclib.ec` → `btclib.curves` rename kept none: an old spelling left
+  reachable is a second name for one object, kept true release after
+  release for the sake of code that one search and replace fixes once
+  (issue #180)
 - `btclib.b58` no longer imports `btclib.script`: importing an address
   encoding stops pulling the whole script package in, and the cycle b58 ->
   btclib.script -> script.script_pub_key -> b58 is gone. Importing any
@@ -1776,7 +1791,7 @@ edit.
   the type checker's again
 - **the public type aliases are PEP 604 unions**: `Octets = bytes | str`,
   and the same for `String`, `BinaryData`, `Integer`, `Command`, `BIP32Key`,
-  `BIP32DerPath`, `BIP340PubKey`, `Entropy`, `OneOrMoreInt`, `ScriptFlags`,
+  `DerPath`, `BIP340PubKey`, `Entropy`, `OneOrMoreInt`, `ScriptFlags`,
   `PrvKey`, `PubKey`, `Key` and `NoneOneOrMoreInt`. Fifteen of them, and they
   were `Union[...]` for one reason: a type alias is an ordinary assignment,
   not an annotation, so `from __future__ import annotations` does not reach

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -182,6 +182,13 @@ against the `v2023.7.12` tag.
   Core's PSBT stores it. Nothing replaces the call — `PsbtOut.assert_valid`
   simply no longer parses the leaves — and a caller that wants to know
   whether a leaf can be executed runs it.
+- **`BIP32DerPath` is `DerPath`, and the three `*_from_bip32_path`
+  converters are `*_from_der_path`.** `indexes_from_bip32_path`,
+  `str_from_bip32_path` and `bytes_from_bip32_path` answer as they did
+  under `indexes_from_der_path`, `str_from_der_path` and
+  `bytes_from_der_path`, so a search and replace for `bip32_path` and
+  `BIP32DerPath` is the whole cost. No alias is kept, as the `btclib.ec`
+  rename kept none.
 
 Two changes are deliberately *not* on that list, because what they change
 stays compatible. The new `BTClibTypeError`, `NotAPrvKeyError` and

--- a/btclib/bip32/__init__.py
+++ b/btclib/bip32/__init__.py
@@ -19,10 +19,10 @@ from btclib.bip32.bip32 import (
     xpub_from_xprv,
 )
 from btclib.bip32.der_path import (
-    bytes_from_bip32_path,
-    indexes_from_bip32_path,
+    bytes_from_der_path,
+    indexes_from_der_path,
     int_from_index_str,
-    str_from_bip32_path,
+    str_from_der_path,
     str_from_index_int,
 )
 from btclib.bip32.key_origin import (
@@ -40,17 +40,17 @@ __all__ = [
     "BIP32KeyOrigin",
     "HdKeyPaths",
     "assert_valid_hd_key_paths",
-    "bytes_from_bip32_path",
+    "bytes_from_der_path",
     "crack_prv_key",
     "decode_from_bip32_derivs",
     "decode_hd_key_paths",
     "derive",
     "derive_from_account",
     "encode_to_bip32_derivs",
-    "indexes_from_bip32_path",
+    "indexes_from_der_path",
     "int_from_index_str",
     "rootxprv_from_seed",
-    "str_from_bip32_path",
+    "str_from_der_path",
     "str_from_index_int",
     "xpub_from_xprv",
 ]

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -41,8 +41,8 @@ from btclib import base58
 from btclib.alias import INF, BinaryData, Octets, Point, String
 from btclib.bip32.der_path import (
     _HARDENED_OFFSET,
-    BIP32DerPath,
-    indexes_from_bip32_path,
+    DerPath,
+    indexes_from_der_path,
 )
 from btclib.curves import (
     bytes_from_point,
@@ -493,12 +493,12 @@ def _force_version(version: bytes, forced_version: Octets) -> bytes:
 
 
 def _derive(
-    xkey: BIP32Key, der_path: BIP32DerPath, forced_version: Octets | None = None
+    xkey: BIP32Key, der_path: DerPath, forced_version: Octets | None = None
 ) -> BIP32KeyData:
     if not isinstance(xkey, BIP32KeyData):
         xkey = BIP32KeyData.b58decode(xkey)
 
-    indexes = indexes_from_bip32_path(der_path)
+    indexes = indexes_from_der_path(der_path)
 
     final_depth = xkey.depth + len(indexes)
     if final_depth > 255:
@@ -529,18 +529,18 @@ def _derive(
 
 
 def derive(
-    xkey: BIP32Key, der_path: BIP32DerPath, forced_version: Octets | None = None
+    xkey: BIP32Key, der_path: DerPath, forced_version: Octets | None = None
 ) -> str:
     """Derive a BIP32 key across a path spanning multiple depth levels.
 
-    Valid BIP32DerPath examples:
+    Valid DerPath examples:
 
     - string like "m/44h/0'/1H/0/10"
     - iterable integer indexes
     - one single integer index
     - bytes in multiples of the 4-bytes index
 
-    BIP32DerPath is case/blank/extra-slash insensitive
+    DerPath is case/blank/extra-slash insensitive
     (e.g. "M /44h / 0' /1H // 0/ 10 / ").
     """
     xkey = _derive(xkey, der_path, forced_version)

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -60,7 +60,7 @@ def str_from_index_int(i: int, hardening: str = _HARDENING) -> str:
     return str(i - _HARDENED_OFFSET) + hardening
 
 
-def _indexes_from_bip32_path_str(der_path: str, skip_m: bool = True) -> list[int]:
+def _indexes_from_der_path_str(der_path: str, skip_m: bool = True) -> list[int]:
     steps = [x.strip().lower() for x in der_path.split("/")]
     if skip_m and steps[0] == "m":
         steps = steps[1:]
@@ -73,12 +73,12 @@ def _indexes_from_bip32_path_str(der_path: str, skip_m: bool = True) -> list[int
     return indexes
 
 
-BIP32DerPath = str | Sequence[int] | int | bytes
+DerPath = str | Sequence[int] | int | bytes
 
 
-def indexes_from_bip32_path(der_path: BIP32DerPath) -> list[int]:
+def indexes_from_der_path(der_path: DerPath) -> list[int]:
     if isinstance(der_path, str):
-        return _indexes_from_bip32_path_str(der_path)
+        return _indexes_from_der_path_str(der_path)
 
     if isinstance(der_path, int):
         return [der_path]
@@ -96,17 +96,17 @@ def indexes_from_bip32_path(der_path: BIP32DerPath) -> list[int]:
     return [int(i) for i in der_path]
 
 
-def _str_from_bip32_path(der_path: BIP32DerPath, hardening: str = _HARDENING) -> str:
-    indexes = indexes_from_bip32_path(der_path)
+def _str_from_der_path(der_path: DerPath, hardening: str = _HARDENING) -> str:
+    indexes = indexes_from_der_path(der_path)
     return "/".join(str_from_index_int(i, hardening) for i in indexes)
 
 
-def str_from_bip32_path(
-    der_path: BIP32DerPath,
+def str_from_der_path(
+    der_path: DerPath,
     master_fingerprint: Octets | None = None,
     hardening: str = _HARDENING,
 ) -> str:
-    result = _str_from_bip32_path(der_path, hardening)
+    result = _str_from_der_path(der_path, hardening)
     if master_fingerprint:
         if isinstance(master_fingerprint, str):
             first_element = master_fingerprint.strip()
@@ -121,7 +121,7 @@ def str_from_bip32_path(
     return first_element + (f"/{result}" if result else "")
 
 
-def bytes_from_bip32_path(der_path: BIP32DerPath) -> bytes:
-    indexes = indexes_from_bip32_path(der_path)
+def bytes_from_der_path(der_path: DerPath) -> bytes:
+    indexes = indexes_from_der_path(der_path)
     result = [i.to_bytes(4, byteorder="little", signed=False) for i in indexes]
     return b"".join(result)

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -16,10 +16,10 @@ from dataclasses import dataclass
 
 from btclib.alias import Octets
 from btclib.bip32.der_path import (
-    BIP32DerPath,
-    bytes_from_bip32_path,
-    indexes_from_bip32_path,
-    str_from_bip32_path,
+    DerPath,
+    bytes_from_der_path,
+    indexes_from_der_path,
+    str_from_der_path,
 )
 from btclib.exceptions import BTClibValueError
 from btclib.utils import bytes_from_octets
@@ -32,19 +32,19 @@ class BIP32KeyOrigin:
 
     @property
     def description(self) -> str:
-        return str_from_bip32_path(self.der_path, self.master_fingerprint)
+        return str_from_der_path(self.der_path, self.master_fingerprint)
 
     def __init__(
         self,
         master_fingerprint: Octets,
-        der_path: BIP32DerPath,
+        der_path: DerPath,
         *,
         check_validity: bool = True,
     ) -> None:
         object.__setattr__(
             self, "master_fingerprint", bytes_from_octets(master_fingerprint)
         )
-        object.__setattr__(self, "der_path", indexes_from_bip32_path(der_path))
+        object.__setattr__(self, "der_path", indexes_from_der_path(der_path))
 
         if check_validity:
             self.assert_valid()
@@ -68,7 +68,7 @@ class BIP32KeyOrigin:
 
         return {
             "master_fingerprint": self.master_fingerprint.hex(),
-            "path": str_from_bip32_path(self.der_path),
+            "path": str_from_der_path(self.der_path),
         }
 
     @classmethod
@@ -88,7 +88,7 @@ class BIP32KeyOrigin:
         if check_validity:
             self.assert_valid()
 
-        return self.master_fingerprint + bytes_from_bip32_path(self.der_path)
+        return self.master_fingerprint + bytes_from_der_path(self.der_path)
 
     @classmethod
     def parse(
@@ -97,7 +97,7 @@ class BIP32KeyOrigin:
         """Return a BIP32KeyOrigin by parsing binary data."""
         data = bytes_from_octets(data)
         master_fingerprint = data[:4]
-        der_path = indexes_from_bip32_path(data[4:])
+        der_path = indexes_from_der_path(data[4:])
 
         return cls(master_fingerprint, der_path, check_validity=check_validity)
 
@@ -149,7 +149,7 @@ def encode_to_bip32_derivs(
         {
             "pub_key": pub_key.hex(),
             "master_fingerprint": key_origin.master_fingerprint.hex(),
-            "path": str_from_bip32_path(key_origin.der_path),
+            "path": str_from_der_path(key_origin.der_path),
         }
         for pub_key, key_origin in sorted(hd_key_paths.items())
     ]
@@ -162,7 +162,7 @@ def _decode_from_bip32_deriv(
     # master_fingerprint or pub_key cannot be instantiated even deliberately
     # -- a check_validity question, now that the flag is keyword-only
     master_fingerprint = bytes_from_octets(bip32_deriv["master_fingerprint"], 4)
-    der_path = indexes_from_bip32_path(bip32_deriv["path"])
+    der_path = indexes_from_der_path(bip32_deriv["path"])
     key_origin = BIP32KeyOrigin(master_fingerprint, der_path)
     return bytes_from_octets(bip32_deriv["pub_key"]), key_origin
 

--- a/btclib/bip32/slip132.py
+++ b/btclib/bip32/slip132.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from btclib import b32, b58
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, derive, xpub_from_xprv
-from btclib.bip32.der_path import BIP32DerPath
+from btclib.bip32.der_path import DerPath
 from btclib.exceptions import BTClibValueError
 from btclib.network import (
     NETWORKS,
@@ -86,7 +86,7 @@ def _helper_checks(
 
 
 def p2pkh_xkey(
-    xkey: BIP32Key, der_path: BIP32DerPath = "m/44h/0h/0h", check_root_xkey: bool = True
+    xkey: BIP32Key, der_path: DerPath = "m/44h/0h/0h", check_root_xkey: bool = True
 ) -> str:
     """Return a p2pkh BIP32 xprv/xpub key at the derivation path."""
     xkey, network = _helper_checks(xkey, check_root_xkey)
@@ -95,7 +95,7 @@ def p2pkh_xkey(
 
 
 def p2wpkh_p2sh_xkey(
-    xkey: BIP32Key, der_path: BIP32DerPath = "m/49h/0h/0h", check_root_xkey: bool = True
+    xkey: BIP32Key, der_path: DerPath = "m/49h/0h/0h", check_root_xkey: bool = True
 ) -> str:
     """Return a p2wpkh-p2sh BIP32 yprv/ypub key at the derivation path."""
     xkey, network = _helper_checks(xkey, check_root_xkey)
@@ -108,7 +108,7 @@ def p2wpkh_p2sh_xkey(
 
 
 def p2wpkh_xkey(
-    xkey: BIP32Key, der_path: BIP32DerPath = "m/84h/0h/0h", check_root_xkey: bool = True
+    xkey: BIP32Key, der_path: DerPath = "m/84h/0h/0h", check_root_xkey: bool = True
 ) -> str:
     """Return a p2wpkh BIP32 zprv/zpub master key at the derivation path."""
     xkey, network = _helper_checks(xkey, check_root_xkey)

--- a/btclib/bip44.py
+++ b/btclib/bip44.py
@@ -36,8 +36,8 @@ from btclib.alias import BIP44ScriptType, NetworkType
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, derive
 from btclib.bip32.der_path import (
     _HARDENED_OFFSET,
-    BIP32DerPath,
-    indexes_from_bip32_path,
+    DerPath,
+    indexes_from_der_path,
     str_from_index_int,
 )
 from btclib.exceptions import BTClibValueError
@@ -207,7 +207,7 @@ def _indexes_left_to_derive(xkey: BIP32KeyData, indexes: list[int]) -> list[int]
 
 
 def address_from_der_path(
-    xkey: BIP32Key, der_path: BIP32DerPath, script_type: BIP44ScriptType | None = None
+    xkey: BIP32Key, der_path: DerPath, script_type: BIP44ScriptType | None = None
 ) -> str:
     """Return the address of a BIP44 derivation path.
 
@@ -230,7 +230,7 @@ def address_from_der_path(
     if not isinstance(xkey, BIP32KeyData):
         xkey = BIP32KeyData.b58decode(xkey)
 
-    indexes = indexes_from_bip32_path(der_path)
+    indexes = indexes_from_der_path(der_path)
     _assert_valid_path(indexes)
 
     if script_type is None:

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -21,7 +21,7 @@ from typing import Any
 from btclib import var_bytes, var_int
 from btclib.alias import BinaryData, Octets
 from btclib.bip32 import BIP32KeyOrigin
-from btclib.bip32.der_path import indexes_from_bip32_path, str_from_bip32_path
+from btclib.bip32.der_path import indexes_from_der_path, str_from_der_path
 from btclib.exceptions import BTClibValueError
 from btclib.script.sig_hash import DEFAULT, SIG_HASH_TYPES
 from btclib.script.taproot import assert_valid_control_block
@@ -256,7 +256,7 @@ def taproot_bip32_to_dict(
             "pub_key": pub_key.hex(),
             "leaf_hashes": [x.hex() for x in leaf_hashes],
             "master_fingerprint": key_origin.master_fingerprint.hex(),
-            "path": str_from_bip32_path(key_origin.der_path),
+            "path": str_from_der_path(key_origin.der_path),
         }
         for pub_key, (leaf_hashes, key_origin) in sorted(taproot_hd_key_paths.items())
     ]
@@ -271,7 +271,7 @@ def taproot_bip32_from_dict(
             [bytes_from_octets(x) for x in bip32_deriv["leaf_hashes"]],
             BIP32KeyOrigin(
                 bytes_from_octets(bip32_deriv["master_fingerprint"], 4),
-                indexes_from_bip32_path(bip32_deriv["path"]),
+                indexes_from_der_path(bip32_deriv["path"]),
             ),
         )
         for bip32_deriv in taproot_hd_key_paths

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -26,7 +26,7 @@ from btclib.bip32 import (
     xpub_from_xprv,
 )
 from btclib.bip32.bip32 import _derive
-from btclib.bip32.der_path import _indexes_from_bip32_path_str
+from btclib.bip32.der_path import _indexes_from_der_path_str
 from btclib.curves import secp256k1 as ec
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
@@ -231,7 +231,7 @@ def test_derive() -> None:
         for der_path, address in value:
             assert address == p2pkh(derive(rootxprv, der_path))
 
-            indexes = _indexes_from_bip32_path_str(der_path)
+            indexes = _indexes_from_der_path_str(der_path)
             assert address == p2pkh(derive(rootxprv, indexes))
 
         assert derive(rootxprv, "m") == rootxprv

--- a/tests/bip32/der_path_test.py
+++ b/tests/bip32/der_path_test.py
@@ -7,22 +7,22 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Tests for the `btclib.bip32_path` module."""
+"""Tests for the `btclib.bip32.der_path` module."""
 
 import pytest
 
 from btclib.bip32 import (
-    bytes_from_bip32_path,
-    indexes_from_bip32_path,
+    bytes_from_der_path,
+    indexes_from_der_path,
     int_from_index_str,
-    str_from_bip32_path,
+    str_from_der_path,
     str_from_index_int,
 )
-from btclib.bip32.der_path import _HARDENING, _indexes_from_bip32_path_str
+from btclib.bip32.der_path import _HARDENING, _indexes_from_der_path_str
 from btclib.exceptions import BTClibValueError
 
 
-def test_from_bip32_path_str() -> None:
+def test_from_der_path_str() -> None:
     test_reg_str_vectors = [
         # account 0, external branch, address_index 463
         (f"m/0{_HARDENING}/0/463", [0x80000000, 0, 463]),
@@ -30,23 +30,23 @@ def test_from_bip32_path_str() -> None:
         (f"m/0{_HARDENING}/1/267", [0x80000000, 1, 267]),
     ]
 
-    for bip32_path_str, bip32_path_ints in test_reg_str_vectors:
+    for der_path_str, der_path_ints in test_reg_str_vectors:
         # recover ints from str
-        assert bip32_path_ints == _indexes_from_bip32_path_str(bip32_path_str)
-        assert bip32_path_ints == indexes_from_bip32_path(bip32_path_str)
+        assert der_path_ints == _indexes_from_der_path_str(der_path_str)
+        assert der_path_ints == indexes_from_der_path(der_path_str)
         # recover ints from ints
-        assert bip32_path_ints == indexes_from_bip32_path(bip32_path_ints)
+        assert der_path_ints == indexes_from_der_path(der_path_ints)
         # recover str from str
-        assert bip32_path_str == str_from_bip32_path(bip32_path_str)
+        assert der_path_str == str_from_der_path(der_path_str)
         # recover str from ints
-        assert bip32_path_str == str_from_bip32_path(bip32_path_ints)
+        assert der_path_str == str_from_der_path(der_path_ints)
         # ensure bytes from ints == bytes from str
-        bip32_path_bytes = bytes_from_bip32_path(bip32_path_ints)
-        assert bip32_path_bytes == bytes_from_bip32_path(bip32_path_str)
+        der_path_bytes = bytes_from_der_path(der_path_ints)
+        assert der_path_bytes == bytes_from_der_path(der_path_str)
         # recover ints from bytes
-        assert bip32_path_ints == indexes_from_bip32_path(bip32_path_bytes)
+        assert der_path_ints == indexes_from_der_path(der_path_bytes)
         # recover str from bytes
-        assert bip32_path_str == str_from_bip32_path(bip32_path_bytes)
+        assert der_path_str == str_from_der_path(der_path_bytes)
 
     test_irregular_str_vectors = [
         # account 0, external branch, address_index 463
@@ -59,37 +59,37 @@ def test_from_bip32_path_str() -> None:
         ("m // 0' / 1 / 267", [0x80000000, 1, 267]),
     ]
 
-    for bip32_path_str, bip32_path_ints in test_irregular_str_vectors:
+    for der_path_str, der_path_ints in test_irregular_str_vectors:
         # recover ints from str
-        assert bip32_path_ints == _indexes_from_bip32_path_str(bip32_path_str)
-        assert bip32_path_ints == indexes_from_bip32_path(bip32_path_str)
+        assert der_path_ints == _indexes_from_der_path_str(der_path_str)
+        assert der_path_ints == indexes_from_der_path(der_path_str)
         # recover ints from ints
-        assert bip32_path_ints == indexes_from_bip32_path(bip32_path_ints)
+        assert der_path_ints == indexes_from_der_path(der_path_ints)
         # irregular str != normalized str
-        assert bip32_path_str != str_from_bip32_path(bip32_path_str)
+        assert der_path_str != str_from_der_path(der_path_str)
         # irregular str != normalized str from ints
-        assert bip32_path_str != str_from_bip32_path(bip32_path_ints)
+        assert der_path_str != str_from_der_path(der_path_ints)
         # ensure bytes from ints == bytes from str
-        bip32_path_bytes = bytes_from_bip32_path(bip32_path_ints)
-        assert bip32_path_bytes == bytes_from_bip32_path(bip32_path_str)
+        der_path_bytes = bytes_from_der_path(der_path_ints)
+        assert der_path_bytes == bytes_from_der_path(der_path_str)
         # recover ints from bytes
-        assert bip32_path_ints == indexes_from_bip32_path(bip32_path_bytes)
+        assert der_path_ints == indexes_from_der_path(der_path_bytes)
         # irregular str != normalized str from bytes
-        assert bip32_path_str != str_from_bip32_path(bip32_path_bytes)
+        assert der_path_str != str_from_der_path(der_path_bytes)
 
     with pytest.raises(BTClibValueError, match="invalid index: "):
-        _indexes_from_bip32_path_str("m/1/2/-3h/4")
+        _indexes_from_der_path_str("m/1/2/-3h/4")
 
     with pytest.raises(BTClibValueError, match="invalid index: "):
-        _indexes_from_bip32_path_str("m/1/2/-3/4")
+        _indexes_from_der_path_str("m/1/2/-3/4")
 
     i = 0x80000000
 
     with pytest.raises(BTClibValueError, match="invalid index: "):
-        _indexes_from_bip32_path_str(f"m/1/2/{i}/4")
+        _indexes_from_der_path_str(f"m/1/2/{i}/4")
 
     with pytest.raises(BTClibValueError, match="invalid index: "):
-        _indexes_from_bip32_path_str(f"m/1/2/{i}h/4")
+        _indexes_from_der_path_str(f"m/1/2/{i}h/4")
 
 
 def test_index_int_to_from_str() -> None:
@@ -108,12 +108,12 @@ def test_index_int_to_from_str() -> None:
         str_from_index_int(0x80000000, "hardened")
 
 
-def test_str_from_bip32_path() -> None:
+def test_str_from_der_path() -> None:
     der_path = "/44h/0h"
-    assert str_from_bip32_path(der_path) == f"m{der_path}"
+    assert str_from_der_path(der_path) == f"m{der_path}"
     m_fngrprnt = "deadbeef"
-    assert str_from_bip32_path(der_path, m_fngrprnt) == m_fngrprnt + der_path
+    assert str_from_der_path(der_path, m_fngrprnt) == m_fngrprnt + der_path
 
     err_msg = "invalid master fingerprint length: "
     with pytest.raises(BTClibValueError, match=err_msg):
-        str_from_bip32_path(der_path, "baaaad")
+        str_from_der_path(der_path, "baaaad")

--- a/tests/bip32/key_origin_test.py
+++ b/tests/bip32/key_origin_test.py
@@ -7,7 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Tests for the `btclib.bip32_path` module."""
+"""Tests for the `btclib.bip32.key_origin` module."""
 
 import pytest
 


### PR DESCRIPTION
`btclib/bip32/der_path.py` exported `BIP32DerPath` and three
`*_from_bip32_path` converters while every parameter in the file was already
called `der_path`. The prefix was contradicted by the file it lives in and by
the signatures it exports; inside `btclib.bip32` it also says nothing the
import path does not, and `BIP32DerPath` reads as though a derivation path
were a BIP32-specific notion rather than the one SLIP132 and the PSBT key
origins hand to this very module.

## What was renamed

| before | after |
| --- | --- |
| `BIP32DerPath` | `DerPath` |
| `indexes_from_bip32_path` | `indexes_from_der_path` |
| `str_from_bip32_path` | `str_from_der_path` |
| `bytes_from_bip32_path` | `bytes_from_der_path` |
| `_indexes_from_bip32_path_str` | `_indexes_from_der_path_str` |
| `_str_from_bip32_path` | `_str_from_der_path` |

122 references across nine files, the `btclib.bip32` package `__all__`
included. Two test docstrings claimed to cover `btclib.bip32_path`, a module
no release has ever had, and name the one they test instead. The `# FIXME
bip32_path should be der_path, BIP32DerPath DerPath, etc` that asked for this
is already gone — removing it is what filed the issue — so the rename is what
closes it.

## What a caller has to change

Behaviour is untouched: each name is the same object under the new spelling.
A search and replace for `bip32_path` and `BIP32DerPath` is the whole cost.

```python
from btclib.bip32 import indexes_from_bip32_path   # before
from btclib.bip32 import indexes_from_der_path     # after
```

## The #148 precedent

`btclib.ec` → `btclib.curves` (commit `c50b524b`) kept **no** back-compat
alias and recorded the break in HISTORY.md's list. This does the same: an old
spelling left reachable is a second name for one object, kept true release
after release for the sake of code that one search and replace fixes once.

Source-breaking, so it costs the three extra edits: a bullet in HISTORY.md's
breaking-changes list, that list's count (`Twenty-nine` → `Thirty` — verified
by counting the bullets, not estimated), and CHANGELOG.md's cross-reference to
it. Every "before" spelling above was checked against the `v2023.7.12` tag,
where all four public names exist with exactly those spellings — as does the
FIXME, at `der_path.py:66`. CHANGELOG.md gains one entry (178 → 179) in
*The public API and the module layout*, beside the `btclib.ec` one, and its
`Types` entry listing the PEP 604 aliases now names `DerPath`.

## Verification

Each gate run on the final tree, exit code checked, all 0:

- `uv run pytest` — 14787 passed
- `uv run pre-commit run --all-files` — every hook passed, nothing rewritten
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — build succeeded

Sibling PRs move the CHANGELOG entry count and the breaking-changes count too;
re-derive both at merge.

Closes #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename the BIP32 derivation path type and related helpers to generic derivation-path names and update all uses and documentation references accordingly.

Enhancements:
- Adopt the `DerPath` type alias and `*_from_der_path` helper names in the bip32 derivation path module, replacing the previous `BIP32DerPath` and `*_from_bip32_path` names to better reflect their general applicability beyond BIP32.

Documentation:
- Update CHANGELOG.md and HISTORY.md to record the derivation-path API rename as a source-breaking change and adjust release entry counts.
- Fix test module docstrings to reference the correct bip32 modules.

Tests:
- Update bip32-related tests to use the new derivation-path helper names, keeping behavior unchanged.

Chores:
- Align bip32, SLIP132, PSBT utilities, and public `btclib.bip32` exports with the new derivation-path naming scheme without adding compatibility aliases.