### PR TITLE
Recover public keys in libsecp256k1, and let it name the recovery flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2440,6 +2440,37 @@ edit.
 
 ### Performance
 
+- **message signing goes through libsecp256k1's recovery module** (issue
+  #269): `bms.sign` is 102 µs against 4360, `bms.verify` 97 against 2782,
+  both the mean over 40 random keys. The signing gain is not a faster
+  search but no search at all. `recovery.sign` returns the recovery id
+  beside r and s, and that id *is* the `key_id` the recovery flag carries
+  — the parity of the nonce's point and whether its x-coordinate exceeded
+  the group order, both of which the signer had in hand — where `sign`
+  used to sign and then recover candidate after candidate until one
+  equalled its own public key: 2977 µs where the signer's key was the
+  first candidate, 5492 where it was the second and the first had been
+  computed only to be discarded. Verification delegates the
+  single-candidate `dsa.recover_pub_key` to `secp256k1_ecdsa_recover`,
+  95 µs against 2330, so every caller of that function gains and not
+  only bms; the plural `recover_pub_keys` has no counterpart in the
+  bindings, stays Python whatever the curve, and is what the tests hold
+  the singular against. bms takes the sec octets the recovery answers
+  straight to `hash160`, an address being a hash of those bytes: no point
+  is built on either side of the module any more, so the affine
+  conversion of a recovered key and the multiplication behind
+  `bytes_from_point(mult(q))` are both gone. The lower-s rule stays
+  btclib's own, the recoverable parser taking any s in 1..n-1 as it must
+  — a malleated signature recovers a key too, and `lower_s` is the caller
+  saying whether that answer is wanted. What is left of those hundred
+  microseconds is no longer curve arithmetic: 76 of them are
+  `dsa.Sig.assert_valid` checking that r is congruent to a valid
+  x-coordinate, which is one modular square root in Python. bms is
+  secp256k1 only, so unlike taproot or ECDH no second curve keeps its
+  Python implementation reached: it stays as the reference the delegation
+  is measured against, and the tests reach it with both dispatches
+  patched off — every published base64 vector in the file signed and
+  verified twice, once each way
 - **the two generator multiplications of `dsa` go through `mult`**, which
   is where the libsecp256k1 dispatch lives, instead of calling the `_mult`
   underneath it (issue #272). Both scalars are secret and neither was

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -81,6 +81,11 @@ used to teach and to prototype as much as to build:
     signature asks for. The rest of that signature is not — the
     inversion of the nonce and the arithmetic on the key around it are
     Python integers.
+    `bms.sign` is delegated outright, `recovery.sign` signing and naming
+    the recovery flag in one call: message signing is defined for
+    secp256k1 alone, so there is no argument that sends it down the
+    Python path — which the test suite reaches by switching the dispatch
+    off, and which no caller can.
     Anything else — another
     curve, another hash function, another message size, a nonce of your
     own — runs the Python implementation, whose scalar multiplication is

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -154,13 +154,17 @@ import secrets
 from dataclasses import dataclass
 from hashlib import sha256
 
+from btclib_libsecp256k1 import recovery as libsecp256k1_recovery
+
 from btclib.alias import BinaryData, Octets, String
 from btclib.b32 import has_segwit_prefix, p2wpkh, witness_from_address
 from btclib.b58 import h160_from_address, p2pkh, p2wpkh_p2sh, wif_from_prv_key
-from btclib.curves import bytes_from_point, mult, secp256k1
+from btclib.curves import bytes_from_point, bytes_from_prv_key_int, mult, secp256k1
+from btclib.curves.curve import _libsecp256k1_applicable
 from btclib.ecc import dsa
+from btclib.ecc.dsa import _libsecp256k1_recover_sec_
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
-from btclib.hashes import hash160, magic_message
+from btclib.hashes import hash160, magic_message, reduce_to_hlen
 from btclib.network import NETWORKS
 from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
 from btclib.utils import bytesio_from_binarydata
@@ -291,17 +295,15 @@ def gen_keys(
     return wif, p2pkh(wif)
 
 
-def sign(msg: Octets, prv_key: PrvKey, addr: String | None = None) -> Sig:
-    """Generate address-based compact signature for the provided message."""
-    # first sign the message
-    magic_msg = magic_message(msg)
-    q, network, compressed = prv_keyinfo_from_prv_key(prv_key)
-    dsa_sig = dsa.sign(magic_msg, q)
+def _search_key_id(magic_msg: bytes, dsa_sig: dsa.Sig, q: int) -> int:
+    """Return the key_id that recovers the public key of q.
 
-    # now calculate the key_id: the candidate that is this key, named by
-    # the key_id that recovers it. key_id is in [0, 3], and the first two
-    # bits in rf are reserved for it
-    #
+    The candidate that is this key, named by the key_id that recovers it.
+    key_id is in [0, 3], and the first two bits in rf are reserved for it.
+
+    This is the question a recoverable signature answers as it signs, so
+    `sign` asks it only where the bindings are not the signer.
+    """
     # one candidate at a time, stopping at the match, rather than
     # dsa.recover_pub_keys(magic_msg, dsa_sig).index(Q) -- every candidate
     # and then a search. Two things this buys: on secp256k1 the list is
@@ -326,14 +328,47 @@ def sign(msg: Octets, prv_key: PrvKey, addr: String | None = None) -> Sig:
         # means "not this one" and not "no key": see dsa._recover_pub_keys_
         with contextlib.suppress(BTClibValueError, BTClibRuntimeError):
             if dsa.recover_pub_key(key_id, magic_msg, dsa_sig) == Q:
-                break
-    else:
-        # unreachable: dsa_sig was just signed with q, so some key_id
-        # recovers mult(q)
-        err_msg = "no key_id recovers the public key"  # pragma: no cover
-        raise BTClibRuntimeError(err_msg)  # pragma: no cover
+                return key_id
 
-    pub_key = bytes_from_point(Q, compressed=compressed)
+    # unreachable: dsa_sig was just signed with q, so some key_id does
+    # recover the public key of q
+    err_msg = "no key_id recovers the public key"  # pragma: no cover
+    raise BTClibRuntimeError(err_msg)  # pragma: no cover
+
+
+def sign(msg: Octets, prv_key: PrvKey, addr: String | None = None) -> Sig:
+    """Generate address-based compact signature for the provided message."""
+    magic_msg = magic_message(msg)
+    q, network, compressed = prv_keyinfo_from_prv_key(prv_key)
+
+    # signing and naming the key_id are one call, not two: recoverable
+    # signing is the shape libsecp256k1 offers precisely because the recid
+    # falls out of the signature -- it is the parity of the nonce's point
+    # and whether its x-coordinate exceeded the group order, both of which
+    # the signer had in hand -- so `_search_key_id` does not get faster,
+    # it goes away. 102 us against 4360, the mean over 40 random keys, and
+    # the search was all of it: 2977 us where the signer's key is key_id 0
+    # and one recovery finds it, 5492 where it is key_id 1 and the first
+    # candidate is computed only to be discarded. 76 of the 102 that
+    # remain are the Sig validation below
+    if _libsecp256k1_applicable(secp256k1):
+        sig_bytes, key_id = libsecp256k1_recovery.sign(reduce_to_hlen(magic_msg), q)
+        n_size = secp256k1.n_size
+        r = int.from_bytes(sig_bytes[:n_size], byteorder="big", signed=False)
+        s = int.from_bytes(sig_bytes[n_size:], byteorder="big", signed=False)
+        # check_validity=False, and the Sig returned below does validate:
+        # asserting r congruent to an x-coordinate is a modular square
+        # root, 76 us of the 102, and paying it twice over the one
+        # signature is most of what is left to save here
+        dsa_sig = dsa.Sig(r, s, secp256k1, check_validity=False)
+    else:
+        dsa_sig = dsa.sign(magic_msg, q)
+        key_id = _search_key_id(magic_msg, dsa_sig, q)
+
+    # bytes_from_prv_key_int, not bytes_from_point(mult(q)): the address
+    # wants the octets, and on secp256k1 they come out of the bindings'
+    # own serialization without a point in between (issue #127)
+    pub_key = bytes_from_prv_key_int(q, compressed=compressed)
 
     if isinstance(addr, str):
         addr = addr.strip()
@@ -424,10 +459,20 @@ def assert_as_valid(
     # 39-27 = 001100;  40-27 = 001101;  41-27 = 001110;  42-27 = 001111
     key_id = sig.rf - 27 & 0b11
     magic_msg = magic_message(msg)
-    Q = dsa.recover_pub_key(key_id, magic_msg, sig.dsa_sig, lower_s, sha256)
     compressed = sig.rf > 30
-    # signature is valid only if the provided address is matched
-    pub_key = bytes_from_point(Q, compressed=compressed)
+    # signature is valid only if the provided address is matched, and an
+    # address is a hash of the sec octets: no point is built here, the
+    # bindings answering the octets themselves -- which is the mod_inv of
+    # an affine conversion not paid either. `verify` is 97 us against 2782,
+    # the mean over 40 random keys, of which 76 are the r-congruence square
+    # root of the Sig validation above and some 20 the recovery itself
+    if _libsecp256k1_applicable(secp256k1):
+        pub_key = _libsecp256k1_recover_sec_(
+            key_id, reduce_to_hlen(magic_msg), sig.dsa_sig, lower_s, compressed
+        )
+    else:
+        Q = dsa.recover_pub_key(key_id, magic_msg, sig.dsa_sig, lower_s, sha256)
+        pub_key = bytes_from_point(Q, compressed=compressed)
 
     # the address says which of the three checks applies, and each of them
     # carries the recovery-flag range that belongs to its type: the flag

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -33,6 +33,8 @@ from io import BytesIO
 from typing import overload
 
 from btclib_libsecp256k1 import dsa as libsecp256k1_dsa
+from btclib_libsecp256k1 import keys as libsecp256k1_keys
+from btclib_libsecp256k1 import recovery as libsecp256k1_recovery
 
 from btclib import var_bytes
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point
@@ -805,6 +807,11 @@ def _recover_pub_keys_(
 ) -> list[JacPoint]:
     # Private function provided for testing purposes only.
 
+    # libsecp256k1 has no counterpart to enumerate with -- its recover
+    # answers for a recid it is given -- so this is the Python path
+    # whatever the curve, and it is what the tests hold the delegated
+    # single-candidate recovery against.
+    #
     # every candidate is a key_id, so this is _recover_pub_key_ over the
     # whole range of them and nothing else: a j in [0, ec.cofactor] (step
     # 1 of SEC 1 v.2 section 4.1.6) and a y_K-coordinate parity, the even
@@ -901,6 +908,56 @@ def _recover_pub_key_(
     return QJ
 
 
+def _libsecp256k1_recover_sec_(
+    key_id: int, msg_hash: bytes, sig: Sig, lower_s: bool, compressed: bool
+) -> bytes:
+    # Private function: the caller has asked _libsecp256k1_applicable
+    # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
+    #
+    # secp256k1_ecdsa_recover is step 1.6 of SEC 1 v.2 section 4.1.6 for
+    # the one named candidate: 19 us here against the two milliseconds of
+    # the Python path, which is `recover_pub_key` 95 us against 2330 once
+    # the Sig validation both of them pay is counted in. It answers sec
+    # octets rather than a point, which is what an address wants, so bms
+    # hashes these very bytes and never builds a point.
+    #
+    # Step 1.6.2 -- that the recovered key verifies the signature -- is
+    # not skipped by delegating: the key returned satisfies the signature
+    # equation by construction, and a candidate whose x-coordinate is not
+    # on the curve is the failure caught below.
+    #
+    # The lower-s rule is checked here and not there. The recoverable
+    # parser takes any s in [1, n-1], as it must: a malleated signature
+    # recovers a key too, and lower_s is the caller saying whether that
+    # answer is wanted -- the same question _assert_as_valid_ answers with
+    # this very message
+    if lower_s and sig.s > sig.ec.n // 2:
+        raise BTClibValueError("not a low s")
+
+    n_size = sig.ec.n_size
+    compact = sig.r.to_bytes(n_size, byteorder="big", signed=False)
+    compact += sig.s.to_bytes(n_size, byteorder="big", signed=False)
+    try:
+        sec = libsecp256k1_recovery.recover(msg_hash, compact, key_id)
+    except ValueError as e:
+        # a bare ValueError is not what the Python path raises for a
+        # candidate that recovers nothing -- BTClibValueError when x_K
+        # misses the curve, BTClibRuntimeError when the key it yields does
+        # not verify -- and bms.sign suppresses those two by name, which a
+        # ValueError does not answer to, being their base and not a
+        # subclass
+        raise BTClibValueError(f"invalid key_id or signature: {e}") from e
+
+    if compressed:
+        return sec
+    # the bindings serialize compressed unless asked otherwise, and the
+    # rf <= 30 case of a message signature hashes the uncompressed form:
+    # 29 us against the 19 above, the difference being a pubkey_parse
+    # undoing a serialization the same library has just made -- which
+    # recover leaves no way around, answering octets and not a pubkey
+    return libsecp256k1_keys.serialize(libsecp256k1_keys.parse(sec), compressed=False)
+
+
 def recover_pub_key_(
     key_id: int,
     msg_hash: Octets,
@@ -921,6 +978,28 @@ def recover_pub_key_(
     # The message msg_hash: a hf_len array
     hf_len = hf().digest_size
     msg_hash = bytes_from_octets(msg_hash, hf_len)
+
+    # a recid is two bits, i.e. a key_id in [0, 3], which is every
+    # candidate a curve of cofactor 1 has; _recover_pub_key_ below reads a
+    # key_id up to 7 as j up to 3, and no j above 1 is reachable on
+    # secp256k1 anyway -- x_K = r + 2*ec.n exceeds ec.p for every r.
+    # Where both answer, they answer the same: the bindings require
+    # r < ec.p - ec.n for j = 1, and the % ec.p of the Python path leaves
+    # x_K = r + ec.n - ec.p otherwise, which fails step 1.6.2 for every r
+    # -- passing it would need ec.p ≡ 0 mod ec.n
+    if _libsecp256k1_applicable(sig.ec, hf) and 0 <= key_id <= 3:
+        sec = _libsecp256k1_recover_sec_(
+            key_id, msg_hash, sig, lower_s, compressed=False
+        )
+        # 0x04 || x || y (SEC 1 v.2, section 2.3.3), read rather than
+        # parsed through point_from_octets: this is a point libsecp256k1
+        # has just created, and proving it on the curve again is work with
+        # a known answer
+        p_size = sig.ec.p_size
+        return (
+            int.from_bytes(sec[1 : 1 + p_size], byteorder="big", signed=False),
+            int.from_bytes(sec[1 + p_size :], byteorder="big", signed=False),
+        )
 
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -774,6 +774,91 @@ def test_a_key_id_that_recovers_nothing() -> None:
             dsa.recover_pub_key(key_id, magic_msg, bms_sig.dsa_sig)
 
 
+def test_recoverable_signing_answers_the_key_id_the_search_finds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The recid libsecp256k1 reports is the key_id, and r and s agree too.
+
+    `sign` reads the key_id off a recoverable signature instead of signing
+    and then recovering candidate after candidate until one is the signer's
+    own key. The recid is the same thing arrived at from the other side --
+    the parity of the nonce's point and whether its x-coordinate exceeded
+    the group order, both of which the signer had in hand -- so what has to
+    hold is that the two name one signature, r, s and key_id all three.
+
+    Held over random pairs and not fixed vectors, r and s being what
+    RFC6979 makes of each: the fixed vectors are the base64 signatures of
+    the tests above, which this reproduces through
+    `test_the_python_path_answers_the_same`.
+    """
+    for i in range(20):
+        msg = f"message {i}".encode()
+        wif, addr = bms.gen_keys()
+        bms_sig = bms.sign(msg, wif)
+
+        magic_msg = magic_message(msg)
+        q = prv_keyinfo_from_prv_key(wif)[0]
+        dsa_sig = dsa.sign(magic_msg, q)
+        assert bms_sig.dsa_sig == dsa_sig
+        key_id = bms_sig.rf - 27 & 0b11
+        assert key_id == bms._search_key_id(magic_msg, dsa_sig, q)
+        # and the search asked of the implementation that did not report
+        # the recid, so that the two derivations are independent
+        with monkeypatch.context() as no_bindings:
+            no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            assert key_id == bms._search_key_id(magic_msg, dsa_sig, q)
+
+        bms.assert_as_valid(msg, addr, bms_sig)
+
+
+# the sibling test functions are called rather than reimplemented, as
+# tests/script_engine/python_path_test.py does with the vector walks: two
+# copies of a vector drift, and what has to be identical between the two
+# runs is precisely the vector -- only the implementation underneath
+# differs. Which is what makes these the fixed vectors of the delegation:
+# every base64 signature the tests below assert is a published one, from
+# Core, Electrum, Ledger or BIP137, and the Python path has to produce and
+# verify each of them exactly as the bindings do
+@pytest.mark.parametrize(
+    "vector_test",
+    [
+        test_signature,
+        test_exceptions,
+        test_one_prv_key_multiple_addresses,
+        test_msgsign_p2pkh,
+        test_msgsign_p2pkh_2,
+        test_verify_p2pkh,
+        test_segwit,
+        test_sign_strippable_message,
+        test_ledger,
+        test_the_recovery_flag_carries_a_key_id_not_a_list_index,
+        test_a_key_id_that_recovers_nothing,
+    ],
+    ids=lambda vector_test: vector_test.__name__,
+)
+def test_the_python_path_answers_the_same(
+    vector_test: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """bms is secp256k1 only, so nothing else keeps its Python path reached.
+
+    Unlike taproot or ECDH there is no second curve to fall back for, and
+    no message length the bindings decline: `Sig.assert_valid` refuses any
+    other curve, so in production the dispatch always answers yes. The
+    Python implementation stays as the reference the delegation is held
+    against, and this is what reaches it.
+
+    Two patches, one per module, because there are two dispatches on the
+    way down: bms asks before it signs or recovers, and `dsa.sign` and
+    `dsa.recover_pub_key` under it ask again -- patching bms alone would
+    exercise the key_id search with libsecp256k1 doing the recovery
+    inside it.
+    """
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(bms, "_libsecp256k1_applicable", lambda *_: False)
+        no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+        vector_test()
+
+
 def test_parse_length_is_not_a_validity_opinion() -> None:
     """65 bytes is what makes the [rf][r][s] slices mean anything.
 

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -16,7 +16,7 @@ from typing import Any
 import pytest
 from btclib_libsecp256k1 import dsa as libsecp256k1_dsa
 
-from btclib.alias import INF
+from btclib.alias import INF, Point
 from btclib.curves import (
     Curve,
     bytes_from_point,
@@ -520,6 +520,61 @@ def test_libsecp256k1() -> None:
     assert btclib_sig.serialize() == libsecp256k1_sig
     assert libsecp256k1_dsa.verify(msg_hash, pub_key, btclib_sig.serialize())
     assert dsa.verify_(msg_hash, pub_key, libsecp256k1_sig)
+
+
+def _recovered(
+    key_id: int, msg: bytes, sig: dsa.Sig, lower_s: bool = True
+) -> Point | None:
+    """The recovered key, or None for a candidate that recovers nothing."""
+    try:
+        return dsa.recover_pub_key(key_id, msg, sig, lower_s)
+    except (BTClibValueError, BTClibRuntimeError):
+        return None
+
+
+def test_libsecp256k1_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`recover_pub_key` through secp256k1_ecdsa_recover.
+
+    A recid is a key_id -- the same two bits, in the same order -- so the
+    two implementations have to answer the same point for every candidate,
+    and the same refusal for the candidates that recover nothing, which on
+    secp256k1 is key_id 2 and 3. That is what the delegation rests on: the
+    recovery flag of a message signature carries a key_id from outside, so
+    the number has to mean there what it means here.
+
+    `recover_pub_keys` beside them is the enumeration, which has no
+    counterpart in the bindings and stays Python whatever the curve.
+    """
+    msg = b"Satoshi Nakamoto"
+    for q in (0x1, 0x2, prv_key_int, secp256k1.n - 1):
+        prv_key, Q = dsa.gen_keys(q)
+        sig = dsa.sign(msg, prv_key)
+        keys = dsa.recover_pub_keys(msg, sig)
+        assert Q in keys
+
+        recovering = []
+        for key_id in range(2 * (secp256k1.cofactor + 1)):
+            delegated = _recovered(key_id, msg, sig)
+            with monkeypatch.context() as no_bindings:
+                no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+                python = _recovered(key_id, msg, sig)
+            assert delegated == python
+            if delegated is not None:
+                assert delegated in keys
+                recovering.append(key_id)
+        # the signer's own key has j = 0, so it is one of the first pair,
+        # and the second pair recovers nothing: r + ec.n < ec.p is some
+        # 2^-127 of signatures, and both implementations require it
+        assert recovering == [0, 1]
+
+        # the lower-s rule is the caller's, and it is btclib that applies
+        # it: the recoverable parser takes any s in [1, n-1]
+        key_id = next(k for k in recovering if _recovered(k, msg, sig) == Q)
+        malleated = dsa.Sig(sig.r, secp256k1.n - sig.s)
+        err_msg = "not a low s"
+        with pytest.raises(BTClibValueError, match=err_msg):
+            dsa.recover_pub_key(key_id ^ 1, msg, malleated)
+        assert _recovered(key_id ^ 1, msg, malleated, lower_s=False) == Q
 
 
 def signature_vectors(fname: str) -> list[Any]:


### PR DESCRIPTION
Closes #269.

`bms` recovered public keys in Python, the most expensive thing the
library did per call. libsecp256k1's `recovery` module answers the same
questions in microseconds, and it answers one of them in a shape that
removes the work rather than speeding it up.

## Measured on this tree, mean over 40 random keys

| | Python | delegated |
| --- | --- | --- |
| `bms.sign` | 4360 µs | 102 µs |
| `bms.verify` | 2782 µs | 97 µs |
| `dsa.recover_pub_key` | 2330 µs | 95 µs |

`bms.sign` cost double what verification did because it did not know the
`key_id`: it signed, then recovered candidate after candidate until one
equalled the signer's own key. 2977 µs where that key was the first
candidate, 5492 where it was the second and the first had been computed
only to be discarded — half the keys each.

**`secp256k1_ecdsa_sign_recoverable` returns the recid beside r and s**,
and that recid *is* the `key_id` the recovery flag carries: it is the
parity of the nonce's point and whether its x-coordinate exceeded the
group order, both of which the signer had in hand. So the search does not
get faster, it goes away — and the cost is flat in the `key_id` where it
used to double.

## What is delegated, and what stays Python

- the single-candidate `dsa.recover_pub_key` goes to
  `secp256k1_ecdsa_recover`, so every caller of it gains and not only
  bms. The plural `recover_pub_keys` has no counterpart in the bindings,
  stays Python whatever the curve, and is what the tests hold the
  singular against
- **no point is built on either side of the module.** An address is a
  hash of the sec octets and the recovery answers those octets;
  `keys.parse`/`keys.serialize` give the uncompressed form the `rf <= 30`
  case wants, and signing takes its own public key from
  `bytes_from_prv_key_int`. The affine conversion of a recovered key, and
  the `mod_inv` per candidate the old comment weighed, are both gone
- **the lower-s rule stays btclib's.** The recoverable parser takes any s
  in 1..n-1, as it must: a malleated signature recovers a key too, and
  `lower_s` is the caller saying whether that answer is wanted
- **a recid is a `key_id`**, the same two bits in the same order, and
  where both implementations answer they answer the same. For j = 1 the
  bindings require `r + ec.n < ec.p`, exactly the condition the Python
  path's `ec.y_even` can meet; the `% ec.p` wrap it takes otherwise fails
  step 1.6.2 for every r, since passing it would need `ec.p ≡ 0 mod ec.n`.
  A `key_id` above 3 has no recid and stays Python — on secp256k1 no such
  candidate exists
- **bms is secp256k1 only**, so unlike taproot or ECDH there is no second
  curve keeping its Python implementation reached. It stays as the
  reference the delegation is measured against, and the tests reach it
  with both dispatches patched off — bms's and dsa's, because patching
  bms alone would exercise the `key_id` search with libsecp256k1 doing
  the recovery inside it

## Tests

Eleven of the module's own test functions are re-run through the Python
path rather than reimplemented, as `python_path_test.py` does with the
vector walks, so every published base64 signature in the file — Core,
Electrum, Ledger, BIP137 — is produced and verified twice, once each way.
Beside them, over twenty random pairs, the recid is held to the `key_id`
the search finds and r and s to `dsa.sign`'s; and in `dsa_test`, every
candidate of every key to the point, and to the refusal, the Python path
gives.

## Not in this PR, and filed

- **#284**: 76 µs of the ~100 that remain are `dsa.Sig.assert_valid`
  checking that r is congruent to a valid x-coordinate — one modular
  square root in Python, now the dominant cost of both functions, and
  paid by every `dsa.Sig` validation in the library rather than by bms
  alone. `keys.parse(b"\x02" + r)` answers the same question in 2.3 µs
- **#285**: the Python path here still finds the `key_id` by recovering,
  3717 µs, because btclib has no `dsa.sign_recoverable`. The recid is two
  bits of the nonce point `_sign_` already computes and throws away: a
  prototype measures 112 µs, agrees with `secp256k1_ecdsa_sign_recoverable`
  on r, s and recid over 200 random pairs, and with the search on 3168
  low-cardinality signatures. That would leave bms with no Python
  recovery in either path

`uv run pytest` (16438 passed), `uv run pre-commit run --all-files`, the
sphinx `-W` docs build, and coverage at 100.00% all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
