### PR TITLE
A guide arranged by task, in examples the suite runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2914,6 +2914,39 @@ edit.
 
 ### Documentation and the website
 
+- **The documentation has a page that is not the API reference.** Issue
+  #120 asked for worked examples for beginners — "sending transactions,
+  deriving wallets, etc." — against fifteen pages of `automodule` stanzas
+  that answer "what does this function take" and never "which function do
+  I call". `docs/source/guide.rst` is arranged by task instead of by
+  module: a mnemonic and the seed under it, an account xpub and the
+  BIP44/49/84/86 addresses under that, reading a raw transaction,
+  building one and computing the hash it commits to, signing it and
+  checking the result against btclib's own script interpreter, ECDSA and
+  BIP340 on their own, a message signed with an address, and the BIP174
+  roles. It says the things a reference cannot: that a `str` is hex and
+  not text wherever a signature says `Octets`, which is the first mistake
+  everybody makes; that a WIF is a better private key to hand in than an
+  integer, carrying the network and the compressed flag with it; and what
+  btclib deliberately does not do — no network, no wallet, no persistence,
+  no fee estimation, no coin selection. Every private key on it is a
+  published vector of BIP39, BIP143 or BIP340, so each answer is
+  checkable against the specification that published it, and a warning
+  says as much where a reader would otherwise reuse one
+- **The examples in the documentation are executed, not asserted.** An
+  output pasted by hand is true on the afternoon it was pasted and
+  silently false after the next rename, so every example on the guide
+  page is a doctest and `tests/docs_examples_test.py` runs it: what
+  follows a `>>>` is what the library answered, and drift is a red test
+  rather than something a reader discovers by typing the page in. Which
+  pages are examined is read off the pages — a doctest prompt is what
+  makes one an example page — so the next one is covered without a line
+  here to remember. Not `sphinx-build -b doctest`: that needs a job of
+  its own, reports on one runner, and would have to be added to the
+  branch rule to gate anything, where a test runs on every interpreter of
+  the matrix, is gated by `tests-passed` already, and leaves `uv run
+  pytest` the whole command. No doctest option flags either, elision
+  included: an example checked in part is not the promise the page makes
 - **The `bms` docstring says the message is signed byte-for-byte, and
   that Electrum's gui disagrees.** btclib does not strip whitespace
   from the message — a signature must commit to the exact bytes — and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,6 +303,17 @@ warning. `docs/source/conf.py` resolves those links and suppresses no
 grep asks the same question of the HTML, where no suppression can hide the
 answer.
 
+Both steps ask whether a page renders and whether its links resolve, and
+nothing more. Whether the worked examples on it are still true is a
+different question, asked by `tests/docs_examples_test.py`: any page under
+`docs/source/` carrying a `>>>` prompt is run as a doctest by the suite, so
+an example is edited by running `uv run pytest tests/docs_examples_test.py`
+and pasting back what the library answered — never by writing what it ought
+to answer. Keep them deterministic, which for `ssa.sign` means passing
+`aux` and for a mnemonic means passing the entropy; and keep every key on
+those pages a published test vector, so that a reader who copies one copies
+something already known to the world.
+
 The only check with no local equivalent is CodeQL, which GitHub runs on
 its side; its findings appear under the Security tab.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -270,6 +270,14 @@ and `verify` families now let a `TypeError` out where they used to answer
   is the third scheme beside BIP39 and Electrum, and until now btclib
   could not read a single share of the Shamir backup every Trezor since
   2019 offers.
