### PR TITLE
Send the root files' links to the pages that render them

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -159,3 +159,25 @@ jobs:
         run: >
           uv run --locked --no-default-groups --group docs
           sphinx-build -W --keep-going -b html docs/source docs/build/html
+      # the one defect the build above cannot report on itself: a relative
+      # link myst cannot resolve is rendered as an anchor on the page it is
+      # already on -- href="#./CONTRIBUTING.md", an id nothing has -- so
+      # -W passes over a dead link (issue 195). conf.py resolves those
+      # links and no longer suppresses myst.xref_missing, which makes the
+      # build fail on the next one; this step is the same claim made about
+      # the artifact rather than about the configuration, and it is what
+      # would catch a suppression added back.
+      #
+      # Not lychee: links.yml reads the sources, where "./CONTRIBUTING.md"
+      # is a correct path, and pointing it at docs/build/html would mean
+      # building the documentation inside a workflow that gates nothing
+      # and re-requesting every external url these pages carry.
+      # Not a pre-commit hook either: it would have to build the
+      # documentation, which is the very reason this job exists apart from
+      # the lint one
+      - name: Check the built pages for unresolved links
+        run: |
+          if grep -rn 'href="#\./' docs/build/html --include='*.html'; then
+            echo "::error::the links above resolve to no page"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2494,3 +2494,22 @@ edit.
   constructor. `6a00` is the row that agrees with Core by arithmetic
   rather than by rule, the `00` read here as a zero-length push's marker
   and there as OP_0
