### PR TITLE
Share the doublings when the scalars are few, and count them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1892,6 +1892,36 @@ edit.
   crossover; what pays is the toy curves of the test suite, n = 11 and
   n = 31, some 2 us a call, and a size guard would have bought a fraction of
   a second back at the price of a branch inside signature verification
+- **the multi multiplication behind batch verification picks its
+  algorithm by size**, and the small sizes are the ones that got faster.
+  `curve_group._multi_mult` was Bos-Coster whatever the batch; it is now
+  Strauss' interleaved wNAF — `_multi_mult_w_NAF`, the many-point form of
+  the double multiplication above — below fifty-six nonzero scalars, and
+  Bos-Coster from there on. Sharing one doubling per bit among all the
+  points is what wins on few scalars: on secp256k1, best of interleaved
+  reps over random 256-bit scalars, 1.99 ms against 3.91 at two scalars,
+  2.59 against 4.56 at three, 3.92 against 6.34 at five, 6.96 against
+  10.02 at ten. `ssa.assert_batch_as_valid_` spends two scalars per
+  signature and inherits the curve: 5.93 ms against 7.79 for two
+  signatures, 7.32 against 9.65 for three, 10.01 against 12.77 for five,
+  16.87 against 20.38 for ten, and the same 47.6 either way at
+  thirty-two, which is where the dispatch has already changed hands.
+  What does not win is the tail: the shared doublings amortize to nothing
+  and the per-scalar cost is all that is left, 50 point operations against
+  the 44.5 Bos-Coster settles at, so 56 is where the two measure the same
+  and the dispatch changes hands. Nonzero scalars, because a zero is
+  dropped before either algorithm sees it: 56 scalars of which 2 are
+  nonzero is a batch of two, and dispatching it on its length would cost
+  1.81 ms where the wNAF takes 1.02, against the 0.8 us of counting the
+  zeros out. Both implementations stay, tested against each other and
+  against the plain sum of scalar multiplications on every curve of the
+  catalogue; the threshold is a measurement, not libsecp256k1's 88, whose
+  algorithms and machine are not these. Pippenger is *not* in the tree
+  for the same reason: prototyped with sparse buckets and the running-sum
+  trick, best window per size, it lost at every size measured — 162 ms
+  against Bos-Coster's 125 at 256 scalars, 284 against 225 at 512, 500
+  against 406 at 1024 — because in python its bucket sums are additions
+  like any other, where in C they are the cheap part (issue #212)
 - signing or verifying a transaction is linear in the number of its
   inputs, where it was Θ(N²). `segwit_v0` and `taproot` rebuilt, for
   every input, the hashes that depend on the whole transaction — its

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -340,7 +340,9 @@ def multi_mult(
 ) -> Point:
     """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
 
-    Use Bos-Coster's algorithm for efficient computation.
+    Interleaved wNAF on few scalars, Bos-Coster on many: curve_group's
+    _multi_mult dispatches on the count, at the size the two measure the
+    same.
     """
     if len(scalars) != len(points):
         err_msg = "mismatch between number of scalars and points: "

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -646,6 +646,69 @@ def convert_number_to_base(i: int, base: int) -> list[int]:
     return digits[::-1]
 
 
+def mods(m: int, w: int) -> int:
+    """Signed modulo function."""
+    w2: int = pow(2, w)
+    M = m % w2
+    return M - w2 if M >= (w2 // 2) else M
+
+
+def wNAF_of_m(m: int, w: int) -> list[int]:
+    """WNAF (width-w Non-adjacent form) of number m.
+
+    Given an integer m, wNAF is a method of representation
+    with powers of 2, where the coefficients are odd or 0,
+    and where at most one of any w consecutive digits is nonzero.
+    It has the following properties:
+    - m has a unique width-w NAF.
+    -The length of wNAF(m) is at most one more than the length of the binary
+    representation of k.
+    -The average density of nonzero digits is approximately 1/(w + 1).
+
+    This recoding sits here next to convert_number_to_base, the same kind
+    of integer-only helper, rather than with the wNAF multiplications of
+    curve_group_2: the interleaved _multi_mult_w_NAF below needs it, and
+    curve_group cannot import the module that imports it.
+
+    For complete reference see:
+    D. Hankerson, 'Guide to Elliptic Curve Cryptography' chapter 3
+    """
+    i = 0
+
+    M: list[int] = []
+    while m > 0:
+        if (m % 2) == 1:
+            if w == 1:
+                # Computing binary NAF of m
+                M.append(2 - (m % 4))
+            else:
+                # Computing wNAF of m
+                M.append(mods(m, w))
+            m -= M[i]
+        else:
+            M.append(0)
+        m //= 2
+        i += 1
+
+    return M
+
+
+def odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
+    """Return the odd multiples 1*Q, 3*Q, ..., (2^(w-1) - 1)*Q.
+
+    The table a width-w NAF indexes: its digits are odd and smaller than
+    2^(w-1) in absolute value, so a digit d picks entry (abs(d) - 1) // 2,
+    to be negated on the fly when d is negative. For w of 1 or 2 the
+    digits are only +-1 and the table is the point itself.
+    """
+    T = [Q]
+    if w > 2:
+        Q2 = ec.double_jac(Q)
+        for _ in range(2 ** (w - 2) - 1):
+            T.append(ec.add_jac(T[-1], Q2))
+    return T
+
+
 def mult_mont_ladder(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     """Scalar multiplication using 'Montgomery ladder' algorithm.
 
@@ -835,7 +898,98 @@ def _double_mult(
     return R
 
 
-def _multi_mult(
+def _multi_mult_pairs(
+    scalars: Sequence[int], jac_points: Sequence[JacPoint]
+) -> list[tuple[int, JacPoint]]:
+    """Check the arguments of a multi multiplication and drop the zeros.
+
+    Shared by the two implementations below so that they answer the same
+    errors to the same arguments: whichever of them _multi_mult calls is
+    a performance decision, and a caller must not be able to tell which
+    it got. A zero scalar contributes nothing to the sum and is dropped
+    rather than carried, which Bos-Coster needs -- it would be a zero
+    divisor in its Euclidean step -- and interleaved wNAF is glad of,
+    a scalar of zero costing a table it would never index.
+    """
+    if len(scalars) != len(jac_points):
+        err_msg = "mismatch between number of scalars and points: "
+        err_msg += f"{len(scalars)} vs {len(jac_points)}"
+        raise BTClibValueError(err_msg)
+
+    if len(scalars) < 2:
+        raise BTClibValueError("not a multi_mult")
+
+    pairs: list[tuple[int, JacPoint]] = []
+    for n, PJ in zip(scalars, jac_points, strict=True):
+        if n < 0:
+            raise BTClibValueError(f"negative coefficient: {hex(n)}")
+        if n:
+            pairs.append((n, PJ))
+    return pairs
+
+
+def _multi_mult_w_NAF(
+    scalars: Sequence[int], jac_points: Sequence[JacPoint], ec: CurveGroup, w: int = 5
+) -> JacPoint:
+    """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
+
+    Strauss' algorithm with interleaved wNAFs, the many-point form of
+    curve_group_2's double_mult_w_NAF (HMV algorithm 3.51): each scalar
+    gets its own width-w NAF and its own table of odd multiples, and a
+    single left-to-right loop shares one doubling per bit position among
+    all of them, adding a (possibly negated) table entry wherever a NAF
+    has a nonzero digit.
+
+    Sharing the doublings is the whole of the idea, and what the dispatch
+    of _multi_mult weighs: the ~256 doublings a 256-bit scalar needs are
+    paid once for the batch instead of once per point, leaving some 50
+    point operations per scalar of its own. Bos-Coster has no fixed cost
+    to share and settles at 44.5 per scalar, so few scalars is where the
+    sharing pays and many is where the per-scalar figure is all there is.
+
+    Cost here is a function of the bit length of the scalars and of
+    nothing else, so no pair of magnitudes is pathological the way
+    10**6 next to 1 is for a subtractive Bos-Coster step (issue 175).
+
+    w=5 by measurement, on random 256-bit scalars: the table costs
+    2^(w-2) - 1 additions and a doubling per point while the NAF has one
+    nonzero digit in w+1, so the total falls to w=5 and rises again at
+    w=6 (per scalar at 128 scalars: 57.7 operations at w=4, 53.3 at w=5,
+    55.1 at w=6). In milliseconds over 10 scalars: 7.81 at w=4, 7.27 at
+    w=5, 7.38 at w=6, 8.68 at w=7.
+
+    No GLV splitting of the scalars, which would halve the doublings on
+    secp256k1: the split is curve-specific, this function serves every
+    curve, and the doublings it would halve are already shared.
+
+    The input points are assumed to be on curve, the scalar coefficients
+    are assumed to have been reduced mod n if appropriate (e.g. cyclic
+    groups of order n).
+    """
+    # a number cannot be written in basis 1 (ie w=0)
+    if w <= 0:
+        raise BTClibValueError(f"non positive w: {w}")
+
+    pairs = _multi_mult_pairs(scalars, jac_points)
+    if not pairs:
+        return INFJ
+
+    nafs = [wNAF_of_m(n, w) for n, _ in pairs]
+    tables = [odd_multiples(PJ, ec, w) for _, PJ in pairs]
+
+    R = INFJ
+    for j in range(max(len(naf) for naf in nafs) - 1, -1, -1):
+        R = ec.double_jac(R)
+        for naf, T in zip(nafs, tables, strict=True):
+            # a scalar shorter than the longest one has run out of digits
+            if j < len(naf) and naf[j] != 0:
+                d = naf[j]
+                QJ = T[(d - 1) // 2] if d > 0 else ec.negate_jac(T[(-d - 1) // 2])
+                R = ec.add_jac(R, QJ)
+    return R
+
+
+def _multi_mult_bos_coster(
     scalars: Sequence[int], jac_points: Sequence[JacPoint], ec: CurveGroup
 ) -> JacPoint:
     """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
@@ -857,32 +1011,29 @@ def _multi_mult(
     subtraction: n1/n2 steps to do what one divmod does (issue 175) --
     multi_mult([10**6, 1], [G, H]) would take 10.6 s, and both
     multi_mult([n-1, 1], [G, H]) and multi_mult([-1, 1], [G, H]) would
-    never finish, on scalars a caller has every right to pass.
+    never finish, on scalars a caller has every right to pass. The whole
+    of Euclid is what makes this a live path rather than a reading
+    exercise: _multi_mult calls it above its threshold.
+
+    Where the interleaved wNAF above shares one doubling per bit among
+    all the points, this one has no fixed cost to amortize at all -- the
+    heap converges towards scalars of the same size, and the quotient is
+    1 about 40% of the time (Gauss-Kuzmin), so a step is usually one
+    addition. That is why it wins on many scalars and loses on few: 44.5
+    point operations per scalar over 128 random 256-bit scalars, against
+    267.5 over two.
 
     The input points are assumed to be on curve, the scalar coefficients
     are assumed to have been reduced mod n if appropriate (e.g. cyclic
     groups of order n).
     """
     # source: https://cr.yp.to/badbatch/boscoster2.py
-    if len(scalars) != len(jac_points):
-        err_msg = "mismatch between number of scalars and points: "
-        err_msg += f"{len(scalars)} vs {len(jac_points)}"
-        raise BTClibValueError(err_msg)
-
-    if len(scalars) < 2:
-        raise BTClibValueError("not a multi_mult")
-
-    x: list[tuple[int, JacPoint]] = []
-    for n, PJ in zip(scalars, jac_points, strict=True):
-        if n == 0:  # mandatory check: a zero would be a zero divisor below
-            continue
-        if n < 0:
-            raise BTClibValueError(f"negative coefficient: {hex(n)}")
-        x.append((-n, PJ))
-
-    if not x:
+    pairs = _multi_mult_pairs(scalars, jac_points)
+    if not pairs:
         return INFJ
 
+    # a max-heap, which python spells as a min-heap of negated scalars
+    x: list[tuple[int, JacPoint]] = [(-n, PJ) for n, PJ in pairs]
     heapq.heapify(x)
     while len(x) > 1:
         np1 = heapq.heappop(x)
@@ -906,3 +1057,53 @@ def _multi_mult(
     # n_1 is left as it is rather than reduced mod n: _mult reduces, and
     # the scalars reaching here are already below the order
     return _mult(n_1, p_1, ec)
+
+
+# the number of nonzero scalars from which Bos-Coster is the cheaper of
+# the two, measured here rather than borrowed: libsecp256k1 dispatches
+# at 88, but it dispatches between other algorithms, on machine words,
+# in C, and a number that has not been measured on python integers is
+# decoration.
+# Best of five interleaved reps, random 256-bit scalars on secp256k1,
+# python 3.14, macOS arm64, wNAF over Bos-Coster: 0.91 at 40 scalars,
+# 0.94 at 48, 1.000 at 56, 1.001 at 64, 1.04 at 72, 1.09 at 96. The two
+# meet at 56, so 56 it is; anywhere in 56..64 measures the same, and the
+# cost of being wrong by a dozen scalars either way is under 1%.
+BOS_COSTER_THRESHOLD = 56
+
+
+def _multi_mult(
+    scalars: Sequence[int], jac_points: Sequence[JacPoint], ec: CurveGroup
+) -> JacPoint:
+    """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
+
+    Interleaved wNAF up to BOS_COSTER_THRESHOLD nonzero scalars and
+    Bos-Coster from there on, the two crossing where the shared doublings
+    stop paying for themselves (issue 212). Both are kept, and not only to
+    be dispatched between: the library is didactic as much as it is a
+    library, and Bos-Coster is the one that can be read in twenty lines.
+
+    Pippenger, the third algorithm libsecp256k1 has, is *not* here, and
+    the measurement is the reason. Prototyped with sparse buckets and the
+    running-sum trick, best window per size, it lost at every size tried:
+    against Bos-Coster in ms, 162 vs 125 at 256 scalars, 284 vs 225 at
+    512, 500 vs 406 at 1024. Its bucket sums are additions of points that
+    cost the same as any other addition in python, where in C they are
+    the cheap part, so the crossover it has there is beyond any batch
+    btclib is asked to verify -- and a threshold nobody reaches is a
+    branch nobody takes.
+
+    The zeros are counted out before the dispatch rather than left to
+    len(), because a zero scalar is dropped downstream and the batch that
+    reaches either implementation is the nonzero one: 56 scalars of which
+    2 are nonzero is a batch of two, and sending it to Bos-Coster on its
+    length costs 1.81 ms against the wNAF's 1.02. The pass that counts
+    them is 0.8 us at that size, under a thousandth of either.
+
+    The input points are assumed to be on curve, the scalar coefficients
+    are assumed to have been reduced mod n if appropriate (e.g. cyclic
+    groups of order n).
+    """
+    if sum(1 for n in scalars if n) < BOS_COSTER_THRESHOLD:
+        return _multi_mult_w_NAF(scalars, jac_points, ec)
+    return _multi_mult_bos_coster(scalars, jac_points, ec)

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -47,10 +47,6 @@ tracks the smaller follow-ups; what is here is the rest:
         - https://crypto.stackexchange.com/questions/58506/what-is-the-curve-type-of-secp256k1
         - 1-s_2.0-S1071579704000395-main (the file name it was saved as; the
           paper it refers to has not been identified)
-    - Strauss-wNAF, and Pippenger above a measured threshold, as the
-      multi_mult libsecp256k1 dispatches between: issue 212. Bos-Coster
-      stays whichever of them lands, the library being didactic as well --
-      it is the one of the three that can be read in twenty lines
     - Peter Dettman's field inverses and square roots, a sliding window over
       blocks of 1s:
 
@@ -65,50 +61,18 @@ tracks the smaller follow-ups; what is here is the rest:
 from __future__ import annotations
 
 from btclib.alias import INFJ, JacPoint
-from btclib.curves.curve_group import CurveGroup, convert_number_to_base
+
+# the wNAF recoding and the table of odd multiples it indexes live in
+# curve_group, next to convert_number_to_base and for the same reason:
+# its interleaved _multi_mult_w_NAF needs them, and the dependency runs
+# one way, this module importing that one
+from btclib.curves.curve_group import (
+    CurveGroup,
+    convert_number_to_base,
+    odd_multiples,
+    wNAF_of_m,
+)
 from btclib.exceptions import BTClibValueError
-
-
-def mods(m: int, w: int) -> int:
-    """Signed modulo function."""
-    w2: int = pow(2, w)
-    M = m % w2
-    return M - w2 if M >= (w2 // 2) else M
-
-
-def wNAF_of_m(m: int, w: int) -> list[int]:
-    """WNAF (width-w Non-adjacent form) of number m.
-
-    Given an integer m, wNAF is a method of representation
-    with powers of 2, where the coefficients are odd or 0,
-    and where at most one of any w consecutive digits is nonzero.
-    It has the following properties:
-    - m has a unique width-w NAF.
-    -The length of wNAF(m) is at most one more than the length of the binary
-    representation of k.
-    -The average density of nonzero digits is approximately 1/(w + 1).
-
-    For complete reference see:
-    D. Hankerson, 'Guide to Elliptic Curve Cryptography' chapter 3
-    """
-    i = 0
-
-    M: list[int] = []
-    while m > 0:
-        if (m % 2) == 1:
-            if w == 1:
-                # Computing binary NAF of m
-                M.append(2 - (m % 4))
-            else:
-                # Computing wNAF of m
-                M.append(mods(m, w))
-            m -= M[i]
-        else:
-            M.append(0)
-        m //= 2
-        i += 1
-
-    return M
 
 
 def _sliding_window_table(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
@@ -294,18 +258,10 @@ def double_mult_w_NAF(
     us = wNAF_of_m(u, w)
     vs = wNAF_of_m(v, w)
 
-    # the odd multiples 1*P, 3*P, ..., (2^(w-1) - 1)*P of each point; a
-    # digit d of a width-w NAF is odd with |d| < 2^(w-1), so d*P is
-    # T[(|d| - 1) // 2], negated on the fly when d < 0. For w of 1 or 2
-    # the digits are only +-1 and the tables are the points themselves
-    H2 = ec.double_jac(HJ)
-    TH = [HJ]
-    for _ in range(2 ** (w - 2) - 1 if w > 2 else 0):
-        TH.append(ec.add_jac(TH[-1], H2))
-    Q2 = ec.double_jac(QJ)
-    TQ = [QJ]
-    for _ in range(2 ** (w - 2) - 1 if w > 2 else 0):
-        TQ.append(ec.add_jac(TQ[-1], Q2))
+    # one table of odd multiples per point, the same curve_group's
+    # interleaved _multi_mult_w_NAF builds for each of its own
+    TH = odd_multiples(HJ, ec, w)
+    TQ = odd_multiples(QJ, ec, w)
 
     R = INFJ
     for j in range(max(len(us), len(vs)) - 1, -1, -1):

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -9,19 +9,24 @@
 # or distributed except according to the terms contained in the LICENSE file.
 """Tests for the `btclib.curve_group` module."""
 
+import random
+
 import pytest
 
-from btclib.alias import INF, INFJ
-from btclib.curves import Curve, secp256k1
+from btclib.alias import INF, INFJ, JacPoint
+from btclib.curves import Curve, CurveGroup, secp256k1
 
 # the eight mult_* variants under test, and the helpers they are built on,
 # come from the module that defines them: btclib.curves exports mult,
 # double_mult and multi_mult, not a menu of implementations
 from btclib.curves.curve_group import (
+    BOS_COSTER_THRESHOLD,
     MAX_W,
     _double_mult,
     _mult,
     _multi_mult,
+    _multi_mult_bos_coster,
+    _multi_mult_w_NAF,
     cached_multiples,
     jac_from_aff,
     mult_aff,
@@ -435,6 +440,156 @@ def test_mult_on_a_characteristic_7_curve() -> None:
         for j in range(ec.n):
             shamir = _double_mult(k, ec.GJ, j, ec.GJ, ec)
             assert ec.aff_from_jac(shamir) == mult_aff(k + j, ec.G, ec), (k, j)
+
+
+def _sum_of_mults(
+    scalars: list[int], jac_points: list[JacPoint], ec: CurveGroup
+) -> JacPoint:
+    """Return the sum the multi multiplications have to agree with.
+
+    One scalar multiplication per point and then the additions: the
+    answer no algorithm is clever about, and the one both of them are
+    checked against.
+    """
+    R = INFJ
+    for n, PJ in zip(scalars, jac_points, strict=True):
+        R = ec.add_jac(R, _mult(n, PJ, ec))
+    return R
+
+
+def test_multi_mult_w_NAF() -> None:
+    """Interleaved wNAF against Bos-Coster and the plain sum of mults.
+
+    Exhaustive over the scalar pairs of two low-cardinality curves, for
+    the widths where the table of odd multiples has one entry (w of 1 and
+    2, digits of +-1 only) and where it has more, and with the zero
+    scalar, the point at infinity and a scalar of one digit against one
+    of five -- the case where a wNAF runs out of digits before the loop
+    does.
+    """
+    for ec in (low_card_curves["ec13_11"], ec23_31):
+        HJ = jac_from_aff(second_generator(ec))
+        for w in (1, 2, 3, 5):
+            for k1 in range(ec.n):
+                for k2 in range(ec.n):
+                    scalars = [k1, k2, ec.n // 3]
+                    points = [ec.GJ, HJ, ec.GJ]
+                    expected = _sum_of_mults(scalars, points, ec)
+                    got = _multi_mult_w_NAF(scalars, points, ec, w)
+                    assert ec.jac_equality(got, expected), (k1, k2, w)
+                    assert ec.jac_equality(
+                        got, _multi_mult_bos_coster(scalars, points, ec)
+                    ), (k1, k2, w)
+
+            # a zero scalar, an INF point, and scalars of distant lengths
+            assert ec.jac_equality(_multi_mult_w_NAF([0, 0], [ec.GJ, HJ], ec, w), INFJ)
+            for scalars in ([0, 3], [3, 0], [1, ec.n - 1], [ec.n - 1, 1]):
+                for points in ([ec.GJ, HJ], [INFJ, HJ], [ec.GJ, INFJ]):
+                    expected = _sum_of_mults(scalars, points, ec)
+                    got = _multi_mult_w_NAF(scalars, points, ec, w)
+                    assert ec.jac_equality(got, expected), (scalars, w)
+
+        # a window wider than the order itself, where the table of odd
+        # multiples wraps past n and holds the point at infinity among
+        # its entries -- and where a scalar of this curve is one digit.
+        # Not in the exhaustive loop above: the table is 2^(w-2) entries
+        # and every pair would pay for it, for a case the digits below
+        # 2^(w-1) already cover
+        for w in (ec.n.bit_length() + 1, ec.n.bit_length() + 3):
+            for scalars in ([1, ec.n - 1], [ec.n // 2, 3], [0, ec.n - 1]):
+                points = [ec.GJ, HJ]
+                expected = _sum_of_mults(scalars, points, ec)
+                got = _multi_mult_w_NAF(scalars, points, ec, w)
+                assert ec.jac_equality(got, expected), (scalars, w)
+
+    ec = secp256k1
+    with pytest.raises(BTClibValueError, match="non positive w: "):
+        _multi_mult_w_NAF([1, 1], [ec.GJ, ec.GJ], ec, 0)
+
+
+def test_multi_mult_agrees_across_curves() -> None:
+    """Random scalars on every curve in the catalogue, not just secp256k1.
+
+    The two implementations and the sum of mults, on three points of
+    each: a fixed seed, so a failure is reproducible, and the curves that
+    are not secp256k1 are the ones only the python path ever answers.
+    """
+    rnd = random.Random(0x2AC0FFEE)
+    for ec in all_curves.values():
+        HJ = jac_from_aff(second_generator(ec))
+        points = [ec.GJ, HJ, _mult(3, ec.GJ, ec)]
+        scalars = [rnd.randrange(ec.n) for _ in points]
+        expected = _sum_of_mults(scalars, points, ec)
+        assert ec.jac_equality(_multi_mult_w_NAF(scalars, points, ec), expected)
+        assert ec.jac_equality(_multi_mult_bos_coster(scalars, points, ec), expected)
+
+
+def test_multi_mult_dispatch() -> None:
+    """Both sides of the threshold, and the errors they share.
+
+    The count of the nonzero scalars is what picks the implementation, so
+    the test is a batch one scalar short of BOS_COSTER_THRESHOLD and one
+    exactly on it: the two have to answer the same point, and the same
+    error to the same bad arguments. Scalars from 1 rather than from 0,
+    so that the batch is the size it is named: a zero among them would
+    move the dispatch to the other side of the threshold and the test
+    would still pass, testing the other branch twice.
+    """
+    ec = ec23_31
+    HJ = jac_from_aff(second_generator(ec))
+    rnd = random.Random(0x175212)
+    for size in (BOS_COSTER_THRESHOLD - 1, BOS_COSTER_THRESHOLD):
+        points = [ec.GJ if i % 2 else HJ for i in range(size)]
+        scalars = [rnd.randrange(1, ec.n) for _ in range(size)]
+        expected = _sum_of_mults(scalars, points, ec)
+        assert ec.jac_equality(_multi_mult(scalars, points, ec), expected)
+        assert ec.jac_equality(_multi_mult_w_NAF(scalars, points, ec), expected)
+        assert ec.jac_equality(_multi_mult_bos_coster(scalars, points, ec), expected)
+
+        # all zero, whatever the algorithm: nothing to sum. Asked of
+        # both by name, the dispatch no longer being able to reach
+        # Bos-Coster with it -- a batch of nothing but zeros is a batch
+        # of no nonzero scalars, which is below any threshold
+        assert ec.jac_equality(_multi_mult([0] * size, points, ec), INFJ)
+        assert ec.jac_equality(_multi_mult_w_NAF([0] * size, points, ec), INFJ)
+        assert ec.jac_equality(_multi_mult_bos_coster([0] * size, points, ec), INFJ)
+
+        # a batch of this length whose *work* is two scalars: the zeros
+        # are dropped downstream, so the count that dispatches counts
+        # them out first and this goes to the interleaved wNAF
+        sparse = [scalars[0], *([0] * (size - 2)), scalars[-1]]
+        assert ec.jac_equality(
+            _multi_mult(sparse, points, ec), _sum_of_mults(sparse, points, ec)
+        )
+
+        err_msg = "mismatch between number of scalars and points: "
+        with pytest.raises(BTClibValueError, match=err_msg):
+            _multi_mult(scalars, points[1:], ec)
+        with pytest.raises(BTClibValueError, match="negative coefficient: "):
+            _multi_mult([-1, *scalars[1:]], points, ec)
+
+    with pytest.raises(BTClibValueError, match="not a multi_mult"):
+        _multi_mult([1], [ec.GJ], ec)
+
+
+def test_multi_mult_distant_magnitudes() -> None:
+    """Issue 175, asked of the implementation that can still hang.
+
+    _multi_mult sends two scalars to the interleaved wNAF, which is
+    indifferent to their magnitudes, so the pathological pairs reach
+    Bos-Coster only inside a batch above the threshold -- where they are
+    the whole of the batch's cost. Euclid's quotient is what bounds it:
+    the subtractive step takes 10.6 s on the first pair and does not
+    finish on the third, and this test would say so by not returning.
+    """
+    ec = secp256k1
+    HJ = jac_from_aff(second_generator(ec))
+    for scalars in ([10**6, 1], [1, 10**6], [ec.n - 1, 1], [ec.n - 1, ec.n - 2]):
+        expected = _sum_of_mults(scalars, [ec.GJ, HJ], ec)
+        assert ec.jac_equality(_multi_mult(scalars, [ec.GJ, HJ], ec), expected)
+        assert ec.jac_equality(
+            _multi_mult_bos_coster(scalars, [ec.GJ, HJ], ec), expected
+        )
 
 
 def test_jac_equality() -> None:


### PR DESCRIPTION
`_multi_mult` was Bos-Coster whatever the batch. It is now Strauss'
interleaved wNAF below fifty-six scalars and Bos-Coster from there on:
one width-w NAF and one table of odd multiples per point, and a single
left-to-right loop sharing one doubling per bit position among all of
them. Both implementations stay in the library — `_multi_mult_w_NAF` and
`_multi_mult_bos_coster` — as the issue asks: btclib is didactic as much
as it is a library, and the heap one is the twenty lines that can be
read. `_multi_mult` is the dispatch, and it is the only thing that had
to be decided.

No GLV split (curve-specific, and this path serves every curve; the
doublings it would halve are already shared) and no Pippenger, on the
measurement below.

## What it costs and what it buys

Best of interleaved reps, random 256-bit scalars on secp256k1, python
3.14, macOS arm64, ms:

| scalars | Bos-Coster | wNAF w=5 | naive | speedup |
| --- | --- | --- | --- | --- |
| 2 | 3.91 | 1.99 | 3.11 | 1.96x |
| 3 | 4.56 | 2.59 | 4.58 | 1.76x |
| 5 | 6.34 | 3.92 | 7.74 | 1.62x |
| 10 | 10.02 | 6.96 | 15.62 | 1.44x |
| 32 | 23.36 | 20.45 | 49.75 | 1.14x |
| 56 | 36.13 | 36.30 | 90.09 | 1.00x |
| 64 | 41.71 | 41.99 | 100.65 | 0.99x |
| 128 | 70.69 | 80.83 | 202.86 | 0.87x |

`ssa.assert_batch_as_valid_`, which spends two scalars per signature:

| signatures | scalars | Bos-Coster | dispatched | speedup |
| --- | --- | --- | --- | --- |
| 2 | 4 | 7.79 | 5.93 | 1.31x |
| 3 | 6 | 9.65 | 7.32 | 1.28x |
| 5 | 10 | 12.77 | 10.01 | 1.28x |
| 10 | 20 | 20.38 | 16.87 | 1.21x |
| 16 | 32 | 28.28 | 24.74 | 1.14x |
| 32 | 64 | 47.75 | 47.60 | 1.00x |
| 64 | 128 | 82.00 | 82.14 | 1.00x |

The threshold is where the two meet, measured and not borrowed:
wNAF over Bos-Coster is 0.91 at 40 scalars, 0.94 at 48, 1.000 at 56,
1.001 at 64, 1.04 at 72, 1.09 at 96. Point operations say the same in a
form no machine load can move: 44.5 per scalar for Bos-Coster over 128
scalars against 53.3 for the wNAF, and 270 against 178 over two. `w=5`
by the same measurement — 57.7 operations per scalar at w=4, 53.3 at
w=5, 55.1 at w=6; over ten scalars 7.81 ms, 7.27 and 7.38.

The issue's bar was 0.54 ms per scalar above 32 scalars, and this does
not beat it: the wNAF's own per-scalar cost is ~0.64 ms and what it
saves is the fixed one, so the win is on few scalars and the dispatch is
the honest way to keep it.

## Pippenger: measured, and not implemented

Prototyped with sparse buckets, the running-sum trick over the nonempty
ones, and the best window per size. It lost at every size tried, against
Bos-Coster: 162 ms vs 125 at 256 scalars, 284 vs 225 at 512, 500 vs 406
at 1024 (best windows c=6, c=7, c=8). On python integers a bucket sum is
an addition of points that costs what any addition costs, where in C it
is the cheap part, so its crossover — if it has one — is past any batch
btclib is asked to verify. Copying libsecp256k1's 88 would have been
decoration. The numbers and the reasoning are in `_multi_mult`'s
docstring, so the next person does not have to run it again.

## Issue #175's cure stays

The whole of Euclid in the Bos-Coster step is what keeps that path from
hanging on a distant pair of magnitudes, and that path is live above the
threshold: deleting it would put the hang back for exactly the batches
it now answers. The interleaved wNAF is indifferent to magnitude in the
first place, its cost being a function of bit length alone.
`multi_mult([10**6, 1])`, `([-1, 1])` — which is `[n-1, 1]` after the
public wrapper reduces mod n, the contract being that negatives are
reduced there and refused below it — and `([n-1, 1])` are asserted
against both implementations, and run in milliseconds.

## Verification

- `uv run pytest` — exit 0, 14791 passed
- `uv run pre-commit run --all-files` — exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — exit 0 on a clean
  `docs/build`, which is where it first failed: `(abs(d) - 1)` in a
  docstring, because docutils reads the pipes of the mathematical
  spelling as a substitution reference
- coverage of `btclib/curves/curve_group.py` is 100.00%: the tests cover
  both table branches (w of 1 and 2 against 3 and 5), the zero scalar,
  the point at infinity, the negative digits, a wNAF shorter than the
  longest, and both sides of the threshold
- the two implementations are checked against each other and against the
  plain sum of scalar multiplications, exhaustively over the scalar pairs
  of two low-cardinality curves and with fixed-seed random scalars on
  every curve of the catalogue, not only secp256k1

The wNAF recoding and the table of odd multiples move to `curve_group`,
next to `convert_number_to_base` and for the same reason: the
interleaved multi multiplication needs them and `curve_group` cannot
import `curve_group_2`. `double_mult_w_NAF` builds its two tables with
that same function now.

Sibling PRs move the CHANGELOG entry count too; re-derive it at merge
with `grep -c '^- ' CHANGELOG.md`.

Closes #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Dispatch multi scalar multiplication between interleaved wNAF and Bos-Coster based on batch size to improve performance for small scalar sets while preserving the existing Euclid-based fix for pathological magnitudes.

New Features:
- Add an interleaved width-w wNAF-based multi scalar multiplication implementation that shares doublings across points.
- Expose a configurable Bos-Coster threshold constant to switch algorithms by scalar count.

Enhancements:
- Refactor multi-mult argument validation and zero-scalar handling into a shared helper used by both implementations.
- Move wNAF recoding and odd-multiples table construction into the core curve_group module for reuse across implementations.
- Reuse the shared odd-multiples helper in double_mult_w_NAF to simplify table construction and align behavior.

Documentation:
- Update CHANGELOG and HISTORY to document the new multi-mult dispatch behavior and its measured performance characteristics.
- Clarify curve.multi_mult docstring to describe algorithm selection between interleaved wNAF and Bos-Coster.

Tests:
- Add comprehensive tests verifying interleaved wNAF multi multiplication against Bos-Coster and the plain sum-of-mults across curves, widths, and edge cases.
- Add dispatch tests to ensure _multi_mult chooses the correct algorithm around the threshold and shares identical error semantics.
- Add regression tests covering distant scalar magnitudes to ensure the Bos-Coster path remains bounded and matches expected results.