### PR TITLE
Retarget the difficulty, weigh the chain, and mine a toy block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1371,6 +1371,34 @@ edit.
 
 ### Transactions, blocks and PSBT
 
+- **The difficulty retarget, the work behind a chain, the hash rate it
+  implies, and a toy miner.** `btclib.block.proof_of_work` holds the first
+  three as pure functions over the four `bits` bytes a header carries,
+  because "which of two competing chains is best" is a question asked of
+  both at once and answered by comparing their work, not their heights.
+  `next_bits` is Bitcoin Core's `CalculateNextWorkRequired`: the factor of
+  four clamped onto the measured timespan either way, the pow-limit clamp,
+  the 256-bit ring the multiplication happens in, and the compact
+  re-encoding, whose rounding down is part of the answer. Its window is
+  the one `retarget_first_height` names, 2015 intervals between the
+  timestamps of the 2016 blocks a period holds — the off-by-one Core keeps
+  for compatibility, and the reason blocks come out 0.05% faster than the
+  ten minutes aimed at. `bits_from_target` is the `GetCompact` that
+  `BlockHeader.target` had no inverse for, including the rule that shifts
+  a significand whose high bit would read as the sign; `block_work` and
+  `chain_work` are `GetBlockProof` and `nChainWork`, and `hash_rate` is
+  difficulty times 2^32 over the observed interval, with the variance that
+  makes it an estimate — 1/sqrt(n), still 2% over a whole window — in its
+  docstring. `btclib.block.mining` is the fourth:
+  `candidate_block_header` computes the merkle root over a transaction
+  list and leaves the nonce at zero, `mine` searches the four bytes up to
+  a bound and answers `None` rather than hanging. A toy at one python hash
+  at a time, and not a toy about what it produces: the merkle root comes
+  from the function `Block.assert_valid_merkle_root` checks against, now
+  shared rather than written twice, and the tests mine a block and let
+  `Block.assert_valid` have the last word. The retarget is tested against
+  the four mainnet vectors of Core's `pow_tests.cpp` and the round trip
+  against the bits of every vendored block (issue #188)
 - **A psbt can carry a taproot signature with its sig_hash type.** BIP341
   spends with 64 bytes of signature, or 65 when the sig_hash type is not
   the default one — the extra byte being that type — and BIP371 says "64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,16 @@ edit.
 
 ### Consensus rules
 
+- **a hash equal to the target is a valid proof-of-work.**
+  `BlockHeader.assert_valid_pow` rejected on `hash >= target`, where
+  Core's `CheckProofOfWork` rejects on `hash > bnTarget`: the target is a
+  bound the hash may reach, so the one hash that lands on it solved the
+  block for every node on the network and for btclib alone did not. The
+  error message says `>` rather than `>=` for the same reason. No vector
+  can exhibit it — equality asks a 256-bit hash for one exact value, and
+  the compact form cannot be nudged to meet a given hash either, its
+  significand holding three bytes — which is precisely why the comparison
+  has to be read off Core rather than tested against it
 - **btclib can check a Merkle proof, not only compute a root.** It had
   the builder's side, `merkle_root_and_mutated_from_hashes`, and no
   entry point for the verifier's: from a txid, a branch of siblings and
@@ -1392,7 +1402,7 @@ edit.
   docstring. `btclib.block.mining` is the fourth:
   `candidate_block_header` computes the merkle root over a transaction
   list and leaves the nonce at zero, `mine` searches the four bytes up to
-  a bound and answers `None` rather than hanging. A toy at one python hash
+  a bound and answers `None` rather than hanging. A toy at one Python hash
   at a time, and not a toy about what it produces: the merkle root comes
   from the function `Block.assert_valid_merkle_root` checks against, now
   shared rather than written twice, and the tests mine a block and let

--- a/btclib/block/__init__.py
+++ b/btclib/block/__init__.py
@@ -9,8 +9,8 @@
 # or distributed except according to the terms contained in the LICENSE file.
 """Module btclib.block."""
 
-from btclib.block import merkle_proof
+from btclib.block import merkle_proof, mining, proof_of_work
 from btclib.block.block import Block
 from btclib.block.block_header import BlockHeader
 
-__all__ = ["Block", "BlockHeader", "merkle_proof"]
+__all__ = ["Block", "BlockHeader", "merkle_proof", "mining", "proof_of_work"]

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -39,6 +39,28 @@ _COMMITMENT_PREFIX = bytes.fromhex("6a24aa21a9ed")
 _COMMITMENT_LENGTH = len(_COMMITMENT_PREFIX) + 32
 
 
+def merkle_root_and_mutated_from_transactions(
+    transactions: Sequence[Tx],
+) -> tuple[bytes, bool]:
+    """Return a header's merkle root over a list of transactions.
+
+    The leaves are the transactions serialized *without* witness data,
+    i.e. their txids, and the root is reversed into the byte order a
+    header carries. See merkle_root_and_mutated_from_hashes for the
+    second returned value, the CVE-2012-2459 flag.
+
+    One implementation, because the block builder and the block
+    validator must agree by construction: assert_valid_merkle_root
+    compares this against the header at hand, and mining.py's candidate
+    header is built from it.
+    """
+    data = [
+        tx.serialize(include_witness=False, check_validity=False) for tx in transactions
+    ]
+    root, mutated = merkle_root_and_mutated(data, _HF)
+    return root[::-1], mutated
+
+
 @dataclass
 class Block:
     header: BlockHeader
@@ -120,12 +142,9 @@ class Block:
         return any(tx.is_segwit() for tx in self.transactions)
 
     def assert_valid_merkle_root(self) -> None:
-        data = [
-            tx.serialize(include_witness=False, check_validity=False)
-            for tx in self.transactions
-        ]
-        root, mutated = merkle_root_and_mutated(data, _HF)
-        merkle_root_ = root[::-1]
+        merkle_root_, mutated = merkle_root_and_mutated_from_transactions(
+            self.transactions
+        )
         if merkle_root_ != self.header.merkle_root:
             err_msg = f"invalid merkle root: {self.header.merkle_root.hex()}"
             err_msg += f" instead of: {merkle_root_.hex()}"

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -169,9 +169,16 @@ class BlockHeader:
         calls CheckProofOfWork by default: a Block is a block, and the
         proof-of-work is what its transactions are committed by.
         """
-        if self.hash >= self.target:
+        # the target is a bound the hash may reach: CheckProofOfWork
+        # rejects on "hash > bnTarget", so a hash equal to the target is
+        # the last one that solves the block, and refusing it would be
+        # refusing a block every node on the network accepts. No vector
+        # can show the difference -- equality asks a 256-bit hash for one
+        # exact value -- so the comparison is right by matching Core's,
+        # which is the only way it can be right here
+        if self.hash > self.target:
             err_msg = f"invalid proof-of-work: {self.hash.hex()}"
-            err_msg += f" >= {self.target.hex()}"
+            err_msg += f" > {self.target.hex()}"
             raise BTClibValueError(err_msg)
 
     def assert_valid(self) -> None:

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from btclib.alias import BinaryData, Octets
+from btclib.block.proof_of_work import target_from_bits
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash256
 from btclib.utils import bytes_from_octets, bytesio_from_binarydata
@@ -65,28 +66,7 @@ class BlockHeader:
         The target yyzzww * 256^(xx-3) is represented in the blockhader
         by the 4 bytes 'bits' xxyyzzww
         """
-        # significand (also known as mantissa or coefficient)
-        significand = int.from_bytes(self.bits[1:], byteorder="big", signed=False)
-        # power term, also called characteristics. Core's SetCompact
-        # shifts rather than multiplying by a power of 256, and so does
-        # this: pow(256, -1) is a float in Python, so an exponent below
-        # 3 would send a 256-bit number through float arithmetic
-        exponent = self.bits[0]
-        if exponent < 3:
-            value = significand >> (8 * (3 - exponent))
-        else:
-            value = significand << (8 * (exponent - 3))
-
-        # the compact form can denote what 32 bytes cannot hold, which
-        # to_bytes would answer with an OverflowError. Core raises the
-        # same objection through the fOverflow flag of SetCompact, on
-        # which CheckProofOfWork rejects the header
-        if value >= 256**_HF_LEN:
-            err_msg = f"invalid proof-of-work target: 0x{self.bits.hex()}"
-            err_msg += f" overflows {_HF_LEN} bytes"
-            raise BTClibValueError(err_msg)
-
-        return value.to_bytes(_HF_LEN, "big", signed=False)
+        return target_from_bits(self.bits)
 
     @property
     def difficulty(self) -> float:

--- a/btclib/block/mining.py
+++ b/btclib/block/mining.py
@@ -10,7 +10,7 @@
 """Candidate block headers, and a toy search for the nonce that solves one.
 
 A toy, and the word is meant: `mine` hashes one nonce at a time in
-python, in one process, over a header it re-serializes on every
+Python, in one process, over a header it re-serializes on every
 evaluation. That is some five orders of magnitude short of what a single
 mainnet block needs, so what this is for is a regtest-grade target, a
 test, or watching the search work.
@@ -108,8 +108,9 @@ def mine(header: BlockHeader, max_tries: int = 1 << 20) -> BlockHeader | None:
     for nonce in range(candidate.nonce, stop):
         candidate.nonce = nonce
         # the comparison assert_valid_pow makes, so that what is returned
-        # from here is what a Block will accept
-        if candidate.hash < target:
+        # from here is what a Block will accept: the target is a bound the
+        # hash may reach, Core rejecting on "hash > bnTarget"
+        if candidate.hash <= target:
             return candidate
 
     return None

--- a/btclib/block/mining.py
+++ b/btclib/block/mining.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Candidate block headers, and a toy search for the nonce that solves one.
+
+A toy, and the word is meant: `mine` hashes one nonce at a time in
+python, in one process, over a header it re-serializes on every
+evaluation. That is some five orders of magnitude short of what a single
+mainnet block needs, so what this is for is a regtest-grade target, a
+test, or watching the search work.
+
+What it is not a toy about is the header it produces. The merkle root
+comes from the same function `Block.assert_valid_merkle_root` checks
+against, and the solved header satisfies `assert_valid_pow`, so the
+result is a block every other implementation accepts -- at a difficulty
+nobody has to be convinced by.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import replace
+from datetime import datetime
+
+from btclib.alias import Octets
+from btclib.block.block import merkle_root_and_mutated_from_transactions
+from btclib.block.block_header import BlockHeader
+from btclib.exceptions import BTClibValueError
+from btclib.tx import Tx
+
+# BIP9 leaves the top three bits of the version at 001 and signals in the
+# 29 below, so this is the version of a block that signals for nothing.
+# Not 1, which BIP34 made unacceptable at height 227,836 and BIP66 and
+# BIP65 raised twice more: a candidate carrying it would be rejected by
+# every node on the network for a reason that has nothing to do with its
+# proof-of-work
+VERSION = 0x20000000
+
+# a nonce is four bytes, so this many evaluations exhaust the field
+NONCE_SPACE = 0x100000000
+
+
+def candidate_block_header(
+    previous_block_hash: Octets,
+    transactions: Sequence[Tx],
+    time: datetime,
+    bits: Octets,
+    *,
+    version: int = VERSION,
+) -> BlockHeader:
+    """Return the unsolved header committing to a list of transactions.
+
+    Everything the header needs except the work: the merkle root is
+    computed here, and the nonce starts at zero for `mine` to search
+    from. The result is structurally valid -- `assert_valid` passes,
+    `serialize` and `hash` work -- and has no proof-of-work, which is
+    the state a header is in while it is being mined.
+
+    A transaction list whose merkle tree is the CVE-2012-2459 mutation
+    of a shorter one is refused: the header would commit to both lists,
+    so it is not a candidate for the one at hand.
+    """
+    merkle_root, mutated = merkle_root_and_mutated_from_transactions(transactions)
+    if mutated:
+        raise BTClibValueError("duplicate transaction")
+
+    return BlockHeader(
+        version=version,
+        previous_block_hash=previous_block_hash,
+        merkle_root=merkle_root,
+        time=time,
+        bits=bits,
+        nonce=0,
+    )
+
+
+def mine(header: BlockHeader, max_tries: int = 1 << 20) -> BlockHeader | None:
+    """Return the header solved by a nonce, or None if none was found.
+
+    The search runs from the nonce the candidate carries and stops at
+    `max_tries` evaluations or at the end of the four-byte field,
+    whichever comes first, so it always terminates. None is the honest
+    answer to a bounded search: the target may still be satisfiable by a
+    nonce past the bound.
+
+    Exhausting the field is not the end of mining, which is why this is
+    a toy rather than a miner. A real one then changes what it is
+    hashing -- the extranonce in the coinbase script_sig, the timestamp,
+    the transaction set -- and searches the four bytes again over the
+    new merkle root. Building that header again is `candidate_block_header`.
+
+    The caller's header is left alone: what comes back is a copy.
+    """
+    if max_tries < 1:
+        raise BTClibValueError(f"invalid max_tries: {max_tries}")
+
+    # a copy taken once, not one per nonce: replace() runs assert_valid,
+    # and validating the same header a million times is the whole budget
+    candidate = replace(header)
+    target = candidate.target
+    stop = min(candidate.nonce + max_tries, NONCE_SPACE)
+    for nonce in range(candidate.nonce, stop):
+        candidate.nonce = nonce
+        # the comparison assert_valid_pow makes, so that what is returned
+        # from here is what a Block will accept
+        if candidate.hash < target:
+            return candidate
+
+    return None

--- a/btclib/block/proof_of_work.py
+++ b/btclib/block/proof_of_work.py
@@ -71,7 +71,7 @@ def target_from_bits(bits: Octets) -> bytes:
     significand = int.from_bytes(bits[1:], byteorder="big", signed=False)
     # power term, also called characteristics. Core's SetCompact shifts
     # rather than multiplying by a power of 256, and so does this:
-    # pow(256, -1) is a float in python, so an exponent below 3 would send
+    # pow(256, -1) is a float in Python, so an exponent below 3 would send
     # a 256-bit number through float arithmetic
     exponent = bits[0]
     if exponent < 3:

--- a/btclib/block/proof_of_work.py
+++ b/btclib/block/proof_of_work.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Proof-of-work arithmetic: compact targets, retargeting, work, hash rate.
+
+Pure functions over the four `bits` bytes a header carries and the times
+two headers carry, deliberately: which chain is best, what the next
+target is and how fast the network hashes are three questions asked of
+several competing chains at once, and a function taking a chain object
+could answer them for one. `BlockHeader` supplies the inputs and this
+module does the arithmetic; nothing here reads or builds a header.
+
+Bitcoin Core's `pow.cpp` and `arith_uint256.cpp` are the reference for
+every value returned. The functions are named after what they answer
+rather than after Core's spelling -- `bits_from_target` is `GetCompact`,
+`target_from_bits` is `SetCompact`, `next_bits` is
+`CalculateNextWorkRequired`, `block_work` is `GetBlockProof` -- and each
+docstring names its counterpart.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime
+
+from btclib.alias import Octets
+from btclib.exceptions import BTClibValueError
+from btclib.utils import bytes_from_octets
+
+# a target is a 256-bit number, i.e. the hash it is compared against
+TARGET_SIZE = 32
+
+# two weeks, the timespan a difficulty period aims at
+POW_TARGET_TIMESPAN = 14 * 24 * 60 * 60
+# ten minutes, the block interval it aims at
+POW_TARGET_SPACING = 10 * 60
+# 2016 blocks
+DIFFICULTY_ADJUSTMENT_INTERVAL = POW_TARGET_TIMESPAN // POW_TARGET_SPACING
+
+# the easiest target a network allows, as bits rather than as the 32
+# bytes Core's params.powLimit holds: every network's limit is exactly
+# representable in the compact form -- it is where the compact form came
+# from -- so nothing is lost, and a caller reads the same four bytes a
+# header carries. Mainnet's is the genesis block target, which is why the
+# genesis difficulty is 1, and testnet3 and testnet4 share it
+MAINNET_POW_LIMIT_BITS = b"\x1d\x00\xff\xff"
+# regtest's, the one loose enough to mine against in a test. Not
+# something to hand to next_bits as a starting target: regtest sets
+# fPowNoRetargeting, so Core never retargets from it, and 2^255 is a
+# target the retarget's own multiplication overflows -- see the note
+# there. As the pow_limit_bits of a network that does retarget it is
+# fine, being compared and never multiplied
+REGTEST_POW_LIMIT_BITS = b"\x20\x7f\xff\xff"
+
+
+def target_from_bits(bits: Octets) -> bytes:
+    """Return the 32-byte target the compact `bits` denote.
+
+    The target yyzzww * 256^(xx-3) is represented by the 4 bytes
+    'bits' xxyyzzww. Bitcoin Core spells this `SetCompact`.
+    """
+    bits = bytes_from_octets(bits, 4)
+
+    # significand (also known as mantissa or coefficient)
+    significand = int.from_bytes(bits[1:], byteorder="big", signed=False)
+    # power term, also called characteristics. Core's SetCompact shifts
+    # rather than multiplying by a power of 256, and so does this:
+    # pow(256, -1) is a float in python, so an exponent below 3 would send
+    # a 256-bit number through float arithmetic
+    exponent = bits[0]
+    if exponent < 3:
+        value = significand >> (8 * (3 - exponent))
+    else:
+        value = significand << (8 * (exponent - 3))
+
+    # the compact form can denote what 32 bytes cannot hold, which
+    # to_bytes would answer with an OverflowError. Core raises the same
+    # objection through the fOverflow flag of SetCompact, on which
+    # CheckProofOfWork rejects the header
+    if value >= 256**TARGET_SIZE:
+        err_msg = f"invalid proof-of-work target: 0x{bits.hex()}"
+        err_msg += f" overflows {TARGET_SIZE} bytes"
+        raise BTClibValueError(err_msg)
+
+    return value.to_bytes(TARGET_SIZE, "big", signed=False)
+
+
+def bits_from_target(target: Octets) -> bytes:
+    """Return the compact `bits` denoting a target, rounded down.
+
+    The inverse of target_from_bits, i.e. Bitcoin Core's `GetCompact`,
+    and lossy in the direction that keeps the target harder: the
+    significand holds three bytes, so everything below them is dropped.
+    A target that came from bits is recovered exactly.
+
+    The sign bit of the significand is what makes this more than a
+    change of base. The compact form reads 0x00800000 as "negative", so
+    a significand whose high bit is set is divided by 256 and the
+    exponent raised -- 0x800000 is written 0x04008000, four bytes rather
+    than three, and never 0x03800000, which denotes a negative number no
+    header may carry.
+    """
+    target = bytes_from_octets(target)
+    if len(target) > TARGET_SIZE:
+        err_msg = f"invalid target: {len(target)} bytes"
+        err_msg += f" instead of at most {TARGET_SIZE}"
+        raise BTClibValueError(err_msg)
+
+    value = int.from_bytes(target, byteorder="big", signed=False)
+    # ceil(bit_length / 8), the number of bytes the value occupies, which
+    # is Core's CeilDiv(bits(), 8): zero occupies none, so bits 0x00000000
+    # is what a zero target is written as
+    exponent = (value.bit_length() + 7) // 8
+    if exponent <= 3:
+        significand = value << (8 * (3 - exponent))
+    else:
+        significand = value >> (8 * (exponent - 3))
+
+    if significand & 0x00800000:
+        significand >>= 8
+        exponent += 1
+
+    return bytes([exponent]) + significand.to_bytes(3, "big", signed=False)
+
+
+def retarget_first_height(last_height: int) -> int:
+    """Return the height the retarget window is measured from.
+
+    The window ends at `last_height`, the last block of a difficulty
+    period, and this is the first block of that same period: 2015 blocks
+    back, not 2016.
+
+    That is the off-by-one Bitcoin Core keeps for compatibility. The
+    period holds 2016 blocks but only 2015 intervals between their
+    timestamps, and the retarget divides the measured timespan by two
+    weeks all the same, so the difficulty is set as if 2016 intervals had
+    been observed and blocks come out roughly 0.05% faster than the ten
+    minutes aimed at. Fixing it would be a hard fork over a rounding
+    error, so `GetNextWorkRequired` still reads
+    `nHeight - (DifficultyAdjustmentInterval() - 1)`.
+    """
+    # Core only retargets when the *next* height is a multiple of 2016,
+    # so the last block of a period is the one 2015 blocks after its
+    # first. Refused rather than answered for any other height: the
+    # answer would be a window Core never measures, and the caller
+    # asking has mistaken which block ends the period
+    if (last_height + 1) % DIFFICULTY_ADJUSTMENT_INTERVAL:
+        err_msg = f"invalid retarget height: {last_height}"
+        err_msg += f" is not a multiple of {DIFFICULTY_ADJUSTMENT_INTERVAL}"
+        err_msg += " minus one"
+        raise BTClibValueError(err_msg)
+
+    return last_height - (DIFFICULTY_ADJUSTMENT_INTERVAL - 1)
+
+
+def next_bits(
+    bits: Octets,
+    first_block_time: datetime,
+    last_block_time: datetime,
+    *,
+    pow_limit_bits: Octets = MAINNET_POW_LIMIT_BITS,
+) -> bytes:
+    """Return the compact target of the difficulty period that follows.
+
+    `bits` is what the last block of the ending period carries,
+    `last_block_time` its timestamp and `first_block_time` the timestamp
+    of the block `retarget_first_height` names -- 2015 blocks earlier,
+    which is the off-by-one documented there.
+
+    The new target is the old one scaled by the measured timespan over
+    the two weeks aimed at, so a period mined too fast tightens it. The
+    timespan itself is clamped to a quarter and to four times two weeks
+    *before* the scaling, which is what bounds a single retarget to a
+    factor of four either way; the result is then clamped to the
+    network's easiest target and re-encoded, and the rounding of that
+    re-encoding is part of the answer.
+
+    Bitcoin Core spells this `CalculateNextWorkRequired`.
+    """
+    # the difference of two datetimes, not two timestamp() calls: aware
+    # or naive, the subtraction is the same number of seconds, so the
+    # answer does not depend on the machine's time zone for the naive
+    # datetime that BlockHeader.assert_valid rejects but arithmetic here
+    # has no reason to
+    actual_timespan = int((last_block_time - first_block_time).total_seconds())
+    actual_timespan = max(actual_timespan, POW_TARGET_TIMESPAN // 4)
+    actual_timespan = min(actual_timespan, POW_TARGET_TIMESPAN * 4)
+
+    target = int.from_bytes(target_from_bits(bits), "big", signed=False)
+    # Core multiplies in arith_uint256, which wraps: the mask is that
+    # wrap, and it is the difference between matching Core and being
+    # right in a way no node agrees with. Written as arithmetic rather
+    # than as a comment, because an answer that differs from Core's is
+    # not a target.
+    # The product overflows above 2^256 / 4838400, i.e. above roughly
+    # 2^233.8, which is well over mainnet's pow limit of 2^224 and over
+    # testnet3's and testnet4's, they being the same one. Regtest's is
+    # 2^255 and would overflow on any timespan at all -- which is
+    # consistent rather than a hole, Core setting fPowNoRetargeting there
+    # and never reaching this line
+    target = (target * actual_timespan) % 2**256
+    target //= POW_TARGET_TIMESPAN
+
+    pow_limit = int.from_bytes(target_from_bits(pow_limit_bits), "big", signed=False)
+    target = min(target, pow_limit)
+
+    return bits_from_target(target.to_bytes(TARGET_SIZE, "big", signed=False))
+
+
+def block_work(bits: Octets) -> int:
+    """Return the expected number of hashes a block of this target costs.
+
+    A hash satisfies the target with probability (target + 1) / 2^256,
+    so 2^256 / (target + 1) evaluations are expected before one does.
+    This is the block's contribution to the chain work, and Bitcoin Core
+    spells it `GetBlockProof`.
+
+    Core answers 0 for a zero target, and for the two `SetCompact` flags
+    besides, because `GetBlockProof` doubles as the gate that keeps an
+    invalid header from being credited with work. Here both are
+    exceptions instead: target_from_bits raises on the overflow, and a
+    zero target -- which no hash can ever satisfy, so no block can ever
+    carry it -- raises here rather than being reported as free.
+    """
+    target = int.from_bytes(target_from_bits(bits), "big", signed=False)
+    if not target:
+        raise BTClibValueError(
+            f"zero proof-of-work target: 0x{bytes_from_octets(bits).hex()}"
+        )
+
+    return 2**256 // (target + 1)
+
+
+def chain_work(bits_sequence: Sequence[Octets]) -> int:
+    """Return the cumulative work of the blocks carrying these bits.
+
+    Which of two chains is best is this number's comparison, not a
+    height comparison: a longer chain of easier blocks is not the one
+    with the most work behind it, and only the second is expensive to
+    replace. Bitcoin Core accumulates the same sum as `nChainWork`.
+    """
+    return sum(block_work(bits) for bits in bits_sequence)
+
+
+def hash_rate(difficulty: float, timespan: float, block_count: int = 1) -> float:
+    """Return the hashes per second a window of blocks implies.
+
+    A block of difficulty d costs d * 2^32 hash evaluations on average,
+    so `block_count` of them found over `timespan` seconds put the
+    network at that many hashes per second. `BlockHeader.difficulty`
+    supplies the first argument, and the timestamps of the window's ends
+    the second.
+
+    This is an estimate of a quantity nobody can measure, and a noisy
+    one: hashing is a Poisson process, so the timespan of n blocks is a
+    sum of n exponential intervals and its relative standard deviation
+    is 1/sqrt(n) -- 100% over a single block, 8% over a day's 144, and
+    still 2% over a whole 2016-block window. A number that has moved by
+    less than that has not moved.
+
+    Two things also make the inputs less solid than they look. The
+    timestamps are the miners' own, constrained only by the median of
+    the last eleven blocks below and two hours ahead of the node's clock
+    above, so a short window's timespan can be negative in the middle of
+    it; Core's `getnetworkhashps` takes the minimum and the maximum time
+    over the window rather than its ends for exactly that reason. And a
+    window spanning a retarget has no single difficulty to be given
+    here: sum the `block_work` of the blocks in it and divide by the
+    timespan instead, which is what Core does, and which this agrees
+    with to within the 1/65536 by which the genesis target falls short
+    of 2^224.
+    """
+    if timespan <= 0:
+        raise BTClibValueError(f"invalid timespan: {timespan}")
+    if block_count < 1:
+        raise BTClibValueError(f"invalid block count: {block_count}")
+    if difficulty <= 0:
+        raise BTClibValueError(f"invalid difficulty: {difficulty}")
+
+    return difficulty * 2**32 * block_count / timespan

--- a/docs/source/btclib.block.rst
+++ b/docs/source/btclib.block.rst
@@ -28,6 +28,22 @@ btclib.block.merkle\_proof module
    :undoc-members:
    :show-inheritance:
 
+btclib.block.mining module
+--------------------------
+
+.. automodule:: btclib.block.mining
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+btclib.block.proof\_of\_work module
+-----------------------------------
+
+.. automodule:: btclib.block.proof_of_work
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/tests/block/mining_test.py
+++ b/tests/block/mining_test.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Tests for the `btclib.block.mining` module.
+
+The target mined against is `2000ffff`, easier than anything a network
+allows and harder than regtest's own limit: it is satisfied by one hash
+in 256, so the search takes a few hundred evaluations and under a
+millisecond, and is still a search rather than a lucky first nonce. The
+nonces asserted below are therefore fixed by the candidate they solve --
+change a byte of one and its nonce moves. Every assertion goes through the
+ordinary validation -- `Block.assert_valid`, which asserts the
+proof-of-work, the merkle root and the coinbase -- so what is being
+checked is that a block built here is a block, not that two copies of
+the same arithmetic agree.
+"""
+
+from datetime import datetime, timezone
+
+import pytest
+
+from btclib import var_bytes
+from btclib.block import Block, BlockHeader
+from btclib.block.mining import VERSION, candidate_block_header, mine
+from btclib.block.proof_of_work import REGTEST_POW_LIMIT_BITS
+from btclib.exceptions import BTClibValueError
+from btclib.script import ScriptPubKey
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
+from btclib.utils import encode_num
+
+# 0xffff * 2^232, i.e. one chance in 256 that a given nonce solves it
+_EASY_BITS = "2000ffff"
+_PREVIOUS = "00000000000000000024fb37364cbf81fd49cc2d51c09c75c35433c3a1945d04"
+_TIME = datetime(2024, 5, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _coinbase(height: int, extranonce: int = 0) -> Tx:
+    """Return a coinbase paying nothing, with the BIP34 height in it."""
+    # the height is a serialized CScript push, as Block.height reads it;
+    # the extranonce is what a real miner rolls when the four nonce bytes
+    # run out, and it is here to keep the script_sig over the two bytes
+    # consensus requires
+    script_sig = var_bytes.serialize(encode_num(height))
+    script_sig += var_bytes.serialize(encode_num(extranonce))
+    tx_in = TxIn(OutPoint(), script_sig, 0xFFFFFFFF)
+    tx_out = TxOut(50_00000000, ScriptPubKey(b"\x51"))  # OP_1
+    return Tx(1, 0, [tx_in], [tx_out])
+
+
+def _spend() -> Tx:
+    """Return an ordinary transaction, so the merkle tree has two leaves."""
+    tx_in = TxIn(OutPoint(b"\x01" * 32, 0), "0102", 0xFFFFFFFF)
+    tx_out = TxOut(10_00000000, ScriptPubKey(b"\x51"))
+    return Tx(1, 0, [tx_in], [tx_out])
+
+
+def test_a_mined_block_is_a_block() -> None:
+    """Assemble, mine, and let the ordinary validation have the last word."""
+    transactions = [_coinbase(700_000), _spend()]
+    candidate = candidate_block_header(_PREVIOUS, transactions, _TIME, _EASY_BITS)
+
+    # a candidate is structurally valid and carries no work: that split
+    # is what lets it be built at all
+    candidate.assert_valid()
+    assert candidate.nonce == 0
+    assert candidate.version == VERSION
+    assert len(candidate.serialize()) == 80
+    with pytest.raises(BTClibValueError, match="invalid proof-of-work: "):
+        candidate.assert_valid_pow()
+
+    header = mine(candidate)
+    assert header is not None
+    assert header.nonce == 373
+    assert header.hash < header.target
+    header.assert_valid_pow()
+
+    # everything except the nonce is what the candidate carried
+    assert header.merkle_root == candidate.merkle_root
+    assert header.previous_block_hash == candidate.previous_block_hash
+    assert header.time == candidate.time
+    assert header.bits == candidate.bits
+
+    # and the block it heads validates in full: work, merkle root,
+    # coinbase, witness commitment
+    block = Block(header, transactions)
+    block.assert_valid()
+    assert block.height == 700_000
+    assert block == Block.parse(block.serialize())
+
+    # the caller's candidate was not touched
+    assert candidate.nonce == 0
+
+
+def test_the_merkle_root_is_the_one_the_block_checks() -> None:
+    """The builder and the validator share a function, and must agree."""
+    transactions = [_coinbase(1), _spend(), _spend()]
+    candidate = candidate_block_header(_PREVIOUS, transactions, _TIME, _EASY_BITS)
+
+    # assert_valid_merkle_root is the check, and it passes on a header
+    # that has no work yet
+    Block(candidate, transactions, check_validity=False).assert_valid_merkle_root()
+
+    # a transaction list whose tree is the CVE-2012-2459 mutation of a
+    # shorter one heads no candidate: the header would commit to both
+    mutated = [*transactions, transactions[-1]]
+    with pytest.raises(BTClibValueError, match="duplicate transaction"):
+        candidate_block_header(_PREVIOUS, mutated, _TIME, _EASY_BITS)
+
+    # and neither does no transaction list at all
+    with pytest.raises(BTClibValueError, match="empty merkle tree"):
+        candidate_block_header(_PREVIOUS, [], _TIME, _EASY_BITS)
+
+
+def test_regtest_target_is_solved_by_the_first_nonce() -> None:
+    """Regtest's limit is 2^255: one try in two solves it."""
+    transactions = [_coinbase(1)]
+    candidate = candidate_block_header(
+        _PREVIOUS, transactions, _TIME, REGTEST_POW_LIMIT_BITS
+    )
+    header = mine(candidate, 2)
+    assert header is not None
+    assert header.nonce == 0
+    Block(header, transactions).assert_valid()
+
+
+def test_a_bounded_search_can_find_nothing() -> None:
+    """None is the honest answer: a nonce past the bound may still solve."""
+    transactions = [_coinbase(1)]
+    candidate = candidate_block_header(_PREVIOUS, transactions, _TIME, _EASY_BITS)
+
+    # the nonce that solves this one is 53, so a search of 53 -- nonces
+    # 0 to 52 -- stops one short of it
+    assert mine(candidate, 53) is None
+    solved = mine(candidate, 54)
+    assert solved is not None
+    assert solved.nonce == 53
+
+    # a mainnet-grade target is not found either, and the bound is what
+    # makes that a return rather than a hang
+    hard = candidate_block_header(_PREVIOUS, transactions, _TIME, "1d00ffff")
+    assert mine(hard, 1000) is None
+
+
+def test_the_nonce_field_is_four_bytes() -> None:
+    """The search stops at the end of the field, not at max_tries.
+
+    Rolling past it is what a real miner does by changing the extranonce
+    in the coinbase and building the candidate again, which is the line
+    between this and mining.
+    """
+    transactions = [_coinbase(1)]
+    candidate = candidate_block_header(_PREVIOUS, transactions, _TIME, "1d00ffff")
+    candidate.nonce = 0xFFFFFFFF
+
+    # one nonce left to try, however many were asked for
+    assert mine(candidate, 1 << 30) is None
+
+    # the extranonce is the way out: a different coinbase is a different
+    # merkle root, hence four fresh bytes to search
+    other = candidate_block_header(
+        _PREVIOUS, [_coinbase(1, extranonce=7)], _TIME, _EASY_BITS
+    )
+    assert other.merkle_root != candidate.merkle_root
+    assert mine(other) is not None
+
+
+def test_mine_exceptions() -> None:
+    transactions = [_coinbase(1)]
+    candidate = candidate_block_header(_PREVIOUS, transactions, _TIME, _EASY_BITS)
+
+    for max_tries in (0, -1):
+        with pytest.raises(BTClibValueError, match="invalid max_tries: "):
+            mine(candidate, max_tries)
+
+    # a header whose bits denote no target is not mineable, and it is
+    # target_from_bits that says so
+    candidate.bits = bytes.fromhex("22ffffff")
+    with pytest.raises(BTClibValueError, match="invalid proof-of-work target: "):
+        mine(candidate)
+
+
+def test_candidate_version() -> None:
+    """BIP9 leaves the top three bits at 001, and version 1 is dead."""
+    assert VERSION == 0x20000000
+
+    transactions = [_coinbase(1)]
+    # the caller can still say otherwise: a version is a signalling
+    # decision, not arithmetic
+    candidate = candidate_block_header(
+        _PREVIOUS, transactions, _TIME, _EASY_BITS, version=0x20000004
+    )
+    assert candidate.version == 0x20000004
+    assert BlockHeader.parse(candidate.serialize()).version == 0x20000004

--- a/tests/block/mining_test.py
+++ b/tests/block/mining_test.py
@@ -77,7 +77,7 @@ def test_a_mined_block_is_a_block() -> None:
     header = mine(candidate)
     assert header is not None
     assert header.nonce == 373
-    assert header.hash < header.target
+    assert header.hash <= header.target
     header.assert_valid_pow()
 
     # everything except the nonce is what the candidate carried

--- a/tests/block/proof_of_work_test.py
+++ b/tests/block/proof_of_work_test.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Tests for the `btclib.block.proof_of_work` module.
+
+Every retarget vector below is mainnet history, and every number in it
+comes from one of two places, named per test:
+
+- `bitcoin/src/test/pow_tests.cpp`, whose own comments give the height
+  each timestamp belongs to. One value there is flagged by Core itself as
+  "NOT an actual block time", and this file repeats the flag;
+- the `_data/block_*.bin` files this directory already vendors, which
+  verify themselves: `Block.parse` recomputes each hash from the bytes,
+  so the `bits` taken from them are bits that satisfied real work.
+"""
+
+from datetime import datetime, timedelta, timezone
+from os import path
+
+import pytest
+
+from btclib.block import Block
+from btclib.block.proof_of_work import (
+    DIFFICULTY_ADJUSTMENT_INTERVAL,
+    MAINNET_POW_LIMIT_BITS,
+    POW_TARGET_SPACING,
+    POW_TARGET_TIMESPAN,
+    REGTEST_POW_LIMIT_BITS,
+    bits_from_target,
+    block_work,
+    chain_work,
+    hash_rate,
+    next_bits,
+    retarget_first_height,
+    target_from_bits,
+)
+from btclib.exceptions import BTClibValueError
+
+
+def _time(timestamp: int) -> datetime:
+    return datetime.fromtimestamp(timestamp, timezone.utc)
+
+
+def _bits_of(fname: str) -> bytes:
+    """Return the bits of a vendored block, which verifies itself."""
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        block_bytes = file_.read()
+    return Block.parse(block_bytes).header.bits
+
+
+def test_consensus_parameters() -> None:
+    assert POW_TARGET_TIMESPAN == 14 * 24 * 60 * 60
+    assert POW_TARGET_SPACING == 10 * 60
+    assert DIFFICULTY_ADJUSTMENT_INTERVAL == 2016
+
+    # mainnet's limit is the genesis block target, which is what makes
+    # the genesis difficulty 1
+    assert (
+        target_from_bits(MAINNET_POW_LIMIT_BITS).hex()
+        == f"{'00' * 4}{'ff' * 2}{'00' * 26}"
+    )
+    assert _bits_of("block_1.bin") == MAINNET_POW_LIMIT_BITS
+
+
+def test_target_from_bits() -> None:
+    """The compact form, exponent by exponent."""
+    # exponent below 3: the significand shifted *down*, discarding the
+    # low bytes rather than multiplying by a fractional power of 256
+    assert int.from_bytes(target_from_bits("0200ffff"), "big") == 0xFFFF >> 8
+    assert int.from_bytes(target_from_bits("0100ffff"), "big") == 0xFFFF >> 16
+    assert int.from_bytes(target_from_bits("0000ffff"), "big") == 0
+
+    # exponent 3 exactly: neither shift
+    assert int.from_bytes(target_from_bits("0300ffff"), "big") == 0xFFFF
+
+    # and above it
+    assert int.from_bytes(target_from_bits("0400ffff"), "big") == 0xFFFF << 8
+
+    # what 32 bytes cannot hold, which Core flags as fOverflow
+    for bits in ("22ffffff", "ff000001", "fdffffff"):
+        with pytest.raises(BTClibValueError, match="invalid proof-of-work target: "):
+            target_from_bits(bits)
+
+    # bits are four bytes, whatever else is handed over
+    with pytest.raises(BTClibValueError, match="invalid size: 3 bytes instead of 4"):
+        target_from_bits("00ffff")
+
+
+def test_bits_from_target_round_trip() -> None:
+    """Bits taken from real headers survive the round trip."""
+    # every vendored block, i.e. every bits value this directory already
+    # knows to have satisfied real work
+    vendored = {
+        "block_1.bin": "1d00ffff",
+        "block_170.bin": "1d00ffff",
+        "block_200000.bin": "1a05db8b",
+        "block_481824.bin": "18013ce9",
+    }
+    for fname, bits_hex in vendored.items():
+        bits = _bits_of(fname)
+        assert bits.hex() == bits_hex
+        assert bits_from_target(target_from_bits(bits)) == bits
+
+    # the two pow limits, and the four old/new bits of the retarget
+    # vectors below
+    for bits_hex in (
+        "1d00ffff",
+        "207fffff",
+        "1d00d86a",
+        "1c05a3f4",
+        "1c0168fd",
+        "1c387f6f",
+        "1d00e1fd",
+    ):
+        bits = bytes.fromhex(bits_hex)
+        assert bits_from_target(target_from_bits(bits)) == bits
+
+
+def test_bits_from_target_edges() -> None:
+    # the significand holds three bytes, so everything below them is
+    # dropped and the round trip is lossy the other way: what comes back
+    # is the same target or a harder one, never an easier one
+    all_ones = b"\xff" * 32
+    assert bits_from_target(all_ones).hex() == "2100ffff"
+    assert target_from_bits("2100ffff") < all_ones
+
+    # the sign bit: 0x800000 needs a fourth byte, because 0x03800000
+    # denotes a negative number no header may carry
+    assert bits_from_target((0x800000).to_bytes(32, "big")).hex() == "04008000"
+    assert bits_from_target((0x7FFFFF).to_bytes(32, "big")).hex() == "037fffff"
+    assert bits_from_target((0x80).to_bytes(32, "big")).hex() == "02008000"
+
+    # a value occupying fewer than three bytes is shifted *up* into the
+    # significand, which is the exponent <= 3 branch of Core's GetCompact
+    assert bits_from_target("01").hex() == "01010000"
+    assert bits_from_target("0102").hex() == "02010200"
+
+    # zero occupies no bytes at all
+    assert bits_from_target(b"").hex() == "00000000"
+    assert bits_from_target(b"\x00" * 32).hex() == "00000000"
+
+    # a target is 256 bits
+    with pytest.raises(BTClibValueError, match="invalid target: 33 bytes"):
+        bits_from_target(b"\xff" * 33)
+
+
+def test_retarget_first_height() -> None:
+    """The window measures 2015 intervals, not 2016.
+
+    The pairings are Core's own: `pow_tests.cpp` puts `pindexLast` at
+    height 32255 and comments its `nLastRetargetTime` with "Block
+    #30240", at 68543 with "Block #66528", and at 2015 with "Block #0".
+    """
+    assert retarget_first_height(2015) == 0
+    assert retarget_first_height(32255) == 30240
+    assert retarget_first_height(68543) == 66528
+    assert retarget_first_height(46367) == 44352
+
+    # the interval is what separates the two, one short of the 2016
+    # blocks the period holds
+    for last in (2015, 32255, 68543):
+        assert last - retarget_first_height(last) == DIFFICULTY_ADJUSTMENT_INTERVAL - 1
+
+    # any other height ends no period, so it names no window
+    for last in (0, 1, 2014, 2016, 32256):
+        with pytest.raises(BTClibValueError, match="invalid retarget height: "):
+            retarget_first_height(last)
+
+
+def test_next_bits_mainnet_history() -> None:
+    """The four retarget vectors of Core's `pow_tests.cpp`.
+
+    Heights and timestamps are that file's, which names each height in a
+    comment beside the value. The genesis timestamp is also the lower
+    bound `BlockHeader.assert_valid` already enforces, and the old bits
+    of the first two are those of `block_1.bin`, vendored here.
+    """
+    # get_next_work: the first difficulty change mainnet ever made, at
+    # height 32256. Blocks #30240 and #32255, 11.8 days apart, so the
+    # target tightens and difficulty goes from 1 to 1.18
+    assert next_bits(
+        _bits_of("block_1.bin"), _time(1261130161), _time(1262152739)
+    ) == bytes.fromhex("1d00d86a")
+
+    # get_next_work_pow_limit: blocks #0 and #2015, 23.8 days apart. The
+    # target wants to grow and cannot, mainnet's limit being the genesis
+    # target -- which is why the first sixteen periods all sat at
+    # difficulty 1 and the change above is the first one
+    assert next_bits(
+        _bits_of("block_1.bin"), _time(1231006505), _time(1233061996)
+    ) == bytes.fromhex("1d00ffff")
+
+    # get_next_work_lower_limit_actual: blocks #66528 and #68543, 3.35
+    # days apart, i.e. less than the quarter of two weeks the timespan is
+    # clamped at. Without the clamp the target would tighten by 4.2 and
+    # not by 4
+    assert next_bits("1c05a3f4", _time(1279008237), _time(1279297671)) == bytes.fromhex(
+        "1c0168fd"
+    )
+
+    # get_next_work_upper_limit_actual: block #46367 and a first time
+    # Core's own comment flags as "NOT an actual block time" -- 70 days
+    # before it, chosen to reach the other clamp. The target loosens by 4
+    assert next_bits("1c387f6f", _time(1263163443), _time(1269211443)) == bytes.fromhex(
+        "1d00e1fd"
+    )
+
+
+def test_next_bits_clamps() -> None:
+    """The factor of four holds either way, whatever the timespan.
+
+    The significand of these bits is a multiple of four and stays inside
+    three bytes when quadrupled, so both clamped answers are exactly
+    representable and the compact rounding is out of the way.
+    """
+    bits = bytes.fromhex("1b0404cc")
+    first = _time(1262152739)
+
+    quarter = timedelta(seconds=POW_TARGET_TIMESPAN // 4)
+    fourfold = timedelta(seconds=POW_TARGET_TIMESPAN * 4)
+
+    # a period mined instantly is a period mined in 3.5 days
+    assert next_bits(bits, first, first) == next_bits(bits, first, first + quarter)
+    # and one that took a year is one that took eight weeks
+    year = timedelta(days=365)
+    assert next_bits(bits, first, first + year) == next_bits(
+        bits, first, first + fourfold
+    )
+
+    # the clamped answers are the old target divided and multiplied by
+    # four, up to the rounding of the compact re-encoding
+    target = int.from_bytes(target_from_bits(bits), "big")
+    hardest = next_bits(bits, first, first)
+    easiest = next_bits(bits, first, first + fourfold)
+    assert int.from_bytes(target_from_bits(hardest), "big") == target // 4
+    assert int.from_bytes(target_from_bits(easiest), "big") == target * 4
+
+    # two weeks exactly changes nothing
+    unchanged = next_bits(bits, first, first + timedelta(seconds=POW_TARGET_TIMESPAN))
+    assert unchanged == bits
+
+
+def test_next_bits_pow_limit_is_per_network() -> None:
+    """The clamp is the network's, and it is what stops the loosening."""
+    first = _time(1262152739)
+    slow = first + timedelta(seconds=POW_TARGET_TIMESPAN * 4)
+
+    # mainnet is already at its limit, so a period four times too slow
+    # loosens it by nothing at all
+    assert next_bits(MAINNET_POW_LIMIT_BITS, first, slow) == MAINNET_POW_LIMIT_BITS
+
+    # the same target and the same period under regtest's far looser
+    # limit: the factor of four is the only thing left holding it, and
+    # the answer is the mainnet limit times four
+    loose = next_bits(
+        MAINNET_POW_LIMIT_BITS, first, slow, pow_limit_bits=REGTEST_POW_LIMIT_BITS
+    )
+    assert loose == bytes.fromhex("1d03fffc")
+    assert int.from_bytes(target_from_bits(loose), "big") == 4 * int.from_bytes(
+        target_from_bits(MAINNET_POW_LIMIT_BITS), "big"
+    )
+
+
+def test_next_bits_wraps_as_core_does() -> None:
+    """Core multiplies in arith_uint256, and arith_uint256 wraps.
+
+    Multiplying by the timespan and dividing by it is the identity over
+    the integers and not over the 256-bit ring, which is where Core does
+    it. The bits below denote 0xff * 2^248, the largest kind of target
+    `SetCompact` accepts without flagging an overflow, and two weeks
+    exactly is the timespan that leaves both clamps alone: the product is
+    a multiple of 2^256, so the answer is a zero target rather than the
+    unchanged one integer arithmetic would give.
+
+    No chain reaches this. Every network refuses a target above its pow
+    limit, and mainnet's is 2^224, so the case exists only to pin the
+    ring the arithmetic happens in.
+    """
+    two_weeks = timedelta(seconds=POW_TARGET_TIMESPAN)
+    first = _time(1262152739)
+
+    # not an overflow: Core's SetCompact accepts it, and so does btclib
+    assert target_from_bits("220000ff")[0] == 0xFF
+
+    assert next_bits("220000ff", first, first + two_weeks) == bytes(4)
+
+
+def test_block_work() -> None:
+    """Work is 2^256 / (target + 1), the hashes a block is worth."""
+    # the genesis block, whose difficulty is 1: 2^32 hash evaluations,
+    # give or take the 1/65535 by which 0xffff falls short of 2^16
+    assert block_work(MAINNET_POW_LIMIT_BITS) == 2**48 // 0xFFFF
+    assert block_work(MAINNET_POW_LIMIT_BITS) == 4_295_032_833
+    assert 1 < block_work(MAINNET_POW_LIMIT_BITS) / 2**32 < 1.0000153
+
+    # a harder target is more work, and 2^32 times the difficulty is the
+    # same number to within that ratio
+    bits = _bits_of("block_481824.bin")
+    difficulty = 888_171_856_257
+    assert 1 < block_work(bits) / (difficulty * 2**32) < 1.0000153
+
+    # no hash can satisfy a zero target, so no block can carry one.
+    # Core answers 0 there, GetBlockProof doubling as the validity gate
+    for bits_hex in ("00000000", "03000000", "1d000000"):
+        with pytest.raises(BTClibValueError, match="zero proof-of-work target: "):
+            block_work(bits_hex)
+
+
+def test_chain_work() -> None:
+    """Best is most work, not most blocks."""
+    easy = MAINNET_POW_LIMIT_BITS
+    hard = _bits_of("block_200000.bin")
+
+    assert chain_work([]) == 0
+    assert chain_work([easy, easy]) == 2 * block_work(easy)
+
+    # ten easy blocks are a longer chain than one hard block and a
+    # cheaper one to replace, which is the whole reason this is the
+    # comparison and height is not
+    long_and_cheap = [easy] * 10
+    short_and_dear = [hard]
+    assert len(long_and_cheap) > len(short_and_dear)
+    assert chain_work(long_and_cheap) < chain_work(short_and_dear)
+
+
+def test_hash_rate() -> None:
+    """Difficulty times 2^32, over the seconds a block took."""
+    # the genesis difficulty over the ten minutes aimed at: 2^32 hashes
+    # in 600 seconds
+    assert hash_rate(1.0, POW_TARGET_SPACING) == 2**32 / 600
+
+    # block 481,824's difficulty, at the spacing the retarget aims at:
+    # 6.36 EH/s, which is the order mainnet was hashing at in August 2017
+    august_2017 = hash_rate(888_171_856_257, POW_TARGET_SPACING)
+    assert 6.35e18 < august_2017 < 6.36e18
+
+    # a window of blocks: n of them over a timespan is n times one of
+    # them over the same timespan
+    assert hash_rate(1.0, 2 * POW_TARGET_TIMESPAN, DIFFICULTY_ADJUSTMENT_INTERVAL) == (
+        hash_rate(1.0, 2 * POW_TARGET_TIMESPAN) * DIFFICULTY_ADJUSTMENT_INTERVAL
+    )
+    # a window mined in half the time it aimed at doubles the estimate
+    full = hash_rate(1.0, POW_TARGET_TIMESPAN, DIFFICULTY_ADJUSTMENT_INTERVAL)
+    half = hash_rate(1.0, POW_TARGET_TIMESPAN // 2, DIFFICULTY_ADJUSTMENT_INTERVAL)
+    assert half == 2 * full
+
+    # the same window measured through the work of its blocks, which is
+    # what Core's getnetworkhashps sums: the two agree to the 1/65536 the
+    # genesis target falls short of 2^224 by
+    through_work = chain_work([MAINNET_POW_LIMIT_BITS] * 4) / POW_TARGET_TIMESPAN
+    through_difficulty = hash_rate(1.0, POW_TARGET_TIMESPAN, 4)
+    assert 1 < through_work / through_difficulty < 1.0000153
+
+
+def test_hash_rate_exceptions() -> None:
+    # no timespan, no rate: Core's getnetworkhashps returns 0 when the
+    # window's ends carry the same time, and a negative one is what
+    # miner-supplied timestamps can produce
+    for timespan in (0, -1.0):
+        with pytest.raises(BTClibValueError, match="invalid timespan: "):
+            hash_rate(1.0, timespan)
+
+    with pytest.raises(BTClibValueError, match="invalid block count: "):
+        hash_rate(1.0, 600.0, 0)
+
+    with pytest.raises(BTClibValueError, match="invalid difficulty: "):
+        hash_rate(0.0, 600.0)


### PR DESCRIPTION
All three TODO lines of the issue, plus the two functions the issue's own
comment named as needed beside them. Two new modules under `btclib/block/`,
both leaves in the layering: `proof_of_work.py` imports nothing from
`block/`, and `mining.py` imports `block.py` and never the reverse.

## 1. Difficulty adjustment — `btclib.block.proof_of_work`

`next_bits(bits, first_block_time, last_block_time, *, pow_limit_bits)` is
Bitcoin Core's `CalculateNextWorkRequired`, matched line for line:

- the measured timespan clamped to a quarter and to four times two weeks
  *before* the scaling, which is what bounds one retarget to a factor of
  four either way;
- the pow-limit clamp, per network, as bits rather than as the 32 bytes
  `params.powLimit` holds (every network's limit is exactly representable
  in the compact form);
- **the 256-bit ring.** Core multiplies in `arith_uint256`, which wraps, so
  the product is masked. Unreachable above mainnet's 2^224 limit — the
  product overflows only above ~2^233.8 — and regtest's limit is 2^255,
  which is exactly why Core sets `fPowNoRetargeting` there. Tested: two
  weeks exactly, which is the identity over the integers, answers a zero
  target in the ring Core computes in;
- the compact re-encoding, whose rounding down is part of the answer.

`retarget_first_height(last_height)` is the off-by-one: the window is 2015
intervals between the timestamps of the 2016 blocks a period holds, which
is what makes blocks come out ~0.05% faster than the ten minutes aimed at.
It refuses any height that ends no period.

`bits_from_target` is the `GetCompact` that `BlockHeader.target` had no
inverse for, including the rule that shifts a significand whose high bit
would read as the sign (`0x800000` is `0x04008000`, never `0x03800000`).
`BlockHeader.target` now calls `target_from_bits` rather than carrying a
second `SetCompact` beside it.

`block_work` and `chain_work` are `GetBlockProof` and `nChainWork` — the
issue comment asked for cumulative chainwork as the thing that makes the
rest useful, and "which of two chains is best" is now expressible. Both
raise where Core returns `0`, that return being `GetBlockProof`'s validity
gate and not a measure.

## 2. Hash-rate estimation

`hash_rate(difficulty, timespan, block_count)` — difficulty times 2^32 over
the observed interval, pure arithmetic on the three numbers. The docstring
carries the variance caveat: hashing is a Poisson process, so the timespan
of n blocks has relative standard deviation 1/sqrt(n) — 100% over one
block, 8% over a day's 144, still 2% over a whole 2016-block window, and a
number that has moved by less than that has not moved. It also names the
two things that make the inputs softer than they look (miner-supplied
timestamps, which is why Core's `getnetworkhashps` takes min and max rather
than the window's ends; and a window spanning a retarget, which has no
single difficulty and should be summed through `block_work` instead).

## 3. Block creation / toy mining — `btclib.block.mining`

`candidate_block_header(previous_block_hash, transactions, time, bits)`
computes the merkle root and leaves the nonce at zero; `mine(header,
max_tries)` searches the four bytes to a bound and answers `None` rather
than hanging, stopping at the end of the field as well as at `max_tries`.
Explicitly a toy — one Python hash at a time — and not a toy about what it
produces: the merkle root comes from
`merkle_root_and_mutated_from_transactions`, factored out of
`Block.assert_valid_merkle_root` so the builder and the validator cannot
drift apart, and the tests mine a block, hand it to `Block.assert_valid`
and let the ordinary validation have the last word (work, merkle root,
coinbase, witness commitment, BIP34 height). The mined target is
`2000ffff`, one hash in 256, so the search is a few hundred evaluations and
under a millisecond.

## Where the cross-check numbers come from

Every retarget number is real mainnet history, from Bitcoin Core's
`src/test/pow_tests.cpp`, whose own comments name the height beside each
timestamp:

| vector | old bits | window | source |
| --- | --- | --- | --- |
| first difficulty change ever (height 32256) | `1d00ffff` | blocks #30240 → #32255, 11.8 days | `pow_tests.cpp` `get_next_work` |
| the period that wanted to loosen past the genesis target | `1d00ffff` | blocks #0 → #2015, 23.8 days | `get_next_work_pow_limit` |
| the ÷4 timespan clamp | `1c05a3f4` | blocks #66528 → #68543, 3.35 days | `get_next_work_lower_limit_actual` |
| the ×4 timespan clamp | `1c387f6f` | block #46367, first time **not an actual block time** — Core's own comment says so, and the test repeats the flag | `get_next_work_upper_limit_actual` |

Two of those numbers are cross-checked against data already in this repo
rather than taken on trust: the old bits of the first two vectors are read
out of `tests/block/_data/block_1.bin` at test time, and 1231006505 is the
genesis timestamp `BlockHeader.assert_valid` already bounds against. The
compact round trip is checked against the bits of *every* vendored block
(`1d00ffff`, `1a05db8b`, `18013ce9`), which verify themselves — `Block.parse`
recomputes each hash from the bytes, so those are bits that satisfied real
work. `retarget_first_height` is checked against Core's own pairings
(32255 → 30240, 68543 → 66528, 2015 → 0).

## The #177 finding

**#177 does not block anything; it is closed, and it was never about
candidate headers.** The issue was two `assert_valid` completeness gaps (a
4-byte timestamp bound, and zero transactions), both fixed in `e7ebedec`
and `c1e7e807`. What #188 depends on — a *candidate* header being
constructible at all — is already true in the tree: `assert_valid_pow` is
separate from `assert_valid`, its docstring says a header being mined is
structurally valid with no proof-of-work yet, and
`tests/block/block_test.py::test_a_candidate_header_can_be_built` pins it.
So all three pieces ship; nothing was held back.

## Verification

Each command run as documented, exit code checked, never a grep of the
output — re-run in full after the rebase onto `0bca6be1` and the review
fixes, in a private worktree so the shared checkout was never touched:

- `uv run pytest` — **exit 0**, 15109 passed
- `uv run pre-commit run --all-files` — **exit 0**, no file rewritten
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — **exit 0** (both new
  modules are in `docs/source/btclib.block.rst`)
- `uv run pytest --cov=btclib --cov=tests` — **exit 0**; `btclib/block/` is
  at **100.00%**, every new statement covered, and the two uncovered
  statements in the tree are `btclib/mnemonic/electrum.py:325-326`, a
  defensive raise inside `_search_mnemonic` in a file this branch does not
  touch

One thing deliberately not done: no bullet was added to HISTORY.md, since
CLAUDE.md reserves it for what a user has to act on, and nothing here is
that — the `assert_valid_pow` change below only *accepts* what it used to
refuse. Say the word if a new capability belongs there.

## The Sourcery review

Both comments taken, in `c649a97a`, and the first one is not the one-line
change it looked like.

**`mine`'s hash/target comparison.** Sourcery is right that consensus
accepts a hash *equal* to the target — Core's `CheckProofOfWork` rejects
on `hash > bnTarget` — but the strict `<` in `mine` was faithfully
reproducing `BlockHeader.assert_valid_pow`, which rejected on
`hash >= target`. That is the pre-existing deviation, and changing `mine`
alone would have made it return headers btclib itself rejects, which is
the one thing that comparison exists to prevent. So both moved together:
`assert_valid_pow` is `hash > target` and its message says `>` rather than
`>=`, `mine` is `<=`, and the comment beside each records that the rule is
read off Core. It cannot be read off a vector: equality asks a 256-bit
hash for one exact value, and the target cannot be nudged to meet a given
hash either, the compact significand holding three bytes. CHANGELOG.md's
**Consensus rules** group carries the entry.

**"one python hash at a time".** Three lines rather than one, and a typo
the rebase created rather than found: `2330b5be` on `dev` capitalized the
language in `block_header.py`'s `SetCompact` comment exactly while this
branch was moving that comment into `proof_of_work.py`, so the lowercase
travelled with it. Fixed there, in `mining.py`'s docstring, and in the
CHANGELOG bullet quoting it. What stays lowercase is what that commit
leaves lowercase: the `python3` of a shebang, and `docs.python.org`.

## The rebase

Twice, `dev` having moved while the matrix ran, and the interesting one
was the first: onto `452c4d59`, a conflict in
`btclib/block/block_header.py`, where `dev` edited the `SetCompact`
comment inside `BlockHeader.target` while this branch deleted the whole
body in favour of `target_from_bits`. Resolved as the delegation, with
`dev`'s edit carried into the moved comment — see above. Then onto
`0bca6be1`, cleanly: nothing that landed there touches `btclib/block/`,
and CHANGELOG.md is the only file both sides edit, `merge=union` doing its
job. The branch states no entry count.

Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce proof-of-work utilities and toy mining helpers, integrate them with block header handling, and document the new capabilities.

New Features:
- Add `btclib.block.proof_of_work` module providing target/compact bits conversion, difficulty retargeting, block and chain work computation, and hash rate estimation.
- Add `btclib.block.mining` module to build candidate block headers from transactions and perform a bounded nonce search for a valid proof-of-work.
- Expose the new `mining` and `proof_of_work` modules from the `btclib.block` package API.

Enhancements:
- Factor out merkle root computation over transactions into a shared helper used by both block validation and mining to keep builder and validator consistent.
- Simplify `BlockHeader.target` by delegating compact bits decoding to the new `target_from_bits` helper.

Documentation:
- Update CHANGELOG and HISTORY entry counts and add release notes describing the proof-of-work and toy mining capabilities.
- Include the new block modules in Sphinx documentation for the btclib.block package.

Tests:
- Add comprehensive tests for proof-of-work arithmetic, difficulty retargeting, chain work, and hash rate estimation against Bitcoin Core reference vectors and vendored blocks.
- Add tests for candidate block header construction and toy mining behavior, including merkle root consistency, nonce search boundaries, and regtest scenarios.
