### PR TITLE
Compute what dust is, rather than tabulate one limit per type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1713,6 +1713,33 @@ edit.
   BIP341 and `bip32` may not import `script`. The vectors are BIP49's,
   BIP84's and BIP86's own, and SLIP132's for purpose 44, which publishes
   no address of its own (issue #197)
+- **`btclib.fee` is the fee arithmetic**: `FeeRate`, `fee_from_vsize` and
+  `dust_threshold`, which every spending path needed and none of which the
+  library had — `amount.py` took `dust` as a *parameter* and carried no rule
+  for it. A `FeeRate` holds an integer number of satoshi per kvB, Core's own
+  unit and the only exact one, and it is keyword-only: `FeeRate(3000)` is the
+  off-by-a-thousand the type exists to prevent and is a TypeError, where
+  `FeeRate(sats_per_kvbyte=3000)` and `FeeRate.from_sats_per_vbyte("1.5")`
+  both say which unit they were handed. The sat/vB constructor refuses a rate
+  it could not hold rather than truncating one, and the sat/vB accessor
+  answers a `Decimal`. `fee_from_vsize` rounds *up*, which is Core's
+  `CFeeRate::GetFee`: a fee one satoshi short of the rate does not relay, and
+  exact ceiling division on ints gives the one-satoshi floor that Core's
+  float-era code needed a branch for. `dust_threshold` is Core's
+  `GetDustThreshold` — the dust relay rate, 3000 sat/kvB and a defaulted
+  parameter as `-dustrelayfee` is an option, over the output's own serialized
+  size plus the input that will spend it. Computed and not tabulated, which
+  is the whole point: p2tr answers 330 with taproot named nowhere in the
+  module, and so will the next output type, where electrum's five
+  `DUST_LIMIT_*` constants need an edit apiece. The tests check the computed
+  answers against that table — 546 p2pkh, 540 p2sh, 330 p2wsh, 294 p2wpkh,
+  354 unknown segwit — and against the 182 and 98 virtual bytes Core works
+  out by hand above `GetDustThreshold`. Unspendability is Core's
+  `IsUnspendable` and not btclib's narrower `is_nulldata` (issue #211), so a
+  bare OP_RETURN gets the zero threshold a node gives it. What is *not* here
+  is everything downstream of a network: mempool histograms, fee estimates
+  for a confirmation target, ETAs. Those are policy fed by live data and
+  belong to an application; the module docstring says so (issue #205)
 
 ### Types
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Included features are:
 - legacy, segwit_v0 and taproot transaction hash signatures
 - [BIP174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki)
   partially signed bitcoin transactions (PSBT):
-  PsbtIn, PbstOut, and Psbt data classes
+  PsbtIn, PsbtOut, and Psbt data classes
 - fee rates carrying their unit (sat/kvB and sat/vB), the fee a virtual
   size owes at one, and the dust threshold of any output type — computed
   the way Bitcoin Core computes it, rather than tabulated

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Included features are:
 - [BIP174](https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki)
   partially signed bitcoin transactions (PSBT):
   PsbtIn, PbstOut, and Psbt data classes
+- fee rates carrying their unit (sat/kvB and sat/vB), the fee a virtual
+  size owes at one, and the dust threshold of any output type — computed
+  the way Bitcoin Core computes it, rather than tabulated
 
 ---
 

--- a/btclib/fee.py
+++ b/btclib/fee.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Fee rates, the fee a virtual size owes, and the dust threshold.
+
+Three answers, each a function of its arguments alone: what a fee rate
+is, what fee a transaction of a given virtual size owes at that rate, and
+how small an output has to be before the network refuses to relay it.
+
+A fee rate is a price, and the unit is where the mistakes are. Bitcoin
+Core states it in satoshi per kilo-virtual-byte, wallets and their users
+state it in satoshi per virtual byte, and the two differ by a factor of a
+thousand that a bare int does not record. `FeeRate` names the unit in the
+one constructor and in both accessors, so the factor is never the
+caller's to remember, and it refuses a sat/vB rate it could not hold
+exactly rather than truncating one.
+
+Explicitly not here, and the boundary is the point: everything downstream
+of a network. Mempool histograms, a fee estimate for a confirmation
+target, an ETA, a "how many blocks" slider -- those are policy fed by
+live data. They need a node, they answer differently every minute, and
+they belong to an application rather than to a library. What this module
+computes it computes from its arguments and from Bitcoin Core's
+constants, and the same arguments give the same answer forever.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from btclib import var_int
+from btclib.alias import Octets
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.script.limits import MAX_SCRIPT_SIZE
+from btclib.script.script import BYTE_FROM_OP_CODE_NAME
+from btclib.script.script_pub_key import is_segwit
+from btclib.utils import bytes_from_octets
+
+# the kilo in sat/kvB, i.e. how many virtual bytes a rate is quoted over
+_VBYTES_PER_KVBYTE = 1000
+
+
+@dataclass(frozen=True, order=True, kw_only=True)
+class FeeRate:
+    """A fee rate, held as an integer number of satoshi per kvB.
+
+    sat/kvB as an int is the exact representation, and the only one that
+    is. It is what Core stores, so no conversion stands between this
+    number and the fee a node computes; it is integral, so the arithmetic
+    is Python's unbounded int rather than a float that stops counting in
+    ones somewhere below MAX_MONEY; and it is fine enough to hold every
+    rate a user can state, sat/vB being quoted to three decimals at most
+    -- 1.5 sat/vB is exactly 1500 sat/kvB. Storing sat/vB instead would
+    make the common unit the lossy one: 1.5 is not representable as an
+    int, and as a float it is one of the few decimals that happen to be
+    exact, which is worse than none of them being.
+
+    Keyword-only, so that no bare number is ever passed to the
+    constructor without its unit beside it: `FeeRate(3000)` is the
+    off-by-a-thousand this class exists to prevent, and it is a
+    TypeError. There is no `from_sats_per_kvbyte` classmethod either --
+    the field is that constructor, already spelled with its unit, and a
+    second spelling of one thing is a menu rather than an API.
+
+    Ordered, because comparing two prices is the question a caller
+    actually asks of them, and the comparison is exact for the same
+    reason the storage is.
+    """
+
+    sats_per_kvbyte: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.sats_per_kvbyte, int):
+            raise BTClibTypeError(
+                f"non-integer sat/kvB fee rate: {self.sats_per_kvbyte}"
+            )
+        # Core's CFeeRate admits a negative rate, and its GetFee floors
+        # the result at -1 satoshi when it sees one. That is not leniency
+        # to copy: the fraction CFeeRate stores is also the slope of a
+        # feerate diagram, where the difference between two chunks can
+        # run downhill, and the floor is there for that use. A FeeRate
+        # here is only ever a price, never a difference, so a negative
+        # one is a caller's mistake and the floor has nothing to protect
+        if self.sats_per_kvbyte < 0:
+            raise BTClibValueError(f"negative fee rate: {self.sats_per_kvbyte} sat/kvB")
+
+    @classmethod
+    def from_sats_per_vbyte(cls, sats_per_vbyte: Any) -> FeeRate:
+        """Return the fee rate quoted in satoshi per virtual byte.
+
+        Args:
+            sats_per_vbyte (Any): The rate in sat/vB: a Decimal, an int,
+                a string, or anything else str() renders as a decimal
+                number. A float is read through its repr, so 1.1 is the
+                1.1 that was written rather than the binary fraction
+                nearest to it.
+
+        Raises:
+            BTClibValueError: If the rate is not finite, or if it is not
+                a whole number of millisatoshi per virtual byte -- i.e.
+                if sat/kvB could not hold it exactly.
+
+        Returns:
+            FeeRate: The same rate, in sat/kvB.
+        """
+        rate = Decimal(str(sats_per_vbyte))
+        # as_integer_ratio raises OverflowError on an infinity and
+        # ValueError on a NaN, and the first of those is outside this
+        # library's exception contract: both are refused here instead
+        if not rate.is_finite():
+            raise BTClibValueError(f"invalid sat/vB fee rate: {sats_per_vbyte}")
+        # the ratio is exact and reads no decimal context, where
+        # multiplying the Decimal by a thousand would round to whatever
+        # precision the caller's context happens to carry. A conversion
+        # whose reason for existing is that truncation must be impossible
+        # cannot be the place that truncates
+        numerator, denominator = rate.as_integer_ratio()
+        sats_per_kvbyte, remainder = divmod(numerator * _VBYTES_PER_KVBYTE, denominator)
+        if remainder:
+            raise BTClibValueError(
+                "sat/vB fee rate finer than a millisatoshi per virtual byte: "
+                f"{sats_per_vbyte}"
+            )
+        return cls(sats_per_kvbyte=sats_per_kvbyte)
+
+    @property
+    def sats_per_vbyte(self) -> Decimal:
+        """Return the rate in satoshi per virtual byte, exactly.
+
+        A Decimal and not a float, for the reason the class docstring
+        gives: the unit users speak is the unit a binary fraction cannot
+        hold, and handing back 1.1000000000000001 would undo the
+        conversion that refused to truncate on the way in.
+        """
+        whole, milli_sats = divmod(self.sats_per_kvbyte, _VBYTES_PER_KVBYTE)
+        # built from its digits rather than by dividing two Decimals,
+        # which rounds to the ambient context precision: what a caller
+        # has set that to is no business of a fee rate.
+        # normalize() strips the trailing zeros, as btc_from_sats does,
+        # so that equal rates print the same way
+        return Decimal(f"{whole}.{milli_sats:03d}").normalize()
+
+
+def fee_from_vsize(vsize: int, fee_rate: FeeRate) -> int:
+    """Return the fee in satoshi owed by a transaction of that virtual size.
+
+    Rounded up, which is what Core's `CFeeRate::GetFee` does and the
+    reason it does it: a fee one satoshi short of the rate is a fee below
+    the rate, and a transaction paying it does not relay.
+
+    Args:
+        vsize (int): The virtual size, in virtual bytes.
+        fee_rate (FeeRate): The rate the fee is owed at.
+
+    Raises:
+        BTClibValueError: If the virtual size is negative.
+
+    Returns:
+        int: The fee, in satoshi.
+    """
+    if vsize < 0:
+        raise BTClibValueError(f"negative virtual size: {vsize}")
+    # integer division and a bump, not math.ceil of a quotient: the
+    # quotient would be a float, and Core's own comment on this
+    # computation is that "we've previously had bugs creep in from silent
+    # double->int conversion".
+    #
+    # No floor at one satoshi either, though GetFee carries a branch that
+    # looks like one. Exact ceiling division already returns at least 1
+    # for any nonzero rate over a nonzero size -- one satoshi per kvB
+    # over a single virtual byte is a fee of one satoshi, not of none --
+    # so what is left of that branch upstream catches negative rates
+    # alone, which this module has none of. A zero rate owes zero at
+    # every size, and that is the answer rather than an edge case: it is
+    # also how Core answers for a rate it holds as no rate at all
+    sats, remainder = divmod(fee_rate.sats_per_kvbyte * vsize, _VBYTES_PER_KVBYTE)
+    return sats + 1 if remainder else sats
+
+
+# Core's DUST_RELAY_TX_FEE, the default of its -dustrelayfee option. A
+# FeeRate and not the bare 3000 of policy.h, so that the default and the
+# parameter it defaults are the same type: handing a number to something
+# that wants a rate is the mistake this module exists to make impossible
+DUST_RELAY_FEE_RATE = FeeRate(sats_per_kvbyte=3000)
+
+# what spending an output costs, in the two shapes Core measures: 32
+# bytes of previous-output hash, 4 of previous-output index, 1 for the
+# length of the script_sig, 107 of script_sig -- a DER signature and a
+# compressed public key, the minimum satisfaction of a p2pkh output --
+# and 4 of sequence
+_SPEND_SIZE = 32 + 4 + 1 + 107 + 4
+# the same input spending a witness program, where those 107 bytes sit in
+# the witness and weigh a quarter. The division is integer and Core's,
+# WITNESS_SCALE_FACTOR being 4, so the discount is 26 and not 26.75.
+# The 107 is a p2wpkh satisfaction and is used for every witness version,
+# taproot included, whose real minimum is a single 64-byte BIP340
+# signature: Core measured taproot with the p2wpkh figure rather than
+# lower the dust level further, and matching Core is the whole point here
+_SEGWIT_SPEND_SIZE = 32 + 4 + 1 + 107 // 4 + 4
+
+# 8 bytes of value, and then the script behind its var_int length prefix:
+# the output as it sits in the transaction that creates it
+_TXOUT_VALUE_SIZE = 8
+
+
+def dust_threshold(
+    script_pub_key: Octets, fee_rate: FeeRate = DUST_RELAY_FEE_RATE
+) -> int:
+    """Return the smallest relayable value, in satoshi, for such an output.
+
+    Core's `GetDustThreshold`, computed and not tabulated: the fee, at
+    the dust relay rate, of the output itself plus the input that will
+    one day spend it. An output worth less than that costs more to spend
+    than it holds.
+
+    Computing it is what makes it follow the script type on its own. p2tr
+    answers 330 without p2tr being named anywhere below, and so will
+    whatever output type comes next; a table of one limit per type is
+    accurate the day it is written and needs an edit every time the
+    network grows a type.
+
+    An unspendable output has no input to pay for, so its threshold is
+    zero and no value is dust.
+
+    Args:
+        script_pub_key (Octets): The output script.
+        fee_rate (FeeRate, optional): The dust relay fee rate. Defaults
+            to DUST_RELAY_FEE_RATE, Core's 3000 sat/kvB.
+
+    Returns:
+        int: The threshold, in satoshi. An output is dust when its value
+        is below this; an output worth exactly this is not.
+    """
+    script_pub_key = bytes_from_octets(script_pub_key)
+
+    # Core's CScript::IsUnspendable, spelled out rather than read off
+    # btclib's is_nulldata, which is narrower on purpose (issue #211): a
+    # bare OP_RETURN, and an OP_RETURN followed by several pushes, are
+    # unknown to that classifier and unspendable to a node, and asking it
+    # would hand each of them a threshold it does not have.
+    # Sliced and not indexed, so that an empty script is a script with no
+    # leading OP_RETURN rather than an IndexError
+    if (
+        script_pub_key[:1] == BYTE_FROM_OP_CODE_NAME["OP_RETURN"]
+        or len(script_pub_key) > MAX_SCRIPT_SIZE
+    ):
+        return 0
+
+    size = (
+        _TXOUT_VALUE_SIZE
+        + len(var_int.serialize(len(script_pub_key)))
+        + len(script_pub_key)
+    )
+    size += _SEGWIT_SPEND_SIZE if is_segwit(script_pub_key) else _SPEND_SIZE
+    return fee_from_vsize(size, fee_rate)

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -99,6 +99,14 @@ btclib.exceptions module
    :undoc-members:
    :show-inheritance:
 
+btclib.fee module
+-----------------
+
+.. automodule:: btclib.fee
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 btclib.hashes module
 --------------------
 

--- a/tests/fee_test.py
+++ b/tests/fee_test.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Tests for the `btclib.fee` module.
+
+The dust tests are the interesting half. `dust_threshold` computes what
+other wallets tabulate, so the check that matters is computed against
+tabulated: electrum's `electrum/bitcoin.py` carries five constants --
+DUST_LIMIT_P2PKH 546, DUST_LIMIT_P2SH 540, DUST_LIMIT_P2WSH 330,
+DUST_LIMIT_P2WPKH 294, DUST_LIMIT_UNKNOWN_SEGWIT 354 -- and Bitcoin
+Core's own comment above `GetDustThreshold` works two of them out by
+hand, 182 and 98 virtual bytes at 3000 sat/kvB. Nothing in btclib names
+any of those numbers, so agreeing with them is evidence rather than
+tautology.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.fee import (
+    DUST_RELAY_FEE_RATE,
+    FeeRate,
+    dust_threshold,
+    fee_from_vsize,
+)
+from btclib.script import ScriptPubKey, serialize
+from btclib.script.limits import MAX_SCRIPT_SIZE
+
+_PUB_KEY = "02cc71eb30d653c0c3163990c47b976f3fb3f37cccdcbedb169a1dfef58bbfbfaf"
+
+
+def test_the_unit_is_in_the_name() -> None:
+    """A bare number never reaches the constructor without its unit."""
+    with pytest.raises(TypeError):
+        FeeRate(3000)  # type: ignore[call-arg]
+
+    rate = FeeRate(sats_per_kvbyte=3000)
+    assert rate.sats_per_kvbyte == 3000
+    assert rate.sats_per_vbyte == 3
+    assert rate == FeeRate.from_sats_per_vbyte(3)
+
+
+@pytest.mark.parametrize(
+    ("sats_per_vbyte", "sats_per_kvbyte"),
+    [
+        (0, 0),
+        (1, 1000),
+        ("1.5", 1500),
+        ("0.001", 1),
+        (Decimal("2.345"), 2345),
+        # a float is read through its repr, so what was written is what
+        # is meant: 1.1 is 1100 sat/kvB and not the 1099 or 1101 that
+        # the nearest binary fraction could argue for
+        (1.1, 1100),
+        ("1e3", 1_000_000),
+    ],
+)
+def test_sats_per_vbyte_round_trip(sats_per_vbyte: Any, sats_per_kvbyte: int) -> None:
+    rate = FeeRate.from_sats_per_vbyte(sats_per_vbyte)
+    assert rate.sats_per_kvbyte == sats_per_kvbyte
+    assert rate.sats_per_vbyte == Decimal(str(sats_per_vbyte))
+    # and back again, from the accessor into the constructor
+    assert FeeRate.from_sats_per_vbyte(rate.sats_per_vbyte) == rate
+
+
+def test_sats_per_vbyte_is_exact_or_it_is_an_error() -> None:
+    """Truncation is refused, not performed."""
+    err_msg = "sat/vB fee rate finer than a millisatoshi per virtual byte"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        FeeRate.from_sats_per_vbyte("0.0005")
+    with pytest.raises(BTClibValueError, match=err_msg):
+        FeeRate.from_sats_per_vbyte(Decimal(1) / 3)
+    # the boundary: three decimals are held, a fourth is not
+    assert FeeRate.from_sats_per_vbyte("0.001").sats_per_kvbyte == 1
+    with pytest.raises(BTClibValueError, match=err_msg):
+        FeeRate.from_sats_per_vbyte("0.0001")
+
+
+@pytest.mark.parametrize("rate", ["NaN", "Infinity", "-Infinity"])
+def test_a_rate_that_is_not_a_number(rate: str) -> None:
+    err_msg = "invalid sat/vB fee rate: "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        FeeRate.from_sats_per_vbyte(rate)
+
+
+def test_a_rate_is_a_non_negative_integer_number_of_sats_per_kvbyte() -> None:
+    err_msg = "non-integer sat/kvB fee rate: "
+    with pytest.raises(BTClibTypeError, match=err_msg):
+        FeeRate(sats_per_kvbyte=1.5)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match=err_msg):
+        FeeRate(sats_per_kvbyte="3000")  # type: ignore[arg-type]
+
+    err_msg = "negative fee rate: "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        FeeRate(sats_per_kvbyte=-1)
+    # Core would take this one and floor the fee it computes at -1
+    # satoshi; here it is refused before there is a fee to floor
+    with pytest.raises(BTClibValueError, match=err_msg):
+        FeeRate.from_sats_per_vbyte("-1.5")
+
+
+def test_rates_compare_and_hash() -> None:
+    slow = FeeRate(sats_per_kvbyte=1000)
+    fast = FeeRate.from_sats_per_vbyte("1.001")
+    assert slow < fast
+    assert max(slow, fast) is fast
+    assert sorted([fast, slow]) == [slow, fast]
+    assert len({slow, fast, FeeRate(sats_per_kvbyte=1000)}) == 2
+
+
+@pytest.mark.parametrize(
+    ("sats_per_kvbyte", "vsize", "fee"),
+    [
+        # the rate is per thousand virtual bytes, so a thousand of them
+        # owe exactly the rate: no rounding to hide a factor of 1000 in
+        (3000, 1000, 3000),
+        (1000, 141, 141),
+        # rounded up, and by the smallest amount there is: 140.999 sat
+        # is not 140 sat, because 140 sat does not pay the rate
+        (999, 141, 141),
+        (1, 141, 1),
+        # the smallest fee a nonzero rate can owe for a nonzero size is
+        # one satoshi, and exact ceiling division gives it without a
+        # special case
+        (1, 1, 1),
+        # a zero rate owes zero at any size, and a zero size owes zero at
+        # any rate: neither is a division by zero, here or in Core
+        (0, 1000, 0),
+        (0, 0, 0),
+        (3000, 0, 0),
+        # Core's own worked examples, from the comment above
+        # GetDustThreshold
+        (3000, 182, 546),
+        (3000, 98, 294),
+    ],
+)
+def test_fee_from_vsize(sats_per_kvbyte: int, vsize: int, fee: int) -> None:
+    assert fee_from_vsize(vsize, FeeRate(sats_per_kvbyte=sats_per_kvbyte)) == fee
+
+
+def test_the_fee_rounds_up_at_every_remainder() -> None:
+    """One satoshi per kvB, over every size a kilo-virtual-byte holds.
+
+    The rate that makes the rounding visible everywhere: the fee is 1 for
+    every size from 1 to 1000 and 2 for 1001, so a floor anywhere in the
+    arithmetic is a wrong answer 999 times over.
+    """
+    rate = FeeRate(sats_per_kvbyte=1)
+    assert fee_from_vsize(0, rate) == 0
+    assert all(fee_from_vsize(vsize, rate) == 1 for vsize in range(1, 1001))
+    assert fee_from_vsize(1001, rate) == 2
+
+
+def test_a_negative_virtual_size_is_not_a_size() -> None:
+    with pytest.raises(BTClibValueError, match="negative virtual size: "):
+        fee_from_vsize(-1, DUST_RELAY_FEE_RATE)
+
+
+def _script_pub_keys() -> dict[str, bytes]:
+    """The output types, built by btclib rather than written out.
+
+    The sizes the threshold is computed from are then the sizes btclib's
+    own constructors produce, which a script literal copied into this
+    file would not be evidence of.
+    """
+    redeem_script = ScriptPubKey.p2pkh(_PUB_KEY).script
+    return {
+        "p2pkh": ScriptPubKey.p2pkh(_PUB_KEY).script,
+        "p2sh": ScriptPubKey.p2sh(redeem_script).script,
+        "p2wpkh": ScriptPubKey.p2wpkh(_PUB_KEY).script,
+        "p2wsh": ScriptPubKey.p2wsh(redeem_script).script,
+        "p2tr": ScriptPubKey.p2tr(_PUB_KEY).script,
+        # the largest witness program there is, at a version no proposal
+        # has claimed: the "unknown segwit" electrum tabulates
+        "unknown_segwit": serialize(["OP_16", bytes(40)]),
+        "p2pk": ScriptPubKey.p2pk(_PUB_KEY).script,
+    }
+
+
+@pytest.mark.parametrize(
+    ("script_type", "threshold"),
+    [
+        # electrum/bitcoin.py's DUST_LIMIT_* table, every entry of it
+        ("p2pkh", 546),
+        ("p2sh", 540),
+        ("p2wsh", 330),
+        ("p2wpkh", 294),
+        ("unknown_segwit", 354),
+        # not in that table, and computed all the same: a taproot output
+        # is a 34-byte witness program like a p2wsh one, so it costs the
+        # same to spend. Nothing in btclib.fee mentions taproot
+        ("p2tr", 330),
+        # a bare public key, 33 of them compressed plus the push and the
+        # OP_CHECKSIG: 8 + 1 + 35 + 148 = 192 vB at 3000 sat/kvB
+        ("p2pk", 576),
+    ],
+)
+def test_dust_threshold_against_the_tabulated_limits(
+    script_type: str, threshold: int
+) -> None:
+    assert dust_threshold(_script_pub_keys()[script_type]) == threshold
+
+
+def test_dust_threshold_takes_a_hex_string_too() -> None:
+    script_pub_key = _script_pub_keys()["p2wpkh"]
+    assert dust_threshold(script_pub_key.hex()) == dust_threshold(script_pub_key)
+
+
+def test_the_dust_relay_rate_is_a_parameter() -> None:
+    """-dustrelayfee is Core's option, and this is the same knob."""
+    script_pub_key = _script_pub_keys()["p2pkh"]
+    assert DUST_RELAY_FEE_RATE == FeeRate(sats_per_kvbyte=3000)
+    assert dust_threshold(script_pub_key, DUST_RELAY_FEE_RATE) == 546
+    # the 182 virtual bytes Core's comment names, at three other rates
+    assert dust_threshold(script_pub_key, FeeRate(sats_per_kvbyte=1000)) == 182
+    assert dust_threshold(script_pub_key, FeeRate.from_sats_per_vbyte(1)) == 182
+    assert dust_threshold(script_pub_key, FeeRate(sats_per_kvbyte=0)) == 0
+    # rounded up like any other fee: 182 * 1.5 is 273 exactly, 182 * 1.501
+    # is 273.182 and costs the extra satoshi
+    assert dust_threshold(script_pub_key, FeeRate.from_sats_per_vbyte("1.5")) == 273
+    assert dust_threshold(script_pub_key, FeeRate.from_sats_per_vbyte("1.501")) == 274
+
+
+@pytest.mark.parametrize(
+    "script_pub_key",
+    [
+        # every shape Core's IsUnspendable answers True for: a standard
+        # nulldata output, a bare OP_RETURN and an OP_RETURN that btclib's
+        # own is_nulldata refuses (issue #211), plus a script one byte
+        # over MAX_SCRIPT_SIZE
+        pytest.param(serialize(["OP_RETURN", b"\xde\xad\xbe\xef"]), id="nulldata"),
+        pytest.param(b"\x6a", id="bare OP_RETURN"),
+        pytest.param(b"\x6a\x51", id="OP_RETURN OP_1"),
+        pytest.param(b"\x6a" + bytes(MAX_SCRIPT_SIZE), id="huge OP_RETURN"),
+        pytest.param(b"\x51" * (MAX_SCRIPT_SIZE + 1), id="over MAX_SCRIPT_SIZE"),
+    ],
+)
+def test_an_unspendable_output_has_no_dust_threshold(script_pub_key: bytes) -> None:
+    assert dust_threshold(script_pub_key) == 0
+
+
+def test_the_unspendable_test_is_cores_and_not_the_nulldata_classifier() -> None:
+    """`is_nulldata` is narrower than Core's `IsUnspendable`, on purpose.
+
+    Reading the answer off the classifier would give a bare OP_RETURN and
+    an OP_RETURN followed by several pushes a threshold apiece, which a
+    node that will never let either be spent does not agree with.
+    """
+    from btclib.script import is_nulldata  # noqa: PLC0415
+
+    assert not is_nulldata(b"\x6a")
+    assert not is_nulldata(b"\x6a\x51")
+    assert dust_threshold(b"\x6a") == 0
+    assert dust_threshold(b"\x6a\x51") == 0
+
+
+def test_a_script_that_is_no_type_at_all_still_has_a_threshold() -> None:
+    """Unknown is not unspendable, and the arithmetic needs no type.
+
+    A script btclib cannot classify is spent by an input of some size all
+    the same, so it gets the non-witness figure: 8 for the value, the
+    var_int length prefix, the script, and 148 for the input.
+    """
+    # the empty script: 8 + 1 + 0 + 148 = 157 vB, 471 satoshi
+    assert dust_threshold(b"") == 471
+    # a witness program at the shortest length segwit admits
+    assert dust_threshold(serialize(["OP_1", bytes(2)])) == 240
+    # one byte longer than any witness program, so not one: it takes the
+    # 148-byte input rather than the 67-byte one, and 8 + 1 + 43 + 148 is
+    # 200 vB against the 118 the 40-byte program above pays for
+    assert dust_threshold(serialize(["OP_1", bytes(41)])) == 600
+
+
+def test_the_var_int_prefix_is_counted() -> None:
+    """A script over 252 bytes takes a three-byte length prefix.
+
+    The one place the output's own serialized size stops being
+    len(script) + 9, and the boundary nothing else in the suite crosses.
+    """
+    at_the_limit = b"\x51" * 252
+    over_it = b"\x51" * 253
+    # 8 + 1 + 252 + 148 = 409 vB, and then 8 + 3 + 253 + 148 = 412
+    assert dust_threshold(at_the_limit) == 1227
+    assert dust_threshold(over_it) == 1236


