### PR TITLE
Ask slip39 too, and ask it first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2042,7 +2042,24 @@ edit.
   the reason — a version prefix is a deliberate marker present by chance
   in one sentence in 256, a valid BIP39 checksum in one in sixteen. The
   dispatcher normalizes nothing of its own, each scheme normalizing as it
-  defines, which leaves issue #201 to decide that once for all of them
+  defines, which leaves issue #201 to decide that once for all of them.
+  **`mnemonic.dispatch` answers `"slip39"` too**, and it answers it
+  *first*, ahead of Electrum and BIP39. The order is measured rather than
+  assumed, and it is the one place it changes an answer: Electrum's
+  version check is an HMAC over the sentence and consults no word-list at
+  all, so it claims a share whenever the HMAC happens to start `01` — 80
+  of 20000 random 1-of-1 shares, one in 250. The reverse never happened,
+  0 of 2000 Electrum seeds and 0 of 2000 BIP39 mnemonics reading as a
+  share, because 1495 of BIP39's 2048 English words are absent from
+  SLIP-0039's list; so a share is the rarer signal by orders of magnitude
+  — 30 checksum bits over words that must every one of them be among
+  SLIP-0039's 1024 — and last in the chain would report one share in 250
+  as an Electrum seed. `"slip39"` says the sentence in hand is one
+  well-formed share and nothing about the set it belongs to: of
+  SLIP-0039's 30 invalid vectors, 8 carry a fault inside a share and are
+  refused here, while 22 are unusable sets of individually sound shares
+  and are reported `"slip39"` with `master_secret_from_mnemonics` left to
+  refuse the set
 - **`btclib.mnemonic.slip39` is the third mnemonic scheme**, SLIP-0039
   Shamir backup: the split-into-shares format every Trezor since 2019
   offers, and the one a hardware-wallet user is most likely to be

--- a/btclib/mnemonic/dispatch.py
+++ b/btclib/mnemonic/dispatch.py
@@ -17,6 +17,11 @@ mnemonic at once, and the three derive three different wallets.
 
 The answers, one string each:
 
+- "slip39" -- one SLIP-0039 share: every word in SLIP-0039's own
+  1024-word list, a length it defines, and an RS1024 checksum that
+  verifies. One share and not a set of them, a sentence at a time being
+  all this is given; recovering the secret needs the threshold number of
+  them, which is mnemonic.slip39's business and not this function's.
 - "electrum_old", "electrum_standard", "electrum_segwit",
   "electrum_2fa", "electrum_2fa_segwit" -- the five Electrum reports.
   Prefixed, because "standard" says nothing once BIP39 is in the running.
@@ -46,17 +51,32 @@ rather than again here. Old first is the load-bearing part -- a pre-2.0
 seed carries no version prefix and can match one by chance, and calling
 it "standard" would hand back the wrong derivation without a word.
 
-**Electrum before BIP39** is btclib's, Electrum having no such order to
-copy: its wizard asks the user which variant a sentence is, and
+**Between the schemes** it is btclib's, none of them having an order to
+copy: Electrum's wizard asks the user which variant a sentence is, and
 validate_seed then dispatches on that answer instead of guessing. The
