### PR TITLE
Delegate the taproot tweaks, ECDH and BIP32 derivation to libsecp256k1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ edit.
 A hundred and seventy-nine entries, grouped. The order runs from what breaks
 A hundred and eighty entries, grouped. The order runs from what breaks
 A hundred and eighty-one entries, grouped. The order runs from what breaks
+A hundred and eighty-two entries, grouped. The order runs from what breaks
 a caller to what only maintainers see; [HISTORY.md](./HISTORY.md) lists the
 twenty-nine source-breaking changes on their own.
 
@@ -1956,6 +1957,18 @@ twenty-nine source-breaking changes on their own.
   for the `a == p-3` of most catalogued curves, and `JacPoint` is public.
   Every gain is a uniform one, so the comparisons the `curve_group_2`
   docstrings draw between the algorithms still hold as measured
+- **BIP32 private derivation adds the offset in constant time**:
+  `keys.prvkey_tweak_add`, where it was `(kpar + IL) % n` on python
+  integers — variable in time with the operands, and leaving an
+  unzeroized copy of every intermediate behind. The parent key goes in
+  as the 32 bytes it is stored as, so no arithmetic on the secret
+  happens on this side of the call at all. It costs 0.55 µs against
+  0.03, on a derivation whose hmac and public key are some 15 µs of
+  their own. BIP32's three invalid children are unchanged, and still
+  `invalid child index N`: the range check on `parse256(IL)` stays in
+  python, and the one sum libsecp256k1 refuses past it is the zero child
+  BIP32 refuses too. Not gated on the curve, unlike the library's other
+  delegations, there being no second curve BIP32 is defined over
 - **ECDH computes the shared point in libsecp256k1**, and in constant
   time: `dh.diffie_hellman` calls `keys.pubkey_tweak_mul` on secp256k1,
   13.7 µs against the 1.07 ms of `mult(dU, QV)` — some seventy-eight

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ maintainers see; [HISTORY.md](./HISTORY.md) lists the source-breaking
 changes on their own. Neither file counts its entries: `grep -c '^- '`
 does that, whereas a stated number is a line every open branch has to
 edit.
+A hundred and seventy-nine entries, grouped. The order runs from what breaks
+a caller to what only maintainers see; [HISTORY.md](./HISTORY.md) lists the
+twenty-nine source-breaking changes on their own.
 
 ### Repository
 
@@ -1951,6 +1954,19 @@ edit.
   for the `a == p-3` of most catalogued curves, and `JacPoint` is public.
   Every gain is a uniform one, so the comparisons the `curve_group_2`
   docstrings draw between the algorithms still hold as measured
+- **the taproot output key is tweaked by libsecp256k1**, both where it is
+  built and where a control block is checked against it:
+  `taproot.output_pubkey` calls `xonly.tweak_add`, and
+  `check_output_pubkey` calls `xonly.tweak_add_check`, the dedicated
+  verification. Each of the two lifted the x-only key to a point with
+  `ec.y_even` and added `mult(t)` to it in python: 12.0 µs against 109.3
+  for an output key, 2000 tweaks best of nine, of which the modular square
+  root alone was 74. The python arithmetic stays, and the tests compute
+  every tweak twice to hold the two answers to each other — taproot has no
+  second curve to reach that path with, a toy curve failing BIP341's range
+  check on a 256-bit tweak before any arithmetic happens.
+  `check_output_pubkey` keeps answering the python comparison for a q that
+  is not 32 bytes, which `tweak_add_check` refuses instead of answering
 - **`mult` takes the GLV endomorphism on secp256k1** wherever the bindings
   cannot answer: `curve_group_2.mult_endomorphism_secp256k1`, 0.53 ms
   against the 0.84 of the generic `_mult`. The bindings take the generator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ does that, whereas a stated number is a line every open branch has to
 edit.
 A hundred and seventy-nine entries, grouped. The order runs from what breaks
 A hundred and eighty entries, grouped. The order runs from what breaks
+A hundred and eighty-one entries, grouped. The order runs from what breaks
 a caller to what only maintainers see; [HISTORY.md](./HISTORY.md) lists the
 twenty-nine source-breaking changes on their own.
 
@@ -1955,6 +1956,18 @@ twenty-nine source-breaking changes on their own.
   for the `a == p-3` of most catalogued curves, and `JacPoint` is public.
   Every gain is a uniform one, so the comparisons the `curve_group_2`
   docstrings draw between the algorithms still hold as measured
+- **ECDH computes the shared point in libsecp256k1**, and in constant
+  time: `dh.diffie_hellman` calls `keys.pubkey_tweak_mul` on secp256k1,
+  13.7 µs against the 1.07 ms of `mult(dU, QV)` — some seventy-eight
+  times, this being the multiplication of a point that is *not* the
+  generator, the one case `mult` never delegated, with the private key
+  as the scalar. The derivation is unchanged and still ANSI-X9.63-KDF,
+  which is why the bindings' own `ecdh.shared_secret` is not a
+  substitute: that one hashes the compressed shared point with SHA256.
+  Every other curve keeps the python multiplication, GEC 2's secp160r1
+  vector now checked through `diffie_hellman` itself, and so does a
+  scalar that is zero mod n — the infinity point, which the bindings
+  have no scalar for and which is still `invalid (INF) key`
 - **the taproot output *private* key is tweaked by libsecp256k1 too**, and
   in constant time: `taproot.output_prvkey` calls
   `xonly.prvkey_tweak_add`, which is BIP341's tweaking of an x-only
@@ -1986,6 +1999,13 @@ twenty-nine source-breaking changes on their own.
   secp256k1 point — and the operation that means is ECDH:
   `dh.diffie_hellman` measures 0.56 ms against 0.87, a third off, and so
   does any caller multiplying a point of its own. The dispatch asks the
+  cannot answer: `curve_group_2.mult_endomorphism_secp256k1`, 1.03 ms
+  against the 1.52 of the generic `_mult`. The bindings take the generator
+  and a non-zero scalar, so what reaches the python path is every *other*
+  secp256k1 point: any caller multiplying a point of its own gains that
+  third. Not ECDH any more, which measured 1.07 ms against 1.56 until
+  `dh.diffie_hellman` began asking libsecp256k1 for the shared point
+  itself, and which reaches this only on another curve. The dispatch asks the
   same `_libsecp256k1_applicable` the bindings dispatch asks, so the two
   cannot drift apart, and every other curve still runs `_mult` untouched.
   The algorithm is not new either: m as m1 + m2*lambda with both halves

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ A hundred and seventy-nine entries, grouped. The order runs from what breaks
 A hundred and eighty entries, grouped. The order runs from what breaks
 A hundred and eighty-one entries, grouped. The order runs from what breaks
 A hundred and eighty-two entries, grouped. The order runs from what breaks
+A hundred and eighty-three entries, grouped. The order runs from what breaks
 a caller to what only maintainers see; [HISTORY.md](./HISTORY.md) lists the
 twenty-nine source-breaking changes on their own.
 
@@ -1957,6 +1958,16 @@ twenty-nine source-breaking changes on their own.
   for the `a == p-3` of most catalogued curves, and `JacPoint` is public.
   Every gain is a uniform one, so the comparisons the `curve_group_2`
   docstrings draw between the algorithms still hold as measured
+- **BIP32 public derivation stays serialized throughout**:
+  `keys.pubkey_tweak_add` adds the generator times the offset to the
+  parent's 33 bytes and hands back the child's, where python multiplied
+  the generator, added the two points and serialized the sum — 12.4 µs
+  against 33.4. The bindings answer uncompressed, deliberately: the
+  cached point wants the y coordinate, and taking it back from a
+  compressed key is the modular square root of `point_from_octets`, some
+  74 µs to undo a serialization libsecp256k1 had just made. A child at
+  infinity is still `invalid child index N`, and still refused before
+  the key data is touched
 - **BIP32 private derivation adds the offset in constant time**:
   `keys.prvkey_tweak_add`, where it was `(kpar + IL) % n` on python
   integers — variable in time with the operands, and leaving an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,6 @@ maintainers see; [HISTORY.md](./HISTORY.md) lists the source-breaking
 changes on their own. Neither file counts its entries: `grep -c '^- '`
 does that, whereas a stated number is a line every open branch has to
 edit.
