### PR TITLE
Fix flaky Portuguese mnemonic word-count test

### DIFF
--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -413,17 +413,16 @@ def _random_int_entropy(lang: str) -> int:
     """Return the entropy electrum's make_seed draws when given none.
 
     132 bits rounded up to whole words, with anything below one word less
-    drawn again: that is what makes the leading word uniformly
-    distributed and the sentence twelve words long. secrets.randbits(128)
-    instead leaves the word count to follow the bit length, and the word
-    count is the one thing about the answer a caller cannot correct
-    afterwards.
+    drawn again: that is electrum's guard against a short sentence.
+    secrets.randbits(128) instead leaves the word count to follow the bit
+    length, and the word count is the one thing about the answer a caller
+    cannot correct afterwards.
 
     Bits per word is a float, as it is in electrum: for a 2048-word list
-    it is 11.0 and the rounding is exact, but Portuguese has 1626 words
-    and 10.667 bits, thirteen of which are 138 bits and not 130. int() on
-    it would round the sentence down to twelve words, i.e. to a mnemonic
-    electrum would never draw.
+    it is 11.0 and the rounding is exact. Portuguese has 1626 words and
+    10.667 bits, so the lower bound is below the first integer that needs
+    thirteen words. A small share of accepted draws therefore has twelve
+    words, exactly as it does in electrum.
     """
     bits_per_word = math.log2(ELECTRUM_WORDLISTS.language_length(lang))
     nbits = int(math.ceil(_RANDOM_ENTROPY_BITS / bits_per_word) * bits_per_word)

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -828,13 +828,15 @@ def test_electrum_wordlists() -> None:
 
 
 def test_portuguese_word_count() -> None:
-    """1626 words is 10.667 bits, so the sentence is thirteen words long.
+    """The first entropy needing thirteen base-1626 digits has thirteen words.
 
-    Rounding that down to ten bits a word would make it twelve, i.e. a
-    sentence electrum would never draw, and rounding the entropy down
-    with it: the sentence carries 138 bits and not 130.
+    Pin the entropy because electrum's random lower bound is slightly
+    below this base-conversion boundary and can also draw twelve words.
     """
-    mnemonic = electrum.mnemonic_from_entropy("standard", None, "pt")
+    first_thirteen_word_entropy = ELECTRUM_WORDLISTS.language_length("pt") ** 12
+    mnemonic = electrum.mnemonic_from_entropy(
+        "standard", first_thirteen_word_entropy, "pt"
+    )
     assert len(mnemonic.split()) == 13
     assert len(electrum.entropy_from_mnemonic(mnemonic, "pt")) == 139
 
@@ -844,6 +846,23 @@ def test_portuguese_word_count() -> None:
     # BIP39's portuguese is another word-list, and cannot read it
     with pytest.raises(BTClibValueError, match="unknown 'pt' word: "):
         bip39.entropy_from_mnemonic(mnemonic, "pt")
+
+
+def test_portuguese_random_word_count(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Electrum's random lower bound permits a twelve-word Portuguese seed."""
+    base = ELECTRUM_WORDLISTS.language_length("pt")
+    twelve_word_entropy = base**12 - 1000
+
+    def draw_below_thirteen_words(upper_bound: int) -> int:
+        assert upper_bound == (1 << 138) - 1
+        # randbelow returns one less because _random_int_entropy adds one.
+        return twelve_word_entropy - 1
+
+    monkeypatch.setattr(electrum.secrets, "randbelow", draw_below_thirteen_words)
+    mnemonic = electrum.mnemonic_from_entropy("standard", None, "pt")
+
+    assert len(mnemonic.split()) == 12
+    assert len(electrum.entropy_from_mnemonic(mnemonic, "pt")) == 129
 
 
 def test_is_bip39_mnemonic() -> None:

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -22,6 +22,7 @@ for a candidate electrum passes over, and `electrum_test_vectors.json`
 has no upstream at all.
 """
 
+import secrets
 from hashlib import sha256
 from unicodedata import normalize
 
@@ -858,7 +859,7 @@ def test_portuguese_random_word_count(monkeypatch: pytest.MonkeyPatch) -> None:
         # randbelow returns one less because _random_int_entropy adds one.
         return twelve_word_entropy - 1
 
-    monkeypatch.setattr(electrum.secrets, "randbelow", draw_below_thirteen_words)
+    monkeypatch.setattr(secrets, "randbelow", draw_below_thirteen_words)
     mnemonic = electrum.mnemonic_from_entropy("standard", None, "pt")
 
     assert len(mnemonic.split()) == 12


### PR DESCRIPTION
Fixes #293. Alternative to #295, carrying its two commits forward with
one fixup so the required Lint and type-check check stays green.

## Summary

- pin the thirteen-word Portuguese test at the first base-1626 entropy
  that requires thirteen words
- add a deterministic random-draw case proving that Electrum-compatible
  generation can return twelve words
- correct `_random_int_entropy`'s docstring without changing generation
  behavior
- fixup: patch `secrets.randbelow` via a direct `import secrets` in the
  test instead of reaching through `electrum.secrets` — the latter
  fails mypy's strict re-export check (`Module "btclib.mnemonic.electrum"
  does not explicitly export attribute "secrets"`), which is the
  required `Lint and type-check` job. Importing `secrets` directly
  patches the same shared module object (electrum.py's own `import
  secrets` resolves `secrets.randbelow` against it at call time), so
  behavior is unchanged and mypy keeps checking the attribute name and
  signature statically — no change to `electrum.py` needed.

The first two commits are @happykawayigt's from #295, carried over as
a cherry-pick to keep authorship; the fixup is a separate commit on
top.

## Validation

- `uv run pre-commit run --files btclib/mnemonic/electrum.py
  tests/mnemonic/electrum_test.py`: all hooks pass, including mypy
- `uv run pytest -q`: full suite passes, 16574 tests

## Summary by Sourcery

Stabilize Electrum Portuguese mnemonic word-count behavior by pinning deterministic entropy for the 13‑word case and documenting the true distribution of 12‑ vs 13‑word outputs.

Bug Fixes:
- Prevent flakiness in the Portuguese mnemonic word-count test by fixing the entropy used so it always produces a 13-word mnemonic.
- Add a deterministic random-draw test to verify that Electrum-compatible generation can legitimately return a 12-word Portuguese mnemonic.

Enhancements:
- Clarify the `_random_int_entropy` docstring to accurately describe the word-count distribution and lower-bound behavior of Electrum entropy generation.

Tests:
- Extend Electrum mnemonic tests to cover both fixed-entropy 13-word and patched-random 12-word Portuguese mnemonics, using direct `secrets.randbelow` monkeypatching.