-reason for this order is the base rate. An Electrum version prefix is a
-deliberate marker, present by chance in one sentence in 256 for "01" and
-one in 4096 for the three-nibble prefixes, while a valid BIP39 checksum
-is present by chance in one twelve-word sentence in sixteen; the rarer
-signal is the one carrying information about where a sentence came from.
-The choice is not hidden either: all_seed_types_from_mnemonic names every
-scheme that claims the sentence, so a caller preferring the other order
-has what it needs to take it.
+reason for the order is the base rate, and the principle is that the
+rarer signal is the one carrying information about where a sentence came
+from. A valid BIP39 checksum is present by chance in one twelve-word
+sentence in sixteen. An Electrum version prefix is rarer, one sentence in
+256 for "01" and one in 4096 for the three-nibble prefixes. A SLIP-0039
+share is rarer again by orders of magnitude: 30 checksum bits over words
+that must every one of them be among SLIP-0039's 1024, which is why it
+goes first. The choice is not hidden either:
+all_seed_types_from_mnemonic names every scheme that claims the sentence,
+so a caller preferring another order has what it needs to take it.
+
+**SLIP-0039 first is measured, not assumed**, and it is the one place
+where the order changes an answer. Electrum's version check is an HMAC
+over the sentence and consults no word-list at all, so it claims a share
+whenever the HMAC happens to start "01": 80 of 20000 random 1-of-1
+shares, one in 250, and 14 of the first 4000 were "electrum_standard"
+with one "electrum_segwit". The reverse never happened -- 0 of 2000
+Electrum seeds and 0 of 2000 BIP39 mnemonics read as a share -- because
+1495 of BIP39's 2048 English words are absent from SLIP-0039's list, so a
+sentence has to be built from that list to pass its checksum at all. Last
+in the chain would therefore report one share in 250 as an Electrum seed
+and hand the caller the wrong scheme, which is the failure "old before
+standard" exists to prevent, one scheme further out.
 
 Normalization is deliberately not done here. Each branch normalizes as
 its own scheme defines -- Electrum's NFKD, lower-casing, accent dropping
@@ -66,27 +86,46 @@ BIP39 mnemonic. That is a difference between the two schemes as they
 stand, not a decision taken here; what btclib should normalize, once and
 for every scheme, is issue 201.
 
-SLIP-0039 is the third member of the family, and mnemonic.slip39 reads
-and writes it -- but this dispatcher does not ask it yet, so a share is
-reported as unknown. Wiring it in is a decision and not an omission:
-what a share is claimed *as* has to be settled first, a single share
-being a share of a secret rather than a sentence that derives a wallet
-on its own. The place it goes is the end of the chain, after BIP39; a
-share carries none of the signals above -- its words come from
-SLIP-0039's own 1024-word list, so no Electrum prefix and no BIP39
-word-list test can match one -- which is why the order costs nothing
-either way.
+What "slip39" does not say is how many shares are wanted. A share names
+its group and member thresholds, so the count is there to be read, but
+reading one sentence cannot tell whether the others are to hand; that is
+master_secret_from_mnemonics' answer, and it refuses a set that is short.
+A restore flow asking this function what it has been handed gets the
+scheme, and asks slip39 for the rest.
 """
 
 from __future__ import annotations
 
 from btclib.exceptions import BTClibValueError
-from btclib.mnemonic import bip39, electrum
+from btclib.mnemonic import bip39, electrum, slip39
 from btclib.mnemonic.mnemonic import Mnemonic, indexes_from_mnemonic
 
 # the sentence lengths BIP39 defines, and so the only ones it defines a
 # checksum for
 _BIP39_WORD_COUNTS = (12, 15, 18, 21, 24)
+
+
+def _slip39_seed_type(mnemonic: Mnemonic) -> str:
+    """Return "slip39" for one readable SLIP-0039 share, "" otherwise.
+
+    share_from_mnemonic is the whole test: it checks the word count, looks
+    every word up in SLIP-0039's list and verifies the RS1024 checksum,
+    which is the same three things the other branches check for their own
+    schemes. Asking it rather than repeating it is what keeps the two from
+    disagreeing.
+
+    No language parameter, unlike the BIP39 branch: SLIP-0039 defines one
+    word-list and no localization, so there is nothing for a caller to
+    choose.
+    """
+    try:
+        slip39.share_from_mnemonic(mnemonic)
+    except ValueError:
+        # BTClibValueError for a bad checksum, length or field, and a
+        # plain ValueError from list.index for a word that is not in the
+        # list; BTClibValueError is a ValueError, so this catches both
+        return ""
+    return "slip39"
 
 
 def _bip39_seed_type(mnemonic: Mnemonic, lang: str) -> str:
@@ -126,14 +165,15 @@ def all_seed_types_from_mnemonic(mnemonic: Mnemonic, lang: str = "en") -> list[s
     The list is empty when nothing claims it, and holds more than one
     entry when the schemes overlap -- which is the case worth seeing,
     since seed_type_from_mnemonic can only answer with the first of them.
-    Two entries at most today: Electrum resolves its own five against
-    each other before answering, so at most one of those appears, and
-    BIP39 gives at most one answer of its own.
+    Three entries at most: each of the three schemes answers at most once,
+    Electrum resolving its own five against each other before it reports.
 
-    The module docstring has the order and where each half of it comes
-    from.
+    The module docstring has the order and the measurements behind it.
     """
     seed_types = []
