### PR TITLE
Run a MuSig2 session over a psbt: BIP373's three roles, and taproot finalization (#266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1538,6 +1538,50 @@ edit.
 
 ### Transactions, blocks and PSBT
 
+- **a MuSig2 session is carried out over a psbt** (issue #266, the second
+  half): `btclib.psbt.musig2` is BIP373's three roles over
+  `btclib.ecc.musig2` — `add_participant_pub_keys` for an Updater,
+  `nonce_gen` and `partial_sign` for the two rounds a Signer runs,
+  `partial_sig_verify` for what BIP327 asks every signer to check, and
+  `partial_sigs_agg` for a Finalizer, which writes the aggregate BIP340
+  signature into `PSBT_IN_TAP_KEY_SIG` or `PSBT_IN_TAP_SCRIPT_SIG` and
+  drops the session. **The secret nonce is returned to the caller and
+  never held** — the `bytearray` `ecc.musig2.sign` consumes and zeroes —
+  because a psbt is a file that gets copied and a secnonce that signs
+  twice hands out the private key; the same answer serves the
+  libsecp256k1 musig module and the threshold signing of issue #257.
+  What the psbt says is how the aggregate key reaches the output, and all
+  four of BIP373's ways are read off it: the aggregate key as the output
+  key, as the internal key with the BIP341 tweak, as a key in a leaf
+  script, and as the parent of an internal key derived per BIP328 — one
+  plain tweak per step of `PSBT_IN_TAP_BIP32_DERIVATION`. The session is
+  keyed as Bitcoin Core keys it, by the aggregate key *as tweaked*, which
+  is what the four vectors show and is not the key the participants are
+  filed under. Every partial signature BIP373 publishes verifies in the
+  session btclib derives, aggregates, finalizes, and the extracted
+  transaction passes btclib's own script engine.
+- **`finalize_psbt` finalizes a taproot input**, which it never could:
+  the witness of a key path spend is the signature, of a script path
+  spend the signature, the leaf script and its control block, and each is
+  verified against the hash it says it committed to before the witness is
+  built. What it used to do with a p2tr input was build a legacy
+  script_sig out of `PSBT_IN_PARTIAL_SIG`, which BIP341 gives no meaning
+  to; such an input is now refused as "missing taproot signature". Two
+  script path signatures are refused as well, the psbt not saying which
+  leaf to spend, and so is a leaf script that is not a single key and
+  OP_CHECKSIG — what else its witness would carry is not something a psbt
+  records.
+- `psbt.prevouts`, `psbt.taproot_sig_hash` and `psbt.leaf_script` are the
+  three questions that took: the output every input spends, the BIP341 or
+  BIP342 hash of an input, and the leaf script a tapleaf hash names. A
+  missing utxo raises rather than answering None, which is the honest
+  answer for taproot: the hash commits to the amount and script of every
+  input, so one missing utxo leaves none of them signable.
+- `bip32.pub_key_derivation_tweaks` returns the scalar each step of an
+  unhardened public derivation adds. A public child is the parent plus
+  `IL*G`, so a path is a list of tweaks — which is what a key with no
+  private key needs: BIP328 derives from a MuSig2 aggregate key, and the
+  signers apply the derivation as tweaks of the group key.
 - **the four MuSig2 psbt fields of BIP373 are fields, in both psbt
   versions** (issue #266): `PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS`,
   `PSBT_IN_MUSIG2_PUB_NONCE` and `PSBT_IN_MUSIG2_PARTIAL_SIG` on

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -42,6 +42,14 @@ against the `v2023.7.12` tag.
   `0x06`, input `0x0e` to `0x12`, output `0x03` and `0x04` — as a spare
   slot for data of your own: pick a byte no BIP has taken, or `0xfc`,
   which is reserved for exactly that.
+- **`finalize_psbt` refuses a taproot input that carries no taproot
+  signature**, where it used to build a script_sig out of the input's
+  `PSBT_IN_PARTIAL_SIG` entries — a spend BIP341 gives no meaning to and
+  btclib's own script engine rejects. A p2tr input is now finalized from
+  `PSBT_IN_TAP_KEY_SIG` or `PSBT_IN_TAP_SCRIPT_SIG`, which is what
+  `btclib.psbt.musig2` writes for a MuSig2 session and what any taproot
+  signer writes; an input carrying neither answers "missing taproot
+  signature".
 - **a psbt whose MuSig2 fields are malformed is refused**, where all four
   type bytes BIP373 defines were filed under `unknown` and round-tripped:
   input `0x1a`, `0x1b` and `0x1c`, output `0x08`. They are fields now, so

--- a/btclib/bip32/__init__.py
+++ b/btclib/bip32/__init__.py
@@ -15,6 +15,7 @@ from btclib.bip32.bip32 import (
     crack_prv_key,
     derive,
     derive_from_account,
+    pub_key_derivation_tweaks,
     rootxprv_from_seed,
     xpub_from_xprv,
 )
@@ -49,6 +50,7 @@ __all__ = [
     "encode_to_bip32_derivs",
     "indexes_from_der_path",
     "int_from_index_str",
+    "pub_key_derivation_tweaks",
     "rootxprv_from_seed",
     "str_from_der_path",
     "str_from_index_int",

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -444,12 +444,58 @@ def __prv_key_derivation(xkey: _BIP32KeyData, index: int, pub_key: bytes) -> Non
     xkey.key = b"\x00" + key
 
 
-def __pub_key_derivation(xkey: _BIP32KeyData, index: int) -> None:
-    xb = xkey.key + index.to_bytes(4, byteorder="big", signed=False)
-    hmac_ = hmac.new(xkey.chain_code, xb, "sha512").digest()
+def _pub_key_offset(chain_code: bytes, key: bytes, index: int) -> tuple[int, bytes]:
+    """Return what an unhardened index adds, and the child chain code.
+
+    The scalar alone, without the point it is added to: BIP32 derives a
+    public child as P + IL*G, so this is the whole of the arithmetic that
+    a caller which is not deriving a key of its own needs --
+    `pub_key_derivation_tweaks` below, and through it the MuSig2
+    aggregate keys of BIP328, which have no private key to derive with.
+    """
+    xb = key + index.to_bytes(4, byteorder="big", signed=False)
+    hmac_ = hmac.new(chain_code, xb, "sha512").digest()
     offset = int.from_bytes(hmac_[:32], byteorder="big", signed=False)
     if offset >= secp256k1.n:
         raise _invalid_child(index, "the hmac left half is not a valid scalar")
+    return offset, hmac_[32:]
+
+
+def pub_key_derivation_tweaks(
+    pub_key: Octets, chain_code: Octets, der_path: DerPath
+) -> list[bytes]:
+    """Return the 32-byte tweak each step of a public derivation adds.
+
+    A public child is the parent point plus IL*G, so a whole path is a
+    list of scalars that can be applied wherever the point itself is not
+    available to derive from. That is what a BIP327 MuSig2 aggregate key
+    needs: the group has no private key, so BIP328 derivation reaches the
+    signers as plain tweaks of the aggregate key, and BIP373 carries a
+    psbt signed under a key derived that way.
+
+    Hardened indexes are refused before any step is walked, as
+    __pub_key_path_derivation refuses them: they need a private key that
+    by construction does not exist.
+    """
+    key = bytes_from_octets(pub_key, secp256k1.p_size + 1)
+    code = bytes_from_octets(chain_code, 32)
+    indexes = indexes_from_der_path(der_path)
+    if any(index >= _HARDENED_OFFSET for index in indexes):
+        raise BTClibValueError("invalid hardened derivation from public key")
+
+    tweaks: list[bytes] = []
+    for index in indexes:
+        offset, code = _pub_key_offset(code, key, index)
+        tweaks.append(offset.to_bytes(32, byteorder="big"))
+        # the child key, which the next index hashes: the point is not
+        # needed here and libsecp256k1 adds the tweak to the serialized
+        # key, as __pub_key_derivation does one function below
+        key = libsecp256k1_keys.pubkey_tweak_add(key, offset, compressed=True)
+    return tweaks
+
+
+def __pub_key_derivation(xkey: _BIP32KeyData, index: int) -> None:
+    offset, chain_code = _pub_key_offset(xkey.chain_code, xkey.key, index)
 
     # the parent point plus the generator times the offset, which is
     # what secp256k1_ec_pubkey_tweak_add computes: 12.4 us against the
@@ -473,7 +519,7 @@ def __pub_key_derivation(xkey: _BIP32KeyData, index: int) -> None:
             index, "the child public key is the point at infinity"
         ) from e
 
-    xkey.chain_code = hmac_[32:]
+    xkey.chain_code = chain_code
     y = int.from_bytes(sec[33:], byteorder="big", signed=False)
     xkey.pub_key_point = (int.from_bytes(sec[1:33], byteorder="big", signed=False), y)
     # the compressed spelling of what came back, as bytes_from_point

--- a/btclib/psbt/musig2.py
+++ b/btclib/psbt/musig2.py
@@ -198,7 +198,7 @@ def _tweaks(
 class _SessionParts(NamedTuple):
     """What a session is, before the nonces of round 1 exist.
 
-    `session_key` is the aggregate key **as tweaked for this session**,
+    `tweaked_pub_key` is the aggregate key **as tweaked for this session**,
     compressed, and it is what the nonces and the partial signatures of
     the input are keyed by -- not the aggregate key the participants are
     filed under, which is the untweaked one. The two differ in exactly
@@ -213,7 +213,7 @@ class _SessionParts(NamedTuple):
     tweaks: list[bytes]
     is_xonly: list[bool]
     msg: bytes
-    session_key: bytes
+    tweaked_pub_key: bytes
 
 
 def _session_parts(
@@ -240,7 +240,7 @@ def _session_parts(
     key_agg_ctx = musig2.key_agg_and_tweak(participants, tweaks, is_xonly)
     expected = _script_key(psbt_in, leaf_hash) if leaf_hash else output_key
     if key_agg_ctx.x_only_pub_key != expected:
-        err_msg = f"musig2 session key {key_agg_ctx.x_only_pub_key.hex()} is not "
+        err_msg = f"the tweaked musig2 key {key_agg_ctx.x_only_pub_key.hex()} is not "
         err_msg += f"the key being spent, {expected.hex()}"
         raise BTClibValueError(err_msg)
 
@@ -257,7 +257,7 @@ def _script_key(psbt_in: PsbtIn, leaf_hash: bytes) -> bytes:
     """Return the X-only key the leaf script of a script path spend signs with.
 
     BIP342 spends a leaf with what its own script asks for, so what the
-    session key is checked against is a key in that script -- the one and
+    tweaked key is checked against is a key in that script -- the one and
     only one of a `<key> OP_CHECKSIG` leaf, which is the shape a MuSig2
     aggregate key in a script takes and the shape BIP373's own vector
     uses. `single_leaf_key` is the same question the Finalizer asks of
@@ -282,7 +282,9 @@ def session_context(
     aggregate_pub_key = bytes_from_octets(aggregate_pub_key, MUSIG2_PUB_KEY_SIZE)
     leaf_hash = bytes_from_octets(leaf_hash)
     parts = _session_parts(psbt, vin_i, aggregate_pub_key, leaf_hash)
-    pub_nonces = _session_pub_nonces(psbt.inputs[vin_i], parts.session_key, leaf_hash)
+    pub_nonces = _session_pub_nonces(
+        psbt.inputs[vin_i], parts.tweaked_pub_key, leaf_hash
+    )
     if not pub_nonces:
         err_msg = "no musig2 public nonce for aggregate key "
         err_msg += aggregate_pub_key.hex()
@@ -300,36 +302,36 @@ def session_context(
 
 
 def _key_data(
-    participant_pub_key: bytes, session_key: bytes, leaf_hash: bytes
+    participant_pub_key: bytes, tweaked_pub_key: bytes, leaf_hash: bytes
 ) -> bytes:
     """Return the key data BIP373 files a nonce and a partial signature under.
 
-    The session key, not the aggregate key of the participants field:
+    The tweaked key, not the aggregate key of the participants field:
     `_SessionParts` says why, and it is the one place the difference
     between the two has to be got right.
     """
-    return participant_pub_key + session_key + leaf_hash
+    return participant_pub_key + tweaked_pub_key + leaf_hash
 
 
 def _session_pub_nonces(
-    psbt_in: PsbtIn, session_key: bytes, leaf_hash: bytes
+    psbt_in: PsbtIn, tweaked_pub_key: bytes, leaf_hash: bytes
 ) -> dict[bytes, bytes]:
     """Return the public nonces of one session, by participant key."""
     return {
         key_data[:MUSIG2_PUB_KEY_SIZE]: pub_nonce
         for key_data, pub_nonce in psbt_in.musig2_pub_nonces.items()
-        if key_data[MUSIG2_PUB_KEY_SIZE:] == session_key + leaf_hash
+        if key_data[MUSIG2_PUB_KEY_SIZE:] == tweaked_pub_key + leaf_hash
     }
 
 
 def _session_partial_sigs(
-    psbt_in: PsbtIn, session_key: bytes, leaf_hash: bytes
+    psbt_in: PsbtIn, tweaked_pub_key: bytes, leaf_hash: bytes
 ) -> dict[bytes, bytes]:
     """Return the partial signatures of one session, by participant key."""
     return {
         key_data[:MUSIG2_PUB_KEY_SIZE]: psig
         for key_data, psig in psbt_in.musig2_partial_sigs.items()
-        if key_data[MUSIG2_PUB_KEY_SIZE:] == session_key + leaf_hash
+        if key_data[MUSIG2_PUB_KEY_SIZE:] == tweaked_pub_key + leaf_hash
     }
 
 
@@ -364,9 +366,9 @@ def nonce_gen(
         raise BTClibValueError(err_msg)
 
     sec_nonce, pub_nonce = musig2.nonce_gen(
-        prv_key, pub_key, parts.session_key[1:], parts.msg, extra_in
+        prv_key, pub_key, parts.tweaked_pub_key[1:], parts.msg, extra_in
     )
-    key_data = _key_data(pub_key, parts.session_key, leaf_hash)
+    key_data = _key_data(pub_key, parts.tweaked_pub_key, leaf_hash)
     psbt.inputs[vin_i].musig2_pub_nonces[key_data] = pub_nonce
     return sec_nonce
 
@@ -395,8 +397,10 @@ def partial_sign(
     leaf_hash = bytes_from_octets(leaf_hash)
     psbt_in = psbt.inputs[vin_i]
     pub_key = musig2.individual_pub_key(prv_key)
-    session_key = _session_parts(psbt, vin_i, aggregate_pub_key, leaf_hash).session_key
-    key_data = _key_data(pub_key, session_key, leaf_hash)
+    tweaked_pub_key = _session_parts(
+        psbt, vin_i, aggregate_pub_key, leaf_hash
+    ).tweaked_pub_key
+    key_data = _key_data(pub_key, tweaked_pub_key, leaf_hash)
     pub_nonce = psbt_in.musig2_pub_nonces.get(key_data)
     if pub_nonce is None:
         err_msg = f"no musig2 public nonce of {pub_key.hex()} for aggregate key "
@@ -436,8 +440,10 @@ def partial_sig_verify(
     leaf_hash = bytes_from_octets(leaf_hash)
     participant_pub_key = bytes_from_octets(participant_pub_key, MUSIG2_PUB_KEY_SIZE)
     psbt_in = psbt.inputs[vin_i]
-    session_key = _session_parts(psbt, vin_i, aggregate_pub_key, leaf_hash).session_key
-    key_data = _key_data(participant_pub_key, session_key, leaf_hash)
+    tweaked_pub_key = _session_parts(
+        psbt, vin_i, aggregate_pub_key, leaf_hash
+    ).tweaked_pub_key
+    key_data = _key_data(participant_pub_key, tweaked_pub_key, leaf_hash)
     psig = psbt_in.musig2_partial_sigs.get(key_data)
     pub_nonce = psbt_in.musig2_pub_nonces.get(key_data)
     if psig is None or pub_nonce is None:
@@ -471,9 +477,11 @@ def partial_sigs_agg(
     aggregate_pub_key = bytes_from_octets(aggregate_pub_key, MUSIG2_PUB_KEY_SIZE)
     leaf_hash = bytes_from_octets(leaf_hash)
     psbt_in = psbt.inputs[vin_i]
-    session_key = _session_parts(psbt, vin_i, aggregate_pub_key, leaf_hash).session_key
+    tweaked_pub_key = _session_parts(
+        psbt, vin_i, aggregate_pub_key, leaf_hash
+    ).tweaked_pub_key
     session_ctx = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
-    partial_sigs = _session_partial_sigs(psbt_in, session_key, leaf_hash)
+    partial_sigs = _session_partial_sigs(psbt_in, tweaked_pub_key, leaf_hash)
     missing = [key for key in session_ctx.pub_keys if key not in partial_sigs]
     if missing:
         err_msg = "missing musig2 partial signature of "
@@ -505,23 +513,23 @@ def partial_sigs_agg(
     else:
         psbt_in.taproot_key_spend_signature = signature
 
-    _drop_session(psbt_in, aggregate_pub_key, session_key, leaf_hash)
+    _drop_session(psbt_in, aggregate_pub_key, tweaked_pub_key, leaf_hash)
     return sig
 
 
 def _drop_session(
     psbt_in: PsbtIn,
     aggregate_pub_key: bytes,
-    session_key: bytes,
+    tweaked_pub_key: bytes,
     leaf_hash: bytes,
 ) -> None:
     """Remove the nonces, the partial signatures and the participants.
 
     Two keys, because the fields are keyed by two: the nonces and the
-    partial signatures by the session key, the participants by the
+    partial signatures by the tweaked key, the participants by the
     aggregate key they aggregate to.
     """
-    tail = session_key + leaf_hash
+    tail = tweaked_pub_key + leaf_hash
     for field in (psbt_in.musig2_pub_nonces, psbt_in.musig2_partial_sigs):
         for key_data in [k for k in field if k[MUSIG2_PUB_KEY_SIZE:] == tail]:
             del field[key_data]

--- a/btclib/psbt/musig2.py
+++ b/btclib/psbt/musig2.py
@@ -1,0 +1,547 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""The three roles BIP373 defines, over `btclib.ecc.musig2`.
+
+https://github.com/bitcoin/bips/blob/master/bip-0373.mediawiki
+
+`btclib.psbt.psbt_in` and `psbt_out` carry the four MuSig2 fields; what
+is here is what they mean. One function per role, and the roles are
+BIP373's own:
+
+- **Updater**: `add_participant_pub_keys` aggregates a list of keys and
+  files it under the aggregate key it makes, on an input or an output;
+- **Signer**: `nonce_gen` writes the public nonce of round 1 and
+  `partial_sign` the partial signature of round 2;
+- **Finalizer**: `partial_sigs_agg` adds the partial signatures up into
+  the BIP340 signature the spend needs, writes it to
+  `PSBT_IN_TAP_KEY_SIG` or `PSBT_IN_TAP_SCRIPT_SIG`, and drops the
+  session.
+
+**Where the secret nonce lives is the caller's business, and this module
+holds nothing.** `nonce_gen` hands back the `bytearray` that
+`btclib.ecc.musig2.sign` consumes, and `partial_sign` takes it back;
+between the two rounds it is in the caller's hands and never in the psbt,
+which travels. That is not squeamishness about serialization: a secnonce
+that signs twice hands out the private key by elementary algebra, and a
+psbt is a file that gets copied, combined and re-read. A session object
+owned by btclib would have to be as careful as the bytearray already is,
+with a lifetime the library cannot see the end of -- so the decision is
+to own no state at all, which is also the answer the libsecp256k1 musig
+module gives (an opaque secnonce its own API invalidates after use) and
+the shape an interactive threshold scheme needs (issue #257).
+
+What a psbt says, and what it therefore need not be told, is how the
+aggregate key reaches the output being spent. Four ways, and BIP373
+publishes a vector for each:
+
+- the aggregate key **is** the taproot output key: nothing to tweak;
+- the aggregate key is the **internal key**: one X-only tweak, the BIP341
+  commitment to the merkle root the input carries;
+- the aggregate key is a **key in a leaf script**: nothing to tweak, and
+  the message is BIP342's rather than BIP341's -- which is why every
+  function here takes the tapleaf hash the key data carries;
+- the internal key is **derived** from the aggregate key: BIP328
+  derivation, i.e. one plain tweak per step of the path in
+  `PSBT_IN_TAP_BIP32_DERIVATION`, then the X-only one.
+
+`session_context` is where those four are read off the psbt, and it is
+public because a signer needs it for what BIP327 asks beyond signing:
+`btclib.ecc.musig2.partial_sig_verify_` against another signer's nonce.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import NamedTuple
+
+from btclib.alias import Octets
+from btclib.bip32 import pub_key_derivation_tweaks
+from btclib.curves import secp256k1
+from btclib.curves.sec_point import bytes_from_point
+from btclib.ecc import musig2, ssa
+from btclib.exceptions import BTClibValueError
+from btclib.hashes import hash160, tagged_hash
+from btclib.psbt.psbt import (
+    Psbt,
+    leaf_script,
+    prevouts,
+    single_leaf_key,
+    taproot_sig_hash,
+)
+from btclib.psbt.psbt_in import PsbtIn
+from btclib.psbt.psbt_out import PsbtOut
+from btclib.psbt.psbt_utils import (
+    MUSIG2_PUB_KEY_SIZE,
+    assert_valid_musig2_pub_key,
+)
+from btclib.script import type_and_payload
+from btclib.to_prv_key import PrvKey
+from btclib.utils import bytes_from_octets
+
+# BIP328's chain code, which is the sha256 of "MuSig2MuSig2MuSig2": an
+# aggregate key has no chain code of its own, so a synthetic xpub is the
+# key plus this constant, and every implementation deriving from an
+# aggregate key has to use the same one or derive other children
+_BIP328_CHAIN_CODE = bytes.fromhex(
+    "868087ca02a6f974c4598924c36b57762d32cb45717167e300622c7167e38965"
+)
+
+
+def add_participant_pub_keys(
+    psbt_map: PsbtIn | PsbtOut,
+    participant_pub_keys: Sequence[Octets],
+    *,
+    sort: bool = False,
+) -> bytes:
+    """Add the participants of one aggregate key, and return that key.
+
+    The Updater role, and the aggregate key is not a parameter because it
+    is not a choice: `KeyAgg` computes it from the list, so a caller
+    handing in both could file a list under a key it does not aggregate
+    to -- which is exactly the field's meaning gone, and no reader could
+    tell.
+
+    sort=True aggregates the sorted list, as BIP327's `KeySort` sorts it
+    and as BIP373 requires whenever sorting was used at all: the order is
+    part of the key, so it is stored in the order it was aggregated in.
+    """
+    keys = musig2.key_sort(participant_pub_keys) if sort else participant_pub_keys
+    aggregate_pub_key = bytes_from_point(musig2.key_agg(keys).Q, secp256k1)
+    psbt_map.musig2_participant_pub_keys[aggregate_pub_key] = [
+        bytes_from_octets(key, MUSIG2_PUB_KEY_SIZE) for key in keys
+    ]
+    return aggregate_pub_key
+
+
+def _participants(psbt_in: PsbtIn, aggregate_pub_key: bytes) -> list[bytes]:
+    """Return the participants of an aggregate key, in aggregation order."""
+    participants = psbt_in.musig2_participant_pub_keys.get(aggregate_pub_key)
+    if not participants:
+        err_msg = "no musig2 participants for aggregate key "
+        err_msg += aggregate_pub_key.hex()
+        raise BTClibValueError(err_msg)
+    return participants
+
+
+def _derivation_tweaks(psbt_in: PsbtIn, aggregate_pub_key: bytes) -> list[bytes]:
+    """Return the BIP328 tweaks from the aggregate key to the internal one.
+
+    The path is the one `PSBT_IN_TAP_BIP32_DERIVATION` files the internal
+    key under, and what says it starts at the aggregate key is the master
+    fingerprint: BIP328's synthetic xpub is the aggregate key with the
+    fixed chain code above, so its fingerprint is hash160 of that key.
+    BIP373 lets that field be assumed to be BIP328 derivation whenever no
+    `PSBT_GLOBAL_XPUB` names a synthetic xpub, which is what makes the
+    fingerprint enough to recognize it.
+    """
+    internal_key = psbt_in.taproot_internal_key
+    fingerprint = hash160(aggregate_pub_key)[:4]
+    derivation = psbt_in.taproot_hd_key_paths.get(internal_key)
+    if derivation is None or derivation[1].master_fingerprint != fingerprint:
+        err_msg = "no BIP328 derivation from musig2 aggregate key "
+        err_msg += f"{aggregate_pub_key.hex()} to taproot internal key "
+        err_msg += internal_key.hex()
+        raise BTClibValueError(err_msg)
+    return pub_key_derivation_tweaks(
+        aggregate_pub_key, _BIP328_CHAIN_CODE, derivation[1].der_path
+    )
+
+
+def _tweaks(
+    psbt_in: PsbtIn, aggregate_pub_key: bytes, leaf_hash: bytes, output_key: bytes
+) -> tuple[list[bytes], list[bool]]:
+    """Return the tweaks between the aggregate key and what is spent.
+
+    Which of BIP373's four ways this psbt is written in is read here, and
+    the module docstring lists them. A psbt saying none of them is
+    refused rather than signed under an untweaked key: the partial
+    signatures would add up to a signature valid under a key the output
+    does not commit to, i.e. to nothing at all, and the psbt is where a
+    signer can still notice.
+    """
+    x_only_aggregate = aggregate_pub_key[1:]
+
+    # a key in a script signs as itself: the taproot tweak belongs to the
+    # output key, which the script path does not sign for
+    if leaf_hash:
+        return [], []
+
+    if psbt_in.taproot_internal_key:
+        tweaks = (
+            []
+            if psbt_in.taproot_internal_key == x_only_aggregate
+            else _derivation_tweaks(psbt_in, aggregate_pub_key)
+        )
+        # BIP341: the output key commits to the internal key and the root
+        # of the script tree, which is empty for an output with no scripts
+        taproot_tweak = tagged_hash(
+            b"TapTweak",
+            psbt_in.taproot_internal_key + psbt_in.taproot_merkle_root,
+        )
+        return [*tweaks, taproot_tweak], [False] * len(tweaks) + [True]
+
+    if output_key == x_only_aggregate:
+        return [], []
+
+    err_msg = f"musig2 aggregate key {aggregate_pub_key.hex()} is neither "
+    err_msg += "the taproot output key nor the internal key of the input"
+    raise BTClibValueError(err_msg)
+
+
+class _SessionParts(NamedTuple):
+    """What a session is, before the nonces of round 1 exist.
+
+    `session_key` is the aggregate key **as tweaked for this session**,
+    compressed, and it is what the nonces and the partial signatures of
+    the input are keyed by -- not the aggregate key the participants are
+    filed under, which is the untweaked one. The two differ in exactly
+    the cases where the aggregate key is not what the spend verifies
+    against: Bitcoin Core keys these fields by its `plain_pub`, which is
+    the aggregate key carried through the derivation and the taproot
+    tweak (`SignMuSig2` in script/sign.cpp), and a psbt keyed either
+    other way is one no other implementation reads.
+    """
+
+    participants: list[bytes]
+    tweaks: list[bytes]
+    is_xonly: list[bool]
+    msg: bytes
+    session_key: bytes
+
+
+def _session_parts(
+    psbt: Psbt, vin_i: int, aggregate_pub_key: bytes, leaf_hash: bytes
+) -> _SessionParts:
+    """Return everything a signer derives from the psbt before round 1.
+
+    Which is why it is not `session_context` itself: round 1 needs the
+    message -- BIP327 binds the nonce to it -- and the aggregate nonce it
+    is about to contribute to is not there yet.
+    """
+    psbt_in = psbt.inputs[vin_i]
+    output_key = type_and_payload(prevouts(psbt)[vin_i].script_pub_key.script)[1]
+    participants = _participants(psbt_in, aggregate_pub_key)
+    tweaks, is_xonly = _tweaks(psbt_in, aggregate_pub_key, leaf_hash, output_key)
+    msg = taproot_sig_hash(psbt, vin_i, leaf_hash=leaf_hash)
+
+    # what the tweaks were read off the psbt for: the key the signatures
+    # will verify under has to be the key the spend needs, which is the
+    # output key of a key path spend and the script's own key otherwise.
+    # A merkle root, a derivation path or a tapleaf hash that does not
+    # belong to this input fails here, before a secret nonce is spent on
+    # a signature nobody can use
+    key_agg_ctx = musig2.key_agg_and_tweak(participants, tweaks, is_xonly)
+    expected = _script_key(psbt_in, leaf_hash) if leaf_hash else output_key
+    if key_agg_ctx.x_only_pub_key != expected:
+        err_msg = f"musig2 session key {key_agg_ctx.x_only_pub_key.hex()} is not "
+        err_msg += f"the key being spent, {expected.hex()}"
+        raise BTClibValueError(err_msg)
+
+    return _SessionParts(
+        participants,
+        tweaks,
+        is_xonly,
+        msg,
+        bytes_from_point(key_agg_ctx.Q, secp256k1),
+    )
+
+
+def _script_key(psbt_in: PsbtIn, leaf_hash: bytes) -> bytes:
+    """Return the X-only key the leaf script of a script path spend signs with.
+
+    BIP342 spends a leaf with what its own script asks for, so what the
+    session key is checked against is a key in that script -- the one and
+    only one of a `<key> OP_CHECKSIG` leaf, which is the shape a MuSig2
+    aggregate key in a script takes and the shape BIP373's own vector
+    uses. `single_leaf_key` is the same question the Finalizer asks of
+    the same field, and it is asked in one place for that reason.
+    """
+    script, _ = leaf_script(psbt_in, leaf_hash)
+    return single_leaf_key(script)
+
+
+def session_context(
+    psbt: Psbt, vin_i: int, aggregate_pub_key: Octets, *, leaf_hash: Octets = b""
+) -> musig2.SessionContext:
+    """Return the BIP327 session the psbt describes for one aggregate key.
+
+    The aggregate nonce is the sum of the public nonces the input carries
+    for this session, so every signer that has published one is in it: a
+    context built before the last nonce arrives is a different context,
+    and the partial signatures made against the two do not add up.
+    `btclib.ecc.musig2.partial_sig_verify_` is what catches that, and
+    this is what it takes.
+    """
+    aggregate_pub_key = bytes_from_octets(aggregate_pub_key, MUSIG2_PUB_KEY_SIZE)
+    leaf_hash = bytes_from_octets(leaf_hash)
+    parts = _session_parts(psbt, vin_i, aggregate_pub_key, leaf_hash)
+    pub_nonces = _session_pub_nonces(psbt.inputs[vin_i], parts.session_key, leaf_hash)
+    if not pub_nonces:
+        err_msg = "no musig2 public nonce for aggregate key "
+        err_msg += aggregate_pub_key.hex()
+        raise BTClibValueError(err_msg)
+    # in aggregation order and not in the order the map holds them: an
+    # aggregate nonce is a sum, so the order is not what it changes --
+    # what it changes is which signer a missing nonce is missing for,
+    # and `partial_sig_verify` reports that as a False of its own
+    agg_nonce = musig2.nonce_agg(
+        [pub_nonces[key] for key in parts.participants if key in pub_nonces]
+    )
+    return musig2.SessionContext(
+        agg_nonce, parts.participants, parts.tweaks, parts.is_xonly, parts.msg
+    )
+
+
+def _key_data(
+    participant_pub_key: bytes, session_key: bytes, leaf_hash: bytes
+) -> bytes:
+    """Return the key data BIP373 files a nonce and a partial signature under.
+
+    The session key, not the aggregate key of the participants field:
+    `_SessionParts` says why, and it is the one place the difference
+    between the two has to be got right.
+    """
+    return participant_pub_key + session_key + leaf_hash
+
+
+def _session_pub_nonces(
+    psbt_in: PsbtIn, session_key: bytes, leaf_hash: bytes
+) -> dict[bytes, bytes]:
+    """Return the public nonces of one session, by participant key."""
+    return {
+        key_data[:MUSIG2_PUB_KEY_SIZE]: pub_nonce
+        for key_data, pub_nonce in psbt_in.musig2_pub_nonces.items()
+        if key_data[MUSIG2_PUB_KEY_SIZE:] == session_key + leaf_hash
+    }
+
+
+def _session_partial_sigs(
+    psbt_in: PsbtIn, session_key: bytes, leaf_hash: bytes
+) -> dict[bytes, bytes]:
+    """Return the partial signatures of one session, by participant key."""
+    return {
+        key_data[:MUSIG2_PUB_KEY_SIZE]: psig
+        for key_data, psig in psbt_in.musig2_partial_sigs.items()
+        if key_data[MUSIG2_PUB_KEY_SIZE:] == session_key + leaf_hash
+    }
+
+
+def nonce_gen(
+    psbt: Psbt,
+    vin_i: int,
+    prv_key: PrvKey,
+    aggregate_pub_key: Octets,
+    *,
+    leaf_hash: Octets = b"",
+    extra_in: Octets | None = None,
+) -> bytearray:
+    """Write the public nonce of round 1, and return the secret one.
+
+    The Signer role, first half. The returned bytearray is what
+    `partial_sign` consumes and what must not be copied, written down or
+    put in the psbt: the module docstring says why the decision is to
+    hand it back rather than keep it.
+
+    The nonce is bound to everything BIP327 lets it be bound to -- the
+    signer's key, the aggregate key of the session and the message --
+    because all three are in the psbt, and a nonce derived from fewer of
+    them is one a faulty random source can repeat across sessions.
+    """
+    aggregate_pub_key = bytes_from_octets(aggregate_pub_key, MUSIG2_PUB_KEY_SIZE)
+    leaf_hash = bytes_from_octets(leaf_hash)
+    parts = _session_parts(psbt, vin_i, aggregate_pub_key, leaf_hash)
+    pub_key = musig2.individual_pub_key(prv_key)
+    if pub_key not in parts.participants:
+        err_msg = f"{pub_key.hex()} is not a participant of aggregate key "
+        err_msg += aggregate_pub_key.hex()
+        raise BTClibValueError(err_msg)
+
+    sec_nonce, pub_nonce = musig2.nonce_gen(
+        prv_key, pub_key, parts.session_key[1:], parts.msg, extra_in
+    )
+    key_data = _key_data(pub_key, parts.session_key, leaf_hash)
+    psbt.inputs[vin_i].musig2_pub_nonces[key_data] = pub_nonce
+    return sec_nonce
+
+
+def partial_sign(
+    psbt: Psbt,
+    vin_i: int,
+    sec_nonce: bytearray,
+    prv_key: PrvKey,
+    aggregate_pub_key: Octets,
+    *,
+    leaf_hash: Octets = b"",
+) -> bytes:
+    """Write the partial signature of round 2, and return it.
+
+    The Signer role, second half. The secnonce is consumed by
+    `btclib.ecc.musig2.sign`, which zeroes it: this function cannot be
+    called twice with one nonce, and that is the point.
+
+    The signature is verified before it is written, against the session
+    the psbt describes: a signer that publishes a partial signature of a
+    session it got wrong has published a number the others cannot use and
+    cannot make it un-published.
+    """
+    aggregate_pub_key = bytes_from_octets(aggregate_pub_key, MUSIG2_PUB_KEY_SIZE)
+    leaf_hash = bytes_from_octets(leaf_hash)
+    psbt_in = psbt.inputs[vin_i]
+    pub_key = musig2.individual_pub_key(prv_key)
+    session_key = _session_parts(psbt, vin_i, aggregate_pub_key, leaf_hash).session_key
+    key_data = _key_data(pub_key, session_key, leaf_hash)
+    pub_nonce = psbt_in.musig2_pub_nonces.get(key_data)
+    if pub_nonce is None:
+        err_msg = f"no musig2 public nonce of {pub_key.hex()} for aggregate key "
+        err_msg += aggregate_pub_key.hex()
+        raise BTClibValueError(err_msg)
+
+    session_ctx = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
+    psig = musig2.sign(sec_nonce, prv_key, session_ctx)
+    if not musig2.partial_sig_verify_(psig, pub_nonce, pub_key, session_ctx):
+        # unreachable short of a defect in either this module or `sign`:
+        # the context is the one the signature was just made against.
+        # It stays because what it costs is one verification against a
+        # partial signature that no other signer can be told to ignore
+        raise BTClibValueError("invalid musig2 partial signature")  # pragma: no cover
+    psbt_in.musig2_partial_sigs[key_data] = psig
+    return psig
+
+
+def partial_sig_verify(
+    psbt: Psbt,
+    vin_i: int,
+    participant_pub_key: Octets,
+    aggregate_pub_key: Octets,
+    *,
+    leaf_hash: Octets = b"",
+) -> bool:
+    """Verify one participant's partial signature, as the psbt holds it.
+
+    What BIP327 asks every signer to do before aggregating, over the psbt
+    the partial signature arrived in: the nonce it is checked against is
+    the one the same input carries for the same participant, so a
+    signature that was made against another session answers False here
+    rather than at aggregation time, where the only news is that the
+    total does not verify.
+    """
+    aggregate_pub_key = bytes_from_octets(aggregate_pub_key, MUSIG2_PUB_KEY_SIZE)
+    leaf_hash = bytes_from_octets(leaf_hash)
+    participant_pub_key = bytes_from_octets(participant_pub_key, MUSIG2_PUB_KEY_SIZE)
+    psbt_in = psbt.inputs[vin_i]
+    session_key = _session_parts(psbt, vin_i, aggregate_pub_key, leaf_hash).session_key
+    key_data = _key_data(participant_pub_key, session_key, leaf_hash)
+    psig = psbt_in.musig2_partial_sigs.get(key_data)
+    pub_nonce = psbt_in.musig2_pub_nonces.get(key_data)
+    if psig is None or pub_nonce is None:
+        err_msg = f"no musig2 partial signature of {participant_pub_key.hex()} "
+        err_msg += f"for aggregate key {aggregate_pub_key.hex()}"
+        raise BTClibValueError(err_msg)
+    session_ctx = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
+    return musig2.partial_sig_verify_(psig, pub_nonce, participant_pub_key, session_ctx)
+
+
+def partial_sigs_agg(
+    psbt: Psbt, vin_i: int, aggregate_pub_key: Octets, *, leaf_hash: Octets = b""
+) -> ssa.Sig:
+    """Aggregate the session's partial signatures, and drop the session.
+
+    The Finalizer role. The BIP340 signature goes where the spend reads
+    it -- `PSBT_IN_TAP_KEY_SIG` for a key path spend, and
+    `PSBT_IN_TAP_SCRIPT_SIG` under the key and tapleaf hash for a script
+    path one -- with the sig_hash type appended when the input asks for
+    one other than the default, as BIP341 appends it.
+
+    Every participant must have signed: MuSig2 is n-of-n, so a missing
+    partial signature is not a smaller quorum but an aggregate signature
+    that verifies under nothing.
+
+    The three MuSig2 fields of that session are then removed. What
+    replaces them is the signature itself, and a nonce that has been used
+    is worse than useless: keeping it invites a second session with the
+    same nonce, which is the one thing that hands out a private key.
+    """
+    aggregate_pub_key = bytes_from_octets(aggregate_pub_key, MUSIG2_PUB_KEY_SIZE)
+    leaf_hash = bytes_from_octets(leaf_hash)
+    psbt_in = psbt.inputs[vin_i]
+    session_key = _session_parts(psbt, vin_i, aggregate_pub_key, leaf_hash).session_key
+    session_ctx = session_context(psbt, vin_i, aggregate_pub_key, leaf_hash=leaf_hash)
+    partial_sigs = _session_partial_sigs(psbt_in, session_key, leaf_hash)
+    missing = [key for key in session_ctx.pub_keys if key not in partial_sigs]
+    if missing:
+        err_msg = "missing musig2 partial signature of "
+        err_msg += ", ".join(key.hex() for key in missing)
+        raise BTClibValueError(err_msg)
+
+    sig = musig2.partial_sig_agg(
+        [partial_sigs[key] for key in session_ctx.pub_keys], session_ctx
+    )
+    key_agg_ctx = musig2.key_agg_and_tweak(
+        session_ctx.pub_keys, session_ctx.tweaks, session_ctx.is_xonly
+    )
+    if not ssa.verify_(session_ctx.msg, key_agg_ctx.x_only_pub_key, sig):
+        # a partial signature that verifies on its own and does not add
+        # up is what a peer sending one of another session produces, so
+        # this is the Finalizer's check and not a belt-and-braces one
+        err_msg = "the musig2 partial signatures do not add up to a signature "
+        err_msg += f"of {key_agg_ctx.x_only_pub_key.hex()}"
+        raise BTClibValueError(err_msg)
+
+    signature = sig.serialize()
+    if psbt_in.sig_hash_type:
+        # BIP341: the type is appended, and its absence is SIGHASH_DEFAULT
+        signature += psbt_in.sig_hash_type.to_bytes(1, "big")
+    if leaf_hash:
+        psbt_in.taproot_script_spend_signatures[
+            key_agg_ctx.x_only_pub_key + leaf_hash
+        ] = signature
+    else:
+        psbt_in.taproot_key_spend_signature = signature
+
+    _drop_session(psbt_in, aggregate_pub_key, session_key, leaf_hash)
+    return sig
+
+
+def _drop_session(
+    psbt_in: PsbtIn,
+    aggregate_pub_key: bytes,
+    session_key: bytes,
+    leaf_hash: bytes,
+) -> None:
+    """Remove the nonces, the partial signatures and the participants.
+
+    Two keys, because the fields are keyed by two: the nonces and the
+    partial signatures by the session key, the participants by the
+    aggregate key they aggregate to.
+    """
+    tail = session_key + leaf_hash
+    for field in (psbt_in.musig2_pub_nonces, psbt_in.musig2_partial_sigs):
+        for key_data in [k for k in field if k[MUSIG2_PUB_KEY_SIZE:] == tail]:
+            del field[key_data]
+    psbt_in.musig2_participant_pub_keys.pop(aggregate_pub_key, None)
+
+
+def assert_valid_participants(psbt_map: PsbtIn | PsbtOut) -> None:
+    """Raise unless every participant list aggregates to the key it is under.
+
+    The check `assert_valid` cannot make: it is `KeyAgg` over the list,
+    which is the aggregation this module exists to do, and a codec that
+    depended on it would depend on a signing scheme. What it catches is
+    the one way the field can be wrong while every length is right --
+    a list that is not the aggregate key's -- which no signer can use and
+    no Updater should have written.
+    """
+    for aggregate_pub_key, participants in psbt_map.musig2_participant_pub_keys.items():
+        assert_valid_musig2_pub_key(aggregate_pub_key, "musig2 aggregate pub key")
+        computed = bytes_from_point(musig2.key_agg(participants).Q, secp256k1)
+        if computed != aggregate_pub_key:
+            err_msg = f"musig2 participants aggregate to {computed.hex()}, "
+            err_msg += f"not to {aggregate_pub_key.hex()}"
+            raise BTClibValueError(err_msg)

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -39,6 +39,7 @@ from io import BytesIO
 from math import ceil
 from typing import Any, TypeVar, cast
 
+from btclib import var_bytes
 from btclib.alias import BinaryData, Octets, ScriptList, String
 from btclib.bip32 import (
     BIP32KeyOrigin,
@@ -48,13 +49,14 @@ from btclib.bip32 import (
     decode_hd_key_paths,
     encode_to_bip32_derivs,
 )
-from btclib.ecc import dsa
+from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
-from btclib.hashes import hash160, sha256
+from btclib.hashes import hash160, sha256, tagged_hash
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
 from btclib.psbt.psbt_size import estimated_input_sizes
 from btclib.psbt.psbt_utils import (
+    LEAF_HASH_SIZE,
     PSBT_SEPARATOR,
     assert_not_a_v2_field,
     assert_valid_unknown,
@@ -82,8 +84,9 @@ from btclib.script import (
     sig_hash,
     type_and_payload,
 )
+from btclib.script.sig_hash import DEFAULT
 from btclib.tx import Tx, TxIn, TxOut
-from btclib.utils import bytesio_from_binarydata
+from btclib.utils import bytes_from_octets, bytesio_from_binarydata
 
 # the whole of BIP174's <magic>, five bytes: the four of "psbt" and the
 # 0xff that makes a psbt fail to deserialize as a transaction. It is one
@@ -1336,6 +1339,183 @@ def _finalized_input(psbt_in: PsbtIn) -> tuple[bytes, Witness]:
     return serialize(cast(ScriptList, [*cmds, *redeem_script])), Witness()
 
 
+# the codesep position BIP341 writes when no OP_CODESEPARATOR was
+# executed, which is every script Core's own signer supports signing:
+# "Only support non-OP_CODESEPARATOR BIP342 signing for now"
+_NO_CODESEP = 0xFFFFFFFF
+
+# a tapscript spending a single key: a 32-byte push of it followed by
+# OP_CHECKSIG, which is the leaf shape whose witness is one signature and
+# therefore the only script path a Finalizer here can build
+_SINGLE_KEY_LEAF_SIZE = 34
+_PUSH_32 = 0x20
+_OP_CHECKSIG = 0xAC
+
+
+def prevouts(psbt: Psbt) -> list[TxOut]:
+    """Return the output each input of the psbt spends.
+
+    A taproot signature commits to the amount and script of *every*
+    input (BIP341's sha_amounts and sha_scriptpubkeys), not only of the
+    one being signed, so a single missing utxo leaves the whole
+    transaction unsignable rather than one input of it -- which is why
+    this raises where `_prev_out` answers None.
+    """
+    outs: list[TxOut] = []
+    for i, psbt_in in enumerate(psbt.inputs):
+        prev_out = _prev_out(psbt_in)
+        if prev_out is None:
+            err_msg = f"no utxo for input {i}: a taproot signature commits "
+            err_msg += "to the amount and script of every input"
+            raise BTClibValueError(err_msg)
+        outs.append(prev_out)
+    return outs
+
+
+def taproot_sig_hash(
+    psbt: Psbt, vin_i: int, *, leaf_hash: Octets = b"", hash_type: int | None = None
+) -> bytes:
+    """Return the hash a taproot spend of one input signs.
+
+    BIP341 for a key path spend, BIP342 for a script path one, and the
+    tapleaf hash is what tells the two apart: given one, the message
+    carries it along with the key version and the codesep position, as
+    the script engine's own OP_CHECKSIG builds them.
+
+    hash_type defaults to the type the input asks for, and to
+    SIGHASH_DEFAULT when it asks for none. Passing it is what a Finalizer
+    does: a taproot signature carries its own type appended, so the hash
+    to check it against is the one *it* committed to.
+
+    The annex is empty: BIP341 leaves it undefined, no psbt field carries
+    one, and a signer cannot invent what the spender will put on the
+    stack.
+    """
+    leaf_hash = bytes_from_octets(leaf_hash)
+    if hash_type is None:
+        hash_type = psbt.inputs[vin_i].sig_hash_type or DEFAULT
+    ext = leaf_hash + b"\x00" + _NO_CODESEP.to_bytes(4, "little") if leaf_hash else b""
+    return sig_hash.taproot(
+        psbt.tx, vin_i, prevouts(psbt), hash_type, int(bool(ext)), b"", ext
+    )
+
+
+def leaf_script(psbt_in: PsbtIn, leaf_hash: Octets) -> tuple[bytes, bytes]:
+    """Return the leaf script of a tapleaf hash, and its control block.
+
+    `PSBT_IN_TAP_LEAF_SCRIPT` is keyed by control block and holds the
+    script and its leaf version, while every other taproot field names a
+    leaf by its BIP341 hash: this is that lookup, and it computes the
+    hashes rather than trusting a second index of them.
+    """
+    leaf_hash = bytes_from_octets(leaf_hash, LEAF_HASH_SIZE)
+    for control_block, (script, leaf_version) in psbt_in.taproot_leaf_scripts.items():
+        preimage = leaf_version.to_bytes(1, "big") + var_bytes.serialize(script)
+        if tagged_hash(b"TapLeaf", preimage) == leaf_hash:
+            return script, control_block
+    raise BTClibValueError(f"no leaf script for tapleaf hash {leaf_hash.hex()}")
+
+
+def single_leaf_key(script: bytes) -> bytes:
+    """Return the key of a `<32-byte key> OP_CHECKSIG` leaf script.
+
+    What a Finalizer has to know to build the witness of a script path
+    spend is what the leaf script pops, and that is a property of the
+    script rather than of the psbt: one signature for this shape, and for
+    a leaf that asks for more -- a threshold of CHECKSIGADD, a hash
+    preimage -- the psbt says nothing about what else goes on the stack.
+    """
+    if (
+        len(script) != _SINGLE_KEY_LEAF_SIZE
+        or script[0] != _PUSH_32
+        or script[-1] != _OP_CHECKSIG
+    ):
+        err_msg = "cannot finalize a taproot script path whose leaf script "
+        err_msg += f"is not a single key and OP_CHECKSIG: {script.hex()}"
+        raise BTClibValueError(err_msg)
+    return script[1:-1]
+
+
+def _assert_taproot_sig_hash_type(signature: bytes, psbt_in: PsbtIn, what: str) -> int:
+    """Return the sig_hash type a taproot signature commits to.
+
+    BIP341 appends the type to the 64 bytes when it is not the default
+    one, so the signature says which hash it signed; what this adds is
+    that it must be the type the *input* asks for, as
+    `_assert_sig_hash_type` asks of a partial signature. A Finalizer that
+    skipped the comparison would happily build a witness whose signature
+    commits to other outputs than the ones the psbt was built for.
+    """
+    hash_type = signature[-1] if len(signature) == 65 else DEFAULT
+    if (psbt_in.sig_hash_type or DEFAULT) != hash_type:
+        err_msg = f"invalid {what} sig_hash type: {hash_type}, "
+        err_msg += f"the input asks for {psbt_in.sig_hash_type}"
+        raise BTClibValueError(err_msg)
+    return hash_type
+
+
+def _finalized_taproot_input(psbt: Psbt, vin_i: int) -> tuple[bytes, Witness]:
+    """Return the script_sig and witness a taproot input is spent with.
+
+    An empty script_sig, always: BIP341 spends a witness v1 program with
+    the witness alone, and a p2sh-wrapped one is unspendable by
+    consensus.
+
+    The key path is preferred when the input carries both, as Bitcoin
+    Core's finalizer prefers it: it is the cheaper spend and the one the
+    output key commits to directly. The script path witness is the
+    signature, the leaf script and its control block, which is BIP341's
+    order and needs the leaf to be a single-key one.
+
+    Each signature is verified against the hash it says it committed to,
+    for the reason the legacy path verifies its own: a Finalizer is the
+    last role that can still refuse, and a witness built from a bad
+    signature is a transaction the network drops.
+    """
+    psbt_in = psbt.inputs[vin_i]
+
+    if psbt_in.taproot_key_spend_signature:
+        signature = psbt_in.taproot_key_spend_signature
+        hash_type = _assert_taproot_sig_hash_type(
+            signature, psbt_in, "taproot key path signature"
+        )
+        msg = taproot_sig_hash(psbt, vin_i, hash_type=hash_type)
+        output_key = type_and_payload(prevouts(psbt)[vin_i].script_pub_key.script)[1]
+        if not ssa.verify_(msg, output_key, signature[:64]):
+            err_msg = "invalid taproot key path signature for output key "
+            err_msg += output_key.hex()
+            raise BTClibValueError(err_msg)
+        return b"", Witness([signature])
+
+    if not psbt_in.taproot_script_spend_signatures:
+        raise BTClibValueError("missing taproot signature")
+
+    if len(psbt_in.taproot_script_spend_signatures) > 1:
+        # which leaf to spend is a choice, and one the psbt does not
+        # record: two signatures under two leaves are two spends, both
+        # valid, and picking either would be this function deciding what
+        # the transaction costs
+        err_msg = f"{len(psbt_in.taproot_script_spend_signatures)} taproot script "
+        err_msg += "path signatures: the psbt does not say which leaf to spend"
+        raise BTClibValueError(err_msg)
+
+    key_data, signature = next(iter(psbt_in.taproot_script_spend_signatures.items()))
+    pub_key, leaf_hash = key_data[:LEAF_HASH_SIZE], key_data[LEAF_HASH_SIZE:]
+    hash_type = _assert_taproot_sig_hash_type(
+        signature, psbt_in, "taproot script path signature"
+    )
+    script, control_block = leaf_script(psbt_in, leaf_hash)
+    if single_leaf_key(script) != pub_key:
+        err_msg = f"taproot script path signature of {pub_key.hex()}, which is "
+        err_msg += f"not the key of leaf script {script.hex()}"
+        raise BTClibValueError(err_msg)
+    msg = taproot_sig_hash(psbt, vin_i, leaf_hash=leaf_hash, hash_type=hash_type)
+    if not ssa.verify_(msg, pub_key, signature[:64]):
+        err_msg = f"invalid taproot script path signature for key {pub_key.hex()}"
+        raise BTClibValueError(err_msg)
+    return b"", Witness([signature, script, control_block])
+
+
 def _witness_v0_script_code(psbt_in: PsbtIn, script: bytes) -> bytes:
     """Return the script code BIP-143 signs the segwit v0 input against.
 
@@ -1490,6 +1670,17 @@ def finalize_psbt(psbt: Psbt) -> Psbt:
     # every signature is against the same one
     tx = psbt.tx
     for vin_i, psbt_in in enumerate(psbt.inputs):
+        # a taproot input is finalized from its own fields and not from
+        # partial_sigs, which is keyed by compressed key and holds ECDSA
+        # signatures: a schnorr signature travels in PSBT_IN_TAP_KEY_SIG
+        # or PSBT_IN_TAP_SCRIPT_SIG, and BIP373 is what writes the
+        # aggregate signature of a MuSig2 session into them
+        if is_p2tr(_spent_script(psbt_in)):
+            script_sig, witness = _finalized_taproot_input(psbt, vin_i)
+            psbt_in.final_script_sig = script_sig
+            psbt_in.final_script_witness = witness
+            continue
+
         if not psbt_in.partial_sigs:
             raise BTClibValueError("missing signatures")
         _assert_sig_hash_type(psbt_in)

--- a/docs/source/btclib.psbt.rst
+++ b/docs/source/btclib.psbt.rst
@@ -12,6 +12,14 @@ btclib.psbt.psbt module
    :undoc-members:
    :show-inheritance:
 
+btclib.psbt.musig2 module
+-------------------------
+
+.. automodule:: btclib.psbt.musig2
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 btclib.psbt.psbt\_in module
 ---------------------------
 

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -22,6 +22,7 @@ from btclib.bip32 import (
     crack_prv_key,
     derive,
     derive_from_account,
+    pub_key_derivation_tweaks,
     rootxprv_from_seed,
     xpub_from_xprv,
 )
@@ -622,3 +623,29 @@ def test_the_coercion_still_happens_in_init() -> None:
     assert isinstance(coerced.index, int)
     assert coerced.b58encode() == XKEY
     assert BIP32KeyData.b58decode(coerced.b58encode()) == coerced
+
+
+def test_the_tweaks_of_a_public_derivation_are_the_derivation() -> None:
+    """The scalars a path adds up to, against the key the path derives.
+
+    What they are for is a key that cannot be derived from -- a BIP327
+    MuSig2 aggregate key has no private key, so BIP328 derivation reaches
+    the signers as tweaks (BIP373, `btclib.psbt.musig2`) -- and what says
+    they are right is that applying them by hand lands on the key `derive`
+    answers for the same path.
+    """
+    rootxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
+    xpub = BIP32KeyData.b58decode(xpub_from_xprv(rootxprv))
+
+    tweaks = pub_key_derivation_tweaks(xpub.key, xpub.chain_code, "m/1/2")
+    derived = BIP32KeyData.b58decode(derive(xpub_from_xprv(rootxprv), "m/1/2"))
+    point = point_from_octets(xpub.key, ec)
+    for tweak in tweaks:
+        point = ec.add(point, mult(int.from_bytes(tweak, "big"), ec.G, ec))
+    assert bytes_from_point(point, ec) == derived.key
+
+    # a hardened index needs the private key, and the refusal comes before
+    # any step of the path is walked
+    err_msg = "invalid hardened derivation from public key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        pub_key_derivation_tweaks(xpub.key, xpub.chain_code, "m/1h")

--- a/tests/psbt/musig2_test.py
+++ b/tests/psbt/musig2_test.py
@@ -66,7 +66,7 @@ def session_of(psbt: Psbt) -> tuple[bytes, bytes]:
     Two different keys live in these fields, and this is the place the
     difference shows: `musig2_participant_pub_keys` is keyed by the plain
     aggregate key, which is what the roles take, while the nonces and the
-    partial signatures are keyed by that key *as tweaked for the session*
+    partial signatures are keyed by that key *as tweaked for the spend*
     -- the taproot output key in two of these four vectors. The tapleaf
     hash is read off the key data, being the same in both.
     """
@@ -295,7 +295,7 @@ def test_a_session_the_psbt_does_not_describe() -> None:
         musig2.session_context(psbt, 0, aggregate_pub_key)
 
     # the merkle root of another script tree: the tweak is then not the
-    # one the output key commits to, and the session key is not it either
+    # one the output key commits to, and the tweaked key is not it either
     psbt = _bip373_psbt("internal key is a MuSig2 Aggregate Pubkey, with participant")
     psbt.inputs[0].taproot_merkle_root = b"\x01" * 32
     with pytest.raises(BTClibValueError, match="is not the key being spent"):

--- a/tests/psbt/musig2_test.py
+++ b/tests/psbt/musig2_test.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Tests for the `btclib.psbt.musig2` module."""
+
+from typing import Any
+
+import pytest
+
+from btclib.curves import secp256k1
+from btclib.ecc import ssa
+from btclib.exceptions import BTClibValueError
+from btclib.psbt import Psbt, extract_tx, finalize_psbt, musig2
+from btclib.psbt.psbt import prevouts, taproot_sig_hash
+from btclib.script import type_and_payload
+from btclib.script.engine import verify_transaction
+from tests import load, vector_id
+
+# BIP373's own participants, whose keys every vector of it aggregates.
+# The private keys are the BIP's, published beside the public ones: they
+# spend the outputs of a transaction that exists in no chain, and they are
+# what lets a whole session be run here rather than only checked
+# hex rather than the WIF the BIP prints, which decodes to exactly this
+# and reads as a credential to every secret scanner that meets it
+PARTICIPANT_PRV_KEYS = (
+    "9e3d0fd1845e73fc5eb4202c047631e9bd45aee639c93de0e21ef7efe1100812",
+    "754f619cf0f5a9cce70168bb4ea613804e53e4c2487a967d1e2564cf8007ad25",
+    "0000000000000000000000000000000000000000000000000000000000000003",
+)
+
+AGGREGATE_PUB_KEY = "030b58e337aa4d3852a8c29387c42408d8cfbe3a613a5e397e0a9f01a5fb7107d4"
+
+PARTICIPANT_PUB_KEYS = (
+    "02346b99593357107c9d3459e9deba8d3eaf44e6636c85c7f853eb90ba52e8cd00",
+    "024fafd65f8169186fc2bfdb2233c77e630d10be280a24c7165c09a27611775c2c",
+    "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9",
+)
+
+
+def signed_vectors() -> list[Any]:
+    """The four BIP373 psbts that carry a complete set of partial signatures."""
+    return [
+        pytest.param(test_vector, id=vector_id(index, test_vector["description"]))
+        for index, test_vector in enumerate(
+            [
+                test_vector
+                for test_vector in load("psbt", "_data", "bip373_test_vectors.json")[
+                    "valid psbts"
+                ]
+                if "all partial signatures" in test_vector["description"]
+            ],
+            1,
+        )
+    ]
+
+
+def session_of(psbt: Psbt) -> tuple[bytes, bytes]:
+    """The aggregate key of the participants, and the tapleaf hash if any.
+
+    Two different keys live in these fields, and this is the place the
+    difference shows: `musig2_participant_pub_keys` is keyed by the plain
+    aggregate key, which is what the roles take, while the nonces and the
+    partial signatures are keyed by that key *as tweaked for the session*
+    -- the taproot output key in two of these four vectors. The tapleaf
+    hash is read off the key data, being the same in both.
+    """
+    psbt_in = psbt.inputs[0]
+    aggregate_pub_key = next(iter(psbt_in.musig2_participant_pub_keys))
+    leaf_hash = next(iter(psbt_in.musig2_partial_sigs))[66:]
+    return aggregate_pub_key, leaf_hash
+
+
+@pytest.mark.parametrize("test_vector", signed_vectors())
+def test_the_partial_signatures_of_bip373_verify(test_vector: dict[str, str]) -> None:
+    """Bitcoin Core signed these, and the session is rebuilt from the psbt.
+
+    Which is the whole of what BIP373 asks a Signer to get right: the
+    message is the BIP341 or BIP342 hash of the transaction the psbt
+    describes, the tweaks are how the aggregate key reaches the output
+    being spent -- nothing, the taproot commitment, or a BIP328
+    derivation and then the commitment -- and the aggregate nonce is the
+    sum of the nonces the input carries. Get any of the three wrong and
+    every one of these partial signatures fails, which is why they are
+    the test: they were made by another implementation, against a session
+    btclib has to derive rather than choose.
+    """
+    psbt = Psbt.b64decode(test_vector["encoded psbt"])
+    aggregate_pub_key, leaf_hash = session_of(psbt)
+
+    for participant_pub_key in psbt.inputs[0].musig2_participant_pub_keys[
+        aggregate_pub_key
+    ]:
+        assert musig2.partial_sig_verify(
+            psbt, 0, participant_pub_key, aggregate_pub_key, leaf_hash=leaf_hash
+        )
+
+
+@pytest.mark.parametrize("test_vector", signed_vectors())
+def test_aggregating_bip373s_partial_signatures_spends_the_output(
+    test_vector: dict[str, str],
+) -> None:
+    """The Finalizer's half, and the answer is a transaction that verifies.
+
+    `partial_sigs_agg` writes the BIP340 signature where the spend reads
+    it, `finalize_psbt` builds the witness, and btclib's own script
+    engine is what says the result is a spend of that output -- consensus
+    rules over the extracted transaction, not a signature check of
+    btclib's against a message of btclib's.
+    """
+    psbt = Psbt.b64decode(test_vector["encoded psbt"])
+    aggregate_pub_key, leaf_hash = session_of(psbt)
+    spent = prevouts(psbt)
+
+    musig2.partial_sigs_agg(psbt, 0, aggregate_pub_key, leaf_hash=leaf_hash)
+
+    # the session is gone, and what replaced it is the signature
+    assert not psbt.inputs[0].musig2_pub_nonces
+    assert not psbt.inputs[0].musig2_partial_sigs
+    assert not psbt.inputs[0].musig2_participant_pub_keys
+    if leaf_hash:
+        assert psbt.inputs[0].taproot_script_spend_signatures
+    else:
+        assert len(psbt.inputs[0].taproot_key_spend_signature) == 64
+
+    tx = extract_tx(finalize_psbt(psbt))
+    verify_transaction(spent, tx)
+
+
+def test_a_whole_session_is_run_over_the_psbt() -> None:
+    """Both rounds and every role, with btclib as all three signers.
+
+    The psbt is BIP373's own first vector, which carries the participants
+    and nothing else, so what is exercised is what a Signer and a
+    Finalizer add to it: three public nonces, three partial signatures,
+    the aggregate signature, and a transaction the script engine accepts.
+
+    The secret nonces stay in this function, which is the point of
+    `nonce_gen` returning them -- and each is spent exactly once, `sign`
+    zeroing the bytearray it consumes.
+    """
+    encoded = next(
+        test_vector["encoded psbt"]
+        for test_vector in load("psbt", "_data", "bip373_test_vectors.json")[
+            "valid psbts"
+        ]
+        if test_vector["description"].startswith(
+            "Spend of a Taproot output where the output key"
+        )
+        and "participant pubkeys only" in test_vector["description"]
+    )
+    psbt = Psbt.b64decode(encoded)
+    aggregate_pub_key = bytes.fromhex(AGGREGATE_PUB_KEY)
+    spent = prevouts(psbt)
+
+    sec_nonces = [
+        musig2.nonce_gen(psbt, 0, prv_key, aggregate_pub_key)
+        for prv_key in PARTICIPANT_PRV_KEYS
+    ]
+    assert len(psbt.inputs[0].musig2_pub_nonces) == 3
+
+    for prv_key, sec_nonce in zip(PARTICIPANT_PRV_KEYS, sec_nonces, strict=True):
+        musig2.partial_sign(psbt, 0, sec_nonce, prv_key, aggregate_pub_key)
+        # spent, and the bytearray says so: a second signature under one
+        # secnonce is what hands out a private key
+        with pytest.raises(BTClibValueError, match="secnonce value is out of range"):
+            musig2.partial_sign(psbt, 0, sec_nonce, prv_key, aggregate_pub_key)
+
+    for participant_pub_key in PARTICIPANT_PUB_KEYS:
+        assert musig2.partial_sig_verify(
+            psbt, 0, participant_pub_key, aggregate_pub_key
+        )
+
+    sig = musig2.partial_sigs_agg(psbt, 0, aggregate_pub_key)
+    # the aggregate signature is a BIP340 signature under the output key,
+    # which is the aggregate key itself in this vector
+    output_key = type_and_payload(spent[0].script_pub_key.script)[1]
+    assert ssa.verify_(taproot_sig_hash(psbt, 0), output_key, sig)
+
+    tx = extract_tx(finalize_psbt(psbt))
+    verify_transaction(spent, tx)
+
+
+def test_the_updater_files_a_list_under_the_key_it_aggregates_to() -> None:
+    """The Updater role: the aggregate key is computed, never taken.
+
+    BIP373's own participants and their aggregate key, which the BIP
+    publishes: `add_participant_pub_keys` has to arrive at it from the
+    list alone, in the order the list is in.
+    """
+    psbt_in = Psbt.b64decode(
+        next(
+            test_vector["encoded psbt"]
+            for test_vector in load("psbt", "_data", "bip373_test_vectors.json")[
+                "valid psbts"
+            ]
+            if "participant pubkeys only" in test_vector["description"]
+        )
+    ).inputs[0]
+    psbt_in.musig2_participant_pub_keys = {}
+
+    aggregate_pub_key = musig2.add_participant_pub_keys(
+        psbt_in, list(PARTICIPANT_PUB_KEYS)
+    )
+    assert aggregate_pub_key.hex() == AGGREGATE_PUB_KEY
+    assert psbt_in.musig2_participant_pub_keys == {
+        aggregate_pub_key: [bytes.fromhex(key) for key in PARTICIPANT_PUB_KEYS]
+    }
+    musig2.assert_valid_participants(psbt_in)
+
+    # the order is part of the key: the same keys in another order are
+    # another group, and sorting is how a group agrees on one -- BIP327's
+    # KeySort, which BIP373 asks for whenever sorting was used at all.
+    # These three are published in sorted order, so sorting a shuffled
+    # list arrives back at the same aggregate key and the shuffle on its
+    # own does not
+    shuffled = list(reversed(PARTICIPANT_PUB_KEYS))
+    assert musig2.add_participant_pub_keys(psbt_in, shuffled) != aggregate_pub_key
+    assert (
+        musig2.add_participant_pub_keys(psbt_in, shuffled, sort=True)
+        == aggregate_pub_key
+    )
+    musig2.assert_valid_participants(psbt_in)
+
+    # a list filed under a key it does not aggregate to is the one way
+    # the field can be wrong with every length right
+    psbt_in.musig2_participant_pub_keys[aggregate_pub_key] = [
+        bytes.fromhex(key) for key in reversed(PARTICIPANT_PUB_KEYS)
+    ]
+    with pytest.raises(BTClibValueError, match="musig2 participants aggregate to "):
+        musig2.assert_valid_participants(psbt_in)
+
+
+def test_a_signer_that_is_not_a_participant_is_refused() -> None:
+    encoded = next(
+        test_vector["encoded psbt"]
+        for test_vector in load("psbt", "_data", "bip373_test_vectors.json")[
+            "valid psbts"
+        ]
+        if "participant pubkeys only" in test_vector["description"]
+    )
+    psbt = Psbt.b64decode(encoded)
+    aggregate_pub_key = bytes.fromhex(AGGREGATE_PUB_KEY)
+    err_msg = "is not a participant of aggregate key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        musig2.nonce_gen(psbt, 0, 0xDEAD, aggregate_pub_key)
+
+
+def _bip373_psbt(description: str) -> Psbt:
+    """The valid BIP373 psbt whose description contains this."""
+    return Psbt.b64decode(
+        next(
+            test_vector["encoded psbt"]
+            for test_vector in load("psbt", "_data", "bip373_test_vectors.json")[
+                "valid psbts"
+            ]
+            if description in test_vector["description"]
+        )
+    )
+
+
+def test_a_session_the_psbt_does_not_describe() -> None:
+    """Each of the four ways a psbt can fail to say what is being signed.
+
+    A Signer has to derive the session rather than choose it, so every one
+    of these is a psbt that cannot be signed rather than one that signs
+    something else -- which is the difference the checks buy.
+    """
+    aggregate_pub_key = bytes.fromhex(AGGREGATE_PUB_KEY)
+
+    # no participants for the key the caller names
+    psbt = _bip373_psbt("output key is a MuSig2 Aggregate Pubkey, with participant")
+    psbt.inputs[0].musig2_participant_pub_keys = {}
+    with pytest.raises(BTClibValueError, match="no musig2 participants for aggregate"):
+        musig2.session_context(psbt, 0, aggregate_pub_key)
+
+    # an aggregate key that is neither the output key nor the internal one
+    psbt = _bip373_psbt("output key is a MuSig2 Aggregate Pubkey, with participant")
+    other = musig2.add_participant_pub_keys(
+        psbt.inputs[0], list(reversed(PARTICIPANT_PUB_KEYS))
+    )
+    err_msg = "is neither the taproot output key nor the internal key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        musig2.session_context(psbt, 0, other)
+
+    # an internal key the aggregate key does not derive to
+    psbt = _bip373_psbt("internal key is derived from a MuSig2")
+    psbt.inputs[0].taproot_hd_key_paths = {}
+    with pytest.raises(BTClibValueError, match="no BIP328 derivation from musig2"):
+        musig2.session_context(psbt, 0, aggregate_pub_key)
+
+    # the merkle root of another script tree: the tweak is then not the
+    # one the output key commits to, and the session key is not it either
+    psbt = _bip373_psbt("internal key is a MuSig2 Aggregate Pubkey, with participant")
+    psbt.inputs[0].taproot_merkle_root = b"\x01" * 32
+    with pytest.raises(BTClibValueError, match="is not the key being spent"):
+        musig2.session_context(psbt, 0, aggregate_pub_key)
+
+
+def test_a_round_that_the_other_round_has_not_reached() -> None:
+    """Each round needs what the one before wrote, and says what is missing."""
+    aggregate_pub_key = bytes.fromhex(AGGREGATE_PUB_KEY)
+    prv_key = PARTICIPANT_PRV_KEYS[0]
+
+    # no nonce at all: there is no session to build a context of
+    psbt = _bip373_psbt("output key is a MuSig2 Aggregate Pubkey, with participant")
+    with pytest.raises(BTClibValueError, match="no musig2 public nonce for aggregate"):
+        musig2.session_context(psbt, 0, aggregate_pub_key)
+
+    # round 2 without this signer's own nonce, the others' being there
+    psbt = _bip373_psbt("output key is a MuSig2 Aggregate Pubkey, with all pubnonces")
+    key_data = next(
+        k
+        for k in psbt.inputs[0].musig2_pub_nonces
+        if k[:33] == bytes.fromhex(PARTICIPANT_PUB_KEYS[0])
+    )
+    del psbt.inputs[0].musig2_pub_nonces[key_data]
+    with pytest.raises(BTClibValueError, match="no musig2 public nonce of"):
+        musig2.partial_sign(psbt, 0, bytearray(97), prv_key, aggregate_pub_key)
+
+    # a partial signature nobody sent
+    psbt = _bip373_psbt("output key is a MuSig2 Aggregate Pubkey, with all pubnonces")
+    with pytest.raises(BTClibValueError, match="no musig2 partial signature of"):
+        musig2.partial_sig_verify(psbt, 0, PARTICIPANT_PUB_KEYS[0], aggregate_pub_key)
+
+    # aggregation is n-of-n, and one signature short of n it names who
+    psbt = _bip373_psbt("output key is a MuSig2 Aggregate Pubkey, with all partial")
+    key_data = next(
+        k
+        for k in psbt.inputs[0].musig2_partial_sigs
+        if k[:33] == bytes.fromhex(PARTICIPANT_PUB_KEYS[0])
+    )
+    del psbt.inputs[0].musig2_partial_sigs[key_data]
+    err_msg = f"missing musig2 partial signature of {PARTICIPANT_PUB_KEYS[0]}"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        musig2.partial_sigs_agg(psbt, 0, aggregate_pub_key)
+
+
+def test_partial_signatures_that_do_not_add_up() -> None:
+    """A partial signature of another session verifies alone, and adds up
+    to nothing.
+
+    Which is the Finalizer's check: the aggregate signature is verified
+    before it is written, so a psbt combined out of two sessions is
+    refused rather than finalized into a transaction the network drops.
+    """
+    psbt = _bip373_psbt("output key is a MuSig2 Aggregate Pubkey, with all partial")
+    aggregate_pub_key, _ = session_of(psbt)
+    key_data, psig = next(iter(psbt.inputs[0].musig2_partial_sigs.items()))
+    # the same signer's signature, one bit different: every other partial
+    # signature still verifies, and the total does not
+    psbt.inputs[0].musig2_partial_sigs[key_data] = (
+        (int.from_bytes(psig, "big") + 1) % secp256k1.n
+    ).to_bytes(32, "big")
+    with pytest.raises(BTClibValueError, match="do not add up to a signature of"):
+        musig2.partial_sigs_agg(psbt, 0, aggregate_pub_key)
+
+
+def test_a_session_signing_for_a_sig_hash_type_of_its_own() -> None:
+    """SIGHASH_ALL, spelled out: 65 bytes of signature, and the type appended.
+
+    BIP341 appends the type to the 64 bytes whenever it is not the default
+    one, and the input is what asks for it -- so the message every signer
+    commits to changes with it, and the aggregate signature carries the
+    byte that says so.
+    """
+    psbt = _bip373_psbt("output key is a MuSig2 Aggregate Pubkey, with participant")
+    aggregate_pub_key = bytes.fromhex(AGGREGATE_PUB_KEY)
+    psbt.inputs[0].sig_hash_type = 1  # ALL
+    spent = prevouts(psbt)
+
+    # both rounds, in order: a signature made before the last nonce is
+    # published is a signature of another session, which is what
+    # test_partial_signatures_that_do_not_add_up is about
+    sec_nonces = [
+        musig2.nonce_gen(psbt, 0, prv_key, aggregate_pub_key)
+        for prv_key in PARTICIPANT_PRV_KEYS
+    ]
+    for prv_key, sec_nonce in zip(PARTICIPANT_PRV_KEYS, sec_nonces, strict=True):
+        musig2.partial_sign(psbt, 0, sec_nonce, prv_key, aggregate_pub_key)
+    musig2.partial_sigs_agg(psbt, 0, aggregate_pub_key)
+
+    signature = psbt.inputs[0].taproot_key_spend_signature
+    assert len(signature) == 65
+    assert signature[-1] == 1
+    verify_transaction(spent, extract_tx(finalize_psbt(psbt)))

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -17,11 +17,12 @@ from typing import Any
 
 import pytest
 
+from btclib import var_bytes
 from btclib.bip32 import BIP32KeyOrigin
 from btclib.curves import sec_point
 from btclib.ecc import dsa
 from btclib.exceptions import BTClibValueError
-from btclib.hashes import hash160, hash256, ripemd160, sha256
+from btclib.hashes import hash160, hash256, ripemd160, sha256, tagged_hash
 from btclib.psbt import (
     Psbt,
     PsbtIn,
@@ -31,6 +32,7 @@ from btclib.psbt import (
     finalize_psbt,
     join_psbts,
 )
+from btclib.psbt import musig2 as psbt_musig2
 from btclib.psbt.psbt import (
     _V2_GLOBAL_FIELDS,
     HAS_SIG_HASH_SINGLE,
@@ -38,6 +40,8 @@ from btclib.psbt.psbt import (
     OUTPUTS_MODIFIABLE,
     _sig_hash_from_psbt_in,
     _sort_or_shuffle,
+    leaf_script,
+    prevouts,
 )
 from btclib.psbt.psbt_in import _V2_FIELDS as _V2_INPUT_FIELDS
 from btclib.psbt.psbt_in import LOCK_TIME_THRESHOLD
@@ -2100,11 +2104,17 @@ def test_an_input_that_does_not_say_what_it_spends() -> None:
 
 
 def test_the_sig_hash_of_an_input_that_does_not_say_what_it_spends() -> None:
-    """Four inputs whose hash is not computable, each finalized all the same.
+    """Four inputs whose hash is not computable, three finalized all the same.
 
     None out of `_sig_hash_from_psbt_in` is "the psbt does not say what
     is being signed", which is not evidence against the signature: the
     Finalizer leaves such an input alone rather than refusing it.
+
+    The fourth is a p2tr input, and there the Finalizer does refuse: a
+    taproot input is finalized from its taproot fields, so an ECDSA
+    partial signature beside a p2tr script_pub_key is not a spend of it
+    -- and building one out of the partial signatures, as this used to,
+    produced a script_sig BIP341 gives no meaning to.
     """
     # no utxo at all
     psbt = Psbt.b64decode(TO_BE_FINALIZED)
@@ -2132,7 +2142,8 @@ def test_the_sig_hash_of_an_input_that_does_not_say_what_it_spends() -> None:
     psbt.inputs[0].non_witness_utxo = None
     psbt.inputs[0].witness_utxo = TxOut(100000, ScriptPubKey("5120" + "aa" * 32))
     assert _sig_hash_from_psbt_in(psbt.inputs[0], psbt.tx, 0, 1) is None
-    finalize_psbt(psbt)
+    with pytest.raises(BTClibValueError, match="missing taproot signature"):
+        finalize_psbt(psbt)
 
 
 def test_the_sig_hash_of_every_input_kind_a_partial_signature_signs() -> None:
@@ -2173,3 +2184,150 @@ def test_the_outpoint_names_an_output_of_the_non_witness_utxo() -> None:
     err_msg = "outpoint vout out of range for the non-witness utxo"
     with pytest.raises(BTClibValueError, match=err_msg):
         psbt.assert_valid()
+
+
+def _taproot_signed(description: str) -> Psbt:
+    """A BIP373 psbt whose MuSig2 session has been aggregated into a signature.
+
+    Which is the only way this tree produces a taproot signature: BIP371's
+    own valid psbts carry signatures beside utxos that do not commit to
+    the transaction they sit in, so they cannot be finalized -- the hash a
+    taproot signature checks against covers every input.
+    """
+    psbt = Psbt.b64decode(
+        next(
+            test_vector["encoded psbt"]
+            for test_vector in load("psbt", "_data", "bip373_test_vectors.json")[
+                "valid psbts"
+            ]
+            if description in test_vector["description"]
+        )
+    )
+    psbt_in = psbt.inputs[0]
+    aggregate_pub_key = next(iter(psbt_in.musig2_participant_pub_keys))
+    leaf_hash = next(iter(psbt_in.musig2_partial_sigs))[66:]
+    psbt_musig2.partial_sigs_agg(psbt, 0, aggregate_pub_key, leaf_hash=leaf_hash)
+    return psbt
+
+
+def test_a_taproot_input_is_finalized_from_its_own_fields() -> None:
+    """The key path and the script path, and the witness each is spent with.
+
+    BIP341: the witness of a key path spend is the signature alone, and of
+    a script path spend the signature, the leaf script and the control
+    block. The script_sig is empty either way, a witness v1 program having
+    nothing to put in it.
+    """
+    psbt = finalize_psbt(
+        _taproot_signed("output key is a MuSig2 Aggregate Pubkey, with all partial")
+    )
+    assert not psbt.inputs[0].final_script_sig
+    assert psbt.inputs[0].final_script_witness.stack == (
+        _taproot_signed("output key is a MuSig2 Aggregate Pubkey, with all partial")
+        .inputs[0]
+        .taproot_key_spend_signature,
+    )
+
+    psbt = _taproot_signed(
+        "a key in a script is a MuSig2 Aggregate Pubkey, with all partial"
+    )
+    key_data, sig = next(iter(psbt.inputs[0].taproot_script_spend_signatures.items()))
+    script, control_block = leaf_script(psbt.inputs[0], key_data[32:])
+    finalized = finalize_psbt(psbt)
+    assert not finalized.inputs[0].final_script_sig
+    assert finalized.inputs[0].final_script_witness.stack == (
+        sig,
+        script,
+        control_block,
+    )
+
+
+def test_what_a_taproot_input_cannot_be_finalized_from() -> None:
+    """Every way the taproot fields of an input fail to be a spend of it."""
+    # a signature of the wrong sig_hash type: the input asks for one and
+    # the signature commits to another
+    psbt = _taproot_signed("output key is a MuSig2 Aggregate Pubkey, with all partial")
+    psbt.inputs[0].sig_hash_type = 1
+    err_msg = "invalid taproot key path signature sig_hash type"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize_psbt(psbt)
+
+    # a signature of the right shape that signs something else
+    psbt = _taproot_signed("output key is a MuSig2 Aggregate Pubkey, with all partial")
+    psbt.inputs[0].taproot_key_spend_signature = b"\x01" * 64
+    err_msg = "invalid taproot key path signature for output key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize_psbt(psbt)
+
+    # no utxo, which is not one input's problem: a taproot signature
+    # commits to the amount and script of every input, so the hash cannot
+    # be computed for any of them. Not through the Finalizer, which
+    # without a utxo cannot tell the input is taproot at all and answers
+    # "missing signatures" as it does for every input that does not say
+    # what it spends
+    psbt = _taproot_signed("output key is a MuSig2 Aggregate Pubkey, with all partial")
+    psbt.inputs[0].witness_utxo = None
+    with pytest.raises(BTClibValueError, match="no utxo for input 0"):
+        prevouts(psbt)
+    with pytest.raises(BTClibValueError, match="missing signatures"):
+        finalize_psbt(psbt)
+
+    # two script path signatures, i.e. two spends of two leaves
+    psbt = _taproot_signed(
+        "a key in a script is a MuSig2 Aggregate Pubkey, with all partial"
+    )
+    key_data, sig = next(iter(psbt.inputs[0].taproot_script_spend_signatures.items()))
+    psbt.inputs[0].taproot_script_spend_signatures[b"\x01" * 64] = sig
+    err_msg = "2 taproot script path signatures"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize_psbt(psbt)
+
+    # one, under a tapleaf hash the input carries no script for
+    psbt = _taproot_signed(
+        "a key in a script is a MuSig2 Aggregate Pubkey, with all partial"
+    )
+    psbt.inputs[0].taproot_script_spend_signatures = {key_data[:32] + b"\x02" * 32: sig}
+    with pytest.raises(BTClibValueError, match="no leaf script for tapleaf hash"):
+        finalize_psbt(psbt)
+
+    # a leaf whose script is not a single key and OP_CHECKSIG: what else
+    # goes on the stack is not something the psbt says
+    psbt = _taproot_signed(
+        "a key in a script is a MuSig2 Aggregate Pubkey, with all partial"
+    )
+    control_block = next(iter(psbt.inputs[0].taproot_leaf_scripts))
+    psbt.inputs[0].taproot_leaf_scripts[control_block] = (b"\x51", 0xC0)
+    with pytest.raises(BTClibValueError, match="no leaf script for tapleaf hash"):
+        finalize_psbt(psbt)
+
+    # the same, reached by its own hash: the leaf is the one signed for and
+    # the script asks for more than a signature
+    psbt = _taproot_signed(
+        "a key in a script is a MuSig2 Aggregate Pubkey, with all partial"
+    )
+    control_block = next(iter(psbt.inputs[0].taproot_leaf_scripts))
+    script = serialize(["OP_1"])
+    psbt.inputs[0].taproot_leaf_scripts = {control_block: (script, 0xC0)}
+    leaf_hash_ = tagged_hash(b"TapLeaf", b"\xc0" + var_bytes.serialize(script))
+    psbt.inputs[0].taproot_script_spend_signatures = {key_data[:32] + leaf_hash_: sig}
+    err_msg = "not a single key and OP_CHECKSIG"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize_psbt(psbt)
+
+    # a signature filed under a key that is not the leaf's
+    psbt = _taproot_signed(
+        "a key in a script is a MuSig2 Aggregate Pubkey, with all partial"
+    )
+    psbt.inputs[0].taproot_script_spend_signatures = {b"\x03" * 32 + key_data[32:]: sig}
+    err_msg = "which is not the key of leaf script"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize_psbt(psbt)
+
+    # and the leaf's own key, with a signature that signs something else
+    psbt = _taproot_signed(
+        "a key in a script is a MuSig2 Aggregate Pubkey, with all partial"
+    )
+    psbt.inputs[0].taproot_script_spend_signatures = {key_data: b"\x01" * 64}
+    err_msg = "invalid taproot script path signature for key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize_psbt(psbt)


### PR DESCRIPTION
Scope 2 of #266, the half that waited on a decision — and the decision is
the one #266 and #257 share, so it is stated first.

## Where the secret nonce lives: with the caller, and nowhere else

`nonce_gen` returns the `bytearray` that `ecc.musig2.sign` consumes and
zeroes; `partial_sign` takes it back. Between the two rounds it is the
caller's, and it never enters the psbt — a file that gets copied, combined
and re-read, while a secnonce that signs twice hands out the private key by
elementary algebra.

So btclib owns **no session state at all**, rather than owning it
carefully. That is also libsecp256k1's answer (an opaque
`secp256k1_musig_secnonce` its own API invalidates after
`musig_partial_sign`, the note in #128) and the shape FROST needs in #257,
where round 1 produces the same kind of secret with the same single-use
rule. Nothing here has to be redecided there.

## The roles

`btclib.psbt.musig2`, one function per role:

| role | function |
| --- | --- |
| Updater | `add_participant_pub_keys(psbt_map, keys, sort=False)` — aggregates and files the list under the key it makes; the aggregate key is computed, never taken |
| Signer, round 1 | `nonce_gen(psbt, vin_i, prv_key, aggregate_pub_key, leaf_hash=…)` → the secnonce |
| Signer, round 2 | `partial_sign(psbt, vin_i, sec_nonce, prv_key, aggregate_pub_key, …)` |
| any signer | `partial_sig_verify(psbt, vin_i, participant, aggregate_pub_key, …)`, which BIP327 asks of every peer's contribution |
| Finalizer | `partial_sigs_agg(psbt, vin_i, aggregate_pub_key, …)` → `PSBT_IN_TAP_KEY_SIG` or `PSBT_IN_TAP_SCRIPT_SIG`, session dropped |

`session_context` is public too: it is what a signer needs to check
somebody else's partial signature, and it is where the psbt is read.

## What the psbt says, so the caller does not have to

All four of BIP373's ways for an aggregate key to reach the output are
derived from the psbt, one vector each:

- the aggregate key **is** the output key: no tweak;
- the aggregate key is the **internal key**: the BIP341 commitment to the
  merkle root, X-only;
- the aggregate key is a **key in a leaf script**: no tweak, and the
  message is BIP342's;
- the internal key is **derived** from the aggregate key: BIP328
  derivation, one plain tweak per step of `PSBT_IN_TAP_BIP32_DERIVATION`,
  then the X-only one.

The tweaked key is checked against the key the spend actually needs before
a secret nonce is spent on a signature nobody could use.

**One thing the BIP does not say and Core does**: the nonces and partial
signatures are keyed by the aggregate key *as tweaked for the session*,
not by the key the participants are filed under — Core's `plain_pub` in
`SignMuSig2` (script/sign.cpp). Two of the four vectors show it: their key
data carries the taproot output key. A psbt keyed the other way is one no
other implementation reads.

## Taproot finalization, which the aggregate signature needed

`finalize_psbt` could not finalize any taproot input: it built a legacy
script_sig out of `PSBT_IN_PARTIAL_SIG`, which BIP341 gives no meaning to
and btclib's own engine rejects. Now the witness is the signature for a
key path spend, and the signature, the leaf script and its control block
for a script path one, each verified against the hash it says it committed
to. A p2tr input carrying neither taproot signature is refused as
"missing taproot signature" — the one behaviour change a user could
notice, and it is in HISTORY.md.

Two script path signatures are refused (the psbt does not say which leaf
to spend), and so is a leaf that is not `<key> OP_CHECKSIG`: what else its
witness would carry is not something a psbt records.

New, and what that took: `psbt.prevouts`, `psbt.taproot_sig_hash`,
`psbt.leaf_script`, and `bip32.pub_key_derivation_tweaks` — the scalars an
unhardened public derivation adds, which is how a key with no private key
gets derived.

## What says it works

- **all four vectors of BIP373 that carry partial signatures**: Core made
  them, btclib rebuilds the session from the psbt alone, and every partial
  signature verifies. Get the message, a tweak or the aggregate nonce
  wrong and none of them does.
- each is then aggregated, finalized and extracted, and the transaction is
  put through **btclib's own script engine** — consensus rules over the
  bytes, not a signature check against a message of btclib's own choosing.
- **a whole session run here**, all three signers, from BIP373's own
  private keys: two rounds, aggregation, finalization, engine. Plus the
  same with `SIGHASH_ALL` spelled out, where the signature is 65 bytes.
- the failures too: a psbt that does not describe the session, a round run
  before the one before it, a partial signature of another session (it
  verifies alone and does not add up), a secnonce used twice.

## Gates

`uv run pytest` (16569 passed), `uv run pre-commit run --all-files`,
`pytest --cov` at 100.00%, and the `-W` sphinx build. Local, all green.

Not in scope, and stated rather than assumed: `combine_psbts` does not
merge the MuSig2 fields, as it does not merge the taproot ones — a
Combiner over two signers' psbts is its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement MuSig2 PSBT support and taproot finalization, enabling full BIP373 sessions over PSBTs and correct taproot spending.

New Features:
- Add btclib.psbt.musig2 module to run BIP373 MuSig2 sessions over PSBTs, including participant management, nonce generation, partial signing, verification, and aggregation into BIP340 signatures.
- Expose BIP32 pub_key_derivation_tweaks to compute tweak scalars for unhardened public derivation paths, supporting MuSig2 taproot key derivation scenarios.
- Introduce PSBT helpers prevouts, taproot_sig_hash, leaf_script, and single_leaf_key to derive taproot spend context directly from PSBT data.

Bug Fixes:
- Fix finalize_psbt to correctly finalize taproot inputs using taproot key/script signatures and witnesses instead of misusing legacy partial signatures, and to reject taproot inputs missing valid taproot signatures.

Enhancements:
- Extend PSBT finalization to verify taproot signatures against the exact sighash committed to and enforce consistent sighash types for taproot inputs.
- Tighten validation around MuSig2 participant lists and sessions, ensuring participant keys aggregate to their stored aggregate key and that partial signatures and nonces correspond to a single coherent session.
- Refactor BIP32 public derivation internals to share offset computation logic and support reuse by external callers without changing behavior.

Documentation:
- Document new PSBT and MuSig2 behavior in CHANGELOG and HISTORY, including MuSig2-over-PSBT flows and taproot finalization semantics.

Tests:
- Add extensive tests for MuSig2 PSBT flows covering BIP373 vector verification, full multi-round sessions, updater behavior, session validation, and failure modes including mismatched sessions and bad partial signatures.
- Add tests for taproot PSBT finalization covering key/script path witnesses, missing or invalid taproot signatures, ambiguous script paths, and non-simple leaf scripts.
- Add tests for BIP32 pub_key_derivation_tweaks to verify correctness against standard derive and to enforce rejection of hardened public derivations.