### PR TITLE
Multiply the generator through mult in dsa, not through the _mult under it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2419,6 +2419,23 @@ edit.
 
 ### Performance
 
+- **the two generator multiplications of `dsa` go through `mult`**, which
+  is where the libsecp256k1 dispatch lives, instead of calling the `_mult`
+  underneath it (issue #272). Both scalars are secret and neither was
+  delegated: `gen_keys` multiplies the private key — 8.2 µs against 889,
+  a hundred times, and its sibling `ssa.gen_keys` had been computing the
+  same point through `mult` all along — and `_sign_` multiplies the
+  nonce, 107 µs against 976. `_sign_` is what a signature falls to
+  whenever the bindings decline the whole of it, so the second one is the
+  cost of every sign-to-contract signature (991 µs to 124) and of every
+  signature under another hash function (1049 to 111). Speed is not the
+  whole of it: the Python fixed window is not constant time, `SECURITY.md`
+  says so, and these two scalars are a private key and a nonce. The
+  Jacobian coordinates the direct call kept are worth one `mod_inv`
+  against those milliseconds, and the curve gate comes for free, `mult`
+  testing it already: every other curve still runs the Python
+  arithmetic, and the tests hold the two answers to each other with the
+  dispatch patched off
 - **the point arithmetic reduces its intermediates as it forms them**,
   which is worth between 2.0 and 3.0 times on every scalar multiplication
   in the package: `_mult` 2.00x, the fixed window over cached multiples

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,6 +72,12 @@ used to teach and to prototype as much as to build:
     commitment; `taproot.output_prvkey` and `dh.diffie_hellman` for
     secp256k1, the tweaking of a key and the shared point of a key
     agreement being the two other places a secret meets the curve.
+    A signature the bindings decline is not all Python for that:
+    `dsa.gen_keys` and the nonce point of `dsa._sign_` go through `mult`,
+    so those two multiplications are delegated whatever else the
+    signature asks for. The rest of that signature is not — the
+    inversion of the nonce and the arithmetic on the key around it are
+    Python integers.
     Anything else — another
     curve, another hash function, another message size, a nonce of your
     own — runs the Python implementation, whose scalar multiplication is

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -38,7 +38,6 @@ from btclib import var_bytes
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
 from btclib.curves import Curve, mult, secp256k1
 from btclib.curves.curve import _libsecp256k1_applicable
-from btclib.curves.curve_group import _mult
 from btclib.curves.curve_group_2 import double_mult_w_NAF
 from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point_
 from btclib.ecc.rfc6979_nonce import _rfc6979_nonce_, challenge_
@@ -287,9 +286,11 @@ def gen_keys(prv_key: PrvKey | None = None, ec: Curve = secp256k1) -> tuple[int,
     else:
         q = int_from_prv_key(prv_key, ec)
 
-    QJ = _mult(q, ec.GJ, ec)
-    Q = ec.aff_from_jac(QJ)
-    return q, Q
+    # mult, not the _mult under it: the scalar is the private key and the
+    # point is the generator, which is the one multiplication libsecp256k1
+    # is dispatched to -- constant time there, and 8.1 us against 862.
+    # ssa.gen_keys computes this very point the same way
+    return q, mult(q, ec=ec)
 
 
 def _sign_(c: int, q: int, nonce: int, lower_s: bool, ec: Curve) -> Sig:
@@ -297,10 +298,14 @@ def _sign_(c: int, q: int, nonce: int, lower_s: bool, ec: Curve) -> Sig:
     # possible value of the challenge c (for low-cardinality curves).
     # It assume that c is in [0, n-1], while q and nonce are in [1, n-1]
     # Steps numbering follows SEC 1 v.2 section 4.1.3
-    KJ = _mult(nonce, ec.GJ, ec)  # 1
-
-    # affine x_K-coordinate of K (field element)
-    x_K = (KJ[0] * mod_inv(KJ[2] * KJ[2], ec.p)) % ec.p
+    # affine x_K-coordinate of K (field element); mult dispatches the
+    # generator to libsecp256k1 on secp256k1, which is where this
+    # function is reached from whenever the bindings decline the whole
+    # signature -- another hash function, another curve, a nonce the
+    # caller imposed, a sign-to-contract commitment. The nonce is secret
+    # and the Python fixed window is not constant time; the affine
+    # conversion the Jacobian form would have saved is one mod_inv
+    x_K = mult(nonce, ec=ec)[0]  # 1
     # mod n makes it a scalar
     r = x_K % ec.n  # 2, 3
     if r == 0:  # r≠0 required as it multiplies the public key

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -20,6 +20,7 @@ from btclib.alias import INF
 from btclib.curves import (
     Curve,
     bytes_from_point,
+    curve,
     double_mult,
     mult,
     point_from_octets,
@@ -473,6 +474,37 @@ def test_prv_key_is_not_a_pub_key() -> None:
     ):
         assert dsa.verify(msg, pub_key, sig)
         assert dsa.verify(msg, pub_key, sig_sha1, hf=sha1)
+
+
+def test_the_two_secret_multiplications_answer_the_python_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`gen_keys` and `_sign_` multiply the generator through `mult`.
+
+    Both scalars are secret — the private key of a key pair, the nonce
+    of a signature — and both points are the generator's multiples, so
+    on secp256k1 `mult` hands them to libsecp256k1, which is constant
+    time where the Jacobian fixed window under it is not.
+
+    The Python path is what every other curve takes and what
+    `test_low_cardinality` exercises there; here it is computed for
+    secp256k1 too, with the dispatch inside `mult` switched off, and the
+    two answers are held to each other. `_mult` beside them is the third
+    opinion: it is the arithmetic being delegated, called directly.
+    """
+    ec = secp256k1
+    nonce = 0x9E5755E5A8FCC1B0A2FD1E0AD9E8D6B29B67D67E6C6A0DEE01E7E1F30DB9A0BE
+    for q in (0x1, 0x2, prv_key_int, ec.n - 1):
+        _, Q = dsa.gen_keys(q)
+        sig = dsa._sign_(0x1234, q, nonce, True, ec)
+
+        with monkeypatch.context() as no_bindings:
+            no_bindings.setattr(curve, "_libsecp256k1_applicable", lambda *_: False)
+            assert dsa.gen_keys(q)[1] == Q
+            assert dsa._sign_(0x1234, q, nonce, True, ec) == sig
+
+        assert Q == ec.aff_from_jac(_mult(q, ec.GJ, ec))
+        assert sig.r == ec.x_aff_from_jac(_mult(nonce, ec.GJ, ec)) % ec.n
 
 
 def test_libsecp256k1() -> None:


### PR DESCRIPTION
Closes #272.

## The change

Two call sites in `btclib/ecc/dsa.py` multiplied a **secret scalar by the
generator** with `_mult`, the Jacobian primitive `curves.mult` falls back to —
so they skipped the libsecp256k1 dispatch that lives in `mult` itself.

| site | scalar | before | after |
| --- | --- | --- | --- |
| `gen_keys` | the private key | 889 µs | 8.2 µs |
| `_sign_` | the nonce | 976 µs | 107 µs |
| a sign-to-contract `dsa.sign` | (reaches `_sign_`) | 991 µs | 124 µs |
| `dsa.sign` under sha512 | (reaches `_sign_`) | 1049 µs | 111 µs |

Measured on this machine, 500 iterations each.

`gen_keys` becomes `mult(q, ec=ec)`, which is `ssa.gen_keys` verbatim — the
same point, computed the delegated way in a sibling module all along.
`_sign_` becomes `mult(nonce, ec=ec)[0]`; the Jacobian form the direct call
bought is worth one `mod_inv`, against the milliseconds above.

Speed is not the whole of it: both scalars are secret, the Python fixed window
is not constant time (`SECURITY.md` says so), and libsecp256k1's
multiplication is.

## What does not change

The curve gate comes for free — `mult` tests the curve itself — so every other
curve still runs the Python arithmetic and `_sign_` stays reachable for the
low-cardinality curves its docstring names, which `test_low_cardinality`
walks exhaustively. `test_the_two_secret_multiplications_answer_the_python_point`
computes both points a second time with the dispatch inside `mult` patched off
and holds the two answers to each other, with `_mult` called directly as a
third opinion.

The six other bypasses the issue surveys are deliberately left alone:
`Curve.__init__` asks whether `n*G` is the point at infinity, which the
bindings refuse rather than answer, and the five `double_mult_w_NAF` /
`_multi_mult` calls are on public data and bypass `double_mult` and
`multi_mult`, which do not delegate either — they are #268's consumers.

`SECURITY.md` gains the clause: a signature the bindings decline is not all
Python any more, though the nonce inversion and the arithmetic around the key
still are.

## Gates

`uv run pytest --cov`: 16381 passed, 1 xfailed, 100.00%.
`uv run pre-commit run --all-files`: exit 0.
`sphinx-build -W`: build succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Delegate DSA generator multiplications to the generic mult dispatcher for libsecp256k1, improving performance and constant-time behavior, and document and test the new behavior.

Bug Fixes:
- Ensure DSA key generation and signing use the libsecp256k1-backed generator multiplication path instead of the Python fixed-window implementation for secp256k1.

Enhancements:
- Refine DSA gen_keys and _sign_ to call mult directly for generator scalar multiplications, aligning behavior with SSA and leveraging constant-time libsecp256k1 operations where available.
- Extend SECURITY.md to clarify which parts of DSA signing may be delegated to libsecp256k1 versus remaining in Python.

Documentation:
- Document the DSA generator multiplication delegation and performance improvements in the changelog and security guidance.

Tests:
- Add a regression test ensuring DSA secret generator multiplications via mult match the Python _mult implementation and libsecp256k1-dispatch is behaviorally consistent.