-A hundred and seventy-nine entries, grouped. The order runs from what breaks
-A hundred and eighty entries, grouped. The order runs from what breaks
-A hundred and eighty-one entries, grouped. The order runs from what breaks
-A hundred and eighty-two entries, grouped. The order runs from what breaks
-A hundred and eighty-three entries, grouped. The order runs from what breaks
-a caller to what only maintainers see; [HISTORY.md](./HISTORY.md) lists the
-twenty-nine source-breaking changes on their own.
 
 ### Repository
 
@@ -1960,7 +1953,7 @@ twenty-nine source-breaking changes on their own.
   docstrings draw between the algorithms still hold as measured
 - **BIP32 public derivation stays serialized throughout**:
   `keys.pubkey_tweak_add` adds the generator times the offset to the
-  parent's 33 bytes and hands back the child's, where python multiplied
+  parent's 33 bytes and hands back the child's, where Python multiplied
   the generator, added the two points and serialized the sum — 12.4 µs
   against 33.4. The bindings answer uncompressed, deliberately: the
   cached point wants the y coordinate, and taking it back from a
@@ -1969,7 +1962,7 @@ twenty-nine source-breaking changes on their own.
   infinity is still `invalid child index N`, and still refused before
   the key data is touched
 - **BIP32 private derivation adds the offset in constant time**:
-  `keys.prvkey_tweak_add`, where it was `(kpar + IL) % n` on python
+  `keys.prvkey_tweak_add`, where it was `(kpar + IL) % n` on Python
   integers — variable in time with the operands, and leaving an
   unzeroized copy of every intermediate behind. The parent key goes in
   as the 32 bytes it is stored as, so no arithmetic on the secret
@@ -1977,18 +1970,18 @@ twenty-nine source-breaking changes on their own.
   0.03, on a derivation whose hmac and public key are some 15 µs of
   their own. BIP32's three invalid children are unchanged, and still
   `invalid child index N`: the range check on `parse256(IL)` stays in
-  python, and the one sum libsecp256k1 refuses past it is the zero child
+  Python, and the one sum libsecp256k1 refuses past it is the zero child
   BIP32 refuses too. Not gated on the curve, unlike the library's other
   delegations, there being no second curve BIP32 is defined over
 - **ECDH computes the shared point in libsecp256k1**, and in constant
   time: `dh.diffie_hellman` calls `keys.pubkey_tweak_mul` on secp256k1,
-  13.7 µs against the 1.07 ms of `mult(dU, QV)` — some seventy-eight
+  15.2 µs against the 0.55 ms of `mult(dU, QV)` — some thirty-six
   times, this being the multiplication of a point that is *not* the
   generator, the one case `mult` never delegated, with the private key
   as the scalar. The derivation is unchanged and still ANSI-X9.63-KDF,
   which is why the bindings' own `ecdh.shared_secret` is not a
   substitute: that one hashes the compressed shared point with SHA256.
-  Every other curve keeps the python multiplication, GEC 2's secp160r1
+  Every other curve keeps the Python multiplication, GEC 2's secp160r1
   vector now checked through `diffie_hellman` itself, and so does a
   scalar that is zero mod n — the infinity point, which the bindings
   have no scalar for and which is still `invalid (INF) key`
@@ -1996,38 +1989,32 @@ twenty-nine source-breaking changes on their own.
   in constant time: `taproot.output_prvkey` calls
   `xonly.prvkey_tweak_add`, which is BIP341's tweaking of an x-only
   private key — the negation of a key whose public point has an odd y
-  included — where python negated with `ec.n - q` and added with a `%`.
+  included — where Python negated with `ec.n - q` and added with a `%`.
   Neither is constant time; the C one is, and it is a secret scalar. It
   is faster as well, 32.0 µs against 82.3 over 2000 tweaks,
   because the x-only public key the tweak commits to now comes from
-  `bytes_from_prv_key_int` instead of a point built in python and a
-  square root taken to learn that point's parity. The python arithmetic
+  `bytes_from_prv_key_int` instead of a point built in Python and a
+  square root taken to learn that point's parity. The Python arithmetic
   stays, and is compared against the bindings over both parities
 - **the taproot output key is tweaked by libsecp256k1**, both where it is
   built and where a control block is checked against it:
   `taproot.output_pubkey` calls `xonly.tweak_add`, and
   `check_output_pubkey` calls `xonly.tweak_add_check`, the dedicated
   verification. Each of the two lifted the x-only key to a point with
-  `ec.y_even` and added `mult(t)` to it in python: 12.0 µs against 109.3
+  `ec.y_even` and added `mult(t)` to it in Python: 12.0 µs against 109.3
   for an output key over 2000 tweaks, of which the modular square
-  root alone was 74. The python arithmetic stays, and the tests compute
+  root alone was 74. The Python arithmetic stays, and the tests compute
   every tweak twice to hold the two answers to each other — taproot has no
   second curve to reach that path with, a toy curve failing BIP341's range
   check on a 256-bit tweak before any arithmetic happens.
-  `check_output_pubkey` keeps answering the python comparison for a q that
+  `check_output_pubkey` keeps answering the Python comparison for a q that
   is not 32 bytes, which `tweak_add_check` refuses instead of answering
 - **`mult` takes the GLV endomorphism on secp256k1** wherever the bindings
   cannot answer: `curve_group_2.mult_endomorphism_secp256k1`, 0.53 ms
   against the 0.84 of the generic `_mult`. The bindings take the generator
   and a non-zero scalar, so what reaches the Python path is every *other*
-  secp256k1 point — and the operation that means is ECDH:
-  `dh.diffie_hellman` measures 0.56 ms against 0.87, a third off, and so
-  does any caller multiplying a point of its own. The dispatch asks the
-  cannot answer: `curve_group_2.mult_endomorphism_secp256k1`, 1.03 ms
-  against the 1.52 of the generic `_mult`. The bindings take the generator
-  and a non-zero scalar, so what reaches the python path is every *other*
   secp256k1 point: any caller multiplying a point of its own gains that
-  third. Not ECDH any more, which measured 1.07 ms against 1.56 until
+  third. Not ECDH any more, which measured 0.56 ms against 0.87 until
   `dh.diffie_hellman` began asking libsecp256k1 for the shared point
   itself, and which reaches this only on another curve. The dispatch asks the
   same `_libsecp256k1_applicable` the bindings dispatch asks, so the two

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ changes on their own. Neither file counts its entries: `grep -c '^- '`
 does that, whereas a stated number is a line every open branch has to
 edit.
 A hundred and seventy-nine entries, grouped. The order runs from what breaks
+A hundred and eighty entries, grouped. The order runs from what breaks
 a caller to what only maintainers see; [HISTORY.md](./HISTORY.md) lists the
 twenty-nine source-breaking changes on their own.
 
@@ -1954,6 +1955,17 @@ twenty-nine source-breaking changes on their own.
   for the `a == p-3` of most catalogued curves, and `JacPoint` is public.
   Every gain is a uniform one, so the comparisons the `curve_group_2`
   docstrings draw between the algorithms still hold as measured
+- **the taproot output *private* key is tweaked by libsecp256k1 too**, and
+  in constant time: `taproot.output_prvkey` calls
+  `xonly.prvkey_tweak_add`, which is BIP341's tweaking of an x-only
+  private key — the negation of a key whose public point has an odd y
+  included — where python negated with `ec.n - q` and added with a `%`.
+  Neither is constant time; the C one is, and it is a secret scalar. It
+  is faster as well, 32.0 µs against 82.3 (2000 tweaks, best of nine),
+  because the x-only public key the tweak commits to now comes from
+  `bytes_from_prv_key_int` instead of a point built in python and a
+  square root taken to learn that point's parity. The python arithmetic
+  stays, and is compared against the bindings over both parities
 - **the taproot output key is tweaked by libsecp256k1**, both where it is
   built and where a control block is checked against it:
   `taproot.output_pubkey` calls `xonly.tweak_add`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1998,7 +1998,7 @@ twenty-nine source-breaking changes on their own.
   private key — the negation of a key whose public point has an odd y
   included — where python negated with `ec.n - q` and added with a `%`.
   Neither is constant time; the C one is, and it is a secret scalar. It
