### PR TITLE
Cover electrum's round-trip check, and say what FAIL means

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2384,6 +2384,19 @@ edit.
 
 ### Tests
 
+- **the tree measures 100% again**, and the two statements that had gone
+  uncovered were electrum's round-trip check on its own encoding — the
+  one `_search_mnemonic` makes before it returns a candidate. Not
+  reachable with the wordlists btclib ships, `en` and `it` being 2048
+  distinct ASCII words each, so the test patches the decode to reach it,
+  as the ripemd160 fallback test patches its flag; a `pragma: no cover`
+  would have left the message unpinned. They had eaten the whole of the
+  `fail_under` rounding step, which is what made the gate turn red for
+  the next single uncovered line to appear anywhere in the tree —
+  and turn red without warning, because pytest-cov prints its `FAIL
+  Required test coverage ... not reached` on the *unrounded* total while
+  the exit code follows the rounded one, so the run before was already
+  printing FAIL and passing. pyproject.toml's comment now says so
 - **the twelve on-chain scripts of issue #123 are vendored**, in
   `tests/script/_data/unspendable_script_pub_keys.json`: the real
   `scriptPubKey`s of the five transactions the issue lists, each with the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,7 +319,13 @@ precision = 2
 # The comparison is `round(total, precision) < fail_under`, so 99.99 is
 # not "everything covered": it is one rounding step of slack, enough not
 # to turn a single version-gated line into a red build, tight enough
-# that a regression cannot hide in it. Not 99.9, ten times as wide,
+# that a regression cannot hide in it.
+# Read the exit code and not the report: pytest-cov prints `FAIL
+# Required test coverage of 99.99% not reached` on the *unrounded*
+# total, so a run inside that rounding step prints FAIL and exits 0 --
+# 99.9891% both said FAIL and passed, and 99.98% is where the exit code
+# turns 1. The line is a warning that the slack is spent, not the gate.
+# Not 99.9, ten times as wide,
 # which is room for a whole handful of statements to go uncovered and be
 # reported as a pass. How many statements either allows is a division by
 # a total that moves with every commit, so it is not written down here:

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -646,6 +646,34 @@ def test_skipped_candidates() -> None:
     )
 
 
+def test_a_wordlist_the_encoding_does_not_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The search checks its own arithmetic, and says so when it fails.
+
+    Electrum makes the same check inside make_seed, and it is not
+    reachable with the two wordlists btclib ships: `en` and `it` are
+    2048 distinct ASCII words each, so encoding an integer and decoding
+    the sentence hands the integer back for every candidate --
+    measured over the first three thousand and three thousand more
+    above 2**131. Patching the decode reaches it on the wordlists there
+    are, which is what the ripemd160 fallback test does with its flag
+    and what a `pragma: no cover` here would not do.
+
+    What would run it for real is a list added later: a CJK one, where
+    normalization can map two entries onto one string, or any list
+    carrying a repetition. Either writes a seed that reads back as
+    another, so the search refuses rather than returns it.
+    """
+    # a decode that answers 1 whatever it is given: the first candidate
+    # is int_entropy + 1, so 1 here is a mismatch and nothing else is
+    monkeypatch.setattr(electrum, "_bin_str_entropy_from_mnemonic", lambda *_: "1")
+
+    err_msg = "cannot extract the same entropy from mnemonic: "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        electrum._search_mnemonic(1, "01", "en")
+
+
 def test_2fa_words() -> None:
     """ "2fa" wants twelve words or twenty, and a search can end elsewhere.
 


### PR DESCRIPTION
`dev` prints this on every coverage run:

```text
btclib/mnemonic/electrum.py     209      2  99.04%   379-380
TOTAL                         18372      2  99.99%
FAIL Required test coverage of 99.99% not reached. Total coverage: 99.99%
```

## The gate is not red, and that is the trap

That run **exits 0**. pytest-cov prints `FAIL Required test coverage
... not reached` on the *unrounded* total and takes its exit code from
the rounded one, so anything inside the rounding step prints FAIL and
passes. Measured both sides of it:

| total | printed | exit code |
| --- | --- | --- |
| 99.9891% (2 lines, `dev`) | `FAIL ... 99.99%` | 0 |
| 99.98% (3 lines, PR #255) | `FAIL ... 99.98%` | 1 |

So the message is a warning that the slack is spent, not the gate.
`pyproject.toml`'s comment already explained the rounding; it now says
this too, because reading the report instead of the exit code is a
conclusion the file otherwise invites — and one I reached before
checking.

## What was actually wrong

The two statements had eaten the whole of the `fail_under` rounding
step, so the *next* uncovered line to appear anywhere in the tree
turned the gate red. That is exactly what happened to PR #255: one
uncovered line of its own, 2 → 3, and 99.98% with exit 1. CONTRIBUTING
says "99.99%, against the 100% the tree measures today", and the tree
had stopped measuring 100%.

They are electrum's own check that its encode and decode are inverses,
the one `_search_mnemonic` makes before it returns a candidate:

```python
if candidate != int(_bin_str_entropy_from_mnemonic(mnemonic, lang), 2):
    err_msg = f"cannot extract the same entropy from mnemonic: {mnemonic}"
    raise BTClibValueError(err_msg)
```

No candidate reaches it with the wordlists btclib ships — `en` and `it`
are 2048 **distinct ASCII** words each, so the two are exact inverses;
measured over the first three thousand integers and three thousand more
above `2**131`, zero mismatches. What would run it for real is a list
added later: a CJK one, where normalization can map two entries onto
one string, or any list carrying a repetition. Either writes a seed
that reads back as a different one, so the guard earns its place and is
not deleted.

The test patches the decode to reach it, which is the choice
`test_ripemd160_wherever_hashlib_has_none` already makes and states —
"reaching the fallback naturally takes ... a `pragma: no cover` branch
nothing ever exercises. Patching the flag reaches it instead". A pragma
here would have left the message unpinned and the reason unwritten.

## After

```text
TOTAL   18377      0  100.00%
Required test coverage of 99.99% reached. Total coverage: 100.00%
```

Full suite green (15145 passed), every pre-commit hook green, and the
sphinx `-W` docs build succeeds. `uv.lock` untouched — the pyproject
edit is one comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add test coverage for Electrum mnemonic round-trip validation and clarify how pytest-cov’s coverage threshold and FAIL message should be interpreted.

Build:
- Clarify pyproject.toml’s coverage threshold comment to describe pytest-cov’s rounding behavior and the distinction between the FAIL message and the actual coverage gate.

Documentation:
- Update the changelog to explain the restored 100% coverage and the Electrum round-trip check’s behavior and purpose.

Tests:
- Add a test that forces Electrum’s entropy round-trip check to execute, restoring full coverage for the mnemonic search logic.