### PR TITLE
Name the closed vocabularies with Literal aliases, and keep the open ones str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2153,6 +2153,33 @@ edit.
   converter each function calls and by nothing else. `NewType` would let a
   checker separate them at the cost of every caller wrapping its literals,
   which is a different library
+- **the closed vocabularies are `Literal` aliases**, and the open ones are
+  named without being imposed (issue #216). `alias.ScriptType` is the ten
+  values `type_and_payload` returns — `"unknown"` among them, an answer and
+  not an absence, and `"witness_unknown"` beside it, which is Core's own
+  name for a witness version this library cannot spend — and types that
+  function, `ScriptPubKey.type`,
+  `b58.address_from_h160`, `b58.h160_from_address` and the script engine's
+  two witness helpers. `alias.NetworkField` is the eighteen field names of
+  `Network` and types the `key` parameter of the three `*_from_key_value`
+  lookups, the most fragile of the four vocabularies: a misspelled field
+  name matches no network, so the lookup answers `None` — "no network
+  carries this prefix" — where a misspelled network *name* at least raises
+  `KeyError` at the indexing. `alias.NetworkName` and `alias.MnemonicLang`
+  name the five networks and three word-lists btclib ships and type no
+  parameter at all, because `NETWORKS` takes a caller's custom signet and
+  `WordLists.load_lang` a caller's word-list: a `Literal` on `network: str`
+  or `lang: str` would refuse a value the library itself accepts. No enum,
+  and the measurement is the issue's: `class Net(str, Enum)` formats a
+  member as `mainnet` on 3.10 and as `Net.MAINNET` on 3.11 and later, so the
+  six error messages that interpolate a network name — text some tests match
+  verbatim — would read differently on different interpreters, while
+  `enum.StrEnum`, which formats as the value everywhere, is 3.11+ against a
+  3.10 floor; and refusing strings breaks thirty-eight signatures. Nothing
+  here exists at run time, so the two data-derived aliases are checked
+  against the data instead: `network_test.py` against
+  `dataclasses.fields(Network)` and `NETWORKS`, `mnemonic_test.py` against a
+  fresh `WordLists`
 
 ### Performance
 

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -105,10 +105,109 @@ Integer = bytes | str | int
 #
 # A Literal and not an Enum: network names are plain str throughout this
 # library, so a lone enum here would be an island, and mypy strict
-# already rejects the typo an Enum would guard against. Whether btclib
-# should move to enums wholesale -- script types and network names
-# first -- is a real question, and a separate one
+# already rejects the typo an Enum would guard against. That is the same
+# choice the four vocabularies below make, for the reasons written over
+# them
 NetworkType = Literal["main", "test"]
+
+# The closed vocabularies this library passes as plain str, one Literal
+# each: issue #216. Strict mypy refuses a typo at every call site that
+# spells the value out, which is most of them, and refuses nothing where
+# the string is computed at run time -- that is the whole of what a
+# Literal buys and the whole of what it does not.
+#
+# Literal and not Enum, and the issue measures why: `class Net(str,
+# Enum)` formats a member as `mainnet` on 3.10 and as `Net.MAINNET` on
+# 3.11 and later, so a mixin enum would make the six error messages
+# that interpolate a network name -- text some tests match verbatim --
+# read differently on different interpreters, while enum.StrEnum, which
+# formats as the value everywhere, is 3.11+ against a 3.10 floor. A
+# Literal has no runtime existence at all: nothing to format, nothing
+# new for to_dict to serialize, and no signature that stops accepting a
+# str.
+#
+# Which of them a *parameter* may take is the other half of the answer,
+# and it is not the same for all four: an argument annotated with a
+# Literal is a promise that the vocabulary is closed, so only the two
+# whose data is closed are spelled on parameters. The other two name
+# what btclib ships, for a caller who uses only that.
+
+# What a script_pub_key pays to, as script.script_pub_key.type_and_payload
+# names it. Closed, and checked to be: these nine are exactly what that
+# function returns, mypy comparing each return against this alias. Note
+# that "unknown" is one of them -- the answer for bytes this library does
+# not classify, not the absence of an answer -- so there is no None here
+# to widen the type of every caller. Parameters take it: b58's two
+# address functions dispatch on it
+ScriptType = Literal[
+    "nulldata",
+    "p2ms",
+    "p2pk",
+    "p2pkh",
+    "p2sh",
+    "p2tr",
+    "p2wpkh",
+    "p2wsh",
+    "unknown",
+    "witness_unknown",
+]
+
+# A field name of network.Network, which the three *_from_key_value
+# lookups take as a str and resolve with getattr. The most fragile of
+# these vocabularies, and so a parameter type: a misspelled field name
+# matches no network, so the lookup answers None -- "no network carries
+# this prefix" -- where a misspelled network name at least raises
+# KeyError at the indexing. network_test.py checks the members against
+# dataclasses.fields(Network), the one thing mypy cannot check about a
+# name resolved with getattr.
+#
+# Not "NetworkKey": in this library a key is a private or a public one
+NetworkField = Literal[
+    "curve",
+    "network_type",
+    "magic_bytes",
+    "genesis_block",
+    "wif",
+    "p2pkh",
+    "p2sh",
+    "hrp",
+    "bip32_prv",
+    "bip32_pub",
+    "slip132_p2wpkh_p2sh_prv",
+    "slip132_p2wpkh_p2sh_pub",
+    "slip132_p2wsh_p2sh_prv",
+    "slip132_p2wsh_p2sh_pub",
+    "slip132_p2wpkh_prv",
+    "slip132_p2wpkh_pub",
+    "slip132_p2wsh_prv",
+    "slip132_p2wsh_pub",
+]
+
+# The networks btclib ships, i.e. the keys of network.NETWORKS as loaded.
+# Not a parameter type, and that is the honest half of issue #216:
+# NETWORKS is a dict a caller adds a custom signet to, so a `network:
+# NetworkName` would refuse a name the library itself accepts and every
+# such caller would have to cast. It names the five for a caller who
+# uses only those and wants mypy to hold them to it; network.py
+# annotates with it the tuple of names it loads, which is what keeps
+# this list equal to the data
+NetworkName = Literal["mainnet", "testnet", "regtest", "signet", "testnet4"]
+
+# The word-lists btclib ships: BIP39's two languages, and SLIP-0039's
+# single list under a key that is a scheme and not a language code -- the
+# SLIP defines no localization, so "slip39" is the whole of it. Every key
+# of the WORDLISTS registry is named here, which is what keeps this list
+# equal to the data; that the three are not interchangeable is the
+# schemes' business, and bip39 enforces its own half by refusing any list
+# that is not 2048 words long.
+#
+# Open, as NetworkName is, and more plainly so:
+# WordLists.load_lang(lang, filename) adds a language, which is the
+# documented way to use any of the other BIP39 word-lists, so the ten
+# `lang: str` parameters of mnemonic, bip39 and electrum stay str -- a
+# Literal there would type check the library's own languages and reject
+# the file a caller has just loaded
+MnemonicLang = Literal["en", "it", "slip39"]
 
 
 # The four address encodings a purpose level can name: 44 is p2pkh, 49

--- a/btclib/b58.py
+++ b/btclib/b58.py
@@ -21,8 +21,10 @@ address encoding.
 
 from __future__ import annotations
 
+from typing import Literal
+
 from btclib import b32
-from btclib.alias import Octets, String
+from btclib.alias import Octets, ScriptType, String
 from btclib.base58 import b58decode, b58encode
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
@@ -60,8 +62,16 @@ def wif_from_prv_key(
 # 2. base58 address from HASH and vice versa
 
 
-def address_from_h160(script_type: str, h160: Octets, network: str = "mainnet") -> str:
+def address_from_h160(
+    script_type: ScriptType, h160: Octets, network: str = "mainnet"
+) -> str:
     """Return a base58 address from the payload."""
+    # the whole ScriptType and not a Literal of the two encoded here:
+    # base58 encodes a subset of the vocabulary, so the raise below is
+    # this function's answer to a caller holding the "p2tr"
+    # type_and_payload has just returned -- and a parameter that cannot
+    # spell it makes that a cast at every call site rather than a
+    # message from here
     if script_type == "p2sh":
         prefix = NETWORKS[network].p2sh
     elif script_type == "p2pkh":
@@ -73,14 +83,20 @@ def address_from_h160(script_type: str, h160: Octets, network: str = "mainnet") 
     return b58encode(payload).decode("ascii")
 
 
-def h160_from_address(b58addr: String) -> tuple[str, bytes, str]:
+def h160_from_address(b58addr: String) -> tuple[ScriptType, bytes, str]:
     """Return the payload from a base58 address."""
     if isinstance(b58addr, str):
         b58addr = b58addr.strip()
     payload = b58decode(b58addr, 21)
     prefix = payload[:1]
 
-    for script_type in ("p2pkh", "p2sh"):
+    # the two script types a base58 address encodes -- and, the same two
+    # spellings, the two Network fields holding their version prefixes,
+    # which is what lets one loop variable be both a script type and a
+    # lookup key. Annotated because inference widens a tuple of two
+    # str literals to tuple[str, str], and str is neither
+    script_types: tuple[Literal["p2pkh", "p2sh"], ...] = ("p2pkh", "p2sh")
+    for script_type in script_types:
         if network := network_from_key_value(script_type, prefix):
             return script_type, payload[1:], network
 

--- a/btclib/bip32/slip132.py
+++ b/btclib/bip32/slip132.py
@@ -19,6 +19,7 @@ from collections.abc import Callable
 from typing import Any
 
 from btclib import b32, b58
+from btclib.alias import NetworkField
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, derive, xpub_from_xprv
 from btclib.bip32.der_path import DerPath
 from btclib.exceptions import BTClibValueError
@@ -55,7 +56,13 @@ def address_from_xpub(xpub: BIP32Key) -> str:
         # the prefix already says what is wrong
         raise BTClibValueError(f"not a public key: prefix 0x{xpub.key[:1].hex()}")
 
-    version_list = ["bip32_pub", "slip132_p2wpkh_pub", "slip132_p2wpkh_p2sh_pub"]
+    # NetworkField, where inference would widen the three to str: they
+    # are field names of Network, resolved with getattr by the lookup
+    version_list: list[NetworkField] = [
+        "bip32_pub",
+        "slip132_p2wpkh_pub",
+        "slip132_p2wpkh_p2sh_pub",
+    ]
     function_list: list[Callable[[Any, str], str]] = [
         b58.p2pkh,
         b32.p2wpkh,

--- a/btclib/mnemonic/mnemonic.py
+++ b/btclib/mnemonic/mnemonic.py
@@ -33,6 +33,11 @@ class WordLists:
 
     More word-lists can be added using the load_lang method.
 
+    The three above are what alias.MnemonicLang names, and load_lang is
+    why no lang parameter here or in bip39 and electrum is typed with
+    it: the set is open, so a Literal would reject the language a caller
+    has just loaded (issue #216).
+
     Word-lists are loaded only if needed and read only once from disk.
 
     The loading is under a lock, and the reason is not merely that two

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -17,13 +17,13 @@ from dataclasses import dataclass
 from os import path
 from typing import Any
 
-from btclib.alias import NetworkType, Octets
+from btclib.alias import NetworkField, NetworkName, NetworkType, Octets
 from btclib.curves import Curve
 from btclib.curves.curve import CURVES
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.utils import bytes_from_octets
 
-_KEY_SIZE: list[tuple[str, int]] = [
+_KEY_SIZE: list[tuple[NetworkField, int]] = [
     ("magic_bytes", 4),
     ("genesis_block", 32),
     ("wif", 1),
@@ -250,8 +250,21 @@ datadir = path.join(path.dirname(__file__), "_data")
 # prefixes, and appending a newer network cannot change any answer.
 # mainnet first, then the test networks oldest to newest -- signet.json
 # and testnet4.json differ from testnet.json in the genesis block and
-# the p2p magic, and in nothing else
-for net in ("mainnet", "testnet", "regtest", "signet", "testnet4"):
+# the p2p magic, and in nothing else.
+#
+# Annotated, where inference would widen it to tuple[str, ...]: this is
+# what ties NetworkName to the data it names, a sixth file loaded here
+# without a sixth member there being a mypy error. The dict it fills
+# stays dict[str, Network], a caller's custom signet being as much a
+# network as these -- issue #216 for why no parameter below narrows
+_network_names: tuple[NetworkName, ...] = (
+    "mainnet",
+    "testnet",
+    "regtest",
+    "signet",
+    "testnet4",
+)
+for net in _network_names:
     filename = path.join(datadir, f"{net}.json")
     with open(filename, encoding="ascii") as f:
         NETWORKS[net] = Network.from_dict(json.load(f))
@@ -276,7 +289,9 @@ for net in ("mainnet", "testnet", "regtest", "signet", "testnet4"):
 # xprvversions_from_network(net), a prefix equal to NETWORKS[net].wif.
 # That check is exact for all five networks, and issue #207 records the
 # WIF path having got this wrong by comparing reverse-lookup names.
-def networks_from_key_value(key: str, prefix: str | bytes | Curve) -> list[str]:
+def networks_from_key_value(
+    key: NetworkField, prefix: str | bytes | Curve
+) -> list[str]:
     """Return every network with the (key, value) pair, oldest first.
 
     The list is the ordinal the singular lookups below hide: [0] is the
@@ -293,7 +308,9 @@ def networks_from_key_value(key: str, prefix: str | bytes | Curve) -> list[str]:
     ]
 
 
-def network_from_key_value(key: str, prefix: str | bytes | Curve) -> str | None:
+def network_from_key_value(
+    key: NetworkField, prefix: str | bytes | Curve
+) -> str | None:
     """Return the oldest network with the (key, value) pair, else None.
 
     Oldest, i.e. 'testnet' for the prefixes testnet, regtest, signet and
@@ -310,7 +327,7 @@ def network_from_key_value(key: str, prefix: str | bytes | Curve) -> str | None:
 
 
 def network_type_from_key_value(
-    key: str, prefix: str | bytes | Curve
+    key: NetworkField, prefix: str | bytes | Curve
 ) -> NetworkType | None:
     """Return "main" or "test" from a (key, value) pair, None if unknown.
 

--- a/btclib/script/engine/__init__.py
+++ b/btclib/script/engine/__init__.py
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from btclib.alias import Command
+from btclib.alias import Command, ScriptType
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import sha256
 from btclib.script.engine import tapscript
@@ -204,7 +204,7 @@ def _verify_taproot(
 
 
 def _verify_witness_v0(
-    script_type: str,
+    script_type: ScriptType,
     payload: bytes,
     witness: Witness,
     prevouts: list[TxOut],
@@ -259,7 +259,7 @@ def _verify_witness_v0(
 
 def _verify_witness_program(
     script: bytes,
-    script_type: str,
+    script_type: ScriptType,
     payload: bytes,
     segwit_version: int,
     p2sh: bool,

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -15,7 +15,7 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 
 from btclib import b32, b58, var_bytes
-from btclib.alias import Octets, ScriptList, String, TaprootScriptTree
+from btclib.alias import Octets, ScriptList, ScriptType, String, TaprootScriptTree
 from btclib.curves import point_from_octets
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
@@ -309,7 +309,9 @@ def is_p2tr(script_pub_key: Octets) -> bool:
     return _is_funct(assert_p2tr, script_pub_key)
 
 
-def _witness_type_and_payload(script_pub_key: bytes) -> tuple[str, bytes] | None:
+def _witness_type_and_payload(
+    script_pub_key: bytes,
+) -> tuple[ScriptType, bytes] | None:
     """Name the witness program, or None if these bytes are not one.
 
     One function for the family, because the version is what tells them
@@ -349,8 +351,13 @@ def _witness_type_and_payload(script_pub_key: bytes) -> tuple[str, bytes] | None
     return None
 
 
-def type_and_payload(script_pub_key: Octets) -> tuple[str, bytes]:
-    """Return (script_pub_key type, payload) from the input script_pub_key."""
+def type_and_payload(script_pub_key: Octets) -> tuple[ScriptType, bytes]:
+    """Return (script_pub_key type, payload) from the input script_pub_key.
+
+    The returns here and in _witness_type_and_payload are the whole of
+    ScriptType between them, mypy checking each one against it: an
+    eleventh shape classified in either is a member added there.
+    """
     script_pub_key = bytes_from_octets(script_pub_key)
 
     if is_p2pk(script_pub_key):
@@ -409,7 +416,7 @@ class ScriptPubKey(Script):
     network: str
 
     @property
-    def type(self) -> str:
+    def type(self) -> ScriptType:
         return type_and_payload(self.script)[0]
 
     @property

--- a/tests/b58_test.py
+++ b/tests/b58_test.py
@@ -16,7 +16,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from btclib import b32, b58
-from btclib.alias import ScriptList
+from btclib.alias import ScriptList, ScriptType
 from btclib.base58 import b58encode
 from btclib.bip32 import bip32, slip132
 from btclib.curves import bytes_from_point, point_from_octets, secp256k1
@@ -308,7 +308,7 @@ def test_exceptions() -> None:
     h160=st.binary(min_size=20, max_size=20),
     network=st.sampled_from(["mainnet", "testnet"]),
 )
-def test_round_trip_address(script_type: str, h160: bytes, network: str) -> None:
+def test_round_trip_address(script_type: ScriptType, h160: bytes, network: str) -> None:
     """The payload and its script type survive the encoding.
 
     regtest is not among the networks: it shares testnet's version

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -12,10 +12,11 @@
 import builtins
 import threading
 from os import path
-from typing import Any
+from typing import Any, get_args
 
 import pytest
 
+from btclib.alias import MnemonicLang
 from btclib.exceptions import BTClibValueError
 from btclib.mnemonic import (
     WORDLISTS,
@@ -260,3 +261,14 @@ def test_load_lang_is_idempotent_and_reads_once() -> None:
         builtins.open = real_open
 
     assert len(reads) == 1
+
+
+def test_mnemonic_lang_names_the_shipped_word_lists() -> None:
+    """MnemonicLang is what a fresh WordLists knows, and no more.
+
+    A fresh one, not the WORDLISTS singleton the tests above add two
+    languages to: that openness is the reason no lang parameter is typed
+    with the alias (issue #216), and the reason the alias needs a check
+    of its own here rather than one from mypy.
+    """
+    assert set(get_args(MnemonicLang)) == set(WordLists().languages)

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -9,9 +9,13 @@
 # or distributed except according to the terms contained in the LICENSE file.
 """Tests for the `btclib.network` module."""
 
+from dataclasses import fields
+from typing import get_args
+
 import pytest
 
 from btclib import var_bytes
+from btclib.alias import NetworkField, NetworkName
 from btclib.curves.curve import CURVES
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash256
@@ -160,7 +164,7 @@ def test_the_test_networks_differ_from_testnet_in_two_fields() -> None:
 # the prefix fields, i.e. every field a reverse lookup is asked about:
 # the two chain-identity fields and the curve are not prefixes, and no
 # lookup in this library keys on them
-_PREFIX_FIELDS = (
+_PREFIX_FIELDS: tuple[NetworkField, ...] = (
     "wif",
     "p2pkh",
     "p2sh",
@@ -308,3 +312,18 @@ def test_a_non_str_hrp_is_a_type_error() -> None:
         Network.from_dict({**mainnet, "hrp": b"bc"})
     with pytest.raises(BTClibTypeError, match="invalid hrp type: int"):
         Network.from_dict({**mainnet, "hrp": 0})
+
+
+def test_the_literal_vocabularies_name_the_data() -> None:
+    """NetworkField is every field of Network, NetworkName every network.
+
+    Neither can be checked by mypy against what it names: one is
+    resolved with getattr, the other is a dict key, and both are
+    Literals precisely so that nothing of them exists at run time
+    (issue #216). So the equality is asserted here rather than left to
+    drift. Half of the second one mypy does cover, network.py annotating
+    with NetworkName the tuple of names it loads; a member no file loads
+    is the other half, and this is what sees it.
+    """
+    assert set(get_args(NetworkField)) == {field.name for field in fields(Network)}
+    assert set(get_args(NetworkName)) == set(NETWORKS)


### PR DESCRIPTION
Issue #216 asks for a decision between an enum, a `Literal` and neither,
for the four closed vocabularies this API passes as bare `str`. This is
that decision, implemented: **`Literal` aliases, one per vocabulary, and
a parameter narrowed only where the data behind it is closed.** If an
enum is wanted instead, this pull request is the place to say no.

## Why Literal and not enum

The issue's own measurements rule the obvious answer out.

- `class Net(str, Enum)` formats a member as `mainnet` on 3.10 and as
  `Net.MAINNET` on 3.11 and later. Six error messages here interpolate a
  network name, and tests match some of them verbatim, so a mixin enum
  would make the library's error text depend on the interpreter.
  `enum.StrEnum`, which formats as the value everywhere, is 3.11+ against
  a 3.10 floor.
- A plain `Enum` refuses strings, i.e. breaks thirty-eight signatures.
- `to_dict` output is committed as golden files and read back by
  `from_dict`; a `Literal` gives neither anything new to serialize.

A `Literal` has no runtime existence at all: no formatting trap, no
serialization question, no breaking change, and no behaviour change of
any kind. What it does not catch is a string computed at run time, which
is what the issue weighs against it, and the reason the two open
vocabularies below keep `str`.

## Per vocabulary

| alias | members | parameters |
| --- | --- | --- |
| `ScriptType` | the 9 script types | narrowed |
| `NetworkField` | the 18 field names of `Network` | narrowed |
| `NetworkName` | the 5 networks shipped | stay `str` |
| `MnemonicLang` | the 2 word-lists shipped | stay `str` |

**`ScriptType`** — closed, and checked to be: its nine members are exactly
what `type_and_payload` returns, mypy comparing every return against the
alias, so a tenth shape classified there is a member added here.
`"unknown"` is one of them, an answer and not an absence. It types
`type_and_payload`, `ScriptPubKey.type`, `b58.address_from_h160`,
`b58.h160_from_address` and the script engine's two witness helpers.
`address_from_h160` takes the whole `ScriptType` rather than
`Literal["p2pkh", "p2sh"]`: base58 encodes a subset, so the `raise` is its
answer to a caller holding the `"p2tr"` `type_and_payload` just returned,
and a parameter that cannot spell it would make that a cast at every call
site instead of a message.

**`NetworkField`** — the field names of `Network`, resolved with `getattr`
by the three `*_from_key_value` lookups, which now take it. This is the
most fragile hole the issue names: a misspelled field name matches no
network, so the lookup answers `None`, "no network carries this prefix",
where a misspelled network *name* at least raises `KeyError`. Not
`NetworkKey`, because in this library a key is a private or a public one.

**`NetworkName`** — defined, and typing no parameter, which is the honest
half of the issue: `NETWORKS` is a `dict` a caller adds a custom signet
to, so `network: NetworkName` would refuse a name the library itself
accepts and every such caller would have to cast. It names the five for a
caller who uses only those, and `network.py` annotates with it the tuple
of names it loads, which is what keeps the alias equal to the data.

**`MnemonicLang`** — open for the same reason, and more plainly:
`WordLists.load_lang(lang, filename)` adds a language, which is the
documented way to use any of the other BIP39 word-lists. The ten
`lang: str` signatures stay `str`; the `WordLists` docstring says so and
points at the alias.

## What the narrowing cost

Five annotations across the tree and not one cast — each of them a tuple
or list of string literals that inference widens to `str`: `b58`'s
dispatch tuple (typed `Literal["p2pkh", "p2sh"]`, which is both a script
type and a `Network` field name, the pun `h160_from_address` runs on),
`slip132`'s version list, `network.py`'s `_KEY_SIZE`, and in the tests
`_PREFIX_FIELDS` and one hypothesis parameter. Had it exploded into casts,
the narrowing would have been the wrong call; it did not.

Nothing of a `Literal` exists at run time, so the two data-derived aliases
are checked against the data by tests rather than by mypy: `NetworkField`
against `dataclasses.fields(Network)`, `NetworkName` against `NETWORKS`,
`MnemonicLang` against a fresh `WordLists` — a fresh one because the
`WORDLISTS` singleton is what the neighbouring tests add languages to,
which is the openness itself.

Sighash types stay out, as the issue defers them: a serialized byte is a
different compatibility story from a name.

## Verification

Each gate run as documented, exit code checked:

- `uv run pytest` — 14789 passed, exit 0
- `uv run pre-commit run --all-files` — every hook passed, exit 0
  (mypy strict over `btclib` and `tests` among them)
- the docs gate, `sphinx-build -W --keep-going` — build succeeded, exit 0

Sibling PRs move the CHANGELOG entry count too; re-derive it at merge with
`grep -c '^- ' CHANGELOG.md`.

Closes #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce Literal-typed aliases for the library’s closed vocabularies and apply them where data is closed, while keeping open vocabularies as plain strings.

New Features:
- Add ScriptType Literal alias for the set of supported script types and use it in script, address, and witness-related APIs.
- Add NetworkField Literal alias for Network field names and use it for key parameters in network prefix lookup functions.
- Add NetworkName and MnemonicLang Literal aliases to name the shipped networks and BIP39 word lists without constraining user-extensible parameters.

Enhancements:
- Tighten static typing in network, base58, script, and slip132 modules by annotating collections and parameters with the new Literal aliases where appropriate.
- Add tests that assert Literal vocabularies match the underlying runtime data for networks and mnemonic word lists, guarding against drift.
- Clarify documentation strings around mnemonic word list extensibility and how the new aliases relate to open vocabularies.

Documentation:
- Update CHANGELOG and HISTORY entry counts and document the new Literal aliases and their rationale for closed versus open vocabularies.

Tests:
- Add tests to verify NetworkField and NetworkName Literals match Network dataclass fields and NETWORKS keys, and that MnemonicLang matches languages in a fresh WordLists instance.
- Adjust hypothesis strategies and test annotations to use ScriptType where applicable without introducing casts.