### PR DESCRIPTION
## What changed

A new `btclib/fee.py`, with the fee arithmetic and nothing else:
`FeeRate`, `fee_from_vsize`, `dust_threshold`. Nothing in btclib turned a
size and a rate into a fee, and nothing knew what dust was — `amount.py`
takes `dust` as a *parameter* of `valid_btc_amount`/`valid_sats_amount`
and carries no rule for it, so both computations were the caller's.

Placed at the top level beside `amount.py`, and imports run the direction
CLAUDE.md prescribes: `fee` imports `script`, never the reverse.

## The unit, and why sat/kvB as an int

Core speaks sat/kvB, users speak sat/vB, and the factor of a thousand
between them is where the mistakes are. `FeeRate` holds an **integer
number of satoshi per kvB**:

- it is what Core stores, so no conversion stands between the number and
  the fee a node computes;
- it is integral, so the arithmetic is Python's unbounded `int` and not a
  float that stops counting in ones below MAX_MONEY;
- it is fine enough for every rate a user can state, sat/vB being quoted
  to three decimals at most — 1.5 sat/vB is exactly 1500 sat/kvB. Storing
  sat/vB would make the *common* unit the lossy one.

The field is **keyword-only**: `FeeRate(3000)` is the off-by-a-thousand
the type exists to prevent, and it is a `TypeError`.
`FeeRate(sats_per_kvbyte=3000)` and `FeeRate.from_sats_per_vbyte("1.5")`
both name their unit; the `sats_per_vbyte` accessor answers a `Decimal`.
There is deliberately no `from_sats_per_kvbyte` classmethod — the field
*is* that constructor, and a second spelling of one thing is a menu.