-  is faster as well, 32.0 µs against 82.3 (2000 tweaks, best of nine),
+  is faster as well, 32.0 µs against 82.3 over 2000 tweaks,
   because the x-only public key the tweak commits to now comes from
   `bytes_from_prv_key_int` instead of a point built in python and a
   square root taken to learn that point's parity. The python arithmetic
@@ -2009,7 +2009,7 @@ twenty-nine source-breaking changes on their own.
   `check_output_pubkey` calls `xonly.tweak_add_check`, the dedicated
   verification. Each of the two lifted the x-only key to a point with
   `ec.y_even` and added `mult(t)` to it in python: 12.0 µs against 109.3
-  for an output key, 2000 tweaks best of nine, of which the modular square
+  for an output key over 2000 tweaks, of which the modular square
   root alone was 74. The python arithmetic stays, and the tests compute
   every tweak twice to hold the two answers to each other — taproot has no
   second curve to reach that path with, a toy curve failing BIP341's range

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -13,6 +13,7 @@ and what a user gains.
 The first release since 2023, and the largest: a hundred and seventy-nine
 The first release since 2023, and the largest: a hundred and eighty
 The first release since 2023, and the largest: a hundred and eighty-one
+The first release since 2023, and the largest: a hundred and eighty-two
 entries, in [CHANGELOG.md](./CHANGELOG.md). What follows is what a user has
 to act on and what a user gains.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -11,6 +11,7 @@ The first release since 2023, and the largest; every entry of it is in
 [CHANGELOG.md](./CHANGELOG.md). What follows is what a user has to act on
 and what a user gains.
 The first release since 2023, and the largest: a hundred and seventy-nine
+The first release since 2023, and the largest: a hundred and eighty
 entries, in [CHANGELOG.md](./CHANGELOG.md). What follows is what a user has
 to act on and what a user gains.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,6 +10,9 @@ full year, short month, short day (YYYY-M-D)
 The first release since 2023, and the largest; every entry of it is in
 [CHANGELOG.md](./CHANGELOG.md). What follows is what a user has to act on
 and what a user gains.
+The first release since 2023, and the largest: a hundred and seventy-nine
+entries, in [CHANGELOG.md](./CHANGELOG.md). What follows is what a user has
+to act on and what a user gains.
 
 Every change is a *behaviour* change somewhere, so the honest summary is
 this: btclib now refuses input it used to accept, reports errors it used

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@ The first release since 2023, and the largest; every entry of it is in
 and what a user gains.
 The first release since 2023, and the largest: a hundred and seventy-nine
 The first release since 2023, and the largest: a hundred and eighty
+The first release since 2023, and the largest: a hundred and eighty-one
 entries, in [CHANGELOG.md](./CHANGELOG.md). What follows is what a user has
 to act on and what a user gains.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -14,6 +14,7 @@ The first release since 2023, and the largest: a hundred and seventy-nine
 The first release since 2023, and the largest: a hundred and eighty
 The first release since 2023, and the largest: a hundred and eighty-one
 The first release since 2023, and the largest: a hundred and eighty-two
+The first release since 2023, and the largest: a hundred and eighty-three
 entries, in [CHANGELOG.md](./CHANGELOG.md). What follows is what a user has
 to act on and what a user gains.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -10,13 +10,6 @@ full year, short month, short day (YYYY-M-D)
 The first release since 2023, and the largest; every entry of it is in
 [CHANGELOG.md](./CHANGELOG.md). What follows is what a user has to act on
 and what a user gains.
-The first release since 2023, and the largest: a hundred and seventy-nine
-The first release since 2023, and the largest: a hundred and eighty
-The first release since 2023, and the largest: a hundred and eighty-one
-The first release since 2023, and the largest: a hundred and eighty-two
-The first release since 2023, and the largest: a hundred and eighty-three
-entries, in [CHANGELOG.md](./CHANGELOG.md). What follows is what a user has
-to act on and what a user gains.
 
 Every change is a *behaviour* change somewhere, so the honest summary is
 this: btclib now refuses input it used to accept, reports errors it used

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,8 +67,9 @@ used to teach and to prototype as much as to build:
     for secp256k1 and the generator alone; `dsa.sign` for secp256k1 with
     sha256, the lower-s form, no caller-imposed nonce and no commitment;
     `ssa.sign` for secp256k1 with sha256, a 32-byte message and no
-    commitment; `taproot.output_prvkey` for secp256k1, the tweaking of a
-    key being the one other place a secret meets the curve.
+    commitment; `taproot.output_prvkey` and `dh.diffie_hellman` for
+    secp256k1, the tweaking of a key and the shared point of a key
+    agreement being the two other places a secret meets the curve.
     Anything else — another
     curve, another hash function, another message size, a nonce of your
     own — runs the Python implementation, whose scalar multiplication is

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,7 +67,9 @@ used to teach and to prototype as much as to build:
     for secp256k1 and the generator alone; `dsa.sign` for secp256k1 with
     sha256, the lower-s form, no caller-imposed nonce and no commitment;
     `ssa.sign` for secp256k1 with sha256, a 32-byte message and no
-    commitment. Anything else — another
+    commitment; `taproot.output_prvkey` for secp256k1, the tweaking of a
+    key being the one other place a secret meets the curve.
+    Anything else — another
     curve, another hash function, another message size, a nonce of your
     own — runs the Python implementation, whose scalar multiplication is
     a double-and-add in Jacobian coordinates: it is validated against the

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -47,9 +47,7 @@ from btclib.bip32.der_path import (
     indexes_from_der_path,
 )
 from btclib.curves import (
-    bytes_from_point,
     bytes_from_prv_key_int,
-    mult,
     point_from_octets,
     secp256k1,
 )
@@ -453,13 +451,32 @@ def __pub_key_derivation(xkey: _BIP32KeyData, index: int) -> None:
     if offset >= secp256k1.n:
         raise _invalid_child(index, "the hmac left half is not a valid scalar")
 
-    pub_key_point = secp256k1.add(xkey.pub_key_point, mult(offset))
-    if pub_key_point[1] == 0:  # INF, the point at infinity, is (int, 0)
-        raise _invalid_child(index, "the child public key is the point at infinity")
+    # the parent point plus the generator times the offset, which is
+    # what secp256k1_ec_pubkey_tweak_add computes: 12.4 us against the
+    # 33.4 of mult(offset) followed by a python point addition, and the
+    # key stays serialized throughout -- the parent's 33 bytes go in and
+    # the child's come out, with no point built on either side.
+    # Uncompressed on the way out, deliberately: the y coordinate is
+    # what the cached point needs, and recovering it from a compressed
+    # key would be the modular square root of point_from_octets, some
+    # 74 us to undo a serialization libsecp256k1 had just made.
+    #
+    # Not gated on the curve, BIP32 being defined for secp256k1 alone
+    try:
+        sec = libsecp256k1_keys.pubkey_tweak_add(xkey.key, offset, compressed=False)
+    except ValueError as e:
+        # past the range check above, the one sum libsecp256k1 refuses
+        # is the point at infinity BIP32 refuses too
+        raise _invalid_child(
+            index, "the child public key is the point at infinity"
+        ) from e
 
     xkey.chain_code = hmac_[32:]
-    xkey.pub_key_point = pub_key_point
-    xkey.key = bytes_from_point(pub_key_point)
+    y = int.from_bytes(sec[33:], byteorder="big", signed=False)
+    xkey.pub_key_point = (int.from_bytes(sec[1:33], byteorder="big", signed=False), y)
+    # the compressed spelling of what came back, as bytes_from_point
+    # writes it: the prefix is the parity of the y being dropped
+    xkey.key = (b"\x03" if y & 1 else b"\x02") + sec[1:33]
 
 
 def __prv_key_path_derivation(xkey: _BIP32KeyData, indexes: list[int]) -> None:

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -37,6 +37,8 @@ import copy
 import hmac
 from dataclasses import dataclass
 
