### PR TITLE
Let each psbt role do the whole of its job (issue #173)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -684,6 +684,13 @@ edit.
   `sig_hash.from_tx`, which reads the witness script the same way and had
   the same hole — no vector reaches it there, a sig_hash being asked for
   rather than verified (issue #182)
+- `Psbt.assert_valid` requires the outpoint to name an output the
+  non-witness utxo has: `outpoint vout out of range for the non-witness
+  utxo`, where the index was an `IndexError` out of every reader of the
+  spent output — `assert_signable`, through `_signable_payload`, and the
+  sig_hash the Finalizer now verifies against. The tx_id check beside it
+  does not answer this: a psbt can carry the right transaction and name
+  an output it has not got (issue #173)
 
 ### Immutability and shared state
 
@@ -1549,6 +1556,43 @@ edit.
   the psbt ended. Bitcoin Core draws the line in that very place: "extra
   data after PSBT" is `DecodeRawPSBT`'s, the entry point taking a buffer,
   and not the `Unserialize` that reads a stream (issue #179)
+- **A Finalizer refuses an input whose signatures ask for another
+  sighash type.** BIP174 requires it of the role — "if the input has a
+  `PSBT_IN_SIGHASH_TYPE` field, the Input Finalizer must fail to finalize
+  that input if any signature does not match the specified sighash type"
+  — and `finalize_psbt` did not look, so a psbt finalized into a
+  transaction whose signatures commit to something other than the input,
+  i.e. than what the other participants agreed to. The type a signature
+  commits to is the byte appended to its DER encoding, and the answer is
+  `mismatched sig_hash type: 0x1 vs 0x3`. The field's *presence* is what
+  is tested, not its truthiness: `0` is SIGHASH_DEFAULT, a type an input
+  may ask for and no ECDSA signature carries, so an input asking for it
+  is one that no partial signature can finalize (issue #173)
+- **A Finalizer checks each partial signature against the key it is
+  filed under.** `PsbtIn.assert_valid` parses the DER and can do no more,
+  a signature committing to the whole transaction that a per-field
+  validator has not got; the Finalizer has it, and BIP174 charges that
+  role with deciding "if the input has enough data to pass validation".
+  Covered is every input kind a `PSBT_IN_PARTIAL_SIG` can belong to —
+  legacy (p2pk, p2pkh, bare multisig), p2sh, p2wpkh, p2wsh, and either
+  witness kind wrapped in p2sh. An input that does not say what is being
+  signed is left alone rather than refused, that being a missing utxo or
+  a missing script and not evidence against the signature: no utxo, a
+  p2sh input with no redeem script, a p2wsh one with no witness script,
+  and a taproot output, whose signatures are schnorr and travel in the
+  taproot fields. `sig_hash.from_tx` could not serve, reading the redeem
+  script off the input's script_sig and the witness script off its
+  witness stack, which a psbt's unsigned transaction does not carry
+  (issue #173)
+- **A finalized input drops the preimages and the taproot fields too.**
+  What a finalizer consumed is not serialized beside what it produced,
+  and btclib dropped five of the fields BIP174 says so of; the set is now
+  the whole of what Bitcoin Core's `PSBTInput::Serialize` writes inside
+  its `if (final_script_sig.empty() && final_script_witness.IsNull())` —
+  the four preimage maps and the six taproot fields as well. The utxo
+  stays outside the condition, there and here, an Extractor needing it to
+  check the transaction it builds; so do the unknown fields, which no
+  role understands well enough to drop (issue #173)
 - **The header is one constant and a separator is the `0x00`**, as in
   Bitcoin Core: `PSBT_MAGIC_BYTES` is the five bytes `b"psbt\xff"`, where
   it was the four of "psbt" with the `0xff` beside it as `PSBT_SEPARATOR`;
@@ -1632,6 +1676,18 @@ edit.
   only truncation (issue #123) the check had nothing left to refuse, and
   a vacuous validator reads as a guarantee it does not give. What cannot
   execute is unspendable, which a signer learns by running it
+- **`join_psbts` and `join_txs` have lost their `merge_out` parameter.**
+  It was a fourth positional boolean whose only truthy value raised
+  `output merge not implemented yet`, so what it offered was a choice
+  between doing nothing and failing. Specifying it was the alternative,
+  and it is the wrong answer twice over: coalescing two outputs that pay
+  one script changes the output *set*, so every signature already made
+  over the old one stops verifying, and both functions shuffle or sort
+  the outputs first, which would make the result depend on the order the
+  merge ran in. Summing two payments into one output is the caller's, and
+  before signing is the only point at which it is safe. `merge_out=False`
+  is an argument to delete at each call site; nothing else moves
+  (issue #173)
 - **Core's five script limits are `btclib.script.limits`**, under Core's
   own names: `MAX_SCRIPT_ELEMENT_SIZE`, `MAX_OPS_PER_SCRIPT`,
   `MAX_PUBKEYS_PER_MULTISIG`, `MAX_SCRIPT_SIZE`, `MAX_STACK_SIZE`. They
@@ -2430,6 +2486,17 @@ edit.
 
 ### Tests
 
+- **a Combiner's union of the final witnesses is pinned by a test**: two
+  psbts with a different input finalized in each, combined both ways
+  round, keep both — which the marker beside `_combine_field` said they
+  did not. They do, a `Witness` being sized, so the empty one is falsy
+  and the finalized input is the one taken; what the marker's
+  commented-out list branch would have added is the one wrong answer, a
+  witness stack being positional, so two stacks for one input are two
+  spends of it rather than the halves of one. A conflict is picked from
+  and the psbt combined *into* keeps what it has, which is the arbitrary
+  choice BIP174 allows and the one Bitcoin Core's `PSBTInput::Merge`
+  makes; that is now a test too (issue #173)
 - **the tree measures 100% again**, and the two statements that had gone
   uncovered were electrum's round-trip check on its own encoding — the
   one `_search_mnemonic` makes before it returns a candidate. Not

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -177,6 +177,14 @@ against the `v2023.7.12` tag.
   `CScript::IsPushOnly`, which compares each op code against OP_16 — and
   the name says which script it is asked about, the script_sig, at both
   call sites as in Core.
+- **`join_psbts` and `join_txs` no longer take `merge_out`.** It was the
+  fourth positional parameter of both, and `merge_out=True` raised
+  `output merge not implemented yet`: delete the argument at each call
+  site, `merge_out=False` having been the only value that did anything.
+  Merging two outputs that pay one script changes the output set, so
+  every signature already made over it stops verifying, and both
+  functions shuffle or sort the outputs first — summing two payments
+  into one output is the caller's, before signing.
 - **`psbt_utils.assert_valid_taproot_tree` is gone**, with the leaf-script
   validation it performed: a PSBT tap tree is stored as it arrives, as
   Core's PSBT stores it. Nothing replaces the call — `PsbtOut.assert_valid`

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -31,6 +31,7 @@ from btclib.bip32 import (
     decode_hd_key_paths,
     encode_to_bip32_derivs,
 )
+from btclib.ecc import dsa
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
 from btclib.psbt.psbt_in import PsbtIn
@@ -51,11 +52,14 @@ from btclib.script import (
     Witness,
     is_p2pkh,
     is_p2sh,
+    is_p2tr,
     is_p2wpkh,
+    is_p2wsh,
     serialize,
+    sig_hash,
     type_and_payload,
 )
-from btclib.tx import Tx, TxIn, join_txs
+from btclib.tx import Tx, TxIn, TxOut, join_txs
 from btclib.utils import bytesio_from_binarydata
 
 # the whole of BIP174's <magic>, five bytes: the four of "psbt" and the
@@ -191,6 +195,19 @@ class Psbt:
             for psbt_in, tx_in in zip(self.inputs, self.tx.vin, strict=True)
         ):
             err_msg = "mismatched non-witness utxo / outpoint tx_id"
+            raise BTClibValueError(err_msg)
+
+        # the outpoint names one of that transaction's outputs, and the
+        # tx_id check above does not say so: an index past its vout is an
+        # IndexError to everything that reads the spent output --
+        # _signable_payload, the Finalizer's sig_hash -- where malformed
+        # input owes the caller a BTClibValueError
+        if any(
+            psbt_in.non_witness_utxo
+            and tx_in.prev_out.vout >= len(psbt_in.non_witness_utxo.vout)
+            for psbt_in, tx_in in zip(self.inputs, self.tx.vin, strict=True)
+        ):
+            err_msg = "outpoint vout out of range for the non-witness utxo"
             raise BTClibValueError(err_msg)
 
         if len(self.tx.vout) != len(self.outputs):
@@ -433,16 +450,31 @@ class Psbt:
 def _combine_field(
     psbt_map: PsbtIn | PsbtOut | Psbt, out: PsbtIn | PsbtOut | Psbt, key: str
 ) -> None:
+    """Add one field of psbt_map to out, as BIP174's Combiner does.
+
+    "The resulting PSBT must contain all of the key-value pairs from each
+    of the PSBTs", so a field that is *several* key-value pairs -- a map
+    keyed by pub key, by hash, by control block -- is the union of the
+    two, merged pair by pair. A field that is one pair is taken when out
+    has none and kept when out has one, which is the arbitrary choice the
+    BIP allows a Combiner "when conflicts occur" and the choice Bitcoin
+    Core's PSBTInput::Merge makes.
+
+    A final_script_witness is one of the latter, and it survives the
+    combine either way round because a Witness is sized: an empty one is
+    falsy, so the input finalized in the other psbt is the one taken. It
+    is not merged element-wise, which is the one wrong answer here -- a
+    witness stack is positional, so two stacks for one input are two
+    spends of it and not the halves of one.
+    """
     item = getattr(psbt_map, key)
     if not item:
         return
     attr = getattr(out, key)
     if not attr:
         setattr(out, key, item)
-    elif attr != item and isinstance(item, dict):
+    elif isinstance(item, dict):
         attr.update(item)
-        # issue 173: no list branch, so a final_script_witness present in
-        # one psbt and absent from the other does not survive the combine
 
 
 def combine_psbts(psbts: Sequence[Psbt]) -> Psbt:
@@ -483,6 +515,29 @@ def combine_psbts(psbts: Sequence[Psbt]) -> Psbt:
     return final_psbt
 
 
+def _prev_out(psbt_in: PsbtIn, tx_in: TxIn) -> TxOut | None:
+    """Return the output the input spends, or None if the psbt omits it.
+
+    Either utxo field answers the question, and a psbt carries whichever
+    its kind of input needs: the witness_utxo is the spent output itself,
+    the non_witness_utxo the whole transaction it belongs to, indexed by
+    the outpoint.
+
+    The index is bound-checked rather than trusted. Psbt.assert_valid
+    does check it against that transaction's vout, and every caller here
+    runs after it, so this is belt and braces -- but None is a answer both
+    callers already handle, and an IndexError out of a private helper is
+    not.
+    """
+    if psbt_in.witness_utxo:
+        return psbt_in.witness_utxo
+    if psbt_in.non_witness_utxo and tx_in.prev_out.vout < len(
+        psbt_in.non_witness_utxo.vout
+    ):
+        return psbt_in.non_witness_utxo.vout[tx_in.prev_out.vout]
+    return None
+
+
 def _spent_script(psbt_in: PsbtIn, tx_in: TxIn) -> bytes:
     """Return the script the input's signatures satisfy, or b"".
 
@@ -498,15 +553,10 @@ def _spent_script(psbt_in: PsbtIn, tx_in: TxIn) -> bytes:
     an input that does not say what it spends is not one this function
     can contradict.
     """
-    if psbt_in.witness_utxo:
-        script = psbt_in.witness_utxo.script_pub_key.script
-    elif psbt_in.non_witness_utxo and tx_in.prev_out.vout < len(
-        psbt_in.non_witness_utxo.vout
-    ):
-        vout = psbt_in.non_witness_utxo.vout[tx_in.prev_out.vout]
-        script = vout.script_pub_key.script
-    else:
+    prev_out = _prev_out(psbt_in, tx_in)
+    if prev_out is None:
         return b""
+    script = prev_out.script_pub_key.script
     return psbt_in.redeem_script if is_p2sh(script) else script
 
 
@@ -576,6 +626,129 @@ def _finalized_input(psbt_in: PsbtIn, tx_in: TxIn) -> tuple[bytes, Witness]:
     return serialize(cast(ScriptList, [*cmds, *redeem_script])), Witness()
 
 
+def _witness_v0_script_code(psbt_in: PsbtIn, script: bytes) -> bytes:
+    """Return the script code BIP-143 signs the segwit v0 input against.
+
+    For p2wsh it is the witness script, which the input carries; for
+    p2wpkh it is the p2pkh script for the same hash160, which is in no
+    transaction and is built here. b"" is "the input does not say", i.e.
+    a p2wsh input with no witness script.
+    """
+    if is_p2wpkh(script):
+        _, payload = type_and_payload(script)
+        return serialize(
+            ["OP_DUP", "OP_HASH160", payload, "OP_EQUALVERIFY", "OP_CHECKSIG"]
+        )
+    return psbt_in.witness_script
+
+
+def _sig_hash_from_psbt_in(
+    psbt_in: PsbtIn, tx: Tx, vin_i: int, hash_type: int
+) -> bytes | None:
+    """Return the hash the input's partial signatures commit to, or None.
+
+    Covered is every kind of input a PSBT_IN_PARTIAL_SIG can belong to:
+    the legacy ones (p2pk, p2pkh, bare multisig), p2sh, p2wpkh, p2wsh,
+    and either witness kind wrapped in p2sh -- wrapped ones because what
+    the wrapper commits to is the redeem script, which is what the
+    dispatch below looks at once it has unwrapped it.
+
+    None is "this input does not say what is being signed", which is not
+    the same as "the signature is wrong": there is no utxo, or a p2sh
+    input carries no redeem script, or a p2wsh one no witness script. A
+    taproot input is None too, and for good: its signatures are schnorr
+    and travel in the taproot fields, so a partial signature beside a
+    p2tr script_pub_key is not a signature this hash would check.
+
+    sig_hash.from_tx is the same dispatch for a *signed* transaction, and
+    cannot serve here: it reads the redeem script out of the input's
+    script_sig and the witness script off its witness stack, and a psbt's
+    unsigned transaction has neither -- they are the psbt's own fields,
+    which is the whole point of the format.
+    """
+    prev_out = _prev_out(psbt_in, tx.vin[vin_i])
+    if prev_out is None:
+        return None
+
+    script = prev_out.script_pub_key.script
+    if is_p2sh(script):
+        script = psbt_in.redeem_script
+
+    if is_p2wpkh(script) or is_p2wsh(script):
+        script_code = _witness_v0_script_code(psbt_in, script)
+        if not script_code:
+            return None
+        return sig_hash.segwit_v0(script_code, tx, vin_i, hash_type, prev_out.value)
+
+    if not script or is_p2tr(script):
+        return None
+    return sig_hash.legacy(script, tx, vin_i, hash_type)
+
+
+def _assert_sig_hash_type(psbt_in: PsbtIn) -> None:
+    """Raise unless each signature commits to the type the input asks for.
+
+    BIP174 on the Input Finalizer: "If the input has a
+    PSBT_IN_SIGHASH_TYPE field, the Input Finalizer must fail to finalize
+    that input if any signature does not match the specified sighash
+    type". Without the check a psbt finalizes into a transaction whose
+    signatures commit to something other than the input asked for -- and
+    the input is what the other participants agreed to.
+
+    The type a signature commits to is the byte appended to its DER
+    encoding, which is where the script engine reads it too.
+
+    Presence is `is not None` rather than truthiness: 0 is
+    SIGHASH_DEFAULT, which an input may ask for and no ECDSA signature
+    carries, so an input asking for it is exactly an input no partial
+    signature can finalize.
+    """
+    if psbt_in.sig_hash_type is None:
+        return
+    for sig in psbt_in.partial_sigs.values():
+        if sig[-1] != psbt_in.sig_hash_type:
+            err_msg = "mismatched sig_hash type: "
+            err_msg += f"{hex(sig[-1])} vs {hex(psbt_in.sig_hash_type)}"
+            raise BTClibValueError(err_msg)
+
+
+def _assert_partial_sigs_verify(psbt_in: PsbtIn, tx: Tx, vin_i: int) -> None:
+    """Raise unless each partial signature verifies against its own key.
+
+    The Finalizer is where the check belongs, and PsbtIn.assert_valid is
+    not: a signature commits to the whole transaction, which a per-field
+    validator does not have, while the role BIP174 charges with deciding
+    "if the input has enough data to pass validation" holds it.
+
+    An input whose sig_hash is not computable is left alone rather than
+    refused: what is missing there is the utxo or a script, which is not
+    evidence against the signature.
+
+    lower_s=False because the question here is whether that key made that
+    signature: the low-s rule is policy, applied by the script engine
+    under its flags, and Bitcoin Core's CPubKey::Verify normalizes s
+    before verifying for this very reason.
+    """
+    # the hash is the input's and the hash type's, never the key's, so an
+    # n-of-m input whose signatures agree on the type -- which is the
+    # ordinary case, they are signing one thing -- serializes the
+    # transaction once instead of n times. None is a value worth caching
+    # too, so membership and not truthiness says whether it is computed
+    sig_hashes: dict[int, bytes | None] = {}
+    for pub_key, sig in psbt_in.partial_sigs.items():
+        hash_type = sig[-1]
+        if hash_type not in sig_hashes:
+            sig_hashes[hash_type] = _sig_hash_from_psbt_in(
+                psbt_in, tx, vin_i, hash_type
+            )
+        msg_hash = sig_hashes[hash_type]
+        if msg_hash is None:
+            continue
+        if not dsa.verify_(msg_hash, pub_key, sig[:-1], lower_s=False):
+            err_msg = f"invalid partial signature for pub_key {pub_key.hex()}"
+            raise BTClibValueError(err_msg)
+
+
 def finalize_psbt(psbt: Psbt) -> Psbt:
     """Finalize the Psbt.
 
@@ -591,17 +764,24 @@ def finalize_psbt(psbt: Psbt) -> Psbt:
     to allow Transaction Extractors to verify the final network
     serialized transaction.
 
-    What is built is the spend the input's own kind asks for, which is
-    what _finalized_input dispatches on: a witness script alone does not
-    say, being absent from every single-key segwit input.
+    Deciding that an input has enough data is two checks beyond the
+    presence of a signature, and both are per input: the sighash type
+    each signature commits to is the one the input asks for, and each
+    signature verifies against the key it is filed under.
+
+    What is then built is the spend the input's own kind asks for, which
+    is what _finalized_input dispatches on: a witness script alone does
+    not say, being absent from every single-key segwit input.
     """
     psbt = deepcopy(psbt)
     psbt.assert_valid()
-    # issue 173: BIP-174 requires a Finalizer to refuse an input whose
-    # signatures do not match the sighash type it asks for
-    for psbt_in, tx_in in zip(psbt.inputs, psbt.tx.vin, strict=True):
+    for vin_i, (psbt_in, tx_in) in enumerate(
+        zip(psbt.inputs, psbt.tx.vin, strict=True)
+    ):
         if not psbt_in.partial_sigs:
             raise BTClibValueError("missing signatures")
+        _assert_sig_hash_type(psbt_in)
+        _assert_partial_sigs_verify(psbt_in, psbt.tx, vin_i)
         script_sig, witness = _finalized_input(psbt_in, tx_in)
         psbt_in.final_script_sig = script_sig
         psbt_in.final_script_witness = witness
@@ -709,7 +889,6 @@ def join_psbts(
     psbts: Sequence[Psbt],
     enforce_same_tx_version: bool,
     enforce_same_tx_lock_time: bool,
-    merge_out: bool,
     shuffle_inp: bool,
     shuffle_out: bool,
     sort_inp: Callable[[PsbtIn], int] | None = None,
@@ -721,6 +900,14 @@ def join_psbts(
     they are simply concatenated in the same order as psbts are
     specified. A specific ordering can be specified via sort_{inp|out},
     which overwrite shuffle when present.
+
+    Outputs are concatenated and never merged, and there is no parameter
+    asking for it: coalescing two outputs that pay the same script is a
+    change to the output *set*, so every signature already made over the
+    old one stops verifying -- and, after the shuffle or sort above, the
+    result would depend on the order the merge ran in. A caller who wants
+    one output where there were two builds it that way before signing,
+    which is the only point at which it is safe.
     """
     _ensure_consistency(psbts)
 
@@ -734,11 +921,13 @@ def join_psbts(
     }
     version = max(psbt.version for psbt in psbts)
 
+    # the transaction is joined unshuffled: the psbt's inputs and its vin
+    # are one sequence in two lists, so whatever reorders them has to
+    # reorder both, which is what sort_inputs and sort_outputs below do
     merged_tx = join_txs(
         [psbt.tx for psbt in psbts],
         enforce_same_tx_version,
         enforce_same_tx_lock_time,
-        False,
         False,
         False,
     )
@@ -748,11 +937,6 @@ def join_psbts(
         psbt.sort_inputs(sort_inp)
     if shuffle_out or sort_out:
         psbt.sort_outputs(sort_out)
-    if merge_out:
-        # issue 173: merging two outputs paying the same script changes the
-        # output count, so it invalidates any signature already committed to
-        # the previous set -- and after a sort the result depends on the sort
-        raise BTClibValueError("output merge not implemented yet")
 
     psbt.assert_valid()
     return psbt

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -111,19 +111,18 @@ def _assert_valid_partial_sigs(partial_sigs: Mapping[bytes, bytes]) -> None:
             # the DER signature alone: a partial signature is that plus a
             # sighash type byte (bip 174), so it is not itself a DER
             # encoding, and Sig.parse refuses trailing bytes after the
-            # sequence (issue #129). The trailing byte is not checked
-            # here: which hash types are admissible depends on the input
-            # being spent, which a per-field validator does not know, and
-            # issue #173 is where that belongs. Do not let a line of this
-            # comment begin with "# type:", which mypy reads as a PEP 484
-            # type comment and then calls the try block a syntax error
+            # sequence (issue #129). Neither that byte nor the key is
+            # checked against the signature here: both questions need the
+            # transaction -- which sighash types the input admits, and
+            # which hash the signature actually commits to -- so both are
+            # the Finalizer's, and psbt.finalize_psbt asks them. Do not
+            # let a line of this comment begin with "# type:", which mypy
+            # reads as a PEP 484 type comment and then calls the try block
+            # a syntax error
             dsa.Sig.parse(sig[:-1])
         except BTClibValueError as e:
             err_msg = f"invalid partial signature: {sig!r}"
             raise BTClibValueError(err_msg) from e
-        # issue 173: the key is not checked against the signature. Doing so
-        # needs the sighash, i.e. the whole transaction, which a per-field
-        # validator does not have -- so the question is where it belongs
 
 
 def _assert_valid_final_script_sig(final_script_sig: bytes) -> None:
@@ -248,7 +247,13 @@ _SERIALIZED_FIELDS: list[tuple[bytes, str, _Serializer]] = [
 # produced, so an input with a final script_sig or witness serializes
 # without these fields. They are still parsed: dropping what a
 # counterparty sent is the Finalizer role's decision, not a codec's.
-# Issue 173: the taproot fields have no such condition
+# The list is the whole of what Bitcoin Core's PSBTInput::Serialize puts
+# inside its `if (final_script_sig.empty() && final_script_witness
+# .IsNull())`, the preimages and the taproot fields included: each of
+# them is an input to signing, and a finalized input has been signed.
+# The utxo fields are outside it there and here, an Extractor needing
+# them to check the transaction it builds; so are the unknown ones,
+# which no role understands well enough to drop
 _DROPPED_ONCE_FINALIZED = frozenset(
     {
         "partial_sigs",
@@ -256,6 +261,16 @@ _DROPPED_ONCE_FINALIZED = frozenset(
         "redeem_script",
         "witness_script",
         "hd_key_paths",
+        "ripemd160_preimages",
+        "sha256_preimages",
+        "hash160_preimages",
+        "hash256_preimages",
+        "taproot_key_spend_signature",
+        "taproot_script_spend_signatures",
+        "taproot_leaf_scripts",
+        "taproot_hd_key_paths",
+        "taproot_internal_key",
+        "taproot_merkle_root",
     }
 )
 

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -328,10 +328,18 @@ def join_txs(
     txs: Sequence[Tx],
     enforce_same_version: bool,
     enforce_same_lock_time: bool,
-    merge_out: bool,
     shuffle_inp: bool,
     shuffle_out: bool,
 ) -> Tx:
+    """Join transactions into one, concatenating inputs and outputs.
+
+    Outputs are concatenated and never merged, and no parameter asks for
+    it: coalescing two outputs that pay the same script changes the
+    output set, so it invalidates every signature already made over the
+    old one -- and with the shuffle below the result would depend on the
+    order the merge ran in. Summing two payments into one output is the
+    caller's to do before signing.
+    """
     version = max(tx.version for tx in txs)
     if enforce_same_version and any(tx.version != version for tx in txs):
         raise BTClibValueError("Version numbers are not the same")
@@ -347,8 +355,6 @@ def join_txs(
     vin = [vin for tx in txs for vin in tx.vin]
 
     vout = [vout for tx in txs for vout in tx.vout]
-    if merge_out:
-        raise BTClibValueError("output merge not implemented yet")
 
     # avoid leaking matches between inputs and outputs
     if shuffle_inp:

--- a/tests/psbt/psbt_in_test.py
+++ b/tests/psbt/psbt_in_test.py
@@ -11,9 +11,11 @@
 
 from dataclasses import FrozenInstanceError, fields
 from io import BytesIO
+from typing import Any
 
 import pytest
 
+from btclib.bip32 import BIP32KeyOrigin
 from btclib.psbt import Psbt, PsbtIn
 from btclib.psbt.psbt_in import (
     _DROPPED_ONCE_FINALIZED,
@@ -22,6 +24,8 @@ from btclib.psbt.psbt_in import (
     _WHOLE_VALUE_FIELDS,
 )
 from btclib.psbt.psbt_utils import PSBT_SEPARATOR
+from btclib.script import Witness
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests.conftest import JsonGolden
 
 
@@ -93,6 +97,90 @@ def test_key_type_tables_name_every_field() -> None:
     assert (
         len(_SERIALIZED_FIELDS) == len(_WHOLE_VALUE_FIELDS) + len(_KEY_DATA_FIELDS) + 1
     )
+
+
+def test_a_finalized_input_drops_everything_the_finalizer_consumed() -> None:
+    """bip 174: what a finalizer consumed is not carried beside its result.
+
+    The set is Bitcoin Core's: PSBTInput::Serialize writes exactly these
+    fields inside `if (final_script_sig.empty() && final_script_witness
+    .IsNull())`, the preimages and the taproot fields included, and
+    leaves the utxo outside it for the Extractor to check the built
+    transaction against.
+
+    check_validity=False throughout: the values below are placeholders,
+    and what is under test is which fields a finalized input emits --
+    which a signature that no key made answers exactly as a real one
+    would, serialization not being where a signature is checked.
+    """
+    values: dict[str, Any] = {
+        "partial_sigs": {b"\x02" + b"\x01" * 32: b"\x30\x02"},
+        "sig_hash_type": 1,
+        "redeem_script": b"\x51",
+        "witness_script": b"\x51",
+        "hd_key_paths": {b"\x02" + b"\x01" * 32: BIP32KeyOrigin(b"\x00" * 4, "m/0")},
+        "ripemd160_preimages": {b"\x01" * 20: b"\x02"},
+        "sha256_preimages": {b"\x01" * 32: b"\x02"},
+        "hash160_preimages": {b"\x01" * 20: b"\x02"},
+        "hash256_preimages": {b"\x01" * 32: b"\x02"},
+        "taproot_key_spend_signature": b"\x01" * 64,
+        "taproot_script_spend_signatures": {b"\x01" * 64: b"\x02" * 64},
+        "taproot_leaf_scripts": {b"\xc0" + b"\x01" * 32: (b"\x51", 0xC0)},
+        "taproot_hd_key_paths": {
+            b"\x01" * 32: ([b"\x02" * 32], BIP32KeyOrigin(b"\x00" * 4, "m/0"))
+        },
+        "taproot_internal_key": b"\x01" * 32,
+        "taproot_merkle_root": b"\x01" * 32,
+    }
+    # a field added to the set without a value here would be dropped by a
+    # test that never serialized it in the first place
+    assert values.keys() == _DROPPED_ONCE_FINALIZED
+
+    # and what survives, which is the half of the contract a set of names
+    # cannot state: the two utxo fields, the Extractor needing them to
+    # check the transaction it builds, and the unknown ones, which no role
+    # understands well enough to drop. Both utxos at once is not a psbt a
+    # Creator would write, and is what pins each of them separately
+    kept: dict[str, Any] = {
+        "non_witness_utxo": Tx(
+            vin=[TxIn(OutPoint(b"\x01" * 32, 0))],
+            vout=[TxOut(1, b"\x51")],
+        ),
+        "witness_utxo": TxOut(1, b"\x51"),
+        "final_script_witness": Witness([b"\x01"]),
+        "unknown": {b"\xfc\x01": b"\x02"},
+    }
+    # the two dicts and the final script_sig are the whole of an input, so
+    # a field added to PsbtIn and to neither of them fails here rather
+    # than going untested in both directions
+    assert values.keys() | kept.keys() | {"final_script_sig"} == {
+        field.name for field in fields(PsbtIn)
+    }
+
+    bare = PsbtIn(final_script_sig=b"\x51").serialize()
+
+    # one field at a time, which is what tells the two apart: each dropped
+    # field does serialize while the input is not finalized -- or "gone
+    # once it is" would hold whatever the set said -- and is gone once it
+    # is; each kept field is still there
+    for name, value in values.items():
+        psbt_in = PsbtIn(**{name: value}, check_validity=False)
+        assert psbt_in.serialize(check_validity=False) != PSBT_SEPARATOR
+        psbt_in = PsbtIn(
+            **{name: value}, final_script_sig=b"\x51", check_validity=False
+        )
+        assert psbt_in.serialize(check_validity=False) == bare
+    for name, value in kept.items():
+        psbt_in = PsbtIn(
+            **{name: value}, final_script_sig=b"\x51", check_validity=False
+        )
+        assert psbt_in.serialize(check_validity=False) != bare
+
+    # and all of them at once, which is the input a Finalizer hands on
+    finalized = PsbtIn(**values, **kept, final_script_sig=b"\x51", check_validity=False)
+    assert finalized.serialize(check_validity=False) == PsbtIn(
+        **kept, final_script_sig=b"\x51", check_validity=False
+    ).serialize(check_validity=False)
 
 
 def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -10,6 +10,7 @@
 """Tests for the `btclib.psbt.psbt` module."""
 
 import base64
+import inspect
 from io import BytesIO
 from typing import Any
 
@@ -21,10 +22,11 @@ from btclib.ecc import dsa
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, hash256, ripemd160, sha256
 from btclib.psbt import Psbt, combine_psbts, extract_tx, finalize_psbt, join_psbts
-from btclib.psbt.psbt import _sort_or_shuffle_together
+from btclib.psbt.psbt import _sig_hash_from_psbt_in, _sort_or_shuffle_together
 from btclib.psbt.psbt_utils import PSBT_SEPARATOR
 from btclib.script import ScriptPubKey, Witness, serialize, sig_hash
 from btclib.script.engine import verify_transaction
+from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests import load, vector_id
 from tests.conftest import JsonGolden
@@ -227,13 +229,20 @@ def test_psbt_combination() -> None:
         combine_psbts([psbt1, psbt2])
 
 
+# the psbt BIP174's Combiner example produces, which its Finalizer
+# example turns into the one test_finalize compares against: two inputs,
+# a p2sh 2-of-2 and a p2sh-p2wsh 2-of-2, each with both signatures and
+# each asking for SIGHASH_ALL. It is the fixture of every Finalizer test
+# below, the checks a Finalizer makes being per input
+TO_BE_FINALIZED = "cHNidP8BAJoCAAAAAljoeiG1ba8MI76OcHBFbDNvfLqlyHV5JPVFiHuyq911AAAAAAD/////g40EJ9DsZQpoqka7CwmK6kQiwHGyyng1Kgd5WdB86h0BAAAAAP////8CcKrwCAAAAAAWABTYXCtx0AYLCcmIauuBXlCZHdoSTQDh9QUAAAAAFgAUAK6pouXw+HaliN9VRuh0LR2HAI8AAAAAAAEAuwIAAAABqtc5MQGL0l+ErkALaISL4J23BurCrBgpi6vucatlb4sAAAAASEcwRAIgWPb8fGoz4bMVSNSByCbAFb0wE1qtQs1neQ2rZtKtJDsCIEoc7SYExnNbY5PltBaR3XiwDwxZQvufdRhW+qk4FX26Af7///8CgPD6AgAAAAAXqRQPuUY0IWlrgsgzryQceMF9295JNIfQ8gonAQAAABepFCnKdPigj4GZlCgYXJe12FLkBj9hh2UAAAAiAgKVg785rgpgl0etGZrd1jT6YQhVnWxc05tMIYPxq5bgf0cwRAIgdAGK1BgAl7hzMjwAFXILNoTMgSOJEEjn282bVa1nnJkCIHPTabdA4+tT3O+jOCPIBwUUylWn3ZVE8VfBZ5EyYRGMASICAtq2H/SaFNtqfQKwzR+7ePxLGDErW05U2uTbovv+9TbXSDBFAiEA9hA4swjcHahlo0hSdG8BV3KTQgjG0kRUOTzZm98iF3cCIAVuZ1pnWm0KArhbFOXikHTYolqbV2C+ooFvZhkQoAbqAQEDBAEAAAABBEdSIQKVg785rgpgl0etGZrd1jT6YQhVnWxc05tMIYPxq5bgfyEC2rYf9JoU22p9ArDNH7t4/EsYMStbTlTa5Nui+/71NtdSriIGApWDvzmuCmCXR60Zmt3WNPphCFWdbFzTm0whg/GrluB/ENkMak8AAACAAAAAgAAAAIAiBgLath/0mhTban0CsM0fu3j8SxgxK1tOVNrk26L7/vU21xDZDGpPAAAAgAAAAIABAACAAAEBIADC6wsAAAAAF6kUt/X69A49QKWkWbHbNTXyty+pIeiHIgIDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtxHMEQCIGLrelVhB6fHP0WsSrWh3d9vcHX7EnWWmn84Pv/3hLyyAiAMBdu3Rw2/LwhVfdNWxzJcHtMJE+mWzThAlF2xIijaXwEiAgI63ZBPPW3PWd25BrDe4jUpt/+57VDl6GFRkmhgIh8Oc0cwRAIgZfRbpZmLWaJ//hp77QFq8fH5DVSzqo90UKpfVqJRA70CIH9yRwOtHtuWaAsoS1bU/8uI9/t1nqu+CKow8puFE4PSAQEDBAEAAAABBCIAIIwjUxc3Q7WV37Sge3K6jkLjeX2nTof+fZ10l+OyAokDAQVHUiEDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtwhAjrdkE89bc9Z3bkGsN7iNSm3/7ntUOXoYVGSaGAiHw5zUq4iBgI63ZBPPW3PWd25BrDe4jUpt/+57VDl6GFRkmhgIh8OcxDZDGpPAAAAgAAAAIADAACAIgYDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtwQ2QxqTwAAAIAAAACAAgAAgAAiAgOppMN/WZbTqiXbrGtXCvBlA5RJKUJGCzVHU+2e7KWHcRDZDGpPAAAAgAAAAIAEAACAACICAn9jmXV9Lv9VoTatAsaEsYOLZVbl8bazQoKpS2tQBRCWENkMak8AAACAAAAAgAUAAIAA"
+
+
 def test_finalize() -> None:
     psbt_str = "cHNidP8BAJoCAAAAAljoeiG1ba8MI76OcHBFbDNvfLqlyHV5JPVFiHuyq911AAAAAAD/////g40EJ9DsZQpoqka7CwmK6kQiwHGyyng1Kgd5WdB86h0BAAAAAP////8CcKrwCAAAAAAWABTYXCtx0AYLCcmIauuBXlCZHdoSTQDh9QUAAAAAFgAUAK6pouXw+HaliN9VRuh0LR2HAI8AAAAAAAEAuwIAAAABqtc5MQGL0l+ErkALaISL4J23BurCrBgpi6vucatlb4sAAAAASEcwRAIgWPb8fGoz4bMVSNSByCbAFb0wE1qtQs1neQ2rZtKtJDsCIEoc7SYExnNbY5PltBaR3XiwDwxZQvufdRhW+qk4FX26Af7///8CgPD6AgAAAAAXqRQPuUY0IWlrgsgzryQceMF9295JNIfQ8gonAQAAABepFCnKdPigj4GZlCgYXJe12FLkBj9hh2UAAAABB9oARzBEAiB0AYrUGACXuHMyPAAVcgs2hMyBI4kQSOfbzZtVrWecmQIgc9Npt0Dj61Pc76M4I8gHBRTKVafdlUTxV8FnkTJhEYwBSDBFAiEA9hA4swjcHahlo0hSdG8BV3KTQgjG0kRUOTzZm98iF3cCIAVuZ1pnWm0KArhbFOXikHTYolqbV2C+ooFvZhkQoAbqAUdSIQKVg785rgpgl0etGZrd1jT6YQhVnWxc05tMIYPxq5bgfyEC2rYf9JoU22p9ArDNH7t4/EsYMStbTlTa5Nui+/71NtdSrgABASAAwusLAAAAABepFLf1+vQOPUClpFmx2zU18rcvqSHohwEHIyIAIIwjUxc3Q7WV37Sge3K6jkLjeX2nTof+fZ10l+OyAokDAQjaBABHMEQCIGLrelVhB6fHP0WsSrWh3d9vcHX7EnWWmn84Pv/3hLyyAiAMBdu3Rw2/LwhVfdNWxzJcHtMJE+mWzThAlF2xIijaXwFHMEQCIGX0W6WZi1mif/4ae+0BavHx+Q1Us6qPdFCqX1aiUQO9AiB/ckcDrR7blmgLKEtW1P/LiPf7dZ6rvgiqMPKbhROD0gFHUiEDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtwhAjrdkE89bc9Z3bkGsN7iNSm3/7ntUOXoYVGSaGAiHw5zUq4AIgIDqaTDf1mW06ol26xrVwrwZQOUSSlCRgs1R1Ptnuylh3EQ2QxqTwAAAIAAAACABAAAgAAiAgJ/Y5l1fS7/VaE2rQLGhLGDi2VW5fG2s0KCqUtrUAUQlhDZDGpPAAAAgAAAAIAFAACAAA=="
     psbt = Psbt.b64decode(psbt_str)
     assert psbt.b64encode() == psbt_str
 
-    to_be_finalized_psbt_string = "cHNidP8BAJoCAAAAAljoeiG1ba8MI76OcHBFbDNvfLqlyHV5JPVFiHuyq911AAAAAAD/////g40EJ9DsZQpoqka7CwmK6kQiwHGyyng1Kgd5WdB86h0BAAAAAP////8CcKrwCAAAAAAWABTYXCtx0AYLCcmIauuBXlCZHdoSTQDh9QUAAAAAFgAUAK6pouXw+HaliN9VRuh0LR2HAI8AAAAAAAEAuwIAAAABqtc5MQGL0l+ErkALaISL4J23BurCrBgpi6vucatlb4sAAAAASEcwRAIgWPb8fGoz4bMVSNSByCbAFb0wE1qtQs1neQ2rZtKtJDsCIEoc7SYExnNbY5PltBaR3XiwDwxZQvufdRhW+qk4FX26Af7///8CgPD6AgAAAAAXqRQPuUY0IWlrgsgzryQceMF9295JNIfQ8gonAQAAABepFCnKdPigj4GZlCgYXJe12FLkBj9hh2UAAAAiAgKVg785rgpgl0etGZrd1jT6YQhVnWxc05tMIYPxq5bgf0cwRAIgdAGK1BgAl7hzMjwAFXILNoTMgSOJEEjn282bVa1nnJkCIHPTabdA4+tT3O+jOCPIBwUUylWn3ZVE8VfBZ5EyYRGMASICAtq2H/SaFNtqfQKwzR+7ePxLGDErW05U2uTbovv+9TbXSDBFAiEA9hA4swjcHahlo0hSdG8BV3KTQgjG0kRUOTzZm98iF3cCIAVuZ1pnWm0KArhbFOXikHTYolqbV2C+ooFvZhkQoAbqAQEDBAEAAAABBEdSIQKVg785rgpgl0etGZrd1jT6YQhVnWxc05tMIYPxq5bgfyEC2rYf9JoU22p9ArDNH7t4/EsYMStbTlTa5Nui+/71NtdSriIGApWDvzmuCmCXR60Zmt3WNPphCFWdbFzTm0whg/GrluB/ENkMak8AAACAAAAAgAAAAIAiBgLath/0mhTban0CsM0fu3j8SxgxK1tOVNrk26L7/vU21xDZDGpPAAAAgAAAAIABAACAAAEBIADC6wsAAAAAF6kUt/X69A49QKWkWbHbNTXyty+pIeiHIgIDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtxHMEQCIGLrelVhB6fHP0WsSrWh3d9vcHX7EnWWmn84Pv/3hLyyAiAMBdu3Rw2/LwhVfdNWxzJcHtMJE+mWzThAlF2xIijaXwEiAgI63ZBPPW3PWd25BrDe4jUpt/+57VDl6GFRkmhgIh8Oc0cwRAIgZfRbpZmLWaJ//hp77QFq8fH5DVSzqo90UKpfVqJRA70CIH9yRwOtHtuWaAsoS1bU/8uI9/t1nqu+CKow8puFE4PSAQEDBAEAAAABBCIAIIwjUxc3Q7WV37Sge3K6jkLjeX2nTof+fZ10l+OyAokDAQVHUiEDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtwhAjrdkE89bc9Z3bkGsN7iNSm3/7ntUOXoYVGSaGAiHw5zUq4iBgI63ZBPPW3PWd25BrDe4jUpt/+57VDl6GFRkmhgIh8OcxDZDGpPAAAAgAAAAIADAACAIgYDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtwQ2QxqTwAAAIAAAACAAgAAgAAiAgOppMN/WZbTqiXbrGtXCvBlA5RJKUJGCzVHU+2e7KWHcRDZDGpPAAAAgAAAAIAEAACAACICAn9jmXV9Lv9VoTatAsaEsYOLZVbl8bazQoKpS2tQBRCWENkMak8AAACAAAAAgAUAAIAA"
-    to_be_finalized_psbt = Psbt.b64decode(to_be_finalized_psbt_string)
+    to_be_finalized_psbt = Psbt.b64decode(TO_BE_FINALIZED)
     finalized_psbt = finalize_psbt(to_be_finalized_psbt)
     assert finalized_psbt == psbt
 
@@ -755,7 +764,6 @@ def test_join_psbts() -> None:
         [psbt1, psbt2],
         enforce_same_tx_version=True,
         enforce_same_tx_lock_time=True,
-        merge_out=False,
         shuffle_inp=False,
         shuffle_out=False,
     )
@@ -769,14 +777,12 @@ def test_join_psbts() -> None:
         [psbt1, psbt2],
         enforce_same_tx_version=True,
         enforce_same_tx_lock_time=True,
-        merge_out=False,
         shuffle_inp=False,
         shuffle_out=False,
     ) == join_psbts(
         [psbt1, psbt2],
         enforce_same_tx_version=True,
         enforce_same_tx_lock_time=True,
-        merge_out=False,
         shuffle_inp=False,
         shuffle_out=False,
     )
@@ -788,7 +794,6 @@ def test_join_psbts() -> None:
             [psbt1, psbt2],
             enforce_same_tx_version=True,
             enforce_same_tx_lock_time=True,
-            merge_out=False,
             shuffle_inp=True,
             shuffle_out=True,
         )
@@ -803,7 +808,6 @@ def test_join_psbts() -> None:
             [psbt1, psbt2],
             enforce_same_tx_version=True,
             enforce_same_tx_lock_time=True,
-            merge_out=False,
             shuffle_inp=False,
             shuffle_out=False,
         )
@@ -817,7 +821,6 @@ def test_join_psbts() -> None:
             [psbt1, psbt2],
             enforce_same_tx_version=True,
             enforce_same_tx_lock_time=True,
-            merge_out=False,
             shuffle_inp=False,
             shuffle_out=False,
         )
@@ -836,7 +839,6 @@ def test_join_psbts() -> None:
             [psbt1, psbt2],
             enforce_same_tx_version=True,
             enforce_same_tx_lock_time=True,
-            merge_out=False,
             shuffle_inp=False,
             shuffle_out=False,
         )
@@ -858,7 +860,6 @@ def test_join_psbts() -> None:
             [psbt1, psbt2],
             enforce_same_tx_version=True,
             enforce_same_tx_lock_time=True,
-            merge_out=False,
             shuffle_inp=False,
             shuffle_out=False,
         )
@@ -871,21 +872,23 @@ def test_join_psbts() -> None:
             [psbt1, psbt2],
             enforce_same_tx_version=True,
             enforce_same_tx_lock_time=True,
-            merge_out=False,
             shuffle_inp=False,
             shuffle_out=False,
         )
 
-    psbt2 = Psbt.b64decode(psbt2_str)
-    with pytest.raises(BTClibValueError, match="output merge not implemented yet"):
-        join_psbts(
-            [psbt1, psbt2],
-            enforce_same_tx_version=True,
-            enforce_same_tx_lock_time=True,
-            merge_out=True,
-            shuffle_inp=False,
-            shuffle_out=False,
-        )
+    # there is no merge_out parameter to ask for an output merge with:
+    # coalescing two outputs paying one script invalidates every signature
+    # already made over the previous set, and after the shuffle above the
+    # result would depend on the order the merge ran in.
+    # What says so is the parameter list, rather than a merge_out=True
+    # call asserted to raise: that call raises a TypeError whose text is
+    # the interpreter's -- CPython's "unexpected keyword argument" -- and
+    # not a contract of this library, while the two asserts below are the
+    # contract itself, no parameter of that name and no **kwargs to
+    # swallow one
+    params = inspect.signature(join_psbts).parameters
+    assert "merge_out" not in params
+    assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 def test_shuffle_sort_inp_out() -> None:
@@ -1121,13 +1124,130 @@ def test_a_single_key_input_takes_one_signature() -> None:
     A p2wpkh output commits to one public key, so two partial signatures
     are two claims about which key that is; picking one is a guess, and
     the wrong guess builds a witness that will not run.
+
+    The second signature is a real one, made by a second key over the
+    same sig_hash, and it has to be: issue #173 put a signature check in
+    the finalizer ahead of this one, so a signature merely refiled under
+    another key is refused as invalid before the count is ever reached.
+    Two valid signatures are what isolate the count, and they are also
+    the case that matters -- two participants who each signed.
     """
-    psbt, _ = _single_key_psbt("p2wpkh")
-    other_key = bytes.fromhex(
-        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    psbt, prev_outs = _single_key_psbt("p2wpkh")
+    script_code = _p2pkh_script_code(hash160(_PUB_KEY))
+    msg_hash = sig_hash.segwit_v0(script_code, psbt.tx, 0, 1, prev_outs[0].value)
+    other_prv_key = _PRV_KEY + 1
+    other_pub_key = pub_keyinfo_from_prv_key(other_prv_key)[0]
+    psbt.inputs[0].partial_sigs[other_pub_key] = (
+        dsa.sign_(msg_hash, other_prv_key).serialize() + b"\x01"
     )
-    psbt.inputs[0].partial_sigs[other_key] = psbt.inputs[0].partial_sigs[_PUB_KEY]
+
     err_msg = "2 signatures for a single-key input"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize_psbt(psbt)
+
+
+def _one_input_finalized_each() -> tuple[Psbt, Psbt]:
+    """Return the two psbts of two participants, one input finalized each."""
+    finalized = finalize_psbt(Psbt.b64decode(TO_BE_FINALIZED))
+    first = Psbt.b64decode(TO_BE_FINALIZED)
+    second = Psbt.b64decode(TO_BE_FINALIZED)
+    first.inputs[0].final_script_sig = finalized.inputs[0].final_script_sig
+    second.inputs[1].final_script_sig = finalized.inputs[1].final_script_sig
+    second.inputs[1].final_script_witness = finalized.inputs[1].final_script_witness
+    return first, second
+
+
+def test_combining_takes_the_union_of_the_final_witnesses() -> None:
+    """A witness one psbt has and the other has not survives the combine.
+
+    BIP174's Combiner "must merge them into one PSBT", and the result
+    "must contain all of the key-value pairs from each of the PSBTs": two
+    participants finalizing one input each is the case that says so for
+    the witness, which is not a map and so is not merged pair by pair.
+    Both orders, the union being commutative when nothing conflicts.
+    """
+    finalized = finalize_psbt(Psbt.b64decode(TO_BE_FINALIZED))
+    first, second = _one_input_finalized_each()
+    for psbts in ([first, second], list(_one_input_finalized_each())[::-1]):
+        combined = combine_psbts(psbts)
+        assert combined.inputs[0].final_script_sig == (
+            finalized.inputs[0].final_script_sig
+        )
+        assert combined.inputs[1].final_script_witness == (
+            finalized.inputs[1].final_script_witness
+        )
+
+    # what conflicts is picked from, and the psbt combined *into* keeps
+    # what it has: the arbitrary choice BIP174 allows a Combiner, and the
+    # one Bitcoin Core's PSBTInput::Merge makes. Merging the two stacks
+    # element-wise is what must not happen -- a witness stack is
+    # positional, so two of them for one input are two spends of it
+    first, second = _one_input_finalized_each()
+    first.inputs[1].final_script_witness = Witness([b"\x01"])
+    combined = combine_psbts([first, second])
+    assert combined.inputs[1].final_script_witness == Witness([b"\x01"])
+
+
+def test_finalize_refuses_a_signature_of_another_sig_hash_type() -> None:
+    """BIP174 charges the Finalizer with the check, and it is per input.
+
+    "If the input has a PSBT_IN_SIGHASH_TYPE field, the Input Finalizer
+    must fail to finalize that input if any signature does not match the
+    specified sighash type." Skipping it finalizes a psbt into a
+    transaction whose signatures commit to something other than the input
+    asked for, and the input is what the other participants agreed to.
+    """
+    # the vector's own psbt: both inputs ask for SIGHASH_ALL, and every
+    # signature commits to it
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    assert psbt.inputs[0].sig_hash_type == 1
+    assert all(sig[-1] == 1 for sig in psbt.inputs[0].partial_sigs.values())
+    finalize_psbt(psbt)
+
+    psbt.inputs[0].sig_hash_type = 3
+    err_msg = "mismatched sig_hash type: 0x1 vs 0x3"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize_psbt(psbt)
+
+    # 0 is SIGHASH_DEFAULT, a type an input may ask for and no ECDSA
+    # signature carries: what BIP174 tests is the field's presence, so a
+    # falsy value is not an absent field
+    psbt.inputs[0].sig_hash_type = 0
+    err_msg = "mismatched sig_hash type: 0x1 vs 0x0"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize_psbt(psbt)
+
+    # no field, no check: the signatures say which type they commit to
+    psbt.inputs[0].sig_hash_type = None
+    finalize_psbt(psbt)
+
+
+def test_finalize_checks_a_partial_signature_against_its_pub_key() -> None:
+    """A signature filed under a key that did not make it is refused.
+
+    PsbtIn.assert_valid parses the DER and can do no more: what the
+    signature commits to is the whole transaction, which a per-field
+    validator has not got. The Finalizer has it, and BIP174 has it decide
+    "if the input has enough data to pass validation".
+    """
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    finalize_psbt(psbt)
+
+    # the two signatures of the 2-of-2 swapped between its two keys: both
+    # are DER, both keys are on the curve, and neither pair belongs
+    # together
+    keys = list(psbt.inputs[0].partial_sigs)
+    sigs = list(psbt.inputs[0].partial_sigs.values())
+    psbt.inputs[0].partial_sigs = {keys[0]: sigs[1], keys[1]: sigs[0]}
+    err_msg = "invalid partial signature for pub_key "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize_psbt(psbt)
+
+    # and the same for the segwit input, whose hash is BIP143's
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    keys = list(psbt.inputs[1].partial_sigs)
+    sigs = list(psbt.inputs[1].partial_sigs.values())
+    psbt.inputs[1].partial_sigs = {keys[0]: sigs[1], keys[1]: sigs[0]}
     with pytest.raises(BTClibValueError, match=err_msg):
         finalize_psbt(psbt)
 
@@ -1149,3 +1269,79 @@ def test_an_input_that_does_not_say_what_it_spends() -> None:
     psbt_in = finalize_psbt(psbt).inputs[0]
     assert psbt_in.final_script_sig == serialize([sig])
     assert not psbt_in.final_script_witness
+
+
+def test_the_sig_hash_of_an_input_that_does_not_say_what_it_spends() -> None:
+    """Four inputs whose hash is not computable, each finalized all the same.
+
+    None out of `_sig_hash_from_psbt_in` is "the psbt does not say what
+    is being signed", which is not evidence against the signature: the
+    Finalizer leaves such an input alone rather than refusing it.
+    """
+    # no utxo at all
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    psbt.inputs[0].non_witness_utxo = None
+    assert _sig_hash_from_psbt_in(psbt.inputs[0], psbt.tx, 0, 1) is None
+    finalize_psbt(psbt)
+
+    # p2sh with no redeem script: the script_pub_key names a hash, and
+    # the script it hashes is what would be signed
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    psbt.inputs[0].redeem_script = b""
+    assert _sig_hash_from_psbt_in(psbt.inputs[0], psbt.tx, 0, 1) is None
+    finalize_psbt(psbt)
+
+    # p2wsh with no witness script, which is the BIP143 script code
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    psbt.inputs[1].witness_script = b""
+    assert _sig_hash_from_psbt_in(psbt.inputs[1], psbt.tx, 1, 1) is None
+    finalize_psbt(psbt)
+
+    # a taproot output is spent with schnorr signatures, and they travel
+    # in the taproot fields: an ECDSA partial signature beside a p2tr
+    # script_pub_key is not a signature this hash would check
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    psbt.inputs[0].non_witness_utxo = None
+    psbt.inputs[0].witness_utxo = TxOut(100000, ScriptPubKey("5120" + "aa" * 32))
+    assert _sig_hash_from_psbt_in(psbt.inputs[0], psbt.tx, 0, 1) is None
+    finalize_psbt(psbt)
+
+
+def test_the_sig_hash_of_every_input_kind_a_partial_signature_signs() -> None:
+    """The helper's hash is the one the vectors' own signatures verify against.
+
+    BIP174's valid psbts carry three partial signatures, over a p2wsh
+    input and two p2wpkh ones; the p2sh and legacy dispatch is what the
+    Finalizer tests above exercise, that psbt's two inputs being a p2sh
+    2-of-2 and a p2sh-p2wsh one.
+    """
+    vectors = load("psbt", "_data", "bip174_test_vectors.json")["valid psbts"]
+    checked = 0
+    for vector in vectors:
+        psbt = Psbt.b64decode(vector["encoded psbt"])
+        for vin_i, psbt_in in enumerate(psbt.inputs):
+            for pub_key, sig in psbt_in.partial_sigs.items():
+                msg_hash = _sig_hash_from_psbt_in(psbt_in, psbt.tx, vin_i, sig[-1])
+                assert msg_hash is not None
+                assert dsa.verify_(msg_hash, pub_key, sig[:-1], lower_s=False)
+                checked += 1
+    # a count, so that a loop that stops finding signatures is a failure
+    # and not a green run over nothing
+    assert checked == 3
+
+
+def test_the_outpoint_names_an_output_of_the_non_witness_utxo() -> None:
+    """An index past that transaction's vout is refused, not an IndexError.
+
+    The tx_id check beside it does not answer this question, and both
+    readers of the spent output index with it: assert_signable, through
+    _signable_payload, and the sig_hash the Finalizer verifies against.
+    """
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    utxo = psbt.inputs[0].non_witness_utxo
+    assert utxo is not None
+    psbt.tx.vin[0].prev_out = OutPoint(utxo.id, len(utxo.vout))
+
+    err_msg = "outpoint vout out of range for the non-witness utxo"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        psbt.assert_valid()

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -16,6 +16,7 @@ those bytes given a node with the transaction index.
 tests/_data/README.md has its size and wtxid.
 """
 
+import inspect
 from os import path
 
 import pytest
@@ -401,7 +402,6 @@ def test_join_txs() -> None:
         [tx1, tx2],
         enforce_same_version=True,
         enforce_same_lock_time=True,
-        merge_out=False,
         shuffle_inp=False,
         shuffle_out=False,
     )
@@ -423,14 +423,12 @@ def test_join_txs() -> None:
         [tx1, tx2],
         enforce_same_version=True,
         enforce_same_lock_time=True,
-        merge_out=False,
         shuffle_inp=False,
         shuffle_out=False,
     ) == join_txs(
         [tx1, tx2],
         enforce_same_version=True,
         enforce_same_lock_time=True,
-        merge_out=False,
         shuffle_inp=False,
         shuffle_out=False,
     )
@@ -442,7 +440,6 @@ def test_join_txs() -> None:
             [tx1, tx2],
             enforce_same_version=True,
             enforce_same_lock_time=True,
-            merge_out=False,
             shuffle_inp=True,
             shuffle_out=True,
         )
@@ -456,7 +453,6 @@ def test_join_txs() -> None:
             [tx1, tx2],
             enforce_same_version=True,
             enforce_same_lock_time=True,
-            merge_out=False,
             shuffle_inp=False,
             shuffle_out=False,
         )
@@ -468,7 +464,6 @@ def test_join_txs() -> None:
             [tx1, tx2],
             enforce_same_version=True,
             enforce_same_lock_time=True,
-            merge_out=False,
             shuffle_inp=False,
             shuffle_out=False,
         )
@@ -480,21 +475,22 @@ def test_join_txs() -> None:
             [tx1, tx2],
             enforce_same_version=True,
             enforce_same_lock_time=True,
-            merge_out=False,
             shuffle_inp=False,
             shuffle_out=False,
         )
 
-    tx2 = Tx.parse(tx_bytes)
-    with pytest.raises(BTClibValueError, match="output merge not implemented yet"):
-        join_txs(
-            [tx1, tx2],
-            enforce_same_version=True,
-            enforce_same_lock_time=True,
-            merge_out=True,
-            shuffle_inp=False,
-            shuffle_out=False,
-        )
+    # outputs are concatenated and never merged, and no parameter asks for
+    # it: merging two outputs paying one script invalidates every
+    # signature already made over the previous set.
+    # What says so is the parameter list, rather than a merge_out=True
+    # call asserted to raise: that call raises a TypeError whose text is
+    # the interpreter's -- CPython's "unexpected keyword argument" -- and
+    # not a contract of this library, while the two asserts below are the
+    # contract itself, no parameter of that name and no **kwargs to
+    # swallow one
+    params = inspect.signature(join_txs).parameters
+    assert "merge_out" not in params
+    assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
 def test_eq() -> None:


### PR DESCRIPTION
Four unfinished behaviours in `btclib/psbt/`, each about what a BIP174
role is allowed to do, plus one of the two smaller markers the issue
lists beside them.

## 1. `_combine_field` and the witness

The marker claimed a `final_script_witness` present in one psbt and
absent from the other did not survive `combine_psbts`. Measured, it
does: a `Witness` defines `__len__`, so an empty one is falsy and the
`setattr` branch takes the finalized input from the other psbt, either
way round. What was missing was the test and the contract, and both are
here — two psbts with a different input finalized in each, combined both
ways round, and a conflict case pinning that the psbt combined *into*
keeps what it has, which is the arbitrary choice BIP174 allows a
Combiner and the one Bitcoin Core's `PSBTInput::Merge` makes.

The commented-out list branch beside the marker is not restored, and the
docstring says why: merging two witness stacks element-wise is the one
wrong answer, a stack being positional, so two of them for one input are
two spends of it and not the halves of one. `attr != item` is gone from
the dict branch, `update` with an equal map being a no-op.

## 2. `finalize` checks the sighash type

BIP174: "If the input has a `PSBT_IN_SIGHASH_TYPE` field, the Input
Finalizer must fail to finalize that input if any signature does not
match the specified sighash type." `mismatched sig_hash type: 0x1 vs
0x3` is the answer now. The field's *presence* is tested, not its
truthiness: `0` is SIGHASH_DEFAULT, a type an input may ask for and no
ECDSA signature carries, so an input asking for it is one no partial
signature can finalize. Refusal, acceptance, the `0` case and the
no-field case are each a test.

## 3. Output merging: the parameter is dropped

`merge_out` is gone from `join_psbts` **and** from `tx.join_txs`, which
carried the same parameter and the same raise. Specifying it was the
other exit and it is wrong twice over: coalescing two outputs that pay
one script changes the output *set*, so every signature already made
over the old one stops verifying, and both functions shuffle or sort the
outputs first, which would make the result depend on the order the merge
ran in. Summing two payments into one output is the caller's, before
signing, and the reasoning now sits in both docstrings.

Both functions had the parameter in `v2023.7.12`, checked against the
tag, so this is source-breaking: HISTORY.md's list gains a bullet, its
count goes to thirty and CHANGELOG.md's cross-reference with it.
`merge_out=False` is an argument to delete at each call site; nothing
else moves.

## 4. A partial signature is checked against its pub key

Verifying needs the sighash, i.e. the whole transaction, so the check
lives in `finalize_psbt` — the role BIP174 charges with deciding "if the
input has enough data to pass validation" — and `_assert_valid_partial_sigs`
keeps parsing the DER and nothing more, its comment now pointing at the
Finalizer rather than at this issue.

Covered is every input kind a `PSBT_IN_PARTIAL_SIG` can belong to:
legacy (p2pk, p2pkh, bare multisig), p2sh, p2wpkh, p2wsh, and either
witness kind wrapped in p2sh. An input that does not say what is being
signed is left alone rather than refused — no utxo, a p2sh input with no
redeem script, a p2wsh one with no witness script, and a taproot output,
whose signatures are schnorr and travel in the taproot fields. That is
four `None` cases, each tested, and BIP174's own valid vectors are
walked to check the hash the helper computes is the one their three
signatures verify against. `sig_hash.from_tx` could not serve: it reads
the redeem script off the input's `script_sig` and the witness script
off its witness stack, which a psbt's unsigned transaction does not
carry.

Two consequences worth naming. Verification uses `lower_s=False`,
because the question is whether that key made that signature and the
low-s rule is policy the script engine applies under its flags — Core's
`CPubKey::Verify` normalizes `s` for the same reason. And reading the
spent output wanted one more rule in `Psbt.assert_valid`: the outpoint
names an output the non-witness utxo has, where an index past its vout
was an `IndexError` out of `_signable_payload` as well.

## Also: the smaller marker on psbt_in serialization

`_DROPPED_ONCE_FINALIZED` is now the whole of what Core's
`PSBTInput::Serialize` writes inside `if (final_script_sig.empty() &&
final_script_witness.IsNull())`: the four preimage maps and the six
taproot fields join the five btclib already dropped. Small and testable,
so it is taken; no BIP174 or BIP371 vector round-trips differently, and
a data-driven test pins each field of the set as serialized when the
input is not finalized and absent when it is.

The other smaller marker, `bip32/key_origin.py`'s size checks, is **not**
taken: honouring `check_validity=False` there means threading the flag
through `decode_from_bip32_derivs` into `BIP32KeyOrigin` and every
`from_dict` above it, which is a design question rather than a tidy-up.
Its marker still points here, which is why this is `Refs` and not
`Closes`.

## Verification

Every gate run to completion, exit code checked:

- `uv run pytest` — 14794 passed, exit 0
- `uv run pytest --cov=btclib --cov=tests` — 14794 passed; the ratchet
  reports `99.99%` with two statements missed, both in
  `btclib/mnemonic/electrum.py` (317-318) and both pre-existing on `dev`
  from `b9a2f5d9`. Nothing added here is uncovered: with `--cov` limited
  to the touched modules they report complete coverage
- `uv run pre-commit run --all-files` — exit 0 (ruff-check and
  ruff-format rewrote two files on the first pass; re-staged and re-run
  to green)
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — build succeeded,
  exit 0

Sibling PRs move the CHANGELOG entry count too; re-derive it at merge with `grep -c '^- ' CHANGELOG.md`.

Refs #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen PSBT finalization and joining semantics to fully align with BIP174, tighten validation of spent outputs, and document the resulting breaking changes.

New Features:
- Introduce helpers to derive the sighash for each PSBT input type and verify partial signatures against their associated public keys during finalization.
- Extend PSBT input finalization semantics to drop all preimage and taproot-related fields once an input is finalized, matching Bitcoin Core’s behaviour.

Bug Fixes:
- Ensure PSBT validation fails with a clear error when an input’s outpoint index is out of range for the provided non-witness UTXO.
- Guarantee that combining PSBTs preserves finalized witnesses and does not attempt to merge witness stacks element-wise, avoiding invalid spend constructions.
- Treat inputs that lack sufficient UTXO or script data as unverifiable for signature checks without rejecting them outright, preventing incorrect failures.

Enhancements:
- Remove the merge_out parameter from PSBT and transaction joining functions so outputs are always concatenated, avoiding unsafe output coalescing that would invalidate existing signatures.
- Clarify PSBT finalizer responsibilities by enforcing per-input sighash type consistency and signature verification, and updating internal helpers accordingly.

Documentation:
- Update CHANGELOG and HISTORY to describe the new PSBT finalization rules, stricter validation of outpoints, and the removal of the merge_out parameter as source-breaking changes.

Tests:
- Add comprehensive tests covering PSBT combination of finalized witnesses, sighash type mismatches, partial signature verification across all supported input types, behaviour for inputs lacking spend information, and the expanded set of fields dropped on PSBT input finalization.
- Adjust PSBT and transaction joining tests to reflect the removal of the merge_out parameter and the permanent concatenation-only output behaviour.