### PR TITLE
Give bms the wallet its own docstring sends it looking for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1852,6 +1852,36 @@ edit.
   is everything downstream of a network: mempool histograms, fee estimates
   for a confirmation target, ETAs. Those are policy fed by live data and
   belong to an application; the module docstring says so (issue #205)
+- **`btclib.keystore` is the wallet infrastructure `bms` asks for**, and
+  no more of it: `bms`'s own docstring says "at signing time, a wallet
+  infrastructure is required to access the private key corresponding to a
+  given address" and the library had none. A `KeyStore` holds a key
+  source, hands out addresses, remembers the derivation path of each and
+  answers which private key signs for one, which is what lets
+  `keystore.sign(address, msg)` exist — a message signature addressed by
+  *address*, delegated to `bms.sign` and signing nothing itself.
+  `BIP32KeyStore(xkey, "m/84h/0h/0h")` takes an extended key anywhere on
+  the account path and derives the two unhardened levels below it, the
+  purpose choosing the encoding as BIP44/49/84/86 define it; `KeyStore`
+  takes individual keys instead, one address each. The decisions worth
+  knowing: an address the keystore has not handed out is a *raise* and
+  not a None, because "no opinion" and "no key" deserve different answers
+  and `address in keystore` is the question that wants a boolean;
+  addresses are derived on demand rather than precomputed over a gap
+  limit, a gap limit being a scanning parameter that means nothing
+  without a chain to scan; an xpub or a public key is a first-class
+  watch-only keystore, where `sign` raises naming the address rather than
+  returning something falsy; and the script type follows the *path*, not
+  the SLIP132 version bytes, so an xprv and a zprv holding one key cannot
+  hand out two different addresses for one path. p2tr addresses are
+  handed out and cannot be signed for: BMS recovers an ECDSA key against
+  a hash160, a taproot output key is BIP341's tweaked x-only key, and the
+  refusal says so rather than letting `bms` report the generic mismatch.
+  Out of scope and stated in the module docstring: utxo tracking,
+  balances, transaction building, persistence to disk, encryption at rest
+  — the first three need a view of the chain btclib does not have, the
+  last two a file format that would outlive the release choosing it
+  (issue #189)
 
 ### Types
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ Included features are:
 - fee rates carrying their unit (sat/kvB and sat/vB), the fee a virtual
   size owes at one, and the dust threshold of any output type — computed
   the way Bitcoin Core computes it, rather than tabulated
+- keystore: the addresses an extended key or a set of individual keys has
+  handed out, the derivation path of each, and the private key that signs
+  for one — which is what `sign(address, msg)` needs and what a message
+  signature by address had no way to find
 
 ---
 
@@ -139,7 +143,9 @@ of everything: it imports `b58`, `b32`, `amount` and `network`, and nothing
 in the library imports it. `bip44` is the other module up there, and for
 the same reason: an address from an extended key and a derivation path is
 `bip32` and `script.taproot` and both address encodings composed, so it
-imports all four and nothing imports it.
+imports all four and nothing imports it. `keystore` is one level above
+even that: it remembers which addresses `bip44` has handed out and signs
+for one with `ecc.bms`, so it imports `bip44` and nothing imports it.
 
 ---
 

--- a/btclib/bip44.py
+++ b/btclib/bip44.py
@@ -43,6 +43,7 @@ from btclib.bip32.der_path import (
 from btclib.exceptions import BTClibValueError
 from btclib.network import network_from_xkeyversion, network_type_from_xkeyversion
 from btclib.script.taproot import output_pubkey
+from btclib.to_pub_key import Key
 
 # purpose, coin type, account, change, address index: BIP44 fixes the
 # meaning of each level, so a path of any other length is not one
@@ -76,7 +77,7 @@ with open(_PURPOSES_FILE, encoding="ascii") as _purposes:
 _NETWORK_TYPE_FROM_COIN_TYPE: dict[int, NetworkType] = {0: "main", 1: "test"}
 
 
-def _p2tr(key: str, network: str) -> str:
+def _p2tr(key: Key, network: str) -> str:
     """Return the p2tr address of a key, tweaked as BIP86 prescribes.
 
     BIP86 is BIP44 for taproot and the tweak is the whole of it: the
@@ -90,11 +91,16 @@ def _p2tr(key: str, network: str) -> str:
     return b32.p2tr(output_pubkey(key)[0], network)
 
 
-# the derived key and the network in, the address out: four encodings
-# that already exist, named by the script type the purpose resolves to.
-# Keyed by BIP44ScriptType, so the alias and this table are checked
-# against each other -- a fifth encoding is a key mypy does not know
-_ADDRESS_FROM_SCRIPT_TYPE: dict[BIP44ScriptType, Callable[[str, str], str]] = {
+# a key and the network in, the address out: four encodings that already
+# exist, named by the script type the purpose resolves to. Keyed by
+# BIP44ScriptType, so the alias and this table are checked against each
+# other -- a fifth encoding is a key mypy does not know.
+#
+# The key is a Key and not the str this module always passes, because
+# all four encoders take one and `keystore` reaches for this same table
+# with a key that has not been through b58: narrowing it here would make
+# the table this module's rather than the library's, for no check gained
+_ADDRESS_FROM_SCRIPT_TYPE: dict[BIP44ScriptType, Callable[[Key, str], str]] = {
     "p2pkh": b58.p2pkh,
     "p2wpkh-p2sh": b58.p2wpkh_p2sh,
     "p2wpkh": b32.p2wpkh,

--- a/btclib/keystore.py
+++ b/btclib/keystore.py
@@ -1,0 +1,443 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Keystore: the addresses handed out, and the key that signs for each.
+
+`btclib.ecc.bms` says it in its own docstring -- "at signing time, a
+wallet infrastructure is required to access the private key corresponding
+to a given address" -- and then has none to reach for. This module is
+that infrastructure, and no more of it than the sentence asks for: a
+`KeyStore` holds a key source, hands out addresses, remembers the
+derivation path of each, and answers which private key signs for one.
+`sign(address, msg)` is what the three together buy, a message signature
+addressed by *address*, which `bms.sign` cannot offer because it has no
+way to find the key.
+
+Two key sources, one class each. `BIP32KeyStore` takes an extended key
+and the BIP44 account path it sits on, and derives addresses down the two
+unhardened levels below it; `KeyStore` takes individual keys, one address
+each, and is also the base the derivation is added to. Either one is
+watch-only when it holds no private key -- an xpub, or public keys -- and
+that is a first-class state rather than a broken one: watching is most of
+what a keystore does, and `sign` on one raises rather than returning
+something a caller might mistake for a signature.
+
+**What this module is not.** No utxo tracking, no balances, no
+transaction building, no persistence to disk, no encryption at rest. Each
+of those is a decision this module cannot take on its own: the first three
+need a view of the chain, which btclib does not have and does not fetch,
+and the last two need a file format and a key-derivation function that
+would outlive any release choosing them. Without them a keystore is a
+pure function of its key source -- the same source gives the same
+addresses in the same order, every time -- which is what makes it
+testable and what keeps its whole state in memory, where the caller can
+see it. A spender is the larger reading of "wallet" and belongs above
+this, not inside it.
+
+Which encoding an account path means is `bip44`'s question and is
+answered there, not here: this module imports that mapping and those four
+encoders rather than keeping a second copy, so a purpose added to
+`bip44`'s data file is a purpose a keystore hands out. What it does not
+borrow is `bip44.address_from_der_path`, which walks the whole five-level
+path from the extended key it is given; a keystore has already derived
+down to the account at construction, and `bip32.derive_from_account` --
+which imposes the branch and index bounds -- is the two levels left.
+
+https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from btclib import b32, b58
+from btclib.alias import BIP44ScriptType, Octets, String
+from btclib.bip32.bip32 import (
+    BIP32Key,
+    BIP32KeyData,
+    derive,
+    derive_from_account,
+)
+from btclib.bip32.der_path import (
+    _HARDENED_OFFSET,
+    DerPath,
+    indexes_from_der_path,
+    str_from_der_path,
+)
+from btclib.bip44 import _ADDRESS_FROM_SCRIPT_TYPE, _script_type_from_purpose
+from btclib.ecc import bms
+from btclib.exceptions import BTClibValueError
+from btclib.network import NETWORKS, network_from_xkeyversion
+from btclib.to_prv_key import prv_keyinfo_from_prv_key
+from btclib.to_pub_key import Key, pub_keyinfo_from_key, pub_keyinfo_from_pub_key
+
+# purpose, coin type, account: the three hardened levels of a BIP44 path
+# above the two a keystore walks itself
+_ACCOUNT_LEVELS = 3
+
+# native segwit, which is what a wallet created today uses and what
+# `bip32.slip132.p2wpkh_xkey` already defaults to
+_DEFAULT_ACCOUNT = "m/84h/0h/0h"
+_DEFAULT_SCRIPT_TYPE: BIP44ScriptType = "p2wpkh"
+
+
+def _checked_script_type(script_type: str) -> BIP44ScriptType:
+    """Return a script type this module can turn into an address.
+
+    The lookup and not an isinstance, for `bip44`'s reason: the table is
+    the list of encodings that exist, so missing from it and unknown are
+    one thing, and a Literal is a mypy fact rather than a runtime one.
+    What this adds to the caller's `BIP44ScriptType` annotation is the
+    check for a caller who runs no type checker.
+    """
+    if script_type not in _ADDRESS_FROM_SCRIPT_TYPE:
+        known = ", ".join(sorted(_ADDRESS_FROM_SCRIPT_TYPE))
+        err_msg = f"unknown script type: {script_type} not in ({known})"
+        raise BTClibValueError(err_msg)
+    # no cast: the table is keyed by BIP44ScriptType, so the membership
+    # test above narrows the str to it and mypy calls a cast redundant
+    return script_type
+
+
+def _address_str(address: String) -> str:
+    """Return an address spelled the way a keystore records it.
+
+    Bech32 is case insensitive and BIP173 blesses the upper case spelling
+    for QR codes, so an address read off one has to find the lower case
+    one the keystore handed out. Base58 is not case insensitive -- `1Lq`
+    and `1lq` are different payloads -- so it is left exactly as it came.
+    """
+    addr = address.decode("ascii") if isinstance(address, bytes) else address
+    addr = addr.strip()
+    return addr.lower() if b32.has_segwit_prefix(addr) else addr
+
+
+def _wif_if_private(key: Key, network: str) -> str:
+    """Return the WIF of a private key, or "" for a public one.
+
+    Two of the five spellings `to_pub_key.Key` admits say which they are
+    by their type, and are taken first because the ambiguous test below
+    cannot be asked of them: an int is a scalar, so it is a private key,
+    and a point is a pair of coordinates, so it is a public one.
+
+    The rest -- octets, a WIF or an extended key -- are told apart in the
+    order `to_pub_key.pub_keyinfo_from_key` tells them apart, public
+    first: a public key is a complete answer here, the keystore watching
+    that address and unable to sign for it, while anything that is not
+    one has to be a private key, and the error raised for a malformed one
+    is the diagnosis the caller needs rather than a silent demotion to
+    watch-only.
+    """
+    if isinstance(key, int):
+        return b58.wif_from_prv_key(key, network)
+    if isinstance(key, tuple):
+        return ""
+
+    with contextlib.suppress(BTClibValueError):
+        pub_keyinfo_from_pub_key(key, network)
+        return ""
+
+    q, net, compressed = prv_keyinfo_from_prv_key(key, network)
+    return b58.wif_from_prv_key(q, net, compressed)
+
+
+@dataclass(frozen=True)
+class AddressInfo:
+    """What a keystore remembers about one address it has handed out.
+
+    No key material, deliberately: this is the record a caller prints,
+    logs and compares, and the private key is one call away behind
+    `KeyStore.prv_key`, which reads as the request it is. Frozen for the
+    same reason `addresses` hands back a tuple -- what comes out of a
+    keystore is a copy of what it knows, not a handle on it.
+
+    `der_path` is the whole path from the master key, so that it can be
+    handed to `bip32.derive` or written into a PSBT key origin as it
+    stands; it is empty for a key that came into the keystore on its own,
+    which has no path.
+    """
+
+    address: str
+    script_type: BIP44ScriptType
+    der_path: str
+
+
+class KeyStore:
+    """Individual keys, the address of each, and who signs for it.
+
+    The addresses are handed out by `add`, one per key, all of them in
+    the script type the keystore was built with; `BIP32KeyStore` below is
+    the same thing with an extended key underneath and derivation on top.
+
+    A public key is as welcome as a private one and makes that address
+    watch-only. `sign` then raises, naming the address: the alternative
+    would be a keystore that answers a signing request with something
+    falsy, and every caller that forgets to check has published an
+    unsigned message.
+    """
+
+    def __init__(
+        self,
+        keys: Iterable[Key] = (),
+        script_type: BIP44ScriptType = _DEFAULT_SCRIPT_TYPE,
+        network: str = "mainnet",
+    ) -> None:
+        if network not in NETWORKS:
+            raise BTClibValueError(f"unknown network: {network}")
+        self.network = network
+        self.script_type = _checked_script_type(script_type)
+
+        # insertion ordered, which is the order the addresses were handed
+        # out in: `addresses` is that order and nothing else records it
+        self._handed_out: dict[str, AddressInfo] = {}
+        # address -> WIF, and only for the keys that came in on their own.
+        # A BIP32KeyStore re-derives instead of caching, so what is held
+        # here is exactly the key material the caller handed over
+        self._prv_keys: dict[str, str] = {}
+
+        for key in keys:
+            self.add(key)
+
+    def __len__(self) -> int:
+        return len(self._handed_out)
+
+    def __contains__(self, address: String) -> bool:
+        """Whether the keystore has handed this address out.
+
+        The question `address_info` raises on, asked without the
+        exception: a caller deciding what to do about an unknown address
+        is not handling an error, and should not have to write one.
+        """
+        return _address_str(address) in self._handed_out
+
+    @property
+    def addresses(self) -> tuple[str, ...]:
+        """Every address handed out, in the order it was handed out."""
+        return tuple(self._handed_out)
+
+    @property
+    def is_watch_only(self) -> bool:
+        """Whether the keystore holds no private key at all."""
+        return not self._prv_keys
+
+    def add(self, key: Key, script_type: BIP44ScriptType | None = None) -> str:
+        """Take one key into the keystore, and return its address."""
+        script_type = (
+            self.script_type
+            if script_type is None
+            else _checked_script_type(script_type)
+        )
+        pub_key, _ = pub_keyinfo_from_key(key, self.network)
+        # segwit has no uncompressed form, so the three segwit encodings
+        # would silently answer an uncompressed key with the address of
+        # its compressed twin -- an address bms cannot then sign for,
+        # because the recovery flag it would need says compressed
+        if script_type != "p2pkh" and len(pub_key) != 33:
+            err_msg = f"uncompressed key cannot be {script_type}:"
+            err_msg += " segwit has no uncompressed form"
+            raise BTClibValueError(err_msg)
+
+        address = _ADDRESS_FROM_SCRIPT_TYPE[script_type](key, self.network)
+        if wif := _wif_if_private(key, self.network):
+            self._prv_keys[address] = wif
+        self._handed_out[address] = AddressInfo(address, script_type, "")
+        return address
+
+    def address_info(self, address: String) -> AddressInfo:
+        """Return what the keystore remembers about an address.
+
+        A miss raises rather than answering None. A keystore that has not
+        handed an address out has no opinion about it -- not "no key",
+        which is what a watch-only address has -- and the two are worth
+        different answers; and every other lookup in btclib raises, so a
+        None here would be the one place a caller has to remember not to
+        use the result. `address in keystore` is the question that wants
+        a boolean.
+
+        A miss is also not evidence that the keystore cannot reach the
+        address: a `BIP32KeyStore` derives on demand, so an address of
+        its own chain that it has not been asked for yet is a miss.
+        `address(branch, index)` is what puts one in.
+        """
+        addr = _address_str(address)
+        if addr not in self._handed_out:
+            err_msg = f"address not in the keystore: {addr}"
+            raise BTClibValueError(err_msg)
+        return self._handed_out[addr]
+
+    def prv_key(self, address: String) -> str:
+        """Return the WIF of the private key signing for an address."""
+        addr = self.address_info(address).address
+        if addr not in self._prv_keys:
+            raise BTClibValueError(f"watch-only address, no private key: {addr}")
+        return self._prv_keys[addr]
+
+    def sign(self, address: String, msg: Octets) -> bms.Sig:
+        """Return the BMS signature of a message, by address.
+
+        The address is the argument `bms.sign` has no way to resolve on
+        its own; everything after the lookup is `bms.sign`'s, this method
+        signing nothing itself. The resolved address is passed on to it
+        as well as the key, which is what makes the recovery flag name
+        the right address type -- BIP137's 35..38 for the wrapped segwit
+        spelling and 39..42 for the native one -- rather than the
+        compressed p2pkh flag that a key alone would produce.
+        """
+        info = self.address_info(address)
+        # p2tr is the one script type this module hands out and cannot
+        # sign for. BMS recovers an ECDSA public key and matches it
+        # against a hash160; a taproot output key is an x-only BIP340 key
+        # tweaked by BIP341, which none of the sixteen recovery flags
+        # names, so bms would refuse it as a "mismatch between private
+        # key and address" -- true of every wrong key and misleading
+        # here, where the key is right and the scheme is the problem.
+        # BIP322 is the signature a taproot address wants, and btclib has
+        # no implementation of it yet
+        if info.script_type == "p2tr":
+            err_msg = f"BMS cannot sign for a p2tr address: {info.address};"
+            err_msg += " message signing for taproot is BIP322"
+            raise BTClibValueError(err_msg)
+        return bms.sign(msg, self.prv_key(info.address), info.address)
+
+
+class BIP32KeyStore(KeyStore):
+    """An extended key at a BIP44 account, and the addresses below it.
+
+    `xkey` is the master key, the account key, or any key between the
+    two; `der_path` is always the whole account path from the master,
+    `m/purpose'/coin_type'/account'`, because the purpose lives at the
+    top of it and is what says whether the addresses are p2pkh, p2wpkh-
+    p2sh, p2wpkh or p2tr. What is left of the path below the key is
+    derived once, at construction.
+
+    Addresses come from the two unhardened levels BIP44 puts under an
+    account, `branch/index` with branch 0 receiving and 1 change, which
+    is also what public derivation can walk -- so an account *xpub* is a
+    complete watch-only keystore.
+    """
+
+    def __init__(
+        self,
+        xkey: BIP32Key,
+        der_path: DerPath = _DEFAULT_ACCOUNT,
+        script_type: BIP44ScriptType | None = None,
+    ) -> None:
+        if not isinstance(xkey, BIP32KeyData):
+            xkey = BIP32KeyData.b58decode(xkey)
+
+        indexes = indexes_from_der_path(der_path)
+        if len(indexes) != _ACCOUNT_LEVELS:
+            err_msg = f"invalid account path: {len(indexes)} levels"
+            err_msg += f" instead of {_ACCOUNT_LEVELS}"
+            raise BTClibValueError(err_msg)
+        # the hardening is checked and not merely documented because the
+        # purpose is read off the first index: m/84/0h/0h derives an
+        # account no BIP84 wallet has, and reading 84 out of it would
+        # answer that account with p2wpkh addresses as if they were the
+        # ones a BIP84 wallet watches
+        if any(index < _HARDENED_OFFSET for index in indexes):
+            err_msg = "invalid account path: all three levels must be hardened"
+            raise BTClibValueError(err_msg)
+
+        super().__init__(
+            script_type=(
+                _script_type_from_purpose(indexes[0] - _HARDENED_OFFSET)
+                if script_type is None
+                else script_type
+            ),
+            network=network_from_xkeyversion(xkey.version),
+        )
+
+        self.der_path = str_from_der_path(indexes)
+        self._xkey = self._account_xkey(xkey, indexes)
+        # branch -> the index `next_address` will hand out next, which is
+        # one past the highest handed out so far and not a count of them:
+        # `address(0, 7)` on a fresh keystore leaves the next at 8, so
+        # that a keystore restored by replaying the paths it issued does
+        # not reissue one
+        self._next_index: dict[int, int] = {}
+
+    @staticmethod
+    def _account_xkey(xkey: BIP32KeyData, indexes: list[int]) -> BIP32KeyData:
+        """Return the account key, deriving whatever is left of the path.
+
+        The key may be anywhere on the account path, its depth saying how
+        much of the path is already behind it; what it can be checked
+        against is its own index, which is the path element at that
+        depth. That catches the account xpub paired with the path of
+        another account. It cannot catch a key from another purpose or
+        another coin, an extended key recording nothing about where it
+        came from, so the caller's word is taken for the levels above.
+        """
+        if xkey.depth > _ACCOUNT_LEVELS:
+            err_msg = f"invalid key depth: {xkey.depth} is past the"
+            err_msg += f" {_ACCOUNT_LEVELS} levels of an account path"
+            raise BTClibValueError(err_msg)
+        if xkey.depth and xkey.index != indexes[xkey.depth - 1]:
+            err_msg = f"key index {xkey.index} at depth {xkey.depth}"
+            err_msg += f" is not the account path's {indexes[xkey.depth - 1]}"
+            raise BTClibValueError(err_msg)
+
+        # the public `derive` rather than bip32's private `_derive`: what
+        # it costs is one b58 round trip, once, at construction
+        return BIP32KeyData.b58decode(derive(xkey, indexes[xkey.depth :]))
+
+    @property
+    def is_watch_only(self) -> bool:
+        """Whether the keystore holds no private key at all.
+
+        An xpub account is the watch-only case; a private key handed to
+        `add` alongside it is not derived from the account and does not
+        make the account signable, but it does make the keystore hold key
+        material, which is what this answers.
+        """
+        return not self._xkey.is_private and super().is_watch_only
+
+    def address(self, branch: int, index: int) -> str:
+        """Hand out the address at branch/index, and remember the path.
+
+        Idempotent: asking twice derives twice and records once, the
+        keystore being a function of its key source rather than a
+        generator with a position. `bip32.derive_from_account` is what
+        imposes the bounds -- branch 0 or 1, index at most 65535 -- and
+        the message on a violation is its own.
+        """
+        key = derive_from_account(self._xkey, branch, index)
+        address = _ADDRESS_FROM_SCRIPT_TYPE[self.script_type](key, self.network)
+        der_path = f"{self.der_path}/{branch}/{index}"
+        self._handed_out[address] = AddressInfo(address, self.script_type, der_path)
+        self._next_index[branch] = max(self._next_index.get(branch, 0), index + 1)
+        return address
+
+    def next_address(self, branch: int = 0) -> str:
+        """Hand out the next unused address of a branch."""
+        return self.address(branch, self._next_index.get(branch, 0))
+
+    def prv_key(self, address: String) -> str:
+        """Return the WIF of the private key signing for an address."""
+        info = self.address_info(address)
+        # a key added on its own, which the base class holds and this
+        # keystore cannot derive: it has no path, and the account key is
+        # not its parent
+        if info.address in self._prv_keys:
+            return self._prv_keys[info.address]
+
+        if not self._xkey.is_private:
+            err_msg = "watch-only keystore, no private key for"
+            err_msg += f" {info.address} at {info.der_path}"
+            raise BTClibValueError(err_msg)
+
+        # re-derived rather than cached: the path is the record, and one
+        # source of truth cannot disagree with itself. It also keeps the
+        # keystore holding one private key, the account one, however many
+        # addresses it has handed out
+        branch, index = indexes_from_der_path(info.der_path)[-2:]
+        return b58.wif_from_prv_key(derive_from_account(self._xkey, branch, index))

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -115,6 +115,14 @@ btclib.hashes module
    :undoc-members:
    :show-inheritance:
 
+btclib.keystore module
+----------------------
+
+.. automodule:: btclib.keystore
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 btclib.network module
 ---------------------
 

--- a/tests/keystore_test.py
+++ b/tests/keystore_test.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Tests for the `btclib.keystore` module."""
+
+from __future__ import annotations
+
+import pytest
+
+from btclib.alias import BIP44ScriptType
+from btclib.bip32 import bip32
+from btclib.ecc import bms
+from btclib.exceptions import BTClibValueError
+from btclib.keystore import AddressInfo, BIP32KeyStore, KeyStore
+
+# the "abandon abandon ... about" seed, whose master key BIP84 and BIP86
+# both publish as their rootpriv and whose addresses SLIP132, BIP49,
+# BIP84 and BIP86 publish between them
+_ROOT = "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
+# the same seed on testnet, which is BIP49's own masterseed
+_TROOT = "tprv8ZgxMBicQKsPe5YMU9gHen4Ez3ApihUfykaqUorj9t6FDqy3nP6eoXiAo2ssvpAjoLroQxHqr3R5nE3a5dU3DHTjTgJDd7zrbniJr6nrCzd"
+
+# SLIP132's account keys for purpose 44 and 84, the second spelled with
+# the zprv version bytes that SLIP132 exists to define
+_ACCOUNT_44_XPRV = "xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb"
+_ACCOUNT_44_XPUB = "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj"
+_ACCOUNT_84_ZPRV = "zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE"
+# and the same key with the plain xprv version, which is what
+# `bip32.derive` down m/84h/0h/0h from the master gives
+_ACCOUNT_84_XPRV = "xprv9ybY78BftS5UGANki6oSifuQEjkpyAC8ZmBvBNTshQnCBcxnefjHS7buPMkkqhcRzmoGZ5bokx7GuyDAiktd5HemohAU4wV1ZPMDRmLpBMm"
+
+_MSG = b"Hello, keystore"
+
+# the classic uncompressed WIF of the private key 0x01...01 is not
+# wanted here: this is a random key, compressed and uncompressed
+_WIF_COMPRESSED = "L41XHGJA5QX43QRG3FEwPbqD5BYvy6WxUxqAMM9oQdHJ5FcRHcGk"
+_WIF_UNCOMPRESSED = "5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ"
+_PUB_KEY = "0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c"
+
+
+@pytest.mark.parametrize(
+    ("purpose", "script_type", "addresses"),
+    [
+        pytest.param(
+            44,
+            "p2pkh",
+            (
+                "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA",
+                "1Ak8PffB2meyfYnbXZR9EGfLfFZVpzJvQP",
+                "1J3J6EvPrv8q6AC3VCjWV45Uf3nssNMRtH",
+            ),
+            id="44-p2pkh",
+        ),
+        pytest.param(
+            49,
+            "p2wpkh-p2sh",
+            (
+                "37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf",
+                "3LtMnn87fqUeHBUG414p9CWwnoV6E2pNKS",
+                "34K56kSjgUCUSD8GTtuF7c9Zzwokbs6uZ7",
+            ),
+            id="49-p2wpkh-p2sh",
+        ),
+        pytest.param(
+            84,
+            "p2wpkh",
+            (
+                "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu",
+                "bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g",
+                "bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el",
+            ),
+            id="84-p2wpkh",
+        ),
+        pytest.param(
+            86,
+            "p2tr",
+            (
+                "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr",
+                "bc1p4qhjn9zdvkux4e44uhx8tc55attvtyu358kutcqkudyccelu0was9fqzwh",
+                "bc1p3qkhfews2uk44qtvauqyr2ttdsw7svhkl9nkm9s9c3x4ax5h60wqwruhk7",
+            ),
+            id="86-p2tr",
+        ),
+    ],
+)
+def test_published_vectors(
+    purpose: int, script_type: str, addresses: tuple[str, str, str]
+) -> None:
+    """The addresses BIP49, BIP84, BIP86 and SLIP132 publish.
+
+    Three per purpose: the first two of the receiving branch and the
+    first of the change branch, which is the whole of what BIP84 and
+    BIP86 print. Asserted from the master key and again from the account
+    xpub, the two ends a keystore can be built from.
+    """
+    der_path = f"m/{purpose}h/0h/0h"
+    keystore = BIP32KeyStore(_ROOT, der_path)
+    assert keystore.script_type == script_type
+    assert keystore.network == "mainnet"
+    assert keystore.der_path == der_path
+    assert not keystore.is_watch_only
+
+    assert keystore.next_address() == addresses[0]
+    assert keystore.next_address() == addresses[1]
+    assert keystore.next_address(1) == addresses[2]
+    assert keystore.addresses == addresses
+    assert len(keystore) == 3
+
+    account_xpub = bip32.xpub_from_xprv(bip32.derive(_ROOT, der_path))
+    watching = BIP32KeyStore(account_xpub, der_path)
+    assert watching.is_watch_only
+    assert [watching.address(0, 0), watching.address(0, 1), watching.address(1, 0)] == [
+        *addresses
+    ]
+
+
+def test_bip49_testnet_vector() -> None:
+    """BIP49's own vector, which is the only testnet one published."""
+    keystore = BIP32KeyStore(_TROOT, "m/49h/1h/0h")
+    assert keystore.network == "testnet"
+    assert keystore.script_type == "p2wpkh-p2sh"
+    assert keystore.next_address() == "2Mww8dCYPUpKHofjgcXcBCEGmniw9CoaiD2"
+
+
+def test_the_path_says_the_script_type_and_the_version_bytes_do_not() -> None:
+    """A zprv and an xprv holding one key hand out one set of addresses.
+
+    The alternative -- reading the script type off the SLIP132 version
+    bytes, as `bip32.slip132.address_from_xpub` does -- would make the
+    same account answer one path with two different addresses depending
+    on how the key was spelled, and only one of them would be watched.
+    """
+    from_zprv = BIP32KeyStore(_ACCOUNT_84_ZPRV, "m/84h/0h/0h")
+    from_xprv = BIP32KeyStore(_ACCOUNT_84_XPRV, "m/84h/0h/0h")
+    assert from_zprv.address(0, 0) == from_xprv.address(0, 0)
+    assert from_zprv.address(0, 0) == "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+
+
+def test_a_key_anywhere_on_the_account_path() -> None:
+    """Master, an intermediate level, and the account key itself."""
+    address = "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"
+    for xkey in (
+        _ROOT,
+        bip32.derive(_ROOT, "m/44h"),
+        bip32.derive(_ROOT, "m/44h/0h"),
+        _ACCOUNT_44_XPRV,
+        _ACCOUNT_44_XPUB,
+    ):
+        assert BIP32KeyStore(xkey, "m/44h/0h/0h").next_address() == address
+
+
+def test_a_bip32keydata_is_taken_as_it_is() -> None:
+    xkey = bip32.BIP32KeyData.b58decode(_ACCOUNT_44_XPRV)
+    keystore = BIP32KeyStore(xkey, "m/44h/0h/0h")
+    assert keystore.next_address() == "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"
+
+
+def test_the_key_index_must_be_the_path_element_at_its_depth() -> None:
+    # the account 0 xpub against the path of account 1
+    with pytest.raises(BTClibValueError, match="is not the account path's"):
+        BIP32KeyStore(_ACCOUNT_44_XPUB, "m/44h/0h/1h")
+    # a key already below the account level
+    too_deep = bip32.derive(_ACCOUNT_44_XPUB, "m/0/0")
+    with pytest.raises(BTClibValueError, match="invalid key depth: 5 is past the"):
+        BIP32KeyStore(too_deep, "m/44h/0h/0h")
+
+
+@pytest.mark.parametrize(
+    ("der_path", "err_msg"),
+    [
+        ("m/84h/0h", "invalid account path: 2 levels instead of 3"),
+        ("m/84h/0h/0h/0", "invalid account path: 4 levels instead of 3"),
+        ("m/84/0h/0h", "all three levels must be hardened"),
+        ("m/84h/0/0h", "all three levels must be hardened"),
+        ("m/84h/0h/0", "all three levels must be hardened"),
+    ],
+)
+def test_invalid_account_path(der_path: str, err_msg: str) -> None:
+    with pytest.raises(BTClibValueError, match=err_msg):
+        BIP32KeyStore(_ROOT, der_path)
+
+
+def test_an_unknown_purpose_is_refused_and_script_type_is_the_override() -> None:
+    with pytest.raises(BTClibValueError, match="unknown BIP44 purpose: 45"):
+        BIP32KeyStore(_ROOT, "m/45h/0h/0h")
+    keystore = BIP32KeyStore(_ROOT, "m/45h/0h/0h", "p2wpkh")
+    assert keystore.script_type == "p2wpkh"
+    assert keystore.next_address().startswith("bc1q")
+    # and the override wins over a purpose the table does name
+    assert BIP32KeyStore(_ROOT, "m/84h/0h/0h", "p2pkh").next_address().startswith("1")
+
+
+def test_an_unknown_script_type_is_refused() -> None:
+    with pytest.raises(BTClibValueError, match="unknown script type: p2wsh"):
+        BIP32KeyStore(_ROOT, "m/84h/0h/0h", "p2wsh")  # type: ignore[arg-type]
+    with pytest.raises(BTClibValueError, match="unknown script type: p2wsh"):
+        KeyStore(script_type="p2wsh")  # type: ignore[arg-type]
+    with pytest.raises(BTClibValueError, match="unknown script type: p2wsh"):
+        KeyStore().add(_PUB_KEY, "p2wsh")  # type: ignore[arg-type]
+
+
+def test_an_unknown_network_is_refused() -> None:
+    with pytest.raises(BTClibValueError, match="unknown network: regtest2"):
+        KeyStore(network="regtest2")
+
+
+@pytest.mark.parametrize("purpose", [44, 49, 84])
+def test_sign_by_address_verifies_with_bms(purpose: int) -> None:
+    """The whole point: a signature asked for by address, not by key.
+
+    `bms.verify` is the authority -- it is the code a counterparty runs
+    -- and the address it is given is the one the keystore handed out.
+    """
+    keystore = BIP32KeyStore(_ROOT, f"m/{purpose}h/0h/0h")
+    address = keystore.next_address()
+    sig = keystore.sign(address, _MSG)
+    assert bms.verify(_MSG, address, sig)
+    # and the signature is bms's own, reachable the long way round
+    assert sig == bms.sign(_MSG, keystore.prv_key(address), address)
+
+
+def test_the_recovery_flag_names_the_address_type() -> None:
+    """The address reaches `bms.sign`, not only the key.
+
+    A key alone would produce the compressed p2pkh flag 31..34 for all
+    three; passing the address on is what makes the flag say which
+    address type was signed for, which is BIP137's spelling.
+    """
+    flags = {}
+    for purpose in (44, 49, 84):
+        keystore = BIP32KeyStore(_ROOT, f"m/{purpose}h/0h/0h")
+        address = keystore.next_address()
+        flags[purpose] = keystore.sign(address, _MSG).rf
+    assert 30 < flags[44] < 35
+    assert 34 < flags[49] < 39
+    assert flags[84] > 38
+
+
+def test_bms_cannot_sign_for_a_taproot_address() -> None:
+    """The one script type the keystore hands out and cannot sign for."""
+    keystore = BIP32KeyStore(_ROOT, "m/86h/0h/0h")
+    address = keystore.next_address()
+    with pytest.raises(BTClibValueError, match="BMS cannot sign for a p2tr address"):
+        keystore.sign(address, _MSG)
+    # the key is there all the same: it is the scheme that is missing
+    assert keystore.prv_key(address)
+
+
+def test_a_watch_only_keystore_fails_to_sign_and_says_why() -> None:
+    keystore = BIP32KeyStore(_ACCOUNT_44_XPUB, "m/44h/0h/0h")
+    assert keystore.is_watch_only
+    address = keystore.next_address()
+    err_msg = "watch-only keystore, no private key for"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        keystore.prv_key(address)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        keystore.sign(address, _MSG)
+
+
+def test_a_lookup_miss_raises() -> None:
+    keystore = BIP32KeyStore(_ROOT, "m/84h/0h/0h")
+    # an address of its own chain, not handed out yet: a miss all the
+    # same, the map being what the keystore has issued rather than what
+    # it could issue
+    unissued = BIP32KeyStore(_ROOT, "m/84h/0h/0h").address(0, 7)
+    for address in (unissued, "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"):
+        assert address not in keystore
+        with pytest.raises(BTClibValueError, match="address not in the keystore"):
+            keystore.address_info(address)
+        with pytest.raises(BTClibValueError, match="address not in the keystore"):
+            keystore.sign(address, _MSG)
+    assert keystore.next_address() in keystore
+
+
+def test_the_record_is_the_path_and_no_key_material() -> None:
+    keystore = BIP32KeyStore(_ROOT, "m/84h/0h/0h")
+    address = keystore.address(1, 5)
+    info = keystore.address_info(address)
+    assert info == AddressInfo(address, "p2wpkh", "m/84h/0h/0h/1/5")
+    assert address not in repr(keystore)
+    assert keystore.prv_key(address) not in repr(info)
+    # frozen: what comes out of a keystore is a copy of what it knows
+    with pytest.raises(AttributeError):
+        info.address = "whatever"  # type: ignore[misc]
+
+
+def test_handing_out_is_idempotent_and_ordered() -> None:
+    keystore = BIP32KeyStore(_ROOT, "m/84h/0h/0h")
+    first = keystore.address(0, 0)
+    assert keystore.address(0, 0) == first
+    assert len(keystore) == 1
+    # next_address is one past the highest handed out, not a count
+    keystore.address(0, 7)
+    assert keystore.next_address() == keystore.address(0, 8)
+    assert len(keystore) == 3
+    # the branches count separately
+    assert keystore.next_address(1) == keystore.address(1, 0)
+    assert keystore.addresses[0] == first
+
+
+def test_the_derivation_bounds_are_bip32s_own() -> None:
+    keystore = BIP32KeyStore(_ROOT, "m/84h/0h/0h")
+    with pytest.raises(BTClibValueError, match="not in \\(0, 1\\)"):
+        keystore.address(2, 0)
+    with pytest.raises(BTClibValueError, match="invalid address index"):
+        keystore.address(0, 0x10000)
+
+
+@pytest.mark.parametrize(
+    ("script_type", "address"),
+    [
+        ("p2pkh", "14dD6ygPi5WXdwwBTt1FBZK3aD8uDem1FY"),
+        ("p2wpkh-p2sh", "3G6hxdgC91ETUpsGCrVywYRDZBp8LHarPF"),
+        ("p2wpkh", "bc1qylqhfq22y39xtt8t6vxhf75dwgmes3efag3kry"),
+    ],
+)
+def test_individual_keys(script_type: BIP44ScriptType, address: str) -> None:
+    keystore = KeyStore([_WIF_COMPRESSED], script_type)
+    assert keystore.addresses == (address,)
+    assert not keystore.is_watch_only
+    assert keystore.prv_key(address) == _WIF_COMPRESSED
+    assert keystore.address_info(address) == AddressInfo(address, script_type, "")
+    assert bms.verify(_MSG, address, keystore.sign(address, _MSG))
+
+
+def test_a_key_that_says_what_it_is_by_its_type() -> None:
+    """An int is a scalar, a point is a pair: neither needs the guess."""
+    q = 0xCA978112CA1BBDCAFAC231B39A23DC4DA786EFF8147C4E72B9807785AFEE48BB
+    address = "14dD6ygPi5WXdwwBTt1FBZK3aD8uDem1FY"
+    keystore = KeyStore([q], "p2pkh")
+    assert keystore.addresses == (address,)
+    assert keystore.prv_key(address) == _WIF_COMPRESSED
+
+    point = (
+        0x30D54FD0DD420A6E5F8D3624F5F3482CAE350F79D5F0753BF5BEEF9C2D91AF3C,
+        0x04717159CE0828A7F686C2C7510B7AA7D4C685EBC2051642CCBEBC7099E2F679,
+    )
+    watching = KeyStore([point], "p2wpkh")
+    assert watching.is_watch_only
+    assert watching.addresses == ("bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu",)
+
+
+def test_a_public_key_makes_a_watch_only_entry() -> None:
+    keystore = KeyStore([_PUB_KEY])
+    address = keystore.addresses[0]
+    assert keystore.is_watch_only
+    assert address == "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+    with pytest.raises(BTClibValueError, match="watch-only address, no private key"):
+        keystore.prv_key(address)
+    with pytest.raises(BTClibValueError, match="watch-only address, no private key"):
+        keystore.sign(address, _MSG)
+
+
+def test_an_uncompressed_key_can_only_be_p2pkh() -> None:
+    """Segwit has no uncompressed form, so the address would be a lie."""
+    address = KeyStore([_WIF_UNCOMPRESSED], "p2pkh").addresses[0]
+    assert address == "1GAehh7TsJAHuUAeKZcXf5CnwuGuGgyX2S"
+    for script_type in ("p2wpkh-p2sh", "p2wpkh", "p2tr"):
+        with pytest.raises(BTClibValueError, match="uncompressed key cannot be"):
+            KeyStore([_WIF_UNCOMPRESSED], script_type)
+
+
+def test_add_takes_a_script_type_of_its_own() -> None:
+    keystore = KeyStore(script_type="p2pkh")
+    assert not keystore.addresses
+    assert keystore.is_watch_only
+    p2pkh = keystore.add(_WIF_COMPRESSED)
+    p2wpkh = keystore.add(_WIF_COMPRESSED, "p2wpkh")
+    assert keystore.addresses == (p2pkh, p2wpkh)
+    assert keystore.address_info(p2wpkh).script_type == "p2wpkh"
+    assert not keystore.is_watch_only
+
+
+def test_a_key_added_to_a_bip32_keystore_is_not_derived() -> None:
+    keystore = BIP32KeyStore(_ACCOUNT_44_XPUB, "m/44h/0h/0h")
+    derived = keystore.next_address()
+    added = keystore.add(_WIF_COMPRESSED, "p2pkh")
+    # the account is still watch-only, but the keystore now holds a key
+    assert not keystore.is_watch_only
+    assert keystore.prv_key(added) == _WIF_COMPRESSED
+    assert bms.verify(_MSG, added, keystore.sign(added, _MSG))
+    with pytest.raises(BTClibValueError, match="watch-only keystore"):
+        keystore.prv_key(derived)
+    assert keystore.address_info(added).der_path == ""
+
+
+def test_an_address_is_found_however_it_is_spelled() -> None:
+    keystore = BIP32KeyStore(_ROOT, "m/84h/0h/0h")
+    address = keystore.next_address()
+    for spelling in (address.upper(), f"  {address}  ", address.encode("ascii")):
+        assert spelling in keystore
+        assert keystore.address_info(spelling).address == address
+    # base58 is not case insensitive and is left exactly as it came
+    b58_keystore = BIP32KeyStore(_ROOT, "m/44h/0h/0h")
+    b58_address = b58_keystore.next_address()
+    assert b58_address.upper() not in b58_keystore


### PR DESCRIPTION
`btclib.ecc.bms` names the gap in its own docstring — "at signing time, a
wallet infrastructure is required to access the private key corresponding to
a given address" — and the library had none to reach for, so `sign(address,
msg)` could not exist. `btclib.keystore` is that infrastructure.

## The scope taken, and the scope refused

The issue names the trap and answers it: "wallet" spans a keystore to a
utxo-tracking spender, and the second TODO line suggests the smaller reading.
This is the smaller reading and nothing larger.

**Taken.** A `KeyStore` holds a key source, hands out addresses, remembers
the derivation path of each, and answers which private key signs for one.
`sign(address, msg)` on top, delegating to `bms.sign`.

- `BIP32KeyStore(xkey, "m/84h/0h/0h")` — an extended key anywhere on the
  account path, with whatever is left of the path derived once at
  construction; addresses come from the two unhardened levels BIP44 puts
  under an account. The purpose chooses the encoding as BIP44/49/84/86
  define it: 44 p2pkh, 49 p2wpkh-p2sh, 84 p2wpkh, 86 p2tr
- `KeyStore(keys, script_type)` — individual keys instead, one address each,
  and the base class the derivation is added to
- `keystore.sign(address, msg)` — the lookup, then `bms.sign`. It signs
  nothing itself, and passes the *address* on as well as the key: that is
  what makes the recovery flag name the address type, BIP137's 35..38 for
  the wrapped segwit spelling and 39..42 for the native one, rather than the
  compressed p2pkh flag a key alone produces

**Refused, and said so in the module docstring:** utxo tracking, balances,
transaction building, persistence to disk, encryption at rest. The first
three need a view of the chain btclib does not have and does not fetch; the
last two need a file format and a KDF that would outlive any release
choosing them. Without them a keystore is a pure function of its key
source — same source, same addresses, same order, every time — which is what
makes it testable and keeps its whole state in memory where the caller can
see it. The module is 380 lines including its prose, which is the right
outcome.

## The design decisions

- **A lookup miss raises.** `address_info` on an address the keystore has
  not handed out raises `BTClibValueError`, it does not return `None`. "No
  opinion about this address" and "no key for it" are different answers and
  a `None` collapses them; every other lookup in btclib raises, so a `None`
  here would be the one place a caller has to remember not to use the
  result. `address in keystore` is the question that wants a boolean, and it
  is there.
- **Derived on demand, remembered when handed out.** No gap-limit
  precompute. A gap limit is a *scanning* parameter and means nothing
  without a chain to scan, which is exactly the refused scope; it would also
  cost an EC multiplication per address nobody asked for and still miss
  index N+1. What the map holds is then precisely what the keystore has
  issued, which is the question the issue asks. A consequence worth naming:
  an address of the keystore's own chain that it has not been asked for yet
  is a miss — `address(branch, index)` is what puts one in. Tested.
- **Watch-only is representable and `sign` fails clearly.** An account xpub,
  or a public key, is a first-class keystore: watching is most of what a
  keystore does. `prv_key` and `sign` raise naming the address and the path,
  rather than returning something falsy that a caller who forgets to check
  would publish as a signed message.
- **The script type follows the path, not the SLIP132 version bytes.** The
  alternative — what `bip32.slip132.address_from_xpub` does — would make an
  xprv and a zprv holding one key hand out two different addresses for one
  path, and only one of them would be watched. There is a test asserting the
  two agree.
- **An unknown purpose is refused**, with `script_type` as the explicit
  override. Answering `m/45h/...` with p2pkh would be an address the wallet
  that wrote the path does not watch.
- **p2tr is handed out and cannot be signed for.** BMS recovers an ECDSA
  public key and matches it against a hash160; a taproot output key is
  BIP341's tweaked x-only key, which none of the sixteen recovery flags
  names. `bms` would report "mismatch between private key and address" —
  true of every wrong key and misleading here, where the key is right and
  the scheme is missing — so the keystore pre-empts it and cites BIP322.
- **An uncompressed key can only be p2pkh.** Segwit has no uncompressed
  form, so the three segwit encoders would silently answer one with the
  address of its compressed twin, which `bms` then cannot sign for.
- **Records carry no key material.** `AddressInfo` is frozen and holds the
  address, the script type and the path; the WIF is one call away behind
  `prv_key`, which reads as the request it is. `BIP32KeyStore` re-derives
  rather than caching, so however many addresses it has handed out it holds
  one private key, the account one.

## Overlap with #197 / PR #228 — settled, not pending

Both PRs this branch was written alongside have landed, so the rebase paid
the debts they left rather than deferring them again.

**#228 (`bip44`) landed, so the duplication is gone.** The four-row
`_SCRIPT_TYPE_FROM_PURPOSE`, the four-row `_ADDRESS_FROM_SCRIPT_TYPE`, the
`_p2tr` tweak helper and `_script_type_from_purpose` are all deleted from
`keystore.py`; it imports `bip44`'s instead. One mapping now, backed by
`bip44_purposes.json`, so a purpose added to that file is a purpose a
keystore hands out.

What is deliberately **not** borrowed is `bip44.address_from_der_path`: it
walks all five levels from whatever key it is handed, and a keystore has
already derived down to the account at construction. The two levels left are
`bip32.derive_from_account`, which is also what imposes the branch-0-or-1 and
index-≤-65535 bounds the keystore documents. The module docstring says this,
so the next reader does not re-litigate it.

One change on `bip44`'s side, and it is the only file outside this feature
the branch touches: `_ADDRESS_FROM_SCRIPT_TYPE`'s annotation widens from
`Callable[[str, str], str]` to `Callable[[Key, str], str]`, and `_p2tr` with
it. All four encoders have always accepted a `Key` — `bip44` simply only ever
passes a `str`, having just been through `b58` — and `KeyStore.add` reaches
for the same table with a key that has not. Narrowing it would have made the
table `bip44`'s private business rather than the library's, for no check
gained; `bip44`'s own tests are unaffected.

**#223 landed too**, so the module now uses the new spelling throughout:
`DerPath`, `indexes_from_der_path`, `str_from_der_path`.

Script types are typed `BIP44ScriptType` rather than `str` across the public
surface — `KeyStore.__init__`, `add`, `BIP32KeyStore.__init__` and the
`AddressInfo` field — which is what sharing `bip44`'s Literal-keyed table
buys. mypy strict then proved two things worth recording: the `cast` I first
wrote in `_checked_script_type` is redundant, the membership test on a
`BIP44ScriptType`-keyed dict being enough to narrow a `str`; and the three
deliberate `"p2wsh"` violations in the tests need `# type: ignore[arg-type]`,
which is exactly how `tests/bip44_test.py` already spells the same test.

## Verification

Every gate re-run **after** the rebase and the `bip44` collapse, as
documented, exit code checked rather than filtered output:

| gate | result |
| --- | --- |
| `uv run pytest` | **exit 0** — 15085 passed |
| `uv run pre-commit run --all-files` | **exit 0** — all hooks, mypy strict included |
| `sphinx-build -W --keep-going` (docs job) | **exit 0** — build succeeded |

`btclib/keystore.py` is at **100.00%** statement coverage from
`tests/keystore_test.py` alone, and `tests/bip44_test.py` still passes
untouched against the widened annotation. The docs gate caught a real finding
on the way — a backticked name followed by a suffix, which docutils reads as
an unterminated inline reference — and it is fixed rather than suppressed.

The vectors are the published ones, not self-generated: SLIP132's account
keys and address for purpose 44, BIP49's mainnet address and its own testnet
vector, and BIP84's and BIP86's three addresses each (first two receiving,
first change). Each is asserted from the master key and again from the
account xpub — the two ends a keystore can be built from — and every BMS
signature is checked with btclib's own `bms.verify`.

## The rebase

Rebased onto `dev` at `452c4d5`. The CHANGELOG entry merged without a
conflict, `merge=union` doing its job; the section this PR once carried about
re-deriving the stated counts is **gone and should stay gone**, because
`dev` no longer states a count anywhere and `tests/release_notes_test.py`
now fails on one. (`grep -c '^- ' CHANGELOG.md` is 193, measured, and written
down nowhere.)

`README.md` conflicted twice and both sides were kept:

- the feature list — `dev`'s fee-rate bullet and its `PsbtIn, PsbtOut` typo
  fix, plus this branch's keystore bullet
- the module-layout paragraph — `dev`'s sentence about `bip44` sitting on top
  of everything, with keystore placed one level above it, which is where the
  import direction now actually puts it

Closes #189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a keystore module that provides the wallet infrastructure needed for message signing by address, and document its addition in changelog, README, and history.

New Features:
- Add btclib.keystore module with KeyStore and BIP32KeyStore abstractions to manage addresses from individual keys or BIP32 account paths and retrieve the corresponding signing key.
- Support sign(address, msg) style message signatures by delegating to ecc.bms with address-aware recovery flags.
- Allow construction of watch-only keystores from xpubs or public keys while still tracking derivation paths and address metadata.

Enhancements:
- Document the keystore module and its role within the library in CHANGELOG, README, and HISTORY, including its relationship to bip32, address encodings, and bms message signing.

Tests:
- Add comprehensive keystore_test.py covering published BIP49/BIP84/BIP86 and SLIP132 vectors, derivation behavior, watch-only handling, script-type rules, and BMS integration.
