### PR TITLE
Make the device show R before it learns the randomness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1221,6 +1221,42 @@ edit.
   bytearray it is given, because two signatures under one secret nonce hand
   out the private key. Threshold signing, the neighbouring half of #190, is
   not implemented and the issue stays open for it
+- **the ECDSA Anti-Exfil Protocol**, which sign-to-contract is the
+  primitive for. A signing device that picks its own nonce can leak the
+  private key through the nonces themselves, a few bits per signature,
+  and nothing in the signature says that it did; the protocol takes the
+  choice away by having the host contribute randomness `rho` to the nonce
+  derivation. That only holds if the device publishes the nonce's point
+  `R` *before* it learns `rho` — otherwise it grinds `rho` against
+  candidate nonces until one carries the bits it wants out — so
+  `dsa.sign(msg, prv_key, commit=rho)`, which hands the device everything
+  at once, is step 4 alone and cannot enforce the ordering step 2 exists
+  for. The four functions that express the whole handshake are
+  `dsa.anti_exfil_host_commit`, `dsa.anti_exfil_signer_commit`,
+  `dsa.anti_exfil_sign` and `dsa.anti_exfil_host_verify`, one per step,
+  and the second of them is the shape the API did not have: a nonce's
+  point derived and published without signing anything. What lets the two
+  ends meet was already in place — `commit_entropy_` hashes the committed
+  value before it enters the derivation, so the nonce is reachable
+  knowing only a hash of `rho`, and libsecp256k1 states the purpose in as
+  many words: "it should be possible to derive nonces even if only a
+  SHA256 commitment to the data is known. This is important in the ECDSA
+  anti-exfil protocol". `anti_exfil_sign` drops the receipt instead of
+  returning it, as libsecp256k1's does: the host holds that point from
+  step 2, and taking the device's word for it after `rho` was revealed is
+  the one thing the ordering rules out. Two obligations land on the
+  caller and are written into the docstrings — restarting takes
+  **exactly** the same `rho`, with the host checking that the device
+  answers with exactly the same `R`, because selective aborting biases
+  the nonces that reach real signatures; and the device keeps no state
+  between step 2 and step 4, re-deriving the commitment from whatever
+  `rho` arrives, so a mismatch costs a failed verification and never a
+  reused nonce. Both of libsecp256k1-zkp's `expected_s2c_exfil_opening`
+  vectors reproduce, and its `expected_s2c_opening` column is checked
+  beside them as the `R` of step 2 under `anti_exfil_host_commit`: the
+  two columns are one host commitment apart, which is upstream's own
+  bytes saying that step 2 and step 4 reach one nonce. There is no
+  schnorr counterpart upstream to extend this to (issue #222)
 
 ### Script
 

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -15,6 +15,12 @@ http://www.secg.org/sec1-v2.pdf
 
 specialized with bitcoin canonical 'lower-s' form
 to avoid accepting malleable signatures.
+
+``sign`` also takes a value to commit to inside the nonce,
+sign-to-contract style (see btclib.ecc.commit_nonce for the tweak), and
+the four ``anti_exfil_*`` functions here are the protocol that
+construction exists to support: the ECDSA Anti-Exfil Protocol, whose
+five steps and reasoning are in ``anti_exfil_host_commit``.
 """
 
 from __future__ import annotations
@@ -30,7 +36,7 @@ from btclib_libsecp256k1 import dsa as libsecp256k1_dsa
 
 from btclib import var_bytes
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
-from btclib.curves import Curve, secp256k1
+from btclib.curves import Curve, mult, secp256k1
 from btclib.curves.curve import _libsecp256k1_applicable
 from btclib.curves.curve_group import _mult
 from btclib.curves.curve_group_2 import double_mult_w_NAF
@@ -655,6 +661,138 @@ def verify(
     return verify_(
         msg_hash, key, sig, lower_s, hf, commit_hash=commit_hash, receipt=receipt
     )
+
+
+def anti_exfil_host_commit(rho: Octets, hf: HashF = sha256) -> bytes:
+    """Return the host's commitment to rho: step 1 of the anti-exfil protocol.
+
+    A signing device that picks its own nonce can leak the private key
+    through the nonces themselves, a few bits per signature, and no
+    signature says that it did. The ECDSA Anti-Exfil Protocol takes that
+    choice away: the host contributes randomness to the nonce derivation,
+    so the device has nothing left to grind. Which only holds if the
+    device publishes the nonce's point *before* it learns the randomness
+    -- otherwise it grinds the randomness against candidate nonces until
+    one carries the bits it wants out -- so the exchange is a
+    commit-reveal handshake of five steps:
+
+    1. the host draws rho and sends ``anti_exfil_host_commit(rho)``
+    2. the device answers with ``anti_exfil_signer_commit(msg_hash,
+       prv_key, commitment)``, the point R its nonce will have
+    3. the host reveals rho
+    4. the device signs, ``anti_exfil_sign(msg_hash, prv_key, rho)``
+    5. the host checks ``anti_exfil_host_verify`` against the R of step 2
+       and the rho it drew in step 1
+
+    rho is hf_len bytes from a cryptographically secure generator, and it
+    stays secret until step 2 has been answered: revealed earlier it is
+    the device's to grind, which is the whole of what this prevents.
+
+    **Restarting the protocol takes exactly the same rho**, and the host
+    checks that the device answers step 2 with exactly the same R. A
+    device that could make the host draw again by failing would be
+    choosing which nonces reach real signatures, one abort at a time --
+    selective aborting is a bias like any other, and libsecp256k1 puts
+    the scale on it: some hundred aborts before there is a plausible
+    attack, accumulating across a replacement of every device involved,
+    though not across a replacement of the keys.
+
+    The commitment is the committed value as it enters the nonce
+    derivation -- ``commit_entropy_`` under the sign-to-contract data
+    tag, and nothing else -- which is what lets step 2 and step 4 reach
+    one nonce: the device derives it from this hash, and recomputes the
+    same hash from rho when it signs.
+    """
+    return commit_entropy_(bytes_from_octets(rho, hf().digest_size), _S2C_DATA_TAG, hf)
+
+
+def anti_exfil_signer_commit(
+    msg_hash: Octets,
+    prv_key: PrvKey,
+    host_commitment: Octets,
+    ec: Curve = secp256k1,
+    hf: HashF = sha256,
+) -> Point:
+    """Return the signer's public nonce R: step 2 of the anti-exfil protocol.
+
+    The point of the nonce the device is going to use, published before
+    the host reveals what its commitment commits to. Nothing is signed
+    here, and that is the shape the protocol needs: R is a promise, and
+    step 4 is what keeps it.
+
+    The commitment travels as RFC6979 section 3.6 additional data,
+    exactly as the committed value does in ``sign_``, so the two derive
+    one nonce and the R below is the receipt that signature will open
+    with.
+    """
+    c = challenge_(msg_hash, ec, hf)
+    q = int_from_prv_key(prv_key, ec)
+    entropy = bytes_from_octets(host_commitment, hf().digest_size)
+    return mult(_rfc6979_nonce_(c, q, ec, hf, entropy), ec.G, ec)
+
+
+def anti_exfil_sign(
+    msg_hash: Octets,
+    prv_key: PrvKey,
+    rho: Octets,
+    lower_s: bool = True,
+    ec: Curve = secp256k1,
+    hf: HashF = sha256,
+) -> Sig:
+    """Sign committing to the host's rho: step 4 of the anti-exfil protocol.
+
+    Sign-to-contract with rho as the committed value, which is all step 4
+    is: ``sign_`` with that commitment. The receipt it returns is dropped
+    rather than passed on, because the host has it already -- it is the R
+    of step 2, and a host taking the device's word for it here would be
+    accepting a nonce point chosen *after* rho was revealed, which is the
+    one thing the ordering exists to rule out.
+
+    **The device keeps no state between step 2 and step 4.** It does not
+    check rho against the commitment it was given: it re-derives the
+    commitment from rho, and the nonce from that. A rho that does not
+    match yields a different nonce, so the host's step 5 fails and the
+    exchange is over -- and because the R of step 2 belonged to the
+    commitment it was derived from, no nonce is ever used twice and the
+    device's key is never the thing at risk.
+    """
+    sig, _ = sign_(
+        msg_hash,
+        prv_key,
+        None,
+        lower_s,
+        ec,
+        hf,
+        commit_hash=bytes_from_octets(rho, hf().digest_size),
+    )
+    return sig
+
+
+def anti_exfil_host_verify(
+    msg_hash: Octets,
+    key: PubKey,
+    sig: Sig | Octets,
+    rho: Octets,
+    receipt: Point,
+    lower_s: bool = True,
+    hf: HashF = sha256,
+) -> bool:
+    """Check the signature against R and rho: step 5 of the anti-exfil protocol.
+
+    Two questions answered as one, and the host needs both: that this is
+    a valid signature, and that its nonce is the R of step 2 tweaked by
+    the rho of step 1. Either alone is worth nothing -- a valid signature
+    over a nonce nobody constrained is the exfiltration this protects
+    against, and a commitment that opens under an invalid signature is
+    not a signature. Which ``verify_`` already does in one call, both
+    checks running against the same r.
+
+    receipt is the R of step 2, what libsecp256k1 calls the opening.
+    False and not an exception for everything that fails, as ``verify_``
+    answers: a rho of the wrong size is simply a rho this commitment does
+    not open to.
+    """
+    return verify_(msg_hash, key, sig, lower_s, hf, commit_hash=rho, receipt=receipt)
 
 
 def _recover_pub_keys_(

--- a/tests/ecc/anti_exfil_test.py
+++ b/tests/ecc/anti_exfil_test.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Tests for the ECDSA Anti-Exfil Protocol of `btclib.ecc.dsa`.
+
+The protocol is libsecp256k1-zkp's, and its `ecdsa_s2c` module carries
+the vectors: the fixture below is that module's `ecdsa_s2c_tests`, whose
+third column, `expected_s2c_exfil_opening`, is the R that
+`anti_exfil_signer_commit` has to answer with.
+
+The second column is what makes the fixture worth more than two numbers.
+`expected_s2c_opening` is the receipt of a sign-to-contract signature
+over the same data, so the two columns are one `anti_exfil_host_commit`
+apart -- and that is exactly the property the handshake stands on, step
+2 and step 4 reaching one nonce. It is checked here against upstream's
+own bytes rather than against btclib run twice.
+
+```text
+repo    BlockstreamResearch/secp256k1-zkp
+path    src/modules/ecdsa_s2c/tests_impl.h
+commit  baac08d207003151d095423487d3954503a52aeb  2026-04-20
+blob    ba4f158c5d5c63b195011cda8c24331e5d21a4d4
+```
+
+Read at master `2af926dc309a673461f0e2da090105c8f05b4505`, whose tree
+carries that blob; the commit above is the tip of the path. The protocol
+rationale quoted in the docstrings is `include/secp256k1_ecdsa_s2c.h` at
+the same master, blob `c931457d6a53ca8aed8189257e7a2ff496fd084c`.
+"""
+
+from hashlib import sha1, sha256
+
+import pytest
+
+from btclib.curves import bytes_from_point, secp256k1
+from btclib.ecc import dsa
+from btclib.exceptions import BTClibValueError
+
+# the key and the message of test_ecdsa_s2c_fixed_vectors, which
+# test_ecdsa_anti_exfil_signer_commit reuses verbatim
+_PRV_KEY = bytes.fromhex("55" * 32)
+_MSG_HASH = bytes.fromhex("88" * 32)
+_PUB_KEY = dsa.gen_keys(_PRV_KEY)[1]
+
+# s2c_data, expected_s2c_opening, expected_s2c_exfil_opening
+_ZKP_VECTORS = [
+    pytest.param(
+        "1bf6fb42f41eb876c4d7aa0d67242b00baab99dc2084493e4e63277fa1f77f22",
+        "03f030def3188c0f56fcea87435b307643f45dafe22cbc82fd56034fae97417d3a",
+        "02df63755d1f3292bffed82986b106497c93b1f8bdc0454b6b0b0a4779c0ef7188",
+        id="zkp-0",
+    ),
+    pytest.param(
+        "35199a8fbf84ad6ef69a184c1b19285befbe06e60b6264e6d373893f6855e24a",
+        "03901717ce7c7484a2ce1b7dc7403b14e0354971393ec092a7f3e0c8e4e2d2639d",
+        "02c04ac7f771e8ebdbf315ff5e58b7fe9516102103500066172c4fac5b20f9e0ea",
+        id="zkp-1",
+    ),
+]
+
+# a handshake of its own, so that nothing here leans on the fixture's
+# message. rho is a constant because a test has to be reproducible; a
+# host draws it from a cryptographically secure generator, which is what
+# the protocol asks of it and the one thing a test cannot check
+_HANDSHAKE_MSG_HASH = sha256(b"to be signed").digest()
+_RHO = sha256(b"the host's randomness").digest()
+_OTHER_RHO = sha256(b"a second draw").digest()
+
+
+@pytest.mark.parametrize(("rho", "opening", "exfil_opening"), _ZKP_VECTORS)
+def test_signer_commit_vectors(rho: str, opening: str, exfil_opening: str) -> None:
+    """R is the opening test_ecdsa_anti_exfil_signer_commit expects.
+
+    That fixture hands the raw s2c_data to `anti_exfil_signer_commit` as
+    the host commitment -- an unreachable value in a real handshake,
+    where the commitment is a hash -- so this pins the derivation and
+    nothing about the protocol. Which is what a vector is for: the
+    commitment enters as RFC6979 additional data, unhashed, and no other
+    layout reaches these bytes.
+    """
+    R = dsa.anti_exfil_signer_commit(_MSG_HASH, _PRV_KEY, rho)
+    assert bytes_from_point(R, secp256k1).hex() == exfil_opening
+    # the other column is a different R, the s2c signature deriving its
+    # nonce from a hash of this same data: which is the next test
+    assert exfil_opening != opening
+
+
+@pytest.mark.parametrize(("rho", "opening", "exfil_opening"), _ZKP_VECTORS)
+def test_step_2_and_step_4_reach_one_nonce(
+    rho: str, opening: str, exfil_opening: str
+) -> None:
+    """The R promised in step 2 is the R the signature of step 4 has.
+
+    Which is what `commit_entropy_` buys by hashing the committed value
+    before it enters the derivation: the device can reach the nonce
+    knowing only a hash of rho, so it can publish R before rho is
+    revealed. Upstream's two columns are one host commitment apart and
+    say so in their own bytes -- the R derived from
+    `anti_exfil_host_commit(rho)` is the receipt of the sign-to-contract
+    signature over rho.
+    """
+    commitment = dsa.anti_exfil_host_commit(rho)
+    # the raw data is not the commitment, or the two columns would agree
+    assert commitment.hex() != rho
+    assert (
+        bytes_from_point(
+            dsa.anti_exfil_signer_commit(_MSG_HASH, _PRV_KEY, rho), secp256k1
+        ).hex()
+        == exfil_opening
+    )
+
+    R = dsa.anti_exfil_signer_commit(_MSG_HASH, _PRV_KEY, commitment)
+    assert bytes_from_point(R, secp256k1).hex() == opening
+
+    sig, receipt = dsa.sign_(_MSG_HASH, _PRV_KEY, commit_hash=rho)
+    assert receipt == R
+    assert dsa.anti_exfil_sign(_MSG_HASH, _PRV_KEY, rho) == sig
+    assert dsa.anti_exfil_host_verify(_MSG_HASH, _PUB_KEY, sig, rho, R)
+
+
+def test_the_whole_handshake() -> None:
+    """The five steps, in order, and then what each of them refuses."""
+    # 1. the host draws rho and commits to it
+    commitment = dsa.anti_exfil_host_commit(_RHO)
+    # 2. the device answers with the point its nonce will have
+    R = dsa.anti_exfil_signer_commit(_HANDSHAKE_MSG_HASH, _PRV_KEY, commitment)
+    # 3. the host reveals rho
+    # 4. the device signs, committing to it
+    sig = dsa.anti_exfil_sign(_HANDSHAKE_MSG_HASH, _PRV_KEY, _RHO)
+    # 5. the host checks the signature against that R and its own rho
+    assert dsa.anti_exfil_host_verify(_HANDSHAKE_MSG_HASH, _PUB_KEY, sig, _RHO, R)
+
+    # an ordinary ECDSA signature, which is the whole point: nothing on
+    # the chain says the nonce was negotiated
+    assert dsa.verify_(_HANDSHAKE_MSG_HASH, _PUB_KEY, sig)
+    assert dsa.verify_(_HANDSHAKE_MSG_HASH, _PUB_KEY, sig.serialize())
+
+    # not against another message, another rho, or another R
+    assert not dsa.anti_exfil_host_verify(
+        sha256(b"another message").digest(), _PUB_KEY, sig, _RHO, R
+    )
+    assert not dsa.anti_exfil_host_verify(
+        _HANDSHAKE_MSG_HASH, _PUB_KEY, sig, _OTHER_RHO, R
+    )
+    assert not dsa.anti_exfil_host_verify(
+        _HANDSHAKE_MSG_HASH,
+        _PUB_KEY,
+        sig,
+        _RHO,
+        secp256k1.add(R, secp256k1.G),
+    )
+
+
+def test_the_signer_keeps_no_state() -> None:
+    """A rho that does not match the commitment fails step 5, and only that.
+
+    The device does not remember the commitment it answered step 2 with,
+    and does not have to: it re-derives one from whatever rho arrives.
+    A host that reveals something else gets a valid signature over an R
+    that is not the R it holds, so step 5 says no -- and because that R
+    belonged to the commitment it came from, no nonce was reused and the
+    key was never what was at stake.
+    """
+    commitment = dsa.anti_exfil_host_commit(_RHO)
+    R = dsa.anti_exfil_signer_commit(_HANDSHAKE_MSG_HASH, _PRV_KEY, commitment)
+
+    # step 3 reveals the wrong value; step 4 signs it all the same
+    sig = dsa.anti_exfil_sign(_HANDSHAKE_MSG_HASH, _PRV_KEY, _OTHER_RHO)
+    assert dsa.verify_(_HANDSHAKE_MSG_HASH, _PUB_KEY, sig)
+    assert not dsa.anti_exfil_host_verify(_HANDSHAKE_MSG_HASH, _PUB_KEY, sig, _RHO, R)
+
+    # and what it does open under is the R of the rho it was given, a
+    # point the host never saw
+    other_R = dsa.anti_exfil_signer_commit(
+        _HANDSHAKE_MSG_HASH, _PRV_KEY, dsa.anti_exfil_host_commit(_OTHER_RHO)
+    )
+    assert other_R != R
+    assert dsa.anti_exfil_host_verify(
+        _HANDSHAKE_MSG_HASH, _PUB_KEY, sig, _OTHER_RHO, other_R
+    )
+
+
+def test_a_restart_takes_the_same_rho() -> None:
+    """Step 2 is a function of its arguments, so the host's check bites.
+
+    Restarting with the same rho must reach the same R, or the host has
+    nothing to compare and a device could bias the nonces it lets
+    through by aborting selectively. Restarting with a fresh rho reaches
+    a different R, which is why the protocol asks for the old one.
+    """
+    commitment = dsa.anti_exfil_host_commit(_RHO)
+    assert dsa.anti_exfil_host_commit(_RHO) == commitment
+    R = dsa.anti_exfil_signer_commit(_HANDSHAKE_MSG_HASH, _PRV_KEY, commitment)
+    assert dsa.anti_exfil_signer_commit(_HANDSHAKE_MSG_HASH, _PRV_KEY, commitment) == R
+
+    redrawn = dsa.anti_exfil_host_commit(_OTHER_RHO)
+    assert redrawn != commitment
+    assert dsa.anti_exfil_signer_commit(_HANDSHAKE_MSG_HASH, _PRV_KEY, redrawn) != R
+
+
+def test_rho_and_the_commitment_are_hf_len() -> None:
+    """The sizes follow hf, and the two signing steps refuse any other.
+
+    Not decoration: rho is what the device cannot predict, and a host
+    drawing four bytes of it hands the device a value to guess and grind
+    against. Refused where it is drawn and where it is signed with;
+    `anti_exfil_host_verify` answers False instead, verify never raising
+    over what is merely an input the signature does not match.
+    """
+    short = b"\x00" * 31
+    with pytest.raises(BTClibValueError, match="invalid size"):
+        dsa.anti_exfil_host_commit(short)
+    with pytest.raises(BTClibValueError, match="invalid size"):
+        dsa.anti_exfil_sign(_HANDSHAKE_MSG_HASH, _PRV_KEY, short)
+    with pytest.raises(BTClibValueError, match="invalid size"):
+        dsa.anti_exfil_signer_commit(_HANDSHAKE_MSG_HASH, _PRV_KEY, short)
+
+    commitment = dsa.anti_exfil_host_commit(_RHO)
+    R = dsa.anti_exfil_signer_commit(_HANDSHAKE_MSG_HASH, _PRV_KEY, commitment)
+    sig = dsa.anti_exfil_sign(_HANDSHAKE_MSG_HASH, _PRV_KEY, _RHO)
+    assert not dsa.anti_exfil_host_verify(_HANDSHAKE_MSG_HASH, _PUB_KEY, sig, short, R)
+
+    # hf is the one that says what the sizes are, all the way through:
+    # the 20 bytes below reach step 5 and the 32 above would not, each
+    # step measuring against the hf it was handed
+    msg_hash = sha1(b"to be signed").digest()  # noqa: S324
+    rho = sha1(b"the host's randomness").digest()  # noqa: S324
+    commitment = dsa.anti_exfil_host_commit(rho, sha1)
+    with pytest.raises(BTClibValueError, match="invalid size"):
+        dsa.anti_exfil_signer_commit(msg_hash, _PRV_KEY, _RHO, secp256k1, sha1)
+    R = dsa.anti_exfil_signer_commit(msg_hash, _PRV_KEY, commitment, secp256k1, sha1)
+    sig = dsa.anti_exfil_sign(msg_hash, _PRV_KEY, rho, True, secp256k1, sha1)
+    assert dsa.anti_exfil_host_verify(msg_hash, _PUB_KEY, sig, rho, R, True, sha1)


### PR DESCRIPTION
## What changed

`btclib.ecc.dsa` gains the four functions of libsecp256k1-zkp's ECDSA
Anti-Exfil Protocol, one per step of the commit-reveal handshake:

| step | function | what it is |
| --- | --- | --- |
| 1 | `anti_exfil_host_commit(rho, hf)` | the host's tagged-sha256 commitment to `rho` |
| 2 | `anti_exfil_signer_commit(msg_hash, prv_key, commitment, ec, hf)` | the point `R` the device's nonce will have, derived without signing |
| 4 | `anti_exfil_sign(msg_hash, prv_key, rho, lower_s, ec, hf)` | sign-to-contract with `rho` as the committed value |
| 5 | `anti_exfil_host_verify(msg_hash, key, sig, rho, receipt, lower_s, hf)` | the signature *and* the opening, in one answer |

## Why

A signing device that picks its own nonce can leak the private key
through the nonces themselves, a few bits per signature, with nothing in
the signature to say that it did. The protocol takes the choice away by
having the host contribute randomness `rho` to the derivation — and it
only works if the device publishes `R` **before** it learns `rho`,
otherwise it grinds `rho` against candidate nonces until one carries the
bits it wants out. `dsa.sign(msg, prv_key, commit=rho)` hands the device
everything at once, so it is step 4 alone and cannot enforce the ordering
step 2 exists for. Step 2 — a nonce's point derived and published without
signing anything — had no shape in the API at all.

What makes the two ends meet was already in place: `commit_entropy_`
hashes the committed value before it enters the derivation, so the nonce
is reachable knowing only a hash of `rho`. libsecp256k1 states the
purpose in as many words: *"it should be possible to derive nonces even
if only a SHA256 commitment to the data is known. This is important in
the ECDSA anti-exfil protocol"*. `anti_exfil_host_commit` **is** that
hash, which is why `signer_commit` takes the commitment as RFC6979
section 3.6 additional data unhashed while `sign_` hashes `rho` into it
first.

The two protocol obligations the issue named are in the docstrings, taken
from the header's own rationale: restarting takes **exactly** the same
`rho`, with the host checking that the device answers with exactly the
same `R`, because selective aborting biases the nonces that reach real
signatures; and the device keeps **no state** between step 2 and step 4,
re-deriving the commitment from whatever `rho` arrives, so a mismatch
costs a failed verification and never a reused nonce.

## Decisions, and the alternatives declined

- **In `dsa.py`, not a module of its own.** `bms` is the precedent for a
  protocol built on `dsa` getting its own module, but the tags
  `s2c/ecdsa/data` and `s2c/ecdsa/point` are private to `dsa` and a
  neighbour would have to import them; and the names libsecp256k1 and the
  issue both use read as `dsa.anti_exfil_*` here and stutter anywhere
  else. No new `docs/source/*.rst` entry as a result.
- **`anti_exfil_sign` returns the `Sig` alone**, dropping the receipt,
  as `secp256k1_anti_exfil_sign` does by passing `NULL`: the host holds
  that point from step 2, and taking the device's word for it after `rho`
  was revealed is the one thing the ordering rules out. The receipt is
  still available from `dsa.sign_(..., commit_hash=rho)` for anyone who
  wants it.
- **No wrapper around `verify_` beyond the naming.** `anti_exfil_host_verify`
  is a delegation, because `verify_` already runs both checks against the
  same `r` — the issue's point that this, not the bare `s2c_verify_commit`,
  is step 5's contract.
- **`rho` and the commitment are `hf_len` bytes, enforced in the two
  signing steps.** `rho` is what the device must not be able to guess, so
  a four-byte draw is a real weakness, not a formatting question.
  `host_verify` answers `False` instead of raising: `verify` never raises
  over an input the signature merely does not match.
- **No schnorr counterpart.** There is none upstream, and BIP340 says
  nothing about commitments.

## Verification

Every gate run in this worktree, exit code checked (never grepped
output):

- `uv run pytest` — **exit 0**, 14795 passed.
- `uv run pre-commit run --all-files` — **exit 0**, all 35 hooks pass
  (mypy strict, ruff check and format, markdownlint, codespell, typos,
  check-manifest, pyroma…).
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — **exit 0**, build
  succeeded.

Upstream vectors, from `BlockstreamResearch/secp256k1-zkp`
`src/modules/ecdsa_s2c/tests_impl.h`, commit
`baac08d207003151d095423487d3954503a52aeb` (2026-04-20), blob
`ba4f158c5d5c63b195011cda8c24331e5d21a4d4`, read at master
`2af926dc309a673461f0e2da090105c8f05b4505`; the pin is recorded in the
test module's docstring, the vectors being inline as the existing s2c
ones are.

- Both `expected_s2c_exfil_opening` values reproduce, from
  `anti_exfil_signer_commit` with the raw `s2c_data` as the commitment —
  upstream's `test_ecdsa_anti_exfil_signer_commit`, exactly.
- The `expected_s2c_opening` column beside them is checked too, as the
  `R` of step 2 under `anti_exfil_host_commit`. The two columns are one
  host commitment apart, so it is **upstream's own bytes** that say step
  2 and step 4 reach one nonce, rather than btclib run twice; the same
  `R` is the receipt of `dsa.sign_(..., commit_hash=rho)`.
- The handshake round-trips end to end and refuses another message,
  another `rho` and another `R`; a `rho` that does not match the
  commitment yields a valid ECDSA signature that step 5 rejects, which is
  upstream's `test_ecdsa_anti_exfil` in full.
- Restart determinism, and the `hf`-driven sizes all the way through
  (sha1 as well as sha256), are covered.

### One thing that is red and is not this branch

`pytest --cov=btclib --cov=tests` fails `fail_under = 99.99`, and it
already did at the branch point. Measured both ways in this worktree:

```text
0e5d6301 (origin/dev)   15840 stmts, 2 missed   FAIL
this branch             15927 stmts, 2 missed   FAIL
```

The same two statements in both — `btclib/mnemonic/electrum.py:317-318`,
the defensive `cannot extract the same entropy from mnemonic` raise added
by `b9a2f5d9`, which no test reaches. Every statement this branch adds is
covered, so the ratio moves *up*, 99.98737% to 99.98744%. Left alone
here: it belongs to #196's module, not to this change.

Sibling PRs move the CHANGELOG entry count too; re-derive it at merge with `grep -c '^- ' CHANGELOG.md`.

Closes #222.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce first-class support for the ECDSA Anti-Exfil Protocol in the dsa module, including host/device API surface, documentation, and verification against upstream test vectors.

New Features:
- Add anti-exfil ECDSA API to btclib.ecc.dsa with host commitment, signer nonce commit, signing, and host verification helpers for the ECDSA Anti-Exfil Protocol.

Documentation:
- Document the anti-exfil ECDSA protocol, its five-step handshake, and usage constraints in dsa module docstrings and changelog entries.

Tests:
- Add comprehensive anti-exfil protocol tests using libsecp256k1-zkp upstream vectors and end-to-end handshake scenarios, including edge cases around restarts and rho sizing.