### PR TITLE
Cache pedersen.second_generator on (ec, hf)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2615,6 +2615,24 @@ edit.
 
 ### Performance
 
+- **`pedersen.second_generator` is cached on `(ec, hf)`** (issue #287):
+  `second_generator` is 0.02 µs against 74.4 for secp256k1 with sha256,
+  and `commit` -- which calls it, as does every `assert_as_valid` and
+  `verify` -- 13.7 µs against 89.5. The generator is a hash-to-curve of
+  `ec.G` followed by a modular square root for each `x_H` the hash
+  digest and its increments try, and the answer is a constant for a
+  given `(ec, hf)`: recomputing it on every call had been 71% of a
+  commitment's cost, `double_mult` -- the arithmetic a commitment
+  actually is -- the rest. `functools.lru_cache` is the same tool
+  `curve_group.cached_multiples` already puts on a per-curve table, and
+  for the same reason `Curve.__hash__` exists: equal curves share a
+  cache entry. `hf` is compared by identity, the same conservative
+  choice `_libsecp256k1_applicable` makes for sha256. `maxsize` is 128
+  rather than `None`: `ec` is caller-supplied, and an unbounded cache on
+  it would be a memory leak, while 128 clears every curve in the
+  catalogue paired with more than one hash function. The cached value is
+  a `Point`, i.e. a tuple, so handing the same one to every caller is
+  safe -- there is no mutable object to share by accident
 - **verification takes no Python square root any more** (issue #284):
   `dsa.verify_` is 21.7 µs against 244, `ssa.verify_` 21.1 against 243,
   `bms.sign` 24 against the 102 the recovery module had left and

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -29,6 +29,7 @@ It is crucial for H to be Nothing-Up-My-Sleeve (NUMS), i.e.
 the discrete logarithm of H with respect to G must be unknown.
 """
 
+from functools import lru_cache
 from hashlib import sha256
 
 from btclib.alias import HashF, Point
@@ -37,6 +38,16 @@ from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.utils import int_from_bits
 
 
+# (ec, hf) is the cache key: both change the answer, and both are
+# hashable -- Curve.__hash__ exists precisely so that equal curves
+# share cache entries (curve.py's _eq_key), and hf is compared by
+# identity, the same conservative choice _libsecp256k1_applicable
+# makes for sha256. maxsize is a number, not None: ec is
+# caller-supplied, and an unbounded cache on it would be a memory
+# leak. The cached value is a Point, i.e. a tuple, so returning the
+# same one to every caller is safe -- there is no mutable object to
+# share by accident.
+@lru_cache(maxsize=128)
 def second_generator(ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
     """Second (with respect to G) elliptic curve generator.
 
@@ -46,6 +57,9 @@ def second_generator(ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
     The hash of G is coerced it to a point (x_H, y_H).
     If the resulting point is not on the curve, keep on
     incrementing x_H until a valid curve point (x_H, y_H) is obtained.
+
+    The result is cached on (ec, hf): it is a constant for that pair,
+    recomputing it on every call cost 71% of a commitment (issue #287).
 
     idea:
     https://crypto.stackexchange.com/questions/25581/second-generator-for-secp256k1-curve

--- a/tests/ecc/pedersen_test.py
+++ b/tests/ecc/pedersen_test.py
@@ -38,6 +38,26 @@ def test_second_generator() -> None:
     _ = pedersen.second_generator(secp384r1, sha384)
 
 
+def test_second_generator_is_cached() -> None:
+    """Issue #287: (ec, hf) is the cache key, not ec alone.
+
+    A cache hit answers with the very object the first call built --
+    fine here, since a Point is a tuple and so cannot be mutated back
+    into the cache -- and a different hf is a different entry rather
+    than a collision with the one secp256k1/sha256 already filled.
+    """
+    pedersen.second_generator.cache_clear()
+
+    H1 = pedersen.second_generator(secp256k1, sha256)
+    H2 = pedersen.second_generator(secp256k1, sha256)
+    assert H1 is H2
+    assert pedersen.second_generator.cache_info().hits == 1
+
+    H3 = pedersen.second_generator(secp256k1, sha384)
+    assert H3 != H1
+    assert pedersen.second_generator.cache_info().hits == 1
+
+
 def test_commitment() -> None:
     ec = secp256k1
     hf = sha256


### PR DESCRIPTION
## Summary

- `second_generator` hashes `ec.G` and lifts the digest to a curve
  point with a modular square root; the answer is a constant for a
  given `(ec, hf)`, and `commit`, `assert_as_valid` and `verify`
  recomputed it on every call — measured at 71% of a commitment's cost.
- `second_generator` is now `functools.lru_cache`d on `(ec, hf)`,
  `maxsize=128` since `ec` is caller-supplied and an unbounded cache on
  it would be a memory leak. 128 clears every curve in the catalogue
  paired with more than one hash function.
- CHANGELOG.md entry under Performance with before/after timings.

Closes #287.

## Test plan

- [x] `uv run pytest` — 16550 passed
- [x] `uv run pre-commit run --all-files` — all hooks passed
- [x] `sphinx-build -W --keep-going` docs build succeeds
- [x] new `test_second_generator_is_cached` covers the cache-hit
      identity and the `(ec, hf)` key (a different `hf` is a different
      entry, not a collision)

## Summary by Sourcery

Cache the Pedersen second generator per (curve, hash function) pair to reduce commitment and verification cost, and document and test the new caching behavior.

Enhancements:
- Cache `pedersen.second_generator` results using an LRU cache keyed by `(ec, hf)` with a bounded size to avoid recomputation overhead.

Documentation:
- Add a changelog entry describing the performance improvement and caching behavior of `pedersen.second_generator`.

Tests:
- Add a test ensuring `pedersen.second_generator` uses `(ec, hf)` as its cache key and that cache hits return the same point object.