### PR TITLE
Multiply any point in libsecp256k1, and sum them there too (#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2505,14 +2505,52 @@ edit.
   time: `dh.diffie_hellman` calls `keys.pubkey_tweak_mul` on secp256k1,
   15.2 µs against the 0.55 ms of `mult(dU, QV)` — some thirty-six
   times, this being the multiplication of a point that is *not* the
-  generator, the one case `mult` never delegated, with the private key
-  as the scalar. The derivation is unchanged and still ANSI-X9.63-KDF,
+  generator, with the private key as the scalar; it stays a call of its
+  own past the entry below, which delegates that multiplication in
+  `mult` as well, because the shared point never becomes a `Point` here.
+  The derivation is unchanged and still ANSI-X9.63-KDF,
   which is why the bindings' own `ecdh.shared_secret` is not a
   substitute: that one hashes the compressed shared point with SHA256.
   Every other curve keeps the Python multiplication, GEC 2's secp160r1
   vector now checked through `diffie_hellman` itself, and so does a
   scalar that is zero mod n — the infinity point, which the bindings
   have no scalar for and which is still `invalid (INF) key`
+- **`mult` multiplies any point in libsecp256k1, and `double_mult` and
+  `multi_mult` sum them there**: the bindings served the generator alone,
+  so every other multiplication of secp256k1 ran the Python arithmetic —
+  0.55 ms against 13 µs for `mult(m, Q)`, 1.02 ms against 28 µs for
+  `double_mult`, 2.4 ms against 122 µs for a `multi_mult` of eight
+  scalars and 15.2 ms against 1.01 ms for one of sixty-four: 43x, 36x,
+  20x and 15x. `pedersen.commit` and borromean's rings are `double_mult`
+  callers and take it as it is. What the three reach is one
+  bytes-in/bytes-out layer: a term is `keys.pubkey_tweak_mul`, the
+  running total `keys.pubkey_combine`, and no intermediate becomes a
+  `Point` again — uncompressed in both directions, a compressed answer
+  costing the 73 µs modular square root that lifts an x coordinate back
+  to a point and a compressed argument 2.1 µs of libsecp256k1's own.
+  Their signatures and their answers are unchanged, infinity included: a
+  libsecp256k1 public key is a point of the curve and never the identity,
+  so a zero scalar, the point at infinity, and a sum that lands on
+  infinity — `v = n - u` on the same point is the one-line case — are
+  recognized before the call rather than caught from it. That last one
+  costs a combine per term instead of one combine for all of them, 112 µs
+  against 97 on eight terms and 925 against 774 on sixty-four, and buys a
+  `ValueError` from those calls still meaning what it says; two terms,
+  which is `double_mult` and the shape most callers have, pay nothing.
+  BIP340 batch verification is where the many-scalar sum is, libsecp256k1
+  exposing no batch verify of its own: it goes through the public `mult`
+  and `multi_mult` in affine coordinates now, instead of the Jacobian
+  functions under them and an equality of projective coordinates, 3.4 ms
+  against 739 µs for four signatures — most of what is left being one
+  modular square root per signature, to lift an `r` back to a point. The
+  Python arithmetic stays, and stays the reference the bindings are held
+  against: the dispatch is patched off and every one of these answers
+  asserted again, with the bindings themselves replaced by a function
+  that raises, so a path still reaching them cannot pass in silence.
+  `mult` finds its GLV endomorphism there, which is why that arm is
+  spelled `ec == secp256k1` rather than by the bindings predicate — the
+  same test today, a different question. A `multi_mult` of a single
+  scalar is still `not a multi_mult`
 - **the taproot output *private* key is tweaked by libsecp256k1 too**, and
   in constant time: `taproot.output_prvkey` calls
   `xonly.prvkey_tweak_add`, which is BIP341's tweaking of an x-only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,12 @@ the `btclib_libsecp256k1` cffi bindings — and delegated conditionally,
 which is the single most important thing to know before touching
 `btclib/curves/` or `btclib/ecc/`:
 
-- `curves.curve.mult` calls the bindings for secp256k1 and the generator
-  alone; anything else runs the Python double-and-add of
-  `curves/curve_group.py`
+- `curves.curve.mult`, `double_mult` and `multi_mult` call the bindings
+  for secp256k1 and any point of it, a zero scalar and the point at
+  infinity excepted: libsecp256k1 has no scalar for the one and no public
+  key for the other, so those two — and a sum landing on infinity — are
+  recognized before the call and answered by the Python arithmetic of
+  `curves/curve_group.py`, which is what every other curve runs
 - `ecc.dsa.sign` calls them for secp256k1 with sha256, lower-s, and no
   caller-imposed nonce; `ecc.ssa.sign` for secp256k1 with sha256 **and a
   32-byte message**. That last clause is issue 169: BIP340 accepts a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -65,13 +65,16 @@ used to teach and to prototype as much as to build:
     garbage collection, and may have been copied by the interpreter
     meanwhile. The constant-time properties of libsecp256k1 apply to the
     C side of the boundary, not to what happens before and after it
-- not every operation crosses that boundary. `mult` reaches the bindings
-    for secp256k1 and the generator alone; `dsa.sign` for secp256k1 with
-    sha256, the lower-s form, no caller-imposed nonce and no commitment;
-    `ssa.sign` for secp256k1 with sha256, a 32-byte message and no
-    commitment; `taproot.output_prvkey` and `dh.diffie_hellman` for
-    secp256k1, the tweaking of a key and the shared point of a key
-    agreement being the two other places a secret meets the curve.
+- not every operation crosses that boundary. `mult`, `double_mult` and
+    `multi_mult` reach the bindings for secp256k1 and any point of it, a
+    zero scalar and the point at infinity excepted — libsecp256k1 has no
+    scalar for the one and no public key for the other; `dsa.sign` for
+    secp256k1 with sha256, the lower-s form, no caller-imposed nonce and
+    no commitment; `ssa.sign` for secp256k1 with sha256, a 32-byte
+    message and no commitment; `taproot.output_prvkey` and
+    `dh.diffie_hellman` for secp256k1, the tweaking of a key and the
+    shared point of a key agreement being the two other places a secret
+    meets the curve.
     A signature the bindings decline is not all Python for that:
     `dsa.gen_keys` and the nonce point of `dsa._sign_` go through `mult`,
     so those two multiplications are delegated whatever else the

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -18,9 +18,11 @@ from math import sqrt
 from os import path
 from typing import Any
 
+from btclib_libsecp256k1.keys import pubkey_combine as libsecp256k1_pubkey_combine
+from btclib_libsecp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
 from btclib_libsecp256k1.mult import mult as libsecp256k1_mult
 
-from btclib.alias import HashF, Integer, Point
+from btclib.alias import INF, HashF, Integer, Point
 from btclib.curves.curve_group import (
     HEX_THRESHOLD,
     CurveGroup,
@@ -292,13 +294,100 @@ def _libsecp256k1_applicable(ec: Curve, hf: HashF | None = None) -> bool:
     return hf is None or hf is sha256
 
 
+def _sec_from_point(Q: Point) -> bytes:
+    """Return a point of secp256k1 as the octets the bindings parse.
+
+    Neither on-curve nor infinity is checked here: this is the inside of
+    the dispatches below, past their require_on_curve, and sec_point's
+    bytes_from_point is unreachable from this module anyway -- that one
+    is built on this one.
+
+    Uncompressed, 0x04 || x || y, which is what makes the round trip
+    worth taking, in both directions. It is the form ec_pubkey_parse
+    reads without lifting an x coordinate back to a point, 2.1 us of the
+    13 a whole multiplication costs; and, asked of ec_pubkey_serialize on
+    the way out, the form that does not drop a y this side would have to
+    lift again -- 73 us of modular square root against 1.2 us of
+    int.from_bytes, the lesson bip32.py:462 records for public
+    derivation. The 32 octets more cost 0.09 us to write here.
+    """
+    p_size = secp256k1.p_size
+    return b"\x04" + Q[0].to_bytes(p_size, "big") + Q[1].to_bytes(p_size, "big")
+
+
+def _libsecp256k1_multi_mult_(
+    scalars: Sequence[int], secs: Sequence[bytes]
+) -> bytes | None:
+    """Return sum(scalars[i]*points[i]) as octets, None for infinity.
+
+    The bytes-in/bytes-out layer the gain lives on: a term is one
+    ec_pubkey_tweak_mul, the running total one ec_pubkey_combine, and no
+    intermediate becomes a Point -- each of those would pay a parse on
+    the way out and a serialization on the way back in.
+
+    None rather than octets, because infinity has no serialization: a
+    libsecp256k1 pubkey is a point of the curve and never the identity.
+    Every scalar is therefore required to be in [1, n-1] and every point
+    to be a point of secp256k1 that is not infinity -- the callers below
+    gate on exactly that -- which leaves the sum as the one infinity to
+    answer for: u*H + v*Q with v*Q == -u*H, and v = n - u with Q == H is
+    the one-line case of it.
+
+    That sum is recognized from the coordinates, same x and different y,
+    rather than caught from the combine that fails on it, so that a
+    ValueError raised in here still means what it says instead of
+    doubling as a value. Its price is one combine per term rather than
+    one for all of them, a running total being what has an x to compare:
+    measured on eight terms 112 us against 97, and on sixty-four 925
+    against 774, where the Python arithmetic below takes 2.4 ms and 15 ms.
+    Two terms, which is double_mult and the shape most callers have, pay
+    nothing at all: one combine either way.
+    """
+    x_slice = slice(1, secp256k1.p_size + 1)
+    total: bytes | None = None
+    for m, sec in zip(scalars, secs, strict=True):
+        term = libsecp256k1_pubkey_tweak_mul(sec, m, False)
+        if total is None:  # nothing yet, or infinity, and INF + P is P
+            total = term
+        elif total != term and total[x_slice] == term[x_slice]:
+            # same x, different y, i.e. P + (-P): infinity. Equal octets
+            # instead are P + P, which combine doubles like any other sum
+            total = None
+        else:
+            total = libsecp256k1_pubkey_combine([total, term], False)
+    return total
+
+
+def _libsecp256k1_multi_mult(scalars: Sequence[int], points: Sequence[Point]) -> Point:
+    """Return sum(scalars[i]*points[i]), through the bindings.
+
+    The Point signature the callers keep; the arithmetic is the bytes
+    layer above, whose None is this function's INF.
+    """
+    sec = _libsecp256k1_multi_mult_(scalars, [_sec_from_point(Q) for Q in points])
+    if sec is None:
+        return INF
+    p_size = secp256k1.p_size
+    return (
+        int.from_bytes(sec[1 : p_size + 1], "big"),
+        int.from_bytes(sec[p_size + 1 :], "big"),
+    )
+
+
 def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point:
     """Elliptic curve scalar multiplication."""
     m: int = int_from_integer(m_int) % ec.n
 
     # m == 0 is the infinity point, which the bindings reject as a scalar
-    if m and _libsecp256k1_applicable(ec) and (Q is None or Q == ec.G):
-        return libsecp256k1_mult(m)
+    if m and _libsecp256k1_applicable(ec):
+        # the generator is ec_pubkey_create, with no point to parse first
+        if Q is None or Q == ec.G:
+            return libsecp256k1_mult(m)
+        ec.require_on_curve(Q)
+        # any other point, infinity excepted: that one is not a pubkey,
+        # and m*INF == INF is what the Python path below answers anyway
+        if Q[1]:
+            return _libsecp256k1_multi_mult([m], [Q])
 
     if Q is None:
         QJ = ec.GJ
@@ -306,16 +395,18 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
         ec.require_on_curve(Q)
         QJ = jac_from_aff(Q)
 
-    # past the check above, secp256k1 here means a point the bindings do
-    # not take -- any point but the generator -- which is exactly where
-    # the GLV endomorphism pays: 0.53 ms against the 0.84 of _mult, the
-    # decomposition being secp256k1's own lambda and beta. Same predicate
-    # as the bindings dispatch, so the two cannot drift apart
-    R = (
-        mult_endomorphism_secp256k1(m, QJ, ec)
-        if _libsecp256k1_applicable(ec)
-        else _mult(m, QJ, ec)
-    )
+    # what reaches here on secp256k1 is the arguments the bindings decline
+    # -- a zero scalar, or infinity -- and, with the dispatch
+    # above patched off, every multiplication of the curve: that is the
+    # reference implementation the test suite holds the bindings against,
+    # and the GLV endomorphism is its fastest form, 0.53 ms against the
+    # 0.84 of _mult, the decomposition being secp256k1's own lambda and
+    # beta. Not spelled as _libsecp256k1_applicable, though it is the same
+    # test today: what decides here is whether the curve has that
+    # endomorphism, so patching the bindings off must leave this arm --
+    # python_path_test.py's pattern, which otherwise would compare the
+    # bindings against the generic double-and-add of every other curve
+    R = mult_endomorphism_secp256k1(m, QJ, ec) if ec == secp256k1 else _mult(m, QJ, ec)
     return ec.aff_from_jac(R)
 
 
@@ -324,13 +415,20 @@ def double_mult(
 ) -> Point:
     """Double scalar multiplication (u*H + v*Q)."""
     ec.require_on_curve(H)
-    HJ = jac_from_aff(H)
-
     ec.require_on_curve(Q)
-    QJ = jac_from_aff(Q)
 
     u = int_from_integer(u) % ec.n
     v = int_from_integer(v) % ec.n
+
+    # a zero scalar and infinity are what the bindings decline, and the
+    # term they make is nothing: dropping it here would leave the empty
+    # sum -- infinity -- to answer for as well, which the Python path
+    # below answers already, so the whole call goes there instead
+    if u and v and H[1] and Q[1] and _libsecp256k1_applicable(ec):
+        return _libsecp256k1_multi_mult([u, v], [H, Q])
+
+    HJ = jac_from_aff(H)
+    QJ = jac_from_aff(Q)
     R = double_mult_w_NAF(u, HJ, v, QJ, ec)
     return ec.aff_from_jac(R)
 
@@ -342,7 +440,9 @@ def multi_mult(
 
     Interleaved wNAF on few scalars, Bos-Coster on many: curve_group's
     _multi_mult dispatches on the count, at the size the two measure the
-    same.
+    same. On secp256k1 the bindings serve the whole sum instead, and this
+    is the one caller that hands them many scalars at once -- libsecp256k1
+    exposing no batch verification, ssa's is built on this.
     """
     if len(scalars) != len(points):
         err_msg = "mismatch between number of scalars and points: "
@@ -352,7 +452,16 @@ def multi_mult(
     ints = [int_from_integer(s) % ec.n for s in scalars]
     for Q in points:
         ec.require_on_curve(Q)
-    jac_points = [jac_from_aff(Q) for Q in points]
 
+    # as in double_mult; and fewer than two terms is not a multi_mult at
+    # all, an error the Python path below is the one to raise
+    if (
+        len(points) > 1
+        and _libsecp256k1_applicable(ec)
+        and all(m and Q[1] for m, Q in zip(ints, points, strict=True))
+    ):
+        return _libsecp256k1_multi_mult(ints, points)
+
+    jac_points = [jac_from_aff(Q) for Q in points]
     R = _multi_mult(ints, jac_points, ec)
     return ec.aff_from_jac(R)

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -76,8 +76,7 @@ from btclib_libsecp256k1 import ssa as libsecp256k1_ssa
 from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
 from btclib.bip32 import BIP32Key
 from btclib.curves import Curve, secp256k1
-from btclib.curves.curve import _libsecp256k1_applicable, mult
-from btclib.curves.curve_group import _mult, _multi_mult
+from btclib.curves.curve import _libsecp256k1_applicable, mult, multi_mult
 from btclib.curves.curve_group_2 import double_mult_w_NAF
 from btclib.ecc.bip340_nonce import bip340_nonce_
 from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point_
@@ -617,15 +616,14 @@ def assert_batch_as_valid_(
         raise BTClibValueError("not the same curve for all signatures")
     t = 0
     scalars: list[int] = []
-    points: list[JacPoint] = []
+    points: list[Point] = []
     for i, (msg, Q, sig) in enumerate(zip(msgs, Qs, sigs, strict=True)):
         # any size, as in sign_ and assert_as_valid_
         msg = bytes_from_octets(msg)
 
-        KJ = sig.r, ec.y_even(sig.r), 1
+        K = sig.r, ec.y_even(sig.r)
 
         x_Q, y_Q = point_from_bip340pub_key(Q, ec)
-        QJ = x_Q, y_Q, 1
 
         c = challenge_(msg, x_Q, sig.r, ec, hf)
 
@@ -636,20 +634,24 @@ def assert_batch_as_valid_(
         # run of the batch verification algorithm
         rand = 1 if i == 0 else 1 + secrets.randbelow(ec.n - 1)
         scalars.append(rand)
-        points.append(KJ)
+        points.append(K)
         scalars.append(rand * c % ec.n)
-        points.append(QJ)
+        points.append((x_Q, y_Q))
         t += rand * sig.s
 
-    TJ = _mult(t, ec.GJ, ec)
-    RHSJ = _multi_mult(scalars, points, ec)
-
-    # return T == RHS, checked in Jacobian coordinates
-    RHSZ2 = RHSJ[2] * RHSJ[2]
-    TZ2 = TJ[2] * TJ[2]
-    if (TJ[0] * RHSZ2 % ec.p != RHSJ[0] * TZ2 % ec.p) or (
-        TJ[1] * RHSZ2 * RHSJ[2] % ec.p != RHSJ[1] * TZ2 * TJ[2] % ec.p
-    ):
+    # the public mult and multi_mult, in affine coordinates, rather than
+    # the Jacobian functions of curve_group underneath them and an
+    # equality of projective coordinates: those two are where the
+    # libsecp256k1 dispatch lives, and this sum is the one place in btclib
+    # that hands the bindings many scalars at once, libsecp256k1 exposing
+    # no batch verification of its own. Four signatures, i.e. the eight
+    # terms above: 2.4 ms of Python arithmetic against 122 us, and
+    # assert_batch_as_valid_ as a whole 3.4 ms against 739 us -- most of
+    # what is left being one y_even per signature, 74 us of modular
+    # square root to lift an r back to a point. The two affine
+    # conversions the equality costs on every other curve are one modular
+    # inversion each, next to a multi_mult of all the terms
+    if mult(t, ec=ec) != multi_mult(scalars, points, ec):
         raise BTClibRuntimeError("signature verification failed")
     return
 

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -17,7 +17,19 @@ from hashlib import sha256, sha512
 import pytest
 
 from btclib.alias import INF, INFJ, Integer, JacPoint, Point
-from btclib.curves import Curve, CurveGroup, double_mult, mult, multi_mult, secp256k1
+from btclib.curves import (
+    Curve,
+    CurveGroup,
+    bytes_from_point,
+    # the module, not only the names in it: the libsecp256k1 dispatch is a
+    # module attribute, and patching it off is how no_bindings below
+    # reaches the Python arithmetic underneath
+    curve,
+    double_mult,
+    mult,
+    multi_mult,
+    secp256k1,
+)
 from btclib.curves.curve import (
     CURVES,
     NIST,
@@ -30,6 +42,8 @@ from btclib.curves.curve import (
     SEC2v2,
     SEC2v2_params2,
     _libsecp256k1_applicable,
+    _libsecp256k1_multi_mult_,
+    _sec_from_point,
 )
 
 # cached_multiples and jac_from_aff are implementation helpers of
@@ -877,3 +891,142 @@ def test_multi_mult() -> None:
     n = secp256k1.n
     for i, j in ((10**6, 1), (1, 10**6), (n - 1, 1), (n - 1, n - 2)):
         assert double_mult(i, G, j, H) == multi_mult([i, j], [G, H])
+
+
+def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch the libsecp256k1 dispatch off, and the bindings out of reach.
+
+    The predicate is what mult, double_mult and multi_mult ask, and
+    patching it is the pattern of tests/script_engine/python_path_test.py.
+    Replacing the three bindings functions besides is what proves they
+    were not asked anyway: a dispatch this does not cover raises here
+    instead of quietly measuring the bindings against themselves.
+    """
+
+    def refuse(*_: object) -> bytes:
+        # a green suite is one where this never runs: the pragma is the
+        # same one borromean and bms carry, for a line the arithmetic --
+        # here the dispatch above it -- rules out
+        raise AssertionError(  # pragma: no cover
+            "the libsecp256k1 dispatch is patched off"
+        )
+
+    monkeypatch.setattr(curve, "_libsecp256k1_applicable", lambda *_: False)
+    monkeypatch.setattr(curve, "libsecp256k1_mult", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_pubkey_tweak_mul", refuse)
+    monkeypatch.setattr(curve, "libsecp256k1_pubkey_combine", refuse)
+
+
+def test_libsecp256k1_arbitrary_point() -> None:
+    """The bindings' point arithmetic against the Python arithmetic.
+
+    Every multiplication of secp256k1 goes through libsecp256k1 now, the
+    generator's and any other point's, so the Python arithmetic is what
+    the suite has to reach on purpose: the dispatch is patched off and the
+    same call made again. The bindings are the authority on the answer --
+    they are what bitcoin runs -- and the Python implementation is the one
+    being held against them, `mult` reaching its GLV endomorphism there
+    and `multi_mult` its Bos-Coster.
+
+    A spread of scalars and points rather than a random draw, so that a
+    failure is the same failure tomorrow. G is among the points on
+    purpose: it takes the ec_pubkey_create branch of `mult`, where every
+    other point takes the ec_pubkey_tweak_mul one.
+    """
+    n = secp256k1.n
+    scalars = (1, 2, 3, 7, 10**6, n // 2, n - 2, n - 1)
+    points = [mult(k) for k in (1, 2, 3, 7, n // 3, n - 1)]
+    # every scalar paired with a point, the large ones included: a sum of
+    # two small scalars is not what the wNAF and the endomorphism differ on
+    pairs = list(zip(scalars, points + points[:2], strict=True))
+
+    for m, Q in itertools.product(scalars, points):
+        libsecp256k1_answer = mult(m, Q)
+        with pytest.MonkeyPatch.context() as patch:
+            no_bindings(patch)
+            assert mult(m, Q) == libsecp256k1_answer
+
+    for (u, H), (v, Q) in itertools.product(pairs, repeat=2):
+        libsecp256k1_answer = double_mult(u, H, v, Q)
+        assert multi_mult([u, v], [H, Q]) == libsecp256k1_answer
+        with pytest.MonkeyPatch.context() as patch:
+            no_bindings(patch)
+            assert double_mult(u, H, v, Q) == libsecp256k1_answer
+            assert multi_mult([u, v], [H, Q]) == libsecp256k1_answer
+
+    # and the many-scalar sum, which is what ssa's batch verification is
+    libsecp256k1_answer = multi_mult(scalars, points + points[:2])
+    with pytest.MonkeyPatch.context() as patch:
+        no_bindings(patch)
+        assert multi_mult(scalars, points + points[:2]) == libsecp256k1_answer
+
+
+@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
+def test_multiplications_the_bindings_decline(
+    bindings: bool, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A zero scalar, infinity, and a sum that is infinity.
+
+    None of the three is a libsecp256k1 argument or answer -- a pubkey is
+    a point of the curve and never the identity -- and each has to be
+    recognized before the call rather than caught from it. The same table
+    is asserted of both implementations, which is the point of it: what
+    the bindings decline, the Python arithmetic answers, and the two
+    cannot disagree about infinity.
+    """
+    if not bindings:
+        no_bindings(monkeypatch)
+
+    n = secp256k1.n
+    G = secp256k1.G
+    H = second_generator(secp256k1)
+
+    # a zero scalar, and infinity as the point
+    assert mult(0, H) == INF
+    assert mult(n, H) == INF  # n reduces to zero
+    assert mult(3, INF) == INF
+    assert mult(0, INF) == INF
+
+    # both of them again, as one term of a sum
+    assert double_mult(0, H, 0, G) == INF
+    assert double_mult(0, H, 3, G) == mult(3)
+    assert double_mult(3, INF, 5, H) == mult(5, H)
+    assert double_mult(3, H, 5, INF) == mult(3, H)
+    assert multi_mult([0, 0], [H, G]) == INF
+    assert multi_mult([3, 0], [H, G]) == mult(3, H)
+    assert multi_mult([3, 5], [INF, H]) == mult(5, H)
+
+    # and the sum that is infinity: v = n - u with the same point, the
+    # one-line case, then the same through multi_mult
+    assert double_mult(5, H, n - 5, H) == INF
+    assert multi_mult([5, n - 5], [H, H]) == INF
+
+    # an intermediate that is infinity and a total that is not: the
+    # running total starts again from the term that follows it
+    assert multi_mult([5, n - 5, 3], [H, H, H]) == mult(3, H)
+
+    # a total that is infinity from three terms of which no two cancel:
+    # 5 + (n-3) + 2*(n-1) is 2n
+    assert multi_mult([5, n - 3, n - 1], [H, H, mult(2, H)]) == INF
+
+    # the same point twice is P + P, a doubling and not a cancellation
+    assert multi_mult([5, 5], [H, H]) == mult(10, H)
+    assert double_mult(5, H, 5, H) == mult(10, H)
+
+
+def test_libsecp256k1_multi_mult_bytes() -> None:
+    """The bytes boundary the dispatch is built on.
+
+    `_sec_from_point` is `bytes_from_point` without the checks that the
+    dispatch has already made, and asserting the two agree is what keeps
+    it from drifting into a different serialization; `None` is infinity,
+    which has no serialization at all.
+    """
+    H = second_generator(secp256k1)
+    sec = _sec_from_point(H)
+    assert sec == bytes_from_point(H, compressed=False)
+    assert len(sec) == 2 * secp256k1.p_size + 1
+
+    assert _libsecp256k1_multi_mult_([5], [sec]) == _sec_from_point(mult(5, H))
+    assert _libsecp256k1_multi_mult_([5, 3], [sec, sec]) == _sec_from_point(mult(8, H))
+    assert _libsecp256k1_multi_mult_([5, secp256k1.n - 5], [sec, sec]) is None

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -28,7 +28,7 @@ from btclib.hashes import reduce_to_hlen
 from btclib.number_theory import mod_inv
 from btclib.utils import int_from_bits
 from tests import load_csv, vector_id
-from tests.curves.curve_test import low_card_curves, secp256k1_bis
+from tests.curves.curve_test import low_card_curves, no_bindings, secp256k1_bis
 
 
 def test_signature_on_an_equal_curve() -> None:
@@ -313,6 +313,42 @@ def test_batch_validation() -> None:
     with pytest.raises(BTClibRuntimeError, match=err_msg):
         ssa.assert_batch_as_valid_(ms, Qs, sigs)
     assert not ssa.batch_verify_(ms, Qs, sigs)
+
+
+def test_batch_validation_on_the_python_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The batch verification equation, on both point arithmetics.
+
+    Batch verification is btclib's own: libsecp256k1 exposes no batch
+    verify, so what serves it is the multi_mult of curves.curve -- and on
+    secp256k1 that is the bindings, which makes this the one caller
+    handing them many scalars at once. Patching the dispatch off is the
+    only way the Python arithmetic sees a batch, and what this catches is
+    the two implementations disagreeing about the verdict, on a batch that
+    must pass and on one that must fail.
+    """
+    aux = b"\x00" * 32
+    # not the size of the msg_hash, just an arbitrary size for the msg
+    msg_size = 16
+    msgs: list[String] = []
+    Qs: list[int] = []
+    sigs: list[ssa.Sig] = []
+    for i in range(1, 5):
+        msg = bytes(i) * msg_size
+        msgs.append(msg)
+        q, Q = ssa.gen_keys(i)
+        Qs.append(Q)
+        sigs.append(ssa.sign(msg, q, aux))
+
+    ssa.assert_batch_as_valid(msgs, Qs, sigs)
+
+    no_bindings(monkeypatch)
+    ssa.assert_batch_as_valid(msgs, Qs, sigs)
+
+    # one signature belonging to another message of the same batch: the
+    # sum misses, and misses on either arithmetic
+    sigs[-1] = sigs[0]
+    with pytest.raises(BTClibRuntimeError, match="signature verification failed"):
+        ssa.assert_batch_as_valid(msgs, Qs, sigs)
 
 
 def test_musig() -> None:


### PR DESCRIPTION
Refs #268, and does not close it: see *What this does not do* below.

`curves.mult` delegated to libsecp256k1 for the generator alone, so every
other multiplication of secp256k1 ran the Python arithmetic — and so did
both sums. Measured on this branch, secp256k1, random scalars and points,
the same call with the dispatch patched off against the dispatch on:

| operation | Python | bindings | |
| --- | --- | --- | --- |
| `mult(m, Q)` | 554.0 us | 13.0 us | 43x |
| `double_mult(u, H, v, Q)` | 1015.6 us | 28.4 us | 36x |
| `multi_mult`, 8 scalars | 2413.7 us | 122.0 us | 20x |
| `multi_mult`, 64 scalars | 15197.7 us | 1007.8 us | 15x |
| `pedersen.commit` | 1113.0 us | 104.6 us | 11x |
| `ssa.assert_batch_as_valid_`, 4 sigs | 3437.2 us | 738.6 us | 5x |

`pedersen.commit` and borromean's rings are `double_mult` callers and take
it as it is; what is left of the first is 74.3 us of `second_generator`,
recomputed per call, and of the last one `y_even` per signature.

## The three decisions the issue asks for

**The boundary is bytes.** `_libsecp256k1_multi_mult_` takes scalars and
octets and answers octets: a term is `keys.pubkey_tweak_mul`, the running
total `keys.pubkey_combine`, and no intermediate becomes a `Point` again.
Uncompressed in both directions — a compressed answer costs the 73 us
modular square root that lifts an x coordinate back to a point, a
compressed argument 2.1 us of libsecp256k1's own, and the 32 octets more
cost 0.09 us to write. `mult`, `double_mult` and `multi_mult` keep their
`Point` signatures above it.

**Infinity is recognized, not caught.** A libsecp256k1 pubkey is a point
of the curve and never the identity, so the bytes layer answers `None` for
it, and its callers gate on a scalar in `[1, n-1]` and a point that is not
infinity — a zero scalar or an infinity term sends the whole call to the
Python path, which answers all of it already. What is left is the sum:
`u*H + v*Q` with `v*Q == -u*H`, reachable on purpose with `v = n - u` and
`Q = H`. It is read off the coordinates, same x and different y, rather
than caught from the combine that fails on it, so a `ValueError` from
those calls still means what it says. The price is one combine per term
instead of one for all of them — 112 us against 97 on eight terms, 925
against 774 on sixty-four — and two terms, which is `double_mult` and the
shape most callers have, pay nothing at all.

**What stays Python, and why it is not dead code.** Every other curve, and
the reference the bindings are held against. `test_libsecp256k1_arbitrary_point`
patches the dispatch off and asserts every answer again, with the three
bindings functions replaced by one that raises, so a path still reaching
them cannot pass in silence; `test_multiplications_the_bindings_decline` is
one table of infinity cases run against both implementations. That is also
why `mult`'s Python arm is now spelled `ec == secp256k1` instead of
`_libsecp256k1_applicable(ec)`: the same test today, a different question —
whether the curve has the GLV endomorphism — and patching the bindings off
must not send secp256k1 to the generic double-and-add.

## Where it is reached

BIP340 batch verification, the one place in btclib that hands the bindings
many scalars at once (libsecp256k1 exposes no batch verify), now goes
through the public `mult` and `multi_mult` in affine coordinates instead
of the Jacobian functions under them and an equality of projective
coordinates. Same verdicts, on either arithmetic: the new
`test_batch_validation_on_the_python_path` runs a batch that must pass and
one that must fail through both.

`pedersen`, `borromean` and any caller multiplying a point it did not get
from `G` are served by the dispatch itself. A `multi_mult` of a single
scalar is still `not a multi_mult`.

## What this does not do, and why the issue stays open

The Jacobian `double_mult_w_NAF` of `dsa._assert_as_valid_` and
`ssa._assert_as_valid_` — the paths the bindings' own verify declines, a
hash function that is not sha256 and BIP340 with a message that is not 32
bytes (#169). Both take a `JacPoint` and compare projective coordinates,
so delegating them changes the two most important verification functions
in the package and belongs on its own.

## Gates

`pre-commit run --all-files` clean, `pytest --cov=btclib --cov=tests` at
100.00% over 16425 tests, the 3.10 matrix cell green, and the sphinx `-W`
docs build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Delegate secp256k1 point multiplications and multi-scalar sums to libsecp256k1 for arbitrary points while keeping Python implementations as the reference path.

New Features:
- Add libsecp256k1-backed multi-scalar multiplication helper for secp256k1 using byte-encoded points and returning infinity as a sentinel value.
- Enable batch Schnorr (BIP340) verification to use the public affine mult/multi_mult API, allowing bindings-based acceleration for multi-scalar sums.

Enhancements:
- Extend mult, double_mult, and multi_mult to offload all eligible secp256k1 operations to libsecp256k1, including non-generator points, while preserving behavior for zero scalars and infinity.
- Introduce a bytes-level boundary for secp256k1 point serialization consistent with libsecp256k1 expectations and reuse it across bindings-backed operations.
- Clarify and update developer and security documentation to describe which curve operations use libsecp256k1 and how infinity and edge cases are handled.

Tests:
- Add tests that compare libsecp256k1-backed point arithmetic against the Python implementation, including cases where bindings are forcibly disabled.
- Add tests covering edge cases that libsecp256k1 cannot represent (zero scalars, infinity, and sums yielding infinity) to ensure Python and bindings paths agree.
- Add tests ensuring the byte-level multi-mult helper matches higher-level point operations and that batch verification produces consistent results on both arithmetic paths.