+
+    if slip39_seed_type := _slip39_seed_type(mnemonic):
+        seed_types.append(slip39_seed_type)
 
     try:
         version = electrum.version_from_mnemonic(mnemonic)[0]
@@ -145,8 +185,6 @@ def all_seed_types_from_mnemonic(mnemonic: Mnemonic, lang: str = "en") -> list[s
     if bip39_seed_type := _bip39_seed_type(mnemonic, lang):
         seed_types.append(bip39_seed_type)
 
-    # SLIP-0039 goes here, after BIP39 and last; the module docstring has
-    # why mnemonic.slip39 is not asked yet
     return seed_types
 
 
@@ -155,8 +193,8 @@ def seed_type_from_mnemonic(mnemonic: Mnemonic, lang: str = "en") -> str:
 
     The first of all_seed_types_from_mnemonic, which is the answer the
     precedence in the module docstring picks. Where a sentence is claimed
-    by two schemes this is the one that wins and the other is not
-    mentioned, so a caller that has to know about the collision -- a
+    by more than one scheme this is the one that wins and the others are
+    not mentioned, so a caller that has to know about the collision -- a
     restore flow, say, where the wrong choice is a wallet the user cannot
     see -- wants the plural function instead.
     """

--- a/tests/mnemonic/dispatch_test.py
+++ b/tests/mnemonic/dispatch_test.py
@@ -16,15 +16,22 @@ here to pin that the dispatcher reports what that function reports and
 does not re-decide it. The BIP39 half comes from btclib's own
 `bip39_test.py` and from electrum's `Test_BIP39.test_checksum`.
 
-Two cases are neither: the collisions. They are btclib's, found by
-searching -- no upstream publishes a sentence two schemes both read --
-and `electrum_test.py` says where each came from.
+The SLIP-0039 half is trezor/python-shamir-mnemonic's vector file, the
+same one `slip39_test.py` runs, here to pin which of its 45 cases this
+dispatcher claims and which it leaves alone.
+
+Four cases are none of the three: the collisions. They are btclib's,
+found by searching -- no upstream publishes a sentence two schemes both
+read -- and `electrum_test.py` says where the two Electrum/BIP39 ones
+came from. The two SLIP-0039 ones were found here, one per Electrum
+prefix flavour, and the comment beside them gives the rate.
 """
 
 import pytest
 
+from btclib.exceptions import BTClibValueError
 from btclib.mnemonic import bip39, dispatch, electrum, slip39
-from tests import load
+from tests import load, vector_id
 
 # every word in the pre-2.0 list, so electrum reads it as "old" although
 # its HMAC also carries the "01" prefix of a "standard" seed. The
@@ -218,20 +225,165 @@ def test_italian() -> None:
     assert dispatch.all_seed_types_from_mnemonic(mnemonic, "en") == []
 
 
-def test_slip39_is_not_claimed() -> None:
-    """A SLIP-0039 share is reported unknown, and cannot be anything else.
+SLIP39_VECTORS = load("mnemonic", "_data", "vectors.json")
 
-    mnemonic.slip39 reads shares, and this dispatcher does not ask it:
-    what a share is claimed *as* is a decision still to take, one share
-    being a share of a secret rather than a sentence that derives a
-    wallet by itself. What the module docstring says about the order is
-    measured here -- a share carries none of the other schemes' signals,
-    its words coming from SLIP-0039's own 1024-word list, so wiring it in
-    at the end of the chain cannot displace an answer already given.
+# upstream's vectors are all under this passphrase; fixture and not a
+# credential, as slip39_test.py's copy of the constant also says
+SLIP39_PASSPHRASE = "TREZOR"  # noqa: S105
+
+# a share whose RS1024 checksum verifies and whose electrum HMAC also
+# happens to start "01", so two schemes claim it and the order decides
+# which one a caller is told. Found by search: no upstream publishes such
+# a sentence, one scheme in 250 being rare enough that nobody trips over
+# it and common enough that a library will. The second is the same thing
+# against the "102" prefix, to pin that it is the collision and not the
+# "standard" branch in particular
+SLIP39_ELECTRUM_STANDARD = (
+    "enemy frequent academic academic brother remember join timber "
+    "detailed advocate relate together drift careful disaster elder "
+    "friendly fluff fiction muscle"
+)
+SLIP39_ELECTRUM_2FA = (
+    "move fawn academic academic champion parcel picture surprise "
+    "flexible unfair fiction fantasy jacket helpful galaxy vanish "
+    "listen mandate improve element"
+)
+
+
+@pytest.mark.parametrize(
+    "share",
+    [
+        pytest.param(vector[1][0], id=vector_id(index, vector[0]))
+        for index, vector in enumerate(SLIP39_VECTORS)
+        if vector[2]
+    ],
+)
+def test_slip39_vectors(share: str) -> None:
+    """Every valid SLIP-0039 vector share is reported "slip39"."""
+    assert dispatch.seed_type_from_mnemonic(share) == "slip39"
+
+
+# upstream's 30 invalid vectors split in two, and the split is what
+# "slip39" means. These five phrases of upstream's own descriptions name a
+# fault in one sentence -- a checksum, a padding, a length, a threshold
+# above its own group count; the remaining descriptions name a fault
+# between sentences -- mismatching fields, duplicate indices, too few
+# groups, a digest that does not check out. Classified by upstream's
+# words and not by asking share_from_mnemonic, which is the function
+# under test here
+_PER_SHARE_FAULTS = (
+    "invalid checksum",
+    "invalid padding",
+    "greater group threshold than group counts",
+    "insufficient length",
+    "invalid master secret length",
+)
+INVALID_SLIP39_VECTORS = [
+    (index, vector, any(f in vector[0] for f in _PER_SHARE_FAULTS))
+    for index, vector in enumerate(SLIP39_VECTORS)
+    if not vector[2] and vector[1]
+]
+
+
+def test_the_invalid_vectors_split_as_described() -> None:
+    """8 of the 30 are one bad sentence, 22 are a bad set of good ones.
+
+    The counts are here so that the classification below cannot drift
+    silently: a vector upstream adds, or a description it rewords, fails
+    this rather than quietly joining the wrong half.
     """
-    share = load("mnemonic", "_data", "vectors.json")[0][1][0]
-    # a share slip39 does read, so that "unknown" is the dispatcher's
-    # answer and not a sentence nothing at all can make sense of
+    assert len(INVALID_SLIP39_VECTORS) == 30
+    assert sum(per_share for _, _, per_share in INVALID_SLIP39_VECTORS) == 8
+
+
+@pytest.mark.parametrize(
+    "mnemonics",
+    [
+        pytest.param(vector[1], id=vector_id(index, vector[0]))
+        for index, vector, per_share in INVALID_SLIP39_VECTORS
+        if per_share
+    ],
+)
+def test_slip39_bad_sentence_is_not_claimed(mnemonics: list[str]) -> None:
+    """A fault inside one share is one this branch sees.
+
+    share_from_mnemonic is the whole of the test -- word count, every word
+    in SLIP-0039's list, RS1024 -- so a checksum, a padding or a length
+    upstream calls invalid is not claimed here either. The assertion is
+    over the set because these vectors carry one bad sentence among sound
+    ones; what must not happen is every sentence passing.
+    """
+    assert not all(
+        "slip39" in dispatch.all_seed_types_from_mnemonic(mnemonic)
+        for mnemonic in mnemonics
+    )
+
+
+@pytest.mark.parametrize(
+    "mnemonics",
+    [
+        pytest.param(vector[1], id=vector_id(index, vector[0]))
+        for index, vector, per_share in INVALID_SLIP39_VECTORS
+        if not per_share
+    ],
+)
+def test_slip39_bad_set_of_good_sentences(mnemonics: list[str]) -> None:
+    """ "slip39" is about the sentence in hand, not the set it belongs to.
+
+    These 22 vectors are sets that cannot be combined -- mismatching
+    fields, duplicate indices, too few groups, a digest that does not
+    check out -- built from sentences that are every one of them a
+    well-formed share. So each is reported "slip39" and
+    master_secret_from_mnemonics is what refuses the set: a fault between
+    sentences is not one a dispatcher reading a single sentence can see,
+    and reporting "" for a share that is genuinely a share would be the
+    wrong answer to the question actually asked.
+    """
+    for mnemonic in mnemonics:
+        assert dispatch.seed_type_from_mnemonic(mnemonic) == "slip39"
+
+    with pytest.raises(BTClibValueError):
+        slip39.master_secret_from_mnemonics(mnemonics, SLIP39_PASSPHRASE)
+
+
+@pytest.mark.parametrize(
+    ("share", "electrum_type"),
+    [
+        pytest.param(SLIP39_ELECTRUM_STANDARD, "electrum_standard", id="standard"),
+        pytest.param(SLIP39_ELECTRUM_2FA, "electrum_2fa", id="2fa"),
+    ],
+)
+def test_slip39_wins_over_electrum(share: str, electrum_type: str) -> None:
+    """SLIP-0039 first, and this is the sentence where it matters.
+
+    Electrum's version check is an HMAC over the sentence and consults no
+    word-list, so it claims a share whenever the HMAC starts "01" or one
+    of the three-nibble prefixes -- one share in 250, measured. The share
+    is the rarer signal by orders of magnitude, 30 checksum bits over
+    words that must every one of them be among SLIP-0039's 1024, so it is
+    the answer; reporting the electrum type instead would hand back a
+    wallet derived from a share of a secret.
+    """
     assert slip39.mnemonic_from_share(slip39.share_from_mnemonic(share)) == share
-    assert dispatch.all_seed_types_from_mnemonic(share) == []
-    assert dispatch.seed_type_from_mnemonic(share) == ""
+    assert electrum.version_from_mnemonic(share)[0] == electrum_type.removeprefix(
+        "electrum_"
+    )
+    assert dispatch.all_seed_types_from_mnemonic(share) == ["slip39", electrum_type]
+    assert dispatch.seed_type_from_mnemonic(share) == "slip39"
+
+
+def test_the_other_schemes_are_not_read_as_shares() -> None:
+    """Going first costs the other two schemes nothing, and cannot.
+
+    1495 of BIP39's 2048 english words are absent from SLIP-0039's list,
+    so an english sentence has to be built from that list to reach the
+    RS1024 checksum at all -- and 0 of 2000 electrum seeds and 0 of 2000
+    BIP39 mnemonics did, measured. The two collisions above run the order
+    in the direction where it bites; every sentence in the table above
+    runs it in the direction where it must not, this asserting the absence
+    directly rather than leaving it to the expected lists.
+    """
+    for param in DISPATCH_VECTORS:
+        mnemonic = param.values[0]
+        assert isinstance(mnemonic, str)
+        assert "slip39" not in dispatch.all_seed_types_from_mnemonic(mnemonic)


### PR DESCRIPTION
Follow-up to #233 and #238: `mnemonic.dispatch` sat above three schemes
and knew two of them. It knows all three now — `seed_type_from_mnemonic`
answers `"slip39"` for one well-formed SLIP-0039 share — and the seam
`dispatch.py` was carrying is closed rather than reworded.

## The order is the decision, and it is measured

The seam said SLIP-0039 would go last, after BIP39, on the reasoning that
a share carries none of the other schemes' signals. **That reasoning was
wrong**, and measuring it is what showed it: Electrum's version check is
an HMAC over the sentence and consults no word-list at all, so it claims
a share whenever the HMAC happens to start `01` or one of the
three-nibble prefixes.

| direction | measured |
| --- | --- |
| random 1-of-1 shares claimed by an existing scheme | **80 of 20000**, one in 250 |
| … of the first 4000 | 14 `electrum_standard`, 1 `electrum_segwit` |
| Electrum standard seeds read as a share | 0 of 2000 |
| BIP39 18-word mnemonics read as a share | 0 of 2000 |
| BIP39 English words absent from SLIP-0039's list | 1495 of 2048 |

So the asymmetry is total: a share is the rarer signal by orders of
magnitude — 30 checksum bits over words that must every one of them be
among SLIP-0039's 1024 — while an Electrum prefix is eight bits over any
sentence at all. By the base-rate principle the module docstring already
states, the rarer signal wins, so **slip39 goes first**. Last in the
chain would report one share in 250 as an Electrum seed and derive a
wallet from a share of a secret: the failure `old` before `standard`
exists to prevent, one scheme further out.

Going first costs the other two nothing, and cannot — that is what the
two zero rows are for. Two collisions are pinned as fixed cases, one per
prefix flavour; no upstream publishes such a sentence, so both were found
by search.

## What `"slip39"` claims, and what it does not

One well-formed share, not a set that combines. SLIP-0039's own invalid
vectors are what make the distinction concrete, and they split 8/22:

- **8 of the 30** carry a fault inside a single share — checksum,
  padding, length, a group threshold above its own group count — and are
  refused here.
- **22 of the 30** are unusable *sets* of individually sound shares —
  mismatching identifiers or thresholds, duplicate member indices, too
  few groups, a digest that does not check out. Every sentence in them is
  a well-formed share, so every one is reported `"slip39"`, and
  `master_secret_from_mnemonics` is what refuses the set. A fault between
  sentences is not one a dispatcher reading a single sentence can see,
  and answering `""` for a share that is genuinely a share would be the
  wrong answer to the question asked.

The split is classified by **upstream's own descriptions**, not by asking
`share_from_mnemonic` — which is the function under test, so classifying
with it would assert nothing — and both counts are asserted, so a vector
upstream adds or a description it rewords fails the test rather than
quietly joining the wrong half.

## Verification

Exit codes checked, not filtered output:

- `uv run pytest` — exit 0, 15290 passed
- `uv run pre-commit run --all-files` — exit 0, every hook
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Teach the mnemonic dispatcher to recognize SLIP-0039 shares and prioritize them over Electrum and BIP39 based on measured collision rates and base-rate reasoning.

New Features:
- Add SLIP-0039 share detection to mnemonic.dispatch, returning "slip39" for one well-formed share.

Enhancements:
- Adjust seed-type precedence so SLIP-0039 is considered before Electrum and BIP39, reflecting that a valid share is the rarest and most informative signal.
- Document the updated multi-scheme ordering and clarify that "slip39" describes a single valid share, leaving set validation to slip39 APIs.

Documentation:
- Update the changelog to describe SLIP-0039 support in mnemonic.dispatch, its position in the precedence chain, and how invalid SLIP-0039 vectors are handled.

Tests:
- Extend mnemonic dispatch tests with upstream SLIP-0039 valid and invalid vectors to pin which shares are claimed as "slip39" and how per-share vs cross-share faults are treated.
- Add collision tests showing SLIP-0039 shares that Electrum also claims, asserting that the dispatcher reports "slip39" first and that other schemes are not misread as shares.