### PR TITLE
Read the pre-2.0 Electrum seeds, and dispatch on seed type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1882,6 +1882,50 @@ edit.
   — the first three need a view of the chain btclib does not have, the
   last two a file format that would outlive the release choosing it
   (issue #189)
+- **pre-2.0 Electrum seeds are read, and a dispatcher says which scheme a
+  mnemonic belongs to** (issue #208). A wallet created before Electrum 2.0
+  was recognized and nothing more: `version_from_mnemonic` answered
+  `"old"` and every other function refused it. Four functions in
+  `mnemonic.electrum` now read it — `old_mnemonic_from_hex_seed` and
+  `hex_seed_from_old_mnemonic` for the encoding, three words to each
+  32-bit group over the 1626-word list, and
+  `old_master_prv_key_from_mnemonic` and
+  `old_master_pub_key_from_mnemonic` for the stretch, which is a hundred
+  thousand rounds of `sha256(digest + hex_seed)` over the hex
+  *characters*, not PBKDF2 and not the versioned scheme's 2048
+  iterations. **The passphrase is refused rather than defaulted**:
+  nothing but the seed enters the stretch, so accepting one and ignoring
+  it would hand back the wallet of a seed the caller did not ask for, and
+  Electrum's `keystore.from_seed` refuses it the same way. `None` and the
+  empty string are "no passphrase", as they are there. The scheme has no
+  specification — it predates the BIPs — so Electrum's implementation is
+  what correct means and every vector is Electrum's own: the
+  mnemonic-to-hex pair of its `Test_OldMnemonic`, two wallets of its
+  `test_wallet_vertical.py` with their master public keys, and a real
+  pre-2.0 wallet file from its `test_storage_upgrade.py`. Two of them
+  pin a weakness copied rather than fixed, because fixing it would
+  accept or refuse what Electrum does not: three words can carry a group
+  above `2**32`, so twelve words can decode to 33 or 34 hex characters
+  instead of 32, and one of Electrum's own published seeds does — 34,
+  still octets, so the master public key is derived and matches, while
+  the encoder cannot write those twelve words back out and Electrum's
+  `get_seed` cannot either.
+  The dispatcher is the new `mnemonic.dispatch`:
+  `seed_type_from_mnemonic` answers `"electrum_old"`,
+  `"electrum_standard"`, `"electrum_segwit"`, `"electrum_2fa"`,
+  `"electrum_2fa_segwit"`, `"bip39"`, `"bip39_wordlist"` — every word in
+  the list but no valid reading — or `""`, and
+  `all_seed_types_from_mnemonic` returns every scheme that claims the
+  sentence, because the schemes overlap and the collision is worth
+  seeing rather than resolving in silence. Within Electrum the order is
+  `calc_seed_type`'s, old before the four prefixes, so a pre-2.0 seed
+  that matches `"01"` by chance is not handed back as `"standard"`;
+  Electrum before BIP39 is btclib's, Electrum's wizard asking the user
+  which variant a sentence is instead of guessing, and the base rate is
+  the reason — a version prefix is a deliberate marker present by chance
+  in one sentence in 256, a valid BIP39 checksum in one in sixteen. The
+  dispatcher normalizes nothing of its own, each scheme normalizing as it
+  defines, which leaves issue #201 to decide that once for all of them
 
 ### Types
 

--- a/btclib/mnemonic/__init__.py
+++ b/btclib/mnemonic/__init__.py
@@ -13,9 +13,12 @@ bip39 and electrum are the two mnemonic schemes this package is for, and
 neither was exported: `import btclib.mnemonic` followed by
 `btclib.mnemonic.bip39.mnemonic_from_entropy(...)` raised AttributeError
 until something else in the process happened to import the submodule.
+dispatch is exported beside them: it is the entry point that answers
+which of the two a sentence belongs to, and it is of no use to anyone
+who has to import it by name after already knowing.
 """
 
-from btclib.mnemonic import bip39, electrum
+from btclib.mnemonic import bip39, dispatch, electrum
 from btclib.mnemonic.entropy import (
     BinStr,
     Entropy,
@@ -53,6 +56,7 @@ __all__ = [
     "bip39",
     "bytes_entropy_from_str",
     "collect_rolls",
+    "dispatch",
     "electrum",
     "indexes_from_mnemonic",
     "mnemonic_from_indexes",

--- a/btclib/mnemonic/dispatch.py
+++ b/btclib/mnemonic/dispatch.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Which mnemonic scheme claims a sentence, and in what order.
+
+btclib holds a validator for each scheme and had no entry point that
+tries them, so a caller had to know the answer before it could ask the
+question. The schemes overlap, too: the same twelve English words can be
+a pre-2.0 Electrum seed, a versioned Electrum seed and a valid BIP39
+mnemonic at once, and the three derive three different wallets.
+
+The answers, one string each:
+
+- "electrum_old", "electrum_standard", "electrum_segwit",
+  "electrum_2fa", "electrum_2fa_segwit" -- the five Electrum reports.
+  Prefixed, because "standard" says nothing once BIP39 is in the running.
+- "bip39" -- every word in the list, a length BIP39 defines, and a
+  checksum that verifies.
+- "bip39_wordlist" -- every word in the list and nothing else true: the
+  checksum failed, or the word count is not one of BIP39's five. Kept
+  apart from "" rather than folded into it because it is exactly what
+  bip39.mxprv_from_mnemonic reads with verify_checksum=False, and
+  Electrum's own wizard accepts it as BIP39 too (spesmilo/electrum#8720).
+- "" -- no scheme claims it.
+
+Expect "bip39_wordlist" beside most English Electrum seeds, and read
+nothing into it: Electrum's english.txt is BIP39's, byte for byte, so
+every word of an English Electrum seed is a BIP39 word and only the
+checksum says no. The overlap worth noticing is "bip39" beside an
+Electrum type, which is one sentence that two schemes both read as
+valid and derive two different wallets from.
+
+The order is Electrum's where Electrum has one, and btclib's where it
+does not, and the two halves are worth telling apart.
+
+**Within Electrum** it is calc_seed_type's chain: "old" first, then the
+version prefixes "01", "100", "101" (twelve words, or twenty and up) and
+"102". Upstream's, and implemented by electrum.version_from_mnemonic
+rather than again here. Old first is the load-bearing part -- a pre-2.0
+seed carries no version prefix and can match one by chance, and calling
+it "standard" would hand back the wrong derivation without a word.
+
+**Electrum before BIP39** is btclib's, Electrum having no such order to
+copy: its wizard asks the user which variant a sentence is, and
+validate_seed then dispatches on that answer instead of guessing. The
+reason for this order is the base rate. An Electrum version prefix is a
+deliberate marker, present by chance in one sentence in 256 for "01" and
+one in 4096 for the three-nibble prefixes, while a valid BIP39 checksum
+is present by chance in one twelve-word sentence in sixteen; the rarer
+signal is the one carrying information about where a sentence came from.
+The choice is not hidden either: all_seed_types_from_mnemonic names every
+scheme that claims the sentence, so a caller preferring the other order
+has what it needs to take it.
+
+Normalization is deliberately not done here. Each branch normalizes as
+its own scheme defines -- Electrum's NFKD, lower-casing, accent dropping
+and CJK rules inside electrum.py, BIP39's bare whitespace split inside
+bip39.py -- so an upper-cased sentence is an Electrum seed and not a
+BIP39 mnemonic. That is a difference between the two schemes as they
+stand, not a decision taken here; what btclib should normalize, once and
+for every scheme, is issue 201.
+
+SLIP-0039 is issue 206, and is the third member of the family. A share
+is not a mnemonic of either scheme here and is reported as unknown until
+that lands; the place it goes is the end of the chain, after BIP39.
+"""
+
+from __future__ import annotations
+
+from btclib.exceptions import BTClibValueError
+from btclib.mnemonic import bip39, electrum
+from btclib.mnemonic.mnemonic import Mnemonic, indexes_from_mnemonic
+
+# the sentence lengths BIP39 defines, and so the only ones it defines a
+# checksum for
+_BIP39_WORD_COUNTS = (12, 15, 18, 21, 24)
+
+
+def _bip39_seed_type(mnemonic: Mnemonic, lang: str) -> str:
+    """Return "bip39", "bip39_wordlist" or "" for the sentence.
+
+    The three answers are the two booleans of Electrum's
+    bip39_is_checksum_valid, (is_checksum_valid, is_wordlist_valid),
+    written as one string: (True, True), (False, True) and (False,
+    False). Electrum reports the middle one for a wrong checksum and for
+    a word count outside BIP39's five alike, and so does this.
+    """
+    words = mnemonic.split()
+    if not words:
+        # the word-list test is vacuously true of no words at all, so the
+        # empty string would otherwise be "bip39_wordlist". Electrum
+        # rejects it as its own case in validate_seed for the same reason
+        return ""
+    try:
+        indexes_from_mnemonic(mnemonic, lang)
+    except ValueError:
+        # list.index raises a plain ValueError for a word that is not in
+        # the word-list, and BTClibValueError is one, so this catches the
+        # unknown word and the unknown language together
+        return ""
+    if len(words) not in _BIP39_WORD_COUNTS:
+        return "bip39_wordlist"
+    try:
+        bip39.entropy_from_mnemonic(mnemonic, lang)
+    except BTClibValueError:
+        return "bip39_wordlist"
+    return "bip39"
+
+
+def all_seed_types_from_mnemonic(mnemonic: Mnemonic, lang: str = "en") -> list[str]:
+    """Return every seed type that claims the mnemonic, best first.
+
+    The list is empty when nothing claims it, and holds more than one
+    entry when the schemes overlap -- which is the case worth seeing,
+    since seed_type_from_mnemonic can only answer with the first of them.
+    Two entries at most today: Electrum resolves its own five against
+    each other before answering, so at most one of those appears, and
+    BIP39 gives at most one answer of its own.
+
+    The module docstring has the order and where each half of it comes
+    from.
+    """
+    seed_types = []
+
+    try:
+        version = electrum.version_from_mnemonic(mnemonic)[0]
+    except BTClibValueError:
+        pass
+    else:
+        seed_types.append(f"electrum_{version}")
+
+    if bip39_seed_type := _bip39_seed_type(mnemonic, lang):
+        seed_types.append(bip39_seed_type)
+
+    # SLIP-0039 goes here, after BIP39 and last: issue 206
+    return seed_types
+
+
+def seed_type_from_mnemonic(mnemonic: Mnemonic, lang: str = "en") -> str:
+    """Return what the mnemonic is, "" if no scheme claims it.
+
+    The first of all_seed_types_from_mnemonic, which is the answer the
+    precedence in the module docstring picks. Where a sentence is claimed
+    by two schemes this is the one that wins and the other is not
+    mentioned, so a caller that has to know about the collision -- a
+    restore flow, say, where the wrong choice is a wallet the user cannot
+    see -- wants the plural function instead.
+    """
+    seed_types = all_seed_types_from_mnemonic(mnemonic, lang)
+    return seed_types[0] if seed_types else ""

--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -30,6 +30,17 @@ btclib ships two (en, it). English is the shared one, byte for byte, so
 none of the above depends on the data; Italian is btclib's own
 extension, and an "electrum" mnemonic generated in Italian is one
 Electrum cannot read.
+
+The pre-2.0 scheme is here too, and it is a different thing wearing the
+same words. A wallet created before Electrum 2.0 has a twelve- or
+twenty-four-word mnemonic over a word-list of its own, 1626 words long;
+it decodes to a hex master seed rather than to entropy, three words to
+each 32-bit group; the master private key is that seed stretched by a
+hundred thousand rounds of SHA-256 rather than by PBKDF2; and it has no
+passphrase, so one supplied is refused rather than defaulted away. There
+is no specification to follow -- the scheme predates the BIPs and never
+had one -- so Electrum's implementation is what correct means, and every
+vector for it comes from Electrum's own tests.
 """
 
 from __future__ import annotations
@@ -40,11 +51,13 @@ import secrets
 import string
 import unicodedata
 from functools import cache
-from hashlib import pbkdf2_hmac, sha512
+from hashlib import pbkdf2_hmac, sha256, sha512
 from os import path
 
 from btclib.bip32 import derive, rootxprv_from_seed
 from btclib.bip32.der_path import _HARDENED_OFFSET
+from btclib.curves.curve import mult, secp256k1
+from btclib.curves.sec_point import bytes_from_point
 from btclib.exceptions import BTClibValueError
 from btclib.mnemonic import bip39
 from btclib.mnemonic.entropy import (
@@ -60,6 +73,7 @@ from btclib.mnemonic.mnemonic import (
     mnemonic_from_indexes,
 )
 from btclib.network import NETWORKS
+from btclib.to_prv_key import int_from_prv_key
 
 _MNEMONIC_VERSIONS = {
     "standard": "01",  # P2PKH and P2MS-P2SH wallets
@@ -111,9 +125,23 @@ _CJK_INTERVALS = (
     (0xA490, 0xA4CF),  # Yi Radicals
 )
 
+# the pre-2.0 word-list, transcribed from the _words tuple of
+# spesmilo/electrum's electrum/old_mnemonic.py -- MIT, "Copyright (C)
+# 2011 thomasv@gitorious" -- one word per line, in its order, all 1626 of
+# them. Pinned at commit 6be5bf96a89a72ac5b553493f7db385a0519ddb5
+# (2025-07-18), whose blob for that path is
+# c86634378e62935d4a68966ef19e2f6413066283. The order is load-bearing
+# and is not the alphabet's -- the list is a frequency list of
+# contemporary poetry -- so a re-sorted copy decodes every seed to
+# something else. There is no upstream file to compare bytes against,
+# the words living inside a python module rather than in a .txt
 _OLD_WORDLIST_FILE = path.join(
     path.dirname(__file__), "_data", "electrum_old_english.txt"
 )
+
+# the rounds of Old_KeyStore.stretch_key, which is what a pre-2.0 seed
+# has instead of the versioned scheme's 2048 PBKDF2 iterations
+_OLD_STRETCH_ROUNDS = 100_000
 
 
 def _is_cjk(char: str) -> bool:
@@ -155,17 +183,43 @@ def _normalize(text: str) -> str:
 
 
 @cache
-def _old_wordlist() -> frozenset[str]:
-    """Return electrum's pre-2.0 word-list, read once.
+def _old_wordlist() -> tuple[str, ...]:
+    """Return electrum's pre-2.0 word-list, read once, in its own order.
 
     Not a language of WORDLISTS: it has 1626 words, and load_lang rejects
     any count that is not a power of two, rightly -- an index into it is
-    not a whole number of bits, the pre-2.0 scheme not being a base
-    conversion. A set is enough because nothing here decodes an old seed:
-    the only question asked of it is membership.
+    not a whole number of bits, the pre-2.0 scheme being three words to
+    each 32-bit group rather than a base conversion.
     """
     with open(_OLD_WORDLIST_FILE, encoding="ascii") as file_:
-        return frozenset(line.rstrip("\n") for line in file_)
+        return tuple(line.rstrip("\n") for line in file_)
+
+
+@cache
+def _old_word_indexes() -> dict[str, int]:
+    """Return the word-to-index map of electrum's pre-2.0 word-list.
+
+    Electrum's Wordlist keeps the same map for the same reason: the
+    decoder asks for an index once per word and the recognizer asks for
+    membership once per word, and a 1626-tuple answers either by walking
+    itself.
+    """
+    return {word: index for index, word in enumerate(_old_wordlist())}
+
+
+def _is_hex_str(text: str) -> bool:
+    """Return True for a string of hex characters and nothing else.
+
+    Electrum's is_hex_str, and neither of the two shorter spellings:
+    bytes.fromhex skips ASCII whitespace between pairs, so "0123 4567"
+    would pass as four octets, and int(text, 16) takes a sign and
+    underscore separators besides. The length check is what closes both.
+    """
+    try:
+        octets = bytes.fromhex(text)
+    except ValueError:
+        return False
+    return len(text) == 2 * len(octets)
 
 
 def _is_old_mnemonic(mnemonic: Mnemonic) -> bool:
@@ -185,7 +239,7 @@ def _is_old_mnemonic(mnemonic: Mnemonic) -> bool:
     # triples, so a count that is not a multiple of three drops the tail
     # silently rather than complaining. Testing every word gives the same
     # answer wherever the answer is used, the count there being 12 or 24
-    uses_old_words = all(word in _old_wordlist() for word in words)
+    uses_old_words = all(word in _old_word_indexes() for word in words)
     try:
         is_hex = len(bytes.fromhex(mnemonic)) in (16, 32)
     except ValueError:
@@ -381,7 +435,8 @@ def entropy_from_mnemonic(mnemonic: Mnemonic, lang: str = "en") -> BinStr:
     """
     mnemonic_type, mnemonic = version_from_mnemonic(mnemonic)
     if mnemonic_type == "old":
-        err_msg = "pre-2.0 electrum mnemonic: entropy is not a base conversion"
+        err_msg = "pre-2.0 electrum mnemonic: entropy is not a base conversion; "
+        err_msg += "use hex_seed_from_old_mnemonic"
         raise BTClibValueError(err_msg)
     return _bin_str_entropy_from_mnemonic(mnemonic, lang)
 
@@ -417,4 +472,151 @@ def mxprv_from_mnemonic(
         xversion = NETWORKS[network].slip132_p2wpkh_prv
         rootxprv = rootxprv_from_seed(seed, xversion)
         return derive(rootxprv, _HARDENED_OFFSET)  # "m/0h"
-    raise BTClibValueError(f"unmanaged electrum mnemonic version: {version}")
+    err_msg = f"unmanaged electrum mnemonic version: {version}"
+    if version == "old":
+        # the pre-2.0 scheme has no BIP32 master key to return: its keys
+        # hang off the master public key by an addition of its own, not
+        # by a chain code, so there is no xprv this could answer with
+        err_msg += "; use old_master_prv_key_from_mnemonic"
+    raise BTClibValueError(err_msg)
+
+
+def old_mnemonic_from_hex_seed(hex_seed: str) -> Mnemonic:
+    """Return the pre-2.0 Electrum mnemonic of a hex master seed.
+
+    Electrum's old_mnemonic.mn_encode. Each group of eight hex characters
+    -- one 32-bit word -- becomes three words of the 1626-word list, and
+    the second and third are offsets from the one before rather than
+    digits of their own. Electrum's file names the reason: US patent
+    5892470 claims a scheme in which a word stands for a fixed digit, and
+    in this one the digit a word carries depends on the word before it.
+
+    Three words to a group is also why 1626 need not be a power of two,
+    and so why the list is not a WORDLISTS language.
+    """
+    if not _is_hex_str(hex_seed):
+        raise BTClibValueError("pre-2.0 electrum seed is not a hex string")
+    if len(hex_seed) % 8:
+        err_msg = f"invalid pre-2.0 electrum seed: {len(hex_seed)} hex "
+        err_msg += "characters, not a multiple of eight"
+        raise BTClibValueError(err_msg)
+
+    wordlist = _old_wordlist()
+    base = len(wordlist)
+    words = []
+    for i in range(len(hex_seed) // 8):
+        group = int(hex_seed[8 * i : 8 * i + 8], 16)
+        first = group % base
+        second = (group // base + first) % base
+        third = (group // base // base + second) % base
+        words += [wordlist[first], wordlist[second], wordlist[third]]
+    return " ".join(words)
+
+
+def hex_seed_from_old_mnemonic(mnemonic: Mnemonic) -> str:
+    """Return the hex master seed of a pre-2.0 Electrum mnemonic.
+
+    Electrum's Old_KeyStore.format_seed wrapped around
+    old_mnemonic.mn_decode: the sentence is normalized, a seed already
+    written as hex passes through -- pre-2.0 Electrum stored the seed
+    that way, so that is what a user may be holding -- and anything else
+    is decoded three words at a time.
+
+    The hex test here is the loose one, bytes.fromhex alone, because that
+    is the one format_seed uses; the strict test of _is_hex_str is the
+    one Electrum applies a step later, in stretch_key, and the gap
+    between them is upstream's rather than something to close here.
+
+    Whether the answer is a seed at all is a question this cannot answer,
+    and Electrum cannot either: three words can carry a group above
+    2**32, so twelve words can decode to 33 or 34 hex characters instead
+    of 32, and neither decoder notices. Deriving is where that fails, if
+    it fails at all -- 34 characters are still octets, and one of
+    Electrum's own published seeds is exactly that.
+    """
+    if not _is_old_mnemonic(mnemonic):
+        raise BTClibValueError("not a pre-2.0 electrum mnemonic")
+
+    mnemonic = _normalize(mnemonic)
+    try:
+        bytes.fromhex(mnemonic)
+    except ValueError:
+        pass
+    else:
+        return mnemonic
+
+    indexes = _old_word_indexes()
+    words = mnemonic.split()
+    base = len(_old_wordlist())
+    hex_seed = ""
+    # _is_old_mnemonic passed and the string is not hex, so every word is
+    # in the list and there are 12 or 24 of them: the lookups below
+    # cannot fail and no triple is left over
+    for i in range(len(words) // 3):
+        first, second, third = (indexes[word] for word in words[3 * i : 3 * i + 3])
+        group = first
+        group += base * ((second - first) % base)
+        group += base * base * ((third - second) % base)
+        hex_seed += f"{group:08x}"
+    return hex_seed
+
+
+def old_master_prv_key_from_mnemonic(
+    mnemonic: Mnemonic, passphrase: str | None = None
+) -> int:
+    """Return the pre-2.0 Electrum master private key, as an integer.
+
+    Electrum's Old_KeyStore.stretch_key: a hundred thousand rounds of
+    sha256 over the digest so far followed by the seed, where the seed is
+    the hex *characters* and not the octets they spell, and the last
+    digest read as a big-endian integer. Iterated sha256, not PBKDF2, and
+    not the versioned scheme's 2048 iterations of it: that is the fact
+    only a vector pins, and the vectors here are Electrum's own.
+
+    The passphrase is refused rather than defaulted. Nothing but the seed
+    enters the stretch, so there is nowhere for one to go, and accepting
+    it silently would hand back the wallet of a seed the caller did not
+    ask for. Electrum refuses it the same way in keystore.from_seed --
+    "'old'-type electrum seed cannot have passphrase" -- and its
+    can_seed_have_passphrase answers False for this scheme alone; None
+    and the empty string are "no passphrase" there and here.
+    """
+    if passphrase:
+        raise BTClibValueError("pre-2.0 electrum mnemonic cannot have a passphrase")
+
+    hex_seed = hex_seed_from_old_mnemonic(mnemonic)
+    if not _is_hex_str(hex_seed):
+        # electrum asserts is_hex_str here and this is the assertion that
+        # fires: a decode that overflowed 32 bits leaves an odd number of
+        # hex characters, which bytes.fromhex refuses. Neither
+        # implementation can derive from such a seed, and refusing is
+        # what agreeing with electrum means
+        err_msg = f"pre-2.0 electrum mnemonic decodes to {len(hex_seed)} hex "
+        err_msg += "characters, which are not octets"
+        raise BTClibValueError(err_msg)
+
+    encoded = hex_seed.encode("ascii")
+    digest = encoded
+    for _ in range(_OLD_STRETCH_ROUNDS):
+        digest = sha256(digest + encoded).digest()
+    return int.from_bytes(digest, "big")
+
+
+def old_master_pub_key_from_mnemonic(
+    mnemonic: Mnemonic, passphrase: str | None = None
+) -> str:
+    """Return the pre-2.0 Electrum master public key, as Electrum writes it.
+
+    Electrum's Old_KeyStore.mpk_from_seed: the uncompressed SEC point of
+    the stretched key with its 04 prefix cut off, so 128 hex characters
+    of x and then y. That string is what a pre-2.0 wallet file holds
+    under "master_public_key", which is what makes it the value a vector
+    can be taken from.
+    """
+    prv_key = old_master_prv_key_from_mnemonic(mnemonic, passphrase)
+    # int_from_prv_key and not mult alone: mult reduces the scalar mod n
+    # and would answer for a stretch that landed outside 1..n-1, where
+    # electrum's ECPrivkey raises. A 2**-128 disagreement, and refusing
+    # is the side that costs nothing
+    point = mult(int_from_prv_key(prv_key, secp256k1), secp256k1.G, secp256k1)
+    return bytes_from_point(point, secp256k1, compressed=False)[1:].hex()

--- a/docs/source/btclib.mnemonic.rst
+++ b/docs/source/btclib.mnemonic.rst
@@ -12,6 +12,14 @@ btclib.mnemonic.bip39 module
    :undoc-members:
    :show-inheritance:
 
+btclib.mnemonic.dispatch module
+-------------------------------
+
+.. automodule:: btclib.mnemonic.dispatch
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 btclib.mnemonic.electrum module
 -------------------------------
 

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -632,7 +632,29 @@ spesmilo/electrum's own, inline — the `SEED_TEST_CASES` seeds and the
 vendored as files here: each block is small enough to read, and a
 citation two lines above the values is one that gets checked.
 
-Pulled 2018-06-11.
+The pre-2.0 scheme is the same arrangement and four more of upstream's
+values, added for issue #208. The scheme has no specification — it
+predates the BIPs — so a vector btclib generated would be testing btclib
+against itself, and each of these is a value published by
+spesmilo/electrum:
+
+- the mnemonic-to-hex pair of `Test_OldMnemonic.test`, in
+  `tests/test_mnemonic.py`, which is the only published pair and the only
+  thing that pins the encoder;
+- the mnemonic, hex seed and master public key of
+  `test_electrum_seed_old`, and the mnemonic and master public key of
+  `test_sending_offline_old_electrum_seed_online_mpk`, both in
+  `tests/test_wallet_vertical.py`;
+- the hex seed and `master_public_key` of the pre-2.0 wallet file in
+  `tests/test_storage_upgrade.py`.
+
+The word-list they run over is not under `tests/` and so has no entry
+here: `btclib/mnemonic/_data/electrum_old_english.txt` is shipped code,
+transcribed from the `_words` tuple of `electrum/old_mnemonic.py`, and
+`btclib/mnemonic/electrum.py` carries its pin beside the constant that
+names the file.
+
+Pulled 2018-06-11; the pre-2.0 values 2026-08-02.
 
 ### `tests/mnemonic/_data/fakeenglish.txt`
 

--- a/tests/mnemonic/dispatch_test.py
+++ b/tests/mnemonic/dispatch_test.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Tests for the `btclib.mnemonic.dispatch` module.
+
+The Electrum half of the table is electrum's own, from the Test_seeds
+table of `spesmilo/electrum`'s `tests/test_mnemonic.py` -- the same
+sentences `electrum_test.py` measures `version_from_mnemonic` against,
+here to pin that the dispatcher reports what that function reports and
+does not re-decide it. The BIP39 half comes from btclib's own
+`bip39_test.py` and from electrum's `Test_BIP39.test_checksum`.
+
+Two cases are neither: the collisions. They are btclib's, found by
+searching -- no upstream publishes a sentence two schemes both read --
+and `electrum_test.py` says where each came from.
+"""
+
+import pytest
+
+from btclib.mnemonic import bip39, dispatch, electrum
+
+# every word in the pre-2.0 list, so electrum reads it as "old" although
+# its HMAC also carries the "01" prefix of a "standard" seed. The
+# precedence is the whole point of the case: "old" wins, and it wins
+# inside electrum's own chain rather than by anything decided here
+OLD_COLLISION = (
+    "control age around curtain wall velvet limb sadness struggle orange slice yard"
+)
+
+# a valid BIP39 mnemonic that is also a "standard" electrum seed: the one
+# sentence in this file that two schemes both read as valid, and so the
+# one where the order between them is the answer rather than a formality
+BIP39_COLLISION = (
+    "park leaf system perfect top lecture rather foster best nest craft topic"
+)
+
+DISPATCH_VECTORS = [
+    # the pre-2.0 scheme, which is what the dispatcher was missing
+    pytest.param(
+        "powerful random nobody notice nothing important anyway look away "
+        "hidden message over",
+        "electrum_old",
+        ["electrum_old"],
+        id="electrum-old",
+    ),
+    pytest.param(
+        "cell dumb heartbeat north boom tease ship baby bright kingdom rare squeeze",
+        "electrum_old",
+        ["electrum_old"],
+        id="electrum-old-test-seeds",
+    ),
+    pytest.param(
+        "0123456789abcdef" * 2,
+        "electrum_old",
+        ["electrum_old"],
+        id="electrum-old-hex",
+    ),
+    # the four versioned types, each also carrying the weak BIP39 answer:
+    # electrum's english.txt is BIP39's, so the words are BIP39's words
+    pytest.param(
+        "ostrich security deer aunt climb inner alpha arm mutual marble solid task",
+        "electrum_standard",
+        ["electrum_standard", "bip39_wordlist"],
+        id="electrum-standard",
+    ),
+    pytest.param(
+        "frost pig brisk excite novel report camera enlist axis nation novel desert",
+        "electrum_segwit",
+        ["electrum_segwit", "bip39_wordlist"],
+        id="electrum-segwit",
+    ),
+    pytest.param(
+        "science dawn member doll dutch real can brick knife deny drive list",
+        "electrum_2fa",
+        ["electrum_2fa", "bip39_wordlist"],
+        id="electrum-2fa",
+    ),
+    pytest.param(
+        "agree install",
+        "electrum_2fa_segwit",
+        ["electrum_2fa_segwit", "bip39_wordlist"],
+        id="electrum-2fa-segwit",
+    ),
+    # BIP39, checksum and all: the first is electrum's Test_BIP39 vector,
+    # the second BIP39's own first vector
+    pytest.param(
+        "gravity machine north sort system female filter attitude volume "
+        "fold club stay feature office ecology stable narrow fog",
+        "bip39",
+        ["bip39"],
+        id="bip39-18-words",
+    ),
+    pytest.param(
+        "abandon abandon abandon abandon abandon abandon abandon abandon "
+        "abandon abandon abandon about",
+        "bip39",
+        ["bip39"],
+        id="bip39-12-words",
+    ),
+    # the same twelve words with the checksum word wrong: BIP39's list,
+    # BIP39's length, and no valid reading
+    pytest.param(
+        "abandon abandon abandon abandon abandon abandon abandon abandon "
+        "abandon abandon abandon abandon",
+        "bip39_wordlist",
+        ["bip39_wordlist"],
+        id="bip39-bad-checksum",
+    ),
+    # thirteen words is not a length BIP39 defines, and electrum reports
+    # the same pair for it as for a failed checksum
+    pytest.param(
+        "abandon abandon abandon abandon abandon abandon abandon abandon "
+        "abandon abandon abandon abandon abandon",
+        "bip39_wordlist",
+        ["bip39_wordlist"],
+        id="bip39-13-words",
+    ),
+    pytest.param("not a seed", "", [], id="unknown"),
+    pytest.param("", "", [], id="empty"),
+    pytest.param("   \t\n  ", "", [], id="whitespace"),
+]
+
+
+@pytest.mark.parametrize(("mnemonic", "seed_type", "seed_types"), DISPATCH_VECTORS)
+def test_dispatch_vectors(mnemonic: str, seed_type: str, seed_types: list[str]) -> None:
+    assert dispatch.seed_type_from_mnemonic(mnemonic) == seed_type
+    assert dispatch.all_seed_types_from_mnemonic(mnemonic) == seed_types
+
+
+def test_old_beats_a_lucky_prefix() -> None:
+    """A pre-2.0 seed wins over the version prefix it happens to carry.
+
+    Electrum's calc_seed_type tests is_old_seed before any prefix, and
+    the dispatcher inherits that by asking version_from_mnemonic rather
+    than re-deciding: the sentence below hashes to "01" and would be a
+    "standard" seed if the order were the other way round, deriving a
+    BIP32 wallet from a seed whose keys hang off a stretched master key
+    instead.
+    """
+    assert electrum._seed_version(OLD_COLLISION).startswith("01")
+    assert dispatch.seed_type_from_mnemonic(OLD_COLLISION) == "electrum_old"
+    # and it is a pre-2.0 seed that reads, not one that only looks like one
+    assert electrum.hex_seed_from_old_mnemonic(OLD_COLLISION)
+
+
+def test_electrum_beats_a_valid_bip39_checksum() -> None:
+    """Two valid readings, and the order between them is btclib's.
+
+    Electrum has none to copy here: its wizard asks the user which
+    variant a sentence is and dispatches on the answer. Electrum first is
+    the base rate -- a version prefix is a deliberate marker present by
+    chance in one sentence in 256, a valid BIP39 checksum in one in
+    sixteen -- and the plural function is what keeps the choice visible.
+    """
+    assert bip39.entropy_from_mnemonic(BIP39_COLLISION)
+    assert electrum.version_from_mnemonic(BIP39_COLLISION)[0] == "standard"
+
+    assert dispatch.seed_type_from_mnemonic(BIP39_COLLISION) == "electrum_standard"
+    assert dispatch.all_seed_types_from_mnemonic(BIP39_COLLISION) == [
+        "electrum_standard",
+        "bip39",
+    ]
+
+    # the old collision is claimed twice as well, and by the weak BIP39
+    # answer rather than a valid one: its words are BIP39 words and its
+    # checksum is not a BIP39 checksum
+    assert dispatch.all_seed_types_from_mnemonic(OLD_COLLISION) == [
+        "electrum_old",
+        "bip39_wordlist",
+    ]
+
+
+def test_no_normalization_of_its_own() -> None:
+    """Each scheme normalizes as it defines, and the dispatcher adds nothing.
+
+    An upper-cased sentence is an electrum seed, electrum lower-casing
+    before it hashes, and is not a BIP39 mnemonic, btclib's BIP39 reader
+    splitting on whitespace and nothing more. That difference belongs to
+    the two schemes as they stand; what btclib should normalize, once and
+    for all of them, is issue 201, and this pins the position the
+    dispatcher takes until that is settled: none.
+    """
+    shouted = (
+        "OSTRICH SECURITY DEER AUNT CLIMB INNER ALPHA ARM MUTUAL MARBLE SOLID TASK"
+    )
+    assert dispatch.all_seed_types_from_mnemonic(shouted) == ["electrum_standard"]
+
+    shouted_bip39 = (
+        "ABANDON ABANDON ABANDON ABANDON ABANDON ABANDON ABANDON ABANDON "
+        "ABANDON ABANDON ABANDON ABOUT"
+    )
+    assert dispatch.all_seed_types_from_mnemonic(shouted_bip39) == []
+
+    # whitespace, on the other hand, both schemes already collapse
+    spaced = "  abandon  abandon\tabandon abandon abandon abandon abandon "
+    spaced += "abandon abandon abandon abandon\nabout  "
+    assert dispatch.seed_type_from_mnemonic(spaced) == "bip39"
+
+
+def test_italian() -> None:
+    """The language reaches the BIP39 branch, and only that branch.
+
+    Electrum's word-list is not a parameter of its version check: the
+    HMAC is over the sentence, so a language btclib has and electrum does
+    not still gets an electrum answer. BIP39 is where the word-list is
+    consulted, and where "en" would report nothing.
+    """
+    mnemonic = bip39.mnemonic_from_entropy(0x0102030405060708090A0B0C0D0E0F10, "it")
+    assert dispatch.seed_type_from_mnemonic(mnemonic, "it") == "bip39"
+    # the same sentence against the english list: no word of it is there
+    assert dispatch.all_seed_types_from_mnemonic(mnemonic, "en") == []

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -22,6 +22,8 @@ for a candidate electrum passes over, and `electrum_test_vectors.json`
 has no upstream at all.
 """
 
+from hashlib import sha256
+
 import pytest
 
 from btclib.bip32 import bip32, slip132
@@ -347,12 +349,14 @@ def test_version_vectors(mnemonic: str, version: str) -> None:
 
 
 def test_old_mnemonic() -> None:
-    """A pre-2.0 seed is reported as "old", and nothing more is done with it.
+    """A pre-2.0 seed is reported as "old", and read by its own functions.
 
-    The cases are electrum's is_old_seed tests. The point of recognizing
-    the scheme without implementing it is that an old seed derives keys
-    another way: reporting it as one of the four new versions would be
-    handing back the wrong wallet without a word.
+    The cases are electrum's is_old_seed tests. Recognizing the scheme is
+    what keeps an old seed away from the four new versions, which derive
+    keys another way: reporting it as one of them would be handing back
+    the wrong wallet without a word. What it *is* read by is
+    hex_seed_from_old_mnemonic and the two old_master_ functions, and
+    both refusals below name the one to use instead.
     """
     assert electrum.version_from_mnemonic(" ".join(["like"] * 12))[0] == "old"
     assert electrum.version_from_mnemonic(" ".join(["like"] * 24))[0] == "old"
@@ -373,6 +377,237 @@ def test_old_mnemonic() -> None:
         electrum.entropy_from_mnemonic(old)
     with pytest.raises(BTClibValueError, match="unmanaged electrum mnemonic version: "):
         electrum.mxprv_from_mnemonic(old)
+
+
+# electrum's own pre-2.0 fixtures, and every one of them is a value taken
+# from a test or a wallet file of spesmilo/electrum rather than from
+# btclib. The scheme has no specification to check against -- it predates
+# the BIPs -- so an invented vector would be testing btclib against
+# btclib, and there is nothing else these could be checked with.
+#
+# 1. tests/test_mnemonic.py, Test_OldMnemonic.test: the only published
+#    mnemonic-to-hex pair, and the only one that pins the encoder.
+# 2. tests/test_wallet_vertical.py, test_electrum_seed_old: mnemonic, hex
+#    seed and master public key of one wallet, restored from either form.
+# 3. tests/test_wallet_vertical.py,
+#    test_sending_offline_old_electrum_seed_online_mpk: a mnemonic and
+#    the master public key its watch-only half is built from.
+# 4. tests/test_storage_upgrade.py: a real pre-2.0 wallet file, holding
+#    the hex seed and the "master_public_key" beside it.
+OLD_HEX_SEEDS = [
+    pytest.param(
+        "8edad31a95e7d59f8837667510d75a4d",
+        "hardly point goal hallway patience key stone difference ready "
+        "caught listen fact",
+        None,
+        id="test-mnemonic",
+    ),
+    pytest.param(
+        "acb740e454c3134901d7c8f16497cc1c",
+        "powerful random nobody notice nothing important anyway look away "
+        "hidden message over",
+        "e9d4b7866dd1e91c862aebf62a49548c7dbf7bcc6e4b7b8c9da820c7737968df"
+        "9c09d5a3e271dc814a29981f81b3faaf2737b551ef5dcc6189cf0f8252c442b3",
+        id="wallet-vertical",
+    ),
+    pytest.param(
+        "14039a74100162d9d0cc3c31f100168ddc",
+        "alone body father children lead goodbye phone twist exist grass kick join",
+        "cd805ed20aec61c7a8b409c121c6ba60a9221f46d20edbc2be83ebd91460e979"
+        "37cd7d782e77c1cb08364c6bc1c98bc040fdad53f22f29f7d3a85c8e51f9c875",
+        id="offline-signing",
+    ),
+    pytest.param(
+        "2605aafe50a45bdf2eb155302437e678",
+        "flirt angel five creation swim bridge chocolate sport another "
+        "hill secret whatever",
+        "756d1fe6ded28d43d4fea902a9695feb785447514d6e6c3bdf369f7c3432fdde"
+        "4409e4efbffbcf10084d57c5a98d1f34d20ac1f133bdb64fa02abf4f7bde1dfb",
+        id="storage-upgrade",
+    ),
+]
+
+
+@pytest.mark.parametrize(("hex_seed", "mnemonic", "master_pub_key"), OLD_HEX_SEEDS)
+def test_old_vectors(hex_seed: str, mnemonic: str, master_pub_key: str | None) -> None:
+    """The pre-2.0 scheme, both directions and the stretch, against electrum.
+
+    Only the hex seed and the master public key are upstream values in
+    the third and fourth cases: the mnemonic of the third is what
+    electrum publishes and the hex seed is this decoder's answer for it,
+    and the fourth is the other way round, a wallet file holding a hex
+    seed and no words. Each is still pinned at both ends, the master
+    public key being downstream of the hex seed and upstream of nothing.
+    """
+    assert electrum.hex_seed_from_old_mnemonic(mnemonic) == hex_seed
+    assert electrum.version_from_mnemonic(mnemonic)[0] == "old"
+
+    if len(hex_seed) % 8:
+        # electrum's offline-signing seed is the weak decoder caught in
+        # the wild: two of its four groups exceeded 2**32, so twelve words
+        # decoded to 34 hex characters rather than 32. Even, so it is
+        # still octets and the stretch below runs on it and matches the
+        # published master public key -- but electrum's own get_seed
+        # cannot show the user those twelve words again, mn_encode
+        # asserting a multiple of eight. Refusing the same way is what
+        # agreeing means; a 17-byte seed is not a seed the encoder has an
+        # answer for
+        with pytest.raises(BTClibValueError, match="not a multiple of eight"):
+            electrum.old_mnemonic_from_hex_seed(hex_seed)
+    else:
+        assert electrum.old_mnemonic_from_hex_seed(hex_seed) == mnemonic
+
+    if master_pub_key is None:
+        # no wallet was ever published for this one: it is the encoder
+        # vector, and encoding is where it has been checked
+        return
+
+    assert electrum.old_master_pub_key_from_mnemonic(mnemonic) == master_pub_key
+
+    if len(hex_seed) in (32, 64):
+        # the hex seed is a seed electrum restores from as readily as the
+        # words, which is what makes the hex branch of the recognizer
+        # more than a curiosity
+        assert electrum.old_master_pub_key_from_mnemonic(hex_seed) == master_pub_key
+    else:
+        # and the same 34-character seed is not one it restores from:
+        # is_old_seed takes 16 or 32 octets of hex and no other length,
+        # so that wallet can be reopened from its twelve words alone
+        with pytest.raises(BTClibValueError, match="not a pre-2.0 electrum mnemonic"):
+            electrum.old_master_pub_key_from_mnemonic(hex_seed)
+
+
+def test_old_stretch() -> None:
+    """The stretch is iterated sha256 over the hex characters, not PBKDF2.
+
+    The master private key of electrum's test_electrum_seed_old wallet,
+    which is the integer its master public key is the point of. Spelled
+    out here because the construction is the thing a vector has to pin:
+    the digest starts as the hex seed, each round hashes the digest
+    followed by that same hex seed, a hundred thousand times, and the
+    seed is the sixteen ascii characters rather than the eight octets
+    they spell.
+    """
+    mnemonic = (
+        "powerful random nobody notice nothing important anyway look away "
+        "hidden message over"
+    )
+    prv_key = electrum.old_master_prv_key_from_mnemonic(mnemonic)
+    assert prv_key == 0x21B880FDA2FD30081834683A7049AC9E3941A42ADBC3A4616C9A9275AA960C0D
+
+    # the same number, reached without the module: electrum's stretch_key
+    # transcribed, so that a change to either side has to break this
+    hex_seed = "acb740e454c3134901d7c8f16497cc1c"
+    encoded = hex_seed.encode("ascii")
+    digest = encoded
+    for _ in range(100000):
+        digest = sha256(digest + encoded).digest()
+    assert int.from_bytes(digest, "big") == prv_key
+
+
+def test_old_no_passphrase() -> None:
+    """The pre-2.0 scheme has no passphrase, and says so.
+
+    Electrum's keystore.from_seed raises "'old'-type electrum seed cannot
+    have passphrase" and its can_seed_have_passphrase answers False for
+    this scheme alone. Nothing but the seed enters the stretch, so a
+    passphrase accepted would be a passphrase ignored -- the wallet of a
+    seed the caller did not ask for, handed back without a word. None and
+    the empty string are "no passphrase", there and here.
+    """
+    mnemonic = (
+        "powerful random nobody notice nothing important anyway look away "
+        "hidden message over"
+    )
+    master_pub_key = (
+        "e9d4b7866dd1e91c862aebf62a49548c7dbf7bcc6e4b7b8c9da820c7737968df"
+        "9c09d5a3e271dc814a29981f81b3faaf2737b551ef5dcc6189cf0f8252c442b3"
+    )
+    assert electrum.old_master_pub_key_from_mnemonic(mnemonic, None) == master_pub_key
+    assert electrum.old_master_pub_key_from_mnemonic(mnemonic, "") == master_pub_key
+
+    for function in (
+        electrum.old_master_prv_key_from_mnemonic,
+        electrum.old_master_pub_key_from_mnemonic,
+    ):
+        with pytest.raises(BTClibValueError, match="cannot have a passphrase"):
+            function(mnemonic, "Did you ever hear the tragedy of Darth Plagueis")
+
+
+def test_old_normalization() -> None:
+    """An old seed is normalized before it is decoded, as electrum does it.
+
+    Electrum's format_seed calls normalize_text first, so the mixed-case
+    and doubled-whitespace forms of its Test_seeds table are the same
+    seed as the plain one. The hex form is normalized too, which is why
+    the upper-case hex of is_old_seed's own test decodes at all.
+    """
+    plain = "cell dumb heartbeat north boom tease ship baby bright kingdom rare squeeze"
+    shouted = (
+        "cElL DuMb hEaRtBeAt nOrTh bOoM TeAsE ShIp bAbY BrIgHt kInGdOm rArE SqUeEzE"
+    )
+    spaced = (
+        "   cElL  DuMb hEaRtBeAt nOrTh bOoM  TeAsE ShIp    bAbY BrIgHt "
+        "kInGdOm rArE SqUeEzE   "
+    )
+    hex_seed = electrum.hex_seed_from_old_mnemonic(plain)
+    assert electrum.hex_seed_from_old_mnemonic(shouted) == hex_seed
+    assert electrum.hex_seed_from_old_mnemonic(spaced) == hex_seed
+
+    # a seed written as hex is lower-cased, and is its own answer
+    assert electrum.hex_seed_from_old_mnemonic("0123456789ABCDEF" * 2) == (
+        "0123456789abcdef" * 2
+    )
+    assert electrum.hex_seed_from_old_mnemonic("0123456789ABCDEF" * 4) == (
+        "0123456789abcdef" * 4
+    )
+
+
+def test_old_weak_decoder() -> None:
+    """Twelve words can decode to 33 hex characters, and electrum agrees.
+
+    The "invalid old" seed of electrum's Test_seeds table. Three words
+    carry a group that can exceed 2**32 -- the largest is 1625 * (1 +
+    1626 + 1626**2), about 4.3 billion against 4.29 -- and the decoder
+    writes it out as nine hex characters instead of eight without
+    noticing. Electrum's decoder does the same and its stretch_key then
+    asserts is_hex_str and fails, so refusing here is what agreeing means.
+    """
+    mnemonic = (
+        "hurry idiot prefer sunset mention mist jaw inhale impossible "
+        "kingdom rare squeeze"
+    )
+    assert electrum.version_from_mnemonic(mnemonic)[0] == "old"
+    hex_seed = electrum.hex_seed_from_old_mnemonic(mnemonic)
+    assert hex_seed == "025d2f2d005036911003ca78900ca155c"
+    assert len(hex_seed) == 33
+
+    with pytest.raises(BTClibValueError, match="decodes to 33 hex characters"):
+        electrum.old_master_prv_key_from_mnemonic(mnemonic)
+
+
+def test_old_invalid() -> None:
+    """What the two pre-2.0 converters refuse, and where the line is."""
+    # the encoder takes hex and only hex: bytes.fromhex would skip the
+    # space and int() would take the underscore, and neither is a seed
+    for hex_seed in ("nonsense", "0123456789abcde", "01234567 89abcdef", "0123_4567"):
+        with pytest.raises(BTClibValueError, match="not a hex string"):
+            electrum.old_mnemonic_from_hex_seed(hex_seed)
+
+    # eight hex characters to a group, so a length that is not a multiple
+    # of eight has no third word for its last group
+    with pytest.raises(BTClibValueError, match="not a multiple of eight"):
+        electrum.old_mnemonic_from_hex_seed("0123456789abcdef" * 2 + "abcdef")
+
+    # the decoder takes what the recognizer accepts and nothing else: a
+    # versioned electrum seed is not a pre-2.0 one, whatever it decodes to
+    for mnemonic in (
+        "ostrich security deer aunt climb inner alpha arm mutual marble solid task",
+        " ".join(["like"] * 18),
+        "",
+    ):
+        with pytest.raises(BTClibValueError, match="not a pre-2.0 electrum mnemonic"):
+            electrum.hex_seed_from_old_mnemonic(mnemonic)
 
 
 def test_skipped_candidates() -> None:


### PR DESCRIPTION
## What changed, and why

`btclib/mnemonic/electrum.py` knew the versioned Electrum seeds and
recognised the pre-2.0 ones without being able to read them:
`version_from_mnemonic` answered `"old"` and `entropy_from_mnemonic`,
`mxprv_from_mnemonic` and everything else refused them by name — the
seam #196 left. Those wallets are read now, and a dispatcher answers the
question a caller had to answer for itself before it could ask anything:
what kind of mnemonic is this.

### The pre-2.0 scheme, in `mnemonic.electrum`

Four public functions, and a fifth thing the module gained: an ordered
word-list where it had a `frozenset`, since membership was all the
recogniser needed and a decoder needs indexes.

- `old_mnemonic_from_hex_seed` / `hex_seed_from_old_mnemonic` —
  Electrum's `mn_encode` / `mn_decode` wrapped in its `format_seed`.
  Three words to each 32-bit group over the 1626-word list, the second
  and third words offsets from the one before rather than digits of
  their own; Electrum's file names US patent 5892470 as the reason, and
  the comment carries it. A seed already written as hex passes through,
  which is how pre-2.0 Electrum stored it.
- `old_master_prv_key_from_mnemonic` / `old_master_pub_key_from_mnemonic`
  — Electrum's `stretch_key` and `mpk_from_seed`. A hundred thousand
  rounds of `sha256(digest + hex_seed)`, over the hex **characters** and
  not the octets they spell, read back as a big-endian integer; the
  master public key is the uncompressed SEC point without its `04`, the
  128 hex characters a pre-2.0 wallet file stores under
  `master_public_key`. Iterated SHA-256, not PBKDF2, and not the
  versioned scheme's 2048 iterations of it — the fact only a vector
  pins, and three vectors pin it.

The BIP32 route stays closed and now says where to go instead:
`mxprv_from_mnemonic` appends `use old_master_prv_key_from_mnemonic` for
an old seed, because that scheme has no chain code and so no xprv to
return, and `entropy_from_mnemonic` points at
`hex_seed_from_old_mnemonic`.

### The no-passphrase refusal

`if passphrase: raise BTClibValueError("pre-2.0 electrum mnemonic cannot
have a passphrase")`, on both `old_master_*` functions. Nothing but the
seed enters the stretch, so a passphrase accepted is a passphrase
ignored — the wallet of a seed the caller did not ask for, handed back
without a word. This is Electrum's own rule, not an invention:
`keystore.from_seed` raises `"'old'-type electrum seed cannot have
passphrase"` and `can_seed_have_passphrase` answers `False` for this
scheme alone. `None` and `""` are "no passphrase" there and here, which
is why the check is on truthiness rather than on `is not None`.

### The dispatcher, `mnemonic.dispatch`

- `seed_type_from_mnemonic(mnemonic, lang="en") -> str` — one of
  `"electrum_old"`, `"electrum_standard"`, `"electrum_segwit"`,
  `"electrum_2fa"`, `"electrum_2fa_segwit"`, `"bip39"`,
  `"bip39_wordlist"`, or `""`.
- `all_seed_types_from_mnemonic(...) -> list[str]` — every scheme that
  claims the sentence, in the same order. The schemes overlap, and a
  collision resolved in silence is a wallet the user cannot see.

`"bip39_wordlist"` is Electrum's `bip39_is_checksum_valid` pair
`(is_checksum_valid=False, is_wordlist_valid=True)` written as a string:
every word in the list, no valid reading, because the checksum failed or
the length is not one of BIP39's five. Kept apart from `""` because it is
exactly what `bip39.mxprv_from_mnemonic(..., verify_checksum=False)`
reads and what Electrum's wizard accepts (spesmilo/electrum#8720).

### Precedence, and where each half comes from

**Within Electrum — upstream's.** `calc_seed_type`'s chain, in
`electrum/mnemonic.py`: `is_old_seed` first, then the prefixes `01`,
`100`, `101` (twelve words, or twenty and up) and `102`. The dispatcher
does not re-decide it; it asks `electrum.version_from_mnemonic`, which
#196 already built to that order. Old first is the load-bearing part: a
pre-2.0 seed carries no version prefix and can match one by chance —
`control age around curtain wall velvet limb sadness struggle orange
slice yard` hashes to `01` and is every word of it in the pre-2.0 list —
and reporting it as `"standard"` hands back the wrong derivation. That
case is in the tests, and so is a lucky BIP39 checksum losing to it.

**Electrum before BIP39 — btclib's**, and marked as such, because
Electrum has no order here to copy: `wizard.py`'s `validate_seed`
dispatches on a `seed_variant` the user picked, so upstream never
guesses. The argument for this order is the base rate. An Electrum
version prefix is a deliberate marker present by chance in one sentence
in 256 (`01`) or 4096 (the three-nibble prefixes), while a valid BIP39
checksum is present by chance in one twelve-word sentence in sixteen; the
rarer signal is the one that says where a sentence came from. The choice
is not hidden — `all_seed_types_from_mnemonic` names both, and
`park leaf system perfect top lecture rather foster best nest craft
topic` (valid BIP39 **and** `"standard"` Electrum) is pinned returning
`["electrum_standard", "bip39"]`.

**Normalisation: none of its own**, deliberately. Each branch normalises
as its scheme defines — Electrum's NFKD, lower-casing, accent dropping
and CJK rules inside `electrum.py`; BIP39's bare whitespace split inside
`bip39.py` — so an upper-cased sentence is an Electrum seed and not a
BIP39 mnemonic. That is a difference between the two schemes as they
stand, not a decision taken here, and `test_no_normalization_of_its_own`
pins the position so #201 can change it in one place. `bip39.py` is
untouched.

**SLIP-0039**: a seam, not a dependency. One comment at the end of the
chain naming #206, and one paragraph in the module docstring saying a
share is reported unknown until that lands.

## Vector provenance

The scheme predates the BIPs and has no specification, so Electrum's
implementation is what "correct" means and a vector btclib generated
would be btclib testing itself. Every value is upstream's:

| vector | upstream |
| --- | --- |
| hex ↔ 12 words | `tests/test_mnemonic.py`, `Test_OldMnemonic.test` |
| words, hex, master public key | `tests/test_wallet_vertical.py`, `test_electrum_seed_old` |
| words, master public key | `tests/test_wallet_vertical.py`, `test_sending_offline_old_electrum_seed_online_mpk` |
| hex, `master_public_key` | `tests/test_storage_upgrade.py`, a real pre-2.0 wallet file |
| the seed-type table | `tests/test_mnemonic.py`, `Test_seeds.mnemonics` |

All three published master public keys reproduce byte for byte through
the stretch. The word-list itself was checked element by element against
the `_words` tuple of `electrum/old_mnemonic.py` at commit
`6be5bf96a89a72ac5b553493f7db385a0519ddb5` (blob
`c86634378e62935d4a68966ef19e2f6413066283`): 1626 words, identical, and
in the same order — which matters, the order being a poetry frequency
list rather than the alphabet. The pin lives beside the constant that
names the file, and `tests/_data/README.md` records the four fixture
sources.

Two vectors pin a weakness **copied rather than fixed**, because fixing
it would accept or refuse what Electrum does not. Three words can carry a
group above `2**32`, so twelve words can decode to more than 32 hex
characters and neither decoder notices:

- `hurry idiot prefer sunset mention mist jaw inhale impossible kingdom
  rare squeeze` (Electrum's own "invalid old" case) decodes to 33
  characters — odd, so `is_hex_str` fails and both implementations refuse
  to derive.
- `alone body father children lead goodbye phone twist exist grass kick
  join`, from Electrum's offline-signing test, decodes to **34** — even,
  so it is still octets, the stretch runs and the published master public
  key matches. Its own words cannot be written back out, `mn_encode`
  asserting a multiple of eight, and `is_old_seed` will not take the
  34-character hex either: that wallet reopens from its twelve words
  alone. Both halves are pinned.

## Verification

Every gate run in this worktree, exit code checked, not filtered output:

- `uv run pytest` — **exit 0**, 14816 passed.
- `uv run pre-commit run --all-files` — **exit 0**, every hook (`ruff
  format` rewrote two files on the first pass; re-staged and re-run to
  green).
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — **exit 0**,
  `build succeeded`, no warnings. `btclib.mnemonic.dispatch` is in
  `docs/source/btclib.mnemonic.rst`.

One gate is red and was red before this branch: `uv run --locked
--no-default-groups --group test pytest --cov=btclib --cov=tests` fails
`fail_under = 99.99`. Measured on `origin/dev` with this branch's work
stashed: same two statements missed, same 99.99% total, same failure —
`_search_mnemonic`'s `cannot extract the same entropy from mnemonic`
self-check, which came in with #196 and cannot fire, Electrum's encode
and decode being exact inverses for every positive integer. Not this
branch's to close, and this branch does not widen it: every statement
added here is covered.

## Notes

Sibling PRs move the CHANGELOG entry count too; re-derive it at merge
with `grep -c '^- ' CHANGELOG.md`.

Closes #208.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for Electrum pre-2.0 mnemonics and a dispatcher that identifies mnemonic schemes, with comprehensive tests and documentation updates.

New Features:
- Introduce decoding and encoding of pre-2.0 Electrum seeds, including master private and public key derivation.
- Add a mnemonic dispatcher module that classifies mnemonics as Electrum or BIP39 variants and exposes it via the btclib.mnemonic package.

Enhancements:
- Extend Electrum mnemonic handling to provide clearer error messages and guidance for unsupported old versions.
- Document and pin upstream Electrum test vectors and wordlists for pre-2.0 seeds, and update release history metadata.

Documentation:
- Update mnemonic documentation and test data README to describe pre-2.0 Electrum support, dispatcher behavior, and provenance of upstream vectors.

Tests:
- Add extensive test coverage for pre-2.0 Electrum seeds, including vectors, normalization, edge cases, and passphrase handling, as well as dispatcher behavior across overlapping schemes.