### PR TITLE
Take infinity before the doubling test misreads it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ release-notes length in the first place, and are still in
 
 ## v2026.8 (work in progress, not released yet)
 
-A hundred and seventy-eight entries, grouped. The order runs from what breaks
+A hundred and eighty entries, grouped. The order runs from what breaks
 a caller to what only maintainers see; [HISTORY.md](./HISTORY.md) lists the
 twenty-nine source-breaking changes on their own.
 
@@ -864,6 +864,26 @@ twenty-nine source-breaking changes on their own.
 
 ### Curves, signatures and keys
 
+- **`add_jac` no longer reads the point at infinity as a doubling**
+  (issue #171). Its doubling test compares affine coordinates, and a
+  Jacobian `Z == 0` leaves `X` and `Y` free to be anything: `INFJ` is
+  `(7, 0, 0)` and `jac_from_aff(INF)` is `(5, 0, 0)`, x-coordinates picked
+  for being invalid rather than for being zero, so on a curve of
+  characteristic 7 or 5 they reduce to zero, the test read "same x, same
+  y" and doubled. `P + INFJ` answered `2*P`, and with it eight of the ten
+  scalar multiplications this package offers were wrong for most scalars
+  on every `p == 7` curve — 6 of 13 scalars for `mult_jac`, 12 of 13 for
+  the Montgomery ladder and for `mult_recursive_jac`, and 100 of the 169
+  coefficient pairs for `_double_mult`, which `curves.double_mult`, `dsa`
+  and `ssa` verification all reach. The all-zero triple, which
+  `jac_equality` reads as infinity too, did it on every curve, secp256k1
+  included. Infinity is taken first now, ahead of the arithmetic, and that
+  is also cheaper than the deferred fix-up it replaces: that one ran the
+  whole formula and then picked from a four-entry table by the very two
+  comparisons it was avoiding. The tests gained every pair of points of
+  every low-cardinality curve — the whole group, in two Jacobian frames
+  and three infinity spellings, against a textbook group law written the
+  other way round — and every multiplication of a `p == 7` curve
 - **`btclib.mnemonic.electrum` is Electrum's scheme, both directions**
   (issue #196). The module named the scheme and implemented five things
   differently, and the worst of them was silent: the same entropy gave
@@ -1675,6 +1695,28 @@ twenty-nine source-breaking changes on their own.
 
 ### Performance
 
+- **the point arithmetic reduces its intermediates as it forms them**,
+  which is worth between 2.0 and 3.0 times on every scalar multiplication
+  in the package: `_mult` 2.00x, the fixed window over cached multiples
+  2.88x, `_double_mult` 2.32x, `double_mult_w_NAF` 2.45x, the GLV
+  `mult_endomorphism_secp256k1` 2.42x, `mult_jac` 2.55x, all at 256 bits
+  on secp256k1, and 2.13x to 2.82x on secp256r1; at 32 bits the same
+  span. The formulas are the same ones and so is every answer: what
+  changed is that `add_jac` and the doubling helper let `V3` and `M*V2`
+  grow to `p^9`, and the products that close `X` and `Y` to `p^12` —
+  three thousand bits for secp256k1 — before a single reduction at the
+  end, and python multiplies whatever it is handed. Reducing also makes
+  the doubling test free, `V` and `W` being the differences the formula
+  needs anyway: issue #171 counted four multiplications for that test,
+  and they were never its cost. `add_aff` and `double_aff` take the same
+  treatment for 6%, `mod_inv` being what dominates in affine coordinates,
+  and the tiny curves of the test suite gain nothing at all, `p^9` of a
+  five-bit prime being one machine word. Complete formulas were measured
+  rather than assumed — Renes-Costello-Batina in homogeneous coordinates,
+  no exceptional case at all, is 34% slower for `a == 0` and 59% slower
+  for the `a == p-3` of most catalogued curves, and `JacPoint` is public.
+  Every gain is a uniform one, so the comparisons the `curve_group_2`
+  docstrings draw between the algorithms still hold as measured
 - **`mult` takes the GLV endomorphism on secp256k1** wherever the bindings
   cannot answer: `curve_group_2.mult_endomorphism_secp256k1`, 1.03 ms
   against the 1.52 of the generic `_mult`. The bindings take the generator

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,7 +7,7 @@ full year, short month, short day (YYYY-M-D)
 
 ## v2026.8 (work in progress, not released yet)
 
-The first release since 2023, and the largest: a hundred and seventy-eight
+The first release since 2023, and the largest: a hundred and eighty
 entries, in [CHANGELOG.md](./CHANGELOG.md). What follows is what a user has
 to act on and what a user gains.
 

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -233,92 +233,137 @@ class CurveGroup:
 
     def add_jac(self, Q: JacPoint, R: JacPoint) -> JacPoint:
         # points are assumed to be on curve
-        # to keep this function constant time, Q or R equal to INFJ is
-        # not handled as a special case here but at the end, after all
-        # calculations have been performed, even if useless
 
-        RZ2 = R[2] * R[2]
-        RZ3 = RZ2 * R[2]
-        QZ2 = Q[2] * Q[2]
-        QZ3 = QZ2 * Q[2]
+        # infinity first, and as a branch. Z == 0 leaves X and Y
+        # unconstrained, so the doubling test below -- a test on the
+        # affine coordinates -- has nothing there to read: the x of INFJ
+        # is 7 and the x of jac_from_aff(INF) is 5, picked for being
+        # invalid rather than for being zero, so on a curve of
+        # characteristic 7 or 5 they reduce to zero and the test fires on
+        # an operand that is not a point at all. P + INFJ then
+        # answers 2*P, and eight of the ten scalar multiplications this
+        # package offers are wrong for most scalars on every p == 7 curve
+        # (issue 171). Deferring it instead -- run the whole formula, then
+        # pick from [(X, Y, Z), R, Q, INFJ] by (Q is INF) + 2*(R is INF)
+        # -- spends that arithmetic to avoid two comparisons it then makes
+        # anyway, and buys a constant time the doubling test right below
+        # spends: SECURITY.md says of this path that it "is not
+        # constant-time and does not try to be"
+        if Q[2] == 0:
+            return R
+        if R[2] == 0:
+            return Q
 
-        M = Q[0] * RZ2
-        N = R[0] * QZ2
+        p = self.p
+        # every intermediate reduced as it is formed, which is what makes
+        # this the fast path rather than a transcription of the formula:
+        # left to grow, V3 and M*V2 reach p^9 and the products that close
+        # X and Y reach p^12 -- three thousand bits on secp256k1 -- and
+        # python multiplies whatever it is handed. Worth between 2.0 and
+        # 3.0 times over every mult_* variant in the package, measured
+        # against the unreduced spelling on secp256k1 and secp256r1
+        RZ2 = R[2] * R[2] % p
+        RZ3 = RZ2 * R[2] % p
+        QZ2 = Q[2] * Q[2] % p
+        QZ3 = QZ2 * Q[2] % p
 
-        T = Q[1] * RZ3
-        U = R[1] * QZ3
+        # the two points in a common frame: V is the difference of their
+        # affine x-coordinates and W of their affine y ones, up to that
+        # frame. Which is what makes the doubling test free, both being
+        # needed by the formula below -- the four multiplications issue
+        # 171 counted were never its cost either, M, N, T and U all
+        # feeding it too, and only the reductions comparing them extra
+        M = Q[0] * RZ2 % p
+        T = Q[1] * RZ3 % p
+        V = (R[0] * QZ2 - M) % p
+        W = (R[1] * QZ3 - T) % p
 
-        # issue 171: it would be better if doubling was not a special case.
-        # Four multiplications and two reductions on every addition, in the
-        # inner loop of every scalar multiplication, to detect one case
-        # if same affine x and same affine y, then point doubling
-        if M % self.p == N % self.p and T % self.p == U % self.p:
+        # the same affine point, where the chord is the tangent and the
+        # slope W/V below is 0/0. No caller in the package reaches it --
+        # every mult_* doubles through double_jac, and over six of them 0
+        # of 5997 add_jac calls took this branch -- but add_jac is public
+        # and P + P has to be P doubled. Complete formulas would retire
+        # it: Renes-Costello-Batina, homogeneous coordinates, no
+        # exceptional case at all -- and measured on this very fixed
+        # window 34% slower for a == 0 and 59% slower for the a == p-3 of
+        # most catalogued curves, on top of JacPoint being public
+        if V == 0 and W == 0:
             return self._double_jac_helper(Q, QZ2)
-        W = U - T
-        V = N - M
 
-        V2 = V * V
-        V3 = V2 * V
-        MV2 = M * V2
+        V2 = V * V % p
+        V3 = V2 * V % p
+        MV2 = M * V2 % p
 
-        X = (W * W - V3 - 2 * MV2) % self.p
-        Y = (W * (MV2 - X) - T * V3) % self.p
-        Z = (V * Q[2] * R[2]) % self.p
-
-        # Z is zero if Q or R are equal to INFJ,
-        # so (X, Y, Z) is INFJ instead of being R or Q (respectively)
-        # let's fix it
-
-        # possible return values are:
-        ret_values = [(X, Y, Z), R, Q, INFJ]
-        # the index is (Q is INFJ) plus (R is INFJ) times 2:
-        #            0  +          0  * 2 = 0 → (X, Y, Z)
-        #            1  +          0  * 2 = 1 → R
-        #            0  +          1  * 2 = 2 → Q
-        #            1  +          1  * 2 = 3 → INFJ
-        i = (Q[2] == 0) + (R[2] == 0) * 2
-        return ret_values[i]
+        X = (W * W - V3 - 2 * MV2) % p
+        Y = (W * (MV2 - X) - T * V3) % p
+        # V == 0 with W != 0 is P + (-P), and needs no branch of its own:
+        # Z comes out zero, which is the infinity the caller is owed
+        Z = V * Q[2] % p * R[2] % p
+        return X, Y, Z
 
     def double_jac(self, Q: JacPoint) -> JacPoint:
         # point is assumed to be on curve
-        QZ2 = Q[2] * Q[2]
-        return self._double_jac_helper(Q, QZ2)
+        return self._double_jac_helper(Q, Q[2] * Q[2] % self.p)
 
     def _double_jac_helper(self, Q: JacPoint, QZ2: int) -> JacPoint:
-        QY2 = Q[1] * Q[1]
-        W = 3 * Q[0] * Q[0] + self._a * QZ2 * QZ2
-        V = 4 * Q[0] * QY2
-        X = W * W - 2 * V
-        Y = W * (V - X) - 8 * QY2 * QY2
-        Z = 2 * Q[1] * Q[2]
-        return X % self.p, Y % self.p, Z % self.p
+        # QZ2 is Q[2]^2 reduced mod p, which add_jac has already formed
+        p = self.p
+        QY2 = Q[1] * Q[1] % p
+        W = (3 * Q[0] * Q[0] + self._a * QZ2 * QZ2) % p
+        V = 4 * Q[0] * QY2 % p
+        X = (W * W - 2 * V) % p
+        Y = (W * (V - X) - 8 * QY2 * QY2) % p
+        # Q[1] == 0 is both the infinity point and the two-torsion, and
+        # both double to infinity, which is what Z == 0 says
+        Z = 2 * Q[1] * Q[2] % p
+        return X, Y, Z
 
     def add_aff(self, Q: Point, R: Point) -> Point:
         # points are assumed to be on curve
-        # issue 171: it would be better if INF handling was not a special
-        # case, nor come before the doubling check below
+
+        # infinity is a special case here and cannot stop being one: an
+        # affine point is two field elements and the group has one point
+        # more than any pair of them can name, so INF is spelled y == 0
+        # (alias.py) and no formula reaches it. That spelling is also why
+        # a two-torsion point, the one real point with y == 0, has no
+        # affine form at all -- Jacobian coordinates do hold it, Z != 0
+        # telling it from infinity, and add_jac doubles it to infinity
+        # correctly; none of the low-cardinality test curves has one.
+        # The order is load-bearing too, and it is this one rather than
+        # the doubling test first: INF is (5, 0), its x-coordinate
+        # arbitrary, so a doubling test reading it ahead of here answers
+        # "same x, different y, hence INF" for INF + P whenever P has
+        # x == 5 -- and ec23_19 of the test suite is generated by (5, 4),
+        # which is exactly that point (issue 171)
         if R[1] == 0:  # Infinity point in affine coordinates
             return Q
         if Q[1] == 0:  # Infinity point in affine coordinates
             return R
 
-        # issue 171, with the INF handling above
+        # then doubling, for the reason add_jac has it: two equal points
+        # make the chord a tangent and the slope below 0/0
         if R[0] == Q[0]:
             return self.double_aff(R) if R[1] == Q[1] else INF
-        lam = (R[1] - Q[1]) * mod_inv(R[0] - Q[0], self.p)
-        x = lam * lam - Q[0] - R[0]
-        y = lam * (Q[0] - x) - Q[1]
-        return x % self.p, y % self.p
+
+        p = self.p
+        # lam reduced before it is squared, as in add_jac, though here it
+        # is worth 6% of mult_aff rather than a factor of two: mod_inv is
+        # what affine coordinates cost, and is why the ladders are not
+        lam = (R[1] - Q[1]) * mod_inv(R[0] - Q[0], p) % p
+        x = (lam * lam - Q[0] - R[0]) % p
+        y = (lam * (Q[0] - x) - Q[1]) % p
+        return x, y
 
     def double_aff(self, Q: Point) -> Point:
         # point is assumed to be on curve
         if Q[1] == 0:  # Infinity point in affine coordinates
             return INF
 
-        lam = (3 * Q[0] * Q[0] + self._a) * mod_inv(2 * Q[1], self.p)
-        x = lam * lam - Q[0] - Q[0]
-        y = lam * (Q[0] - x) - Q[1]
-        return x % self.p, y % self.p
+        p = self.p
+        lam = (3 * Q[0] * Q[0] + self._a) * mod_inv(2 * Q[1], p) % p
+        x = (lam * lam - Q[0] - Q[0]) % p
+        y = (lam * (Q[0] - x) - Q[1]) % p
+        return x, y
 
     def _y2(self, x: int) -> int:
         # skipping a crucial check here:

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -31,9 +31,9 @@ References:
 Further improvements, and the material for them. These are not
 bibliography: each is an improvement this module could take, with what
 would be needed to take it, kept here rather than in TODO.md so that it
-sits next to the code it is about. Issue 171 tracks the point-addition
-special cases and issue 183 the smaller follow-ups; what is here is the
-rest:
+sits next to the code it is about. The point-addition special cases are
+settled where they live, in `curve_group`'s own comments, and issue 183
+tracks the smaller follow-ups; what is here is the rest:
 
     - Computational cost of the different multiplications, measured rather
       than assumed: which of the six is fastest, and at what scalar size

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -12,7 +12,7 @@
 import pytest
 
 from btclib.alias import INF, INFJ
-from btclib.curves import secp256k1
+from btclib.curves import Curve, secp256k1
 
 # the eight mult_* variants under test, and the helpers they are built on,
 # come from the module that defines them: btclib.curves exports mult,
@@ -403,6 +403,38 @@ def test_assorted_jac_mult() -> None:
         _double_mult(-5, HJ, 1, ec.GJ, ec)
     with pytest.raises(BTClibValueError, match="negative second coefficient: "):
         _double_mult(1, HJ, -5, ec.GJ, ec)
+
+
+def test_mult_on_a_characteristic_7_curve() -> None:
+    """Every multiplication, on the curve where INFJ's x-coordinate is 0.
+
+    INFJ is (7, 0, 0), so p == 7 is where that arbitrary x reduces to
+    zero and add_jac's doubling test can mistake the identity for the
+    other operand (issue 171). Before it was fixed, mult_jac answered
+    wrong for 6 of the 13 scalars here, the ladder and mult_recursive_jac
+    for 12 of 13, and _double_mult for 100 of the 169 coefficient pairs;
+    _mult and the cached fixed window happened not to, every scalar of a
+    curve this small fitting in one base-16 digit -- which is why the
+    reference here is mult_aff, the one multiplication that forms no
+    Jacobian point at all.
+    """
+    ec = Curve(7, 0, 3, (1, 2), 13, 1, False)
+    variants = (
+        _mult,
+        mult_jac,
+        mult_recursive_jac,
+        mult_mont_ladder,
+        mult_base_3,
+        mult_fixed_window,
+        mult_fixed_window_cached,
+    )
+    for k in range(ec.n):
+        expected = mult_aff(k, ec.G, ec)
+        for mult_f in variants:
+            assert ec.aff_from_jac(mult_f(k, ec.GJ, ec)) == expected, mult_f.__name__
+        for j in range(ec.n):
+            shamir = _double_mult(k, ec.GJ, j, ec.GJ, ec)
+            assert ec.aff_from_jac(shamir) == mult_aff(k + j, ec.G, ec), (k, j)
 
 
 def test_jac_equality() -> None:

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -15,7 +15,7 @@ from hashlib import sha256, sha512
 
 import pytest
 
-from btclib.alias import INF, INFJ, Integer
+from btclib.alias import INF, INFJ, Integer, JacPoint, Point
 from btclib.curves import Curve, CurveGroup, double_mult, mult, multi_mult, secp256k1
 from btclib.curves.curve import (
     CURVES,
@@ -37,7 +37,7 @@ from btclib.curves.curve import (
 from btclib.curves.curve_group import cached_multiples, jac_from_aff, mult_jac
 from btclib.ecc import second_generator
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.number_theory import mod_sqrt
+from btclib.number_theory import mod_inv, mod_sqrt
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from tests import load, vector_id
 
@@ -327,6 +327,119 @@ def test_add_double_aff_jac() -> None:
         assert R == ec.aff_from_jac(RJ)
         assert R == ec.add_aff(Q, Q)
         assert ec.jac_equality(RJ, ec.add_jac(QJ, QJ))
+
+
+def _textbook_add(ec: CurveGroup, P: Point | None, Q: Point | None) -> Point | None:
+    """The chord-and-tangent law, with infinity spelled as None.
+
+    The reference the two library routines are held against below, and
+    deliberately not written the way they are: infinity is a value of its
+    own here rather than the y == 0 of `alias`, so no ordering of the
+    special cases can hide inside it.
+    """
+    if P is None:
+        return Q
+    if Q is None:
+        return P
+    if P[0] == Q[0] and (P[1] + Q[1]) % ec.p == 0:
+        return None
+    if P == Q:
+        lam = (3 * P[0] * P[0] + ec._a) * mod_inv(2 * P[1], ec.p) % ec.p
+    else:
+        lam = (Q[1] - P[1]) * mod_inv(Q[0] - P[0], ec.p) % ec.p
+    x = (lam * lam - P[0] - Q[0]) % ec.p
+    return x, (lam * (P[0] - x) - P[1]) % ec.p
+
+
+def _jac_spellings(ec: CurveGroup, P: Point | None) -> list[JacPoint]:
+    """Two Jacobian frames of a point, or three spellings of infinity.
+
+    (x*z^2, y*z^3, z) is the same affine point for every z != 0, and
+    add_jac compares coordinates that only a common frame makes
+    comparable, so one frame would not exercise the comparison. Infinity
+    is any Z == 0 triple: the INFJ constant, what `jac_from_aff` turns
+    the affine INF into, and the all-zero triple that `jac_equality`
+    reads as equal to everything.
+    """
+    if P is None:
+        return [INFJ, jac_from_aff(INF), (0, 0, 0)]
+    return [(P[0] * z * z % ec.p, P[1] * z**3 % ec.p, z) for z in (1, 2)]
+
+
+def test_point_addition_exhaustive() -> None:
+    """Every pair of points of every low-cardinality curve, both routines.
+
+    All of the group, not the prime-order subgroup: what the tiny curves
+    are for is that "every point plus every point" fits in a test, and
+    the special cases -- infinity on either side, doubling, P + (-P) --
+    are then reached by construction rather than by being named one at a
+    time, in every Jacobian frame rather than in the one the caller
+    happened to hand over.
+    """
+    for name, ec in low_card_curves.items():
+        # no curve in the table has a point with y == 0, which is the one
+        # affine coordinates cannot tell from INF. Asserted rather than
+        # worked around, so that a curve added to the table cannot
+        # quietly weaken the affine half below
+        assert all(ec._y2(x) for x in range(ec.p)), name
+
+        points: list[Point | None] = [None]
+        points.extend(
+            (x, y)
+            for x in range(ec.p)
+            for y in range(ec.p)
+            if ec._y2(x) == y * y % ec.p
+        )
+        for P in points:
+            for Q in points:
+                expected = _textbook_add(ec, P, Q)
+                for PJ in _jac_spellings(ec, P):
+                    for QJ in _jac_spellings(ec, Q):
+                        RJ = ec.add_jac(PJ, QJ)
+                        got = None if RJ[2] == 0 else ec.aff_from_jac(RJ)
+                        assert got == expected, f"{name}: {PJ} + {QJ}"
+                R = ec.add_aff(INF if P is None else P, INF if Q is None else Q)
+                assert R == (INF if expected is None else expected), (
+                    f"{name}: {P} + {Q}"
+                )
+
+
+def test_add_jac_infinity_is_not_a_doubling() -> None:
+    """P + infinity is P, whatever Z == 0 triple infinity arrives as.
+
+    add_jac's doubling test compares affine coordinates, and Z == 0
+    leaves X and Y free to be anything at all: INFJ is (7, 0, 0) and
+    `jac_from_aff(INF)` is (5, 0, 0), those x-coordinates picked for
+    being invalid rather than for being zero. On a curve of
+    characteristic 7 or 5 they reduce to zero, the test reads "same x,
+    same y" and doubles -- issue 171, where P + INFJ answered 2*P. The
+    all-zero triple does it on every curve, secp256k1 included.
+    """
+    for ec in (
+        Curve(7, 1, 6, (1, 1), 11, 1, False),
+        Curve(5, 2, 1, (0, 1), 7, 1, False),
+        secp256k1,
+    ):
+        for infinity in (INFJ, jac_from_aff(INF), (0, 0, 0)):
+            assert ec.aff_from_jac(ec.add_jac(ec.GJ, infinity)) == ec.G
+            assert ec.aff_from_jac(ec.add_jac(infinity, ec.GJ)) == ec.G
+            assert ec.add_jac(infinity, infinity)[2] == 0
+
+
+def test_add_aff_takes_infinity_before_doubling() -> None:
+    """The order of add_aff's two special cases is the working one.
+
+    Not an inelegance to be tidied by testing for doubling first (issue
+    171): INF is (5, 0) and its x-coordinate is arbitrary, so a doubling
+    test reading it would answer "same x, different y, hence INF" for
+    INF + P whenever P has x == 5. ec23_19 is generated by (5, 4), which
+    is exactly that point, and every curve whose generator shares an
+    x-coordinate with INF is.
+    """
+    ec = low_card_curves["ec23_19"]
+    assert ec.G[0] == INF[0]
+    assert ec.add_aff(INF, ec.G) == ec.G
+    assert ec.add_aff(ec.G, INF) == ec.G
 
 
 def test_ec_repr() -> None:


### PR DESCRIPTION
Three FIXMEs on `add_jac` and `add_aff`, and the one that reads as an
inelegance turned out to be a defect. The issue asked three things to be
settled; each is answered below with the measurement that settled it.

## 1. The doubling detection in `add_jac`

**(a) The branch stays — and the four multiplications were never its
cost.** `M`, `N`, `T` and `U` all feed the general formula, so only the
reductions comparing them were extra. What cost was that *nothing* was
reduced until the end: `V3` and `M*V2` grew to `p^9`, and the products
that close `X` and `Y` to `p^12` — three thousand bits on secp256k1 —
and python multiplies whatever it is handed. Reducing each intermediate
as it is formed makes the doubling test free, `V` and `W` being the
differences the formula needs anyway, and is worth 2.0x to 3.0x on
every scalar multiplication in the package. Over 8 random 256-bit
scalars, min of 9 interleaved rounds, ms per operation:

| | secp256k1 before | after | | secp256r1 before | after | |
|---|---|---|---|---|---|---|
| `mult_jac` | 4.669 | 1.832 | 2.55x | 7.534 | 2.897 | 2.60x |
| `mult_recursive_jac` | 2.824 | 1.235 | 2.29x | | | |
| `mult_mont_ladder` | 4.858 | 2.093 | 2.32x | | | |
| `mult_base_3` | 7.633 | 2.519 | 3.03x | | | |
| `mult_fixed_window` | 2.818 | 1.376 | 2.05x | | | |
| `mult_fixed_window_cached` | 3.138 | 1.090 | 2.88x | | | |
| `mult_sliding_window` | 2.769 | 1.246 | 2.22x | | | |
| `mult_w_NAF` | 2.777 | 1.306 | 2.13x | | | |
| `_mult` | 2.741 | 1.370 | 2.00x | 3.425 | 1.608 | 2.13x |
| `mult_endomorphism` | 2.125 | 0.878 | 2.42x | | | |
| `_double_mult` | 4.696 | 2.024 | 2.32x | 5.710 | 2.025 | 2.82x |
| `double_mult_w_NAF` | 3.727 | 1.524 | 2.45x | 4.317 | 1.856 | 2.33x |

At 32 bits the same span, 2.05x to 2.64x. `add_aff` and `double_aff`
take the same reduction for 6%, `mod_inv` being what affine coordinates
cost; the tiny test curves gain nothing at all, `p^9` of a five-bit
prime being one machine word.

**(b) Complete formulas do not land.** Renes-Costello-Batina in
homogeneous coordinates, no exceptional case anywhere, prototyped and
checked against the library on both curves, then timed on the same fixed
window: **34% slower** for `a == 0` (algorithm 7, the cheap one) and
**59% slower** for the `a == p-3` of most catalogued curves (algorithm
1). They would also replace the public `JacPoint` alias and everything
built on it. The side-channel argument that usually carries them does
not apply here, as the issue notes, so speed or clarity was the whole
case and they lose on both.

**(c) The ladders already call `double_jac` directly.** Instrumented
over six `mult_*` variants: **0 of 5997** `add_jac` calls take the
doubling branch. It stays because `add_jac` is public and `P + P` must
be `P` doubled, and it now costs nothing.

## 2. `add_aff`'s ordering note — and a defect next door

**The `add_aff` ordering is the working one, not an inelegance.** `INF`
is `(5, 0)` and its x-coordinate is arbitrary, so a doubling test read
ahead of the infinity handling answers "same x, different y, hence INF"
for `INF + P` whenever `P` has `x == 5` — and the suite's `ec23_19` is
generated by `(5, 4)`, exactly that point. Infinity cannot stop being a
special case either: an affine point is two field elements and the group
has one point more than any pair of them can name, which is why `INF` is
spelled `y == 0`, and why a two-torsion point has no affine form at all
while Jacobian coordinates hold it and double it to infinity correctly.
No curve in the test table has one; the exhaustive test now asserts
that, so a curve added later cannot quietly weaken it. Both FIXMEs
become why-not comments.

**`add_jac`'s equivalent ordering is a defect, and it is fixed.** The
doubling test compares affine coordinates, and a Jacobian `Z == 0`
leaves `X` and `Y` free: the x of `INFJ` is 7 and the x of
`jac_from_aff(INF)` is 5, picked for being invalid rather than for being
zero, so on a curve of characteristic 7 or 5 they reduce to zero, the
test reads "same x, same y" and doubles. `P + INFJ` answered `2*P`. On
every `p == 7` curve that made `mult_jac` wrong for 6 of 13 scalars, the
Montgomery ladder and `mult_recursive_jac` for 12 of 13, and
`_double_mult` — which `curves.double_mult`, `dsa` and `ssa`
verification all reach — for 100 of 169 coefficient pairs. The all-zero
triple, which `jac_equality` also reads as infinity, does it on every
curve, secp256k1 included: 1182 of 34563 exhaustive additions over
twelve tiny curves. Infinity returns first now, which is also cheaper
than the deferred fix-up it replaces — that ran the whole formula and
then indexed a four-entry table by the very two comparisons it was
avoiding, and the constant time it bought was already spent by the
doubling test one line above; `SECURITY.md` says of this path that it
"is not constant-time and does not try to be".

## 3. Proof

- **Exhaustive**: every pair of points of every low-cardinality curve —
  the whole group, not the prime-order subgroup, in two Jacobian frames
  and three infinity spellings each — against a textbook group law
  written the other way round, infinity a value of its own rather than
  `y == 0`, so no ordering of the special cases can hide inside it.
- **Against the bindings on secp256k1**: unchanged, the whole existing
  suite being the check, and every one of its 14791 tests passes.
- **Regression**: every multiplication of a `p == 7` curve against
  `mult_aff`, the one multiplication that forms no Jacobian point.
  Three of the four new tests fail on the old arithmetic.
- The `curve_group_2` docstrings' comparisons were re-measured and all
  still hold: `double_mult_w_NAF` over `_double_mult` is 0.75 against a
  documented 0.73, `_mult` over the GLV multiplication 1.56 against
  1.50, the wNAF crossover still between 16 and 32 bits. Their absolute
  milliseconds are left alone, this box measuring the *pre-change* code
  some 1.8x above them throughout, so no number written here would be
  comparable to theirs.

## Verification

| gate | result |
|---|---|
| `uv run pytest` | exit 0, 14791 passed |
| `uv run pre-commit run --all-files` | exit 0 |
| `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html` | exit 0 |

Sibling PRs move the CHANGELOG entry count too; re-derive it at merge
with `grep -c '^- ' CHANGELOG.md`.

Closes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix point-at-infinity handling in Jacobian addition while optimizing point arithmetic and expanding test coverage around edge cases and performance claims.

Bug Fixes:
- Ensure add_jac treats Jacobian infinity as a true identity element instead of triggering the doubling path, fixing scalar multiplication results on characteristic-7 curves and other infinity spellings.
- Preserve add_aff’s infinity-first ordering so affine infinity cannot be misclassified as a doubling case for points sharing the INF x-coordinate.

Enhancements:
- Reduce intermediates modulo p throughout Jacobian and affine addition and doubling routines to lower arithmetic cost and make the doubling check effectively free without changing results.
- Clarify internal documentation in curve_group_2 about where point-addition special cases are now described.

Documentation:
- Update CHANGELOG and HISTORY to reflect the new entry count and to document the infinity-handling fix and point-arithmetic performance improvements.

Tests:
- Add exhaustive point-addition tests over all points of low-cardinality curves, checking both affine and Jacobian implementations against a textbook group law with an explicit infinity value.
- Add targeted tests confirming that Jacobian infinity is never misread as a doubling and that add_aff’s ordering of infinity vs doubling is required for correctness on specific test curves.
- Add regression tests for all scalar multiplication variants on a characteristic-7 curve to ensure agreement with the affine implementation even when INFJ’s x-coordinate reduces to zero.