### PR TITLE
Give BIP39 the NFKD it mandates, and one reading of whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -893,6 +893,31 @@ edit.
   every low-cardinality curve — the whole group, in two Jacobian frames
   and three infinity spellings, against a textbook group law written the
   other way round — and every multiplication of a `p == 7` curve
+- **BIP39 normalizes NFKD, and every mnemonic path reads whitespace the
+  same way** (issue #201). `bip39.seed_from_mnemonic` collapsed the
+  whitespace of the sentence and normalized nothing, where BIP39 asks for
+  the opposite: "a mnemonic sentence (in UTF-8 NFKD) used as the password
+  and the string `mnemonic` + passphrase (again in UTF-8 NFKD) used as
+  the salt". All twenty-four of BIP39's own Japanese vectors were wrong
+  seeds, measured, and every English one passed throughout — `TREZOR` and
+  `english.txt` are ASCII, which is NFKD already, so nothing in the suite
+  could see it. The two are now both done, in the order the spec implies:
+  the new `mnemonic.normalize_mnemonic` decomposes and *then* treats any
+  run of unicode whitespace as one separator, so `abandon  abandon` and
+  `abandon abandon` reach one seed, a mnemonic typed in fullwidth latin
+  is read rather than refused, and U+3000 — the ideographic space those
+  Japanese vectors separate words with — is a separator because NFKD says
+  so and not because btclib says so. The passphrase is decomposed and
+  otherwise untouched: its whitespace is content the user chose, so
+  collapsing a doubled space there would open another wallet. Refusing
+  anything but a single space is the other defensible answer and is what
+  trezor's `python-mnemonic` reads, but only where it *checks* a
+  mnemonic — its `to_seed` normalizes and stops, so a trailing newline
+  there stretches into a different seed in silence, which is the one
+  outcome worse than a refusal. `electrum.py` already collapsed
+  whitespace and keeps its own stronger normalization, which cannot be
+  shared: it drops the combining characters, undoing the very
+  decomposition BIP39 requires
 - **`btclib.mnemonic.electrum` is Electrum's scheme, both directions**
   (issue #196). The module named the scheme and implemented five things
   differently, and the worst of them was silent: the same entropy gave

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -145,6 +145,14 @@ against the `v2023.7.12` tag.
   start with one of the four prefixes, named a new version and handed
   back the wrong derivation; and it accepts what Electrum accepts, so an
   upper-cased or accented mnemonic is read rather than refused.
+- **`bip39.seed_from_mnemonic` normalizes NFKD, so a non-ASCII mnemonic or
+  passphrase derives another wallet than it used to.** BIP39 stretches the
+  sentence and the passphrase in UTF-8 NFKD and btclib normalized neither,
+  which made all twenty-four of BIP39's Japanese vectors wrong seeds.
+  ASCII is NFKD already, so an English mnemonic with an ASCII passphrase
+  is untouched; anyone whose passphrase or mnemonic holds a character
+  outside ASCII was deriving a wallet no other implementation agrees with,
+  and has to re-derive from the same words to reach the right one.
 - **`Script(script_bytes)` no longer raises for a script that cannot be
   executed.** A push over 520 bytes and a push declaring more bytes than
   follow it used to be `Invalid pushdata length` and `Not enough data for

--- a/btclib/mnemonic/__init__.py
+++ b/btclib/mnemonic/__init__.py
@@ -35,6 +35,7 @@ from btclib.mnemonic.mnemonic import (
     Mnemonic,
     indexes_from_mnemonic,
     mnemonic_from_indexes,
+    normalize_mnemonic,
 )
 
 __all__ = [
@@ -55,5 +56,6 @@ __all__ = [
     "electrum",
     "indexes_from_mnemonic",
     "mnemonic_from_indexes",
+    "normalize_mnemonic",
     "wordlist_indexes_from_bin_str_entropy",
 ]

--- a/btclib/mnemonic/bip39.py
+++ b/btclib/mnemonic/bip39.py
@@ -36,6 +36,7 @@ Checksummed entropy (**ENT+CS**) is converted from/to mnemonic.
 from __future__ import annotations
 
 import secrets
+import unicodedata
 from hashlib import pbkdf2_hmac, sha256
 
 from btclib.bip32 import rootxprv_from_seed
@@ -53,6 +54,7 @@ from btclib.mnemonic.mnemonic import (
     Mnemonic,
     indexes_from_mnemonic,
     mnemonic_from_indexes,
+    normalize_mnemonic,
 )
 from btclib.network import NETWORKS
 
@@ -103,8 +105,14 @@ def mnemonic_from_entropy(entropy: Entropy | None = None, lang: str = "en") -> M
 
 
 def entropy_from_mnemonic(mnemonic: Mnemonic, lang: str = "en") -> BinStr:
-    """Return the entropy from the BIP39 checksummed mnemonic sentence."""
-    indexes = indexes_from_mnemonic(mnemonic, lang)
+    """Return the entropy from the BIP39 checksummed mnemonic sentence.
+
+    The sentence is normalized first, so that the word looked up in the
+    word-list is the NFKD one the word-list holds: a mnemonic typed on a
+    japanese IME arrives in fullwidth latin, and U+FF41 is not "a" until
+    it is decomposed.
+    """
+    indexes = indexes_from_mnemonic(normalize_mnemonic(mnemonic), lang)
     base = WORDLISTS.language_length(lang)
     cs_entropy = bin_str_entropy_from_wordlist_indexes(indexes, base)
 
@@ -125,12 +133,25 @@ def seed_from_mnemonic(
     """Return the seed from the provided BIP39 mnemonic sentence.
 
     The mnemonic checksum verification can be skipped if needed.
+
+    Both the sentence and the passphrase are normalized NFKD, which is
+    what BIP39 stretches: "a mnemonic sentence (in UTF-8 NFKD) used as
+    the password and the string 'mnemonic' + passphrase (again in UTF-8
+    NFKD) used as the salt". Without it the twenty-four japanese vectors
+    are twenty-four wrong seeds, and every english one still passes --
+    "TREZOR" and the english word-list being ASCII, which is NFKD
+    already.
     """
-    # clean up mnemonic from spurious whitespaces
-    mnemonic = " ".join(mnemonic.split())
+    mnemonic = normalize_mnemonic(mnemonic)
 
     if verify_checksum:
         entropy_from_mnemonic(mnemonic)
+
+    # the passphrase is decomposed and otherwise left alone: its
+    # whitespace is content the user chose, not a separator between
+    # words, so collapsing a doubled space there would stretch a
+    # passphrase nobody typed and lose the wallet it opens
+    passphrase = unicodedata.normalize("NFKD", passphrase)
 
     hf_name = "sha512"
     password = mnemonic.encode()

--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -126,6 +126,13 @@ def _normalize(text: str) -> str:
     and whitespace between two CJK characters removed. It applies to the
     passphrase as well as to the mnemonic, which is why it takes a plain
     string rather than a Mnemonic.
+
+    Not mnemonic.py's normalize_mnemonic, which is BIP39's reading of the
+    same question and agrees with this one on the whitespace alone. The
+    two cannot be merged: dropping the combining characters undoes the
+    decomposition BIP39 requires, and joining the words either side of a
+    CJK space would hand PBKDF2 one long word where BIP39's japanese
+    vectors expect twelve.
     """
     text = unicodedata.normalize("NFKD", text)
     text = text.lower()

--- a/btclib/mnemonic/mnemonic.py
+++ b/btclib/mnemonic/mnemonic.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import threading
+import unicodedata
 from collections.abc import Sequence
 from os import path
 
@@ -119,6 +120,51 @@ class WordLists:
 WORDLISTS = WordLists()
 
 Mnemonic = str
+
+
+def normalize_mnemonic(mnemonic: Mnemonic) -> Mnemonic:
+    r"""Return the mnemonic as btclib reads it, whatever separates its words.
+
+    NFKD first, then every run of unicode whitespace becomes one space,
+    so that `" abandon  abandon\tabandon "` and
+    `"abandon abandon abandon"` are the same sentence and reach the same
+    seed. That is btclib's answer for every mnemonic scheme: BIP39
+    mandates the NFKD and describes words separated by spaces, but says
+    nothing about a doubled space, a tab, or the newline a mnemonic
+    wrapped across two lines of a paper backup carries.
+
+    The NFKD comes first, and not merely because BIP39 asks for it.
+    U+3000, the ideographic space BIP39's own Japanese vectors separate
+    words with, decomposes to U+0020, so the separator question is
+    answered by the normalization the spec already requires rather than
+    by a rule of btclib's; and normalizing first leaves no run of
+    whitespace for the collapse to miss, which the other order does --
+    U+00A8 decomposes to a space plus a combining diaeresis, so
+    collapsing before normalizing hands PBKDF2 two adjacent spaces.
+
+    Refusing anything but a single space is the other defensible
+    position, and it is what the reference implementation reads: trezor's
+    python-mnemonic splits on `" "`, so a doubled space is an empty word
+    and an error. It is not taken here because that implementation is
+    strict only where it checks a mnemonic -- its `to_seed` applies NFKD
+    and nothing else, so a leading space or a trailing newline stretches
+    into a *different seed* with no complaint, and an unreadable wallet
+    is the one outcome worse than a refusal. Collapsing cannot do that,
+    and it refuses nothing a wallet, a mail client or an editor can
+    plausibly produce.
+
+    Zero-width characters stay: U+200B and U+FEFF carry no White_Space
+    property and survive NFKD, so a word holding one is an unknown word
+    rather than two words -- which is a refusal, the safe answer, and not
+    a silently different seed.
+
+    This is not electrum's normalization, and cannot be: `electrum.py`
+    lower-cases, drops the combining characters and joins words that NFKD
+    left either side of a space between two CJK characters. Dropping
+    combining characters undoes the very decomposition BIP39 requires, so
+    the two schemes need two functions, and electrum keeps its own.
+    """
+    return " ".join(unicodedata.normalize("NFKD", mnemonic).split())
 
 
 def mnemonic_from_indexes(indexes: Sequence[int], lang: str) -> Mnemonic:

--- a/tests/mnemonic/bip39_test.py
+++ b/tests/mnemonic/bip39_test.py
@@ -10,14 +10,16 @@
 """Tests for the `btclib.bip39` module."""
 
 import secrets
+import unicodedata
 from math import ceil
 
 import pytest
 
 from btclib.bip32 import bip32
 from btclib.exceptions import BTClibValueError
-from btclib.mnemonic import bip39
+from btclib.mnemonic import bip39, normalize_mnemonic
 from tests import load, vector_id
+from tests.mnemonic.mnemonic_test import fullwidth
 
 
 def test_bip39() -> None:
@@ -59,16 +61,17 @@ def test_vectors(entr: str, mnemonic: str, seed: str, xprv: str) -> None:
 
     Upstream's 24 English vectors, in order and value for value, plus a
     25th that is btclib's own: the last one repeated with tabs, newlines
-    and doubled spaces through the mnemonic, which is what the
-    `" ".join(mnemonic.split())` below is there to normalise. Only the
-    English array was ever taken, `english.txt` being the one wordlist
-    shipped; tests/_data/README.md pins the revision.
+    and doubled spaces through the mnemonic. Only the English array was
+    ever taken, `english.txt` being the one wordlist shipped;
+    tests/_data/README.md pins the revision.
+
+    That 25th vector reaches the library with its whitespace intact:
+    normalising it here first would ask `" ".join(mnemonic.split())`
+    whether it collapses whitespace, and never ask btclib.
     """
     lang = "en"
     entropy = bytes.fromhex(entr)
-    # clean up mnemonic from spurious whitespaces
-    mnemonic = " ".join(mnemonic.split())
-    assert mnemonic == bip39.mnemonic_from_entropy(entropy, lang)
+    assert normalize_mnemonic(mnemonic) == bip39.mnemonic_from_entropy(entropy, lang)
     assert seed == bip39.seed_from_mnemonic(mnemonic, "TREZOR").hex()
 
     raw_entr = bip39.entropy_from_mnemonic(mnemonic, lang)
@@ -82,6 +85,125 @@ def test_mnemonic_from_entropy() -> None:
     bip39.mnemonic_from_entropy(secrets.randbits(127), "en")
     # random mnemonic
     bip39.mnemonic_from_entropy()
+
+
+# BIP39's japanese vectors, from bip32JP/bip32JP.github.io's
+# test_JP_BIP39.json, the file bip-0039.mediawiki links as the japanese
+# test vectors. Two of the twenty-four inline, the first and the last:
+# what they pin is the NFKD, and two pin it as well as twenty-four would.
+#
+# The words are joined here rather than written as one string, because
+# the separator is the point: U+3000 IDEOGRAPHIC SPACE is what the
+# vectors put between words, and NFKD is what makes it U+0020 -- so a
+# separator BIP39 never names is handled by the normalization BIP39 does.
+#
+# The passphrase is the vectors' own and decomposes twice over: U+334D
+# SQUARE MEETORU is a compatibility character NFKD expands to four kana,
+# and the voiced kana carry dakuten that separate from the kana they sit
+# on. Without the NFKD BIP39 mandates, all twenty-four seeds come out
+# wrong while every english vector still passes, "TREZOR" and
+# `english.txt` being ASCII, which is NFKD already.
+#
+# S105 reads the name and sees a hardcoded password: it is one, and it is
+# a published test vector guarding no wallet. Renaming it around the
+# check would cost the reader the one word that says what BIP39 does with
+# the string
+JAPANESE_PASSPHRASE = "㍍ガバヴァぱばぐゞちぢ十人十色"  # noqa: S105
+
+JAPANESE_VECTORS = [
+    pytest.param(
+        ["あいこくしん"] * 11 + ["あおぞら"],
+        "a262d6fb6122ecf45be09c50492b31f92e9beb7d9a845987a02cefda57a15f9c"
+        "467a17872029a9e92299b5cbdf306e3a0ee620245cbd508959b6cb7ca637bd55",
+        "xprv9s21ZrQH143K258jAiWPAM6JYT9hLA91MV3AZUKfxmLZJCjCHeSjBvMbDy8C1mJ2FL5ytExyS97FAe6pQ6SD5Jt9SwHaLorA8i5Eojokfo1",
+        id="jp-0",
+    ),
+    pytest.param(
+        [
+            "うちゅう",
+            "ふそく",
+            "ひしょ",
+            "がちょう",
+            "うけもつ",
+            "めいそう",
+            "みかん",
+            "そざい",
+            "いばる",
+            "うけとる",
+            "さんま",
+            "さこつ",
+            "おうさま",
+            "ぱんつ",
+            "しひょう",
+            "めした",
+            "たはつ",
+            "いちぶ",
+            "つうじょう",
+            "てさぎょう",
+            "きつね",
+            "みすえる",
+            "いりぐち",
+            "かめれおん",
+        ],
+        "346b7321d8c04f6f37b49fdf062a2fddc8e1bf8f1d33171b65074531ec546d1d"
+        "3469974beccb1a09263440fc92e1042580a557fdce314e27ee4eabb25fa5e5fe",
+        "xprv9s21ZrQH143K2qVq43Phs1xyVc6jSxXHWJ6CDJjod3cgyEin7hgeQV6Dkw6s1LSfMYxoah4bPAnW4wmXfDUS9ghBEM18xoY634CBtX8HPrA",
+        id="jp-23",
+    ),
+]
+
+
+@pytest.mark.parametrize(("words", "seed", "xprv"), JAPANESE_VECTORS)
+def test_nfkd_japanese_vectors(words: list[str], seed: str, xprv: str) -> None:
+    """BIP39 stretches the NFKD of the sentence and of the passphrase.
+
+    The checksum goes unverified because there is no japanese word-list
+    to verify it against -- btclib ships english and italian -- which is
+    why these are a seed test and not a round trip. The seed is what the
+    normalization decides, so nothing is lost.
+    """
+    mnemonic = "　".join(words)
+    assert bip39.seed_from_mnemonic(mnemonic, JAPANESE_PASSPHRASE, False).hex() == seed
+    assert bip32.rootxprv_from_seed(seed) == xprv
+
+    # the ideographic separator is not privileged: an ASCII space, a
+    # newline or a doubled U+3000 is the same sentence and the same seed
+    for separator in (" ", "\n", "　　", " \t"):
+        respaced = separator.join(words)
+        assert (
+            bip39.seed_from_mnemonic(respaced, JAPANESE_PASSPHRASE, False).hex() == seed
+        )
+
+    # and the passphrase is normalized where it stands: handing over the
+    # decomposition BIP39 asks for reaches the same seed, which is the
+    # whole claim
+    decomposed = unicodedata.normalize("NFKD", JAPANESE_PASSPHRASE)
+    assert decomposed != JAPANESE_PASSPHRASE
+    assert bip39.seed_from_mnemonic(mnemonic, decomposed, False).hex() == seed
+
+    # the passphrase's own whitespace is content, not a separator: a
+    # doubled space in it is a different passphrase and must not collapse
+    spaced = f"{JAPANESE_PASSPHRASE}  x"
+    collapsed = f"{JAPANESE_PASSPHRASE} x"
+    assert bip39.seed_from_mnemonic(
+        mnemonic, spaced, False
+    ) != bip39.seed_from_mnemonic(mnemonic, collapsed, False)
+
+
+def test_nfkd_fullwidth_latin() -> None:
+    """A japanese IME types english words in fullwidth latin.
+
+    U+FF41 is not "a" until NFKD decomposes it, so without the
+    normalization the word-list lookup fails and a mnemonic a user can
+    read back to themselves is refused.
+    """
+    mnemonic = "abandon abandon atom trust ankle walnut oil across awake bunker divorce abstract"
+    wide = " ".join(fullwidth(word) for word in mnemonic.split())
+    assert wide != mnemonic
+    assert normalize_mnemonic(wide) == mnemonic
+    assert bip39.entropy_from_mnemonic(wide) == bip39.entropy_from_mnemonic(mnemonic)
+    assert bip39.seed_from_mnemonic(wide, "") == bip39.seed_from_mnemonic(mnemonic, "")
+    assert bip39.mxprv_from_mnemonic(wide) == bip39.mxprv_from_mnemonic(mnemonic)
 
 
 def test_mxprv_from_mnemonic() -> None:

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -17,7 +17,14 @@ from typing import Any
 import pytest
 
 from btclib.exceptions import BTClibValueError
-from btclib.mnemonic import WORDLISTS, indexes_from_mnemonic, mnemonic_from_indexes
+from btclib.mnemonic import (
+    WORDLISTS,
+    bip39,
+    electrum,
+    indexes_from_mnemonic,
+    mnemonic_from_indexes,
+    normalize_mnemonic,
+)
 from btclib.mnemonic.mnemonic import WordLists
 
 
@@ -31,6 +38,121 @@ def test_mnemonic() -> None:
     assert indexes == expected
     mnemonic = mnemonic_from_indexes(expected, lang)
     assert mnemonic == mnem
+
+
+def fullwidth(text: str) -> str:
+    # ASCII lower-case as a japanese IME types it, U+FF41 upwards. Built
+    # rather than written out: the fullwidth letters are indistinguishable
+    # from the ASCII ones in a diff, which is the whole reason NFKD has to
+    # reach them
+    return "".join(chr(ord(char) - ord("a") + 0xFF41) for char in text)
+
+
+def test_normalize_mnemonic() -> None:
+    # the ideographic space BIP39's japanese vectors separate words with
+    # is a separator because NFKD says so, not because btclib says so
+    assert normalize_mnemonic("\u3000a\u3000b\u3000") == "a b"
+    # and so is every other run of unicode whitespace
+    assert normalize_mnemonic(" \ta\r\n\v\fb\u00a0\u1680") == "a b"
+    # fullwidth latin decomposes: an IME types the same sentence
+    assert normalize_mnemonic(fullwidth("abandon")) == "abandon"
+    # NFKD before the collapse and not after: U+00A8 decomposes to a
+    # space plus a combining diaeresis, so the other order hands PBKDF2
+    # two adjacent spaces
+    assert normalize_mnemonic("x \u00a8y") == "x \u0308y"
+    # zero-width characters carry no White_Space property and survive
+    # NFKD, so a word holding one stays one unknown word -- a refusal,
+    # which is safe, rather than a silently different seed
+    assert normalize_mnemonic("a\u200bb") == "a\u200bb"
+    assert normalize_mnemonic("a\ufeffb") == "a\ufeffb"
+    # idempotent, so normalizing twice is not a second answer
+    assert normalize_mnemonic(normalize_mnemonic(" a\tb ")) == "a b"
+
+
+# every shape a mnemonic's whitespace plausibly arrives in: a paper
+# backup transcribed over two lines, a sentence pasted out of a mail
+# client, the leading space a double-click selection picks up, the
+# ideographic space a japanese keyboard produces. btclib's answer is the
+# canonical sentence's answer in all of them, whichever scheme reads it
+WHITESPACE_SHAPES = [
+    pytest.param("", " ", "", id="canonical"),
+    pytest.param(" ", " ", "", id="leading-space"),
+    pytest.param("", " ", " ", id="trailing-space"),
+    pytest.param("\n\t", " ", " \n", id="leading-and-trailing"),
+    pytest.param("", "  ", "", id="doubled-space"),
+    pytest.param("", "\t", "", id="tab"),
+    pytest.param("", "\n", "", id="newline"),
+    pytest.param("", "\r\n", "", id="crlf"),
+    pytest.param("", "\v", "", id="vertical-tab"),
+    pytest.param("", "\f", "", id="form-feed"),
+    pytest.param("", "\x85", "", id="next-line"),
+    pytest.param("", "\u00a0", "", id="no-break-space"),
+    pytest.param("", "\u1680", "", id="ogham-space-mark"),
+    pytest.param("", "\u2003", "", id="em-space"),
+    pytest.param("", "\u2028", "", id="line-separator"),
+    pytest.param("", "\u202f", "", id="narrow-no-break-space"),
+    pytest.param("", "\u205f", "", id="medium-mathematical-space"),
+    pytest.param("", "\u3000", "", id="ideographic-space"),
+    pytest.param(" \t\n", " \u3000\t\u00a0 ", "\u3000 ", id="all-at-once"),
+]
+
+BIP39_MNEMONIC = (
+    "abandon abandon atom trust ankle walnut oil across awake bunker divorce abstract"
+)
+
+# electrum's own "standard" vector, from tests/mnemonic/electrum_test.py:
+# mxprv_from_mnemonic answers for it, which "segwit" and the two "2fa"
+# versions do not, so one mnemonic covers all three entry points
+ELECTRUM_MNEMONIC = (
+    "diagram crouch ball canal then hat panda spatial company "
+    "liberty fetch awful ability"
+)
+
+
+def respace(mnemonic: str, prefix: str, separator: str, suffix: str) -> str:
+    return prefix + separator.join(mnemonic.split()) + suffix
+
+
+@pytest.mark.parametrize(("prefix", "separator", "suffix"), WHITESPACE_SHAPES)
+def test_bip39_whitespace(prefix: str, separator: str, suffix: str) -> None:
+    mnemonic = respace(BIP39_MNEMONIC, prefix, separator, suffix)
+    assert normalize_mnemonic(mnemonic) == BIP39_MNEMONIC
+    assert bip39.entropy_from_mnemonic(mnemonic) == bip39.entropy_from_mnemonic(
+        BIP39_MNEMONIC
+    )
+    assert bip39.seed_from_mnemonic(mnemonic, "") == bip39.seed_from_mnemonic(
+        BIP39_MNEMONIC, ""
+    )
+    assert bip39.mxprv_from_mnemonic(mnemonic) == bip39.mxprv_from_mnemonic(
+        BIP39_MNEMONIC
+    )
+
+
+@pytest.mark.parametrize(("prefix", "separator", "suffix"), WHITESPACE_SHAPES)
+def test_electrum_whitespace(prefix: str, separator: str, suffix: str) -> None:
+    mnemonic = respace(ELECTRUM_MNEMONIC, prefix, separator, suffix)
+    assert electrum.version_from_mnemonic(mnemonic) == electrum.version_from_mnemonic(
+        ELECTRUM_MNEMONIC
+    )
+    assert electrum.entropy_from_mnemonic(mnemonic) == electrum.entropy_from_mnemonic(
+        ELECTRUM_MNEMONIC
+    )
+    assert electrum.mxprv_from_mnemonic(mnemonic) == electrum.mxprv_from_mnemonic(
+        ELECTRUM_MNEMONIC
+    )
+
+
+@pytest.mark.parametrize(("prefix", "separator", "suffix"), WHITESPACE_SHAPES)
+def test_indexes_from_mnemonic_whitespace(
+    prefix: str, separator: str, suffix: str
+) -> None:
+    # the shared layer answers the same question the two schemes do:
+    # str.split() with no argument is already a split on any run of
+    # unicode whitespace, which is half of normalize_mnemonic
+    mnemonic = respace(BIP39_MNEMONIC, prefix, separator, suffix)
+    assert indexes_from_mnemonic(mnemonic, "en") == indexes_from_mnemonic(
+        BIP39_MNEMONIC, "en"
+    )
 
 
 def test_wordlist_1() -> None:


### PR DESCRIPTION
Issue #201 asks what btclib does with whitespace BIP39 leaves unsaid, and
says btclib's own position has to be settled before anything is reported
upstream. Measuring it turned up a larger answer: the whitespace half was
already settled, and the NFKD half was missing entirely.

## The before-picture, measured

Every path, every whitespace shape, on `0e5d6301`. `SAME` means the seed,
entropy or xprv equals the canonical sentence's:

| shape | `indexes_from_mnemonic` | `bip39.entropy` | `bip39.seed` | `bip39.mxprv` | `electrum.version` | `electrum.entropy` | `electrum.mxprv` |
|---|---|---|---|---|---|---|---|
| leading / trailing space | SAME | SAME | SAME | SAME | SAME | SAME | SAME |
| doubled space | SAME | SAME | SAME | SAME | SAME | SAME | SAME |
| tab, newline, CRLF, VT, FF | SAME | SAME | SAME | SAME | SAME | SAME | SAME |
| NBSP U+00A0, narrow NBSP U+202F | SAME | SAME | SAME | SAME | SAME | SAME | SAME |
| ogham U+1680, em space U+2003 | SAME | SAME | SAME | SAME | SAME | SAME | SAME |
| ideographic space U+3000 | SAME | SAME | SAME | SAME | SAME | SAME | SAME |

So the whitespace question was *already* answered permissively on every
path, and by accident rather than by decision: `str.split()` with no
argument splits on any run of unicode whitespace. Nothing tested it, and
nothing wrote it down. U+200B and U+FEFF are the boundary — no
`White_Space` property, so they were and remain part of a word.

The NFKD half was the finding:

| | before | after |
|---|---|---|
| BIP39's 24 Japanese vectors (`bip32JP/bip32JP.github.io`, `test_JP_BIP39.json`) | **0/24** | **24/24** |
| composed `が` vs decomposed `か`+U+3099 | different seeds | same seed |
| NFC vs NFKD passphrase (`㍍ガバヴァ…`) | different seeds | same seed |
| fullwidth latin mnemonic | `ValueError: list.index(x): x not in list` | reads as the ASCII sentence |

`bip39.seed_from_mnemonic` collapsed whitespace and normalized nothing,
where BIP39 says the opposite: *"a mnemonic sentence (in UTF-8 NFKD) used
as the password and the string `mnemonic` + passphrase (again in UTF-8
NFKD) used as the salt"*. Every English vector passed throughout —
`TREZOR` and `english.txt` are ASCII, which is NFKD already — so the
suite could not see it.

## The position chosen

**Normalize NFKD, then treat any run of unicode whitespace as one
separator.** In `mnemonic.normalize_mnemonic`, used by both BIP39 entry
points; `electrum.py` already did the equivalent and keeps its own.

Why NFKD *first*, and not the reverse: U+3000 — the separator BIP39's own
Japanese vectors use — decomposes to U+0020, so the separator question is
answered by the normalization the spec already mandates rather than by a
rule of btclib's. And normalizing first leaves no run of whitespace for
the collapse to miss: U+00A8 decomposes to a space plus U+0308, so
`"x ¨y"` collapses to `"x ̈y"` one way and `"x  ̈y"` — two
spaces — the other. On the 24 official vectors the two orders agree, so
nothing upstream distinguishes them; the order is chosen for the case
that has no vector.

**Why not strict single-space**, which #201 rightly calls defensible and
which is what trezor's `python-mnemonic` reads (`normalize_string(m).split(" ")`):
that implementation is strict only where it *checks* a mnemonic. Its
`to_seed` applies NFKD and stops, with no whitespace handling at all, so
a leading space or a trailing newline stretches into a **different seed
in silence** — the one outcome worse than a refusal. Collapsing cannot do
that, and it refuses nothing a wallet, a mail client or an editor
plausibly produces. Both readings agree on every canonical mnemonic; they
differ only on input python-mnemonic would either reject or silently
misread.

**The passphrase is decomposed and otherwise untouched.** Its whitespace
is content the user chose, not a separator, so collapsing a doubled space
there would open another wallet. python-mnemonic agrees.

**Electrum's normalization is not shared, and cannot be** — the concrete
obstacle to #201's "answer it once for all schemes". `normalize_text`
drops the combining characters after NFKD, undoing the very decomposition
BIP39 requires, and removes whitespace between CJK characters: run over
BIP39's Japanese vector 0 it joins the twelve words into one and the seed
does not match. Measured, not inferred. Two schemes, two functions; the
docstrings on both say so.

## Tests

- `test_normalize_mnemonic` — the helper directly: U+3000, the ASCII
  shapes, fullwidth latin, the NFKD-before-collapse ordering, zero-width
  characters preserved, idempotence.
- `test_bip39_whitespace`, `test_electrum_whitespace`,
  `test_indexes_from_mnemonic_whitespace` — 19 whitespace shapes ×
  3 schemes, each asserting the canonical answer. All the invisible
  characters are written as escapes.
- `test_nfkd_japanese_vectors` — BIP39's Japanese vectors 0 and 23 inline
  with their citation, seed and xprv, plus: the ideographic separator is
  not privileged, the passphrase's decomposition reaches the same seed,
  and the passphrase's *own* doubled space does not collapse.
- `test_nfkd_fullwidth_latin` — checksum-verifiable, since NFKD maps
  U+FF41.. onto the English wordlist.
- `test_vectors` no longer pre-normalizes: the 25th vector, btclib's own
  whitespace case, now reaches the library with its whitespace intact.
  Normalizing it in the test asked `" ".join(mnemonic.split())` whether
  it collapses whitespace and never asked btclib.

## Verification — each run as documented, exit code checked

| gate | result |
|---|---|
| `uv run pytest` | **exit 0**, 14848 passed |
| `uv run pre-commit run --all-files` | **exit 0**, every hook |
| `sphinx-build -W --keep-going` (the `Build the documentation` job) | **exit 0**, build succeeded |
| `pytest --cov=btclib --cov=tests` | 2 statements missed, `electrum.py` — **identical on `origin/dev`** |

That last one is pre-existing and not from this branch: `origin/dev` at
`0e5d6301` reports the same two statements (`_search_mnemonic`'s
round-trip guard, which no test reaches) and the same `fail_under`
failure. Checked out and measured, not assumed. This branch adds 62
statements, all covered, so it moves the ratio the right way.

## Counts

`grep -c '^- ' CHANGELOG.md` is **179** in this checkout after the edit,
and both headers say "a hundred and seventy-nine". The breaking-changes
tally goes to thirty in HISTORY.md and in CHANGELOG.md's cross-reference:
a non-ASCII mnemonic or passphrase now derives a different wallet, which
is a user action, and it sits beside the electrum entry that is there for
the same reason. **Re-derive all three at merge** — #206 and #208 are
moving them concurrently and any number here is stale the moment another
branch lands.

## Overlap

#208 adds a seed-type dispatcher and touches `mnemonic/electrum.py`; #206
adds SLIP-0039. This branch deliberately builds **no dispatcher**: it adds
one shared `normalize_mnemonic` in `mnemonic/mnemonic.py`, which is the
single place either of those can call. The only `electrum.py` change is
seven lines of docstring saying why its normalization is not the shared
one. Conflicts should be confined to the CHANGELOG/HISTORY counts.

Refs #201. The upstream-report half stays open by design: the issue asks
for btclib's position first, and these measurements are the material for
the report rather than the report itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Normalize BIP39 mnemonics to NFKD with unified whitespace handling and align behavior with the spec across mnemonic schemes.

New Features:
- Introduce a shared normalize_mnemonic helper to NFKD-normalize and collapse unicode whitespace in mnemonic sentences.

Bug Fixes:
- Correct BIP39 seed and entropy derivation for non-ASCII mnemonics and passphrases, including official Japanese test vectors and fullwidth Latin input.
- Ensure passphrase normalization follows BIP39’s NFKD requirements without altering its intentional whitespace.

Enhancements:
- Unify whitespace handling across BIP39, Electrum, and shared mnemonic index paths while keeping Electrum’s stronger normalization separate.
- Document and expose normalize_mnemonic in the mnemonic public API.

Documentation:
- Update changelog and history to record the NFKD normalization behavior and its breaking-change impact on non-ASCII mnemonics and passphrases.

Tests:
- Add comprehensive tests covering Japanese BIP39 vectors, fullwidth Latin mnemonics, and a matrix of whitespace shapes across BIP39, Electrum, and shared mnemonic index functions.
- Adjust existing BIP39 vector tests to rely on library-side normalization instead of pre-normalizing test data.