### PR TITLE
Multiply in libsecp256k1 the verifications its own verify declines (#268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2551,6 +2551,33 @@ edit.
   spelled `ec == secp256k1` rather than by the bindings predicate — the
   same test today, a different question. A `multi_mult` of a single
   scalar is still `not a multi_mult`
+- **the verification a signature's own bindings decline still multiplies in
+  libsecp256k1**: `dsa._assert_as_valid_` and `ssa._assert_as_valid_` are
+  what answers when `ecdsa_verify` and BIP340's verify are not asked — a
+  hash function that is not sha256, a commitment to check, a
+  caller-imposed nonce, a BIP340 message of a size other than 32 bytes,
+  which is issue #169 and four of BIP340's own vectors — and each paid a
+  Python `double_mult` underneath whatever the reason. They now reach the
+  dispatching one: ECDSA verification with sha512 is 128 µs against
+  1.10 ms, BIP340 verification of a 30-byte message 183 µs against
+  1.17 ms, and what is left of the second is mostly the modular square
+  root that lifts the signature's `r` back to a point. Both keep their
+  Jacobian shape rather than being rewritten in affine coordinates,
+  because it is not only their arithmetic that is projective: so are the
+  infinity test, the y parity and the x comparison each makes, and so is
+  the `QJ` that public key recovery threads through `dsa`'s. What makes
+  that exact is `jac_from_aff` answering `z == 0` for the infinity the
+  other side of the boundary has no serialization for, so each function
+  still raises what it raised before, from the same line — `invalid (INF)
+  key` for the ECDSA `K` that is infinity, from the same `KJ[2] == 0`.
+  The two conversions it costs are 0.39 µs each on the `z == 1` a parsed
+  key arrives as; the shortcut that would skip them, the affine point
+  being the same pair of coordinates, saves 0.75 µs of 28 and is not
+  worth a branch. Every other curve is untouched, measured: secp256r1
+  ECDSA verification is 1.21 ms either way. `tests/script_engine`'s
+  bindings-less configuration patches the curve dispatch off as well now,
+  which is what keeps it one: the verdict was already the Python
+  implementation's, and now the multiplication under it is too
 - **the taproot output *private* key is tweaked by libsecp256k1 too**, and
   in constant time: `taproot.output_prvkey` calls
   `xonly.prvkey_tweak_add`, which is BIP341's tweaking of an x-only

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,8 +77,9 @@ used to teach and to prototype as much as to build:
     meets the curve.
     A signature the bindings decline is not all Python for that:
     `dsa.gen_keys` and the nonce point of `dsa._sign_` go through `mult`,
-    so those two multiplications are delegated whatever else the
-    signature asks for. The rest of that signature is not — the
+    and the verification equation of both `dsa` and `ssa` through
+    `double_mult`, so those multiplications are delegated whatever else
+    the signature asks for. The rest of that signature is not — the
     inversion of the nonce and the arithmetic on the key around it are
     Python integers.
     Anything else — another

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -22,7 +22,7 @@ from btclib_libsecp256k1.keys import pubkey_combine as libsecp256k1_pubkey_combi
 from btclib_libsecp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
 from btclib_libsecp256k1.mult import mult as libsecp256k1_mult
 
-from btclib.alias import INF, HashF, Integer, Point
+from btclib.alias import INF, HashF, Integer, JacPoint, Point
 from btclib.curves.curve_group import (
     HEX_THRESHOLD,
     CurveGroup,
@@ -431,6 +431,39 @@ def double_mult(
     QJ = jac_from_aff(Q)
     R = double_mult_w_NAF(u, HJ, v, QJ, ec)
     return ec.aff_from_jac(R)
+
+
+def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> JacPoint:
+    """Return u*HJ + v*QJ in Jacobian coordinates, delegated where it can be.
+
+    double_mult for a caller whose equation is written in projective
+    coordinates: dsa's and ssa's _assert_as_valid_, which are the two
+    verifications the bindings' own decline -- a hash function that is not
+    sha256, a BIP340 message that is not 32 bytes (issue 169), a
+    caller-imposed nonce, another curve -- and which paid a Python
+    double_mult underneath whatever the reason. 1.02 ms against 28 us on
+    secp256k1.
+
+    Jacobian in and Jacobian out, rather than those two rewritten in
+    affine coordinates, because it is not only their arithmetic that is
+    projective: so are the infinity test, the y parity and the x
+    comparison each makes, and so is the QJ that public key recovery
+    threads through dsa's. jac_from_aff is what keeps that exact --
+    infinity has no serialization on the other side of the boundary, and
+    it answers the z == 0 both functions already recognize, so each still
+    raises what it raised before, from the same line.
+
+    The two conversions in cost 0.39 us each on the z == 1 that a parsed
+    key and a lifted r arrive as, and a shortcut for that case -- the
+    affine point being the same pair of coordinates, no inversion at all
+    -- saves 0.75 us of the 28. Not worth a branch, and neither is the
+    caller's own mod_inv(1) on the way back out, 0.14 us.
+    """
+    if not _libsecp256k1_applicable(ec):
+        return double_mult_w_NAF(u, HJ, v, QJ, ec)
+
+    R = double_mult(u, ec.aff_from_jac(HJ), v, ec.aff_from_jac(QJ), ec)
+    return jac_from_aff(R)
 
 
 def multi_mult(

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -37,7 +37,7 @@ from btclib_libsecp256k1 import dsa as libsecp256k1_dsa
 from btclib import var_bytes
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
 from btclib.curves import Curve, mult, secp256k1
-from btclib.curves.curve import _libsecp256k1_applicable
+from btclib.curves.curve import _jac_double_mult, _libsecp256k1_applicable
 from btclib.curves.curve_group_2 import double_mult_w_NAF
 from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point_
 from btclib.ecc.rfc6979_nonce import _rfc6979_nonce_, challenge_
@@ -505,7 +505,14 @@ def _assert_as_valid_(
     u = c * w % ec.n
     v = r * w % ec.n  # 4
     # Let K = u*G + v*Q.
-    KJ = double_mult_w_NAF(v, QJ, u, ec.GJ, ec)  # 5
+    # the dispatching double_mult of curves.curve, not the Python
+    # arithmetic under it: what reaches here is the verification the
+    # bindings' own ecdsa_verify declined -- another hash function, a
+    # commitment to check, a caller-imposed nonce, a curve of its own --
+    # and on secp256k1 the multiplication is theirs all the same, 28 us
+    # against 1.02 ms, which is this whole verification 128 us against
+    # 1.10 ms of it
+    KJ = _jac_double_mult(v, QJ, u, ec.GJ, ec)  # 5
 
     # Fail if infinite(K).
     # K = w*(c + r*q)*G is INF whenever c == -r*q (mod n)

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -76,7 +76,12 @@ from btclib_libsecp256k1 import ssa as libsecp256k1_ssa
 from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
 from btclib.bip32 import BIP32Key
 from btclib.curves import Curve, secp256k1
-from btclib.curves.curve import _libsecp256k1_applicable, mult, multi_mult
+from btclib.curves.curve import (
+    _jac_double_mult,
+    _libsecp256k1_applicable,
+    mult,
+    multi_mult,
+)
 from btclib.curves.curve_group_2 import double_mult_w_NAF
 from btclib.ecc.bip340_nonce import bip340_nonce_
 from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point_
@@ -417,8 +422,15 @@ def _assert_as_valid_(c: int, QJ: JacPoint, r: int, s: int, ec: Curve) -> None:
     # It raises Errors, while verify should always return True or False
 
     # Let K = sG - eQ.
-    # in Jacobian coordinates
-    KJ = double_mult_w_NAF(ec.n - c, QJ, s, ec.GJ, ec)
+    # in Jacobian coordinates, and through the dispatching double_mult of
+    # curves.curve rather than the Python arithmetic under it: what
+    # reaches here is the verification the bindings' own declined -- a
+    # message that is not 32 bytes above all, which is issue 169 and four
+    # of BIP340's own vectors -- and on secp256k1 the multiplication is
+    # still theirs, 28 us against 1.02 ms. This whole verification is then
+    # 183 us against 1.17 ms, most of what is left being the y_even that
+    # lifts the r of the signature back to a point
+    KJ = _jac_double_mult(ec.n - c, QJ, s, ec.GJ, ec)
 
     # The following check is prescribed by BIP340 but it is useless:
     # if moved after 'Fail if x_K ≠ r' it would never be executed

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -10,7 +10,7 @@
 """Tests for the `btclib.dsa` module."""
 
 import secrets
-from hashlib import sha1, sha256
+from hashlib import sha1, sha256, sha512
 from typing import Any
 
 import pytest
@@ -34,7 +34,7 @@ from btclib.hashes import reduce_to_hlen
 from btclib.number_theory import mod_inv
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from tests import load, vector_id
-from tests.curves.curve_test import low_card_curves, secp256k1_bis
+from tests.curves.curve_test import low_card_curves, no_bindings, secp256k1_bis
 from tests.to_key_test import Q as pub_key_point
 from tests.to_key_test import Q_compressed as pub_key_compressed
 from tests.to_key_test import q as prv_key_int
@@ -585,6 +585,43 @@ def test_verify_infinity_point() -> None:
     err_msg = r"invalid \(INF\) key"
     with pytest.raises(BTClibRuntimeError, match=err_msg):
         dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, True, ec)
+
+
+def test_verify_with_another_hash_function_on_both_arithmetics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The verification equation the bindings decline, on both arithmetics.
+
+    A hash function that is not sha256 is one of the reasons
+    `libsecp256k1_dsa.verify` is not asked -- a commitment to check, a
+    caller-imposed nonce and another curve are the others -- and what
+    answers instead is `_assert_as_valid_`, whose multiplication is the
+    bindings' all the same: 128 us against the 1.10 ms of the Python
+    arithmetic, which is the whole of this verification either way.
+
+    The two must not disagree, about a valid signature or an invalid one,
+    and least of all about the infinity point: a libsecp256k1 pubkey is
+    never the identity, so the K that is INF is answered on this side of
+    the boundary -- from the z == 0 of `jac_from_aff`, in the same line
+    that answered it before.
+    """
+    msg = b"a message to sign"
+    q, Q = dsa.gen_keys(0x1234567890ABCDEF)
+    sig = dsa.sign(msg, q, hf=sha512)
+    ec = sig.ec
+
+    def checks() -> None:
+        dsa.assert_as_valid(msg, Q, sig, hf=sha512)
+        assert dsa.verify(msg, Q, sig, hf=sha512)
+        # the same signature over another message
+        assert not dsa.verify(b"another message", Q, sig, hf=sha512)
+        # K = u*G + v*Q is INF for Q = G, r = s = 1 and c = n-1
+        with pytest.raises(BTClibRuntimeError, match=r"invalid \(INF\) key"):
+            dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, True, ec)
+
+    checks()
+    no_bindings(monkeypatch)
+    checks()
 
 
 def test_verify_answers_about_signatures_not_about_types() -> None:

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -250,6 +250,35 @@ def test_low_cardinality() -> None:
                             ssa._assert_as_valid_(e, QJ, r, (s - 1) % ec.n, ec)
 
 
+def test_verify_with_a_message_that_is_not_32_bytes_on_both_arithmetics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue 169's path, on both arithmetics.
+
+    BIP340 takes a message of any size and so does btclib, while the
+    bindings answer "the message hash must be 32 bytes", so any other
+    length is verified by `_assert_as_valid_` -- the only path that can
+    verify four of BIP340's own vectors. Its multiplication is the
+    bindings' all the same on secp256k1, 183 us against the 1.17 ms of
+    the Python arithmetic, and the two must not disagree about a
+    signature.
+    """
+    msg = b"a message that is not 32 bytes"
+    assert len(msg) != 32
+    q, x_Q = ssa.gen_keys(0x1234567890ABCDEF)
+    sig = ssa.sign_(msg, q)
+
+    def checks() -> None:
+        ssa.assert_as_valid_(msg, x_Q, sig)
+        assert ssa.verify_(msg, x_Q, sig)
+        # the same signature over another message of the same size
+        assert not ssa.verify_(b"another message of the same size", x_Q, sig)
+
+    checks()
+    no_bindings(monkeypatch)
+    checks()
+
+
 def test_batch_validation() -> None:
     ms: list[String] = []
     Qs: list[int] = []

--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -40,7 +40,7 @@ from typing import Any
 
 import pytest
 
-from btclib.curves import point_from_octets
+from btclib.curves import curve, point_from_octets
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
 from btclib.script.engine import script as engine_script
@@ -82,9 +82,17 @@ def python_verification(monkeypatch: pytest.MonkeyPatch) -> None:
     own reference to the bindings' verify, and `btclib.ecc` would hand
     secp256k1 with sha256 straight back to them -- the very dispatch that
     makes the Python path unreachable in the first place.
+
+    A third patch, one curve deeper, is what keeps the arithmetic Python
+    too: `dsa._assert_as_valid_` and `ssa._assert_as_valid_` reach the
+    `double_mult` of `curves.curve`, which delegates any point of
+    secp256k1 to the bindings. Without it the verdict below would still be
+    the Python implementation's, and the multiplication under it would not
+    -- a bindings-less configuration in name only.
     """
     monkeypatch.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
     monkeypatch.setattr(ssa, "_libsecp256k1_applicable", lambda *_: False)
+    monkeypatch.setattr(curve, "_libsecp256k1_applicable", lambda *_: False)
     monkeypatch.setattr(engine_script, "_libsecp256k1_dsa_verify", python_dsa_verify)
     monkeypatch.setattr(engine_tapscript, "_libsecp256k1_ssa_verify", python_ssa_verify)
 


### PR DESCRIPTION
Refs #268. The follow-up to #279, which has landed: this now targets `dev`
directly, rebased onto its squash merge, and the diff is only this half.

This is the "what this does not do" of #279. `dsa._assert_as_valid_` and
`ssa._assert_as_valid_` are what answers when the bindings' own
`ecdsa_verify` and BIP340 verify are not asked — a hash function that is
not sha256, a commitment to check, a caller-imposed nonce, a BIP340
message of a size other than 32 bytes, which is #169 and four of BIP340's
own vectors — and each then paid a Python `double_mult` underneath,
whatever the reason it got there. Both now reach the dispatching one.

Measured on this branch, the same call with the curve dispatch patched off
against the dispatch on, interleaved because the machine is busy:

| operation | Python | bindings | |
| --- | --- | --- | --- |
| `dsa.verify`, sha512 | 1100 us | 128 us | 8.6x |
| `ssa.verify_`, 31-byte message | 1169 us | 183 us | 6.4x |
| `dsa.verify_`, secp256r1 | 1208 us | 1209 us | 1.0x |

The last row is the point of the third: every other curve is untouched,
and measured so rather than argued. What is left of the BIP340 figure is
mostly the 74 µs modular square root that lifts the signature's `r` back
to a point.

## Jacobian in, Jacobian out

`_jac_double_mult` is one private helper in `curves.curve`, and the two
call sites are one line each. The two functions keep their projective
shape rather than being rewritten in affine coordinates, because it is not
only their arithmetic that is projective: so are the infinity test, the y
parity and the x comparison each makes, and so is the `QJ` that dsa's
public key recovery threads through `_assert_as_valid_`.

What makes that exact is `jac_from_aff` answering `z == 0` for the
infinity that has no serialization on the other side of the boundary. So
each function still raises what it raised before, from the same line —
`test_verify_infinity_point` is that claim, unchanged: `invalid (INF) key`
out of the same `KJ[2] == 0`, for the `K` that is infinity when
`c == -r*q (mod n)`.

The conversions cost 0.39 µs each on the `z == 1` that a parsed key and a
lifted `r` arrive as. The shortcut that would skip them — the affine point
being the same pair of coordinates — saves 0.75 µs of 28, and is not worth
a branch; neither is the caller's own `mod_inv(1)` on the way back out,
0.14 µs.

## The bindings-less configuration stays one

`tests/script_engine/python_path_test.py` says it is "the bindings-less
configuration, without the packaging". Its fixture patched the two `ecc`
dispatches; with this change that would leave the *verdict* Python and the
*multiplication* under it delegated, so the fixture patches the curve
dispatch as well. Same 5185 vectors, same runtime as before the change.

Two new tests hold the two arithmetics to each other on the paths this is
about — ECDSA with sha512 and BIP340 with a 30-byte message, each with a
valid signature and an invalid one, run once through the bindings and once
through `no_bindings`.

## What is still left of #268

The `double_mult_w_NAF` of `dsa._recover_pub_key_` and
`ssa._recover_pub_key_`. Public key recovery is the same shape and the
same win, and it is deliberately not here: #269 is live in that code, and
two sessions editing one function is how a rebase eats a change.

## Gates

`pre-commit run --all-files` clean, `pytest --cov=btclib --cov=tests` at
100.00% over 16427 tests, the 3.10 matrix cell green, sphinx `-W` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Delegate ECDSA and Schnorr verification equations that fall back to Python (e.g., non-standard hashes or non-32-byte messages) to libsecp256k1-backed double multiplication while preserving Jacobian semantics, and extend tests and docs to cover these paths and the bindings-less configuration.

Bug Fixes:
- Ensure dsa._assert_as_valid_ and ssa._assert_as_valid_ use the libsecp256k1-backed double_mult on secp256k1 even when bindings-level verify is skipped, keeping behavior consistent and faster.
- Keep the bindings-less script engine configuration fully Python by disabling curve-level libsecp256k1 dispatch in tests.

Enhancements:
- Introduce a Jacobian-based double-mult helper that reuses the existing affine dispatch and conversion for libsecp256k1-backed multiplications.
- Align SECURITY and CHANGELOG documentation with the new behavior of delegated verification multiplications.

Documentation:
- Document in CHANGELOG and SECURITY that verification multiplications for signatures the bindings decline are now delegated to libsecp256k1 while other arithmetic remains in Python.

Tests:
- Add ECDSA and BIP340 tests that compare bindings-backed and no-bindings verification paths for non-standard hash functions and non-32-byte messages, including infinity-handling cases.
- Update script engine tests to patch curve-level libsecp256k1 applicability, ensuring the pure-Python verification path remains intact.
