### PR TITLE
Fix flaky Portuguese mnemonic word-count test

### DIFF
--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -413,17 +413,16 @@ def _random_int_entropy(lang: str) -> int:
     """Return the entropy electrum's make_seed draws when given none.
 
     132 bits rounded up to whole words, with anything below one word less
-    drawn again: that is what makes the leading word uniformly
-    distributed and the sentence twelve words long. secrets.randbits(128)
-    instead leaves the word count to follow the bit length, and the word
-    count is the one thing about the answer a caller cannot correct
-    afterwards.
+    drawn again: that is electrum's guard against a short sentence.
+    secrets.randbits(128) instead leaves the word count to follow the bit
+    length, and the word count is the one thing about the answer a caller
+    cannot correct afterwards.
 
     Bits per word is a float, as it is in electrum: for a 2048-word list
-    it is 11.0 and the rounding is exact, but Portuguese has 1626 words
-    and 10.667 bits, thirteen of which are 138 bits and not 130. int() on
-    it would round the sentence down to twelve words, i.e. to a mnemonic
-    electrum would never draw.
+    it is 11.0 and the rounding is exact. Portuguese has 1626 words and
+    10.667 bits, so the lower bound is below the first integer that needs
+    thirteen words. A small share of accepted draws therefore has twelve
+    words, exactly as it does in electrum.
     """
     bits_per_word = math.log2(ELECTRUM_WORDLISTS.language_length(lang))
     nbits = int(math.ceil(_RANDOM_ENTROPY_BITS / bits_per_word) * bits_per_word)

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -828,13 +828,15 @@ def test_electrum_wordlists() -> None:
 
 
 def test_portuguese_word_count() -> None:
-    """1626 words is 10.667 bits, so the sentence is thirteen words long.
+    """The first entropy needing thirteen base-1626 digits has thirteen words.
 
-    Rounding that down to ten bits a word would make it twelve, i.e. a
-    sentence electrum would never draw, and rounding the entropy down
-    with it: the sentence carries 138 bits and not 130.
+    Pin the entropy because electrum's random lower bound is slightly
+    below this base-conversion boundary and can also draw twelve words.
     """
-    mnemonic = electrum.mnemonic_from_entropy("standard", None, "pt")
+    first_thirteen_word_entropy = ELECTRUM_WORDLISTS.language_length("pt") ** 12
+    mnemonic = electrum.mnemonic_from_entropy(
+        "standard", first_thirteen_word_entropy, "pt"
+    )
     assert len(mnemonic.split()) == 13
     assert len(electrum.entropy_from_mnemonic(mnemonic, "pt")) == 139
 
@@ -844,6 +846,23 @@ def test_portuguese_word_count() -> None:
     # BIP39's portuguese is another word-list, and cannot read it
     with pytest.raises(BTClibValueError, match="unknown 'pt' word: "):
         bip39.entropy_from_mnemonic(mnemonic, "pt")
+
+
+def test_portuguese_random_word_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Electrum's random lower bound permits a twelve-word Portuguese seed."""
+    base = ELECTRUM_WORDLISTS.language_length("pt")
+    twelve_word_entropy = base**12 - 1000
+
+    def draw_below_thirteen_words(upper_bound: int) -> int:
+        assert upper_bound == (1 << 138) - 1
+        # randbelow returns one less because _random_int_entropy adds one.
+        return twelve_word_entropy - 1
+
+    monkeypatch.setattr(electrum.secrets, "randbelow", draw_below_thirteen_words)
+    mnemonic = electrum.mnemonic_from_entropy("standard", None, "pt")
+
+    assert len(mnemonic.split()) == 12
+    assert len(electrum.entropy_from_mnemonic(mnemonic, "pt")) == 129
 
 
 def test_is_bip39_mnemonic() -> None:


### PR DESCRIPTION
Fixes #293.

## Summary

- pin the thirteen-word Portuguese test at the first base-1626 entropy that requires thirteen words
- add a deterministic random-draw case proving that Electrum-compatible generation can return twelve words
- correct `_random_int_entropy`'s docstring without changing generation behavior

## Validation

- both focused Portuguese word-count tests pass
- `ruff check` passes for the changed files
- `ruff format --check` passes for the changed files
- `git diff --check` passes

The full locked environment could not be built locally on Windows because `btclib_libsecp256k1` invokes the NMake generator with `-A x64`; CI remains the authoritative full-suite check.

## Summary by Sourcery

Stabilize and clarify Electrum Portuguese mnemonic word-count behavior and its tests.

Bug Fixes:
- Make the Portuguese mnemonic word-count test deterministic by pinning it to the first entropy value that requires thirteen words.
- Add a deterministic random-draw test case to confirm that Electrum-compatible random generation can legitimately produce twelve-word Portuguese mnemonics.

Enhancements:
- Clarify the documentation of Electrum's random entropy generation behavior, particularly around Portuguese wordlist bit-length and resulting word counts.

Tests:
- Update the Portuguese word-count test to use a fixed entropy boundary and add a new test covering the twelve-word random generation case.