+from btclib_libsecp256k1 import keys as libsecp256k1_keys
+
 from btclib import base58
 from btclib.alias import INF, BinaryData, Octets, Point, String
 from btclib.bip32.der_path import (
@@ -417,15 +419,31 @@ def __prv_key_derivation(xkey: _BIP32KeyData, index: int, pub_key: bytes) -> Non
     offset = int.from_bytes(hmac_[:32], byteorder="big", signed=False)
     if offset >= secp256k1.n:
         raise _invalid_child(index, "the hmac left half is not a valid scalar")
-    prv_key_int = (xkey.prv_key_int + offset) % secp256k1.n
-    if prv_key_int == 0:
-        raise _invalid_child(index, "the child private key is zero")
+
+    # the sum of two scalars, one of them the parent private key:
+    # secp256k1_ec_seckey_tweak_add computes it in constant time, where
+    # python's own `(a + b) % n` is variable in time with the operands
+    # and leaves an unzeroized copy of each intermediate behind. The key
+    # goes in as the 32 bytes it is stored as rather than as
+    # xkey.prv_key_int, so that no arithmetic on the secret happens
+    # here; it costs 0.55 us against 0.03, on a derivation whose hmac
+    # and public key are some 15 us of their own.
+    #
+    # BIP32 is defined for secp256k1 and for nothing else, so this is
+    # not gated on the curve as the rest of the library's dispatches
+    # are: there is no other curve for a fallback to serve
+    try:
+        key = libsecp256k1_keys.prvkey_tweak_add(xkey.key[1:], offset)
+    except ValueError as e:
+        # past the range check above, the one sum libsecp256k1 refuses
+        # is the zero BIP32 refuses too
+        raise _invalid_child(index, "the child private key is zero") from e
 
     # xkey is mutated only past the checks, so a rejected index leaves
     # it the key it was rather than half a derivation
     xkey.chain_code = hmac_[32:]
-    xkey.prv_key_int = prv_key_int
-    xkey.key = b"\x00" + prv_key_int.to_bytes(32, byteorder="big", signed=False)
+    xkey.prv_key_int = int.from_bytes(key, byteorder="big", signed=False)
+    xkey.key = b"\x00" + key
 
 
 def __pub_key_derivation(xkey: _BIP32KeyData, index: int) -> None:
@@ -434,6 +452,7 @@ def __pub_key_derivation(xkey: _BIP32KeyData, index: int) -> None:
     offset = int.from_bytes(hmac_[:32], byteorder="big", signed=False)
     if offset >= secp256k1.n:
         raise _invalid_child(index, "the hmac left half is not a valid scalar")
+
     pub_key_point = secp256k1.add(xkey.pub_key_point, mult(offset))
     if pub_key_point[1] == 0:  # INF, the point at infinity, is (int, 0)
         raise _invalid_child(index, "the child public key is the point at infinity")

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -420,7 +420,7 @@ def __prv_key_derivation(xkey: _BIP32KeyData, index: int, pub_key: bytes) -> Non
 
     # the sum of two scalars, one of them the parent private key:
     # secp256k1_ec_seckey_tweak_add computes it in constant time, where
-    # python's own `(a + b) % n` is variable in time with the operands
+    # Python's own `(a + b) % n` is variable in time with the operands
     # and leaves an unzeroized copy of each intermediate behind. The key
     # goes in as the 32 bytes it is stored as rather than as
     # xkey.prv_key_int, so that no arithmetic on the secret happens
@@ -453,7 +453,7 @@ def __pub_key_derivation(xkey: _BIP32KeyData, index: int) -> None:
 
     # the parent point plus the generator times the offset, which is
     # what secp256k1_ec_pubkey_tweak_add computes: 12.4 us against the
-    # 33.4 of mult(offset) followed by a python point addition, and the
+    # 33.4 of mult(offset) followed by a Python point addition, and the
     # key stays serialized throughout -- the parent's 33 bytes go in and
     # the child's come out, with no point built on either side.
     # Uncompressed on the way out, deliberately: the y coordinate is

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -72,7 +72,7 @@ def diffie_hellman(
     The shared point is the multiplication of a point that is not the
     generator, which is the one case `mult` does not delegate: on
     secp256k1 it is `secp256k1_ec_pubkey_tweak_mul` that computes it
-    here, 13.7 us against the 1066 of the python endomorphism path and,
+    here, 15.2 us against the 549 of the Python endomorphism path and,
     dU being a secret, in constant time -- which that path is not.
 
     `ecdh.shared_secret` of the bindings is a different function and not
@@ -83,7 +83,7 @@ def diffie_hellman(
 
     # d == 0 is the infinity point, which the bindings reject as a
     # scalar; so is a low-order QV on a curve with a cofactor, which
-    # they have no serialization for either. Both are the python path's
+    # they have no serialization for either. Both are the Python path's
     # to answer, and it answers them below
     if d and _libsecp256k1_applicable(ec):
         sec = libsecp256k1_keys.pubkey_tweak_mul(bytes_from_point(QV, ec), d)

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -23,8 +23,11 @@ from __future__ import annotations
 from hashlib import sha256
 from math import ceil
 
+from btclib_libsecp256k1 import keys as libsecp256k1_keys
+
 from btclib.alias import HashF, Point
-from btclib.curves import Curve, mult, secp256k1
+from btclib.curves import Curve, bytes_from_point, mult, secp256k1
+from btclib.curves.curve import _libsecp256k1_applicable
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 
 
@@ -65,7 +68,27 @@ def diffie_hellman(
     """Diffie-Hellman elliptic curve key agreement scheme.
 
     http://www.secg.org/sec1-v2.pdf, section 6.1
+
+    The shared point is the multiplication of a point that is not the
+    generator, which is the one case `mult` does not delegate: on
+    secp256k1 it is `secp256k1_ec_pubkey_tweak_mul` that computes it
+    here, 13.7 us against the 1066 of the python endomorphism path and,
+    dU being a secret, in constant time -- which that path is not.
+
+    `ecdh.shared_secret` of the bindings is a different function and not
+    a substitute: it hashes the compressed shared point with SHA256,
+    libsecp256k1's default, where this derives through ANSI-X9.63-KDF.
     """
+    d = dU % ec.n
+
+    # d == 0 is the infinity point, which the bindings reject as a
+    # scalar; so is a low-order QV on a curve with a cofactor, which
+    # they have no serialization for either. Both are the python path's
+    # to answer, and it answers them below
+    if d and _libsecp256k1_applicable(ec):
+        sec = libsecp256k1_keys.pubkey_tweak_mul(bytes_from_point(QV, ec), d)
+        return ansi_x9_63_kdf(sec[1:], size, hf, shared_info)
+
     shared_secret_point = mult(dU, QV, ec)
     # a degenerate dU, zero mod n, maps every QV here
     if shared_secret_point[1] == 0:

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -178,7 +178,7 @@ def output_pubkey(
     # secp256k1_xonly_pubkey_tweak_add is this very operation, parity
     # included, and it answers the pair this function returns. 12.0 us
     # against 109.3 for the three lines below, over 2000 tweaks: the
-    # python path lifts the x-only key to a point with
+    # Python path lifts the x-only key to a point with
     # ec.y_even, i.e. a modular square root, which is 74 us of that on
     # its own -- while libsecp256k1 needs no such lift, having the
     # y coordinate as it goes
@@ -204,7 +204,7 @@ def output_prvkey(
     # secp256k1_keypair_xonly_tweak_add is the whole of this function
     # below the tweak: it negates the key whose public point has an odd
     # y, as BIP341 requires, and adds the tweak to it -- in constant
-    # time, which the python `%` on a secret scalar is not. The x-only
+    # time, which the Python `%` on a secret scalar is not. The x-only
     # public key the tweak commits to comes from the bindings too, and
     # the parity byte dropped from it is the one they will decide again
     # for themselves: 32.0 us against 82.3 over 2000 tweaks, the
@@ -269,14 +269,14 @@ def check_output_pubkey(
     # Only for a 32-byte q, which is what it takes: a q of any other
     # length is not a taproot output key, but it is not necessarily
     # unequal either -- b"\x00" + 32 bytes reads as the same integer the
-    # comparison below makes -- so the answer for it stays the python
+    # comparison below makes -- so the answer for it stays the Python
     # one rather than becoming an exception
     if _libsecp256k1_applicable(ec) and len(q) == 32:
         try:
             return libsecp256k1_xonly.tweak_add_check(q, control[0] & 1, p_bytes, t)
         except ValueError as e:
             # an internal key that is not a point leaves the bindings
-            # through a plain ValueError and the python path below
+            # through a plain ValueError and the Python path below
             # through the BTClibValueError of ec.y_even. The engine
             # catches the library's own error, so the two must agree on
             # what they raise as well as on what they answer

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -177,8 +177,8 @@ def output_pubkey(
 
     # secp256k1_xonly_pubkey_tweak_add is this very operation, parity
     # included, and it answers the pair this function returns. 12.0 us
-    # against 109.3 for the three lines below (2000 tweaks, best of
-    # nine): the python path lifts the x-only key to a point with
+    # against 109.3 for the three lines below, over 2000 tweaks: the
+    # python path lifts the x-only key to a point with
     # ec.y_even, i.e. a modular square root, which is 74 us of that on
     # its own -- while libsecp256k1 needs no such lift, having the
     # y coordinate as it goes
@@ -207,8 +207,8 @@ def output_prvkey(
     # time, which the python `%` on a secret scalar is not. The x-only
     # public key the tweak commits to comes from the bindings too, and
     # the parity byte dropped from it is the one they will decide again
-    # for themselves: 32.0 us against 82.3 (2000 tweaks, best of nine),
-    # the difference being the point this path never materializes and
+    # for themselves: 32.0 us against 82.3 over 2000 tweaks, the
+    # difference being the point this path never materializes and
     # the square root it never takes to check that point's parity
     if _libsecp256k1_applicable(ec):
         pub_key = bytes_from_prv_key_int(internal_prvkey, ec)[1:]

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -25,7 +25,7 @@ from btclib.alias import (
     TaprootLeafPaths,
     TaprootScriptTree,
 )
-from btclib.curves import Curve, mult, secp256k1
+from btclib.curves import Curve, bytes_from_prv_key_int, mult, secp256k1
 from btclib.curves.curve import _libsecp256k1_applicable
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import tagged_hash
@@ -143,6 +143,20 @@ def _tree_helper(script_tree: TaprootScriptTree) -> tuple[TaprootLeafPaths, byte
     return ([((leaf_version, script), b"")], h)
 
 
+def _tap_tweak(pub_key: bytes, h: bytes, ec: Curve) -> int:
+    """Return the BIP341 tweak an x-only key and a tree hash commit to.
+
+    One function for the three tweaks, the two that build an output and
+    the one that checks a control block against it, so that the rule
+    below cannot hold in one of them and not in another.
+    """
+    t = int.from_bytes(tagged_hash(b"TapTweak", pub_key + h), "big")
+    # BIP341: fail if t is not smaller than the group order
+    if t >= ec.n:
+        raise BTClibValueError("Invalid script tree hash")
+    return t
+
+
 def output_pubkey(
     internal_pubkey: Key | None = None,
     script_tree: TaprootScriptTree | None = None,
@@ -159,10 +173,7 @@ def output_pubkey(
         _, h = tree_helper(script_tree)
     else:
         h = b""
-    t = int.from_bytes(tagged_hash(b"TapTweak", pub_key + h), "big")
-    # BIP341: fail if t is not smaller than the group order
-    if t >= ec.n:
-        raise BTClibValueError("Invalid script tree hash")
+    t = _tap_tweak(pub_key, h, ec)
 
     # secp256k1_xonly_pubkey_tweak_add is this very operation, parity
     # included, and it answers the pair this function returns. 12.0 us
@@ -185,23 +196,30 @@ def output_prvkey(
     ec: Curve = secp256k1,
 ) -> int:
     internal_prvkey: int = int_from_prv_key(prv_key)
-    P = mult(internal_prvkey)
     if script_tree:
         _, h = tree_helper(script_tree)
     else:
         h = b""
+
+    # secp256k1_keypair_xonly_tweak_add is the whole of this function
+    # below the tweak: it negates the key whose public point has an odd
+    # y, as BIP341 requires, and adds the tweak to it -- in constant
+    # time, which the python `%` on a secret scalar is not. The x-only
+    # public key the tweak commits to comes from the bindings too, and
+    # the parity byte dropped from it is the one they will decide again
+    # for themselves: 32.0 us against 82.3 (2000 tweaks, best of nine),
+    # the difference being the point this path never materializes and
+    # the square root it never takes to check that point's parity
+    if _libsecp256k1_applicable(ec):
+        pub_key = bytes_from_prv_key_int(internal_prvkey, ec)[1:]
+        t = _tap_tweak(pub_key, h, ec)
+        tweaked = libsecp256k1_xonly.prvkey_tweak_add(internal_prvkey, t)
+        return int.from_bytes(tweaked, "big")
+
+    P = mult(internal_prvkey)
     has_even_y = ec.y_even(P[0]) == P[1]
     internal_prvkey = internal_prvkey if has_even_y else ec.n - internal_prvkey
-    t: int = int.from_bytes(
-        tagged_hash(b"TapTweak", P[0].to_bytes(32, "big") + h), "big"
-    )
-    # BIP341: fail if t is not smaller than the group order.
-    # Unreachable in the suite, unlike its two siblings: P is a
-    # secp256k1 point whatever ec says, so a toy curve fails
-    # ec.y_even(P[0]) above before getting here, and for secp256k1
-    # itself a 256-bit tagged hash reaches n with probability 2**-128
-    if t >= ec.n:
-        raise BTClibValueError("Invalid script tree hash")  # pragma: no cover
+    t = _tap_tweak(P[0].to_bytes(32, "big"), h, ec)
     return (internal_prvkey + t) % ec.n
 
 
@@ -242,12 +260,8 @@ def check_output_pubkey(
         else:
             k = tagged_hash(b"TapBranch", e + k)
     p_bytes = control[1:33]
-    t_bytes = tagged_hash(b"TapTweak", p_bytes + k)
     p = int.from_bytes(p_bytes, "big")
-    t = int.from_bytes(t_bytes, "big")
-    # BIP341: fail if t is not smaller than the group order
-    if t >= ec.n:
-        raise BTClibValueError("Invalid script tree hash")
+    t = _tap_tweak(p_bytes, k, ec)
 
     # secp256k1_xonly_pubkey_tweak_add_check is the call libsecp256k1
     # provides for this very question, and it compares the serialized

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from io import BytesIO
 from typing import cast
 
+from btclib_libsecp256k1 import xonly as libsecp256k1_xonly
+
 from btclib import var_bytes
 from btclib.alias import (
     BinaryData,
@@ -24,6 +26,7 @@ from btclib.alias import (
     TaprootScriptTree,
 )
 from btclib.curves import Curve, mult, secp256k1
+from btclib.curves.curve import _libsecp256k1_applicable
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import tagged_hash
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
@@ -160,6 +163,17 @@ def output_pubkey(
     # BIP341: fail if t is not smaller than the group order
     if t >= ec.n:
         raise BTClibValueError("Invalid script tree hash")
+
+    # secp256k1_xonly_pubkey_tweak_add is this very operation, parity
+    # included, and it answers the pair this function returns. 12.0 us
+    # against 109.3 for the three lines below (2000 tweaks, best of
+    # nine): the python path lifts the x-only key to a point with
+    # ec.y_even, i.e. a modular square root, which is 74 us of that on
+    # its own -- while libsecp256k1 needs no such lift, having the
+    # y coordinate as it goes
+    if _libsecp256k1_applicable(ec):
+        return libsecp256k1_xonly.tweak_add(pub_key, t)
+
     P_x = int.from_bytes(pub_key, "big")
     Q = ec.add((P_x, ec.y_even(P_x)), mult(t))
     return Q[0].to_bytes(32, "big"), Q[1] % 2
@@ -234,6 +248,26 @@ def check_output_pubkey(
     # BIP341: fail if t is not smaller than the group order
     if t >= ec.n:
         raise BTClibValueError("Invalid script tree hash")
+
+    # secp256k1_xonly_pubkey_tweak_add_check is the call libsecp256k1
+    # provides for this very question, and it compares the serialized
+    # keys instead of tweaking into a point and back.
+    # Only for a 32-byte q, which is what it takes: a q of any other
+    # length is not a taproot output key, but it is not necessarily
+    # unequal either -- b"\x00" + 32 bytes reads as the same integer the
+    # comparison below makes -- so the answer for it stays the python
+    # one rather than becoming an exception
+    if _libsecp256k1_applicable(ec) and len(q) == 32:
+        try:
+            return libsecp256k1_xonly.tweak_add_check(q, control[0] & 1, p_bytes, t)
+        except ValueError as e:
+            # an internal key that is not a point leaves the bindings
+            # through a plain ValueError and the python path below
+            # through the BTClibValueError of ec.y_even. The engine
+            # catches the library's own error, so the two must agree on
+            # what they raise as well as on what they answer
+            raise BTClibValueError(f"invalid internal public key: {e}") from e
+
     P = (p, secp256k1.y_even(p))
     Q = secp256k1.add(P, mult(t))
     return Q[0] == int.from_bytes(q, "big") and control[0] & 1 == Q[1] % 2

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -27,7 +27,12 @@ from btclib.bip32 import (
 )
 from btclib.bip32.bip32 import _derive
 from btclib.bip32.der_path import _indexes_from_der_path_str
-from btclib.curves import bytes_from_prv_key_int
+from btclib.curves import (
+    bytes_from_point,
+    bytes_from_prv_key_int,
+    mult,
+    point_from_octets,
+)
 from btclib.curves import secp256k1 as ec
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
@@ -465,13 +470,14 @@ def _force_hmac(monkeypatch: pytest.MonkeyPatch, il: int, chain_code: bytes) -> 
 
 
 def test_derivation_is_the_arithmetic_bip32_defines() -> None:
-    """The private derivation, against the scalar arithmetic in python.
+    """Both derivations, against the scalar and point arithmetic in python.
 
-    libsecp256k1 adds the offset to the key, and BIP32 is defined for
-    secp256k1 alone: there is no other curve for a fallback to serve, so
-    nothing in the library computes that sum the other way any more.
-    What holds the delegation to BIP32's own equation is having it here
-    -- `ki = parse256(IL) + kpar (mod n)` -- written out over the same
+    libsecp256k1 adds the offset to the key, privately and publicly, and
+    BIP32 is defined for secp256k1 alone: there is no other curve for a
+    fallback to serve, so nothing in the library computes either sum the
+    other way any more. What holds the delegation to BIP32's own
+    equations is having them here -- `ki = parse256(IL) + kpar (mod n)`
+    and `Ki = point(parse256(IL)) + Kpar` -- written out over the same
     hmac the derivation takes, and the shipped vectors for the rest.
     """
     rootxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
@@ -494,10 +500,11 @@ def test_derivation_is_the_arithmetic_bip32_defines() -> None:
         32, byteorder="big", signed=False
     )
 
-    # the public derivation of the same index, which BIP32 requires to
-    # be the public key of that private child
+    child_pub_key_point = ec.add(point_from_octets(parent_pub_key), mult(offset))
     child_pub = BIP32KeyData.b58decode(derive(xpub_from_xprv(rootxprv), f"m/{index}"))
     assert child_pub.chain_code == hmac_[32:]
+    assert child_pub.key == bytes_from_point(child_pub_key_point)
+    # and the two derivations of one index meet, as BIP32 requires
     assert child_pub.key == bytes_from_prv_key_int(child_prv_key)
 
 

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -470,7 +470,7 @@ def _force_hmac(monkeypatch: pytest.MonkeyPatch, il: int, chain_code: bytes) -> 
 
 
 def test_derivation_is_the_arithmetic_bip32_defines() -> None:
-    """Both derivations, against the scalar and point arithmetic in python.
+    """Both derivations, against the scalar and point arithmetic in Python.
 
     libsecp256k1 adds the offset to the key, privately and publicly, and
     BIP32 is defined for secp256k1 alone: there is no other curve for a

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -27,6 +27,7 @@ from btclib.bip32 import (
 )
 from btclib.bip32.bip32 import _derive
 from btclib.bip32.der_path import _indexes_from_der_path_str
+from btclib.curves import bytes_from_prv_key_int
 from btclib.curves import secp256k1 as ec
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
@@ -461,6 +462,43 @@ def _force_hmac(monkeypatch: pytest.MonkeyPatch, il: int, chain_code: bytes) -> 
     """
     digest = il.to_bytes(32, byteorder="big", signed=False) + chain_code
     monkeypatch.setattr(hmac, "new", lambda *args, **kwargs: _ForcedHmac(digest))
+
+
+def test_derivation_is_the_arithmetic_bip32_defines() -> None:
+    """The private derivation, against the scalar arithmetic in python.
+
+    libsecp256k1 adds the offset to the key, and BIP32 is defined for
+    secp256k1 alone: there is no other curve for a fallback to serve, so
+    nothing in the library computes that sum the other way any more.
+    What holds the delegation to BIP32's own equation is having it here
+    -- `ki = parse256(IL) + kpar (mod n)` -- written out over the same
+    hmac the derivation takes, and the shipped vectors for the rest.
+    """
+    rootxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
+    parent = BIP32KeyData.b58decode(rootxprv)
+    index = 42
+    parent_prv_key = int.from_bytes(parent.key[1:], byteorder="big", signed=False)
+    parent_pub_key = bytes_from_prv_key_int(parent_prv_key)
+
+    hmac_ = hmac.new(
+        parent.chain_code,
+        parent_pub_key + index.to_bytes(4, byteorder="big", signed=False),
+        "sha512",
+    ).digest()
+    offset = int.from_bytes(hmac_[:32], byteorder="big", signed=False)
+
+    child_prv_key = (parent_prv_key + offset) % ec.n
+    child = BIP32KeyData.b58decode(derive(rootxprv, f"m/{index}"))
+    assert child.chain_code == hmac_[32:]
+    assert child.key == b"\x00" + child_prv_key.to_bytes(
+        32, byteorder="big", signed=False
+    )
+
+    # the public derivation of the same index, which BIP32 requires to
+    # be the public key of that private child
+    child_pub = BIP32KeyData.b58decode(derive(xpub_from_xprv(rootxprv), f"m/{index}"))
+    assert child_pub.chain_code == hmac_[32:]
+    assert child_pub.key == bytes_from_prv_key_int(child_prv_key)
 
 
 def test_invalid_child_prv_key(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/ecc/dh_test.py
+++ b/tests/ecc/dh_test.py
@@ -15,7 +15,7 @@ import pytest
 
 from btclib.curves import bytes_from_point, mult
 from btclib.curves.curve import CURVES
-from btclib.ecc import ansi_x9_63_kdf, diffie_hellman, dsa
+from btclib.ecc import ansi_x9_63_kdf, dh, diffie_hellman, dsa
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 
 
@@ -103,6 +103,10 @@ def test_gec_2() -> None:
         z.to_bytes(ec.p_size, byteorder="big", signed=False), size, hf, None
     )
     assert keyingdata.hex() == "744ab703f5bc082e59185f6d049d2d367db245c2"
+    # the whole scheme, on the curve the bindings do not serve: this
+    # vector is what covers the python shared point, secp256k1 having
+    # been handed to libsecp256k1
+    assert diffie_hellman(dU, QV, size, None, ec, hf) == keyingdata
 
     # 4.1.5
     z, _ = mult(dV, QU, ec)  # x coordinate only
@@ -241,6 +245,27 @@ def test_capv() -> None:
             None if shared_info is None else bytes.fromhex(shared_info),
         )
         assert result == bytes.fromhex(key_data)
+
+
+def test_the_python_shared_point_is_the_bindings_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One shared key, whoever multiplies the point.
+
+    Three ways to the same bytes: libsecp256k1 for each side of the
+    agreement, and the python endomorphism path for one of them. The
+    patch is how that path is reached on secp256k1 at all, `mult`
+    delegating every scalar but zero once the point is a public key
+    rather than the generator.
+    """
+    a, A = dsa.gen_keys()  # Alice
+    b, B = dsa.gen_keys()  # Bob
+
+    shared_key = diffie_hellman(a, B, 32)
+    assert diffie_hellman(b, A, 32) == shared_key
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(dh, "_libsecp256k1_applicable", lambda *_: False)
+        assert diffie_hellman(a, B, 32) == shared_key
 
 
 def test_infinity_shared_secret() -> None:

--- a/tests/ecc/dh_test.py
+++ b/tests/ecc/dh_test.py
@@ -104,7 +104,7 @@ def test_gec_2() -> None:
     )
     assert keyingdata.hex() == "744ab703f5bc082e59185f6d049d2d367db245c2"
     # the whole scheme, on the curve the bindings do not serve: this
-    # vector is what covers the python shared point, secp256k1 having
+    # vector is what covers the Python shared point, secp256k1 having
     # been handed to libsecp256k1
     assert diffie_hellman(dU, QV, size, None, ec, hf) == keyingdata
 
@@ -253,7 +253,7 @@ def test_the_python_shared_point_is_the_bindings_one(
     """One shared key, whoever multiplies the point.
 
     Three ways to the same bytes: libsecp256k1 for each side of the
-    agreement, and the python endomorphism path for one of them. The
+    agreement, and the Python endomorphism path for one of them. The
     patch is how that path is reached on secp256k1 at all, `mult`
     delegating every scalar but zero once the point is a public key
     rather than the generator.

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -33,6 +33,7 @@ from btclib.script import (
     is_p2tr,
     output_prvkey,
     output_pubkey,
+    taproot,
     type_and_payload,
 )
 from btclib.script.taproot import parse, serialize
@@ -81,21 +82,109 @@ def test_valid_script_path(vector: dict[str, Any]) -> None:
     assert check_output_pubkey(Q, script, control)
 
 
+# the key path, one leaf and a two-leaf branch: the three shapes a tweak
+# can commit to, shared by the tests below rather than spelled out in
+# each -- what they must agree about is the tweak, not the tree
+SCRIPT_TREES: list[TaprootScriptTree | None] = [
+    None,
+    [(0xC0, ["OP_1"])],
+    [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]],
+]
+
+
 def test_taproot_key_tweaking() -> None:
     prv_key = 123456
     pub_key = mult(prv_key)
 
-    script_trees: list[TaprootScriptTree | None] = [
-        None,
-        [(0xC0, ["OP_1"])],
-        [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]],
-    ]
-
-    for script_tree in script_trees:
+    for script_tree in SCRIPT_TREES:
         tweaked_prvkey = output_prvkey(prv_key, script_tree)
         tweaked_pubkey = output_pubkey(pub_key, script_tree)[0]
 
         assert tweaked_pubkey == mult(tweaked_prvkey)[0].to_bytes(32, "big")
+
+
+def test_the_python_tweak_is_the_bindings_tweak(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The output key, computed twice, is the same key on secp256k1.
+
+    The bindings are the authority on the answer and the python
+    arithmetic is the reference implementation of it, so what has to be
+    asserted is that the two are one answer. It takes the patch because
+    there is no second curve to reach the python path with: a toy curve
+    fails the BIP341 range check on a 256-bit tweak before any
+    arithmetic happens, and taproot is defined over secp256k1 alone.
+    """
+    pub_key = mult(0xC0FFEE)
+
+    for script_tree in SCRIPT_TREES:
+        delegated = output_pubkey(pub_key, script_tree)
+        with monkeypatch.context() as no_bindings:
+            no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
+            assert output_pubkey(pub_key, script_tree) == delegated
+
+
+def test_the_python_commitment_check_is_the_bindings_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The control block verdict, taken twice, is the same verdict.
+
+    Both verdicts, because a check that only ever says True is a check
+    that says nothing: the false one is the same output key with a byte
+    flipped, which commits to nothing and must fail on either path.
+    """
+    pub_key = mult(0xC0FFEE)
+    script_tree: TaprootScriptTree = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
+    q = output_pubkey(pub_key, script_tree)[0]
+    not_q = bytes([q[0] ^ 1]) + q[1:]
+    script, control = input_script_sig(pub_key, script_tree, 0)
+    script_bytes = serialize(script)
+
+    assert check_output_pubkey(q, script_bytes, control)
+    assert not check_output_pubkey(not_q, script_bytes, control)
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
+        assert check_output_pubkey(q, script_bytes, control)
+        assert not check_output_pubkey(not_q, script_bytes, control)
+
+
+def test_check_output_pubkey_of_a_key_that_is_not_32_bytes() -> None:
+    """A q of another length is answered, not refused.
+
+    `tweak_add_check` takes 32 bytes and raises for anything else, so
+    the dispatch asks for that size and leaves every other q to the
+    python comparison. Which is not a length test but an integer one:
+    it says no to a truncated key and yes to a zero-padded one, and
+    that second answer is why the dispatch falls through here instead
+    of turning the size into a refusal.
+    """
+    script_tree: TaprootScriptTree = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
+    pub_key = output_pubkey(None, script_tree)[0]
+    script, control = input_script_sig(None, script_tree, 0)
+
+    assert not check_output_pubkey(pub_key[:31], serialize(script), control)
+    assert check_output_pubkey(b"\x00" + pub_key, serialize(script), control)
+
+
+def test_check_output_pubkey_of_an_internal_key_that_is_not_a_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both paths refuse an internal key with no y, and refuse it alike.
+
+    x = 5 is not the x-coordinate of a secp256k1 point: 5**3 + 7 is not
+    a quadratic residue. libsecp256k1 rejects it while parsing and
+    ec.y_even while lifting it, and the two errors have to be the same
+    kind, the script engine catching the library's own.
+    """
+    control = b"\xc0" + (5).to_bytes(32, "big")
+    err_msg = "invalid"
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        check_output_pubkey(b"\x00" * 32, b"\x51", control)
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
+        with pytest.raises(BTClibValueError, match=err_msg):
+            check_output_pubkey(b"\x00" * 32, b"\x51", control)
 
 
 def test_invalid_control_block() -> None:

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -106,7 +106,7 @@ def test_taproot_key_tweaking() -> None:
 def test_the_python_tweak_is_the_bindings_tweak(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The output key, computed twice, is the same key on secp256k1.
+    """Both output keys, computed twice, are the same keys on secp256k1.
 
     The bindings are the authority on the answer and the python
     arithmetic is the reference implementation of it, so what has to be
@@ -114,14 +114,22 @@ def test_the_python_tweak_is_the_bindings_tweak(
     there is no second curve to reach the python path with: a toy curve
     fails the BIP341 range check on a 256-bit tweak before any
     arithmetic happens, and taproot is defined over secp256k1 alone.
+
+    The private key is the one whose public point has an odd y, the case
+    the tweaking negates: with an even one the two paths would agree
+    over a negation neither of them performed.
     """
-    pub_key = mult(0xC0FFEE)
+    prv_key = 0xC0FFEE
+    pub_key = mult(prv_key)
+    assert pub_key[1] % 2 == 1
 
     for script_tree in SCRIPT_TREES:
         delegated = output_pubkey(pub_key, script_tree)
+        delegated_prvkey = output_prvkey(prv_key, script_tree)
         with monkeypatch.context() as no_bindings:
             no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
             assert output_pubkey(pub_key, script_tree) == delegated
+            assert output_prvkey(prv_key, script_tree) == delegated_prvkey
 
 
 def test_the_python_commitment_check_is_the_bindings_one(

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -108,10 +108,10 @@ def test_the_python_tweak_is_the_bindings_tweak(
 ) -> None:
     """Both output keys, computed twice, are the same keys on secp256k1.
 
-    The bindings are the authority on the answer and the python
+    The bindings are the authority on the answer and the Python
     arithmetic is the reference implementation of it, so what has to be
     asserted is that the two are one answer. It takes the patch because
-    there is no second curve to reach the python path with: a toy curve
+    there is no second curve to reach the Python path with: a toy curve
     fails the BIP341 range check on a 256-bit tweak before any
     arithmetic happens, and taproot is defined over secp256k1 alone.
 
@@ -161,7 +161,7 @@ def test_check_output_pubkey_of_a_key_that_is_not_32_bytes() -> None:
 
     `tweak_add_check` takes 32 bytes and raises for anything else, so
     the dispatch asks for that size and leaves every other q to the
-    python comparison. Which is not a length test but an integer one:
+    Python comparison. Which is not a length test but an integer one:
     it says no to a truncated key and yes to a zero-padded one, and
     that second answer is why the dispatch falls through here instead
     of turning the size into a refusal.


### PR DESCRIPTION
A first tranche of #128: five of its checklist items, chosen for being
clean delegations, plus a measurement that argues against three more.

## Shipped

- **Taproot output key** — `taproot.output_pubkey` calls `xonly.tweak_add`
  and `check_output_pubkey` calls `xonly.tweak_add_check`, the dedicated
  verification. 12.0 µs against 109.3 for an output key, over 2000 tweaks:
  the Python path lifted the x-only key to a point with `ec.y_even`, a
  modular square root worth 74 µs of that.
- **Taproot output private key** — `xonly.prvkey_tweak_add`, which is the
  BIP341 tweaking of an x-only private key, negation of an odd-y key
  included, and constant time where Python's `ec.n - q` and `%` are not.
  32.0 µs against 82.3.
- **ECDH** — `keys.pubkey_tweak_mul` for the shared point, the one
  multiplication `mult` never delegated: 15.2 µs against 549, some
  thirty-six times, with the private key as the scalar and therefore
  in constant time. `ecdh.shared_secret` is deliberately *not* what is
  called: it hashes the compressed point with SHA256, where
  `diffie_hellman` derives through ANSI-X9.63-KDF.
- **BIP32 private derivation** — `keys.prvkey_tweak_add`, the parent key
  passed as the 32 bytes it is stored as, so no arithmetic on the secret
  happens on this side of the call. 0.55 µs against 0.03, on a derivation
  whose hmac and public key are some 15 µs of their own.
- **BIP32 public derivation** — `keys.pubkey_tweak_add`, serialized
  throughout, 12.4 µs against 33.4. Uncompressed on the way out, because
  the cached point wants the y coordinate and taking it back from a
  compressed key is `point_from_octets`' square root.

BIP32's three invalid children keep their own messages: the
`parse256(IL) >= n` check stays in Python ahead of the call, so the one
failure libsecp256k1 can still report is the zero child, or the child at
infinity, and the mapping is unambiguous.

## Not shipped, with the measurement that says why

- **Tagged hashes** (`hashes.tagged_hash` → `hashes.tagged_sha256`) —
  *slower, at every size*: 0.53 µs against 0.46 on an empty message, 0.65
  against 0.47 on 64 bytes, 2.31 against 0.74 on 1 KiB, 115.9 against 19.8
  on 64 KiB. hashlib's SHA256 is OpenSSL's, hardware-accelerated;
  libsecp256k1's is its own portable C. The Python path also has to stay
  for `hf != sha256`, so the delegation would buy neither speed nor one
  less implementation.
- **Private key validation** (`to_prv_key` → `keys.prvkey_verify`) — 0.24 µs
  against 0.024 for `0 < q < ec.n`, ten times the cost of the comparison
  it replaces, on a value that is already a python int in memory: no
  constant-time gain to pay for it.
- **BIP67 ordering** (`sorted(pub_keys)` → `keys.pubkey_sort`) — this one
  is a behaviour change and not only a speed question. `pubkey_cmp` orders
  by the *compressed* serialization whichever form the key is given in,
  while Bitcoin Core's `CPubKey::operator<` compares the serialization as
  given (`a.vch[0] < b.vch[0] || (… && memcmp(a.vch, b.vch, a.size()) < 0)`,
  src/pubkey.h), which is what `sorted()` does today. For uncompressed
  keys the two orders differ, so delegating would move btclib's `p2ms`
  script — and its address — away from Core's `sortedmulti`. The caveat
  in the comment there is therefore *correct as it stands*, and the issue's
  remark about the binding settling it is the thing to decide before
  touching it.
- **Sign-to-contract** (`commit_nonce.commit_point_` →
  `keys.pubkey_tweak_add`) — measures about twice as fast and has a real
  fallback (`ec`, `hf` are parameters), so it belongs in the next tranche;
  it is left out only because the tranche was cut where every item could
  still be re-gated.

ElligatorSwift and MuSig2 are out of scope, as the issue says. Public key
recovery and arbitrary point multiplication are untouched.

## Every Python path stays reachable, and is tested against the bindings

- taproot: no second curve can reach the Python arithmetic — a toy curve
  fails BIP341's range check on a 256-bit tweak first — so the tests
  compute every tweak **twice**, with the dispatch patched off, and hold
  the two answers to each other, over both y parities.
- ECDH: the fallback is another curve, and GEC 2's secp160r1 vector now
  runs through `diffie_hellman` itself; the secp256k1 Python path is
  reached with the same patch and agrees with the bindings.
- BIP32: there is no other curve to serve — BIP32 is defined for secp256k1
  alone — so the delegation is not gated on the curve, and the test writes
  BIP32's own equations out over the same hmac instead.
- `check_output_pubkey` keeps two behaviours that the bindings would have
  changed: a q that is not 32 bytes stays the python comparison's to
  answer (it answers *True* for a zero-padded key), and an internal key
  that is not a point still leaves through `BTClibValueError`, which the
  script engine catches.

SECURITY.md now names `taproot.output_prvkey` and `dh.diffie_hellman`
beside `mult`, `dsa.sign` and `ssa.sign` as the operations that cross into
constant-time C.

## Gates, each run as documented and checked by exit code

- `uv run pytest` — exit 0, 15053 passed
- `uv run --locked --no-default-groups --group test pytest --cov=btclib --cov=tests`
  — exit 0, total 99.99%; the two uncovered statements are
  `mnemonic/electrum.py:325-326`, a file this branch does not touch
- `uv run pre-commit run --all-files` — exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`
  — exit 0, build succeeded

## Rebased on `dev`, and re-measured where the rebase moved the ground

#234 shared the doublings of the endomorphism path, so the 1.07 ms this
branch had compared the shared point against is now 0.56 ms on `dev`:
ECDH is re-measured here rather than left stating a figure that predates
its own baseline — 15.2 µs against 549, thirty-six times rather than
seventy-eight. The four other measurements stand, `mult(t)` and
`mult(offset)` multiplying the generator, which the bindings answered
already.

The rebase itself needed three repairs, each of them the `union` merge
driver keeping both sides on a file where there was nothing to decide:
the entry-count paragraphs `dev` deleted from CHANGELOG.md and
HISTORY.md came back and are deleted again, and the GLV entry kept both
its pre-#234 and post-#234 spellings — `dev`'s numbers are the true
ones, with the ECDH clause rewritten, that path not being ECDH's any
more. Prose the branch adds now spells Python as the proper noun,
2330b5be's convention.

Refs #128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Delegate taproot key tweaking, ECDH shared point computation, and BIP32 key derivation to libsecp256k1 while preserving Python fallbacks and behavior for edge cases.

Enhancements:
- Use libsecp256k1 x-only taproot operations for output public and private key tweaking and control block verification on secp256k1.
- Delegate BIP32 private and public child key derivation to libsecp256k1 for constant‑time scalar operations and serialized pubkey tweaks, keeping BIP32 error semantics unchanged.
- Delegate secp256k1 ECDH shared point computation in Diffie-Hellman to libsecp256k1 while retaining ANSI-X9.63-KDF for key derivation and Python paths for unsupported curves.
- Factor taproot tweak computation into a shared helper to enforce consistent BIP341 range checking across output key construction and verification.

Documentation:
- Update CHANGELOG and HISTORY entry counts and describe the new libsecp256k1-backed performance improvements for taproot, BIP32, and ECDH.
- Extend SECURITY documentation to list taproot.output_prvkey and dh.diffie_hellman as additional operations executed in constant-time C.

Tests:
- Add taproot tests that compare libsecp256k1-based tweaks and commitment checks against the Python implementation, including non-standard key sizes and invalid internal keys.
- Add BIP32 tests that explicitly verify private and public child derivation against the arithmetic defined in BIP32 and ensure libsecp256k1-backed derivation matches.
- Add ECDH tests that validate equality between libsecp256k1-based shared points and the Python endomorphism path, and cover non-secp256k1 curves via existing vectors.
