### PR TITLE
Output descriptors: parse and derive, beyond the checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1566,6 +1566,29 @@ edit.
 
 ### The public API and the module layout
 
+- **`btclib.descriptors` reads a descriptor and derives its scripts**,
+  where it used to compute the checksum and nothing else. `parse` returns
+  a `Descriptor`, one class per grammar function, and
+  `script_pub_keys(index)` answers with the `ScriptPubKey` set the
+  descriptor pays to at that index — with the address of each, where the
+  script has one. The grammar is BIP 380 to BIP 386 and BIP 389 minus
+  miniscript: `pk`, `pkh`, `wpkh`, `combo`, `sh`, `wsh`, `multi`,
+  `sortedmulti`, `addr`, `raw`, and `tr` with a key path and a tree of
+  `pk()` leaves; key expressions cover hex keys compressed, uncompressed
+  and x-only, WIF, xpub/xprv with a derivation path, key origin, the `/*`
+  and `/*h` wildcards and both hardened markers, and
+  `multipath_descriptors` expands the BIP 389 `<a;b>` form into the
+  descriptors it stands for. `strip_checksum` and `add_checksum` are the
+  two halves of the checksum a caller needs, and `parse` verifies one
+  that is there. Every position rule is enforced rather than assumed —
+  `sh()` at the top level only, no uncompressed key inside a witness
+  program, x-only only inside `tr()` — and what is not implemented raises
+  NotImplementedError naming what it is: miniscript is issue #187,
+  `multi_a` and `sortedmulti_a` are BIP 387, `rawtr` is BIP 386 and
+  `musig` is BIP 390. The derivation is checked against Bitcoin Core's
+  own `descriptor_tests.cpp` vectors, both spellings of each, so a WIF
+  and an xprv are checked to reach the script their public halves reach
+  (issue #186)
 - **`script.parse` has lost its `accept_unknown` parameter**, with the
   answer fixed at what every caller in the library passed: a byte no
   table names is an op code all the same, refused by the interpreter that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1569,7 +1569,7 @@ edit.
 - **`btclib.descriptors` reads a descriptor and derives its scripts**,
   where it used to compute the checksum and nothing else. `parse` returns
   a `Descriptor`, one class per grammar function, and
-  `script_pub_keys(index)` answers with the `ScriptPubKey` set the
+  `script_pub_keys(index)` answers with the `ScriptPubKey` set that the
   descriptor pays to at that index — with the address of each, where the
   script has one. The grammar is BIP 380 to BIP 386 and BIP 389 minus
   miniscript: `pk`, `pkh`, `wpkh`, `combo`, `sh`, `wsh`, `multi`,

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -247,6 +247,12 @@ and `verify` families now let a `TypeError` out where they used to answer
   retried as another format; the script verification flags are an
   `enum.Flag`, where a misspelled name used to be a silently disabled
   consensus rule.
+- **A descriptor is now an address, not just a checksum.**
+  `descriptors.parse` reads BIP 380 to BIP 386 and BIP 389 — everything
+  but miniscript — and hands back the scripts and addresses a descriptor
+  pays to at any index, so one line of text is enough to watch a wallet.
+  Checked against Bitcoin Core's own vectors; miniscript and the four
+  functions left out say so by name rather than being read wrong.
 - **BIP340 messages of any size**, as the BIP has allowed since 2023-04:
   the four vectors btclib used to `xfail` all verify.
 - **MuSig2 is implemented**, `btclib.ecc.musig2` against all 56 cases of

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -7,12 +7,59 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Descriptors util functions.
+"""Output descriptors: the checksum, the parser, and the scripts.
+
+A descriptor says which scripts a wallet owns, in one line of text. This
+module reads that line and answers with the scripts, which is the half of
+a descriptor implementation the receiving side needs: `parse` returns a
+`Descriptor`, and `Descriptor.script_pub_keys` returns what the descriptor
+pays to at an index. The other half, satisfying a script -- descriptor
+plus signatures to a witness or a scriptSig -- is not here; the fragment
+classes below are one per grammar function so that it has somewhere to go
+(issue #186).
 
 BIP 380: https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki
+
+The grammar read is BIP 380 to BIP 386 and BIP 389, minus miniscript:
+
+- ``pk``, ``pkh``, ``wpkh``, ``combo`` (BIP 381, BIP 382, BIP 384)
+- ``sh``, ``wsh``, including ``sh(wpkh())`` and ``sh(wsh())``
+- ``multi``, ``sortedmulti`` (BIP 383)
+- ``addr``, ``raw`` (BIP 385)
+- ``tr``, with a key path and a script tree of ``pk()`` leaves (BIP 386)
+- key expressions: hex public keys (compressed, uncompressed and, inside
+  ``tr()``, x-only), WIF private keys, xpub/xprv with a derivation path,
+  key origin, ``/*`` and ``/*h`` wildcards, both ``h`` and ``'`` hardened
+  markers
+- the ``<a;b>`` multipath form of BIP 389, through `multipath_descriptors`
+
+What raises NotImplementedError, rather than being read wrong: every
+miniscript expression, which is issue #187; and ``multi_a``,
+``sortedmulti_a``, ``rawtr`` and ``musig``, which are BIP 387, BIP 386
+and BIP 390 and belong with the work that adds them.
+
+The network is a parameter of `parse` and not part of a descriptor: a
+descriptor names keys and scripts, and the same one means something on
+any chain, which is why Bitcoin Core takes the chain from its own context
+too. ``addr()`` is the exception, an address carrying the network in its
+own prefix.
 """
 
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from btclib.alias import ScriptList, TaprootScriptTree
+from btclib.bip32.bip32 import BIP32KeyData, derive
+from btclib.bip32.der_path import int_from_index_str
+from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
+from btclib.script.script_pub_key import ScriptPubKey
+from btclib.to_pub_key import point_from_pub_key, pub_keyinfo_from_key
+from btclib.utils import bytes_from_octets
 
 INPUT_CHARSET = "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ "
 CHECKSUM_CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l"
@@ -57,6 +104,758 @@ def descriptor_checksum(descriptor: str) -> str:
     return "".join(CHECKSUM_CHARSET[(checksum >> (5 * (7 - i))) & 31] for i in range(8))
 
 
+def strip_checksum(descriptor: str) -> str:
+    """Return the descriptor without its checksum, verifying a present one.
+
+    A descriptor without one comes back unchanged: the checksum is
+    optional in the language, and only some of Bitcoin Core's RPCs
+    require it. What is never accepted is a checksum that does not match,
+    which is what the eight characters are there for.
+    """
+    body, separator, checksum = descriptor.partition("#")
+    if "#" in checksum:
+        raise BTClibValueError(f"more than one '#' in the descriptor: {descriptor}")
+    # computed before the comparison, and whether or not there is one to
+    # compare against: it is also what refuses a character outside
+    # INPUT_CHARSET, which is an error in a descriptor with no checksum
+    expected = descriptor_checksum(body)
+    if separator and checksum != expected:
+        err_msg = f"invalid descriptor checksum: {checksum}, {expected} expected"
+        raise BTClibValueError(err_msg)
+    return body
+
+
+def add_checksum(descriptor: str) -> str:
+    """Return the descriptor with its checksum, verifying a present one."""
+    body = strip_checksum(descriptor)
+    return f"{body}#{descriptor_checksum(body)}"
+
+
 def descriptor_from_address(address: str) -> str:
-    descriptor = f"addr({address})"
-    return f"{descriptor}#{descriptor_checksum(descriptor)}"
+    return add_checksum(f"addr({address})")
+
+
+# the tapscript leaf version, which is the only one a BIP 386 tree has
+_TAPSCRIPT_LEAF_VERSION = 0xC0
+
+# where a SCRIPT expression sits. BIP 381 to BIP 386 give each function a
+# position rule -- sh() is top level only, wpkh() is top level or inside
+# sh(), and so on -- so the context is an argument of the parser, and
+# these strings are what its error messages say
+_TOP = "top level"
+_P2SH = "sh()"
+_P2WSH = "wsh()"
+_P2TR = "tr()"
+
+# BIP 379 fragments that are miniscript and nothing else. pk, pkh and
+# multi are miniscript too, but they are descriptor functions first and
+# are read as such; a wrapper (`s:pk(...)`) is caught by the colon
+_MINISCRIPT_FRAGMENTS = frozenset(
+    (
+        "pk_k",
+        "pk_h",
+        "older",
+        "after",
+        "sha256",
+        "hash256",
+        "ripemd160",
+        "hash160",
+        "andor",
+        "and_v",
+        "and_b",
+        "and_n",
+        "or_b",
+        "or_c",
+        "or_d",
+        "or_i",
+        "thresh",
+    )
+)
+
+# descriptor functions read as such and refused rather than guessed at:
+# each is a specification of its own, and a script derived wrong is an
+# address that loses money
+_UNIMPLEMENTED = {
+    "multi_a": "BIP 387",
+    "sortedmulti_a": "BIP 387",
+    "rawtr": "BIP 386",
+    "musig": "BIP 390",
+}
+
+_FINGERPRINT = re.compile("[0-9a-fA-F]{8}")
+_DERIVATION_INDEX = re.compile("[0-9]+[h']?")
+_HEX = re.compile("[0-9a-fA-F]*")
+_THRESHOLD = re.compile("[0-9]+")
+# the BIP 389 multipath step, brackets included: re.split hands back what
+# it split on when the pattern captures it
+_MULTIPATH_STEP = re.compile("(<[^<>]*>)")
+
+
+@dataclass(frozen=True)
+class KeyExpression:
+    """A BIP 380 KEY expression: an origin, a key, a derivation path.
+
+    Either `pub_key` is the key the descriptor fixes, in SEC bytes, or
+    `xkey` is the extended key that `der_path` and `wildcard` derive
+    from. An x-only key is held as its even-y SEC form, which is what
+    BIP 340 says those 32 bytes mean, so that everything downstream sees
+    one representation of a public key.
+
+    `origin` never changes the script. It says which master key and which
+    path the key came from, which is what a hardware signer needs and
+    what BIP 174 carries in a PSBT.
+    """
+
+    origin: BIP32KeyOrigin | None = None
+    pub_key: bytes | None = None
+    xkey: str = ""
+    der_path: tuple[int, ...] = ()
+    # the final `/*` step, as the offset its hardening adds to the index:
+    # None where the descriptor has no wildcard, 0 for `/*`, 2**31 for
+    # `/*h`. One field rather than a flag and a bool, because "hardened"
+    # is only meaningful when there is a wildcard to harden
+    wildcard: int | None = None
+    x_only: bool = False
+
+    @property
+    def is_ranged(self) -> bool:
+        return self.wildcard is not None
+
+    @property
+    def is_compressed(self) -> bool:
+        """Return False for an uncompressed SEC public key, True otherwise.
+
+        An extended key is compressed by construction: BIP 32 has no
+        uncompressed serialization.
+        """
+        return self.pub_key is None or len(self.pub_key) == 33
+
+    def sec(self, index: int = 0, network: str = "mainnet") -> bytes:
+        """Return the SEC public key bytes, derived at `index` if ranged."""
+        if self.pub_key is not None:
+            return self.pub_key
+        der_path = list(self.der_path)
+        if self.wildcard is not None:
+            der_path.append(self.wildcard + index)
+        return pub_keyinfo_from_key(derive(self.xkey, der_path), network)[0]
+
+
+# a tr() script tree: a `pk()` leaf, or a branch of two subtrees. The
+# leaves are KEY expressions and not scripts because a ranged descriptor
+# has no script until an index is given
+DescriptorTree = KeyExpression | tuple["DescriptorTree", "DescriptorTree"]
+
+
+def _tree_keys(tree: DescriptorTree) -> tuple[KeyExpression, ...]:
+    if isinstance(tree, KeyExpression):
+        return (tree,)
+    return _tree_keys(tree[0]) + _tree_keys(tree[1])
+
+
+def _taproot_script_tree(
+    tree: DescriptorTree, index: int, network: str
+) -> TaprootScriptTree:
+    if isinstance(tree, KeyExpression):
+        script: ScriptList = [tree.sec(index, network)[1:], "OP_CHECKSIG"]
+        return [(_TAPSCRIPT_LEAF_VERSION, script)]
+    return [
+        _taproot_script_tree(tree[0], index, network),
+        _taproot_script_tree(tree[1], index, network),
+    ]
+
+
+@dataclass(frozen=True, kw_only=True)
+class Descriptor(ABC):
+    """A parsed output descriptor: the scripts it describes, on demand.
+
+    Keyword-only so that the fragments below can add positional fields of
+    their own: a dataclass field with a default followed by one without
+    is a TypeError, and `network` has a default.
+    """
+
+    network: str = "mainnet"
+
+    @property
+    @abstractmethod
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return every KEY expression the descriptor holds."""
+
+    @abstractmethod
+    def _scripts(self, index: int) -> list[bytes]:
+        """Return the scriptPubKey bytes at `index`, in Bitcoin Core's order."""
+
+    @property
+    def is_ranged(self) -> bool:
+        """Return True if the descriptor describes a range of scripts."""
+        return any(key.is_ranged for key in self.key_expressions)
+
+    def script_pub_keys(self, index: int = 0) -> list[ScriptPubKey]:
+        """Return the scripts the descriptor describes at `index`.
+
+        A list because ``combo()`` is a set of scripts and not one
+        script; every other fragment answers with exactly one.
+        """
+        if not 0 <= index < 0x80000000:
+            raise BTClibValueError(f"invalid derivation index: {index}")
+        if index and not self.is_ranged:
+            err_msg = f"not a ranged descriptor: no script at index {index}"
+            raise BTClibValueError(err_msg)
+        return [ScriptPubKey(script, self.network) for script in self._scripts(index)]
+
+    def script_pub_key(self, index: int = 0) -> ScriptPubKey:
+        """Return the one script the descriptor describes at `index`."""
+        script_pub_keys = self.script_pub_keys(index)
+        if len(script_pub_keys) != 1:
+            err_msg = f"{len(script_pub_keys)} scripts: use script_pub_keys instead"
+            raise BTClibValueError(err_msg)
+        return script_pub_keys[0]
+
+    def redeem_script(self, index: int = 0) -> bytes:
+        """Return the script that ``sh()`` or ``wsh()`` embeds this one as."""
+        return self.script_pub_key(index).script
+
+    def address(self, index: int = 0) -> str:
+        """Return the address of the script at `index`, if it has one."""
+        return self.script_pub_key(index).address
+
+    def addresses(self, index: int = 0) -> list[str]:
+        """Return the address of each script at `index`, empty where none."""
+        return [
+            script_pub_key.address for script_pub_key in self.script_pub_keys(index)
+        ]
+
+
+@dataclass(frozen=True)
+class PkDescriptor(Descriptor):
+    """``pk(KEY)``: a P2PK output, BIP 381."""
+
+    key: KeyExpression
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        return (self.key,)
+
+    def _scripts(self, index: int) -> list[bytes]:
+        return [ScriptPubKey.p2pk(self.key.sec(index, self.network)).script]
+
+
+@dataclass(frozen=True)
+class PkhDescriptor(Descriptor):
+    """``pkh(KEY)``: a P2PKH output, BIP 381."""
+
+    key: KeyExpression
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        return (self.key,)
+
+    def _scripts(self, index: int) -> list[bytes]:
+        return [ScriptPubKey.p2pkh(self.key.sec(index, self.network)).script]
+
+
+@dataclass(frozen=True)
+class WpkhDescriptor(Descriptor):
+    """``wpkh(KEY)``: a P2WPKH output, BIP 382."""
+
+    key: KeyExpression
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        return (self.key,)
+
+    def _scripts(self, index: int) -> list[bytes]:
+        return [ScriptPubKey.p2wpkh(self.key.sec(index, self.network)).script]
+
+
+@dataclass(frozen=True)
+class ShDescriptor(Descriptor):
+    """``sh(SCRIPT)``: the argument, P2SH-embedded, BIP 381."""
+
+    inner: Descriptor
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        return self.inner.key_expressions
+
+    def _scripts(self, index: int) -> list[bytes]:
+        return [ScriptPubKey.p2sh(self.inner.redeem_script(index)).script]
+
+
+@dataclass(frozen=True)
+class WshDescriptor(Descriptor):
+    """``wsh(SCRIPT)``: the argument, P2WSH-embedded, BIP 382."""
+
+    inner: Descriptor
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        return self.inner.key_expressions
+
+    def _scripts(self, index: int) -> list[bytes]:
+        return [ScriptPubKey.p2wsh(self.inner.redeem_script(index)).script]
+
+
+@dataclass(frozen=True)
+class MultiDescriptor(Descriptor):
+    """``multi(k,KEY,...)`` and ``sortedmulti(k,KEY,...)``, BIP 383."""
+
+    threshold: int
+    keys: tuple[KeyExpression, ...]
+    # BIP 67 ordering, which is the whole difference between the two
+    # functions: the keys of a sortedmulti() are sorted in the script, so
+    # the participants need not agree on an order to agree on an address
+    sort: bool = False
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        return self.keys
+
+    def _scripts(self, index: int) -> list[bytes]:
+        pub_keys = [key.sec(index, self.network) for key in self.keys]
+        script_pub_key = ScriptPubKey.p2ms(
+            self.threshold, pub_keys, self.network, lexicographic_sorting=self.sort
+        )
+        return [script_pub_key.script]
+
+
+@dataclass(frozen=True)
+class ComboDescriptor(Descriptor):
+    """``combo(KEY)``: the scripts an old wallet would have used, BIP 384.
+
+    P2PK and P2PKH, plus P2WPKH and P2SH-P2WPKH when the key is
+    compressed -- an uncompressed key is not allowed in a witness
+    program.
+    """
+
+    key: KeyExpression
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        return (self.key,)
+
+    def _scripts(self, index: int) -> list[bytes]:
+        pub_key = self.key.sec(index, self.network)
+        scripts = [
+            ScriptPubKey.p2pk(pub_key).script,
+            ScriptPubKey.p2pkh(pub_key).script,
+        ]
+        if self.key.is_compressed:
+            p2wpkh = ScriptPubKey.p2wpkh(pub_key).script
+            scripts += [p2wpkh, ScriptPubKey.p2sh(p2wpkh).script]
+        return scripts
+
+
+@dataclass(frozen=True)
+class AddrDescriptor(Descriptor):
+    """``addr(ADDR)``: the script the address expands to, BIP 385."""
+
+    addr: str
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        return ()
+
+    def _scripts(self, index: int) -> list[bytes]:
+        return [ScriptPubKey.from_address(self.addr).script]
+
+
+@dataclass(frozen=True)
+class RawDescriptor(Descriptor):
+    """``raw(HEX)``: the script those bytes are, BIP 385."""
+
+    script: bytes
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        return ()
+
+    def _scripts(self, index: int) -> list[bytes]:
+        return [self.script]
+
+
+@dataclass(frozen=True)
+class TrDescriptor(Descriptor):
+    """``tr(KEY)`` or ``tr(KEY,TREE)``: a P2TR output, BIP 386."""
+
+    internal_key: KeyExpression
+    tree: DescriptorTree | None = None
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        if self.tree is None:
+            return (self.internal_key,)
+        return (self.internal_key, *_tree_keys(self.tree))
+
+    def _scripts(self, index: int) -> list[bytes]:
+        script_tree = (
+            None
+            if self.tree is None
+            else _taproot_script_tree(self.tree, index, self.network)
+        )
+        internal_key = self.internal_key.sec(index, self.network)
+        return [ScriptPubKey.p2tr(internal_key, script_tree).script]
+
+
+def _split_arguments(arguments: str) -> list[str]:
+    """Split a comma-separated argument list, at nesting depth zero.
+
+    Parentheses and braces only: they are what nests and what can hold a
+    comma of its own, a nested SCRIPT expression and a tr() branch. The
+    key origin brackets are deliberately not counted, so that a bracket
+    written wrong reaches the key expression parser, which can say which
+    of the two ways it is wrong.
+    """
+    depth = 0
+    start = 0
+    result = []
+    for i, char in enumerate(arguments):
+        if char in "({":
+            depth += 1
+        elif char in ")}":
+            depth -= 1
+            if depth < 0:
+                raise BTClibValueError(f"unbalanced brackets: {arguments}")
+        elif char == "," and depth == 0:
+            result.append(arguments[start:i])
+            start = i + 1
+    if depth:
+        raise BTClibValueError(f"unbalanced brackets: {arguments}")
+    result.append(arguments[start:])
+    return result
+
+
+def _split_function(expression: str) -> tuple[str, str]:
+    """Return the function name and the argument string it encloses."""
+    open_bracket = expression.find("(")
+    if open_bracket < 1 or not expression.endswith(")"):
+        raise BTClibValueError(f"not a descriptor expression: {expression}")
+    return expression[:open_bracket], expression[open_bracket + 1 : -1]
+
+
+def _assert_implemented(name: str) -> None:
+    if ":" in name or name in _MINISCRIPT_FRAGMENTS:
+        err_msg = f"miniscript is not implemented: {name} (issue #187)"
+        raise NotImplementedError(err_msg)
+    if name in _UNIMPLEMENTED:
+        err_msg = f"{name}() is not implemented ({_UNIMPLEMENTED[name]})"
+        raise NotImplementedError(err_msg)
+
+
+def _assert_position(name: str, context: str, allowed: tuple[str, ...]) -> None:
+    if context not in allowed:
+        raise BTClibValueError(f"{name}() is not allowed inside {context}")
+
+
+def _one_argument(arguments: list[str], name: str) -> str:
+    if len(arguments) != 1:
+        err_msg = f"{name}() takes one argument, {len(arguments)} given"
+        raise BTClibValueError(err_msg)
+    return arguments[0]
+
+
+def _der_path(path: str) -> list[int]:
+    """Return the indexes of a `/`-separated derivation path."""
+    if not path:
+        return []
+    indexes = []
+    for step in path.split("/"):
+        if not _DERIVATION_INDEX.fullmatch(step):
+            raise BTClibValueError(f"invalid derivation index: {step}")
+        # int_from_index_str is what refuses 2**31 and above written
+        # unhardened, there being no such BIP 32 index
+        indexes.append(int_from_index_str(step))
+    return indexes
+
+
+def _key_origin(description: str) -> BIP32KeyOrigin:
+    """Return the key origin of a `[fingerprint/path]` prefix."""
+    fingerprint, _, path = description.partition("/")
+    if not _FINGERPRINT.fullmatch(fingerprint):
+        raise BTClibValueError(f"invalid key origin fingerprint: {fingerprint}")
+    return BIP32KeyOrigin(fingerprint, _der_path(path))
+
+
+def _pub_key_from_hex(key: str, *, x_only: bool) -> tuple[bytes, bool]:
+    """Return the SEC bytes of a hex key, and whether it was x-only."""
+    length = len(key)
+    if length == 64:
+        if not x_only:
+            raise BTClibValueError("x-only public keys are allowed inside tr() only")
+        # the even-y lift of BIP 340, which is what an x-only key means
+        pub_key = b"\x02" + bytes_from_octets(key)
+    elif length in (66, 130):
+        prefix = key[:2]
+        if (length == 66 and prefix not in ("02", "03")) or (
+            length == 130 and prefix != "04"
+        ):
+            # 06 and 07 are the hybrid encoding, which nothing in bitcoin
+            # produces and Bitcoin Core refuses in a descriptor too
+            raise BTClibValueError(f"invalid public key prefix: 0x{prefix}")
+        pub_key = bytes_from_octets(key)
+    else:
+        raise BTClibValueError(f"invalid public key length: {length} characters")
+    # a key expression is parsed in order to be used, and a point off the
+    # curve has no script to derive: refuse it here, where the error can
+    # still say it was the key
+    point_from_pub_key(pub_key)
+    return pub_key, length == 64
+
+
+def _is_extended_key(key: str) -> bool:
+    try:
+        BIP32KeyData.b58decode(key)
+    # ValueError, not Exception: the question is whether these characters
+    # are an extended key, and characters that are not are False
+    except ValueError:
+        return False
+    return True
+
+
+def _origin_and_rest(expression: str) -> tuple[BIP32KeyOrigin | None, str]:
+    """Split the `[fingerprint/path]` prefix off a KEY expression."""
+    if not expression.startswith("["):
+        if "]" in expression:
+            raise BTClibValueError("']' without the '[' that opens a key origin")
+        return None, expression
+    end = expression.find("]")
+    if end < 0:
+        raise BTClibValueError("missing ']' in the key origin")
+    return _key_origin(expression[1:end]), expression[end + 1 :]
+
+
+def _assert_key_characters(rest: str) -> None:
+    """Refuse what a KEY expression cannot hold once the origin is off."""
+    if "]" in rest:
+        raise BTClibValueError("more than one ']' in a single key expression")
+    if "<" in rest:
+        err_msg = "multipath key expression: use multipath_descriptors first"
+        raise BTClibValueError(err_msg)
+    if "(" in rest:
+        # the one KEY expression that is a function is BIP 390's musig(),
+        # and a key nothing reads is not a key to guess at
+        _assert_implemented(rest[: rest.index("(")])
+        raise BTClibValueError("not a key expression")
+
+
+def _split_wildcard(steps: list[str]) -> tuple[list[str], int | None]:
+    """Split the final `/*` step, if any, off a derivation path."""
+    if steps and steps[-1] in ("*", "*'", "*h"):
+        return steps[:-1], 0 if steps[-1] == "*" else 0x80000000
+    return steps, None
+
+
+def _fixed_pub_key(key: str, *, x_only: bool) -> tuple[bytes, bool]:
+    """Return the SEC bytes of a hex or WIF key, and whether x-only."""
+    if _HEX.fullmatch(key):
+        return _pub_key_from_hex(key, x_only=x_only)
+    # what is left is a WIF, and pub_keyinfo_from_key answers both for it
+    # and for characters that are no key expression at all
+    try:
+        return pub_keyinfo_from_key(key)[0], False
+    except (TypeError, ValueError) as e:
+        raise BTClibValueError("invalid key expression") from e
+
+
+def _parse_key(
+    expression: str, *, x_only: bool = False, compressed: bool = False
+) -> KeyExpression:
+    """Return the KeyExpression of a BIP 380 KEY expression.
+
+    Never echo the key in an error message: a KEY expression is a WIF or
+    an xprv as often as it is a public key, and an error message ends up
+    in logs and in bug reports.
+    """
+    origin, rest = _origin_and_rest(expression)
+    _assert_key_characters(rest)
+    key, separator, path = rest.partition("/")
+    if _is_extended_key(key):
+        steps, wildcard = _split_wildcard(path.split("/") if separator else [])
+        return KeyExpression(
+            origin=origin,
+            xkey=key,
+            der_path=tuple(_der_path("/".join(steps))),
+            wildcard=wildcard,
+        )
+    if separator:
+        raise BTClibValueError("derivation path after a key that cannot derive")
+    pub_key, was_x_only = _fixed_pub_key(key, x_only=x_only)
+    key_expression = KeyExpression(origin=origin, pub_key=pub_key, x_only=was_x_only)
+    if compressed and not key_expression.is_compressed:
+        raise BTClibValueError("uncompressed public keys are not allowed here")
+    return key_expression
+
+
+def _parse_tree(expression: str) -> DescriptorTree:
+    """Return the script tree of a BIP 386 TREE expression."""
+    if expression.startswith("{"):
+        if not expression.endswith("}"):
+            raise BTClibValueError(f"unbalanced braces: {expression}")
+        branches = _split_arguments(expression[1:-1])
+        if len(branches) != 2:
+            err_msg = f"a tr() branch takes two subtrees, {len(branches)} given"
+            raise BTClibValueError(err_msg)
+        return (_parse_tree(branches[0]), _parse_tree(branches[1]))
+    name, arguments = _split_function(expression)
+    _assert_implemented(name)
+    if name != "pk":
+        raise NotImplementedError(f"{name}() inside tr() is not implemented")
+    key = _one_argument(_split_arguments(arguments), name)
+    return _parse_key(key, x_only=True, compressed=True)
+
+
+# inside a witness program an uncompressed key is unspendable, so
+# BIP 382 refuses one rather than describing a script nobody can spend;
+# inside tr() the keys are x-only to begin with
+def _no_uncompressed(context: str) -> bool:
+    return context in (_P2WSH, _P2TR)
+
+
+def _parse_pk(args: list[str], context: str, network: str) -> Descriptor:
+    key = _parse_key(
+        _one_argument(args, "pk"),
+        x_only=context == _P2TR,
+        compressed=_no_uncompressed(context),
+    )
+    return PkDescriptor(key, network=network)
+
+
+def _parse_pkh(args: list[str], context: str, network: str) -> Descriptor:
+    key = _parse_key(_one_argument(args, "pkh"), compressed=_no_uncompressed(context))
+    return PkhDescriptor(key, network=network)
+
+
+def _parse_wpkh(args: list[str], context: str, network: str) -> Descriptor:
+    key = _parse_key(_one_argument(args, "wpkh"), compressed=True)
+    return WpkhDescriptor(key, network=network)
+
+
+def _parse_combo(args: list[str], context: str, network: str) -> Descriptor:
+    return ComboDescriptor(_parse_key(_one_argument(args, "combo")), network=network)
+
+
+def _parse_sh(args: list[str], context: str, network: str) -> Descriptor:
+    inner = _parse_expression(_one_argument(args, "sh"), _P2SH, network)
+    return ShDescriptor(inner, network=network)
+
+
+def _parse_wsh(args: list[str], context: str, network: str) -> Descriptor:
+    inner = _parse_expression(_one_argument(args, "wsh"), _P2WSH, network)
+    return WshDescriptor(inner, network=network)
+
+
+def _parse_multi(name: str, args: list[str], context: str, network: str) -> Descriptor:
+    if len(args) < 2:
+        raise BTClibValueError(f"{name}() takes a threshold and at least one key")
+    if not _THRESHOLD.fullmatch(args[0]):
+        raise BTClibValueError(f"invalid {name}() threshold: {args[0]}")
+    keys = tuple(
+        _parse_key(key, compressed=_no_uncompressed(context)) for key in args[1:]
+    )
+    return MultiDescriptor(
+        int(args[0]), keys, sort=name == "sortedmulti", network=network
+    )
+
+
+def _parse_ordered_multi(args: list[str], context: str, network: str) -> Descriptor:
+    return _parse_multi("multi", args, context, network)
+
+
+def _parse_sorted_multi(args: list[str], context: str, network: str) -> Descriptor:
+    return _parse_multi("sortedmulti", args, context, network)
+
+
+def _parse_tr(args: list[str], context: str, network: str) -> Descriptor:
+    if len(args) > 2:
+        err_msg = f"tr() takes a key and at most one tree, {len(args)} given"
+        raise BTClibValueError(err_msg)
+    internal_key = _parse_key(args[0], x_only=True, compressed=True)
+    tree = None if len(args) == 1 else _parse_tree(args[1])
+    return TrDescriptor(internal_key, tree, network=network)
+
+
+def _parse_addr(args: list[str], context: str, network: str) -> Descriptor:
+    address = _one_argument(args, "addr")
+    # the network of an addr() descriptor is the address's own: it is
+    # written in the prefix, so a parameter could only contradict it
+    return AddrDescriptor(address, network=ScriptPubKey.from_address(address).network)
+
+
+def _parse_raw(args: list[str], context: str, network: str) -> Descriptor:
+    hex_script = _one_argument(args, "raw")
+    try:
+        script = bytes_from_octets(hex_script)
+    # bytes.fromhex raises a plain ValueError, and every other way of
+    # writing a descriptor wrong raises a BTClibValueError
+    except ValueError as e:
+        raise BTClibValueError(f"raw() takes a hex script: {hex_script}") from e
+    return RawDescriptor(script, network=network)
+
+
+# every SCRIPT function, where BIP 381 to BIP 386 allow it, and what
+# reads it. A table rather than a chain of comparisons because the
+# position rule is the interesting half and belongs where it can be read
+# beside the others
+_PARSERS: dict[
+    str, tuple[tuple[str, ...], Callable[[list[str], str, str], Descriptor]]
+] = {
+    "pk": ((_TOP, _P2SH, _P2WSH, _P2TR), _parse_pk),
+    "pkh": ((_TOP, _P2SH, _P2WSH), _parse_pkh),
+    "wpkh": ((_TOP, _P2SH), _parse_wpkh),
+    "combo": ((_TOP,), _parse_combo),
+    "sh": ((_TOP,), _parse_sh),
+    "wsh": ((_TOP, _P2SH), _parse_wsh),
+    "multi": ((_TOP, _P2SH, _P2WSH), _parse_ordered_multi),
+    "sortedmulti": ((_TOP, _P2SH, _P2WSH), _parse_sorted_multi),
+    "tr": ((_TOP,), _parse_tr),
+    "addr": ((_TOP,), _parse_addr),
+    "raw": ((_TOP,), _parse_raw),
+}
+
+
+def _parse_expression(expression: str, context: str, network: str) -> Descriptor:
+    """Return the Descriptor of a SCRIPT expression, in its context."""
+    name, arguments = _split_function(expression)
+    _assert_implemented(name)
+    if name not in _PARSERS:
+        raise BTClibValueError(f"unknown descriptor function: {name}()")
+    allowed, parser = _PARSERS[name]
+    _assert_position(name, context, allowed)
+    return parser(_split_arguments(arguments), context, network)
+
+
+def parse(descriptor: str, network: str = "mainnet") -> Descriptor:
+    """Return the Descriptor of a descriptor string, checksum verified."""
+    return _parse_expression(strip_checksum(descriptor), _TOP, network)
+
+
+def multipath_descriptors(descriptor: str) -> list[str]:
+    """Return the single-path descriptors of a BIP 389 multipath one.
+
+    A descriptor with no ``<a;b>`` step is one descriptor, returned
+    checksummed and otherwise unchanged. One with such steps is as many
+    descriptors as a step has elements, the first taking the first
+    element of every step, the second the second, and so on -- which is
+    what makes the two-element form a receiving chain and a change chain.
+
+    The expansion is textual, as BIP 389 defines it, and each result is a
+    descriptor to be parsed on its own.
+    """
+    pieces = _MULTIPATH_STEP.split(strip_checksum(descriptor))
+    # re.split with a capturing pattern alternates text and separator, so
+    # the odd positions are the multipath steps and the even ones the
+    # descriptor around them
+    steps = [piece[1:-1].split(";") for piece in pieces[1::2]]
+    if not steps:
+        return [add_checksum(pieces[0])]
+    lengths = {len(step) for step in steps}
+    if len(lengths) != 1:
+        err_msg = f"multipath steps of different length: {sorted(lengths)}"
+        raise BTClibValueError(err_msg)
+    length = lengths.pop()
+    if length < 2:
+        raise BTClibValueError("a multipath step takes at least two elements")
+    descriptors = []
+    for i in range(length):
+        pieces[1::2] = [step[i] for step in steps]
+        descriptors.append(add_checksum("".join(pieces)))
+    return descriptors

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -682,6 +682,8 @@ def test_key_expression_fields() -> None:
     assert not plain.is_ranged
     assert not plain.is_compressed
     assert plain.sec() == bytes.fromhex(uncompressed)
+    # the index is the wildcard's, so a key without one ignores it
+    assert plain.sec(5) == plain.sec(0)
 
 
 def test_tr_tree_keys() -> None:
@@ -792,6 +794,11 @@ UNPARSABLE = [
     (f"tr({XONLY},pk({XONLY}),pk({XONLY}))", "at most one tree"),
     (f"tr({XONLY},{{pk({XONLY})}})", "two subtrees"),
     (f"tr({XONLY},{{pk({XONLY}),pk({XONLY})}}x)", "unbalanced braces"),
+    # a character the language has no symbol for, which is the checksum's
+    # charset speaking about a descriptor that carries no checksum: every
+    # printable ASCII character is in INPUT_CHARSET, so it takes a
+    # non-ASCII one to be outside it
+    (f"pk(è{KEY[1:]})", "invalid descriptor character"),
 ]
 
 

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -7,19 +7,62 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Tests for the `btclib.descriptors` module."""
+"""Tests for the `btclib.descriptors` module.
+
+The derivation vectors are Bitcoin Core's own, transcribed from the
+`descriptor_test` case of `src/test/descriptor_tests.cpp` at commit
+8ecbe270f0dee68b7eec6cea1714f453c5e215ad (2026-07-29): each `Check(prv,
+pub, ...)` there gives a descriptor in its private and its public
+spelling and the scriptPubKey each expands to, at index 0, 1 and 2 where
+the descriptor is ranged. Both spellings are exercised, so a WIF and an
+xprv are checked to reach the script the public key and the xpub beside
+them reach. Not vendored as a file: the values are extracted from C++
+source rather than copied from a data file, so the citation is the
+commit and the case, and `tests/_data/README.md` covers what is vendored.
+
+Four of those descriptors have no public spelling to check, and Core's
+own flags say why: HARDENED and DERIVE_HARDENED mark a derivation that
+needs the private key, so Core expands the private form alone and this
+module expects the public one to be refused.
+
+The descriptors of Core's `doc/descriptors.md` are already vendored, as
+`tests/_data/descriptor_checksums.json`, and are read here a second
+time: what the checksum test asks of them is the eight characters, what
+the parser test asks is that each one expands and that every address it
+produces is the address of that very script.
+"""
 
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
 from btclib.descriptors import (
+    AddrDescriptor,
+    ComboDescriptor,
+    Descriptor,
+    KeyExpression,
+    MultiDescriptor,
+    PkDescriptor,
+    RawDescriptor,
+    ShDescriptor,
+    TrDescriptor,
+    WshDescriptor,
     __descsum_expand,
+    add_checksum,
     descriptor_checksum,
     descriptor_from_address,
+    multipath_descriptors,
+    parse,
+    strip_checksum,
 )
 from btclib.exceptions import BTClibValueError
+from btclib.script.script_pub_key import ScriptPubKey
 from tests import load, vector_id
+
+DOC_DESCRIPTORS = [
+    descriptor_data["desc"]
+    for descriptor_data in load("_data", "descriptor_checksums.json", encoding="utf-8")
+]
 
 CHECKSUM_VECTORS = [
     pytest.param(
@@ -49,6 +92,25 @@ def test_addr() -> None:
     address = "bc1qnehtvnd4fedkwjq6axfgsrxgllwne3k58rhdh0"
     descriptor = "addr(bc1qnehtvnd4fedkwjq6axfgsrxgllwne3k58rhdh0)#s2y3vepm"
     assert descriptor_from_address(address) == descriptor
+
+
+def test_add_and_strip_checksum() -> None:
+    descriptor = "addr(bc1qnehtvnd4fedkwjq6axfgsrxgllwne3k58rhdh0)"
+    checksummed = f"{descriptor}#s2y3vepm"
+    assert add_checksum(descriptor) == checksummed
+    # adding one to a descriptor that has one verifies it and changes
+    # nothing, which is what makes add_checksum safe to call on input
+    assert add_checksum(checksummed) == checksummed
+    assert strip_checksum(checksummed) == descriptor
+    assert strip_checksum(descriptor) == descriptor
+
+
+def test_invalid_checksum() -> None:
+    descriptor = "addr(bc1qnehtvnd4fedkwjq6axfgsrxgllwne3k58rhdh0)"
+    with pytest.raises(BTClibValueError, match="invalid descriptor checksum"):
+        strip_checksum(f"{descriptor}#00000000")
+    with pytest.raises(BTClibValueError, match="more than one"):
+        strip_checksum(f"{descriptor}#s2y3vepm#s2y3vepm")
 
 
 # what a descriptor is made of: the checksum alphabet is defined over
@@ -85,3 +147,690 @@ def test_a_changed_character_changes_the_checksum(
     if mutated == descriptor:
         return
     assert descriptor_checksum(mutated) != descriptor_checksum(descriptor)
+
+
+# Bitcoin Core's descriptor_test: the private spelling, the public one
+# (None where Core's flags say the public key cannot derive the scripts),
+# and the scriptPubKey set at each index
+CORE_VECTORS: list[tuple[str, str | None, list[list[str]]]] = [
+    (
+        "combo(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+        "combo(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        [
+            [
+                "2103a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bdac",
+                "76a9149a1c78a507689f6f54b847ad1cef1e614ee23f1e88ac",
+                "00149a1c78a507689f6f54b847ad1cef1e614ee23f1e",
+                "a91484ab21b1b2fd065d4504ff693d832434b6108d7b87",
+            ]
+        ],
+    ),
+    (
+        "pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+        "pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        [["2103a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bdac"]],
+    ),
+    (
+        "pkh([deadbeef/1/2'/3/4']L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+        "pkh([deadbeef/1/2'/3/4']03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        [["76a9149a1c78a507689f6f54b847ad1cef1e614ee23f1e88ac"]],
+    ),
+    (
+        "wpkh(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+        "wpkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        [["00149a1c78a507689f6f54b847ad1cef1e614ee23f1e"]],
+    ),
+    (
+        "sh(wpkh(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))",
+        "sh(wpkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+        [["a91484ab21b1b2fd065d4504ff693d832434b6108d7b87"]],
+    ),
+    (
+        "tr(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+        "tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        [["512077aab6e066f8a7419c5ab714c12c67d25007ed55a43cadcacb4d7a970a093f11"]],
+    ),
+    (
+        "combo(5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)",
+        "combo(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)",
+        [
+            [
+                "4104a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235ac",
+                "76a914b5bd079c4d57cc7fc28ecf8213a6b791625b818388ac",
+            ]
+        ],
+    ),
+    (
+        "pk(5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)",
+        "pk(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)",
+        [
+            [
+                "4104a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235ac"
+            ]
+        ],
+    ),
+    (
+        "pkh(5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)",
+        "pkh(04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)",
+        [["76a914b5bd079c4d57cc7fc28ecf8213a6b791625b818388ac"]],
+    ),
+    (
+        "sh(pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))",
+        "sh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+        [["a9141857af51a5e516552b3086430fd8ce55f7c1a52487"]],
+    ),
+    (
+        "sh(pkh(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))",
+        "sh(pkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+        [["a9141a31ad23bf49c247dd531a623c2ef57da3c400c587"]],
+    ),
+    (
+        "wsh(pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))",
+        "wsh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+        [["00202e271faa2325c199d25d22e1ead982e45b64eeb4f31e73dbdf41bd4b5fec23fa"]],
+    ),
+    (
+        "wsh(pkh(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))",
+        "wsh(pkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+        [["0020338e023079b91c58571b20e602d7805fb808c22473cbc391a41b1bd3a192e75b"]],
+    ),
+    (
+        "sh(wsh(pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)))",
+        "sh(wsh(pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)))",
+        [["a91472d0c5a3bfad8c3e7bd5303a72b94240e80b6f1787"]],
+    ),
+    (
+        "sh(wsh(pkh(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)))",
+        "sh(wsh(pkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)))",
+        [["a914b61b92e2ca21bac1e72a3ab859a742982bea960a87"]],
+    ),
+    (
+        "tr(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5,{pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5),{pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1),pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5)}})",
+        "tr(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5,{pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5),{pk(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd),pk(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5)}})",
+        [["51201497ae16f30dacb88523ed9301bff17773b609e8a90518a3f96ea328a47d1500"]],
+    ),
+    (
+        "combo([01234567]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc)",
+        "combo([01234567]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL)",
+        [
+            [
+                "2102d2b36900396c9282fa14628566582f206a5dd0bcc8d5e892611806cafb0301f0ac",
+                "76a91431a507b815593dfc51ffc7245ae7e5aee304246e88ac",
+                "001431a507b815593dfc51ffc7245ae7e5aee304246e",
+                "a9142aafb926eb247cb18240a7f4c07983ad1f37922687",
+            ]
+        ],
+    ),
+    (
+        "pk(xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0)",
+        "pk(xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0)",
+        [["210379e45b3cf75f9c5f9befd8e9506fb962f6a9d185ac87001ec44a8d3df8d4a9e3ac"]],
+    ),
+    (
+        "pkh(xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U/2147483647'/0)",
+        None,
+        [["76a914ebdc90806a9c4356c1c88e42216611e1cb4c1c1788ac"]],
+    ),
+    (
+        "wpkh([ffffffff/13']xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt/1/2/*)",
+        "wpkh([ffffffff/13']xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/1/2/*)",
+        [
+            ["0014326b2249e3a25d5dc60935f044ee835d090ba859"],
+            ["0014af0bd98abc2f2cae66e36896a39ffe2d32984fb7"],
+            ["00141fa798efd1cbf95cebf912c031b8a4a6e9fb9f27"],
+        ],
+    ),
+    (
+        "sh(wpkh(xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/10/20/30/40/*'))",
+        None,
+        [
+            ["a9149a4d9901d6af519b2a23d4a2f51650fcba87ce7b87"],
+            ["a914bed59fc0024fae941d6e20a3b44a109ae740129287"],
+            ["a9148483aa1116eb9c05c482a72bada4b1db24af654387"],
+        ],
+    ),
+    (
+        "combo(xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334/*)",
+        "combo(xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV/*)",
+        [
+            [
+                "2102df12b7035bdac8e3bab862a3a83d06ea6b17b6753d52edecba9be46f5d09e076ac",
+                "76a914f90e3178ca25f2c808dc76624032d352fdbdfaf288ac",
+                "0014f90e3178ca25f2c808dc76624032d352fdbdfaf2",
+                "a91408f3ea8c68d4a7585bf9e8bda226723f70e445f087",
+            ],
+            [
+                "21032869a233c9adff9a994e4966e5b821fd5bac066da6c3112488dc52383b4a98ecac",
+                "76a914a8409d1b6dfb1ed2a3e8aa5e0ef2ff26b15b75b788ac",
+                "0014a8409d1b6dfb1ed2a3e8aa5e0ef2ff26b15b75b7",
+                "a91473e39884cb71ae4e5ac9739e9225026c99763e6687",
+            ],
+        ],
+    ),
+    (
+        "tr(xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc/0/*,pk(xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc/1/*))",
+        "tr(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/0/*,pk(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1/*))",
+        [
+            ["512078bc707124daa551b65af74de2ec128b7525e10f374dc67b64e00ce0ab8b3e12"],
+            ["512001f0a02a17808c20134b78faab80ef93ffba82261ccef0a2314f5d62b6438f11"],
+            ["512021024954fcec88237a9386fce80ef2ced5f1e91b422b26c59ccfc174c8d1ad25"],
+        ],
+    ),
+    (
+        "wsh(multi(1,xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334/0,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1))",
+        "wsh(multi(1,xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV/0,03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd))",
+        [["0020cb155486048b23a6da976d4c6fe071a2dbc8a7b57aaf225b8955f2e2a27b5f00"]],
+    ),
+    (
+        "multi(1,xprvA2JDeKCSNNZky6uBCviVfJSKyQ1mDYahRjijr5idH2WwLsEd4Hsb2Tyh8RfQMuPh7f7RtyzTtdrbdqqsunu5Mm3wDvUAKRHSC34sJ7in334/*,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+        "multi(1,xpub6FHa3pjLCk84BayeJxFW2SP4XRrFd1JYnxeLeU8EqN3vDfZmbqBqaGJAyiLjTAwm6ZLRQUMv1ZACTj37sR62cfN7fe5JnJ7dh8zL4fiyLHV/*,03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        [
+            [
+                "512102df12b7035bdac8e3bab862a3a83d06ea6b17b6753d52edecba9be46f5d09e0762103a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd52ae"
+            ],
+            [
+                "5121032869a233c9adff9a994e4966e5b821fd5bac066da6c3112488dc52383b4a98ec2103a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd52ae"
+            ],
+            [
+                "5121035d30b6c66dc1e036c45369da8287518cf7e0d6ed1e2b905171c605708f14ca032103a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd52ae"
+            ],
+        ],
+    ),
+    (
+        "pkh([01234567/10/20]xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U/2147483647'/0)",
+        None,
+        [["76a914ebdc90806a9c4356c1c88e42216611e1cb4c1c1788ac"]],
+    ),
+    (
+        "multi(1,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)",
+        "multi(1,03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)",
+        [
+            [
+                "512103a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd4104a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea23552ae"
+            ]
+        ],
+    ),
+    (
+        "multi(2,KzoAz5CanayRKex3fSLQ2BwJpN7U52gZvxMyk78nDMHuqrUxuSJy,KwGNz6YCCQtYvFzMtrC6D3tKTKdBBboMrLTsjr2NYVBwapCkn7Mr,KxogYhiNfwxuswvXV66eFyKcCpm7dZ7TqHVqujHAVUjJxyivxQ9X)",
+        "multi(2,03669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0,0260b2003c386519fc9eadf2b5cf124dd8eea4c4e68d5e154050a9346ea98ce600,0362a74e399c39ed5593852a30147f2959b56bb827dfa3e60e464b02ccf87dc5e8)",
+        [
+            [
+                "522103669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0210260b2003c386519fc9eadf2b5cf124dd8eea4c4e68d5e154050a9346ea98ce600210362a74e399c39ed5593852a30147f2959b56bb827dfa3e60e464b02ccf87dc5e853ae"
+            ]
+        ],
+    ),
+    (
+        "sortedmulti(1,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss)",
+        "sortedmulti(1,03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235)",
+        [
+            [
+                "512103a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd4104a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea23552ae"
+            ]
+        ],
+    ),
+    (
+        "sortedmulti(1,5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss,L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+        "sortedmulti(1,04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235,03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        [
+            [
+                "512103a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd4104a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea23552ae"
+            ]
+        ],
+    ),
+    (
+        "sh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))",
+        "sh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))",
+        [["a91445a9a622a8b0a1269944be477640eedc447bbd8487"]],
+    ),
+    (
+        "sortedmulti(2,xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc/*,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0/0/*)",
+        "sortedmulti(2,xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/*,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0/0/*)",
+        [
+            [
+                "5221025d5fc65ebb8d44a5274b53bac21ff8307fec2334a32df05553459f8b1f7fe1b62102fbd47cc8034098f0e6a94c6aeee8528abf0a2153a5d8e46d325b7284c046784652ae"
+            ],
+            [
+                "52210264fd4d1f5dea8ded94c61e9641309349b62f27fbffe807291f664e286bfbe6472103f4ece6dfccfa37b211eb3d0af4d0c61dba9ef698622dc17eecdf764beeb005a652ae"
+            ],
+            [
+                "5221022ccabda84c30bad578b13c89eb3b9544ce149787e5b538175b1d1ba259cbb83321024d902e1a2fc7a8755ab5b694c575fce742c48d9ff192e63df5193e4c7afe1f9c52ae"
+            ],
+        ],
+    ),
+    (
+        "wsh(multi(2,xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U/2147483647'/0,xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt/1/2/*,xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/10/20/30/40/*'))",
+        None,
+        [
+            ["0020b92623201f3bb7c3771d45b2ad1d0351ea8fbf8cfe0a0e570264e1075fa1948f"],
+            ["002036a08bbe4923af41cf4316817c93b8d37e2f635dd25cfff06bd50df6ae7ea203"],
+            ["0020a96e7ab4607ca6b261bfe3245ffda9c746b28d3f59e83d34820ec0e2b36c139c"],
+        ],
+    ),
+    (
+        "tr(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,pk(KzoAz5CanayRKex3fSLQ2BwJpN7U52gZvxMyk78nDMHuqrUxuSJy))",
+        "tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,pk(669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0))",
+        [["512017cf18db381d836d8923b1bdb246cfcd818da1a9f0e6e7907f187f0b2f937754"]],
+    ),
+]
+
+# the public spelling of the four descriptors that derive hardened: Core
+# flags them HARDENED or DERIVE_HARDENED and expands the private one only
+HARDENED_PUBLIC = [
+    "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/2147483647'/0)",
+    "sh(wpkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/10/20/30/40/*'))",
+    "pkh([01234567/10/20]xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/2147483647'/0)",
+    "wsh(multi(2,xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/2147483647'/0,xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/1/2/*,xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/10/20/30/40/*'))",
+]
+
+DERIVATION_VECTORS = [
+    pytest.param(private, public, scripts, id=vector_id(index, public or private))
+    for index, (private, public, scripts) in enumerate(CORE_VECTORS)
+]
+
+
+@pytest.mark.parametrize(("private", "public", "scripts"), DERIVATION_VECTORS)
+def test_core_derivation_vector(
+    private: str, public: str | None, scripts: list[list[str]]
+) -> None:
+    for descriptor in (private, public):
+        if descriptor is None:
+            continue
+        parsed = parse(descriptor)
+        assert parsed.is_ranged == (len(scripts) > 1)
+        for index, expected in enumerate(scripts):
+            derived = parsed.script_pub_keys(index)
+            assert [spk.script.hex() for spk in derived] == expected
+            assert parsed.addresses(index) == [spk.address for spk in derived]
+
+
+@pytest.mark.parametrize(
+    "descriptor",
+    [
+        pytest.param(descriptor, id=vector_id(index, descriptor))
+        for index, descriptor in enumerate(HARDENED_PUBLIC)
+    ],
+)
+def test_hardened_derivation_needs_the_private_key(descriptor: str) -> None:
+    """An xpub cannot answer a hardened step, so the descriptor cannot.
+
+    Bitcoin Core says the same by expanding only the private spelling of
+    these four, and BIP 380 states it as a rule of the language.
+    """
+    parsed = parse(descriptor)
+    with pytest.raises(BTClibValueError, match="hardened derivation"):
+        parsed.script_pub_keys()
+
+
+@pytest.mark.parametrize(
+    "descriptor",
+    [
+        pytest.param(descriptor, id=vector_id(index, descriptor))
+        for index, descriptor in enumerate(DOC_DESCRIPTORS)
+    ],
+)
+def test_doc_descriptor(descriptor: str) -> None:
+    """Every documented descriptor expands, and its addresses round-trip.
+
+    The scripts have no external oracle here -- Core's document lists no
+    script -- so what is checked is btclib against itself: an address is
+    a notation for a script, and `ScriptPubKey.from_address` has to give
+    back the very script the descriptor derived.
+    """
+    if "sortedmulti_a(" in descriptor:
+        with pytest.raises(NotImplementedError, match="sortedmulti_a"):
+            parse(descriptor)
+        return
+    script_pub_keys = parse(descriptor).script_pub_keys()
+    assert script_pub_keys
+    for script_pub_key in script_pub_keys:
+        address = script_pub_key.address
+        # p2pk and bare multisig have no address, which is not a failure
+        if address:
+            assert ScriptPubKey.from_address(address) == script_pub_key
+
+
+def test_doc_descriptors_are_read_but_for_one() -> None:
+    """Seventeen of Core's eighteen documented descriptors expand here.
+
+    The eighteenth is a `sortedmulti_a()`, BIP 387, refused rather than
+    guessed at. Counted rather than assumed, so that refreshing the
+    vendored file cannot move a descriptor from one group to the other
+    unnoticed.
+    """
+    unimplemented = [d for d in DOC_DESCRIPTORS if "sortedmulti_a(" in d]
+    assert len(DOC_DESCRIPTORS) == 18
+    assert len(unimplemented) == 1
+
+
+def test_sortedmulti_sorts_what_multi_leaves_alone() -> None:
+    """Core's document gives the same 2-of-2 twice, sorted and in order.
+
+    The keys of the sortedmulti() are written in the other order, so the
+    two describe one script only if the sorting happens.
+    """
+    ordered = "sh(multi(2,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01,03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe))"
+    sorted_ = "sh(sortedmulti(2,03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01))"
+    assert parse(ordered).script_pub_key() == parse(sorted_).script_pub_key()
+    # and the ordering is not vacuous: written the other way round,
+    # multi() gives another script where sortedmulti() gives this one
+    reversed_ = "sh(multi(2,03acd484e2f0c7f65309ad178a9f559abde09796974c57e714c35f110dfc27ccbe,022f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01))"
+    assert parse(reversed_).script_pub_key() != parse(ordered).script_pub_key()
+
+
+# Bitcoin Core's CheckMultipath vector at line 705 of the same file: one
+# BIP 389 descriptor, the two it expands to, and the scripts of each
+MULTIPATH = "wpkh([ffffffff/13h]xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/<1;3>/2/*)"
+MULTIPATH_EXPANSIONS = [
+    "wpkh([ffffffff/13h]xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/1/2/*)",
+    "wpkh([ffffffff/13h]xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/3/2/*)",
+]
+MULTIPATH_SCRIPTS = [
+    [
+        "0014326b2249e3a25d5dc60935f044ee835d090ba859",
+        "0014af0bd98abc2f2cae66e36896a39ffe2d32984fb7",
+        "00141fa798efd1cbf95cebf912c031b8a4a6e9fb9f27",
+    ],
+    [
+        "001426183882ef9c76b9a44386e9b387f33cee7c3a2d",
+        "001447c1b9dc215c3f8b47e572981eb97528768cde4e",
+        "00146e92cbaa397f9caeccf9a049460258af6ccd67e2",
+    ],
+]
+
+
+def test_multipath() -> None:
+    expanded = multipath_descriptors(MULTIPATH)
+    assert [strip_checksum(d) for d in expanded] == MULTIPATH_EXPANSIONS
+    for descriptor, scripts in zip(expanded, MULTIPATH_SCRIPTS, strict=True):
+        parsed = parse(descriptor)
+        derived = [parsed.script_pub_key(i).script.hex() for i in range(3)]
+        assert derived == scripts
+
+
+def test_multipath_of_a_single_path_descriptor() -> None:
+    """A descriptor with no multipath step is one descriptor, checksummed."""
+    descriptor = (
+        "wpkh(03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)"
+    )
+    assert multipath_descriptors(descriptor) == [add_checksum(descriptor)]
+
+
+def test_multipath_in_two_key_expressions() -> None:
+    """Every step takes its i-th element, which is what BIP 389 says.
+
+    Bitcoin Core's CheckMultipath vector at line 755 of the same file.
+    """
+    descriptor = "multi(2,xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/<1;2>/*,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/<3;4>/0/*)"
+    expansions = [
+        "multi(2,xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1/*,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/3/0/*)",
+        "multi(2,xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/2/*,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/4/0/*)",
+    ]
+    expanded = multipath_descriptors(descriptor)
+    assert [strip_checksum(d) for d in expanded] == expansions
+
+
+def test_invalid_multipath() -> None:
+    xpub = "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y"
+    with pytest.raises(BTClibValueError, match="different length"):
+        multipath_descriptors(f"multi(1,{xpub}/<0;1>/*,{xpub}/<0;1;2>/*)")
+    with pytest.raises(BTClibValueError, match="at least two elements"):
+        multipath_descriptors(f"pk({xpub}/<0>)")
+    # and parse() does not read one, rather than reading it wrong
+    with pytest.raises(BTClibValueError, match="multipath_descriptors"):
+        parse(f"pk({xpub}/<0;1>)")
+
+
+# Bitcoin Core's own, from the multipath example of doc/descriptors.md
+TESTNET_XPUB = "tpubDDjsCRDQ9YzyaAq9rspCfq8RZFrWoBpYnLxK6sS2hS2yukqSczgcYiur8Scx4Hd5AZatxTuzMtJQJhchufv1FRFanLqUP7JHwusSSpfcEp2"
+
+
+def test_network() -> None:
+    """The chain is a parameter, and a key disagreeing with it is an error."""
+    descriptor = f"wpkh([6f53d49c/44h/1h/0h]{TESTNET_XPUB}/0/0)"
+    script_pub_key = parse(descriptor, "testnet").script_pub_key()
+    assert script_pub_key.network == "testnet"
+    assert script_pub_key.address.startswith("tb1")
+    assert ScriptPubKey.from_address(script_pub_key.address) == script_pub_key
+    with pytest.raises(BTClibValueError, match="key for mainnet"):
+        parse(descriptor).script_pub_key()
+
+
+def test_addr_takes_the_network_of_its_address() -> None:
+    """An address states its own chain, so no parameter can contradict it."""
+    address = "tb1qjwxuan3npm4489vlt0gcyqxwvaghkux009tfyd"
+    parsed = parse(f"addr({address})")
+    assert isinstance(parsed, AddrDescriptor)
+    assert parsed.network == "testnet"
+    assert parsed.address() == address
+    assert not parsed.is_ranged
+    assert parsed.key_expressions == ()
+
+
+def test_raw() -> None:
+    script = "76a9149a1c78a507689f6f54b847ad1cef1e614ee23f1e88ac"
+    parsed = parse(f"raw({script})")
+    assert isinstance(parsed, RawDescriptor)
+    assert parsed.script_pub_key().script.hex() == script
+    assert not parsed.is_ranged
+    assert parsed.key_expressions == ()
+
+
+def test_combo_is_a_set_of_scripts() -> None:
+    """`combo()` answers with four scripts, so it answers with no address.
+
+    `script_pub_key` is the one-script question, and asking it of a
+    combo() is a question with no answer rather than one of the four.
+    """
+    key = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+    parsed = parse(f"combo({key})")
+    assert isinstance(parsed, ComboDescriptor)
+    assert len(parsed.script_pub_keys()) == 4
+    with pytest.raises(BTClibValueError, match="use script_pub_keys instead"):
+        parsed.script_pub_key()
+    with pytest.raises(BTClibValueError, match="use script_pub_keys instead"):
+        parsed.address()
+    # the p2pk of the four has no address, and says so with an empty one
+    assert parsed.addresses()[0] == ""
+
+
+def test_redeem_script() -> None:
+    """What sh() hashes is the script of the descriptor it embeds."""
+    key = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+    parsed = parse(f"sh(wpkh({key}))")
+    assert isinstance(parsed, ShDescriptor)
+    assert parsed.inner.redeem_script() == ScriptPubKey.p2wpkh(key).script
+    assert parsed.script_pub_key() == ScriptPubKey.p2sh(parsed.inner.redeem_script())
+
+
+def test_index_out_of_range() -> None:
+    ranged = "wpkh(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/1/2/*)"
+    parsed = parse(ranged)
+    assert parsed.is_ranged
+    with pytest.raises(BTClibValueError, match="invalid derivation index"):
+        parsed.script_pub_keys(-1)
+    with pytest.raises(BTClibValueError, match="invalid derivation index"):
+        parsed.script_pub_keys(0x80000000)
+    key = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+    fixed = parse(f"wpkh({key})")
+    assert not fixed.is_ranged
+    with pytest.raises(BTClibValueError, match="not a ranged descriptor"):
+        fixed.script_pub_keys(1)
+
+
+def test_key_origin_is_kept() -> None:
+    """The origin does not change the script, and is not thrown away."""
+    key = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+    origin = parse(f"pkh([deadbeef/1/2h/3/4h]{key})").key_expressions[0].origin
+    assert origin is not None
+    assert origin.description == "deadbeef/1/2h/3/4h"
+    # the same descriptor with the other hardening marker is the same
+    # descriptor: BIP 380 gives h and ' the same meaning
+    apostrophes = parse(f"pkh([deadbeef/1/2'/3/4']{key})")
+    assert apostrophes.key_expressions[0].origin == origin
+
+
+def test_key_expression_fields() -> None:
+    xpub = "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH"
+    (key,) = parse(f"wpkh({xpub}/1/2/*)").key_expressions
+    assert key == KeyExpression(xkey=xpub, der_path=(1, 2), wildcard=0)
+    assert key.is_ranged
+    assert key.is_compressed
+    (hardened,) = parse(f"pkh({xpub}/1/2/*h)").key_expressions
+    assert hardened.wildcard == 0x80000000
+    uncompressed = "04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235"
+    (plain,) = parse(f"pk({uncompressed})").key_expressions
+    assert not plain.is_ranged
+    assert not plain.is_compressed
+    assert plain.sec() == bytes.fromhex(uncompressed)
+
+
+def test_tr_tree_keys() -> None:
+    internal = "a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+    leaf = "669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0"
+    parsed = parse(f"tr({internal},{{pk({leaf}),pk({internal})}})")
+    assert isinstance(parsed, TrDescriptor)
+    # the internal key and both leaves, in that order
+    assert len(parsed.key_expressions) == 3
+    assert parsed.key_expressions[0].x_only
+    key_path_only = parse(f"tr({internal})")
+    assert isinstance(key_path_only, TrDescriptor)
+    assert key_path_only.tree is None
+    assert len(key_path_only.key_expressions) == 1
+
+
+def test_parsed_types() -> None:
+    key = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+    assert isinstance(parse(f"pk({key})"), PkDescriptor)
+    assert isinstance(parse(f"wsh(pk({key}))"), WshDescriptor)
+    multi = parse(f"multi(1,{key})")
+    assert isinstance(multi, MultiDescriptor)
+    assert multi.threshold == 1
+    assert not multi.sort
+    sorted_multi = parse(f"sortedmulti(1,{key})")
+    assert isinstance(sorted_multi, MultiDescriptor)
+    assert sorted_multi.sort
+
+
+def test_too_many_keys_for_a_multisig() -> None:
+    """OP_CHECKMULTISIG counts with one op code, so n stops at 16.
+
+    Bitcoin Core reads a `multi()` of twenty keys inside `wsh()`, where
+    the count is pushed rather than encoded as OP_1 to OP_16; this
+    library's p2ms builder does not, and refuses it here rather than
+    building a script that says something else.
+    """
+    key = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+    keys = ",".join([key] * 17)
+    with pytest.raises(BTClibValueError, match="invalid n in m-of-n"):
+        parse(f"wsh(multi(1,{keys}))").script_pub_key()
+
+
+def test_descriptor_is_abstract() -> None:
+    """The base class is the interface, and derives no script of its own."""
+    with pytest.raises(TypeError, match="abstract"):
+        Descriptor()  # type: ignore[abstract]
+
+
+KEY = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+UNCOMPRESSED = "04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235"
+XPUB = "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
+XONLY = "a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+OFF_CURVE = "020000000000000000000000000000000000000000000000000000000000000005"
+
+# what a descriptor cannot be, and the message that says so. The first
+# group is Bitcoin Core's own CheckUnparsable cases, from the same
+# descriptor_test; the rest are the position rules of BIP 381 to BIP 386
+# and the shapes a recursive parser has to refuse
+UNPARSABLE = [
+    # Core: an invalid public key, here 64 hex characters where an x-only
+    # key is not allowed
+    (f"sh(wpkh({KEY[:64]}))", "x-only"),
+    # Core: a key origin without its opening bracket
+    (f"pkh(deadbeef/1/2h]{KEY})", "without the "),
+    # Core: two closing brackets for one key
+    (f"pkh([deadbeef][01234567]{KEY})", "more than one"),
+    # Core: no uncompressed key in a witness program
+    (f"wpkh({UNCOMPRESSED})", "uncompressed"),
+    (f"wsh(pk({UNCOMPRESSED}))", "uncompressed"),
+    (f"sh(wpkh({UNCOMPRESSED}))", "uncompressed"),
+    # Core: the hybrid encoding, which nothing in bitcoin produces
+    (f"combo(07{UNCOMPRESSED[2:]})", "public key prefix"),
+    (f"pk(06{UNCOMPRESSED[2:]})", "public key prefix"),
+    # Core: a fingerprint that is not four bytes
+    (f"combo([012345678]{XPUB})", "fingerprint"),
+    # Core: a derivation index that is no BIP 32 index
+    (f"pkh({XPUB}/2147483648)", "invalid index"),
+    (f"pkh({XPUB}/1aa)", "invalid derivation index"),
+    (f"pkh({XPUB}/+1)", "invalid derivation index"),
+    # Core: an address that is not one, and a script that is not hex
+    ("addr(asdf)", "base58"),
+    ("raw(asdf)", "hex script"),
+    # the position rules
+    (f"wsh(sh(pk({KEY})))", "not allowed inside"),
+    (f"sh(combo({KEY}))", "not allowed inside"),
+    (f"wsh(wpkh({KEY}))", "not allowed inside"),
+    (f"sh(tr({XONLY}))", "not allowed inside"),
+    ("sh(addr(1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH))", "not allowed inside"),
+    ("sh(raw(00))", "not allowed inside"),
+    # a key expression written for another position, or not at all
+    (f"pk({XONLY})", "x-only"),
+    (f"pk({KEY}/0)", "cannot derive"),
+    (f"pk({KEY[:-4]})", "public key length"),
+    (f"pk({OFF_CURVE})", "not a public key"),
+    ("pk(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY2)", "key expression"),
+    ("pk(nope(03))", "not a key expression"),
+    (f"pkh([deadbeef{KEY})", "missing "),
+    # the shape of an expression
+    ("pk", "not a descriptor expression"),
+    ("(pk)", "not a descriptor expression"),
+    (f"nope({KEY})", "unknown descriptor function"),
+    (f"pk({KEY},{KEY})", "takes one argument"),
+    (f"multi(x,{KEY})", "threshold"),
+    ("multi(1)", "at least one key"),
+    (f"pk({KEY}))", "unbalanced"),
+    (f"pk(({KEY})", "unbalanced"),
+    (f"tr({XONLY},pk({XONLY}),pk({XONLY}))", "at most one tree"),
+    (f"tr({XONLY},{{pk({XONLY})}})", "two subtrees"),
+    (f"tr({XONLY},{{pk({XONLY}),pk({XONLY})}}x)", "unbalanced braces"),
+]
+
+
+@pytest.mark.parametrize(
+    ("descriptor", "message"),
+    [
+        pytest.param(descriptor, message, id=vector_id(index, descriptor))
+        for index, (descriptor, message) in enumerate(UNPARSABLE)
+    ],
+)
+def test_unparsable(descriptor: str, message: str) -> None:
+    with pytest.raises(BTClibValueError, match=message):
+        parse(descriptor)
+
+
+# what is a descriptor, is not implemented, and is refused by name rather
+# than read wrong
+UNIMPLEMENTED = [
+    (
+        f"wsh(and_v(v:ripemd160(095ff41131e5946f3c85f79e44adbcf8e27e080e),pk({KEY})))",
+        "187",
+    ),
+    (f"wsh(thresh(1,pk({KEY})))", "187"),
+    (f"wsh(s:pk({KEY}))", "187"),
+    (f"tr({XONLY},multi_a(1,{XONLY}))", "BIP 387"),
+    (f"tr({XONLY},sortedmulti_a(1,{XONLY}))", "BIP 387"),
+    (f"tr({XONLY},pkh({KEY}))", "inside tr"),
+    (f"rawtr({XONLY})", "BIP 386"),
+    (f"tr(musig({KEY},{KEY}))", "BIP 390"),
+]
+
+
+@pytest.mark.parametrize(
+    ("descriptor", "message"),
+    [
+        pytest.param(descriptor, message, id=vector_id(index, descriptor))
+        for index, (descriptor, message) in enumerate(UNIMPLEMENTED)
+    ],
+)
+def test_unimplemented(descriptor: str, message: str) -> None:
+    with pytest.raises(NotImplementedError, match=message):
+        parse(descriptor)


### PR DESCRIPTION
`btclib/descriptors.py` computed the BIP-380 checksum and built an
`addr()` string, and stopped there. A descriptor is a line of text whose
whole point is the scripts it stands for, so the module now reads one and
derives them.

## What changed

`parse(descriptor, network="mainnet")` returns a `Descriptor` — one
frozen dataclass per grammar function, `PkDescriptor`, `PkhDescriptor`,
`WpkhDescriptor`, `ShDescriptor`, `WshDescriptor`, `MultiDescriptor`,
`ComboDescriptor`, `AddrDescriptor`, `RawDescriptor`, `TrDescriptor` —
and on it:

- `script_pub_keys(index)`: the `ScriptPubKey` set the descriptor pays to
  at that index (a list because `combo()` is four scripts; every other
  fragment is one)
- `script_pub_key(index)`, `address(index)`, `addresses(index)`,
  `redeem_script(index)`, `is_ranged`, `key_expressions`
- `strip_checksum` and `add_checksum`, the two halves of the checksum a
  caller needs; `parse` verifies one that is present
- `multipath_descriptors`: BIP 389's `<a;b>` expanded into the
  descriptors it stands for, each checksummed

Nothing is reimplemented: `bip32.derive` walks the derivation path,
`ScriptPubKey` builds every script and answers for the address, and
`taproot.output_pubkey` tweaks the `tr()` internal key with the script
tree. The existing `descriptor_checksum` and `descriptor_from_address`
keep their behaviour to the character.

The network is a parameter, as it is context in Bitcoin Core, with
`addr()` the exception: an address carries the chain in its own prefix,
so no parameter can contradict it.

## The grammar shipped

BIP 380 to BIP 386 and BIP 389, minus miniscript:

- `pk`, `pkh`, `wpkh`, `combo`, `sh` (`sh(wpkh())` and `sh(wsh())`
  included), `wsh`, `multi`, `sortedmulti`, `addr`, `raw`
- `tr` with a key path and a script tree of `pk()` leaves, nested to any
  depth
- key expressions: hex public keys compressed, uncompressed and — inside
  `tr()` — x-only; WIF; xpub/xprv with a derivation path; key origin
  `[fingerprint/path]`; the `/*` and `/*h` wildcards; both `h` and `'`
  hardened markers
- the position rules are enforced rather than assumed: `sh()` top level
  only, `wsh()` and `wpkh()` top level or inside `sh()`, `combo()`,
  `addr()`, `raw()` and `tr()` top level only, no uncompressed key inside
  a witness program, no x-only key outside `tr()`

## What raises NotImplementedError

Named, so that nothing is read wrong:

- every miniscript expression, fragment or `x:` wrapper — **issue #187**
- `multi_a()` and `sortedmulti_a()` — BIP 387
- `rawtr()` — BIP 386
- `musig()` — BIP 390

And one library limit is refused rather than mis-encoded: `multi()` above
16 keys, `ScriptPubKey.p2ms` encoding the count as `OP_1`..`OP_16` where
Core pushes it.

`satisfy` — descriptor plus signatures to a witness or scriptSig, the
question raised in the issue thread — is **not** in this PR. The
fragment classes are one per grammar function precisely so that it has
somewhere to go; the object model does not have to change to add it.

## Verification

Every expected script comes from Bitcoin Core or from btclib's own
address round-trip; none is invented.

- 34 vectors from Core's `descriptor_tests.cpp` `descriptor_test`
  (commit `8ecbe270f0dee68b7eec6cea1714f453c5e215ad`, 2026-07-29), in
  both the private and the public spelling — 64 descriptor expansions,
  so a WIF and an xprv are checked to reach the script their public
  halves reach. The four Core flags `HARDENED`/`DERIVE_HARDENED` are
  checked to be *refused* in their public spelling, which is all an xpub
  can honestly say about a hardened step.
- Core's `CheckMultipath` vectors for BIP 389: the expansions and the
  scripts of each.
- Core's `CheckUnparsable` cases plus the position rules: 38 descriptors
  that must not parse, each matched on the message that says why.
- The 18 descriptors of Core's `doc/descriptors.md`, already vendored as
  `tests/_data/descriptor_checksums.json` for the checksum test, read a
  second time: each expands, and every address it yields is the address
  of that very script. 17 of the 18; the 18th is the `sortedmulti_a()`,
  and the count is asserted so that refreshing the file cannot move a
  descriptor between the two groups unnoticed.

Provenance is in the test module's docstring — the values are extracted
from C++ source rather than copied from a data file, so nothing new is
vendored and `tests/_data/README.md` is unchanged.

Gates, exit code 0 each:

- `uv run pytest` — 14909 passed; `btclib/descriptors.py` at 100.00%
  statement coverage
- `uv run pre-commit run --all-files`
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html`

Sibling PRs move the CHANGELOG entry count too; re-derive it at merge
with `grep -c '^- ' CHANGELOG.md`.

Refs #186.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add full output descriptor parsing and script derivation to btclib, aligned with Bitcoin Core descriptor semantics and tests.

New Features:
- Introduce a Descriptor object model and parse(descriptor, network) API that reads BIP 380–386 and BIP 389 descriptors and exposes script_pub_keys, addresses, redeem_script, and key_expressions.
- Add multipath_descriptors to expand BIP 389 multipath (<a;b>) descriptors into individual checksummed single-path descriptors.
- Provide strip_checksum and add_checksum helpers for validating and attaching descriptor checksums, and reuse them in descriptor_from_address.

Enhancements:
- Enforce descriptor position rules and key constraints (e.g., witness-only compressed keys, x-only keys inside tr()) and explicitly raise NotImplementedError for miniscript and other unimplemented descriptor types.
- Model taproot descriptors with internal keys and script trees, deriving P2TR outputs including key-path and script-path leaves.
- Expand documentation and release notes to describe the new descriptor parsing capabilities and their verification against Bitcoin Core test vectors.

Documentation:
- Document the supported descriptor grammar, key expression forms, network semantics, and miniscript/other unimplemented functions in btclib.descriptors module docstring and changelog/history entries.

Tests:
- Add extensive tests for descriptor parsing and derivation using Bitcoin Core descriptor_tests.cpp vectors, documented descriptors, multipath examples, and various invalid/unimplemented cases.
- Verify KeyExpression behavior, network handling, multisig limits, combo semantics, and abstract Descriptor behavior through dedicated unit tests.