### PR TITLE
Bound a block's size and sigops, and check it against a height and a clock (#278)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,74 @@ edit.
 
 ### Consensus rules
 
+- **a block has a maximum size, and `Block.weight` is now the block's.**
+  Nothing bounded either: `bad-blk-length` — the transaction count and the
+  stripped size, each times `WITNESS_SCALE_FACTOR`, against
+  `MAX_BLOCK_WEIGHT` — and `bad-blk-weight`, the weight itself, are now
+  both checked, the second after the witness commitment because that is
+  where Core checks it and for Core's reason: the coinbase witness is not
+  covered by the block hash, so a block over the cap only because that
+  witness was stuffed must not be refused before the commitment to it has
+  been verified. The rules are also what made the property wrong.
+  `Block.weight` was the sum of the transactions' weights, which is
+  neither of the quantities they read; it is now Core's `GetBlockWeight`,
+  the 80-byte header and the var_int holding the transaction count
+  included, so 332 more than before for a block with hundreds of
+  transactions — 3,954,880 for block 481,824 — and 324 more for a block
+  holding one. `Block.stripped_size` is the other quantity, the
+  serialization a legacy node relays, and it is the one real blocks sit
+  against: 3,954,076 of 4,000,000, 98.9% of the cap. `Tx.weight` is
+  unchanged, and `Block.vsize` moves with the weight (issue #278)
+- **the signature check operations a block announces are counted, and
+  bounded** (`bad-blk-sigops`). Nothing counted them at any level.
+  `script.sig_ops.sig_op_count` is Core's `CScript::GetSigOpCount(false)`
+  over the bytes of one script, `Tx.sig_op_count` is what
+  `GetLegacySigOpCount` sums over every `script_sig` and every
+  `script_pub_key`, `Block.sig_op_count` sums that over the transactions,
+  and `assert_valid` bounds it by `MAX_BLOCK_SIGOPS_COST` — 20,000 legacy
+  checks — last of `CheckBlock`'s own questions, where Core asks it. An
+  `OP_CHECKMULTISIG` costs `MAX_PUBKEYS_PER_MULTISIG` however many keys it
+  would check: the accurate count is one Core only asks under P2SH and
+  segwit, where the script being counted comes from the output being
+  spent, so that count and the witness one need the UTXO set and this one
+  underestimates exactly as Core's comment on it says. The walk stops
+  where the script stops parsing and raises nothing, as Core's `GetOp`
+  loop breaks — the coinbase output script of testnet block 987,876 ends
+  in an `OP_CHECKSIG` five bytes inside a push that runs past the end of
+  the script, and neither implementation reaches it: 0 sigops on both
+  sides. The largest count in the suite is block 481,824's 3,409, 17% of
+  the cap, so a block that breaks the rule has to be built for the
+  purpose (issue #278)
+- **a block can be checked against a height and a clock**, which is what
+  `BlockContext` carries and `Block.assert_valid_contextual` reads.
+  `assert_valid` is Core's `CheckBlock`, what the bytes answer on their
+  own, and `Block.parse` calls it with no context to pass — so the two
+  rules of `ContextualCheckBlockHeader` and `ContextualCheckBlock` that
+  need nothing but a caller now have a carrier rather than being absent.
+  `bad-cb-height` is a byte comparison, as Core's is: the coinbase
+  `script_sig` must *start with* `CScript() << nHeight`, which
+  `bip34_commitment` builds, so a height pushed non-minimally is refused
+  although `Block.height` decodes the right number out of it — and for the
+  first seventeen heights that encoding is a one-byte op code (`OP_0`,
+  `OP_1` to `OP_16`) where `script.serialize([height])` writes a data
+  push, which makes them the mainline case rather than an edge: regtest
+  has BIP34 in force from height 1. `time-too-new` is
+  `BlockHeader.assert_valid_time(now)`, the timestamp against a clock the
+  caller supplies and never `datetime.now()` read inside the library,
+  which would have one machine accept what another refuses and would make
+  the test depend on the day it ran on. BIP34's activation height is a
+  field of the context, defaulting to mainnet's 227,931, because the
+  activation is itself contextual: block 200,000 commits its height and is
+  27,931 blocks below the height Core enforces it from, and four of the ten
+  testnet blocks of `blockfilters.json` commit nothing at all. What stays
+  out needs the chain and not merely a context — `time-too-old` and
+  `bad-txns-nonfinal` are the median time past of eleven ancestors,
+  `bad-diffbits` the target of a whole retarget period, `bad-version` two
+  more activation heights — and each is a field of `BlockContext` away
+  once the chain state it reads is there to put in one. The one `xfail` of
+  `tests/block/checkblock_test.py` is a passing vector now:
+  python-bitcoinlib's genesis block, two hours and one second ahead of the
+  `cur_time` beside it (issue #278)
 - **A block carries one coinbase, and `Block.assert_valid` now says so.**
   It asked whether the first transaction is a coinbase and never asked
   the rest, where Bitcoin Core's `CheckBlock` asks both, the second as

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,14 @@ against the `v2023.7.12` tag.
 
 - **`from btclib.ec import ...` is `from btclib.curves import ...`.** Every
   name the package exports is the name it exported before.
+- **`Block.weight` is the weight of the block**, where it was the sum of
+  its transactions' weights: Core's `GetBlockWeight`, so the 80-byte header
+  and the var_int holding the transaction count are counted too — 332 more
+  for a block with hundreds of transactions, 324 for one holding a single
+  transaction — and `Block.vsize` moves with it. `Tx.weight` is unchanged.
+  This is the number consensus reads, `MAX_BLOCK_WEIGHT` bounding it; the
+  sum is still available as `sum(t.weight for t in block.transactions)`,
+  and `Block.stripped_size` is the other quantity a block is bounded by.
 - **a psbt carrying a PSBT v2 field is refused**, where every one of the
   twelve was filed under `unknown` and round-tripped. BIP370 forbids them
   in version 0, which is the only version btclib reads, so
@@ -257,7 +265,11 @@ and `verify` families now let a `TypeError` out where they used to answer
   silence. `Block.assert_valid` now rejects the CVE-2012-2459 merkle
   mutation and checks the BIP141 witness commitment, without which every
   signature in a block could be replaced wholesale with the header
-  untouched. The low-s rule is decided by exact integer division, where
+  untouched; it also bounds the block's size, weight and signature
+  operations, and a caller holding a height and a clock can ask the two
+  rules that need them — the coinbase's BIP34 commitment and the timestamp
+  — through `Block.assert_valid_contextual`. The low-s rule is decided by
+  exact integer division, where
   `ec.n / 2` had put the threshold 2^127 above the true midpoint, and
   `dsa.verify` no longer accepts a *private* key where a public one goes.
 - **Secrets stay out of logs.** A routine network mismatch used to put a

--- a/btclib/block/__init__.py
+++ b/btclib/block/__init__.py
@@ -10,7 +10,20 @@
 """Module btclib.block."""
 
 from btclib.block import merkle_proof, mining, proof_of_work
-from btclib.block.block import Block
+from btclib.block.block import Block, bip34_commitment
+from btclib.block.block_context import BlockContext
 from btclib.block.block_header import BlockHeader
 
-__all__ = ["Block", "BlockHeader", "merkle_proof", "mining", "proof_of_work"]
+# btclib.block.limits is not here, as btclib.script.limits is not in
+# btclib.script: a caller reading a consensus constant names the module it
+# comes from, which is what says the number is Core's and not this
+# library's
+__all__ = [
+    "Block",
+    "BlockContext",
+    "BlockHeader",
+    "bip34_commitment",
+    "merkle_proof",
+    "mining",
+    "proof_of_work",
+]

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -20,14 +20,22 @@ from math import ceil
 from typing import Any
 
 from btclib import var_bytes, var_int
-from btclib.alias import BinaryData
+from btclib.alias import BinaryData, Command
+from btclib.block.block_context import BlockContext
 from btclib.block.block_header import BlockHeader
+from btclib.block.limits import (
+    MAX_BLOCK_SIGOPS_COST,
+    MAX_BLOCK_WEIGHT,
+    WITNESS_SCALE_FACTOR,
+)
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import (
     hash256,
     merkle_root_and_mutated,
     merkle_root_and_mutated_from_hashes,
 )
+from btclib.script.script import op_int
+from btclib.script.script import serialize as serialize_script
 from btclib.tx import Tx
 from btclib.utils import bytesio_from_binarydata, decode_num
 
@@ -61,6 +69,29 @@ def merkle_root_and_mutated_from_transactions(
     return root[::-1], mutated
 
 
+def bip34_commitment(height: int) -> bytes:
+    """Return the height as a coinbase script_sig must commit to it (BIP34).
+
+    Bitcoin Core's `CScript() << nHeight`, which is where the bytes
+    `Block.assert_valid_coinbase_height` compares against come from: the
+    shortest encoding of the number, so `OP_0` for zero and `OP_1` to
+    `OP_16` for one to sixteen -- one byte, no push at all -- and a
+    minimal data push of the script number from seventeen up.
+
+    Those first seventeen are not what `script.serialize([height])`
+    writes. It pushes the number as data -- `0100`, `0101` to `0110` --
+    and warns that an op code says the same, which is a defensible
+    encoding of a number and the wrong answer here: a regtest chain has
+    BIP34 in force from height 1, so those seventeen are where the rule
+    binds first and every node on such a chain compares against the op
+    code.
+    """
+    # Core's push_int64 has three branches -- OP_0 for zero, OP_1..OP_16
+    # for 1 to 16, OP_1NEGATE for -1 -- and op_int names all three
+    command: Command = op_int(height) if -1 <= height <= 16 else height
+    return serialize_script([command])
+
+
 @dataclass
 class Block:
     header: BlockHeader
@@ -71,12 +102,43 @@ class Block:
         return len(self.serialize(check_validity=False))
 
     @property
+    def stripped_size(self) -> int:
+        """Return the size of the block as a legacy node sees it.
+
+        Core's `GetSerializeSize(TX_NO_WITNESS(block))`, and the quantity
+        `assert_valid_length` bounds: the whole block with every witness
+        left out, which is the serialization the witness discount is
+        expressed against and what `getblock` reports under this name.
+        """
+        return len(self.serialize(include_witness=False, check_validity=False))
+
+    @property
     def weight(self) -> int:
-        return sum(t.weight for t in self.transactions)
+        """Return the block weight, as Core's GetBlockWeight computes it.
+
+        Three times the stripped size plus the size, i.e. four times what
+        a legacy node relays plus the witness bytes, over the *block*: the
+        eighty bytes of the header and the var_int of the transaction
+        count are part of it, so this is not the sum of the transactions'
+        weights -- 332 more than that sum for block 481,824, 324 for a
+        block holding one transaction. The sum is the number no rule
+        reads; `MAX_BLOCK_WEIGHT` bounds this one.
+        """
+        return self.stripped_size * (WITNESS_SCALE_FACTOR - 1) + self.size
 
     @property
     def vsize(self) -> int:
         return ceil(self.weight / 4)
+
+    @property
+    def sig_op_count(self) -> int:
+        """Return the legacy sigop count, summed over the transactions.
+
+        What `CheckBlock` sums to enforce `MAX_BLOCK_SIGOPS_COST`; see
+        `script.sig_ops.sig_op_count` for what "legacy" leaves out and
+        why nothing here can add it.
+        """
+        return sum(t.sig_op_count for t in self.transactions)
 
     @property
     def height(self) -> int | None:
@@ -88,9 +150,12 @@ class Block:
         https://github.com/bitcoin/bips/blob/master/bip-0034.mediawiki
         Block 227,835 (2013-03-24 15
         :49: 13 GMT) was the last version 1 block.
+
+        This is the reader and not the check: it decodes whatever the
+        coinbase pushed, where consensus compares bytes.
+        `assert_valid_coinbase_height` is the check.
         """
-        if not self.transactions[0].is_coinbase():
-            raise BTClibValueError("first transaction is not a coinbase")
+        self._assert_coinbase()
 
         if self.header.version == 1:
             return None
@@ -140,6 +205,92 @@ class Block:
 
     def has_segwit_tx(self) -> bool:
         return any(tx.is_segwit() for tx in self.transactions)
+
+    def _assert_coinbase(self) -> None:
+        """Assert that there is a first transaction and that it is a coinbase.
+
+        Every block carries a coinbase, so an empty list is not a block
+        that happens to be empty: it is not a block. Refused here, or
+        transactions[0] answers it with an IndexError -- and a var_int of
+        zero where the transaction count goes is all it takes to serialize
+        one. Core asks the same two questions in one line, `bad-cb-missing`
+        naming the pair.
+
+        Called by everything that reads the coinbase, so that the reader
+        and the rules report it in the same words.
+        """
+        if not self.transactions:
+            raise BTClibValueError("block with no transactions")
+
+        if not self.transactions[0].is_coinbase():
+            raise BTClibValueError("first transaction is not a coinbase")
+
+    def assert_valid_length(self) -> None:
+        """Assert the size limits of Core's CheckBlock (bad-blk-length).
+
+        Two comparisons against MAX_BLOCK_WEIGHT, and neither of them is
+        the weight: the transaction count times WITNESS_SCALE_FACTOR --
+        no transaction serializes to less than a byte, and a byte outside
+        the witness weighs four, so a block holds at most a quarter of the
+        cap in transactions -- and the stripped size times
+        WITNESS_SCALE_FACTOR. The second is what real blocks sit against:
+        3,954,076 of 4,000,000 for block 481,824, 98.9% of the cap. The
+        weight itself is bounded by assert_valid_weight, where Core bounds
+        it.
+
+        The count is compared first, as in Core's single condition, and
+        that is what keeps this cheap: a list too long to be a block is
+        refused without serializing it.
+        """
+        count = len(self.transactions)
+        if count * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT:
+            err_msg = f"invalid transaction count: {count}"
+            err_msg += f" * {WITNESS_SCALE_FACTOR} > {MAX_BLOCK_WEIGHT}"
+            raise BTClibValueError(err_msg)
+
+        stripped_size = self.stripped_size
+        if stripped_size * WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT:
+            err_msg = f"invalid stripped size: {stripped_size}"
+            err_msg += f" * {WITNESS_SCALE_FACTOR} > {MAX_BLOCK_WEIGHT}"
+            raise BTClibValueError(err_msg)
+
+    def assert_valid_sig_op_count(self) -> None:
+        """Assert the sigop bound of Core's CheckBlock (bad-blk-sigops).
+
+        The legacy count of every script in the block, times
+        WITNESS_SCALE_FACTOR, against MAX_BLOCK_SIGOPS_COST -- i.e. 20,000
+        legacy signature checks. It is the only sigop rule reachable from
+        the bytes: what Core adds in ConnectBlock is counted over the
+        outputs being spent, which are in other blocks.
+
+        The largest answer this library has a block for is block 481,824's
+        3,409, so a block that breaks this rule has to be built for the
+        purpose. That is what makes the arithmetic the thing worth
+        testing, and `script.sig_ops` is where it happens.
+        """
+        cost = self.sig_op_count * WITNESS_SCALE_FACTOR
+        if cost > MAX_BLOCK_SIGOPS_COST:
+            err_msg = f"invalid sigop cost: {cost} > {MAX_BLOCK_SIGOPS_COST}"
+            raise BTClibValueError(err_msg)
+
+    def assert_valid_weight(self) -> None:
+        """Assert the weight bound of BIP141 (bad-blk-weight).
+
+        Core asks this in ContextualCheckBlock and not in CheckBlock,
+        though the weight is read off the bytes like everything else, and
+        the reason is the order rather than the context: the coinbase
+        witness is not covered by the block hash, so a block whose weight
+        is over the cap only because that witness was stuffed must not be
+        marked permanently invalid before the commitment to it has been
+        checked. Hence the position here, right after
+        assert_valid_witness_commitment, and hence the same rule twice at
+        different strengths -- assert_valid_length bounds what a legacy
+        node relays, this bounds the block segwit nodes see.
+        """
+        weight = self.weight
+        if weight > MAX_BLOCK_WEIGHT:
+            err_msg = f"invalid weight: {weight} > {MAX_BLOCK_WEIGHT}"
+            raise BTClibValueError(err_msg)
 
     def assert_valid_merkle_root(self) -> None:
         merkle_root_, mutated = merkle_root_and_mutated_from_transactions(
@@ -233,6 +384,59 @@ class Block:
             err_msg += f" instead of: {witness_commitment_.hex()}"
             raise BTClibValueError(err_msg)
 
+    def assert_valid_coinbase_height(self, height: int) -> None:
+        """Assert that the coinbase commits to a height (BIP34, bad-cb-height).
+
+        A byte comparison, as Core's is: the coinbase script_sig must
+        *start with* `CScript() << nHeight`, so a height pushed any other
+        way than the shortest is refused although it decodes to the right
+        number. `Block.height` is the decoder, and comparing what it
+        returns would accept a commitment no other node does --
+        `bip34_commitment` is what the comparison is against.
+
+        Which height, and whether BIP34 is in force at all, are the
+        caller's to say: the second is `BlockContext.bip34_active`, and
+        `assert_valid_contextual` is what applies it. Nothing is skipped
+        here, so a caller that knows the rule binds can ask for it
+        directly -- which is the only way to ask it of a block whose
+        height is all that is known about its place in a chain.
+        """
+        self._assert_coinbase()
+
+        expected = bip34_commitment(height)
+        script_sig = self.transactions[0].vin[0].script_sig
+        if not script_sig.startswith(expected):
+            err_msg = f"invalid coinbase height: {script_sig[: len(expected)].hex()}"
+            err_msg += f" instead of: {expected.hex()}"
+            raise BTClibValueError(err_msg)
+
+    def assert_valid_contextual(self, context: BlockContext) -> None:
+        """Assert the rules a block cannot be checked against on its own.
+
+        Bitcoin Core's ContextualCheckBlockHeader and
+        ContextualCheckBlock, as far as a height and a clock reach:
+        time-too-new, and bad-cb-height wherever BIP34 is in force. In
+        that order, which is Core's -- the header is checked before the
+        block it heads.
+
+        Separate from assert_valid, which is CheckBlock: what the bytes
+        answer for themselves, and therefore what Block.parse can ask.
+        Both are asked of a block being accepted, and by whoever has the
+        context; neither implies the other.
+
+        The rest of those two functions needs the chain and not merely a
+        context: time-too-old is the median time past of eleven ancestors,
+        bad-diffbits is the target of a whole retarget period,
+        bad-version the activation heights of BIP34, BIP66 and BIP65,
+        bad-txns-nonfinal every transaction's lock time against the same
+        median time past. Each is a field of BlockContext away, once the
+        chain state it reads is there to put in one.
+        """
+        self.header.assert_valid_time(context.now)
+
+        if context.bip34_active:
+            self.assert_valid_coinbase_height(context.height)
+
     def assert_valid(self) -> None:
         self.header.assert_valid()
         # the header alone does not assert this: a header being mined is
@@ -245,16 +449,14 @@ class Block:
         # themselves: Block.parse recomputes the hash from the bytes
         self.header.assert_valid_pow()
 
-        # every block carries a coinbase, so an empty list is not a block
-        # that happens to be empty: it is not a block. Refused here, or
-        # transactions[0] below answers it with an IndexError -- and a
-        # var_int of zero where the transaction count goes is all it takes
-        # to serialize one
-        if not self.transactions:
-            raise BTClibValueError("block with no transactions")
+        # Core's bad-blk-length is three questions in one condition -- an
+        # empty transaction list, too many transactions, too many bytes --
+        # and the first of them is answered by _assert_coinbase below: a
+        # block with no transactions has no coinbase, so refusing it in
+        # the size rule as well would be one refusal in two voices
+        self.assert_valid_length()
 
-        if not self.transactions[0].is_coinbase():
-            raise BTClibValueError("first transaction is not a coinbase")
+        self._assert_coinbase()
 
         for transaction in self.transactions[1:]:
             # Bitcoin Core's bad-cb-multiple, asked immediately after the
@@ -275,8 +477,15 @@ class Block:
                 raise BTClibValueError("more than one coinbase")
             transaction.assert_valid()
 
+        # last of CheckBlock's own questions, where Core asks it too:
+        # after every transaction has been checked on its own, the block
+        # is asked what they add up to
+        self.assert_valid_sig_op_count()
+
         self.assert_valid_merkle_root()
         self.assert_valid_witness_commitment()
+        # after the commitment, and the docstring says why
+        self.assert_valid_weight()
 
     def serialize(
         self, include_witness: bool = True, *, check_validity: bool = True

--- a/btclib/block/block_context.py
+++ b/btclib/block/block_context.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""BlockContext dataclass.
+
+What a block cannot be validated against from its own bytes: the height it
+is being accepted at, the instant it is being accepted at, and the height
+BIP34 takes effect at on the chain in question. Bitcoin Core reads all
+three off `pindexPrev` and the chain parameters, which is what
+`ContextualCheckBlockHeader` and `ContextualCheckBlock` are given and
+`CheckBlock` is not -- and `Block.assert_valid` is `CheckBlock`, called by
+`Block.parse` with nothing to give it.
+
+One carrier rather than a parameter per rule, because the list grows and
+each addition is chain state: `time-too-old` is the median time past of
+eleven ancestors, `bad-diffbits` is the target the retarget arithmetic of
+`proof_of_work.py` computes from a whole period, `bad-version` needs two
+more activation heights. Each becomes a field here when the chain state it
+takes arrives, and none of them changes the signature of
+`Block.assert_valid_contextual`.
+
+The rules underneath take the datum they read and not the whole context --
+`BlockHeader.assert_valid_time(now)`,
+`Block.assert_valid_coinbase_height(height)` -- so a caller holding one
+half of a context asks the half it can answer, and nothing is skipped for
+want of the other.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+
+# Core's chainparams: 227,931 on mainnet, 21,111 on testnet3, and 1 on
+# testnet4, signet and regtest. Mainnet is the default, as it is
+# everywhere else in btclib.
+#
+# A field of this dataclass rather than one of `Network`, which holds no
+# consensus parameter at all: the first one to go in belongs there with
+# the others a chain-aware validator needs -- the retarget interval,
+# BIP66's and BIP65's heights, the subsidy halving interval -- and putting
+# this one there alone would answer for a table that is otherwise absent.
+BIP34_HEIGHT = 227_931
+
+
+@dataclass(frozen=True)
+class BlockContext:
+    # the height the block is being accepted at, i.e. Core's
+    # pindexPrev->nHeight + 1
+    height: int
+    # the instant the block is being accepted at, from the caller's clock
+    now: datetime
+    # the height from which the chain enforces BIP34
+    bip34_height: int = BIP34_HEIGHT
+
+    @property
+    def bip34_active(self) -> bool:
+        """Whether the coinbase must commit to the height (BIP34).
+
+        Core's `DeploymentActiveAfter(pindexPrev, DEPLOYMENT_HEIGHTINCB)`,
+        which is this comparison: the rule binds from the activation
+        height on, and not from the block version. A version 1 block at
+        or above it is refused too, by `bad-version`, which needs the
+        chain and is out of scope here.
+        """
+        return self.height >= self.bip34_height
+
+    # frozen, as Script and Witness are: a context is a value, nothing
+    # serializes it, and the two rules that read it must not see it change
+    # between them
+    def __init__(
+        self,
+        height: int,
+        now: datetime,
+        bip34_height: int = BIP34_HEIGHT,
+        *,
+        check_validity: bool = True,
+    ) -> None:
+        object.__setattr__(self, "height", height)
+        object.__setattr__(self, "now", now)
+        object.__setattr__(self, "bip34_height", bip34_height)
+
+        if check_validity:
+            self.assert_valid()
+
+    def assert_valid(self) -> None:
+        for key in ("height", "bip34_height"):
+            value = getattr(self, key)
+            # a float here would compare fine and read as a height, so the
+            # type is checked rather than coerced -- and bool is an int,
+            # which no comparison below can be confused by
+            if not isinstance(value, int):
+                err_msg = f"invalid {key} type: {type(value).__name__}"
+                raise BTClibTypeError(err_msg)
+            if value < 0:
+                raise BTClibValueError(f"invalid {key}: {value}")
+
+        if not isinstance(self.now, datetime):
+            err_msg = f"invalid now type: {type(self.now).__name__}"
+            raise BTClibTypeError(err_msg)
+
+        # a naive datetime has no instant attached to it: timestamp() would
+        # read it as local time, so the same block would be too far in the
+        # future on one machine and not on another
+        if self.now.tzinfo is None or self.now.tzinfo.utcoffset(self.now) is None:
+            raise BTClibValueError(f"naive current time (no time zone): {self.now}")

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -21,6 +21,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from btclib.alias import BinaryData, Octets
+from btclib.block.limits import MAX_FUTURE_BLOCK_TIME
 from btclib.block.proof_of_work import target_from_bits
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash256
@@ -179,6 +180,41 @@ class BlockHeader:
         if self.hash > self.target:
             err_msg = f"invalid proof-of-work: {self.hash.hex()}"
             err_msg += f" > {self.target.hex()}"
+            raise BTClibValueError(err_msg)
+
+    def assert_valid_time(self, now: datetime) -> None:
+        """Assert that the timestamp is not too far ahead of a clock.
+
+        Bitcoin Core's time-too-new, from ContextualCheckBlockHeader: a
+        header more than MAX_FUTURE_BLOCK_TIME ahead of the current time
+        is refused, which is what bounds how far a miner can push a
+        timestamp forward -- and the reason it is a bound rather than an
+        equality is that the network has no clock of its own to check
+        against.
+
+        `now` is the caller's, and never `datetime.now()` read here: a
+        consensus rule taking the wall clock would have one machine accept
+        the block another refuses, and no test of it could be written that
+        did not depend on the day it ran on. Which is also why this is not
+        called by assert_valid, and why Block.assert_valid does not reach
+        it: those two answer for the eighty bytes and for the block, and a
+        clock is neither.
+
+        time-too-old is the other half of the pair Core checks beside this
+        one, and it stays out of reach: it is the median time past of
+        eleven ancestors, i.e. the chain.
+        """
+        if now.tzinfo is None or now.tzinfo.utcoffset(now) is None:
+            raise BTClibValueError(f"naive current time (no time zone): {now}")
+
+        # int(), as assert_valid does and for the same reason: it is the
+        # value the four bytes hold, so a header carrying a fraction of a
+        # second is compared as it serializes. The bound keeps the
+        # fraction of `now`, which is where Core keeps it too -- its clock
+        # is finer than a second and the comparison is in the finer unit
+        if int(self.time.timestamp()) > now.timestamp() + MAX_FUTURE_BLOCK_TIME:
+            err_msg = f"invalid timestamp (too far in the future): {self.time}"
+            err_msg += f" > {now} + {MAX_FUTURE_BLOCK_TIME} seconds"
             raise BTClibValueError(err_msg)
 
     def assert_valid(self) -> None:

--- a/btclib/block/limits.py
+++ b/btclib/block/limits.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""The consensus limits on a block, with Bitcoin Core's names.
+
+Core declares the first three in `consensus/consensus.h` and
+`MAX_FUTURE_BLOCK_TIME` in `chain.h`, beside the wider window the wallet
+compares its own timestamps against; it is a consensus bound all the same,
+and `ContextualCheckBlockHeader` rejects `time-too-new` with it.
+
+A module of its own, as `script/limits.py` is and for the same reason:
+`block.py` is the dataclass and its serialization, while each name here is
+a rule about a block being *accepted*. `WITNESS_SCALE_FACTOR` is not a
+limit but the unit the other two are expressed in -- a byte outside the
+witness weighs four, and so does one legacy signature check -- which is
+why it is here rather than beside the arithmetic that reads it.
+
+Three of `consensus.h`'s constants are deliberately absent.
+`MAX_BLOCK_SERIALIZED_SIZE` is marked in Core's own comment as a buffer
+bound and not a network rule, the weight being what consensus caps.
+`COINBASE_MATURITY` is a rule about spending an output, so it needs the
+chain the output was created on. `MAX_TIMEWARP` is BIP94's bound on the
+first block of a retarget period, which needs the previous block. The two
+`MIN_*_TRANSACTION_WEIGHT` bounds are about a transaction and are read by
+fee estimation rather than by consensus.
+"""
+
+# Maximum allowed weight for a block, see BIP141 (network rule)
+MAX_BLOCK_WEIGHT = 4_000_000
+
+# Maximum allowed cost of the signature check operations in a block
+# (network rule); the cost of a legacy sigop is WITNESS_SCALE_FACTOR, so
+# the bound is 20,000 of them
+MAX_BLOCK_SIGOPS_COST = 80_000
+
+# The weight of a byte a legacy node sees, and the cost of a legacy sigop
+WITNESS_SCALE_FACTOR = 4
+
+# Maximum number of seconds a block timestamp may exceed the current time,
+# spelled as Core spells it
+MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60

--- a/btclib/script/__init__.py
+++ b/btclib/script/__init__.py
@@ -41,6 +41,7 @@ from btclib.script.script_pub_key import (
     is_p2wsh,
     type_and_payload,
 )
+from btclib.script.sig_ops import sig_op_count
 from btclib.script.taproot import (
     check_output_pubkey,
     input_script_sig,
@@ -84,5 +85,6 @@ __all__ = [
     "script_from_dict",
     "script_to_dict",
     "serialize",
+    "sig_op_count",
     "type_and_payload",
 ]

--- a/btclib/script/sig_ops.py
+++ b/btclib/script/sig_ops.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""The legacy signature check operation count of a script.
+
+Bitcoin Core's `CScript::GetSigOpCount(false)`, which `GetLegacySigOpCount`
+sums over the input and output scripts of a transaction and `CheckBlock`
+sums again over the transactions of a block, to bound it by
+`MAX_BLOCK_SIGOPS_COST`. That is the one sigop rule a block can be held to
+from its own bytes, and it is why the count is here: `Tx.sig_op_count` and
+`Block.sig_op_count` are the two sums, each reading this.
+
+The count underestimates, and Core's comment where it is summed says so:
+the P2SH count needs the redeem script the input pushes, the witness count
+needs the `script_pub_key` being spent, and both are outputs of blocks that
+are not this one. `fAccurate` is not a parameter here for that same reason
+-- accurate means `OP_CHECKMULTISIG` costing the number of keys pushed
+before it rather than the twenty of `MAX_PUBKEYS_PER_MULTISIG`, and Core
+only ever asks for it under P2SH and segwit, where the script counted comes
+from the UTXO set.
+
+A module of its own rather than the bottom of `script.py`, which is the
+encoding and reads no limit: `MAX_PUBKEYS_PER_MULTISIG` is a rule about
+executing a script, and a decoder that need not import the limits is what
+`script/limits.py` exists to say. What it does share with the decoder is
+the walk -- `op_code_spans`, i.e. Core's `GetOp` -- because the boundary
+between one op code and the next is the only thing the count depends on.
+"""
+
+from __future__ import annotations
+
+from btclib.alias import Octets
+from btclib.script.limits import MAX_PUBKEYS_PER_MULTISIG
+from btclib.script.script import BYTE_FROM_OP_CODE_NAME, op_code_spans
+from btclib.utils import bytes_from_octets
+
+# read out of the table rather than written as bytes, so that these stay
+# the op codes those names stand for
+_CHECKSIG = {
+    BYTE_FROM_OP_CODE_NAME[name][0] for name in ("OP_CHECKSIG", "OP_CHECKSIGVERIFY")
+}
+_CHECKMULTISIG = {
+    BYTE_FROM_OP_CODE_NAME[name][0]
+    for name in ("OP_CHECKMULTISIG", "OP_CHECKMULTISIGVERIFY")
+}
+
+
+def sig_op_count(script: Octets) -> int:
+    """Return the number of legacy signature checks a script announces.
+
+    One for `OP_CHECKSIG` and `OP_CHECKSIGVERIFY`,
+    `MAX_PUBKEYS_PER_MULTISIG` for `OP_CHECKMULTISIG` and
+    `OP_CHECKMULTISIGVERIFY` however many keys the script actually pushes,
+    and nothing for the rest -- the count is announced by the bytes and is
+    not what executing them would do.
+
+    Where the script stops parsing the count stops too, and no exception
+    is raised: Core's loop `break`s when `GetOp` returns false, which is a
+    push running past the end, and `op_code_spans` ends the same way. The
+    coinbase output script of testnet block 987,876 is that case on chain
+    -- it ends `...d8 3d 0aa68688ac`, and the `OP_CHECKSIG` of that final
+    `ac` is five bytes inside the 61-byte push `3d` announces, so neither
+    implementation ever reaches it and the answer for that script is zero.
+    """
+    script_ = bytes_from_octets(script)
+    count = 0
+    for op_code, _, _ in op_code_spans(script_):
+        if op_code in _CHECKSIG:
+            count += 1
+        elif op_code in _CHECKMULTISIG:
+            count += MAX_PUBKEYS_PER_MULTISIG
+    return count

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -37,6 +37,7 @@ from btclib.alias import BinaryData
 from btclib.amount import _MAX_SATOSHI
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash256
+from btclib.script.sig_ops import sig_op_count as script_sig_op_count
 from btclib.script.witness import Witness
 from btclib.tx.tx_in import TX_IN_COMPARES_WITNESS, TxIn
 from btclib.tx.tx_out import TxOut
@@ -128,6 +129,21 @@ class Tx:
         no_wit = len(self.serialize(include_witness=False, check_validity=False)) * 3
         wit = len(self.serialize(include_witness=True, check_validity=False))
         return no_wit + wit
+
+    @property
+    def sig_op_count(self) -> int:
+        """Return the legacy sigop count, Core's GetLegacySigOpCount.
+
+        Every input's script_sig and every output's script_pub_key,
+        counted from the bytes by `script.sig_ops.sig_op_count`: the P2SH
+        and witness sigops Core adds in ConnectBlock need the outputs
+        being spent, which a transaction does not carry. That module's
+        docstring has what the shortfall is; the block rule this feeds,
+        `Block.assert_valid_sig_op_count`, is the one it is enough for.
+        """
+        return sum(script_sig_op_count(tx_in.script_sig) for tx_in in self.vin) + sum(
+            script_sig_op_count(tx_out.script_pub_key.script) for tx_out in self.vout
+        )
 
     @property
     def vwitness(self) -> list[Witness]:

--- a/docs/source/btclib.block.rst
+++ b/docs/source/btclib.block.rst
@@ -12,10 +12,26 @@ btclib.block.block module
    :undoc-members:
    :show-inheritance:
 
+btclib.block.block\_context module
+----------------------------------
+
+.. automodule:: btclib.block.block_context
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 btclib.block.block\_header module
 ---------------------------------
 
 .. automodule:: btclib.block.block_header
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+btclib.block.limits module
+--------------------------
+
+.. automodule:: btclib.block.limits
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/btclib.script.rst
+++ b/docs/source/btclib.script.rst
@@ -52,6 +52,14 @@ btclib.script.sig\_hash module
    :undoc-members:
    :show-inheritance:
 
+btclib.script.sig\_ops module
+-----------------------------
+
+.. automodule:: btclib.script.sig_ops
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 btclib.script.taproot module
 ----------------------------
 

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -517,8 +517,11 @@ Verdict: **identical**. Core's BIP158 vector file, vendored whole and
 read in part: every row carries a height, a block hash and a full
 serialized block before its filter columns, and `blockfilters_test.py`
 reads those three. All ten blocks parse under the full validity check,
-round-trip byte for byte, hash to the hash the row states, and the six
-that postdate BIP34 commit the height the row states.
+round-trip byte for byte, hash to the hash the row states, and the six at
+or above testnet's BIP34 activation height commit the height the row
+states — in the bytes Core builds, `assert_valid_coinbase_height`
+comparing them. The four below it commit nothing, which is what makes the
+file the vector for the activation gate as well.
 
 btclib implements no block filter, so the filter columns are unread. The
 file is here under its own name anyway rather than as a btclib-named
@@ -666,9 +669,10 @@ which `tests/block/checkblock_test.py` parses with the full validity
 check. Genesis is the merkle tree btclib had no vector for: one leaf, so
 the root is the coinbase txid and nothing is hashed.
 
-The two genesis entries differ only in the `cur_time` beside them, which
-btclib has no use for: it answers "is this timestamp too far in the
-future", and that takes a clock.
+The two genesis entries differ only in the `cur_time` beside them, and it
+is read: it answers "is this timestamp too far in the future", which
+`BlockContext` carries the clock for. The first is one second inside the
+two-hour window and the second is the instant genesis was mined.
 
 ### `tests/block/_data/checkblock_invalid.json`
 
@@ -685,13 +689,14 @@ Verdict: **identical**. Seven blocks consensus refuses, and the only
 vendored negative block vectors there are: what `block_test.py` rejects,
 it rejects from blocks it mutates itself.
 
-btclib rejects six of the seven. The seventh is the genesis block two
-hours and one second ahead of its `cur_time`, and `xfail` is what that
-gets: no clock, no contextual check. Three of the six are rejected for
-the proof-of-work rather than the rule they name, upstream's `fCheckPoW`
-being a switch `Block.assert_valid` does not have; each of those three
-rules is asserted in `block_test.py` instead, from a block mutated for
-the purpose.
+btclib rejects every one of them, and one of them for something
+`assert_valid` cannot see: the genesis block two hours and one second
+ahead of its `cur_time` is a valid block refused by
+`assert_valid_contextual`, Core's `time-too-new`. Three of the rest are
+rejected for the proof-of-work rather than the rule they name, upstream's
+`fCheckPoW` being a switch `Block.assert_valid` does not have; each of
+those three rules is asserted in `block_test.py` instead, from a block
+mutated for the purpose.
 
 One of the seven is misnamed, and the file is vendored with the name
 anyway: "Duplicate transaction" is refused for its merkle root, the

--- a/tests/block/block_context_test.py
+++ b/tests/block/block_context_test.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""The two block rules that need something the block does not carry.
+
+`Block.assert_valid` is Bitcoin Core's `CheckBlock`, and these are the
+reachable part of `ContextualCheckBlockHeader` and `ContextualCheckBlock`:
+`time-too-new`, which needs a clock, and `bad-cb-height`, which needs the
+height the block is being accepted at and the height BIP34 binds from.
+`BlockContext` is what carries the three, and each rule is also a method
+taking the datum it reads, so a caller holding half a context asks the
+half it can answer.
+
+The blocks are the vendored ones, which is what makes these vectors and
+not fixtures: block 481,824 is a mainnet block above BIP34's activation
+height, so its coinbase commitment is one the whole network agreed on.
+"""
+
+from datetime import datetime, timedelta, timezone
+from os import path
+
+import pytest
+
+from btclib.block import Block, BlockContext, bip34_commitment
+from btclib.block.block_context import BIP34_HEIGHT
+from btclib.block.limits import MAX_FUTURE_BLOCK_TIME
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.script import serialize
+from btclib.tx import TxIn
+
+_MAINNET_BIP34_HEIGHT = 227_931
+
+
+def block_of(fname: str) -> Block:
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        return Block.parse(file_.read())
+
+
+def test_the_activation_height_is_cores() -> None:
+    """The default is mainnet's, and mainnet's is 227,931.
+
+    `BlockContext` defaults to it because everything else in btclib
+    defaults to mainnet; testnet3 is 21,111 and testnet4, signet and
+    regtest are 1, which a caller passes. Written out here rather than
+    only imported, so that the number is asserted and not merely reused.
+    """
+    assert BIP34_HEIGHT == _MAINNET_BIP34_HEIGHT
+    now = datetime.now(timezone.utc)
+    assert BlockContext(height=0, now=now).bip34_height == _MAINNET_BIP34_HEIGHT
+
+    # the gate is a comparison, and the activation height is the first
+    # height it lets through
+    for height, active in (
+        (0, False),
+        (_MAINNET_BIP34_HEIGHT - 1, False),
+        (_MAINNET_BIP34_HEIGHT, True),
+        (_MAINNET_BIP34_HEIGHT + 1, True),
+    ):
+        assert BlockContext(height=height, now=now).bip34_active is active
+
+    # regtest has BIP34 in force from its first block, which is why the
+    # one-byte encodings below are the mainline case and not an edge
+    assert BlockContext(height=1, now=now, bip34_height=1).bip34_active
+
+
+def test_a_context_is_a_height_and_an_instant() -> None:
+    """What BlockContext refuses, and why each refusal is there."""
+    now = datetime.now(timezone.utc)
+
+    # a naive datetime has no instant attached to it: timestamp() reads it
+    # as local time, so the same block would be too far in the future on
+    # one machine and not on another
+    err_msg = "naive current time \\(no time zone\\): "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        BlockContext(height=0, now=now.replace(tzinfo=None))
+
+    # a height is a position in a chain: there is no negative one
+    with pytest.raises(BTClibValueError, match="invalid height: -1"):
+        BlockContext(height=-1, now=now)
+    with pytest.raises(BTClibValueError, match="invalid bip34_height: -1"):
+        BlockContext(height=0, now=now, bip34_height=-1)
+
+    # a float would compare fine and read as a height, so it is reported
+    # rather than coerced
+    with pytest.raises(BTClibTypeError, match="invalid height type: float"):
+        BlockContext(height=1.0, now=now)  # type: ignore[arg-type]
+    err_msg = "invalid bip34_height type: float"
+    with pytest.raises(BTClibTypeError, match=err_msg):
+        BlockContext(height=0, now=now, bip34_height=1.0)  # type: ignore[arg-type]
+
+    with pytest.raises(BTClibTypeError, match="invalid now type: int"):
+        BlockContext(height=0, now=0)  # type: ignore[arg-type]
+
+    # frozen, as Script and Witness are: the two rules that read a context
+    # must not see it change between them
+    context = BlockContext(height=0, now=now)
+    with pytest.raises(AttributeError):
+        context.height = 1  # type: ignore[misc]
+
+    # and a context nobody checks can still be built, as everywhere else
+    # in the library
+    assert BlockContext(height=-1, now=now, check_validity=False).height == -1
+
+
+def test_the_height_is_committed_as_core_writes_it() -> None:
+    """BIP34's commitment is the shortest encoding, op codes included.
+
+    Core builds `CScript() << nHeight`, so zero is OP_0 and one to sixteen
+    are OP_1 to OP_16 -- one byte, no push at all -- where
+    `script.serialize([height])` pushes the number as data and warns that
+    an op code says the same. From seventeen up the two agree, which is
+    why the vendored mainnet coinbases match either way and regtest, with
+    BIP34 in force from height 1, does not.
+    """
+    assert bip34_commitment(0) == b"\x00"
+    assert bip34_commitment(1) == b"\x51"
+    assert bip34_commitment(16) == b"\x60"
+    # the first height the two encodings agree on
+    assert bip34_commitment(17) == bytes.fromhex("0111")
+
+    with pytest.warns(UserWarning, match="consider using OP_1 instead"):
+        assert serialize([1]) == bytes.fromhex("0101")
+    assert serialize([17]) == bip34_commitment(17)
+
+    # the two vendored coinbases above the activation height, byte for byte
+    assert bip34_commitment(200_000) == bytes.fromhex("03400d03")
+    assert bip34_commitment(481_824) == bytes.fromhex("03205a07")
+
+
+def test_the_coinbase_commitment_is_compared_as_bytes() -> None:
+    """Core's bad-cb-height compares bytes, not the number they decode to.
+
+    The coinbase script_sig must *start with* the commitment, so a height
+    pushed any other way than the shortest is refused although
+    `Block.height` reads the right number out of it: four bytes of
+    little-endian 481,824 decode to 481,824 and are not what the network
+    committed to.
+    """
+    block = block_of("block_481824_complete.bin")
+    assert block.height == 481_824
+    block.assert_valid_coinbase_height(481_824)
+
+    # the height of the block before it, and of the one after
+    for height in (481_823, 481_825):
+        err_msg = "invalid coinbase height: 03205a07 instead of: "
+        with pytest.raises(BTClibValueError, match=err_msg):
+            block.assert_valid_coinbase_height(height)
+
+    coinbase = block.transactions[0]
+    script_sig = coinbase.vin[0].script_sig
+    non_minimal = bytes([4]) + (481_824).to_bytes(4, "little")
+    coinbase.vin[0] = TxIn(
+        coinbase.vin[0].prev_out,
+        non_minimal + script_sig[4:],
+        coinbase.vin[0].sequence,
+        coinbase.vin[0].script_witness,
+    )
+    assert block.height == 481_824
+    err_msg = "invalid coinbase height: 04205a07 instead of: 03205a07"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        block.assert_valid_coinbase_height(481_824)
+
+
+def test_the_commitment_is_only_asked_where_bip34_binds() -> None:
+    """Block 200,000 commits its height and is 27,931 blocks too early.
+
+    BIP34 activated by supermajority, so version 2 blocks carrying the
+    commitment predate the height Core enforces it from: block 200,000 is
+    one of them. The commitment is there and correct -- the rule passes
+    when it is asked -- and the contextual path does not ask it, which is
+    the gate doing its job on a real mainnet block.
+
+    Block 481,824 is the case above the activation height, where the
+    contextual path does ask.
+    """
+    early = block_of("block_200000.bin")
+    now = early.header.time
+    early.assert_valid_coinbase_height(200_000)
+    early.assert_valid_contextual(BlockContext(height=200_000, now=now))
+    # and a height that is not this block's is not asked about either
+    early.assert_valid_contextual(BlockContext(height=1, now=now))
+    # unless the chain enforces BIP34 from the start, as regtest does
+    with pytest.raises(BTClibValueError, match="invalid coinbase height: "):
+        early.assert_valid_contextual(BlockContext(height=1, now=now, bip34_height=1))
+
+    block = block_of("block_481824_complete.bin")
+    now = block.header.time
+    block.assert_valid_contextual(BlockContext(height=481_824, now=now))
+    with pytest.raises(BTClibValueError, match="invalid coinbase height: "):
+        block.assert_valid_contextual(BlockContext(height=481_825, now=now))
+
+
+def test_a_timestamp_may_be_two_hours_ahead_and_no_more() -> None:
+    """Core's time-too-new, at the second the bound is drawn on.
+
+    The clock is the caller's: `datetime.now()` read inside the library
+    would have one machine accept the block another refuses, and would
+    make this test depend on the day it runs on. Block 1's own timestamp
+    is the block's, and `now` moves around it.
+    """
+    block = block_of("block_1.bin")
+    header = block.header
+    two_hours = timedelta(seconds=MAX_FUTURE_BLOCK_TIME)
+    assert two_hours == timedelta(hours=2)
+
+    # the instant the block was mined, and the last instant a node could
+    # have refused it for its timestamp: the bound may be reached
+    header.assert_valid_time(header.time)
+    header.assert_valid_time(header.time - two_hours)
+
+    err_msg = "invalid timestamp \\(too far in the future\\): "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        header.assert_valid_time(header.time - two_hours - timedelta(seconds=1))
+
+    # the whole block, through the carrier: height 1 leaves bad-cb-height
+    # out of it on mainnet, so the timestamp is what answers
+    now = header.time - two_hours - timedelta(seconds=1)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        block.assert_valid_contextual(BlockContext(height=1, now=now))
+
+    # a naive `now` is refused where it arrives, the context being only
+    # one of the two ways in
+    err_msg = "naive current time \\(no time zone\\): "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        header.assert_valid_time(header.time.replace(tzinfo=None))
+
+
+def test_the_contextual_rules_are_not_asked_by_assert_valid() -> None:
+    """Two questions, and a block answers the first one on its own.
+
+    `Block.parse` calls `assert_valid` with no context to pass it, which
+    is the whole reason these rules are a second entry point: a block
+    read off the wire is checked for what its bytes say, and the caller
+    that knows where it sits in a chain asks the rest.
+    """
+    block = block_of("block_1.bin")
+    block.assert_valid()
+
+    # a context that refuses it, and an assert_valid that does not
+    now = block.header.time - timedelta(days=1)
+    with pytest.raises(BTClibValueError, match="invalid timestamp "):
+        block.assert_valid_contextual(BlockContext(height=1, now=now))
+    block.assert_valid()
+
+    # a coinbase is what both halves read, so both say so in the same
+    # words -- and the height rule can be asked of a block that has none
+    empty = Block(block.header, [], check_validity=False)
+    for err_msg in ("block with no transactions",):
+        with pytest.raises(BTClibValueError, match=err_msg):
+            empty.assert_valid_coinbase_height(1)
+        with pytest.raises(BTClibValueError, match=err_msg):
+            _ = empty.height

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -25,6 +25,11 @@ from os import path
 import pytest
 
 from btclib.block import Block, BlockHeader
+from btclib.block.limits import (
+    MAX_BLOCK_SIGOPS_COST,
+    MAX_BLOCK_WEIGHT,
+    WITNESS_SCALE_FACTOR,
+)
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.network import NETWORKS
 from btclib.script import ScriptPubKey
@@ -43,7 +48,11 @@ def test_block_1() -> None:
     block = Block.parse(block_bytes)
     assert len(block.transactions) == 1
     assert block.size == 215
-    assert block.weight == 536
+    assert block.stripped_size == 215
+    # 215 * 4, the header and the transaction count included: Core's
+    # GetBlockWeight, and 324 more than the 536 of its one transaction
+    assert block.weight == 860
+    assert block.sig_op_count == 1
     assert block.height is None
     assert not block.has_segwit_tx()
     assert block == Block.parse(block.serialize())
@@ -194,7 +203,10 @@ def test_block_170() -> None:
     block = Block.parse(block_bytes)
     assert len(block.transactions) == 2
     assert block.size == 490
-    assert block.weight == 1636
+    assert block.weight == 1960
+    # one for the coinbase output, two for the first payment ever made:
+    # the p2pk it pays to and the p2pk it spends from
+    assert block.sig_op_count == 3
     assert block.height is None
     assert not block.has_segwit_tx()
     assert block == Block.parse(block.serialize())
@@ -227,7 +239,8 @@ def test_block_200000() -> None:
     block = Block.parse(block_bytes)
     assert len(block.transactions) == 388
     assert block.size == 247_533
-    assert block.weight == 989_800
+    assert block.weight == 990_132
+    assert block.sig_op_count == 822
     assert block.height == 200_000
     assert not block.has_segwit_tx()
     assert block == Block.parse(block.serialize())
@@ -315,16 +328,23 @@ def test_block_481824() -> None:
         assert header == BlockHeader.parse(header.serialize())
         assert header == BlockHeader.from_dict(header.to_dict())
 
+        # the same 1866 transactions either way, so the same sigops: the
+        # count is over the script_sig and script_pub_key bytes, which
+        # both serializations carry in full
+        assert block.sig_op_count == 3_409
+
         if i:  # segwit nodes see the witness data
             assert block.has_segwit_tx()
             assert block.size == 989_323
-            assert block.weight == 3_954_548
-            assert block.vsize == 988_637
+            assert block.stripped_size == 988_519
+            assert block.weight == 3_954_880
+            assert block.vsize == 988_720
         else:  # legacy nodes see NO witness data
             assert not block.has_segwit_tx()
             assert block.size == 988_519
-            assert block.weight == 3_953_744
-            assert block.vsize == 988_436
+            assert block.stripped_size == 988_519
+            assert block.weight == 3_954_076
+            assert block.vsize == 988_519
 
 
 def test_block_witness_commitment() -> None:
@@ -655,6 +675,169 @@ def test_a_candidate_header_can_be_built() -> None:
     # the round trip still works for the mined header, work and all
     assert mined.serialize() == header_bytes
     mined.assert_valid_pow()
+
+
+@pytest.mark.parametrize(
+    ("fname", "delta"),
+    [
+        ("block_1.bin", 324),
+        ("block_170.bin", 324),
+        ("block_200000.bin", 332),
+        ("block_481824_complete.bin", 332),
+    ],
+)
+def test_the_weight_is_the_block_and_not_its_transactions(
+    fname: str, delta: int
+) -> None:
+    """`Block.weight` is Core's GetBlockWeight, over the whole block.
+
+    The sum of the transactions' weights is a different number, and it is
+    the one no rule reads: the header weighs 320 units, and the var_int
+    holding the transaction count weighs 4 for the two blocks with fewer
+    than 253 transactions and 12 for the two with hundreds. That is the
+    delta here, and MAX_BLOCK_WEIGHT bounds the larger of the two.
+
+    Both spellings of Core's formula are asserted, because the comment
+    beside it in `consensus/validation.h` is that they are the same one:
+    four times the stripped size plus the witness bytes, and three times
+    the stripped size plus the size.
+    """
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        block_bytes = file_.read()
+
+    block = Block.parse(block_bytes)
+    witness_size = block.size - block.stripped_size
+    assert block.weight == block.stripped_size * WITNESS_SCALE_FACTOR + witness_size
+    assert block.weight == block.stripped_size * 3 + block.size
+    assert block.weight - sum(t.weight for t in block.transactions) == delta
+
+
+def test_a_block_cannot_announce_too_many_sigops() -> None:
+    """Core's bad-blk-sigops, from a block built for the purpose.
+
+    The largest count in this suite is block 481,824's 3,409, 17% of the
+    20,000 legacy signature checks the cost limit allows, so no vendored
+    block comes near it: block 1's coinbase output script is replaced by
+    n OP_CHECKSIG, which is n sigops however unspendable that script is
+    -- the count is what the bytes announce, not what executing them
+    would do.
+
+    The mutation moves the merkle root as well, so the block is invalid
+    twice over, and which answer comes back says where the rule sits:
+    Core asks the sigop question last of CheckBlock's own, after every
+    transaction has been checked on its own.
+    """
+    fname = "block_1.bin"
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        block_bytes = file_.read()
+
+    limit = MAX_BLOCK_SIGOPS_COST // WITNESS_SCALE_FACTOR
+    assert limit == 20_000
+
+    for count in (limit, limit + 1):
+        block = Block.parse(block_bytes)
+        coinbase = block.transactions[0]
+        # a new TxOut rather than a rebound script: ScriptPubKey is frozen
+        coinbase.vout[0] = TxOut(coinbase.vout[0].value, ScriptPubKey(b"\xac" * count))
+        # the coinbase script_sig pushes the extranonce and nothing else,
+        # so the block's count is the output script's
+        assert coinbase.sig_op_count == count
+        assert block.sig_op_count == count
+
+        if count == limit:
+            # the cost is exactly the cap, which the rule allows: the
+            # comparison is a bound the block may reach
+            block.assert_valid_sig_op_count()
+            continue
+
+        err_msg = f"invalid sigop cost: {(count) * WITNESS_SCALE_FACTOR} > 80000"
+        with pytest.raises(BTClibValueError, match=err_msg):
+            block.assert_valid_sig_op_count()
+        with pytest.raises(BTClibValueError, match=err_msg):
+            block.assert_valid()
+
+
+def test_a_block_cannot_hold_too_many_transactions_or_too_many_bytes() -> None:
+    """Core's bad-blk-length, whose two comparisons are neither the weight.
+
+    A transaction weighs at least one unit, so a block cannot hold more
+    of them than MAX_BLOCK_WEIGHT over WITNESS_SCALE_FACTOR: a million,
+    and the list here holds one more -- the same coinbase a million and
+    one times, which costs a list of pointers rather than a gigabyte of
+    transactions. That the count is compared before anything is
+    serialized is what makes this half testable at all.
+
+    The other half is the stripped size, reached with a single
+    million-byte output script.
+    """
+    fname = "block_1.bin"
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        block_bytes = file_.read()
+
+    limit = MAX_BLOCK_WEIGHT // WITNESS_SCALE_FACTOR
+    assert limit == 1_000_000
+
+    block = Block.parse(block_bytes)
+    header, coinbase = block.header, block.transactions[0]
+
+    too_many = Block(header, [coinbase] * (limit + 1), check_validity=False)
+    err_msg = f"invalid transaction count: {limit + 1} \\* 4 > {MAX_BLOCK_WEIGHT}"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        too_many.assert_valid_length()
+
+    block = Block.parse(block_bytes)
+    coinbase = block.transactions[0]
+    coinbase.vout[0] = TxOut(coinbase.vout[0].value, ScriptPubKey(b"\x00" * limit))
+    # the 215 bytes of block 1, less the 67-byte p2pk script and its
+    # one-byte length, plus a million and the five bytes announcing it
+    assert block.stripped_size == 1_000_152
+    err_msg = f"invalid stripped size: 1000152 \\* 4 > {MAX_BLOCK_WEIGHT}"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        block.assert_valid_length()
+    with pytest.raises(BTClibValueError, match=err_msg):
+        block.assert_valid()
+
+
+def test_a_block_cannot_weigh_more_than_the_cap() -> None:
+    """Core's bad-blk-weight, and why it is asked after the commitment.
+
+    Witness bytes are not in the stripped serialization, so a block can
+    pass bad-blk-length and still be over MAX_BLOCK_WEIGHT: block
+    481,824 weighs 3,954,880 of the 4,000,000, and 46,000 bytes of
+    witness handed to its second transaction take it over while the
+    stripped size does not move.
+
+    The same bytes in the *coinbase* witness are what Core's comment
+    there is about: the block hash does not cover that witness, so the
+    weight must not be what answers before the commitment to it has been
+    checked -- a block could otherwise be marked permanently invalid for
+    bytes anyone could have appended. btclib asks them in that order, and
+    this is where that claim is measured.
+    """
+    fname = "block_481824_complete.bin"
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        block_bytes = file_.read()
+
+    stuffing = Witness([b"\x00" * 46_000])
+
+    block = Block.parse(block_bytes)
+    block.transactions[1].vin[0].script_witness = stuffing
+    assert block.stripped_size == 988_519
+    block.assert_valid_length()
+    assert block.weight == 4_000_886
+    err_msg = f"invalid weight: 4000886 > {MAX_BLOCK_WEIGHT}"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        block.assert_valid_weight()
+
+    block = Block.parse(block_bytes)
+    block.transactions[0].vin[0].script_witness = stuffing
+    assert block.weight == 4_000_850
+    with pytest.raises(BTClibValueError, match="invalid witness nonce: "):
+        block.assert_valid()
 
 
 def test_a_block_still_requires_the_work() -> None:

--- a/tests/block/blockfilters_test.py
+++ b/tests/block/blockfilters_test.py
@@ -38,10 +38,35 @@ from typing import Any
 
 import pytest
 
-from btclib.block import Block
+from btclib.block import Block, BlockContext
+from btclib.exceptions import BTClibValueError
 from tests import load, vector_id
 
 _HEADER_ROW = 1  # "Block Height,Block Hash,Block,[Prev Output Scripts ..."
+
+# Core's chainparams for testnet3, which these ten blocks are from: the
+# four rows below it predate the rule, and are the reason the gate exists
+# -- checking bad-cb-height at every height would refuse four blocks the
+# chain accepted
+_TESTNET_BIP34_HEIGHT = 21_111
+
+# the legacy sigop count of each row, which is the arithmetic and not the
+# limit: 21 in all, against a cost cap of 20,000 checks. 987,876 is the
+# zero, its coinbase output script ending in an OP_CHECKSIG inside a push
+# that runs past the end of the script -- an op code no implementation
+# reaches
+_SIG_OP_COUNT = {
+    0: 1,
+    2: 1,
+    3: 1,
+    15007: 1,
+    49291: 2,
+    180480: 8,
+    926485: 6,
+    987876: 0,
+    1263442: 1,
+    1414221: 0,
+}
 
 
 def _rows() -> list[Any]:
@@ -80,6 +105,43 @@ def test_blockfilters_block(height: int, block_hash: str, serialization: str) ->
 
     expected_height = None if block.header.version == 1 else height
     assert block.height == expected_height
+
+    assert block.sig_op_count == _SIG_OP_COUNT[height]
+
+
+@pytest.mark.parametrize(("height", "block_hash", "serialization"), params())
+def test_blockfilters_coinbase_height(
+    height: int, block_hash: str, serialization: str
+) -> None:
+    """Core's bad-cb-height over ten real testnet blocks.
+
+    Six of the rows are at or above testnet3's activation height and
+    commit their own height in the bytes Core builds; the four below it
+    are version 1 blocks that commit nothing, and they are what says the
+    activation height has to be part of the context. Asked through
+    `assert_valid_contextual`, so that the gate is what decides and not
+    the test: the same call over the same block passes below the
+    activation height and asks the question above it.
+    """
+    block = Block.parse(serialization)
+    context = BlockContext(
+        height=height,
+        now=block.header.time,
+        bip34_height=_TESTNET_BIP34_HEIGHT,
+    )
+    assert context.bip34_active == (height >= _TESTNET_BIP34_HEIGHT)
+    block.assert_valid_contextual(context)
+
+    if not context.bip34_active:
+        # the commitment is absent, so asking for it directly is what
+        # measures that the gate above is doing the work
+        with pytest.raises(BTClibValueError, match="invalid coinbase height: "):
+            block.assert_valid_coinbase_height(height)
+        return
+
+    # and above it, the block is refused for any other height
+    with pytest.raises(BTClibValueError, match="invalid coinbase height: "):
+        block.assert_valid_coinbase_height(height + 1)
 
 
 def test_an_output_script_can_be_empty() -> None:

--- a/tests/block/checkblock_test.py
+++ b/tests/block/checkblock_test.py
@@ -16,21 +16,22 @@ negative block vectors: what `block_test.py` rejects, it rejects from
 blocks it mutates itself, so an independent hand is worth the two files.
 
 A vector is `[comment, is_header, check_pow, cur_time, serialization]`.
-The last two fields are contextual and btclib takes neither: `cur_time`
-answers "is this block's timestamp too far in the future", which needs a
-clock, and `check_pow` switches off a check `Block.assert_valid` always
-makes. Both are read here anyway -- `check_pow` because it says which
-rule the vector was written to reach, and the invalid table below records
-where btclib's answer is the proof-of-work instead.
+`cur_time` is the clock the block is being accepted against, which is
+what `BlockContext` carries and `BlockHeader.assert_valid_time` reads;
+`check_pow` switches off a check `Block.assert_valid` always makes, so it
+is read here for what it says about the rule a vector was written to
+reach, and the invalid table below records where btclib's answer is the
+proof-of-work instead.
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
 
-from btclib.block import Block
+from btclib.block import Block, BlockContext
 from btclib.exceptions import BTClibValueError
 from tests import load, vector_id
 
@@ -44,11 +45,13 @@ from tests import load, vector_id
 # block it mutates; the test at the end of this module is why the third
 # of them cannot be covered from its own vector
 _INVALID = {
-    # the one contextual vector: two hours and one second ahead of the
-    # cur_time it carries. btclib has no clock and no cur_time, so it
-    # accepts -- marked xfail rather than dropped, and it turns red the
-    # day a contextual check lands
-    "Genesis block with time set to two hours + 1 second behind": None,
+    # the one contextual vector, and the only entry here answered by
+    # assert_valid_contextual rather than assert_valid: the genesis block
+    # two hours and one second ahead of the cur_time beside it, which is
+    # Core's time-too-new
+    "Genesis block with time set to two hours + 1 second behind": (
+        r"invalid timestamp \(too far in the future\)"
+    ),
     "Genesis with one byte changed": "invalid proof-of-work: ",
     # the intended rule is "vtx empty"; this header carries a timestamp of
     # zero, so the header is refused before the transaction count is read
@@ -71,7 +74,7 @@ _INVALID = {
 }
 
 
-def check_block_vectors(file_name: str) -> list[tuple[int, str, bool, str]]:
+def check_block_vectors(file_name: str) -> list[tuple[int, str, bool, int, str]]:
     """One tuple per vector, the single-string comment entries dropped.
 
     The index kept beside each is the position in the file, comments
@@ -81,33 +84,55 @@ def check_block_vectors(file_name: str) -> list[tuple[int, str, bool, str]]:
     for index, vector in enumerate(load("block", "_data", file_name)):
         if len(vector) == 1:  # a comment, which upstream's loader skips too
             continue
-        comment, is_header, check_pow, _cur_time, serialization = vector
+        comment, is_header, check_pow, cur_time, serialization = vector
         # no vector in either file is a bare 80-byte header, so there is
         # no header branch here to leave untested; a refreshed file that
         # grows one says so instead of being silently read as a block
         assert not is_header, comment
-        vectors.append((index, comment, check_pow, serialization))
+        vectors.append((index, comment, check_pow, cur_time, serialization))
     return vectors
 
 
 def params(file_name: str) -> list[Any]:
     """`check_block_vectors`, as parametrize takes it."""
     return [
-        pytest.param(comment, check_pow, serialization, id=vector_id(index, comment))
-        for index, comment, check_pow, serialization in check_block_vectors(file_name)
+        pytest.param(
+            comment, check_pow, cur_time, serialization, id=vector_id(index, comment)
+        )
+        for index, comment, check_pow, cur_time, serialization in check_block_vectors(
+            file_name
+        )
     ]
 
 
+def context_at(cur_time: int) -> BlockContext:
+    """The vector's `cur_time` as a context, at the height genesis has.
+
+    Every vector of both files is the genesis block or a block of the
+    first hundred thousand, so mainnet's BIP34 activation height leaves
+    bad-cb-height out of the contextual check and the timestamp is what
+    it answers -- which is what these vectors were written for. A height
+    of zero says so rather than claiming a height the files do not carry.
+    """
+    return BlockContext(height=0, now=datetime.fromtimestamp(cur_time, timezone.utc))
+
+
 @pytest.mark.parametrize(
-    ("comment", "check_pow", "serialization"),
+    ("comment", "check_pow", "cur_time", "serialization"),
     params("checkblock_valid.json"),
 )
-def test_checkblock_valid(comment: str, check_pow: bool, serialization: str) -> None:
+def test_checkblock_valid(
+    comment: str, check_pow: bool, cur_time: int, serialization: str
+) -> None:
     """Four real mainnet blocks, genesis among them.
 
     Genesis is the block btclib had no vector for, and it is the shape
     the merkle tree has nowhere else: one leaf, so the root is the txid
     of the coinbase and no hashing happens at all.
+
+    Each is valid at the `cur_time` beside it, the two genesis entries
+    differing in nothing else: the first is one second inside the
+    two-hour window and the second is the instant genesis was mined.
     """
     # every one of the four carries its proof-of-work, so parse() with
     # the default check_validity is the whole assertion
@@ -115,19 +140,30 @@ def test_checkblock_valid(comment: str, check_pow: bool, serialization: str) -> 
     block = Block.parse(serialization)
     assert block.serialize().hex() == serialization
     assert block == Block.parse(block.serialize())
+    block.assert_valid_contextual(context_at(cur_time))
 
 
 @pytest.mark.parametrize(
-    ("comment", "check_pow", "serialization"),
+    ("comment", "check_pow", "cur_time", "serialization"),
     params("checkblock_invalid.json"),
 )
-def test_checkblock_invalid(comment: str, check_pow: bool, serialization: str) -> None:
+def test_checkblock_invalid(
+    comment: str, check_pow: bool, cur_time: int, serialization: str
+) -> None:
     err_msg = _INVALID[comment]
-    if err_msg is None:
-        pytest.xfail("btclib takes no cur_time: no contextual timestamp check")
     # the serialization still has to parse: these are well-formed blocks
     # that consensus refuses, not truncated bytes
     block = Block.parse(serialization, check_validity=False)
+
+    if "time set to two hours" in comment:
+        # the one vector whose block is valid on its own: what it is
+        # refused for is where its timestamp sits relative to a clock, so
+        # assert_valid has to accept it for the vector to mean anything
+        block.assert_valid()
+        with pytest.raises(BTClibValueError, match=err_msg):
+            block.assert_valid_contextual(context_at(cur_time))
+        return
+
     with pytest.raises(BTClibValueError, match=err_msg):
         block.assert_valid()
 
@@ -150,7 +186,7 @@ def test_the_bad_cb_multiple_vector_is_answered_by_the_work() -> None:
     """
     two_coinbases = next(
         serialization
-        for _, comment, _, serialization in check_block_vectors(
+        for _, comment, _, _, serialization in check_block_vectors(
             "checkblock_invalid.json"
         )
         if comment.startswith("More than one coinbase")

--- a/tests/script/sig_ops_test.py
+++ b/tests/script/sig_ops_test.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Tests for the `btclib.script.sig_ops` module.
+
+Bitcoin Core's `CScript::GetSigOpCount(false)`, the count the block rule
+`bad-blk-sigops` bounds. Every case here is a script, because that is what
+the function reads: the two sums over it are asserted where they live,
+`Tx.sig_op_count` in `tests/tx/tx_test.py` and `Block.sig_op_count` in
+`tests/block/block_test.py` and `tests/block/blockfilters_test.py`.
+"""
+
+import pytest
+
+from btclib.script import serialize, sig_op_count
+from btclib.script.limits import MAX_PUBKEYS_PER_MULTISIG
+
+_KEY = bytes.fromhex(
+    "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+)
+
+_MAX = MAX_PUBKEYS_PER_MULTISIG
+
+
+@pytest.mark.parametrize(
+    ("count", "script"),
+    [
+        pytest.param(0, b"", id="an-empty-script-announces-nothing"),
+        pytest.param(1, serialize([_KEY, "OP_CHECKSIG"]), id="p2pk"),
+        pytest.param(1, serialize([_KEY, "OP_CHECKSIGVERIFY"]), id="the-verify-form"),
+        pytest.param(
+            2,
+            serialize([_KEY, "OP_CHECKSIG", _KEY, "OP_CHECKSIG"]),
+            id="one-each",
+        ),
+        pytest.param(
+            _MAX,
+            serialize(["OP_1", _KEY, _KEY, "OP_2", "OP_CHECKMULTISIG"]),
+            id="a-1-of-2-costs-twenty-not-two",
+        ),
+        pytest.param(
+            _MAX,
+            serialize(["OP_1", _KEY, "OP_1", "OP_CHECKMULTISIGVERIFY"]),
+            id="and-so-does-the-verify-form",
+        ),
+        pytest.param(
+            2 * _MAX + 1,
+            serialize(["OP_CHECKMULTISIG", "OP_CHECKMULTISIGVERIFY", "OP_CHECKSIG"]),
+            id="the-op-codes-alone-are-what-is-counted",
+        ),
+        pytest.param(0, bytes.fromhex("01ac"), id="an-op-code-byte-pushed-is-data"),
+        pytest.param(
+            1, bytes.fromhex("01acac"), id="and-the-byte-after-the-push-is-not"
+        ),
+        pytest.param(0, bytes.fromhex("4bac"), id="a-truncated-push-ends-the-walk"),
+        pytest.param(
+            1, bytes.fromhex("ac4bac"), id="what-was-read-before-it-is-counted"
+        ),
+    ],
+)
+def test_sig_op_count(count: int, script: bytes) -> None:
+    """The four op codes that count, and the three things that do not.
+
+    Data is not an op code; a truncated push ends the walk without an
+    exception, Core's loop `break`ing where `GetOp` returns false; and the
+    keys a multisig pushes do not change its cost, `fAccurate` being false
+    here, so every `OP_CHECKMULTISIG` costs `MAX_PUBKEYS_PER_MULTISIG`
+    whatever it would actually check.
+
+    An `OP_CHECKSIG` with nothing to check is still an `OP_CHECKSIG`: the
+    count is what the bytes announce, which is what makes it computable
+    without the outputs being spent.
+    """
+    assert sig_op_count(script) == count
+    # Octets, as the rest of the public surface takes them
+    assert sig_op_count(script.hex()) == count

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -22,7 +22,7 @@ from os import path
 import pytest
 
 from btclib.exceptions import BTClibValueError
-from btclib.script import ScriptPubKey, Witness
+from btclib.script import ScriptPubKey, Witness, sig_op_count
 from btclib.tx import OutPoint, Tx, TxIn, TxOut, join_txs
 from tests.conftest import JsonGolden
 
@@ -258,6 +258,12 @@ def test_coinbase_block_1() -> None:
     assert not any(bool(tx_in.script_witness) for tx_in in tx.vin)
     assert tx.is_coinbase()
 
+    # the p2pk output announces one signature check; the coinbase
+    # script_sig announces none, pushing the extranonce and nothing else
+    assert tx.sig_op_count == 1
+    assert sig_op_count(tx.vin[0].script_sig) == 0
+    assert sig_op_count(tx.vout[0].script_pub_key.script) == 1
+
 
 # https://en.bitcoin.it/wiki/Protocol_documentation#tx
 def test_wiki_transaction() -> None:
@@ -283,6 +289,16 @@ def test_wiki_transaction() -> None:
     assert not any(bool(w) for w in tx.vwitness)
     assert not any(bool(tx_in.script_witness) for tx_in in tx.vin)
     assert not tx.is_coinbase()
+
+    # Core's GetLegacySigOpCount, which is the sum over both lists: the
+    # two p2pkh outputs announce one check each, and the script_sig
+    # answering the p2pkh being spent announces none -- it pushes a
+    # signature and a key, and the OP_CHECKSIG that verifies them is in
+    # the output this transaction spends, i.e. in another block. Which is
+    # what makes the count an underestimate, and what makes it the one a
+    # block can be checked against on its own
+    assert tx.sig_op_count == 2
+    assert sig_op_count(tx.vin[0].script_sig) == 0
 
 
 def test_single_witness() -> None:


### PR DESCRIPTION
Closes #278, whose decision this implements: **C**, the `BlockContext`
dataclass, with the strictest reading of Core wherever the two differ.

Five rules of Core's `CheckBlock` and `ContextualCheckBlock` that a block
carries the bytes for and `Block.assert_valid` did not ask. The fifth,
`bad-blk-weight`, is not on `feature_block.py`'s list — no functional test
there produces it — and is the rule that reads the corrected
`Block.weight`, so it lands with it.

## The size family

`assert_valid_length` is `bad-blk-length`: the transaction count and the
stripped size, each times `WITNESS_SCALE_FACTOR`, against
`MAX_BLOCK_WEIGHT`. The count is compared first and without serializing
anything, which is Core's single condition and what makes that half
testable at all. `assert_valid_weight` is `bad-blk-weight`, and it sits
after `assert_valid_witness_commitment` because that is where Core puts it
and for Core's reason: the coinbase witness is not covered by the block
hash, so a block over the cap only because that witness was stuffed must
not be refused before the commitment to it has been verified. There is a
test for that order.

**`Block.weight` is now Core's `GetBlockWeight`** — a source-breaking
change, in CHANGELOG.md and in HISTORY.md's breaking-changes list. It was
`sum(t.weight for t in transactions)`, which is neither quantity the rules
read: 332 short of the block's weight for a block with hundreds of
transactions, 324 for one holding a single transaction, the 80-byte header
and the transaction-count `var_int` being the difference. `Block.vsize`
moves with it, `Tx.weight` does not, and `Block.stripped_size` is the
third quantity — the serialization a legacy node relays, which is the one
real blocks sit against: 3,954,076 of 4,000,000 for block 481,824.

## The sigop counter

`script/sig_ops.py` holds `sig_op_count(script)`, Core's
`CScript::GetSigOpCount(false)`; `Tx.sig_op_count` is what
`GetLegacySigOpCount` sums over both of a transaction's script lists;
`Block.sig_op_count` sums that over the transactions, and
`assert_valid_sig_op_count` bounds it by `MAX_BLOCK_SIGOPS_COST` — last of
`CheckBlock`'s own questions, where Core asks it. Each level is testable
against a vector of its own.

Legacy only: the P2SH and witness counts need the outputs being spent, so
this one underestimates exactly as Core's comment on it says, and
`fAccurate` is not a parameter for the same reason. The walk stops where
the script stops parsing and raises nothing, as Core's `GetOp` loop
breaks — testnet block 987,876's coinbase output script ends in an
`OP_CHECKSIG` five bytes inside a push that runs past the end of the
script, and neither implementation reaches it.

A module of its own rather than the bottom of `script.py`, which is the
encoding and imports no limit: `MAX_PUBKEYS_PER_MULTISIG` is a rule about
executing a script, and a decoder that need not import the limits is what
`script/limits.py` exists to say.

## The context

`BlockContext(height, now, bip34_height=227_931)` — frozen, and
`Block.assert_valid_contextual(context)` asks the two rules through it.
Each rule is *also* a method taking the datum it reads, which is B's
testability argument kept inside C: `BlockHeader.assert_valid_time(now)`
and `Block.assert_valid_coinbase_height(height)`, so a caller holding half
a context asks the half it can answer and nothing is skipped for want of
the other.

`time-too-new` is on `BlockHeader`, because Core checks it in
`ContextualCheckBlockHeader`: it reads the eighty bytes and nothing else.
`now` is always the caller's — never `datetime.now()` inside the library,
which would have one machine accept what another refuses.

`bad-cb-height` compares bytes, as Core's does: the coinbase `script_sig`
must *start with* `bip34_commitment(height)`, i.e. `CScript() << nHeight`,
so a height pushed non-minimally is refused although `Block.height`
decodes the right number out of it, and for the first seventeen heights
the commitment is a one-byte op code where `script.serialize([height])`
writes a data push — regtest has BIP34 in force from height 1, so those
are where the rule binds first.

BIP34's activation is part of the context because it has to be: block
200,000 commits its height and is 27,931 blocks below the height mainnet
enforces it from, and four of the ten testnet blocks of
`blockfilters.json` commit nothing at all. A rule asked at every height
would refuse five real blocks. The field is here rather than in `Network`
because `Network` holds no consensus parameter at all — the first one to
go in belongs there with the retarget interval and BIP66's and BIP65's
heights, not alone.

## Vectors

- the one `xfail` of `tests/block/checkblock_test.py` is a passing test:
  python-bitcoinlib's genesis block, two hours and one second ahead of the
  `cur_time` beside it. Every `cur_time` in both vendored files is now
  read, the four valid blocks being valid at theirs.
- the ten testnet blocks of `blockfilters.json` carry the BIP34 vector for
  the activation gate: the six at or above 21,111 commit their heights in
  the bytes Core builds, the four below commit nothing, and the same
  `assert_valid_contextual` call is right for both.
- the sigop counts of all fourteen vendored blocks: 1, 3, 822, 3,409 and
  21 across the ten — the largest 17% of the cap, so the blocks that break
  the rules are built for the purpose, as `block_test.py` builds every
  other negative case.

Local gates: `uv run pytest` (16,516 passed, no xfail left in the block
suite), `pytest --cov=btclib --cov=tests` at 100.00%,
`uv run pre-commit run --all-files`, and the sphinx `-W` docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bound block size, weight, sigops, and contextual validity to match Bitcoin Core consensus rules, and updated tests, APIs, and docs accordingly.

Enhancements:
- Redefined Block.weight and related properties to use full block serialization and introduced Block.stripped_size and Block.sig_op_count to align with Core semantics.
- Introduced BlockContext and contextual validation for BIP34 coinbase height commitments and future timestamp limits, separate from non-contextual Block.assert_valid.
- Added consensus limit constants for blocks and timestamps in a dedicated module and exposed new helpers like bip34_commitment and script sigop counting APIs.

Documentation:
- Updated changelog, history, and test-data documentation to describe the new consensus checks, Block.weight semantics, contextual validation, and vector usage.

Tests:
- Expanded block, transaction, script, and blockfilter tests to cover block weight arithmetic, sigop counting, contextual checks, and new consensus limits, achieving full coverage.