+- **A link from one root markdown file to another reaches the page that
+  renders it** (issue #195). README.md, CONTRIBUTING.md, SECURITY.md,
+  HISTORY.md and CHANGELOG.md are included into the documentation
+  verbatim, and their `./FILE.md` links came out of the build as
+  `href="#./FILE.md"` — an anchor to an id no page has, eleven of them.
+  Neither tool that exists to find a broken link could see it: MyST turns
+  a target it cannot resolve into that anchor instead of reporting one, so
+  `sphinx -W` passed, and lychee reads the sources, where the path is
+  right. `docs/source/conf.py` now resolves them against the repository
+  rather than against a table — a file one of the `*_link.md` shims
+  includes becomes a reference to that page, CODE_OF_CONDUCT.md and
+  tests/README.md, which the documentation does not contain, become links
+  to the files on GitHub, and a path that exists nowhere is left to MyST,
+  whose `myst.xref_missing` suppression is gone, so `-W` fails on the next
+  link with no target. The `./FILE.md` spelling in the root files is
+  untouched, being what the GitHub file view, btclib.org and the PyPI long
+  description need. `lint.yml`'s `Build the documentation` job then greps
+  the built HTML for `href="#./`, which asks the same question where no
+  suppression can hide the answer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -287,6 +287,22 @@ uv run --locked --no-default-groups --group docs \
     sphinx-build -W --keep-going -b html docs/source docs/build/html
 ```
 
+That job has a second step, which reads the pages the first one wrote and
+must find nothing — the job fails if this grep exits 0:
+
+```shell
+grep -rn 'href="#\./' docs/build/html --include='*.html'
+```
+
+A link between the root markdown files — `./SECURITY.md` in README.md, the
+spelling GitHub, btclib.org and PyPI need and the one lychee checks — is
+one sphinx cannot resolve on its own, and what MyST emits for a target it
+cannot resolve is an anchor on the page it is already on rather than a
+warning. `docs/source/conf.py` resolves those links and suppresses no
+`myst.xref_missing`, so `-W` fails on the next one that has no target; the
+grep asks the same question of the HTML, where no suppression can hide the
+answer.
+
 The only check with no local equivalent is CodeQL, which GitHub runs on
 its side; its findings appear under the Security tab.
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -138,10 +138,12 @@ html_theme = "sphinx_rtd_theme"
 
 # a shim is one myst include fence, and the path on that line is the file
 # the shim renders
-INCLUDE = re.compile(r"^```\{include\}\s+(\S+)\s*$", re.MULTILINE)
+# match an include fence, capturing the path (which may contain spaces),
+# stopping before any inline options (e.g. " :start-line: 5")
+INCLUDE = re.compile(r"^```\{include\}\s+(.+?)(?=\s+:|$)", re.MULTILINE)
 # repository-relative path -> the docname whose page renders it
 INCLUDED = {
-    str((shim.parent / match.group(1)).resolve().relative_to(ROOT)): shim.stem
+    str((shim.parent / match.group(1).strip()).resolve().relative_to(ROOT)): shim.stem
     for shim in sorted(Path(__file__).parent.glob("*_link.md"))
     for match in INCLUDE.finditer(shim.read_text(encoding="utf-8"))
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,10 +14,23 @@ documentation: https://www.sphinx-
 doc.org/en/master/usage/configuration.html
 """
 
+import posixpath
 import re
 from pathlib import Path
+from typing import Any
 
 import tomllib
+from docutils import nodes
+from sphinx.addnodes import pending_xref
+from sphinx.application import Sphinx
+from sphinx.transforms.post_transforms import SphinxPostTransform
+
+# the repository root, two levels up from this file, and the one place
+# below that is allowed to name it
+ROOT = Path(__file__).parents[2].resolve()
+# read once and read twice from: the version below and the github url the
+# transform at the bottom builds its links on
+PYPROJECT = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -28,16 +41,14 @@ project = "btclib"
 # than imported, for the same reason as the version below
 project_copyright = re.search(
     r'^__copyright__ = "Copyright \(C\) (.+)"$',
-    (Path(__file__).parents[2] / "btclib" / "__init__.py").read_text(encoding="utf-8"),
+    (ROOT / "btclib" / "__init__.py").read_text(encoding="utf-8"),
     re.MULTILINE,
 ).group(1)
 author = "The btclib developers"
 # read from pyproject.toml, the one place the version is declared, and not
 # from importlib.metadata: that would need btclib installed in the
 # environment building the documentation, which read the docs does not do
-release = tomllib.loads(
-    (Path(__file__).parents[2] / "pyproject.toml").read_text(encoding="utf-8")
-)["project"]["version"]
+release = PYPROJECT["project"]["version"]
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -56,21 +67,13 @@ extensions = [
 
 source_suffix = [".rst", ".md"]
 
-# the four markdown pages of the toctree are this repository's README,
-# CONTRIBUTING, SECURITY and HISTORY, pulled in by a myst {include}. They
-# are written for GitHub, where "./SECURITY.md" is a correct link, and
-# sphinx sees them lifted out of the tree that makes it correct: six such
-# links have no target here, and two of them -- CODE_OF_CONDUCT.md and
-# tests/README.md -- are not part of the documentation at all, so no
-# rewriting could give them one.
-# Suppressed by name rather than by dropping the -W that .readthedocs.yaml
-# passes, because -W is there for the failure that actually mattered: an
-# automodule whose module does not import, which is a warning and rendered
-# as an empty page for as long as nobody read the log.
-# Not absolute github urls in the markdown instead: the
-# check-vcs-permalinks hook rejects a blob/master link, rightly, and a
-# permalink pinned to a commit is the wrong thing for a navigation link
-suppress_warnings = ["myst.xref_missing"]
+# no suppress_warnings, and myst.xref_missing least of all: the transform
+# at the bottom of this file resolves every link the included root files
+# carry, so a myst target still missing is a link with nowhere to go and
+# -W is what says so. Suppressing that subtype hides exactly the defect
+# issue #195 is about, because what myst emits for a target it cannot
+# resolve is not a visibly broken link, it is an anchor to an id the page
+# does not have
 
 templates_path = ["_templates"]
 
@@ -93,3 +96,105 @@ html_theme = "sphinx_rtd_theme"
 # was harmless while nothing read it and is a failure now that
 # .readthedocs.yaml builds with -W. Re-add the setting with the directory,
 # not before it
+
+
+# -- Links out of the included root markdown files ----------------------------
+
+# Five pages of the toctree are this repository's README, CONTRIBUTING,
+# SECURITY, HISTORY and CHANGELOG, each pulled into a *_link.md shim by a
+# myst {include}. Those files are written for the three places that read
+# them unrendered -- the GitHub file view, btclib.org, which is served
+# from master's root, and the PyPI long description -- so "./SECURITY.md"
+# is the correct spelling there and the one links.yml checks, resolving it
+# as a path relative to the file. Sphinx sees them lifted out of the tree
+# that makes it correct, and myst resolves not one of those links.
+#
+# What it emits instead is the reason this needs code rather than a
+# warning filter: a target myst cannot resolve becomes an anchor on the
+# page it is already on, href="#./SECURITY.md", an id nothing has. The
+# build succeeds, -W sees nothing, and lychee reads the sources, where the
+# path is right (issue #195).
+#
+# The transform below answers each link from the repository rather than
+# from a table that would have to be kept in step with this directory: a
+# path a *_link.md shim includes becomes a reference to that page, any
+# other path that exists in the tree becomes a link to the file on GitHub,
+# and a path that exists nowhere is left to myst -- which reports it, and
+# -W then fails, now that suppress_warnings no longer hides the subtype.
+#
+# Not the {include} directive's :relative-docs: option, which is what it
+# looks like the job of. It rewrites destinations that begin with the
+# prefix it is given, so "docs/source/" leaves "./SECURITY.md" untouched;
+# and giving it "./" is worse than doing nothing, measured -- the
+# destination becomes "../../SECURITY.md", a path outside srcdir that is
+# no document, sphinx reads it as a download, finds nothing to copy, and
+# renders the link text with no link at all.
+#
+# Not copying the root files into this directory at build time either.
+# CONTRIBUTING.md links to CODE_OF_CONDUCT.md and tests/README.md, neither
+# of which is part of the documentation, so copies leave those two dead
+# however many are made; and the copies are generated files in a source
+# tree, which is a second definition of five files that already exist.
+
+# a shim is one myst include fence, and the path on that line is the file
+# the shim renders
+INCLUDE = re.compile(r"^```\{include\}\s+(\S+)\s*$", re.MULTILINE)
+# repository-relative path -> the docname whose page renders it
+INCLUDED = {
+    str((shim.parent / match.group(1)).resolve().relative_to(ROOT)): shim.stem
+    for shim in sorted(Path(__file__).parent.glob("*_link.md"))
+    for match in INCLUDE.finditer(shim.read_text(encoding="utf-8"))
+}
+# master, not a permalink pinned to a commit: these are navigation links
+# to files that keep changing, and a reader following one wants the file
+# as it stands. The base url comes from pyproject.toml, where every url
+# this project publishes is declared
+BLOB = f"{PYPROJECT['project']['urls']['GitHub']}/blob/master/"
+
+
+class RootFileLinks(SphinxPostTransform):
+    """Resolve the repository-relative links of the included root files."""
+
+    # ahead of myst's own resolver, which runs at 9 and is what turns an
+    # unresolved target into that anchor
+    default_priority = 5
+
+    def run(self, **kwargs: Any) -> None:
+        """Rewrite every myst xref naming a file of this repository."""
+        # the list is taken before the tree is edited: replace_self on a
+        # node the generator is standing on reparents its children under it
+        for node in list(self.document.findall(pending_xref)):
+            # refdomain "doc" is a link myst has already resolved to a
+            # page; None is one it has given up on, and only the shims
+            # hold links written relative to the repository root, so
+            # anywhere else a path that does not resolve is a defect to
+            # report rather than one to rewrite
+            if node.get("reftype") != "myst" or node.get("refdomain") is not None:
+                continue
+            if node.get("refdoc", self.env.docname) not in INCLUDED.values():
+                continue
+            target, _, anchor = node["reftarget"].partition("#")
+            # "./tests/README.md" -> "tests/README.md"; a path climbing out
+            # of the repository is nothing this can answer
+            target = posixpath.normpath(target)
+            if target.startswith(".."):
+                continue
+            if target in INCLUDED:
+                # handed back to myst as the link it would have been
+                # written as, so the page title and the caption are its
+                # business and not this file's
+                node["refdomain"] = "doc"
+                node["reftarget"] = INCLUDED[target]
+                node["reftargetid"] = anchor or None
+            elif (ROOT / target).is_file():
+                fragment = f"#{anchor}" if anchor else ""
+                reference = nodes.reference(
+                    "", "", refuri=f"{BLOB}{target}{fragment}", internal=False
+                )
+                reference.extend(node.children)
+                node.replace_self(reference)
+
+
+def setup(app: Sphinx) -> None:
+    """Register the transform above; sphinx calls this."""
+    app.add_post_transform(RootFileLinks)


### PR DESCRIPTION
## The defect

Built from `origin/dev` at 0e5d6301, before the fix:

```console
$ uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
build succeeded.                       # exit 0
$ grep -ro 'href="#\./[^"]*"' docs/build/html --include='*.html'
docs/build/html/history_link.html:href="#./CHANGELOG.md"
docs/build/html/history_link.html:href="#./CHANGELOG.md"
docs/build/html/changelog_link.html:href="#./HISTORY.md"
docs/build/html/changelog_link.html:href="#./HISTORY.md"
docs/build/html/changelog_link.html:href="#./HISTORY.md"
docs/build/html/readme_link.html:href="#./CONTRIBUTING.md"
docs/build/html/readme_link.html:href="#./SECURITY.md"
docs/build/html/contributing_link.html:href="#./README.md"
docs/build/html/contributing_link.html:href="#./CODE_OF_CONDUCT.md"
docs/build/html/contributing_link.html:href="#./tests/README.md"
docs/build/html/contributing_link.html:href="#./SECURITY.md"
```

Eleven anchors, seven distinct targets, four pages. `#./CONTRIBUTING.md`
is an id no page has, so every one of them goes nowhere — and the build
exits 0 while it happens.

## The fix, and why not the other one

**Fix (1), a resolver.** `docs/source/conf.py` gains a
`SphinxPostTransform` at priority 5, ahead of MyST's own resolver at 9,
which is what turns an unresolved target into that anchor. For a myst
xref raised from one of the `*_link.md` shims it does one of three
things:

- a path one of those shims `{include}`s becomes a `refdomain: "doc"`
  xref to that page, handed back to MyST so the caption and the page
  title stay its business;
- any other path that exists in the repository becomes a link to the
  file on GitHub — `CODE_OF_CONDUCT.md` and `tests/README.md`, both
  linked from CONTRIBUTING.md and neither part of the documentation;
- a path that exists nowhere is left alone, for MyST to report.

The mapping is not written down: it is read out of the `{include}` line
of each `docs/source/*_link.md`, so a new root file and its shim need no
edit here. That answers the cost the issue names against this fix.

`suppress_warnings = ["myst.xref_missing"]` is **gone** with it, which is
the real prize: every link is now resolvable, so `-W` — already a
required check — fails on the next one that is not.

The `./FILE.md` spelling in the root files is untouched, as it must be:
it is what the GitHub file view, btclib.org (served from `master`'s root)
and the PyPI long description need, and what lychee checks as a path.

**Not fix (2), copying the root files into `docs/source/`.**
CONTRIBUTING.md links to `CODE_OF_CONDUCT.md` and `tests/README.md`,
neither of which the documentation contains; copies leave those two dead
however many are made, so the suppression could not be dropped and `-W`
would still be blind. It also puts generated files in a source tree — a
second definition of five files that already exist, plus `.gitignore`
entries and a stale copy after the next rename.

**Not `:relative-docs:` either**, which is what it looks like the job of,
and this one is measured rather than argued. The option rewrites
destinations that *begin with* the prefix it is given, so the
`docs/source/` in three of the shims today leaves `./SECURITY.md`
untouched — it is inert. Setting it to `./` is worse than doing nothing:
the destination becomes `../../SECURITY.md`, a path outside `srcdir` that
is no document, sphinx reads it as a download, finds nothing to copy, and
renders `<span class="xref myst">CONTRIBUTING</span>` — the link text with
no link at all.

## After

```console
$ grep -ro 'href="#\./[^"]*"' docs/build/html --include='*.html'; echo $?
1
```

Nothing, and the links land where they should. Spot-checked by name:

| page | link | target |
| --- | --- | --- |
| `readme_link.html` | CONTRIBUTING | `contributing_link.html` (internal) |
| `readme_link.html` | SECURITY | `security_link.html` (internal) |
| `contributing_link.html` | README | `readme_link.html` (internal) |
| `contributing_link.html` | Code of Conduct | `…/blob/master/CODE_OF_CONDUCT.md` |
| `contributing_link.html` | Tests, code coverage… | `…/blob/master/tests/README.md` |
| `history_link.html` | CHANGELOG.md ×2 | `changelog_link.html` (internal) |
| `changelog_link.html` | HISTORY.md ×3 | `history_link.html` (internal) |

## The check that keeps it fixed

A second step in `lint.yml`'s `Build the documentation` job — the same
job, because the check is about the artifact that job produces:

```yaml
      - name: Check the built pages for unresolved links
        run: |
          if grep -rn 'href="#\./' docs/build/html --include='*.html'; then
            echo "::error::the links above resolve to no page"
            exit 1
          fi
```

Not lychee: `links.yml` reads the sources, where `./CONTRIBUTING.md` is a
correct path, and pointing it at `docs/build/html` would mean building the
documentation inside a workflow that gates nothing and re-requesting every
external URL these pages carry. Not a pre-commit hook: it would have to
build the documentation, which is the very reason this job exists apart
from the lint one. CONTRIBUTING.md carries the command, as it does for
every other CI job.

**Evidence it catches a regression.** `See [REGRESSION](./NO_SUCH_FILE.md).`
added to README.md, then reverted:

1. as this PR leaves the tree — sphinx exits **1**, naming the source:

   ```console
   README.md:173: WARNING: 'myst' cross-reference target not found:
   './NO_SUCH_FILE.md' [myst.xref_missing]
   SPHINX EXIT 1
   ```

2. with `suppress_warnings = ["myst.xref_missing"]` put back, i.e. that
   guard defeated — sphinx exits **0**, and the new step exits **1**:

   ```console
   SPHINX EXIT 0
   $ if grep -rn 'href="#\./' docs/build/html --include='*.html'; then …
   docs/build/html/readme_link.html:273:<p>See <a class="reference internal"
   href="#./NO_SUCH_FILE.md"><span class="xref myst">REGRESSION</span></a>.</p>
   ::error::the links above resolve to no page
   Exit code 1
   ```

Both temporary edits reverted; the branch touches five files and no other.

## Verification

Every gate run as documented, exit code checked, not filtered output:

- `uv run pytest` — **0**, 14787 passed
- `uv run pre-commit run --all-files` — **0**, every hook (actionlint and
  zizmor included, both at zero findings)
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — **0**
- the new grep step — **0** (finds nothing)

## Entry count

`grep -c '^- ' CHANGELOG.md` is 179 with this branch's bullet, and both
headers say "a hundred and seventy-nine". Sibling PRs move the same tally
concurrently and the merge is conflict-free in both directions, so
**re-derive it at merge** with that command and correct both headers if it
has drifted. No HISTORY.md entry beyond its count: nothing here is
something a user has to act on.

Closes #195.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure links between included root markdown files resolve to the correct documentation pages or GitHub files and add a CI check that fails on unresolved anchors in built docs.

New Features:
- Add a Sphinx post-transform that resolves repository-relative links from included root markdown files to either internal documentation pages or GitHub file URLs.

Enhancements:
- Refactor Sphinx configuration to reuse a shared ROOT path and parsed pyproject metadata for version and GitHub URL handling.

CI:
- Extend the documentation build job in lint.yml with a grep-based check that scans built HTML for unresolved href="#./" anchors and fails the job if any are found.

Documentation:
- Document the new documentation link integrity check and its command in CONTRIBUTING.md.
- Update CHANGELOG.md and HISTORY.md entries to describe and count the new fix for root markdown file links.