### PR TITLE
Render the address of a witness program btclib cannot spend (issue #251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1260,6 +1260,26 @@ edit.
 
 ### Script
 
+- **A witness program of version 2 or higher has an address, and btclib
+  now renders it.** `type_and_payload` named five script types, none of
+  which a v2..v16 program is, so `ScriptPubKey.type` answered
+  `"unknown"` and `.address` the empty string — for a script built from
+  a valid bech32m address btclib itself writes and reads. The round trip
+  was broken in the middle, and broken with a value indistinguishable
+  from "this script has no address", which is the right answer for a
+  nulldata output and the wrong one here. The sixth answer is
+  `"witness_unknown"`, Bitcoin Core's own name for the type
+  (`TxoutType::WITNESS_UNKNOWN`), and `.address` is the bech32m one:
+  `EncodeDestination` renders these too, its `WitnessUnknown` case. The
+  line is Core's `Solver`'s — any version but 0 that is not p2tr,
+  including a v1 program that is not 32 bytes; a *version 0* program of
+  an unexpected length stays `"unknown"`, NONSTANDARD to Core, v0 having
+  no upgrade room left for a spend to be defined in. The payload is the
+  witness program, as it is for the three named witness types, and the
+  version is not implied by the answer — it is the op code the program
+  follows, which is where `address` reads it. Nothing changes for the
+  script engine, which dispatches on the version and reaches the same
+  upgrade-room arm it always did (issue #251)
 - **`ScriptPubKey` is a dataclass**, as the `Script` it extends is. It was a
   plain subclass of one, so `network` was a bare annotation rather than a
   field: `dataclasses.fields` reported only `script`, and

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -27,7 +27,17 @@ from btclib.utils import bytes_from_octets, bytesio_from_binarydata
 
 
 def address(script_pub_key: Octets, network: str = "mainnet") -> str:
-    """Return the bech32/base58 address from a script_pub_key."""
+    """Return the bech32/base58 address from a script_pub_key.
+
+    A witness program of version 2 or higher has an address as much as
+    a p2tr one does -- bech32m spells it, `b32.address_from_witness`
+    writes it, and Bitcoin Core renders it, `EncodeDestination` having
+    a `WitnessUnknown` case. Answering "" for one would be
+    indistinguishable from "this script has no address", which is the
+    right answer for a nulldata output and the wrong one where btclib
+    can read the address back into the very script it came from
+    (issue #251).
+    """
     if script_pub_key:
         script_type, payload = type_and_payload(script_pub_key)
         if script_type in ("p2pkh", "p2sh"):
@@ -36,6 +46,11 @@ def address(script_pub_key: Octets, network: str = "mainnet") -> str:
             return b32.address_from_witness(0, payload, network)
         if script_type == "p2tr":
             return b32.address_from_witness(1, payload, network)
+        if script_type == "witness_unknown":
+            # the one type whose version the answer does not imply: it is
+            # the op code the program follows, OP_2..OP_16 being 0x52..0x60
+            version = bytes_from_octets(script_pub_key)[0] - 0x50
+            return b32.address_from_witness(version, payload, network)
 
     # not script_pub_key
     # or
@@ -294,6 +309,46 @@ def is_p2tr(script_pub_key: Octets) -> bool:
     return _is_funct(assert_p2tr, script_pub_key)
 
 
+def _witness_type_and_payload(script_pub_key: bytes) -> tuple[str, bytes] | None:
+    """Name the witness program, or None if these bytes are not one.
+
+    One function for the family, because the version is what tells them
+    apart and the four answers are one decision: v0 of 20 bytes is
+    p2wpkh and of 32 bytes p2wsh, a 32-byte v1 is p2tr, and any other
+    version is a program this library cannot spend -- which is still a
+    type, and still has an address. A v0 program of any other length is
+    none of the four: v0 is defined, so a length it does not define is
+    not upgrade room, and Bitcoin Core's Solver calls it NONSTANDARD.
+
+    The payload is the witness program throughout. For the three named
+    types the version is implied by the answer; for the fourth it is
+    not, and stays in the script, which is where `address` reads it.
+    """
+    if is_p2wpkh(script_pub_key):
+        # p2wpkh: OP_0 pub_key_hash
+        # 0x0014{20-byte pub_key_hash}
+        return "p2wpkh", script_pub_key[2:]
+
+    if is_p2wsh(script_pub_key):
+        # p2wsh: OP_0 script_hash
+        # 0x0020{32-byte script_hash}
+        return "p2wsh", script_pub_key[2:]
+
+    if is_p2tr(script_pub_key):
+        # p2tr: OP_1 output_key
+        # 0x5120{32-byte output key}
+        return "p2tr", script_pub_key[2:]
+
+    if is_segwit(script_pub_key) and script_pub_key[0] != 0:
+        # witness_unknown: Bitcoin Core's own name for the type,
+        # TxoutType::WITNESS_UNKNOWN, and Solver draws the line in the
+        # same place -- any version but 0 that is not p2tr, so a v1
+        # program that is not 32 bytes lands here too
+        return "witness_unknown", script_pub_key[2:]
+
+    return None
+
+
 def type_and_payload(script_pub_key: Octets) -> tuple[str, bytes]:
     """Return (script_pub_key type, payload) from the input script_pub_key."""
     script_pub_key = bytes_from_octets(script_pub_key)
@@ -317,20 +372,8 @@ def type_and_payload(script_pub_key: Octets) -> tuple[str, bytes]:
         # 0xA914{20-byte script_hash}87
         return "p2sh", script_pub_key[2:-1]
 
-    if is_p2wpkh(script_pub_key):
-        # p2wpkh: OP_0 pub_key_hash
-        # 0x0014{20-byte pub_key_hash}
-        return "p2wpkh", script_pub_key[2:]
-
-    if is_p2wsh(script_pub_key):
-        # p2wsh: OP_0 script_hash
-        # 0x0020{32-byte script_hash}
-        return "p2wsh", script_pub_key[2:]
-
-    if is_p2tr(script_pub_key):
-        # p2tr: OP_1 output_key
-        # 0x0120{32-byte script_hash}
-        return "p2tr", script_pub_key[2:]
+    if witness := _witness_type_and_payload(script_pub_key):
+        return witness
 
     if is_nulldata(script_pub_key):
         # nulldata: OP_RETURN data

--- a/tests/script/script_pub_key_test.py
+++ b/tests/script/script_pub_key_test.py
@@ -415,9 +415,69 @@ def test_p2wsh() -> None:
 
 
 def test_unknown() -> None:
-    script_pub_key = serialize(["OP_16", 20 * b"\x00"])
+    """A script of no type at all: no address, and the whole of it back.
+
+    Not a witness program of an unnamed version, which is a type and
+    has an address -- see the two tests below. This one is OP_16
+    followed by 41 bytes, one past the longest program segwit defines,
+    so it is not a witness program at all and no address can carry it.
+    """
+    script_pub_key = serialize(["OP_16", 41 * b"\x00"])
     assert address(script_pub_key) == ""
     assert type_and_payload(script_pub_key) == ("unknown", script_pub_key)
+
+
+def test_a_witness_program_of_an_unnamed_version_has_an_address() -> None:
+    """Versions 2 to 16 round trip, as versions 0 and 1 do (issue #251).
+
+    Each address here is one btclib itself writes and reads; answering
+    "" for the script it decodes to broke the round trip in the middle,
+    and did so with a value indistinguishable from "this script has no
+    address" -- the right answer for a nulldata output and the wrong
+    one where the address exists and btclib can spell it. Bitcoin Core
+    renders them, `EncodeDestination` having a `WitnessUnknown` case,
+    and `witness_unknown` is Core's own name for the type.
+    """
+    program = bytes(range(2, 22))
+    for version in range(2, 17):
+        addr = b32.address_from_witness(version, program)
+        script_pub_key = ScriptPubKey.from_address(addr)
+        assert script_pub_key.type == "witness_unknown"
+        assert script_pub_key.address == addr
+        assert type_and_payload(script_pub_key.script) == (
+            "witness_unknown",
+            program,
+        )
+
+    # the version is the op code the program follows, and it is not
+    # implied by the type: the two extremes are told apart
+    assert address(serialize(["OP_2", program])) != address(
+        serialize(["OP_16", program])
+    )
+
+
+def test_where_witness_unknown_begins_and_ends() -> None:
+    """btclib draws Core's line, `Solver`'s (issue #251).
+
+    Any version but 0 that is not p2tr is `witness_unknown`, a v1
+    program that is not 32 bytes included. A version *0* program of an
+    unexpected length is not: `Solver` calls it NONSTANDARD, and there
+    is no upgrade room left in v0 for a spend to be defined for it, so
+    it has no address to render.
+    """
+    v1_not_32 = serialize(["OP_1", bytes(20)])
+    assert type_and_payload(v1_not_32) == ("witness_unknown", bytes(20))
+    assert address(v1_not_32) == b32.address_from_witness(1, bytes(20))
+
+    # the shortest and the longest program a witness address can carry
+    for length in (2, 40):
+        script_pub_key = serialize(["OP_2", bytes(length)])
+        assert type_and_payload(script_pub_key)[0] == "witness_unknown"
+        assert address(script_pub_key) == b32.address_from_witness(2, bytes(length))
+
+    v0_not_20_or_32 = serialize(["OP_0", bytes(21)])
+    assert type_and_payload(v0_not_20_or_32) == ("unknown", v0_not_20_or_32)
+    assert address(v0_not_20_or_32) == ""
 
 
 def test_p2ms_1() -> None:


### PR DESCRIPTION
Closes #251. This takes **option 1** of the three the issue puts up.

`type_and_payload` named five script types, and a witness program of
version 2 or higher is none of them, so `.type` answered `"unknown"`
and `.address` the empty string — for a script built from a valid
bech32m address btclib itself writes and reads.

The empty string is what settles the choice. It is indistinguishable
from "this script has no address", which is the right answer for a
nulldata output and the wrong one here, and Bitcoin Core renders these:
`EncodeDestination` has a `WitnessUnknown` case. Measured after the
change, each script built by `b32.address_from_witness` and read back
by `ScriptPubKey.from_address`:

```text
v0   type='p2wsh'             .address='bc1qqgpsgpgxquyqjzstpsxsurcszyfpx9q4zct3sxg6rvwp68slyqsswwj02w'
v1   type='p2tr'              .address='bc1pqgpsgpgxquyqjzstpsxsurcszyfpx9q4zct3sxg6rvwp68slyqssyejxjj'
v2   type='witness_unknown'   .address='bc1zqgpsgpgxquyqjzstpsxsurcszyfpx9q40xuctx'
v3   type='witness_unknown'   .address='bc1rqgpsgpgxquyqjzstpsxsurcszyfpx9q4yctnxd'
v16  type='witness_unknown'   .address='bc1sqgpsgpgxquyqjzstpsxsurcszyfpx9q4dl267y'
```

`witness_unknown` is Core's own name for the type,
`TxoutType::WITNESS_UNKNOWN`.

## Where the line is

Core's `Solver`'s: **any version but 0 that is not p2tr**, so a v1
program that is not 32 bytes lands here too. A *version 0* program of
an unexpected length does not — `NONSTANDARD` to Core, `"unknown"`
here — because v0 is defined, so a length it does not define is not
upgrade room and there is no spend to be given one.

The payload is the witness program, as it is for the three named
witness types. Unlike theirs the version is not implied by the answer,
so it stays in the script, where `address` reads it back off the op
code — which is also the one thing a caller reconstructing a script
from `(type, payload)` has to know.

## Two things that do not change

- **the script engine.** It dispatches on the witness *version*, not on
  this name, and reaches the same "everything else" arm — Core's
  upgrade room — that it always did. Only the v0 arm reads the type
  string, and `witness_unknown` never reaches it.
- **`README.md`'s list of ScriptPubKeys**, which enumerates the ones
  btclib *builds*. There is no constructor for a version it cannot
  spend.

## Tests, and the one that had to be updated

`test_unknown` asserted the old answer for `OP_16 <20 bytes>`, which is
precisely one of the eight rows the issue warns about; it now uses a
41-byte push — one past the longest program segwit defines, so not a
witness program at all — and keeps its meaning. Two tests are added:
the round trip for every version 2 to 16, and where the type begins and
ends (a v1 program of 20 bytes, the 2- and 40-byte extremes, and the v0
program of 21 bytes that stays `"unknown"`).

`type_and_payload`'s four witness branches are now one function. That
is what keeps it under the C901 gate the fourth answer pushed it over,
and it reads as the one decision it is; no `noqa` was added, this
repository having factored the last seven out. While moving the p2tr
line: its comment said `0x0120` where OP_1 is `0x51`, and said script
hash where the program is an output key.

## For #218 / PR #236

Eight rows of `key_io_valid.json` are these versions, and they are
vendored there asserting btclib's current answer. That assertion turns
red, as the issue said it would: the expected value is now the address
Core's own file carries.

Full suite green (15087 passed), every pre-commit hook green, and the
sphinx `-W` docs build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Render addresses for segwit witness programs of versions 2–16 and classify them as a dedicated script type instead of "unknown".

New Features:
- Expose a new script type "witness_unknown" for segwit witness programs that btclib cannot spend but can represent and round-trip as addresses.

Bug Fixes:
- Fix address() returning an empty string for valid bech32m witness program outputs (versions 2–16), restoring round-trip between addresses and ScriptPubKey.

Enhancements:
- Refactor witness script type detection into a single helper function that consistently classifies p2wpkh, p2wsh, p2tr, and unknown-version witness programs.
- Clarify address() and test semantics around scripts that genuinely have no address versus witness programs of unsupported versions.

Documentation:
- Document the new handling of witness programs of version 2 or higher in the changelog, including alignment with Bitcoin Core’s WitnessUnknown semantics.

Tests:
- Update the "unknown" script test to use a non-witness script and add coverage for witness_unknown classification, address rendering, and version boundary behavior.