+- **The documentation has a guide and not only a reference.** A new page
+  arranged by task — a mnemonic and its seed, an account xpub and the
+  BIP44/49/84/86 addresses under it, reading a raw transaction, building
+  one and computing the hash it commits to, ECDSA and BIP340, a signed
+  message, a PSBT — where there had been fifteen pages of `automodule`
+  and nothing to start from (issue #120). Every example on it is a
+  doctest the test suite runs, so what follows a `>>>` is what the
+  library answered rather than what somebody expected it to.
 - **Python 3.10 through 3.14**, free-threaded 3.14t included; 3.7, 3.8 and
   3.9 are gone. 3.9 went end-of-life in 2025-10, and it had become the only
   interpreter pulling a second toolchain into the lock: 35 of 132 packages

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -1,0 +1,706 @@
+A guide by task
+===============
+
+The rest of this documentation is the API reference: it answers "what
+does this function take". This page answers the question before it,
+"which function do I call", and it is arranged by what you want to do
+rather than by which module the code lives in.
+
+Every example below is executed by btclib's own test suite, in
+``tests/docs_examples_test.py``. What you see after a ``>>>`` prompt is
+what the library answered, not what somebody expected it to answer, and
+an example that stops being true fails a test rather than sitting here
+misleading you. So type them in: they work.
+
+.. contents:: On this page
+   :local:
+   :depth: 1
+
+What btclib does, and what it will not do for you
+-------------------------------------------------
+
+btclib is a library about the *cryptography and the encodings* of
+bitcoin. Everything on this page happens in your process, offline. In
+particular btclib does **not**:
+
+- talk to the network. There is no node, no RPC client, no block
+  explorer, no broadcasting. The last example on this page produces a
+  fully signed transaction as hex; putting it on the chain is somebody
+  else's job (``bitcoin-cli sendrawtransaction``, for instance)
+- keep a wallet. Nothing is stored between runs, no key is written to
+  disk, no address is remembered as "yours", nothing tracks which of
+  your outputs are unspent. When an example below needs the output being
+  spent, the example supplies it
+- choose coins, estimate a fee, or pick a change amount. A fee is the
+  difference between what the inputs are worth and what the outputs are
+  worth, and that arithmetic is yours; btclib will happily build a
+  transaction that pays a thousand-bitcoin fee
+- protect your secrets from the machine they are on. Read the
+  `limitations section of SECURITY.md <security_link.html>`_ before you
+  use it with a key that holds value: private keys live in ordinary,
+  immutable python objects that are never zeroized, and — this is the
+  one most people miss — **not every operation reaches the constant-time
+  C library**. secp256k1 signing and generator multiplication are
+  delegated to the libsecp256k1 bindings; another curve, another hash
+  function, a nonce of your own, or a message that is not 32 bytes takes
+  the pure python path instead, which is double-and-add and makes no
+  attempt to be constant-time
+
+.. warning::
+
+   Every private key, WIF and mnemonic on this page is a **published
+   test vector**, copied from BIP-39, BIP-143 or BIP-340 so that you can
+   check btclib's answer against the specification itself. They are
+   known to the whole world. Never send bitcoin to an address derived
+   from any of them, and never reuse one for anything real.
+
+Installing
+~~~~~~~~~~
+
+.. code-block:: shell
+
+   python -m pip install --upgrade btclib
+
+btclib requires python 3.10 or later and pulls in
+``btclib_libsecp256k1``, which is a required dependency and not an
+optional accelerator: installing needs one of its wheels or a C
+toolchain to build it.
+
+.. doctest is the reason the version is asserted loosely: the value
+   moves with every release, and pinning it here would make this page
+   fail on the release commit rather than on a real defect
+
+>>> import btclib
+>>> btclib.__version__.startswith("20")
+True
+
+Which type to pass
+------------------
+
+Most of the public API takes "anything convertible" rather than one
+type, which is friendly once you know the rules and baffling until then.
+There are four aliases, all in :mod:`btclib.alias`, and one rule matters
+more than the rest.
+
+**A ``str`` is hexadecimal, not text.** Anywhere the signature says
+``Octets`` — a message to sign, a script, a hash — a ``str`` is parsed
+with ``bytes.fromhex``. This is the single most common first mistake:
+
+>>> from btclib.ecc import dsa
+>>> dsa.sign("hello world", 1)
+Traceback (most recent call last):
+ValueError: non-hexadecimal number found in fromhex() arg at position 0
+
+Pass ``bytes`` when you mean text, and let the hex spelling be for
+things that really are bytes:
+
+>>> sig = dsa.sign(b"hello world", 1)
+>>> type(sig).__name__
+'Sig'
+
+The four aliases:
+
+``Octets = bytes | str``
+    Bytes, or their hex spelling. Blanks inside the hex string are
+    allowed, so ``"02 cc71eb30..."`` is fine. Use
+    ``btclib.utils.bytes_from_octets`` to normalize one yourself.
+
+``String = bytes | str``
+    The same two types, read the other way round: here a ``str`` is
+    *text*, and this is what addresses, WIFs and extended keys are. The
+    alias a function names tells you which reading applies.
+
+``PrvKey``
+    An ``int``, an ``Octets`` scalar, a WIF, a BIP32 ``xprv``, or a
+    ``BIP32KeyData``. **Prefer the WIF or the extended key.** They carry
+    the network and the compressed-public-key flag with them, so
+    ``b58.p2pkh(wif)`` knows which address to build; a bare integer
+    carries neither and everything downstream has to assume mainnet and
+    compressed.
+
+``Key``
+    A public key in any of its spellings — SEC bytes compressed or not,
+    an ``(x, y)`` tuple, an ``xpub`` — and also anything that is a
+    ``PrvKey``, from which the public key is computed. Convert once with
+    ``btclib.to_pub_key.pub_keyinfo_from_key`` if you are about to use
+    it repeatedly.
+
+>>> from btclib import b58
+>>> wif = b58.wif_from_prv_key(1)
+>>> wif
+'KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU73sVHnoWn'
+>>> b58.p2pkh(wif)
+'1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH'
+>>> b58.p2pkh(1)
+'1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH'
+>>> b58.wif_from_prv_key(1, compressed=False)
+'5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAnchuDf'
+>>> b58.p2pkh(b58.wif_from_prv_key(1, compressed=False))
+'1EHNa6Q4Jz2uvNExL497mE43ikXhwF6kZm'
+
+The same scalar, three addresses: the WIF is what remembers whether the
+public key was compressed, and the address follows from that.
+
+A mnemonic, and the seed underneath it
+--------------------------------------
+
+A BIP-39 mnemonic is a human-transcribable encoding of some entropy,
+with a checksum so that a typo is caught. :mod:`btclib.mnemonic.bip39`
+is the whole of it.
+
+To make a fresh one, pass nothing and the operating system's ``secrets``
+module supplies the entropy:
+
+>>> from btclib.mnemonic import bip39
+>>> words = bip39.mnemonic_from_entropy()
+>>> len(words.split())
+12
+
+That one is genuinely random, so this page cannot show you its value.
+The rest of this section uses BIP-39's own first test vector — sixteen
+zero bytes — which is why you may recognize it:
+
+>>> mnemonic = bip39.mnemonic_from_entropy(bytes.fromhex("00" * 16))
+>>> mnemonic
+'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+Note the ``bytes.fromhex``. ``mnemonic_from_entropy`` takes ``Entropy``,
+where a ``str`` is a *binary* ``0``/``1`` string rather than hex, so the
+hex spelling has to be decoded first:
+
+>>> bip39.entropy_from_mnemonic(mnemonic)
+'00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000'
+
+128 bits, and they round-trip. More entropy means more words: 128 bits
+gives 12, 256 bits gives 24.
+
+>>> len(bip39.mnemonic_from_entropy(bytes.fromhex("00" * 32)).split())
+24
+
+The checksum is what catches a backup written down wrong, and it is
+checked on the way back in:
+
+>>> bip39.entropy_from_mnemonic(mnemonic.replace("about", "abandon"))
+Traceback (most recent call last):
+btclib.exceptions.BTClibValueError: invalid checksum: 0000; expected: 0011
+
+From mnemonic to seed is PBKDF2 with 2048 iterations, salted with the
+string ``"mnemonic"`` and the passphrase:
+
+>>> seed = bip39.seed_from_mnemonic(mnemonic, "TREZOR")
+>>> seed.hex()
+'c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f001698e7463b04'
+
+That is byte for byte BIP-39's published seed for this mnemonic and this
+passphrase, which is the point of using a vector.
+
+The passphrase is not a password on the mnemonic: it is an input to the
+derivation, so every passphrase yields a different, equally valid
+wallet, and there is nothing anywhere that can tell you a passphrase was
+wrong.
+
+>>> bip39.seed_from_mnemonic(mnemonic, "").hex()[:32]
+'5eb00bbddcf069084889a8ab91555681'
+>>> bip39.seed_from_mnemonic(mnemonic, "TREZOR") == seed
+True
+
+The root extended private key is the seed run through BIP-32, and
+``mxprv_from_mnemonic`` does both steps:
+
+>>> rootxprv = bip39.mxprv_from_mnemonic(mnemonic, "TREZOR")
+>>> rootxprv
+'xprv9s21ZrQH143K3h3fDYiay8mocZ3afhfULfb5GX8kCBdno77K4HiA15Tg23wpbeF1pLfs1c5SPmYHrEpTuuRhxMwvKDwqdKiGJS9XFKzUsAF'
+
+btclib does not store that anywhere. It is a string in your process, and
+what happens to it next is entirely yours.
+
+An account, its xpub, and the addresses under it
+------------------------------------------------
+
+:mod:`btclib.bip32.bip32` derives keys along a path. ``derive`` takes an
+extended key and a path and hands back another extended key, as a
+string:
+
+>>> from btclib import bip32
+>>> account = bip32.derive(rootxprv, "m/84h/0h/0h")
+>>> xpub = bip32.xpub_from_xprv(account)
+>>> xpub
+'xpub6Crgkie5Rb7wDabkf4Uf6A2qnuERMA3p2QrnmHNQDrsXTaGvz9zugU38Apne8WqrcbSjdLwbhtfHrzWjNCJPVAkkNoQhMfzhBm8rKMA8KxH'
+
+Paths are case-, blank- and slash-insensitive, and hardening may be
+written ``h``, ``H`` or ``'``. The apostrophe is the one from the
+specifications and the one that needs escaping in a shell, so ``h`` is
+usually the easier spelling:
+
+>>> bip32.derive(rootxprv, "m/84'/0'/0'") == account
+True
+>>> bip32.derive(rootxprv, [0x80000054, 0x80000000, 0x80000000]) == account
+True
+
+The account **xpub** is the useful object: it derives every receiving
+and change address of that account and cannot produce a single private
+key. That is what you copy onto the machine that watches the balance.
+
+``derive_from_account`` is the two remaining levels, and it refuses the
+mistakes that make this dangerous — it insists the account key be
+hardened, that the branch be ``0`` (receive) or ``1`` (change), and that
+the index be sane:
+
+>>> bip32.derive_from_account(xpub, 0, 0)
+'xpub6FoBDgKSsn7RYSaiPAFqm476huu2RpAd2XswekGkmvNDRXvvvuqwSLXg1gvaSby83KTLrFNzXCp1gH4V2JJzMJryGNv7gE2Uk4kd8JXmvEF'
+>>> bip32.derive_from_account(xpub, 2, 0)
+Traceback (most recent call last):
+btclib.exceptions.BTClibValueError: invalid branch number: 2 not in (0, 1)
+
+The four address flavours
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Which address a key becomes is a separate decision from where the key
+came from, and BIP-44/49/84/86 are the convention that ties a purpose
+number to a script type. btclib does not enforce the tie — you pick the
+path, then you pick the address function — but following it is what lets
+another wallet find your coins from the same mnemonic.
+
+>>> from btclib import b32, b58
+>>> from btclib.script import taproot
+>>> for purpose, address in [
+...     (44, lambda k: b58.p2pkh(k)),
+...     (49, lambda k: b58.p2wpkh_p2sh(k)),
+...     (84, lambda k: b32.p2wpkh(k)),
+...     (86, lambda k: b32.p2tr(taproot.output_pubkey(k)[0])),
+... ]:
+...     acct = bip32.xpub_from_xprv(bip32.derive(rootxprv, f"m/{purpose}h/0h/0h"))
+...     print(purpose, address(bip32.derive_from_account(acct, 0, 0)))
+44 1PEha8dk5Me5J1rZWpgqSt5F4BroTBLS5y
+49 3Aho3kS7vgVWKTpRHjcqBoPXiCujiSuTaZ
+84 bc1qv5rmq0kt9yz3pm36wvzct7p3x6mtgehjul0feu
+86 bc1p3ryfth56dp058avv97ppn065ctsk263puvwp4rcka3wpg6cudp9qd3jsuu
+
+The taproot one is the odd one out and deliberately so: a BIP-86 address
+is not the hash of the key but the key *tweaked* by a commitment to an
+empty script tree, which ``taproot.output_pubkey`` computes. It returns
+the 32-byte x-only output key and the parity bit that spending it needs.
+
+SLIP-132 version bytes
+~~~~~~~~~~~~~~~~~~~~~~
+
+Some wallets label an account key by script type, spelling it ``ypub``
+or ``zpub`` instead of ``xpub``. That is SLIP-132, and it changes four
+version bytes and nothing else. :mod:`btclib.bip32.slip132` takes the
+**root** key and does the derivation itself, because the version and the
+path have to agree:
+
+>>> from btclib.bip32 import slip132
+>>> bip32.xpub_from_xprv(slip132.p2wpkh_xkey(rootxprv))
+'zpub6rXDN3yuixCtvAyzKn3uWLDr8qXKEQ2orduEL5AAysdHZmuPVUL2vbMQDEhp8L9hRsgM8J8idDNPdZjrob8R5e7x7UoYXVdfjDG96TLa7La'
+>>> bip32.xpub_from_xprv(slip132.p2wpkh_p2sh_xkey(rootxprv))
+'ypub6XRZqAj8R959SPF3UeP8gLsosvY7dskBv68N1rtd6pBwRwvAYJob7XS2VdxawoSdBdNEi32eQatwPBm412BZyfig481iqZKgseAZbdQdmMK'
+
+Hand it something that is not a root key and it says so rather than
+guessing:
+
+>>> slip132.p2wpkh_xkey(xpub)
+Traceback (most recent call last):
+btclib.exceptions.BTClibValueError: not a root key: depth 3, parent fingerprint 0xa40176dc
+
+Addresses and the scripts behind them
+-------------------------------------
+
+An address is a script in disguise. :class:`btclib.script.script_pub_key.ScriptPubKey`
+is the thing itself, and it converts both ways:
+
+>>> from btclib.script.script_pub_key import ScriptPubKey
+>>> script_pub_key = ScriptPubKey.from_address(
+...     "bc1qv5rmq0kt9yz3pm36wvzct7p3x6mtgehjul0feu"
+... )
+>>> script_pub_key.script.hex()
+'00146507b03ecb290510ee3a730585f83136b6b466f2'
+>>> script_pub_key.type
+'p2wpkh'
+>>> script_pub_key.asm
+['OP_0', '6507B03ECB290510EE3A730585F83136B6B466F2']
+>>> script_pub_key.address
+'bc1qv5rmq0kt9yz3pm36wvzct7p3x6mtgehjul0feu'
+
+The network is carried by the object, so a testnet address decodes to a
+testnet script and encodes back to the same address.
+
+Reading a raw transaction
+-------------------------
+
+:class:`btclib.tx.tx.Tx` parses the wire format, hex or bytes. The one
+below is BIP-143's worked example, unsigned:
+
+>>> from btclib.tx import Tx
+>>> raw = (
+...     "0100000002fff7f7881a8099afa6940d42d1e7f6362bec38171ea3edf433541db4"
+...     "e4ad969f0000000000eeffffffef51e1b804cc89d182d279655c3aa89e815b1b30"
+...     "9fe287d9b2b55d57b90ec68a0100000000ffffffff02202cb206000000001976a9"
+...     "148280b37df378db99f66f85c95a783a76ac7a6d5988ac9093510d000000001976"
+...     "a9143bde42dbee7e4dbe6a21b2d50ce2f0167faa815988ac11000000"
+... )
+>>> tx = Tx.parse(raw)
+>>> tx.version
+1
+>>> tx.lock_time
+17
+>>> len(tx.vin), len(tx.vout)
+(2, 2)
+
+The identifier is a property, and it is reversed on the way out because
+that is how bitcoin displays a hash:
+
+>>> tx.id.hex()
+'3335ffae0df20c5407e8de12b49405c8e912371f00fe4132bfaf95ad49c40243'
+>>> tx.size, tx.vsize, tx.weight
+(160, 160, 640)
+
+Watch the parentheses here. ``id``, ``hash``, ``size``, ``vsize``,
+``weight`` and ``vwitness`` are properties; ``is_segwit`` and
+``is_coinbase`` are methods and need calling. Forgetting the call gives
+you a bound method, which is truthy, which is the sort of bug that
+passes review:
+
+>>> tx.is_segwit()
+False
+
+An input names the output it spends. The transaction id inside
+``OutPoint`` is stored in wire order, so it reads back reversed from
+what a block explorer shows:
+
+>>> tx.vin[0].prev_out.tx_id.hex()
+'9f96ade4b41d5433f4eda31e1738ec2b36f6e7d1420d94a6af99801a88f7f7ff'
+>>> tx.vin[0].prev_out.vout
+0
+>>> hex(tx.vin[0].sequence)
+'0xffffffee'
+
+An output is an amount in satoshi and a script, and the script knows its
+own address:
+
+>>> tx.vout[0].value
+112340000
+>>> tx.vout[0].script_pub_key.type
+'p2pkh'
+>>> tx.vout[0].script_pub_key.address
+'1Cu32FVupVCgHkMMRJdYJugxwo2Aprgk7H'
+>>> tx.vout[1].script_pub_key.address
+'16TZ8J6Q5iZKBWizWzFAYnrsaox5Z5aBRV'
+
+Serialization is exact — what went in comes back out:
+
+>>> tx.serialize(include_witness=True).hex() == raw
+True
+
+``to_dict`` gives the shape ``bitcoin-cli decoderawtransaction`` gives,
+which is handy for eyeballing:
+
+>>> sorted(tx.to_dict())
+['hash', 'locktime', 'size', 'txid', 'version', 'vin', 'vout', 'vsize', 'weight']
+
+Building a transaction
+----------------------
+
+A transaction is four fields, and btclib does not hide any of them.
+Amounts are integers in satoshi throughout: there is no float anywhere
+in the library, on purpose.
+
+>>> from btclib.tx import OutPoint, TxIn, TxOut
+>>> funding = OutPoint(
+...     bytes.fromhex(
+...         "8ac60eb9575db5b2d987e29f301b5b819ea83a5c6579d282d189cc04b8e151ef"
+...     ),
+...     1,
+... )
+>>> tx_in = TxIn(funding, b"", 0xFFFFFFFF)
+>>> tx_out = TxOut.from_address(599000000, "bc1qr583w2swedy2acd7rung055k8t3n7udp7vyzyg")
+>>> unsigned = Tx(1, 0, [tx_in], [tx_out])
+>>> unsigned.serialize(include_witness=True).hex()
+'0100000001ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff01c003b423000000001600141d0f172a0ecb48aee1be1f2687d2963ae33f71a100000000'
+
+There is no fee field. The fee is what the inputs are worth minus what
+the outputs are worth, and btclib cannot compute the first half — the
+value of an input lives in the *previous* transaction, which is not in
+this one. You have to supply it:
+
+>>> prevout = TxOut.from_address(600000000, "bc1qr583w2swedy2acd7rung055k8t3n7udp7vyzyg")
+>>> prevout.value - unsigned.vout[0].value
+1000000
+
+The hash that gets signed
+-------------------------
+
+A signature does not sign the transaction; it signs a hash derived from
+it, and *which* hash depends on the script type of the output being
+spent, on the sighash flags, and — for segwit — on the amount. Getting
+this wrong is the classic way to produce a signature that verifies
+against nothing.
+
+:func:`btclib.script.sig_hash.from_tx` is the function to call: give it
+the outputs being spent, the transaction, which input, and the hash
+type, and it dispatches to the legacy, segwit v0 or taproot rule for
+you.
+
+>>> from btclib.script import sig_hash
+>>> sig_hash.from_tx([prevout], unsigned, 0, 0x01).hex()
+'8feec313e988999f1db646742b8a287269d10706cd086f8cda79aa491cc843af'
+
+Check that it agrees with the specification. BIP-143 publishes both the
+transaction and the hash for its native-P2WPKH example, so btclib's
+answer has something to be right about:
+
+>>> from btclib.script.script_pub_key import ScriptPubKey
+>>> bip143_prevouts = [
+...     TxOut(
+...         625000000,
+...         ScriptPubKey(
+...             "2103c9f4836b9a4f77fc0d81f7bcb01b7f1b35916864b9476c241ce9fc198bd25432ac"
+...         ),
+...     ),
+...     TxOut(600000000, ScriptPubKey("00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1")),
+... ]
+>>> sig_hash.from_tx(bip143_prevouts, tx, 1, 0x01).hex()
+'c37af31116d1b27caf68aae9e3ac82f1477929014d5b917657d0eb49478cb670'
+
+That is BIP-143's published ``sigHash``. The hash type ``0x01`` is
+``SIGHASH_ALL``; ``btclib.script.sig_hash`` names the others
+(``NONE``, ``SINGLE``, ``ANYONECANPAY``).
+
+Signing, and checking the result without a node
+-----------------------------------------------
+
+The private key below is BIP-143's, published in the specification.
+
+>>> prv_key = "619c335025c7f4012e556c2a58b2506e30b8511b53ade95ea316fd8c3286feb9"
+>>> from btclib.to_pub_key import pub_keyinfo_from_prv_key
+>>> pub_key = pub_keyinfo_from_prv_key(prv_key)[0]
+>>> pub_key.hex()
+'025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357'
+>>> b32.p2wpkh(prv_key)
+'bc1qr583w2swedy2acd7rung055k8t3n7udp7vyzyg'
+
+Sign the hash from the previous section. Note ``sign_``, with the
+trailing underscore: throughout btclib that suffix means "the caller has
+already reduced the input with the hash function". ``dsa.sign`` would
+hash its argument again, which is not what you want here — the sighash
+*is* the message.
+
+>>> from btclib.ecc import dsa
+>>> msg_hash = sig_hash.from_tx([prevout], unsigned, 0, 0x01)
+>>> sig = dsa.sign_(msg_hash, prv_key)
+>>> sig.serialize().hex()
+'3045022100f6e18672602b1c3cbbd13695c5d83f2d6271b9427836e718de7bc69b1593a222022071f1c0677de22fa18c65e6da25ab68de6280c97b63a1b6fc1c21ba404d6dbe9c'
+
+The nonce is RFC-6979 deterministic and the ``s`` value is the canonical
+low one, so this signature is the same on every machine and every run.
+btclib never invents randomness for an ECDSA signature.
+
+A segwit v0 input is spent with a witness, not with a script_sig: the
+DER signature with the hash type appended, then the public key.
+
+>>> from btclib.script.witness import Witness
+>>> signed = Tx(1, 0, [TxIn(funding, b"", 0xFFFFFFFF)], [tx_out])
+>>> signed.vin[0].script_witness = Witness([sig.serialize() + b"\x01", pub_key])
+>>> signed.is_segwit()
+True
+>>> signed.serialize(include_witness=True).hex()
+'01000000000101ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff01c003b423000000001600141d0f172a0ecb48aee1be1f2687d2963ae33f71a102483045022100f6e18672602b1c3cbbd13695c5d83f2d6271b9427836e718de7bc69b1593a222022071f1c0677de22fa18c65e6da25ab68de6280c97b63a1b6fc1c21ba404d6dbe9c0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635700000000'
+
+Now the two identifiers differ, which is what segwit bought: the witness
+is not covered by the txid.
+
+>>> signed.id.hex()
+'4ebbcec1c2b21740e5e4ffe6aaffe485f6285e7afcbce3130cf34cee05d653c7'
+>>> signed.hash.hex()
+'35c212ed54735c3677aadc9271d1fff153b6e06daea3341ef36323967f5833f2'
+>>> signed.id == unsigned.id
+True
+>>> signed.size, signed.vsize, signed.weight
+(192, 110, 438)
+
+Finally, do not take your own word for it. btclib ships a script
+interpreter, so the transaction can be verified against the outputs it
+spends before it goes anywhere near a node:
+:func:`btclib.script.engine.verify_transaction` raises on a bad one and
+returns ``None`` on a good one.
+
+>>> from btclib.script.engine import verify_transaction
+>>> verify_transaction([prevout], signed)
+
+Change one satoshi of the output and the signature no longer covers it.
+``TxOut`` is a frozen dataclass, so tampering means building another one
+rather than assigning to a field — which is the library saying that an
+output you have already signed over is not yours to edit:
+
+>>> tampered = Tx(1, 0, [TxIn(funding, b"", 0xFFFFFFFF)], [TxOut.from_address(
+...     599000001, "bc1qr583w2swedy2acd7rung055k8t3n7udp7vyzyg"
+... )])
+>>> tampered.vin[0].script_witness = signed.vin[0].script_witness
+>>> verify_transaction([prevout], tampered)
+Traceback (most recent call last):
+btclib.exceptions.BTClibValueError: false top stack element
+
+Signatures on their own
+-----------------------
+
+The two schemes live in :mod:`btclib.ecc.dsa` (ECDSA, what pre-taproot
+bitcoin uses) and :mod:`btclib.ecc.ssa` (BIP-340 Schnorr, what taproot
+uses). Both come in two spellings, and the difference is the trailing
+underscore: ``sign`` hashes its argument for you, ``sign_`` takes the
+hash.
+
+ECDSA
+~~~~~
+
+>>> from btclib.ecc import dsa
+>>> sig = dsa.sign(b"Satoshi Nakamoto", prv_key)
+>>> sig.serialize().hex()
+'3045022100f297566536c80c492421e0e8b4df4749e8e31ab70700519b3b123776823cd6950220627e8c87a97fe41e4a86f2ecfabec52b39a0ab6868617b39bd748d84fabec702'
+>>> dsa.verify(b"Satoshi Nakamoto", pub_key, sig)
+True
+>>> dsa.verify(b"satoshi nakamoto", pub_key, sig)
+False
+
+Verification returns a bool and never raises, which is what you want in
+a loop over untrusted input; ``dsa.assert_as_valid`` is the spelling
+that raises with a reason, for when you want to know why.
+
+BIP-340 Schnorr
+~~~~~~~~~~~~~~~
+
+BIP-340 keys are x-only: 32 bytes, with the y coordinate implied even.
+``gen_keys`` returns the scalar and that x coordinate.
+
+>>> from btclib.ecc import ssa
+>>> q, x_Q = ssa.gen_keys(
+...     "B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF"
+... )
+>>> x_Q.to_bytes(32, "big").hex().upper()
+'DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659'
+
+Unlike ECDSA, a BIP-340 nonce mixes in auxiliary randomness, so
+``ssa.sign`` is **not** deterministic unless you supply the ``aux``
+argument. Supplying it is what makes the example below reproducible, and
+it is exactly what BIP-340's test vector 1 does:
+
+>>> aux = "0000000000000000000000000000000000000000000000000000000000000001"
+>>> msg = "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89"
+>>> sig = ssa.sign_(msg, "B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF", aux)
+>>> sig.serialize().hex().upper()
+'6896BD60EEAE296DB48A229FF71DFE071BDE413E6D43F917DC8DCF8C78DE33418906D11AC976ABCCB20B091292BFF4EA897EFCB639EA871CFA95F6DE339E4B0A'
+>>> ssa.verify_(msg, x_Q, sig)
+True
+
+That is BIP-340's published signature for vector 1. In production leave
+``aux`` alone and let ``secrets`` fill it: the randomness is a defence
+against fault attacks, and the signature is valid either way.
+
+Signing a message with an address
+---------------------------------
+
+:mod:`btclib.ecc.bms` is the "sign this text with the key behind this
+address" scheme that wallets expose. It prefixes the message with the
+magic string ``"Bitcoin Signed Message:\n"``, signs the hash with ECDSA,
+and serializes the result as 65 fixed bytes — a recovery flag, then
+``r``, then ``s`` — base64-encoded. The public key is not transmitted:
+verification recovers it from the signature and checks that it hashes to
+the address.
+
+The message is ``Octets``, so text has to be ``bytes``. It is signed
+byte for byte, with no trimming of your own.
+
+>>> from btclib.ecc import bms
+>>> wif = b58.wif_from_prv_key(prv_key)
+>>> address = b58.p2pkh(wif)
+>>> address
+'13eeg4y5wYGxNTxBEuWLPFauoMJQLxdoip'
+>>> signature = bms.sign(b"paid invoice 42 on 2026-01-01", wif)
+>>> signature.b64encode()
+'IPn1BZ4xi86uCS5NrSrX+2g+RSsHgm94QX5+krikMl4Fd25te6nrF53iI9amQ5XtAcM4fMggHPybYOxufoR8MVA='
+>>> bms.verify(b"paid invoice 42 on 2026-01-01", address, signature)
+True
+>>> bms.verify(b"paid invoice 43 on 2026-01-01", address, signature)
+False
+
+The recovery flag encodes both which of the recovered public keys is the
+right one and what kind of address it is; ``31`` to ``34`` mean a
+compressed p2pkh key, which Electrum also accepts for p2wpkh and
+p2wpkh-p2sh.
+
+>>> signature.rf
+32
+
+The whole point of the scheme is proving control of an address, so sign
+something that cannot be replayed out of context: a date, a
+counterparty, and what the statement is for. The module docstring of
+:mod:`btclib.ecc.bms` says the same at more length, and it is worth
+reading before you use this for anything that matters.
+
+Partially signed transactions
+-----------------------------
+
+A PSBT (BIP-174) is the container that lets an unsigned transaction, the
+data needed to sign it, and the signatures themselves travel between
+programs that do not trust each other — a watch-only wallet, a hardware
+signer, a coordinator. BIP-174 describes the work as *roles*, and
+:mod:`btclib.psbt.psbt` gives you the data structure for each of them,
+not a wallet that plays them.
+
+**Creator.** From an unsigned transaction:
+
+>>> from btclib.psbt import Psbt
+>>> psbt = Psbt.from_tx(unsigned)
+>>> psbt.b64encode()
+'cHNidP8BAFIBAAAAAe9R4bgEzInRgtJ5ZVw6qJ6BWxswn+KH2bK1XVe5DsaKAQAAAAD/////AcADtCMAAAAAFgAUHQ8XKg7LSK7hvh8mh9KWOuM/caEAAAAAAAAA'
+>>> len(psbt.inputs), len(psbt.outputs)
+(1, 1)
+
+**Updater.** A signer cannot compute a segwit sighash without the amount
+being spent, and the amount is not in the transaction, so the updater
+puts it in:
+
+>>> psbt.inputs[0].witness_utxo = prevout
+>>> psbt.inputs[0].witness_utxo.value
+600000000
+
+**Signer.** btclib does not sign a PSBT for you — it has no idea which
+keys are yours. You compute the sighash and put the signature in the
+slot BIP-174 defines for it, keyed by public key, with the hash type
+appended:
+
+>>> msg_hash = sig_hash.from_tx([prevout], psbt.tx, 0, 0x01)
+>>> der = dsa.sign_(msg_hash, prv_key).serialize()
+>>> psbt.inputs[0].partial_sigs = {pub_key: der + b"\x01"}
+>>> psbt.assert_signable()
+
+A PSBT survives base64 round-tripping, which is how it moves between
+programs:
+
+>>> Psbt.b64decode(psbt.b64encode()) == psbt
+True
+
+**Finalizer and Extractor.** ``finalize_psbt`` turns the partial
+signatures into a final script_sig or witness and ``extract_tx`` pulls
+out the network transaction. Be aware of the shape they handle: they
+build what BIP-174's own vectors need, which are p2sh and p2wsh
+multisig, and they do not know that a bare p2wpkh input wants its
+signature in the witness rather than in the script_sig. For a
+single-key segwit input, build the witness yourself as the previous
+section does — two stack items, signature then public key — and use
+``verify_transaction`` to check the result.
+
+Where to go next
+----------------
+
+- the `README <readme_link.html>`_ lists every feature, and its module
+  layout table is the fastest way to guess where something lives
+- `SECURITY.md <security_link.html>`_ has the limitations in full; read
+  it before trusting any of this with value
+- the API reference under :doc:`PYTHON PACKAGE <modules>` documents
+  every module. The docstrings carry the reasoning, not just the
+  signatures
+- the test suite is the second half of the documentation. ``tests/``
+  mirrors ``btclib/`` and reproduces the published vectors of the BIPs,
+  of RFC 6979 and of Bitcoin Core, so if you want to know exactly what
+  btclib promises about something, the test for it is where it is
+  written down

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ Welcome to btclib's documentation
    :caption: Contents:
 
    README <readme_link.md>
+   GUIDE <guide>
    PYTHON PACKAGE <modules>
    CONTRIBUTING <contributing_link.md>
    SECURITY <security_link.md>

--- a/tests/docs_examples_test.py
+++ b/tests/docs_examples_test.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Every example in the documentation is what the library answers.
+
+A page of worked examples is a promise, and prose cannot keep it: an
+output pasted by hand is true on the afternoon it was pasted and silently
+false after the next rename. Written as doctests the examples are run --
+here, by the suite -- so a drifted example is a red test rather than a
+lie a reader discovers by typing it.
+
+A test rather than `sphinx-build -b doctest`. It needs no environment the
+suite does not already have, it runs on every interpreter of the matrix
+instead of on one runner, `tests-passed` gates it without a line being
+added to any `needs` list, and `uv run pytest` stays the whole command.
+The docs build has its own job and asks a different question -- whether
+the page renders -- so neither covers the other.
+
+Which pages are examined is read off the pages: a doctest prompt is what
+makes one an example page, and the api reference stanzas have none. That
+way a page added under `docs/source/` is covered the moment it carries an
+example, with nothing here to remember to update.
+"""
+
+import doctest
+import io
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+_DOCS_DIR = Path(__file__).parents[1] / "docs" / "source"
+_PROMPT = ">>> "
+
+
+def _pages_with_examples() -> list[str]:
+    """The names of the documentation pages that carry doctests."""
+    return sorted(
+        page.name
+        for page in _DOCS_DIR.glob("*.rst")
+        if _PROMPT in page.read_text(encoding="utf-8")
+    )
+
+
+@pytest.mark.parametrize("page_name", _pages_with_examples())
+def test_the_examples_are_what_the_library_answers(page_name: str) -> None:
+    # doctest reports a failure by writing a diff, and the diff is the
+    # whole value of running it: captured here so that it reaches the
+    # assertion message instead of pytest's captured-stdout section,
+    # which xdist does not always show for a parametrized case
+    report = io.StringIO()
+    with redirect_stdout(report):
+        results = doctest.testfile(
+            str(_DOCS_DIR / page_name),
+            module_relative=False,
+            encoding="utf-8",
+            # no optionflags: an example whose output is elided is an
+            # example checked in part, and the point of this file is that
+            # a reader can type the page in and get the page back. Where
+            # a long exception message would make that unreasonable the
+            # page carries an inline "# doctest:" directive, which is
+            # visible in the rendered documentation and therefore
+            # reviewable
+        )
+    assert results.attempted, f"no example ran in {page_name}"
+    assert not results.failed, report.getvalue()
+
+
+def test_the_pages_were_found_at_all() -> None:
+    """Guard the test above against passing vacuously.
+
+    An empty parameter set is a skip, which reads as green: a wrong
+    `_DOCS_DIR`, or a page that stops being reST, would silently stop
+    checking every example in the documentation. The wheel ships no
+    tests, so this file only ever runs from a source tree or an sdist,
+    and both carry `docs/`.
+    """
+    assert _DOCS_DIR.is_dir()
+    assert _pages_with_examples()


### PR DESCRIPTION
Closes #120.

The issue asked for "a detailed example document to help beginners
learn BTC better. For example, sending transactions, deriving wallets,
etc." Today `docs/source/` is fifteen pages of `automodule` stanzas:
they answer "what does this function take" and never "which function do
I call".

## What the guide covers

One new page, `docs/source/guide.rst`, wired into the toctree between
README and PYTHON PACKAGE, arranged by what a reader wants to do:

- what btclib will *not* do — no network, no wallet, no persistence, no
  fee estimation, no coin selection — and a pointer into SECURITY.md's
  limitations, including the one people miss: not every operation
  reaches the constant-time C library
- which of several accepted input types to prefer: that a `str` is hex
  and not text wherever a signature says `Octets` (the first mistake
  everybody makes, shown as a traceback), and that a WIF or an extended
  key is a better `PrvKey` than an integer because it carries the
  network and the compressed flag
- a mnemonic, its checksum, the passphrase, and the seed under it
- an account xpub and the BIP44/49/84/86 addresses under it, plus
  SLIP-132 `ypub`/`zpub` and why they take the *root* key
- addresses and the scripts behind them
- reading a raw transaction — including that `id`/`size`/`vsize` are
  properties while `is_segwit()` is a method
- building one, and the hash it commits to
- signing it, and verifying it offline against btclib's own script
  interpreter — including a tampered copy that fails
- ECDSA and BIP340 Schnorr on their own
- a message signed with an address (BMS)
- the BIP-174 PSBT roles

It links into the API reference rather than restating it.

## How every example is verified

Every example is a doctest. `tests/docs_examples_test.py` runs
`doctest.testfile` over any page under `docs/source/` containing a
`>>>` prompt, so what follows a prompt is what the library answered,
and a drifted example is a red test rather than a lie a reader finds by
typing it. 135 examples run today.

Not `sphinx-build -b doctest`: that wants a job of its own, reports
from one runner, and gates nothing until the branch rule names it —
where a test runs on every interpreter of the matrix, `tests-passed`
already gates it, and `uv run pytest` stays the whole command. No
pytest config change was needed and no CI command changed; `testpaths`
is untouched.

No doctest option flags, elision included: an example checked in part
is not the promise the page makes. Determinism is bought where the API
offers it — `ssa.sign` is given its `aux`, the mnemonic its entropy —
and never with `os.urandom`.

Every key on the page is a **published test vector**, and the page says
so in a warning at the top. The BIP-39 seed, the BIP-143 sighash and
DER signature, and the BIP-340 vector-1 signature are all byte-for-byte
what those specifications publish, so a reader can check btclib against
the spec rather than against this page.

`CONTRIBUTING.md` gains a paragraph next to the docs-build command
saying the examples are doctests, how to edit one (run the test, paste
back what the library answered), and to keep the keys published
vectors.

## What was left out

- **one page, not several.** The topics the issue named fit one page
  with a local table of contents, and one page is one thing to keep
  true. Splitting is easy later; the doctest runner already covers any
  new page that carries a prompt.
- **a finalized single-key PSBT.** `finalize_psbt` builds what
  BIP-174's own vectors need (p2sh and p2wsh multisig) and puts a bare
  p2wpkh signature into the `script_sig`, where segwit wants a witness;
  the extracted transaction does not verify. The guide says so plainly
  and shows the witness being built by hand instead, rather than
  documenting a flow that does not work. Worth a separate issue.
- Electrum mnemonics, descriptors, blocks, Borromean, Pedersen, MuSig
  and threshold signing: all real features, none of them what a
  beginner opens the documentation for.

## Verification

Each run in this branch's worktree, exit code checked (not grepped
output):

| gate | result |
| --- | --- |
| `uv run pytest` | **exit 0** — 14789 passed |
| `uv run pre-commit run --all-files` | **exit 0** — every hook |
| docs build, `sphinx-build -W --keep-going -b html` | **exit 0** |

The coverage job (`pytest --cov=btclib --cov=tests`) reports the same
two uncovered statements before and after this branch —
`btclib/mnemonic/electrum.py:317-318`, total 99.99% — measured by
stashing these changes and re-running. Pre-existing on `dev` and
untouched here; the new test module is fully covered.

## Counts

`grep -c '^- ' CHANGELOG.md` is **180** in this branch, and both stated
counts were moved to match: CHANGELOG.md's "A hundred and eighty
entries" and HISTORY.md's "the largest: a hundred and eighty entries".
Two bullets were added, in the "Documentation and the website" group,
plus one in HISTORY.md's "What it buys". **Both counts must be
re-derived again at merge** — sibling PRs move them, and the merge is
conflict-free even when the number is then wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a task-oriented beginner guide to the documentation and ensure its examples are executed as doctests in the test suite.

Documentation:
- Introduce a new task-focused guide page that walks beginners through common workflows like mnemonics, accounts, transactions, signatures, messages, and PSBTs, clarifying supported and unsupported features.

Tests:
- Add a doctest-based test module that automatically runs all documentation examples containing prompts to keep them synchronized with library behavior.

Chores:
- Update changelog and history entry counts and notes to reflect the new documentation guide and total number of changes.
- Document in CONTRIBUTING how to maintain deterministic doctest examples using published test vectors.