### PR TITLE
A block carries one coinbase (issue #250)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,20 @@ edit.
 
 ### Consensus rules
 
+- **A block carries one coinbase, and `Block.assert_valid` now says so.**
+  It asked whether the first transaction is a coinbase and never asked
+  the rest, where Bitcoin Core's `CheckBlock` asks both, the second as
+  `bad-cb-multiple`. The answer is `more than one coinbase`, raised
+  before the transaction is validated on its own terms: a second
+  coinbase is a second claim on the subsidy, so what is wrong is the
+  shape of the block rather than anything about that transaction. No
+  vector can state the rule — the proof-of-work is checked first, and
+  adding a coinbase to a real block moves the merkle root its header
+  commits to, so a well-formed block with valid work and two coinbases
+  cannot be built. That is the argument for the rule rather than
+  against it: what has no work yet is a block being *assembled*, and a
+  candidate-block path is exactly where nothing else refuses the shape
+  (issue #250)
 - **btclib can check a Merkle proof, not only compute a root.** It had
   the builder's side, `merkle_root_and_mutated_from_hashes`, and no
   entry point for the verifier's: from a txid, a branch of siblings and

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -238,6 +238,22 @@ class Block:
             raise BTClibValueError("first transaction is not a coinbase")
 
         for transaction in self.transactions[1:]:
+            # Bitcoin Core's bad-cb-multiple, asked immediately after the
+            # same first-transaction question: a coinbase is a claim on
+            # the subsidy, so a second one is a second claim, and it is
+            # the *shape* of the block that is wrong rather than anything
+            # about that transaction on its own -- which is all
+            # assert_valid below can see.
+            # Unreachable from a serialized block, and added anyway: the
+            # proof-of-work checked above already refuses one from the
+            # wire, and a coinbase cannot be added to a real block
+            # without moving the merkle root the header commits to, so no
+            # well-formed vector can carry two. What has no work yet is a
+            # block being assembled -- the toy mining of issue #188, and
+            # any candidate-block path after it -- and that is exactly
+            # where nothing else says no
+            if transaction.is_coinbase():
+                raise BTClibValueError("more than one coinbase")
             transaction.assert_valid()
 
         self.assert_valid_merkle_root()

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -503,6 +503,32 @@ def test_block_without_transactions() -> None:
         Block(header, [])
 
 
+def test_a_block_carries_one_coinbase() -> None:
+    """A second coinbase is refused, as Core's bad-cb-multiple.
+
+    No vector can state this. The proof-of-work is checked before the
+    transaction list is read, so a block carrying two coinbases is
+    refused for its work long before the rule would fire, and adding a
+    coinbase to a real block moves the merkle root its header commits
+    to -- there is no well-formed block with valid work and two
+    coinbases to be had. So the block is built here instead: block
+    200000's own coinbase, put back a second time over the transaction
+    that followed it.
+
+    The merkle root the block no longer has is checked after this rule,
+    which is where Core checks it too (issue #250).
+    """
+    fname = "block_200000.bin"
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        block_bytes = file_.read()
+
+    block = Block.parse(block_bytes)
+    block.transactions[1] = block.transactions[0]
+    with pytest.raises(BTClibValueError, match="more than one coinbase"):
+        block.assert_valid()
+
+
 def test_assert_valid_does_not_rewrite_the_header() -> None:
     """A read is a read: assert_valid must not coerce nonce in place.
 


### PR DESCRIPTION
Closes #250.

`Block.assert_valid` consulted `is_coinbase()` once, for the first
transaction, and the loop over the rest never asked. Bitcoin Core's
`CheckBlock` asks both, the second immediately after the first, as
`bad-cb-multiple`.

The rule is now in that loop, ahead of `transaction.assert_valid()`:
a second coinbase is a second claim on the subsidy, so what is wrong
is the *shape* of the block rather than anything that transaction says
on its own — which is all the per-transaction validator can see. The
answer is `more than one coinbase`.

## The test builds the block, because no vector can carry it

`assert_valid_pow` runs before the transaction list is read, so a
block with two coinbases is refused for its work long before the rule
fires; and a coinbase added to a real block moves the merkle root its
header commits to, so a well-formed vector with valid work and two
coinbases cannot be constructed. The issue's own argument, and the
reason python-bitcoinlib's "More than one coinbase" case is recorded
in #199 against `invalid proof-of-work: ` — which it still is, this
change moving nothing there.

So the test takes block 200000 and puts its own coinbase back a second
time over the transaction that followed it. The merkle root the block
no longer has is checked after this rule, which is where Core checks
it too. The test fails on `dev`.

## Why add an unreachable rule

Because what has no proof-of-work yet is a block being *assembled* —
the toy mining of #188, and any candidate-block path after it — and
there the shape is refused by nothing at all. A rule nothing can reach
is also a rule nobody notices is missing.

Full suite green (15086 passed), every pre-commit hook green, and the
sphinx `-W` docs build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce the consensus rule that each block may contain only a single coinbase transaction and document this behaviour.

Bug Fixes:
- Reject blocks that contain multiple coinbase transactions during block validation.

Documentation:
- Document the new consensus check for multiple coinbase transactions in the changelog.

Tests:
- Add a regression test that constructs a synthetic block with two coinbase transactions and asserts it is rejected.