`from_sats_per_vbyte` **refuses** a rate finer than a millisatoshi per
virtual byte rather than truncating it, and converts through
`Decimal.as_integer_ratio`, which is exact and reads no decimal context:
multiplying the Decimal by 1000 would round to whatever precision the
caller's context happens to carry, and a conversion that exists to make
truncation impossible cannot be the place that truncates.

## The rounding

`fee_from_vsize` rounds **up**, matching `CFeeRate::GetFee`: a fee one
satoshi short of the rate is a fee below the rate, and the transaction
does not relay. Read against Core's current `policy/feerate.cpp` and the
`FeeFrac::EvaluateFeeUp` it now delegates to, exact integer ceiling
division. Two consequences, both tested:

- **no one-satoshi floor is needed.** Exact ceiling division already
  returns at least 1 for any nonzero rate over a nonzero size, which is
  why Core's surviving `nFee == 0` branch applies to *negative* rates
  alone. `FeeRate` has none: a negative rate is refused at construction,
  Core's `-1` floor belonging to the feerate diagrams its fraction also
  serves, where a price never runs downhill.
- **no division by zero anywhere.** A zero rate owes zero at every size
  and a zero vsize owes zero at every rate; a negative vsize raises.

## Dust: computed, cross-checked against tabulated

`dust_threshold(script_pub_key, fee_rate=DUST_RELAY_FEE_RATE)` is Core's
`GetDustThreshold` — the dust relay rate over the output's own serialized
size (8 + var_int prefix + script) plus the input that will spend it: 148
bytes, or 67 for a witness program with the 75% discount on the 107-byte
satisfaction, `107 // 4` as Core divides it. `DUST_RELAY_FEE_RATE` is
Core's `DUST_RELAY_TX_FEE`, 3000 sat/kvB, a defaulted parameter because
`-dustrelayfee` is an option.

