### PR TITLE
Reach the three branches no vector reached (issue #252)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2443,6 +2443,33 @@ edit.
   Required test coverage ... not reached` on the *unrounded* total while
   the exit code follows the rounded one, so the run before was already
   printing FAIL and passing. pyproject.toml's comment now says so
+- **the three consensus branches no vector reached are reached**, each
+  by an input rather than by a reworded assertion (issue #252).
+  **The taproot annex on the script path**: `sig_hash.from_tx` was
+  never asked for a script path spend carrying one, so the branch that
+  strips it ran only where there was nothing to strip — a key path
+  spend cannot exercise it, its stack holding the signature alone once
+  the annex is off, which makes the leaf hash the same either way. 58
+  vectors of `script_assets_test.json` now go through it, 11 of them
+  with an annex, selected as the spends of a `<pub_key> OP_CHECKSIG`
+  leaf so that Core's own signature is the authority on the answer; and
+  a round trip signs a script path spend from the shape no vector can
+  carry, the signer's witness of script and control block with no
+  signature on it yet, for btclib's script engine — which strips the
+  annex in its own code and never calls `from_tx` — to accept.
+  **SIGHASH_SINGLE past the last output**: BIP-143's own example signs
+  an input whose index *equals* the output count, and so does every one
+  of the seven such spends in `script_assets_test.json`, so a bound
+  reading `!=` where it should read `<` passed everything there was.
+  Both paths now sign at an index two past the last output: the segwit
+  v0 one against a preimage the test builds from BIP-143's field list,
+  itself checked against the preimage and sigHash the BIP publishes,
+  and the taproot one against the refusal BIP341 requires, by the
+  message it gives. **A script code no op code can be read from at
+  all**: the walk that elides `OP_CODESEPARATOR` keeps whatever is left
+  where the walk stopped, and where it stops at the very first byte
+  that is the script code entire — reachable because 0xab can be in it
+  as data of a push that overruns the end
 - **the twelve on-chain scripts of issue #123 are vendored**, in
   `tests/script/_data/unspendable_script_pub_keys.json`: the real
   `scriptPubKey`s of the five transactions the issue lists, each with the

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -98,6 +98,11 @@ def _script_code_from(script: bytes, codesep_index: int) -> bytes:
     for op_code, _, stop in op_code_spans(script):
         if op_code == OP_CODESEPARATOR:
             found += 1
+            # `>=` here is an equivalent mutant: found rises by one and is
+            # read at each step, and codesep_index is at least 1 -- 0
+            # returned the whole script above -- so the first
+            # `found >= codesep_index` is the first `found ==`. A mutation
+            # run lists it as a survivor with nothing to add (issue #252)
             if found == codesep_index:
                 return script[stop:]
     err_msg = f"OP_CODESEPARATOR index {codesep_index}, but the script has {found}"
@@ -151,6 +156,11 @@ def taproot_annex_and_ext(tx: Tx, vin_i: int) -> tuple[bytes, bytes]:
         stack = stack[:-1]
 
     ext = b""
+    # `!= 1` here is an equivalent mutant: it differs on an empty stack
+    # alone, and there is none to be had -- the raise above refuses one,
+    # and the annex comes off a stack of two or more, which leaves at
+    # least one element. A mutation run lists it as a survivor with
+    # nothing to add (issue #252)
     if len(stack) > 1:
         # the same hole, one element along: with the annex off, stack[-1]
         # is the control block, whose first byte is the leaf version. There

--- a/tests/script/sig_hash_script_code_test.py
+++ b/tests/script/sig_hash_script_code_test.py
@@ -22,6 +22,8 @@ import pytest
 
 from btclib.exceptions import BTClibValueError
 from btclib.script import ScriptPubKey, sig_hash
+from btclib.script.script import op_code_spans
+from btclib.script.sig_hash import _without_op_codeseparators
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
 # OP_PUSHDATA1 of one byte where a one-byte push would do, then
@@ -101,6 +103,32 @@ def test_a_truncated_tail_is_kept_verbatim() -> None:
     truncated = bytes.fromhex("ab05010203")
     assert sig_hash.legacy(truncated, tx, 0, sig_hash.ALL) == sig_hash.legacy(
         bytes.fromhex("05010203"), tx, 0, sig_hash.ALL
+    )
+
+
+def test_a_script_code_no_op_code_can_be_read_from_at_all() -> None:
+    """The tail is the whole of it, and none of it is elided (issue #252).
+
+    The test above truncates after an op code, so the walk yields one
+    span and the tail starts where that span ended. Here the very first
+    byte announces more data than there is, so the walk yields nothing
+    and the tail is the script code entire -- which is Core's GetOp loop
+    ending on its first call and `SerializeScriptCode` copying what is
+    left, i.e. everything.
+
+    Reachable because the elision only runs on a script code containing
+    the separator byte, and 0xab is in this one as *data* that no push
+    can be read from. An implementation whose tail began one byte in
+    would sign a different script here and the same script everywhere
+    else.
+    """
+    unreadable = bytes.fromhex("02ab")  # a push of two bytes with one of them
+    assert not list(op_code_spans(unreadable))
+    assert _without_op_codeseparators(unreadable) == unreadable
+
+    tx = one_input_tx()
+    assert sig_hash.legacy(unreadable, tx, 0, sig_hash.ALL) != sig_hash.legacy(
+        unreadable[1:], tx, 0, sig_hash.ALL
     )
 
 

--- a/tests/script/sig_hash_segwitv0_test.py
+++ b/tests/script/sig_hash_segwitv0_test.py
@@ -13,8 +13,10 @@ test vector at
 https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
 """
 
+from btclib import var_bytes
+from btclib.hashes import hash256
 from btclib.script import Witness, sig_hash
-from btclib.tx import Tx, TxOut
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
 
 def test_native_p2wpkh() -> None:
@@ -184,4 +186,104 @@ def test_wrapped_p2wsh() -> None:
     hash_ = sig_hash.from_tx([utxo], tx, 0, sig_hash.ANYONECANPAY | sig_hash.SINGLE)
     assert hash_ == bytes.fromhex(
         "511e8e52ed574121fc1b654970395502128263f62662e076dc6baf05c2e6a99b"
+    )
+
+
+# issue 252: SIGHASH_SINGLE for an input past the last output
+
+
+# BIP-143's own out-of-range example, the one `test_native_p2wsh` signs:
+# two inputs and a single output, so input 1 has no output of its own
+_BIP143_TX = "0100000002fe3dc9208094f3ffd12645477b3dc56f60ec4fa8e6f5d67c565d1c6b9216b36e0000000000ffffffff0815cf020f013ed6cf91d29f4202e8a58726b1ac6c79da47c23d1bee0a6925f80000000000ffffffff0100f2052a010000001976a914a30741f8145e5acadf23f751864167f32e0963f788ac00000000"
+_WITNESS_SCRIPT = "21026dccc749adc2a9d0d89497ac511f760f45c47dc5ed9cf352a58ac706453880aeadab210255a9626aebf5e29c0e6538428ba0d1dcf6ca98ffdf086aa8ced5e0d0215ea465ac"
+_AMOUNT = 4900000000
+
+
+def _bip143_preimage(
+    tx: Tx, vin_i: int, script_code: bytes, amount: int, hash_outputs: bytes
+) -> bytes:
+    """BIP-143's field list, written out, for a SIGHASH_SINGLE input.
+
+    The rule under test is one field of it — "hashOutputs is a uint256
+    of 0x0000......0000" when the input index is beyond the last output
+    — so the field is a parameter and the other ten are spelled here
+    rather than asked of the code being checked. hashSequence is zero
+    because SINGLE says so, and hashPrevouts is the only one hashed.
+    """
+    prev_outs = b"".join(vin.prev_out.serialize() for vin in tx.vin)
+    return b"".join(
+        [
+            tx.version.to_bytes(4, "little"),
+            hash256(prev_outs),
+            b"\x00" * 32,
+            tx.vin[vin_i].prev_out.serialize(),
+            var_bytes.serialize(script_code),
+            amount.to_bytes(8, "little"),
+            tx.vin[vin_i].sequence.to_bytes(4, "little"),
+            hash_outputs,
+            tx.lock_time.to_bytes(4, "little"),
+            sig_hash.SINGLE.to_bytes(4, "little"),
+        ]
+    )
+
+
+def test_the_hand_built_preimage_is_the_one_bip143_publishes() -> None:
+    """The next test's authority, checked against a published number.
+
+    `_bip143_preimage` is what says the rule below is right, so it is
+    itself checked here — against BIP-143's own preimage for its
+    out-of-range example, printed in the BIP beside the sigHash that
+    `test_native_p2wsh` already pins.
+    """
+    tx = Tx.parse(_BIP143_TX)
+    script_code = bytes.fromhex(_WITNESS_SCRIPT)
+    preimage = _bip143_preimage(tx, 1, script_code, _AMOUNT, b"\x00" * 32)
+    assert preimage.hex() == (
+        "01000000ef546acf4a020de3898d1b8956176bb507e6211b5ed3619cd08b6ea7e2a09d41"
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        "0815cf020f013ed6cf91d29f4202e8a58726b1ac6c79da47c23d1bee0a6925f800000000"
+        "47" + _WITNESS_SCRIPT + "0011102401000000ffffffff"
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        "0000000003000000"
+    )
+    assert hash256(preimage).hex() == (
+        "82dde6e4f1e94d02c2b7ad03d2115d691f48d064e9d52f58194a6637e4194391"
+    )
+
+
+def test_sighash_single_past_the_last_output() -> None:
+    """hashOutputs is 32 zero bytes for every index past the last output.
+
+    BIP-143: "if the sighash type is SINGLE and the input index is
+    smaller than the number of outputs, hashOutputs is the double
+    SHA256 of the output amount with scriptPubKey of the same index as
+    the input; Otherwise, hashOutputs is a uint256 of 0x0000......0000".
+
+    *Every* index past it, which is the part no vector states. BIP-143's
+    own example signs input 1 of a transaction with one output, so it
+    pins the case where the index equals the output count and says
+    nothing about the ones beyond — and an implementation reading the
+    bound as `vin_i != len(tx.vout)` passes every vector there is
+    (issue #252). Here a third input carries the same spend two indices
+    past the last output.
+    """
+    tx = Tx.parse(_BIP143_TX)
+    script_code = bytes.fromhex(_WITNESS_SCRIPT)
+
+    # the index the BIP publishes, and the two beyond it
+    tx.vin.append(TxIn(OutPoint(b"\x11" * 32, 0), b"", 0xFFFFFFFF))
+    tx.vin.append(TxIn(OutPoint(b"\x22" * 32, 1), b"", 0xFFFFFFFF))
+    assert len(tx.vout) == 1
+    for vin_i in (1, 2, 3):
+        preimage = _bip143_preimage(tx, vin_i, script_code, _AMOUNT, b"\x00" * 32)
+        assert sig_hash.segwit_v0(
+            script_code, tx, vin_i, sig_hash.SINGLE, _AMOUNT
+        ) == hash256(preimage)
+
+    # and the index that does have an output of its own is the other
+    # branch: it commits to that output and to no other
+    hash_outputs = hash256(tx.vout[0].serialize())
+    preimage = _bip143_preimage(tx, 0, script_code, _AMOUNT, hash_outputs)
+    assert sig_hash.segwit_v0(script_code, tx, 0, sig_hash.SINGLE, _AMOUNT) == hash256(
+        preimage
     )

--- a/tests/script/sig_hash_taproot_test.py
+++ b/tests/script/sig_hash_taproot_test.py
@@ -26,13 +26,14 @@ from typing import Any
 
 import pytest
 
-from btclib.alias import ScriptList
+from btclib.alias import ScriptList, TaprootScriptTree
 from btclib.ecc import ssa
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.script import (
     ScriptPubKey,
     Witness,
+    input_script_sig,
     is_p2tr,
     output_prvkey,
     parse,
@@ -41,6 +42,8 @@ from btclib.script import (
     type_and_payload,
 )
 from btclib.script.engine import verify_transaction
+from btclib.script.taproot import serialize as taproot_serialize
+from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests import load, vector_id
 
@@ -405,3 +408,183 @@ def test_key_path_spend_round_trip(hash_type: int, script_tree: Any) -> None:
     wrong = ssa.sign_(msg, prv_key)
     with pytest.raises(BTClibRuntimeError, match="signature verification failed"):
         ssa.assert_as_valid_(msg, pub_key, wrong)
+
+
+# issue 252: the script path through `from_tx`, annex and all
+
+
+def has_annex(witness: Witness) -> bool:
+    """BIP341's annex: a last element of at least two, starting with 0x50."""
+    stack = witness.stack
+    return len(stack) >= 2 and stack[-1][:1] == b"\x50"
+
+
+def script_path_vectors() -> list[Any]:
+    """The success vectors spending a leaf of `<pub_key> OP_CHECKSIG`.
+
+    The tapscript has to be one whose signature this test can check, so
+    the leaf is the simplest shape Core's dump carries and the witness
+    is the three elements of a bare script path spend -- signature,
+    script, control block -- with or without an annex after them. 58 of
+    the file's 2244 vectors qualify, 11 of them carrying an annex.
+
+    Nothing else drives `sig_hash.from_tx` down the script path with an
+    annex, which is what leaves the branch that strips one untested:
+    `test_valid_taproot_script_path` below is one spend and carries
+    none, and a key path spend cannot reach the branch at all -- with
+    the annex off its stack holds the signature alone, so the leaf hash
+    is not computed either way and dropping the wrong number of
+    elements changes no answer (issue #252).
+    """
+    params = []
+    for index, x in enumerate(TAPSCRIPT):
+        if "TAPROOT" not in x["flags"]:
+            continue
+        prevouts = [TxOut.parse(prevout) for prevout in x["prevouts"]]
+        if not is_p2tr(prevouts[x["index"]].script_pub_key.script):
+            continue
+        witness = Witness(x["success"]["witness"])
+        stack = witness.stack[:-1] if has_annex(witness) else witness.stack
+        # signature, script, control block: no leaf takes an input off
+        # the stack, so the script is always the last but one
+        if len(stack) != 3 or len(stack[0]) not in (64, 65):
+            continue
+        # <32-byte push> OP_CHECKSIG, and nothing else
+        if len(stack[1]) != 34 or stack[1][0] != 0x20 or stack[1][-1] != 0xAC:
+            continue
+        params.append(pytest.param(x, id=vector_id(index, x["comment"])))
+    return params
+
+
+SCRIPT_PATH_VECTORS = script_path_vectors()
+
+
+def test_script_path_vectors_carry_an_annex() -> None:
+    """The test below covers the annex only if some vector has one.
+
+    Both counts are asserted, not merely the total: a selector that
+    stopped matching the annex cases would leave the branch this was
+    written for untested again, and a green run of 47 vectors is what
+    that failure would look like.
+    """
+    annexed = [
+        vector
+        for vector in SCRIPT_PATH_VECTORS
+        if has_annex(Witness(vector.values[0]["success"]["witness"]))
+    ]
+    assert len(SCRIPT_PATH_VECTORS) == 58
+    assert len(annexed) == 11
+
+
+@pytest.mark.parametrize("vector", SCRIPT_PATH_VECTORS)
+def test_valid_taproot_script_path_vectors(vector: dict[str, Any]) -> None:
+    """Sign-side script path spends, which only these vectors exercise.
+
+    `from_tx` builds the BIP342 message extension for a script path
+    spend -- the leaf hash of the script under the control block -- and
+    strips the annex before reading either. The signature Core's dump
+    carries is the authority on the result: it verifies against the key
+    in the leaf if and only if the hash is the one Core computed.
+    """
+    tx = Tx.parse(vector["tx"])
+    prevouts = [TxOut.parse(prevout) for prevout in vector["prevouts"]]
+    index = vector["index"]
+
+    assert not vector["success"]["scriptSig"]
+
+    witness = Witness(vector["success"]["witness"])
+    tx.vin[index].script_witness = witness
+    stack = witness.stack[:-1] if has_annex(witness) else witness.stack
+
+    signature = stack[0]
+    hash_type = signature[-1] if len(signature) == 65 else 0
+
+    msg_hash = sig_hash.from_tx(prevouts, tx, index, hash_type)
+
+    # the selector pinned the leaf to <32-byte push> OP_CHECKSIG
+    pub_key = stack[1][1:33]
+    ssa.assert_as_valid_(msg_hash, pub_key, signature[:64])
+
+
+def test_taproot_sighash_single_past_the_last_output() -> None:
+    """Every index past the last output is refused, not merely the first.
+
+    BIP341 has no out-of-range rule to apply: "if hash_type & 3 equals
+    SIGHASH_SINGLE and the input index is equal to or greater than the
+    number of outputs, fail". Bitcoin Core's SignatureHashSchnorr
+    returns false there, and btclib raises.
+
+    Equal to *or greater than*, and it is the second half no vector
+    states: `script_assets_test.json` carries seven spends with
+    SIGHASH_SINGLE and no output of their own, and in every one of them
+    the index is exactly the output count -- so a bound written `==`
+    passes the whole file (issue #252).
+    """
+    prv_key = 0x4242424242424242424242424242424242424242424242424242424242424242
+    script_pub_key = ScriptPubKey.p2tr(prv_key)
+    prevouts = [TxOut(100_000, script_pub_key) for _ in range(3)]
+
+    vin = [TxIn(OutPoint(bytes([i + 1]) * 32, 0)) for i in range(3)]
+    for tx_in in vin:
+        # from_tx reads the witness to tell a key path spend from a
+        # script path one, so an unsigned input needs a placeholder
+        tx_in.script_witness = Witness([b"\x00" * 64])
+    tx = Tx(vin=vin, vout=[TxOut(90_000, script_pub_key)])
+
+    # the input that has an output of its own commits to it
+    assert sig_hash.from_tx(prevouts, tx, 0, sig_hash.SINGLE)
+
+    err_msg = "Sighash single without a corresponding output"
+    for vin_i in (1, 2):
+        with pytest.raises(BTClibValueError, match=err_msg):
+            sig_hash.from_tx(prevouts, tx, vin_i, sig_hash.SINGLE)
+        # ANYONECANPAY changes what else is committed to, not this
+        with pytest.raises(BTClibValueError, match=err_msg):
+            sig_hash.from_tx(
+                prevouts, tx, vin_i, sig_hash.ANYONECANPAY | sig_hash.SINGLE
+            )
+
+
+@pytest.mark.parametrize("annex", [b"", b"\x50" + b"\x99" * 8], ids=["bare", "annex"])
+def test_script_path_spend_round_trip(annex: bytes) -> None:
+    """Sign a script path spend with btclib and have btclib's engine take it.
+
+    The signer's witness is the shape no vector can carry: script and
+    control block, with no signature on the stack yet, because the
+    signature is what this call is for. Dropping the annex has to leave
+    two elements there, and the leaf hash the message extension commits
+    to is read off both of them -- so a bound that wanted three, as
+    `len(stack) > 2` would, computes a key path message instead and the
+    engine, which strips the annex in its own code, rejects what comes
+    back (issue #252).
+
+    The engine is the second implementation that makes this a check
+    rather than a restatement: it reaches the leaf through the control
+    block and the taproot commitment, and never calls `from_tx`.
+    """
+    internal_key = 0x4242424242424242424242424242424242424242424242424242424242424242
+    leaf_prv_key = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF
+    leaf_pub_key = pub_keyinfo_from_prv_key(leaf_prv_key)[0][1:]
+
+    script_tree: TaprootScriptTree = [(0xC0, [leaf_pub_key.hex(), "OP_CHECKSIG"])]
+    script_pub_key = ScriptPubKey.p2tr(internal_key, script_tree)
+    leaf, control = input_script_sig(internal_key, script_tree, 0)
+    leaf_bytes = taproot_serialize(leaf)
+
+    prevouts = [TxOut(100_000, script_pub_key)]
+    vin = TxIn(OutPoint(b"\x11" * 32, 0))
+    # what the signer holds: the spend without its signature
+    unsigned_stack = [leaf_bytes, control, annex] if annex else [leaf_bytes, control]
+    vin.script_witness = Witness(unsigned_stack)
+    tx = Tx(vin=[vin], vout=[TxOut(90_000, script_pub_key)])
+
+    msg_hash = sig_hash.from_tx(prevouts, tx, 0, sig_hash.DEFAULT)
+    signature = ssa.sign_(msg_hash, leaf_prv_key)
+    ssa.assert_as_valid_(msg_hash, leaf_pub_key, signature)
+
+    tx.vin[0].script_witness = Witness([signature.serialize(), *unsigned_stack])
+    verify_transaction(prevouts, tx)
+
+    # the signature on the stack is not part of what is signed: the same
+    # message comes back out of the completed spend
+    assert sig_hash.from_tx(prevouts, tx, 0, sig_hash.DEFAULT) == msg_hash


### PR DESCRIPTION
Closes #252. Inputs, not reworded assertions — the issue's own
instruction, and it held for all three clusters.

## What actually survives on `452c4d59`

The issue was measured on `0e5d6301` and the picture has moved since,
so every mutant it names was re-applied by hand to today's `dev` and
the suite run against each. Before this PR:

```text
SURVIVED  annex  stack[:-1] -> stack[:-0]
SURVIVED  annex  len(stack) > 1 -> > 2
SURVIVED  annex  len(stack) > 1 -> != 1
KILLED    annex  stack[-1][:1] -> stack[0][:1]
KILLED    annex  control stack[-1] -> stack[0]
KILLED    annex  leaf_version stack[-1][0] -> stack[0][0]
KILLED    annex  script stack[-2] -> stack[-3]
KILLED    segwit SINGLE  vin_i < len -> <= / and -> or / bound dropped
SURVIVED  segwit SINGLE  vin_i < len -> !=
KILLED    taproot SINGLE >= -> > , >= -> !=
SURVIVED  taproot SINGLE >= -> ==
SURVIVED  codesep found == -> >=
SURVIVED  codesep walked = 0 -> 1
```

Two corrections to the issue fall out of that. The `stack[-1]`
variants of the annex are **already dead**. And the SIGHASH_SINGLE
bound is not unreached — it is reached only at the *boundary*: every
vector there is signs an input whose index **equals** the output count,
so what survives is the mutant that gets that one case right and every
case past it wrong.

## The three inputs

**The taproot annex, script path.** `sig_hash.from_tx` was never asked
for a script path spend carrying an annex, and a key path spend cannot
stand in: with the annex off its stack holds the signature alone, so
`len(stack) > 1` is false either way, the leaf hash is not computed,
and dropping the wrong number of elements changes no answer. Two
additions:

- 58 vectors of `script_assets_test.json`, 11 of them with an annex,
  selected as the spends of a `<pub_key> OP_CHECKSIG` leaf — the
  simplest shape Core's dump carries — so that Core's own signature is
  the authority on the hash. Both counts are asserted, not just the
  total: a selector that stopped matching the annex cases would look
  like a green run of 47.
- a round trip on the shape **no vector can carry**: the signer's
  witness, script and control block with no signature on the stack
  yet, because the signature is what the call is for. btclib signs it
  and btclib's script engine — which strips the annex in its own code
  and never calls `from_tx` — accepts it. That second implementation
  is what makes it a check rather than a restatement, and it is what
  kills `len(stack) > 2`.

**SIGHASH_SINGLE past the last output.** Both paths sign at an index
two past it. The segwit v0 one is asserted against a preimage the test
builds from BIP-143's field list, and that builder is itself checked
against the preimage *and* the sigHash BIP-143 publishes for its
out-of-range example — so the authority is the BIP and not the code
under test. The taproot one is asserted against the refusal BIP341
requires, by the message it gives; today's failure vectors accept any
`BTClibValueError` or `BTClibRuntimeError`, which a mutant that
computes a hash and then fails the signature check satisfies just as
well.

**A script code no op code can be read from at all.** The existing
truncated-tail test truncates *after* an op code, so the walk yields
one span and `walked` is written before it is read. Where the very
first byte announces more data than there is, the walk yields nothing
and the tail is the script code entire — Core's `GetOp` loop ending on
its first call. Reachable because the elision only runs on a script
code containing 0xab, and 0xab can be in one as the data of a push
that overruns the end.

## After

Eleven of the thirteen mutants die, where four did before. The two
that live are **equivalent** — no input can distinguish them, so they
are not coverage to add:

- `len(stack) > 1` → `!= 1` differs only at `len(stack) == 0`, and
  that line cannot see it: an empty stack raises `Empty stack` above,
  and the annex is stripped only when the stack has at least two
  elements, which leaves at least one.
- `found == codesep_index` → `>=` differs never: `found` starts at 0
  and rises by one, and `codesep_index` is at least 1 there (0 returns
  the whole script above), so the first `found >= k` is the first
  `found == k`.

Both are worth stating rather than chasing, and the surviving count in
a future run is two lower for it.

Full suite green (15150 passed, 65 new), every pre-commit hook green,
and the sphinx `-W` docs build succeeds. No library code changes — this
is vectors and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add regression tests that exercise previously unreached consensus-related sig-hash branches for taproot, segwit v0, and legacy script handling, documenting the coverage improvement for issue #252.

Documentation:
- Document the new consensus-coverage tests and their rationale in the changelog under issue #252.

Tests:
- Add taproot script-path tests using real vectors and a btclib round-trip to cover annex stripping logic in sig_hash.from_tx.
- Add segwit v0 SIGHASH_SINGLE tests based on BIP-143’s published preimage to ensure all out-of-range input indices produce the correct hashOutputs behaviour.
- Add legacy script-code tests that verify OP_CODESEPARATOR elision when no opcode can be parsed, ensuring tails are handled correctly.