### PR TITLE
Keep sorted() for BIP67 ordering in p2ms, record why pubkey_sort isn't

### DIFF
--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -557,6 +557,16 @@ class ScriptPubKey(Script):
             pub_keyinfo_from_key(k, network, compressed)[0] for k in keys[1:]
         ]
         if lexicographic_sorting:
+            # btclib_libsecp256k1's keys.pubkey_sort is not called here:
+            # on compressed keys it gives the identical order, byte for
+            # byte, at 11.0 us against sorted()'s 0.062 on three keys --
+            # 180 times the cost for the same answer -- and it re-
+            # serializes an uncompressed key to a compressed one, which
+            # a drop-in delegation cannot do without rewriting the
+            # script. sorted() is also what Bitcoin Core's own
+            # sortedmulti() computes, CPubKey::operator< (src/pubkey.h)
+            # comparing the serialization as received on any input,
+            # compressed or not -- see #267.
             pub_keys = sorted(pub_keys)
 
         script = serialize([op_int(m), *pub_keys, op_int(n), "OP_CHECKMULTISIG"])

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -541,7 +541,12 @@ class ScriptPubKey(Script):
         BIP67 endorses lexicographic sorting of compressed public keys.
 
         Note that sorting uncompressed keys (leading 0x04 byte) would
-        result in a different order.
+        result in a different order. An uncompressed key is not refused
+        here even when lexicographic_sorting is True: BIP67's own
+        compatibility note calls such a key a sign of a non-conforming
+        counterparty, not something to reject, and Bitcoin Core's
+        sortedmulti() accepts the mix and sorts it the same way -- see
+        #299.
 
         https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki
         """


### PR DESCRIPTION
## Summary

- Closes #267: `ScriptPubKey.p2ms`'s `sorted()` for BIP67 lexicographic
  ordering stays as it is, with a comment recording why
  `btclib_libsecp256k1`'s `keys.pubkey_sort`/`pubkey_cmp` aren't used --
  180x the cost for the identical byte-for-byte order on compressed
  keys, and `pubkey_sort` re-serializes an uncompressed key to a
  compressed one, which a drop-in delegation can't do without rewriting
  the script. `sorted()` also matches Bitcoin Core's `sortedmulti()`
  (`CPubKey::operator<`, `src/pubkey.h`) on any input.
- Closes #299: `p2ms` does not refuse a mix of compressed and
  uncompressed keys when `lexicographic_sorting=True`. BIP67's
  compatibility note calls an uncompressed key a sign of a
  non-conforming counterparty, not something to reject, and says
  enforcement is impossible on its own terms (P2SH hides the script;
  enforcing it would be a hard fork). Core's `sortedmulti()` accepts
  the mix and sorts by raw serialization the same way -- refusing it
  here would diverge from Core on input Core itself accepts, and would
  break two of this codebase's own test vectors taken from Core's
  descriptor test suite (`tests/descriptors_test.py:363-373`).
- No behavior change; no tests needed updating -- the Core-derived
  vectors already exercise the accepted compressed/uncompressed mix.

## Test plan

- [x] `uv run pytest` -- 178 passed on the touched files, full suite
  green
- [x] `uv run pre-commit run --all-files` -- all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)