Computing it is the point of the issue: **p2tr answers 330 with taproot
named nowhere in the module**, and so will whatever output type comes
next, where electrum's five `DUST_LIMIT_*` constants need an edit apiece.

The tests are computed-vs-known, which is the check the issue asks for.
Every entry of electrum's table in `electrum/bitcoin.py` is cited and
matched:

| type | electrum | computed |
| --- | --- | --- |
| p2pkh | 546 | 546 |
| p2sh | 540 | 540 |
| p2wsh | 330 | 330 |
| p2wpkh | 294 | 294 |
| unknown segwit | 354 | 354 |
| p2tr | *not tabulated* | 330 |
| p2pk | *not tabulated* | 576 |

Plus Core's own worked examples from the comment above
`GetDustThreshold`, 182 and 98 virtual bytes at 3000 sat/kvB. Nothing in
`btclib.fee` names any of those numbers, so agreeing with them is
evidence rather than tautology. The scripts are built with
`ScriptPubKey.p2pkh`, `.p2tr` and friends rather than written out, so the
sizes are the ones btclib itself produces.

Unspendability is Core's `CScript::IsUnspendable` — leading `OP_RETURN`,
or over `MAX_SCRIPT_SIZE` — and **not** btclib's `is_nulldata`, which is
narrower on purpose (issue #211): a bare `6a` and `6a51` are unknown to
that classifier and unspendable to a node, and reading the answer off it
would hand each of them a threshold.

## Out of scope, restated in the module docstring

Everything downstream of a network: mempool histograms, fee estimates for
a confirmation target, ETAs, the "how many blocks" slider. Policy fed by
live data, an application's to hold.

## Verification

Each run to completion, exit code checked, not filtered output:

- `uv run pytest` — **exit 0**, 14832 passed
- `uv run pytest --cov=btclib --cov=tests` — **exit 0**; `btclib/fee.py`
  and `tests/fee_test.py` at 100.00%, total 99.99% (the two uncovered
  statements are the pre-existing `btclib/mnemonic/electrum.py:317-318`)
- `uv run pre-commit run --all-files` — **exit 0**
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — **exit 0**

`docs/source/btclib.rst` gains the `btclib.fee` automodule stanza, which
`tests/docs_test.py` requires; `uv.lock` is untouched.

## Housekeeping

CHANGELOG.md gains one entry, and both stated counts move with it: "A
hundred and seventy-nine entries, grouped" and HISTORY.md's "the largest:
a hundred and seventy-nine entries", against `grep -c '^- '
CHANGELOG.md` = 179. Not source-breaking, so HISTORY.md's twenty-nine
stays. README.md's feature list gains a line.

Sibling PRs move the CHANGELOG entry count too; re-derive it at merge with `grep -c '^- ' CHANGELOG.md`.

#209 (Psbt vsize) is a sibling PR, not a dependency: a fee rate wants a
vsize and this one takes it as an `int`, so the two compose without
either importing the other.

Closes #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a dedicated fee module that centralizes fee rate handling, fee calculation from virtual size, and dust threshold computation aligned with Bitcoin Core, and wire it into docs and release notes.

New Features:
- Add btclib.fee module providing a FeeRate type that encodes sat/kvB rates with explicit unit-aware construction and sat/vB accessors.
- Expose fee_from_vsize helper to compute transaction fees from virtual size using integer, ceil-style arithmetic consistent with Bitcoin Core.
- Provide dust_threshold helper to compute dust limits for any script type based on output and spend size, rather than relying on tabulated per-type constants.

Enhancements:
- Document the new fee functionality in btclib.rst and README, highlighting unit-safe fee rates and Core-consistent dust computation.

Documentation:
- Update btclib documentation and README feature list to describe the new fee module and its Core-aligned behavior.

Tests:
- Add comprehensive fee_test suite covering FeeRate validation and comparisons, fee rounding behavior, dust threshold calculations for standard and taproot outputs, unspendable scripts, and alignment with Electrum and Bitcoin Core examples.

Chores:
- Update CHANGELOG and HISTORY entry counts and add a changelog entry describing the new fee arithmetic module.