### PR TITLE
Delegate sign-to-contract's two tweaks to libsecp256k1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2990,6 +2990,29 @@ edit.
   this same function it measures 7.67 µs, 0.8% below the slice, so what
   argues for it upstream is the bindings' API convention that public keys
   come out compressed, and not btclib's speed (issue #127)
+- **sign-to-contract's two tweaks go through libsecp256k1, one of them
+  slower on purpose** (issue #271). `commit_point_`'s public half,
+  `keys.pubkey_tweak_add`, computes the receipt plus the tweak times the
+  generator directly on the serialized point: 5.9 µs against 33.9,
+  serialization included. `commit_nonce_`'s secret half is the opposite
+  trade, the one this issue is for and not for the clock: `(nonce +
+  tweak) % n` on Python integers is 0.02 µs, variable in time with the
+  operands and leaving an unzeroized copy of the sum behind, where
+  `keys.prvkey_tweak_add` is 0.50 µs and constant time, the trade BIP32
+  private derivation already took. Both are gated on the curve alone,
+  as taproot, ECDH and BIP32 are, `_tweak`'s own loop keeping every
+  tweak in range before either call is reached; the one sum
+  `prvkey_tweak_add` refuses past that loop is the zero
+  `commit_nonce_` has always refused, and the mapping to
+  `BTClibRuntimeError("failed to sign: zero tweaked nonce")` is
+  unchanged. `pubkey_tweak_add` refuses a result at infinity, where
+  `ec.add` returns it — the one behaviour difference between the two
+  bindings — so that refusal, and `bytes_from_point`'s own refusal of
+  an infinite receipt, both fall through to the Python addition rather
+  than propagating: the one-in-n edge answers what it always answered.
+  Every Python path stays reached, on the low-cardinality curves the
+  tests already used and, new here, with the dispatch patched off on
+  secp256k1 itself, over both parities
 
 ### Tests
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -71,10 +71,11 @@ used to teach and to prototype as much as to build:
     scalar for the one and no public key for the other; `dsa.sign` for
     secp256k1 with sha256, the lower-s form, no caller-imposed nonce and
     no commitment; `ssa.sign` for secp256k1 with sha256, a 32-byte
-    message and no commitment; `taproot.output_prvkey` and
-    `dh.diffie_hellman` for secp256k1, the tweaking of a key and the
-    shared point of a key agreement being the two other places a secret
-    meets the curve.
+    message and no commitment; `taproot.output_prvkey`,
+    `dh.diffie_hellman` and `commit_nonce.commit_nonce_` for secp256k1,
+    the tweaking of a key, the shared point of a key agreement and the
+    tweaking of a sign-to-contract nonce being three other places a
+    secret meets the curve.
     A signature the bindings decline is not all Python for that:
     `dsa.gen_keys` and the nonce point of `dsa._sign_` go through `mult`,
     and the verification equation of both `dsa` and `ssa` through

--- a/btclib/ecc/commit_nonce.py
+++ b/btclib/ecc/commit_nonce.py
@@ -67,8 +67,11 @@ from __future__ import annotations
 
 from hashlib import sha256
 
+from btclib_libsecp256k1 import keys as libsecp256k1_keys
+
 from btclib.alias import HashF, Octets, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
+from btclib.curves.curve import _libsecp256k1_applicable
 from btclib.exceptions import BTClibRuntimeError
 from btclib.hashes import tagged_hash
 from btclib.to_prv_key import PrvKey, int_from_prv_key
@@ -128,7 +131,25 @@ def commit_nonce_(
     """
     nonce = int_from_prv_key(nonce, ec)
     receipt = mult(nonce, ec.G, ec)
-    tweaked_nonce = (nonce + _tweak(commit_hash, receipt, tag, ec, hf)) % ec.n
+    tweak = _tweak(commit_hash, receipt, tag, ec, hf)
+
+    # secp256k1_ec_seckey_tweak_add computes the sum in constant time,
+    # where Python's own `(a + b) % n` is variable in time with the
+    # operands and leaves an unzeroized copy of each intermediate behind
+    # -- this is the one place a secret nonce is tweaked in Python that
+    # the delegation removes. Gated on the curve alone, as BIP32
+    # derivation gates the same call: hf enters only the tagged hash
+    # above, computed in Python either way
+    if _libsecp256k1_applicable(ec):
+        try:
+            tweaked = libsecp256k1_keys.prvkey_tweak_add(nonce, tweak)
+        except ValueError as e:
+            # tweak is in range past _tweak's own loop, so the one sum
+            # the binding refuses is the zero btclib refuses too
+            raise BTClibRuntimeError("failed to sign: zero tweaked nonce") from e
+        return int.from_bytes(tweaked, byteorder="big", signed=False), receipt
+
+    tweaked_nonce = (nonce + tweak) % ec.n
     # the tweak is uniform in 1..n-1, so a zero sum is a one-in-n event
     # and not a rejection to loop over: a second candidate would be a
     # second tweak, and the tweak is what the verifier recomputes.
@@ -153,4 +174,26 @@ def commit_point_(
     element -- so the comparison against r belongs to each scheme and not
     here.
     """
-    return ec.add(receipt, mult(_tweak(commit_hash, receipt, tag, ec, hf), ec.G, ec))
+    tweak = _tweak(commit_hash, receipt, tag, ec, hf)
+
+    # secp256k1_ec_pubkey_tweak_add computes R + tweak*G directly on the
+    # serialized point, with no point built on the Python side. Unlike
+    # the secret half above, refusing a result at infinity is the
+    # binding's own choice and not ec.add's, which returns it: a refusal
+    # here falls through to the Python addition instead of propagating,
+    # so the one-in-n point at infinity is still answered rather than
+    # raised. bytes_from_point's own refusal of an infinite receipt is a
+    # BTClibValueError, a ValueError too, and falls through the same way
+    # for the same reason
+    if _libsecp256k1_applicable(ec):
+        try:
+            sec = bytes_from_point(receipt, ec, compressed=False)
+            tweaked = libsecp256k1_keys.pubkey_tweak_add(sec, tweak, compressed=False)
+        except ValueError:
+            pass
+        else:
+            x = int.from_bytes(tweaked[1:33], byteorder="big", signed=False)
+            y = int.from_bytes(tweaked[33:], byteorder="big", signed=False)
+            return x, y
+
+    return ec.add(receipt, mult(tweak, ec.G, ec))

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -26,9 +26,10 @@ from hashlib import sha1, sha256
 
 import pytest
 
+from btclib.alias import INF
 from btclib.curves import bytes_from_point, mult, secp256k1
 from btclib.curves.curve import CURVES
-from btclib.ecc import dsa, ssa
+from btclib.ecc import commit_nonce, dsa, ssa
 from btclib.ecc.bip340_nonce import bip340_nonce_
 from btclib.ecc.commit_nonce import (
     _tweak,
@@ -360,3 +361,71 @@ def test_zero_tweaked_nonce() -> None:
     )
     with pytest.raises(BTClibRuntimeError, match="zero tweaked nonce"):
         commit_nonce_(commit_hash, nonce, _S2C_POINT_TAG, ec, hf)
+
+
+def test_zero_tweaked_nonce_through_the_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The binding's own refusal of a zero sum maps to the same error.
+
+    On secp256k1 the loop above is not the one to force here --
+    `secp256k1_ec_seckey_tweak_add` refuses a zero result exactly where
+    the Python `% ec.n` in the fallback answers zero, and both have to
+    raise the one error `commit_nonce_` has always raised for it.
+    """
+    ec = secp256k1
+    nonce = 1 + random.randrange(ec.n - 1)
+    monkeypatch.setattr(commit_nonce, "_tweak", lambda *_: ec.n - nonce)
+    with pytest.raises(BTClibRuntimeError, match="zero tweaked nonce"):
+        commit_nonce_(b"", nonce, _S2C_POINT_TAG, ec, sha256)
+
+
+def test_commit_point_falls_back_at_infinity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The tweaked point at infinity is answered as ec.add answers it.
+
+    `secp256k1_ec_pubkey_tweak_add` refuses a result at infinity, where
+    `ec.add` returns it -- the one behaviour difference between the two
+    halves issue #271 calls out, so the fallback has to be exercised
+    rather than trusted: a tweak forced to n - k lands exactly there.
+    """
+    ec = secp256k1
+    k = 1 + random.randrange(ec.n - 1)
+    receipt = mult(k, ec.G, ec)
+    monkeypatch.setattr(commit_nonce, "_tweak", lambda *_: ec.n - k)
+    assert commit_point_(b"", receipt, _S2C_POINT_TAG, ec, sha256) == INF
+
+
+def test_the_python_tweaks_are_the_bindings_tweaks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both halves, computed twice, are the same answer with the dispatch off.
+
+    The bindings are the authority on the sum `commit_nonce_` computes
+    and the point `commit_point_` computes, and the Python arithmetic is
+    the reference implementation of both -- so what has to hold is that
+    the two agree, over both parities of the resulting point, the shape
+    `30e2ec19` used for BIP32 and taproot.
+    """
+    ec, hf = secp256k1, sha256
+    parities = set()
+    for i in range(16):
+        commit_hash = i.to_bytes(4, "big")
+        nonce = 1 + random.randrange(ec.n - 1)
+        delegated_nonce, receipt = commit_nonce_(
+            commit_hash, nonce, _S2C_POINT_TAG, ec, hf
+        )
+        delegated_point = commit_point_(commit_hash, receipt, _S2C_POINT_TAG, ec, hf)
+        parities.add(delegated_point[1] % 2)
+        with monkeypatch.context() as no_bindings:
+            no_bindings.setattr(
+                commit_nonce, "_libsecp256k1_applicable", lambda *_: False
+            )
+            assert commit_nonce_(commit_hash, nonce, _S2C_POINT_TAG, ec, hf) == (
+                delegated_nonce,
+                receipt,
+            )
+            assert (
+                commit_point_(commit_hash, receipt, _S2C_POINT_TAG, ec, hf)
+                == delegated_point
+            )
+    assert parities == {0, 1}


### PR DESCRIPTION
## Summary

- `commit_point_`'s public half now calls `keys.pubkey_tweak_add` instead of `ec.add(receipt, mult(tweak, ec.G, ec))`: 5.9 µs against 33.9, serialization included.
- `commit_nonce_`'s secret half now calls `keys.prvkey_tweak_add` instead of `(nonce + tweak) % ec.n`: slower on purpose (0.50 µs against 0.02), but constant time and with no unzeroized Python intermediate — the one place a secret nonce was still tweaked in Python, the same trade BIP32 private derivation already took.
- Both are gated on the curve alone (`_libsecp256k1_applicable(ec)`), as taproot, ECDH and BIP32 already are; `_tweak`'s own loop keeps every tweak in range before either call is reached.
- Every existing error mapping and edge case is preserved by falling back to the Python path instead of propagating a different exception: the zero tweaked nonce still raises `BTClibRuntimeError("failed to sign: zero tweaked nonce")`, and a tweaked point at infinity — which `pubkey_tweak_add` refuses and `ec.add` does not — still falls through to the answer `ec.add` gives.
- CHANGELOG.md and SECURITY.md updated to match.

Closes #271.

## Test plan

- [x] `uv run pytest tests/ecc/commit_nonce_test.py -q` — new tests cover: the dispatch agreeing with the Python path on secp256k1 itself (dispatch patched off, both parities), the zero-tweaked-nonce mapping through the binding, and the infinity fallback of `commit_point_`.
- [x] `uv run pytest -q` — full suite, 100% coverage maintained.
- [x] `uv run pre-commit run --all-files` — all hooks green.
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html` — docs build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Delegate sign-to-contract nonce and commitment point tweaking to libsecp256k1 on applicable curves while preserving existing behavior and errors, and document the security and behavioral implications.

Bug Fixes:
- Preserve the existing zero-tweaked-nonce error and infinity handling behavior when using libsecp256k1 bindings by falling back to the Python implementation when needed.

Enhancements:
- Use libsecp256k1 key tweak operations for sign-to-contract nonce and point tweaking on secp256k1 to improve performance for public tweaks and constant-time safety for secret tweaks while keeping Python fallbacks.
- Extend the libsecp256k1 applicability gating used for taproot, ECDH, and BIP32 to sign-to-contract tweaks.

Documentation:
- Update CHANGELOG to describe the new libsecp256k1-backed sign-to-contract behavior and its performance and edge-case handling.
- Update SECURITY documentation to include commit_nonce_ as a binding-backed primitive where secrets meet the curve.

Tests:
- Add tests asserting that libsecp256k1-backed tweaks preserve zero-tweaked-nonce error mapping and infinity fallback behavior, and that the Python and binding-based tweak paths agree over both point parities.