### PR TITLE
Satisfy a descriptor: the script_sig and witness that spend it (#263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1932,6 +1932,30 @@ edit.
   own `descriptor_tests.cpp` vectors, both spellings of each, so a WIF
   and an xprv are checked to reach the script their public halves reach
   (issue #186)
+- **`Descriptor.satisfy` spends what `script_pub_keys` receives into**:
+  given a mapping from public key to signature — the shape
+  `PsbtIn.partial_sigs` has — it returns the `script_sig` and the
+  `Witness` an input spends with, one of the two always empty. Keyed by
+  key and not a sequence because the order the signatures go in is the
+  descriptor's knowledge and not the caller's: the key order for
+  `multi()`, the sorted order for `sortedmulti()`. It is one method per
+  fragment class over one notion of a satisfying stack, so `sh()` appends
+  the redeem script to what its argument produced and `wsh()` appends the
+  witness script to its argument's stack. `tr()` is satisfiable on both
+  paths — the key path preferred where both are offered, as Bitcoin Core's
+  finalizer prefers it, and the script path's control block computed from
+  the tree the descriptor holds, which is the one thing satisfaction here
+  knows that `finalize_psbt` has to be told. Three refusals, each a
+  `BTClibValueError` and not the `NotImplementedError` the parser raises
+  for what a later release adds: `addr()` and `raw()` name a script and
+  not the key that spends it, and `combo()` is four scripts, so which one
+  is being spent is the caller's to say. A signature short of what the
+  script pops is an error too, `PsbtIn.partial_sigs` being where a spend
+  waiting for its second signature belongs. `satisfy` assembles and does
+  not verify, having no transaction and therefore no sig_hash to check
+  against; the test suite checks it against `finalize_psbt`, which does
+  have one, and the two build the same bytes for every shape both can
+  express (issue #263)
 - **`btclib.fetch` is new, and is the one package that goes out to the
   network.** `Fetcher` is three questions the library cannot answer from
   bytes it was handed — the transaction with this id, the output an

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -7,16 +7,23 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Output descriptors: the checksum, the parser, and the scripts.
+"""Output descriptors: the checksum, the parser, the scripts, the spend.
 
 A descriptor says which scripts a wallet owns, in one line of text. This
-module reads that line and answers with the scripts, which is the half of
-a descriptor implementation the receiving side needs: `parse` returns a
-`Descriptor`, and `Descriptor.script_pub_keys` returns what the descriptor
-pays to at an index. The other half, satisfying a script -- descriptor
-plus signatures to a witness or a scriptSig -- is not here; the fragment
-classes below are one per grammar function so that it has somewhere to go
-(issue #186).
+module reads that line and answers with both halves of what a wallet
+does with it: `parse` returns a `Descriptor`, whose `script_pub_keys`
+gives what the descriptor pays to at an index -- the receiving side --
+and whose `satisfy` gives the script_sig and the witness that spend one
+of those scripts, the signatures being handed in. The fragment classes
+below are one per grammar function, which is what lets satisfaction be a
+method of each rather than a dispatch table.
+
+`satisfy` assembles and does not verify. A signature is checked against
+the hash it committed to, that hash is a property of the spending
+transaction, and a descriptor has no transaction -- which is also why
+the signatures are a parameter rather than something this module makes.
+`psbt.finalize_psbt` does have one and does check, and builds the same
+bytes from a psbt carrying the same signatures.
 
 BIP 380: https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki
 
@@ -49,15 +56,19 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from typing import cast
 
-from btclib.alias import ScriptList, TaprootScriptTree
+from btclib.alias import Octets, ScriptList, TaprootScriptTree
 from btclib.bip32.bip32 import BIP32KeyData, derive
 from btclib.bip32.der_path import int_from_index_str
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
+from btclib.script.script import serialize
 from btclib.script.script_pub_key import ScriptPubKey
+from btclib.script.taproot import input_script_sig
+from btclib.script.witness import Witness
 from btclib.to_pub_key import point_from_pub_key, pub_keyinfo_from_key
 from btclib.utils import bytes_from_octets
 
@@ -264,6 +275,37 @@ def _taproot_script_tree(
     ]
 
 
+def _offered_signature(
+    signatures: Mapping[bytes, bytes], sec: bytes, *, x_only: bool = False
+) -> bytes | None:
+    """Return the signature offered for a public key, None where none is.
+
+    A taproot key answers to either of its two spellings: the 32 x-only
+    bytes the script holds, and the 33-byte even-y SEC form a
+    KeyExpression keeps it as. Neither is the more correct one, a caller
+    has whichever its signer handed back, and 32 bytes cannot be taken
+    for 33.
+    """
+    if sec in signatures:
+        return signatures[sec]
+    if x_only and sec[1:] in signatures:
+        return signatures[sec[1:]]
+    return None
+
+
+def _required_signature(signatures: Mapping[bytes, bytes], sec: bytes) -> bytes:
+    """Return the signature made with a public key, refusing where none is.
+
+    The key is named in the error: it is public by construction, and
+    which of a descriptor's keys has not signed is the whole content of
+    the refusal.
+    """
+    signature = _offered_signature(signatures, sec)
+    if signature is None:
+        raise BTClibValueError(f"no signature for public key {sec.hex()}")
+    return signature
+
+
 @dataclass(frozen=True, kw_only=True)
 class Descriptor(ABC):
     """A parsed output descriptor: the scripts it describes, on demand.
@@ -289,17 +331,26 @@ class Descriptor(ABC):
         """Return True if the descriptor describes a range of scripts."""
         return any(key.is_ranged for key in self.key_expressions)
 
-    def script_pub_keys(self, index: int = 0) -> list[ScriptPubKey]:
-        """Return the scripts the descriptor describes at `index`.
+    def _assert_index(self, index: int) -> None:
+        """Refuse an index out of range, or one with no script of this.
 
-        A list because ``combo()`` is a set of scripts and not one
-        script; every other fragment answers with exactly one.
+        `satisfy` asks the two questions `script_pub_keys` asks, and has
+        to ask them first: an index out of range would otherwise be a
+        signature looked up under a key derived from it.
         """
         if not 0 <= index < 0x80000000:
             raise BTClibValueError(f"invalid derivation index: {index}")
         if index and not self.is_ranged:
             err_msg = f"not a ranged descriptor: no script at index {index}"
             raise BTClibValueError(err_msg)
+
+    def script_pub_keys(self, index: int = 0) -> list[ScriptPubKey]:
+        """Return the scripts the descriptor describes at `index`.
+
+        A list because ``combo()`` is a set of scripts and not one
+        script; every other fragment answers with exactly one.
+        """
+        self._assert_index(index)
         return [ScriptPubKey(script, self.network) for script in self._scripts(index)]
 
     def script_pub_key(self, index: int = 0) -> ScriptPubKey:
@@ -324,6 +375,64 @@ class Descriptor(ABC):
             script_pub_key.address for script_pub_key in self.script_pub_keys(index)
         ]
 
+    def _stack(self, signatures: Mapping[bytes, bytes], index: int) -> list[bytes]:
+        """Return the elements that satisfy this fragment's own script.
+
+        What ``sh()`` writes into its script_sig and what ``wsh()`` puts
+        in its witness under the script: the same elements, only written
+        somewhere else, which is why this is one method and not two.
+        Answered by the fragments that are a script another one embeds
+        -- ``pk``, ``pkh``, ``wpkh``, ``multi`` -- and refused by the
+        rest. The grammar refuses those in an embedding position too, so
+        what this answers is a descriptor built by hand.
+        """
+        err_msg = f"{type(self).__name__} is not a script another one embeds"
+        raise BTClibValueError(err_msg)
+
+    def satisfy(
+        self, signatures: Mapping[Octets, Octets], index: int = 0
+    ) -> tuple[bytes, Witness]:
+        """Return the script_sig and witness that spend the script at `index`.
+
+        `signatures` maps a public key to the signature made with it,
+        which is the shape `psbt.PsbtIn.partial_sigs` has. Keyed by key
+        and not a sequence because the order the signatures go on the
+        stack is the descriptor's own knowledge -- the key order of a
+        ``multi()``, the sorted order of a ``sortedmulti()`` -- and a
+        caller that had to know it would be building the script itself.
+
+        Both halves come back and one of the two is always empty: a
+        legacy script has no witness, and a native segwit one has the
+        empty script_sig BIP 141 requires.
+
+        A signature short of what the script pops is an error and not a
+        shorter answer. A 2-of-3 holding one signature is a psbt waiting
+        for the second, `psbt.PsbtIn.partial_sigs` is where that state
+        belongs, and bytes that do not spend would be a second and
+        weaker spelling of it.
+        """
+        self._assert_index(index)
+        return self._satisfy(
+            {
+                bytes_from_octets(key): bytes_from_octets(signature)
+                for key, signature in signatures.items()
+            },
+            index,
+        )
+
+    def _satisfy(
+        self, signatures: Mapping[bytes, bytes], index: int
+    ) -> tuple[bytes, Witness]:
+        """Return the satisfaction, the mapping being already in bytes.
+
+        The legacy answer -- the stack pushed into the script_sig, and
+        no witness -- which is what ``pk()``, ``pkh()`` and ``multi()``
+        are spent with; the fragments spent otherwise override it.
+        Separate from `satisfy` so that a wrapper can satisfy its
+        argument without normalizing the same mapping a second time.
+        """
+        return serialize(cast(ScriptList, self._stack(signatures, index))), Witness()
+
 
 @dataclass(frozen=True)
 class PkDescriptor(Descriptor):
@@ -337,6 +446,11 @@ class PkDescriptor(Descriptor):
 
     def _scripts(self, index: int) -> list[bytes]:
         return [ScriptPubKey.p2pk(self.key.sec(index, self.network)).script]
+
+    def _stack(self, signatures: Mapping[bytes, bytes], index: int) -> list[bytes]:
+        # the key is in the script already, so the signature is the whole
+        # of what spending a p2pk output takes
+        return [_required_signature(signatures, self.key.sec(index, self.network))]
 
 
 @dataclass(frozen=True)
@@ -352,6 +466,12 @@ class PkhDescriptor(Descriptor):
     def _scripts(self, index: int) -> list[bytes]:
         return [ScriptPubKey.p2pkh(self.key.sec(index, self.network)).script]
 
+    def _stack(self, signatures: Mapping[bytes, bytes], index: int) -> list[bytes]:
+        # what the output commits to is the hash of the key, so the key
+        # goes on the stack for the script to hash for itself
+        sec = self.key.sec(index, self.network)
+        return [_required_signature(signatures, sec), sec]
+
 
 @dataclass(frozen=True)
 class WpkhDescriptor(Descriptor):
@@ -365,6 +485,21 @@ class WpkhDescriptor(Descriptor):
 
     def _scripts(self, index: int) -> list[bytes]:
         return [ScriptPubKey.p2wpkh(self.key.sec(index, self.network)).script]
+
+    def _stack(self, signatures: Mapping[bytes, bytes], index: int) -> list[bytes]:
+        # the witness of a p2wpkh spend is what the script_sig of a p2pkh
+        # one is, BIP 143 having moved it and changed nothing else
+        sec = self.key.sec(index, self.network)
+        return [_required_signature(signatures, sec), sec]
+
+    def _satisfy(
+        self, signatures: Mapping[bytes, bytes], index: int
+    ) -> tuple[bytes, Witness]:
+        # the empty script_sig of BIP 141, which is not the same as an
+        # empty push: btclib's own engine refuses a native segwit input
+        # whose script_sig is there at all (issue #249). A sh(wpkh())
+        # gets its one push from the sh() above
+        return b"", Witness(self._stack(signatures, index))
 
 
 @dataclass(frozen=True)
@@ -380,6 +515,23 @@ class ShDescriptor(Descriptor):
     def _scripts(self, index: int) -> list[bytes]:
         return [ScriptPubKey.p2sh(self.inner.redeem_script(index)).script]
 
+    def _satisfy(
+        self, signatures: Mapping[bytes, bytes], index: int
+    ) -> tuple[bytes, Witness]:
+        """Return the argument's satisfaction, the redeem script pushed last.
+
+        One rule for the three shapes ``sh()`` wraps, because the two
+        wrapped segwit ones satisfy into the witness and leave the
+        script_sig empty: what is appended is the same push either way,
+        and what it is appended to is nothing where the spend is a
+        witness. Appending is concatenation because a script_sig is
+        pushes and nothing else, so serializing them together and
+        serializing them apart give the same bytes.
+        """
+        script_sig, witness = self.inner._satisfy(signatures, index)
+        redeem_script = self.inner.redeem_script(index)
+        return script_sig + serialize(cast(ScriptList, [redeem_script])), witness
+
 
 @dataclass(frozen=True)
 class WshDescriptor(Descriptor):
@@ -393,6 +545,19 @@ class WshDescriptor(Descriptor):
 
     def _scripts(self, index: int) -> list[bytes]:
         return [ScriptPubKey.p2wsh(self.inner.redeem_script(index)).script]
+
+    def _satisfy(
+        self, signatures: Mapping[bytes, bytes], index: int
+    ) -> tuple[bytes, Witness]:
+        """Return the witness of a p2wsh spend: the stack, then the script.
+
+        The argument's stack and not its satisfaction, which would be
+        those same elements serialized as a script_sig: a witness is a
+        stack already, so BIP 141 puts them in it one by one and the
+        witness script last.
+        """
+        stack = self.inner._stack(signatures, index)
+        return b"", Witness([*stack, self.inner.redeem_script(index)])
 
 
 @dataclass(frozen=True)
@@ -410,12 +575,48 @@ class MultiDescriptor(Descriptor):
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         return self.keys
 
-    def _scripts(self, index: int) -> list[bytes]:
+    def _pub_keys(self, index: int) -> list[bytes]:
+        """Return the keys in the order the script holds them.
+
+        `sorted` and not `p2ms`'s own `lexicographic_sorting`, which
+        sorts identically: the order is also the order the signatures of
+        a satisfaction go in, so one of the two has somewhere to ask for
+        it rather than a second copy of the rule.
+        """
         pub_keys = [key.sec(index, self.network) for key in self.keys]
+        return sorted(pub_keys) if self.sort else pub_keys
+
+    def _scripts(self, index: int) -> list[bytes]:
         script_pub_key = ScriptPubKey.p2ms(
-            self.threshold, pub_keys, self.network, lexicographic_sorting=self.sort
+            self.threshold,
+            self._pub_keys(index),
+            self.network,
+            lexicographic_sorting=False,
         )
         return [script_pub_key.script]
+
+    def _stack(self, signatures: Mapping[bytes, bytes], index: int) -> list[bytes]:
+        """Return the dummy element and `threshold` signatures, in key order.
+
+        OP_CHECKMULTISIG walks the signatures and the keys in one pass
+        and never goes back, so the signatures have to be in the order
+        the script holds the keys in. More signatures than the threshold
+        is not an error and not all of them are used: the script pops
+        exactly as many as it was built for, and the rest are the other
+        keys of the same descriptor having signed too.
+
+        The first element is the one OP_CHECKMULTISIG pops without
+        reading, which BIP 147 requires to be the empty push.
+        """
+        offered = [
+            (sec, _offered_signature(signatures, sec)) for sec in self._pub_keys(index)
+        ]
+        found = [signature for _, signature in offered if signature is not None]
+        if len(found) < self.threshold:
+            missing = ", ".join(sec.hex() for sec, sig in offered if sig is None)
+            err_msg = f"{len(found)} signatures of {self.threshold}, missing {missing}"
+            raise BTClibValueError(err_msg)
+        return [b"", *found[: self.threshold]]
 
 
 @dataclass(frozen=True)
@@ -444,6 +645,19 @@ class ComboDescriptor(Descriptor):
             scripts += [p2wpkh, ScriptPubKey.p2sh(p2wpkh).script]
         return scripts
 
+    def _satisfy(
+        self, signatures: Mapping[bytes, bytes], index: int
+    ) -> tuple[bytes, Witness]:
+        """Refuse: four scripts, and each of them spent differently.
+
+        Which one is being spent is a question the caller answers, by
+        satisfying the descriptor of that script -- ``pk()``, ``pkh()``,
+        ``wpkh()`` or ``sh(wpkh())`` of the same key -- and it is a
+        question `script_pub_keys` can leave open where this cannot.
+        """
+        err_msg = "combo() is four scripts: satisfy the one being spent"
+        raise BTClibValueError(err_msg)
+
 
 @dataclass(frozen=True)
 class AddrDescriptor(Descriptor):
@@ -458,6 +672,18 @@ class AddrDescriptor(Descriptor):
     def _scripts(self, index: int) -> list[bytes]:
         return [ScriptPubKey.from_address(self.addr).script]
 
+    def _satisfy(
+        self, signatures: Mapping[bytes, bytes], index: int
+    ) -> tuple[bytes, Witness]:
+        """Refuse: an address names a script and not what spends it.
+
+        BTClibValueError and not the NotImplementedError the parser
+        raises for what a later release adds: there is nothing to add,
+        an address being a commitment to a key or a script that the
+        descriptor does not carry.
+        """
+        raise BTClibValueError("addr() cannot be satisfied: it holds no key")
+
 
 @dataclass(frozen=True)
 class RawDescriptor(Descriptor):
@@ -471,6 +697,18 @@ class RawDescriptor(Descriptor):
 
     def _scripts(self, index: int) -> list[bytes]:
         return [self.script]
+
+    def _satisfy(
+        self, signatures: Mapping[bytes, bytes], index: int
+    ) -> tuple[bytes, Witness]:
+        """Refuse: a script and no key expression to satisfy it with.
+
+        What ``raw()`` holds is bytes, which say nothing about which key
+        signs for them even where they happen to be a script this module
+        can otherwise read; the descriptor of that script is what is
+        satisfiable.
+        """
+        raise BTClibValueError("raw() cannot be satisfied: it holds no key")
 
 
 @dataclass(frozen=True)
@@ -494,6 +732,51 @@ class TrDescriptor(Descriptor):
         )
         internal_key = self.internal_key.sec(index, self.network)
         return [ScriptPubKey.p2tr(internal_key, script_tree).script]
+
+    def _satisfy(
+        self, signatures: Mapping[bytes, bytes], index: int
+    ) -> tuple[bytes, Witness]:
+        """Return the witness of a key path spend, or of a script path one.
+
+        The key path whenever a signature for the internal key is
+        offered, which is the preference Bitcoin Core's finalizer has:
+        it is the cheaper spend and the one the output key commits to
+        directly. That signature is one the *output* key verifies, the
+        signer having tweaked the key it holds, and it is looked up
+        under the internal key because that is the key the descriptor
+        names.
+
+        A script path witness is the signature, the leaf script and the
+        control block, which is BIP 341's order. Both the parity bit and
+        the merkle path in that control block are the descriptor's to
+        compute, holding the whole tree as it does, where a psbt has to
+        be handed them: it is the one thing satisfaction here knows that
+        finalization there cannot work out.
+
+        The script_sig is empty whichever path is taken: BIP 341 spends
+        a witness v1 program with the witness alone.
+        """
+        internal_key = self.internal_key.sec(index, self.network)
+        signature = _offered_signature(signatures, internal_key, x_only=True)
+        if signature is not None:
+            return b"", Witness([signature])
+        if self.tree is None:
+            raise BTClibValueError("no signature for the tr() internal key")
+        script_tree = _taproot_script_tree(self.tree, index, self.network)
+        # _tree_keys and taproot.tree_helper both walk the left subtree
+        # before the right one, so the n-th key is the n-th leaf and the
+        # number is the one input_script_sig takes
+        for leaf, key in enumerate(_tree_keys(self.tree)):
+            signature = _offered_signature(
+                signatures, key.sec(index, self.network), x_only=True
+            )
+            if signature is not None:
+                script, control_block = input_script_sig(
+                    internal_key, script_tree, leaf
+                )
+                return b"", Witness([signature, serialize(script), control_block])
+        err_msg = "no signature for the tr() internal key or for any of its leaves"
+        raise BTClibValueError(err_msg)
 
 
 def _split_arguments(arguments: str) -> list[str]:

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -36,6 +36,7 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
+from btclib.alias import Octets
 from btclib.descriptors import (
     AddrDescriptor,
     ComboDescriptor,
@@ -55,8 +56,16 @@ from btclib.descriptors import (
     parse,
     strip_checksum,
 )
+from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
+from btclib.psbt.psbt import _finalized_input
+from btclib.psbt.psbt_in import PsbtIn
+from btclib.script import taproot
+from btclib.script.script import serialize
 from btclib.script.script_pub_key import ScriptPubKey
+from btclib.script.witness import Witness
+from btclib.to_pub_key import pub_keyinfo_from_key
+from btclib.tx.tx_out import TxOut
 from tests import load, vector_id
 
 DOC_DESCRIPTORS = [
@@ -841,3 +850,226 @@ UNIMPLEMENTED = [
 def test_unimplemented(descriptor: str, message: str) -> None:
     with pytest.raises(NotImplementedError, match=message):
         parse(descriptor)
+
+
+# three keys and a signature made with each. Real DER signatures rather
+# than placeholder bytes because the psbt finalizer that satisfaction is
+# checked against parses every partial signature it is handed, so a
+# placeholder would not reach the comparison
+PRV_KEYS = (1, 2, 3)
+SEC_KEYS = [pub_keyinfo_from_key(prv_key)[0].hex() for prv_key in PRV_KEYS]
+SIGNATURES = {
+    sec: (dsa.sign(bytes([i]) * 32, prv_key).serialize() + b"\x01").hex()
+    for i, (sec, prv_key) in enumerate(zip(SEC_KEYS, PRV_KEYS, strict=True))
+}
+KEY_A, KEY_B, KEY_C = SEC_KEYS
+# the x-only spelling of the same three, which is what a tr() holds
+XONLY_A, XONLY_B, XONLY_C = (sec[2:] for sec in SEC_KEYS)
+SCHNORR = ssa.sign(bytes(32), 1).serialize().hex()
+
+MULTI = f"multi(2,{KEY_A},{KEY_B},{KEY_C})"
+SORTED_MULTI = f"sortedmulti(2,{KEY_A},{KEY_B},{KEY_C})"
+
+
+def signatures_of(*keys: str) -> dict[Octets, Octets]:
+    """Return the signature of each key, in the shape satisfy takes."""
+    return {key: SIGNATURES[key] for key in keys}
+
+
+# a descriptor, the keys that sign, and the descriptors of the redeem
+# script and of the witness script a psbt would have to be told about --
+# the two fields the finalizer dispatches on, and the ones an Updater
+# built from a descriptor would fill in
+FINALIZER_VECTORS = [
+    pytest.param(f"pk({KEY_A})", [KEY_A], "", "", id="pk"),
+    pytest.param(f"pkh({KEY_A})", [KEY_A], "", "", id="pkh"),
+    pytest.param(f"wpkh({KEY_A})", [KEY_A], "", "", id="wpkh"),
+    pytest.param(f"sh(wpkh({KEY_A}))", [KEY_A], f"wpkh({KEY_A})", "", id="sh-wpkh"),
+    pytest.param(MULTI, [KEY_A, KEY_C], "", "", id="multi"),
+    pytest.param(f"sh({MULTI})", [KEY_A, KEY_C], MULTI, "", id="sh-multi"),
+    pytest.param(f"wsh({MULTI})", [KEY_A, KEY_C], "", MULTI, id="wsh-multi"),
+    pytest.param(
+        f"sh(wsh({MULTI}))",
+        [KEY_A, KEY_C],
+        f"wsh({MULTI})",
+        MULTI,
+        id="sh-wsh-multi",
+    ),
+    pytest.param(
+        f"wsh({SORTED_MULTI})", [KEY_A, KEY_C], "", SORTED_MULTI, id="wsh-sortedmulti"
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("descriptor", "signing_keys", "redeem", "witness"), FINALIZER_VECTORS
+)
+def test_satisfy_matches_the_psbt_finalizer(
+    descriptor: str, signing_keys: list[str], redeem: str, witness: str
+) -> None:
+    """The two ways btclib builds a spend agree, byte for byte.
+
+    `finalize_psbt` assembles the same script_sig and witness from a
+    psbt input carrying the same signatures, and it is the older and the
+    independently tested of the two: BIP 174 describes what it does, and
+    what a descriptor adds is knowing the scripts and the key order
+    without being told them. So the psbt is told them here -- the redeem
+    script, the witness script and the output being spent -- and the two
+    constructions are compared.
+    """
+    parsed = parse(descriptor)
+    psbt_in = PsbtIn(
+        witness_utxo=TxOut(1000, parsed.script_pub_key()),
+        partial_sigs={
+            bytes.fromhex(key): bytes.fromhex(SIGNATURES[key]) for key in signing_keys
+        },
+        redeem_script=parse(redeem).redeem_script() if redeem else b"",
+        witness_script=parse(witness).redeem_script() if witness else b"",
+    )
+    assert parsed.satisfy(signatures_of(*signing_keys)) == _finalized_input(psbt_in)
+
+
+def test_signatures_go_in_the_order_the_script_holds_the_keys() -> None:
+    """OP_CHECKMULTISIG never goes back, so the order is not the caller's.
+
+    The descriptor names the keys C, B, A and the mapping offers them in
+    yet another order: what decides is neither, but the script -- which
+    for `multi()` is the order written and for `sortedmulti()` the
+    sorted one, the two being opposite here on purpose.
+    """
+    keys = f"{KEY_C},{KEY_B},{KEY_A}"
+    signatures = signatures_of(KEY_C, KEY_A)
+    ordered = parse(f"wsh(multi(2,{keys}))").satisfy(signatures)[1]
+    sorted_ = parse(f"wsh(sortedmulti(2,{keys}))").satisfy(signatures)[1]
+    assert ordered.stack[1:3] == (
+        bytes.fromhex(SIGNATURES[KEY_C]),
+        bytes.fromhex(SIGNATURES[KEY_A]),
+    )
+    assert sorted_.stack[1:3] == (
+        bytes.fromhex(SIGNATURES[KEY_A]),
+        bytes.fromhex(SIGNATURES[KEY_C]),
+    )
+    # the empty push BIP 147 requires, both times
+    assert ordered.stack[0] == sorted_.stack[0] == b""
+
+
+def test_more_signatures_than_the_threshold_pops() -> None:
+    """The extra ones are the other keys of the descriptor having signed."""
+    witness = parse(f"wsh({MULTI})").satisfy(signatures_of(*SEC_KEYS))[1]
+    # the witness script last, two signatures and the dummy before it
+    assert len(witness) == 4
+    assert witness.stack[1] == bytes.fromhex(SIGNATURES[KEY_A])
+    assert witness.stack[2] == bytes.fromhex(SIGNATURES[KEY_B])
+
+
+def test_satisfy_a_ranged_descriptor() -> None:
+    """The index derives the key that has to have signed."""
+    descriptor = parse(f"wpkh({XPUB}/0/*)")
+    key = descriptor.key_expressions[0]
+    for index in (0, 1, 2):
+        signature = SIGNATURES[KEY_A]
+        witness = descriptor.satisfy({key.sec(index): signature}, index)[1]
+        assert witness.stack == (bytes.fromhex(signature), key.sec(index))
+    # the signature of index 0 is no signature of the key at index 1
+    with pytest.raises(BTClibValueError, match="no signature for public key"):
+        descriptor.satisfy({key.sec(0): SIGNATURES[KEY_A]}, 1)
+
+
+def test_satisfy_index_out_of_range() -> None:
+    with pytest.raises(BTClibValueError, match="invalid derivation index"):
+        parse(f"wpkh({XPUB}/0/*)").satisfy({}, -1)
+    with pytest.raises(BTClibValueError, match="not a ranged descriptor"):
+        parse(f"wpkh({KEY_A})").satisfy({}, 1)
+
+
+def test_satisfy_taproot_key_path() -> None:
+    """One element, and the internal key is what it is filed under."""
+    descriptor = parse(f"tr({XONLY_A})")
+    expected = (b"", Witness([SCHNORR]))
+    assert descriptor.satisfy({XONLY_A: SCHNORR}) == expected
+    # the same key spelled as the 33-byte even-y SEC form answers too
+    assert descriptor.satisfy({KEY_A: SCHNORR}) == expected
+
+
+def test_satisfy_taproot_script_path() -> None:
+    """Every leaf of an asymmetric tree, and its control block checked.
+
+    `check_output_pubkey` is the verifier's own side of BIP 341: it
+    takes the output key, the leaf script and the control block, and
+    walks the merkle path back to the tweak. That it answers True is
+    what says the parity bit and the path are the ones this leaf needs,
+    and the tree is asymmetric so that a path of one hash and a path of
+    two are both exercised.
+    """
+    descriptor = parse(
+        f"tr({XONLY_A},{{pk({XONLY_B}),{{pk({XONLY_C}),pk({XONLY_A})}}}})"
+    )
+    output_key = descriptor.script_pub_key().script[2:]
+    for leaf_key in (XONLY_B, XONLY_C):
+        script_sig, witness = descriptor.satisfy({leaf_key: SCHNORR})
+        assert script_sig == b""
+        signature, script, control_block = witness.stack
+        assert signature == bytes.fromhex(SCHNORR)
+        assert script == serialize([bytes.fromhex(leaf_key), "OP_CHECKSIG"])
+        assert taproot.check_output_pubkey(output_key, script, control_block)
+
+
+def test_the_taproot_key_path_is_preferred() -> None:
+    """As Bitcoin Core's finalizer prefers it: the cheaper spend.
+
+    The internal key is a leaf of this tree as well, so both paths are
+    open and the answer says which was taken by its length.
+    """
+    descriptor = parse(f"tr({XONLY_A},pk({XONLY_A}))")
+    assert descriptor.satisfy({XONLY_A: SCHNORR}) == (b"", Witness([SCHNORR]))
+
+
+# what cannot be satisfied, and what says so. Each refusal is a
+# BTClibValueError rather than the NotImplementedError the parser raises
+# for miniscript: nothing a later release adds makes any of these
+# spendable from the descriptor alone
+UNSATISFIABLE: list[tuple[str, dict[Octets, Octets], str]] = [
+    (f"pk({KEY_A})", {}, "no signature for public key"),
+    (f"pkh({KEY_A})", {}, "no signature for public key"),
+    (f"wpkh({KEY_A})", {}, "no signature for public key"),
+    (f"sh(wpkh({KEY_A}))", {}, "no signature for public key"),
+    (f"wsh({MULTI})", {KEY_A: SIGNATURES[KEY_A]}, "1 signatures of 2, missing "),
+    (f"combo({KEY_A})", {KEY_A: SIGNATURES[KEY_A]}, "combo\\(\\) is four scripts"),
+    ("addr(1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH)", {}, "addr\\(\\) cannot be satisfied"),
+    ("raw(76a914000000000000000000000000000000000000000088ac)", {}, "raw\\(\\) cannot"),
+    (f"tr({XONLY_A})", {}, "no signature for the tr\\(\\) internal key"),
+    (f"tr({XONLY_A},pk({XONLY_B}))", {}, "or for any of its leaves"),
+]
+
+
+@pytest.mark.parametrize(
+    ("descriptor", "signatures", "message"),
+    [
+        pytest.param(descriptor, signatures, message, id=vector_id(index, descriptor))
+        for index, (descriptor, signatures, message) in enumerate(UNSATISFIABLE)
+    ],
+)
+def test_unsatisfiable(
+    descriptor: str, signatures: dict[Octets, Octets], message: str
+) -> None:
+    with pytest.raises(BTClibValueError, match=message):
+        parse(descriptor).satisfy(signatures)
+
+
+def test_the_missing_keys_are_named() -> None:
+    """Which key has not signed is the whole content of the refusal."""
+    with pytest.raises(BTClibValueError, match=f"missing {KEY_B}, {KEY_C}"):
+        parse(f"wsh({MULTI})").satisfy({KEY_A: SIGNATURES[KEY_A]})
+
+
+def test_only_a_script_is_embeddable() -> None:
+    """The wrappers have no stack of their own to be embedded with.
+
+    The grammar refuses `wsh(tr())` and `sh(addr())` and every other
+    such pair, so this is reachable only by building the descriptor
+    rather than parsing one -- which the dataclasses are public enough
+    to allow.
+    """
+    inner = parse(f"tr({XONLY_A})")
+    with pytest.raises(BTClibValueError, match="TrDescriptor is not a script"):
+        WshDescriptor(inner).satisfy({XONLY_A: SCHNORR})


### PR DESCRIPTION
Closes #263, whose comment records the three decisions this implements
and why each went the way it did.

`Descriptor.satisfy(signatures, index)` is the other direction of
`script_pub_keys`: a mapping from public key to signature in, the
`script_sig` and the `Witness` out. The mapping is the shape
`PsbtIn.partial_sigs` has, and it is keyed by key rather than a sequence
because the order the signatures go in is the descriptor's knowledge and
not the caller's — the key order for `multi()`, the sorted order for
`sortedmulti()`.

### The shape

One method per fragment class, as #263 anticipated, over one protected
`_stack`: the elements that satisfy a fragment's own script, before any
wrapping. That is what makes the two wrappers three lines each rather
than a special case — `sh()` appends the redeem script to the script_sig
its argument produced, `wsh()` appends the witness script to its
argument's stack — and it is the decomposition a miniscript satisfier
needs (#187), which is what the fragment classes were shaped for.

`tr()` is satisfiable on both paths. The key path is taken whenever a
signature for the internal key is offered, which is Bitcoin Core's
finalizer's preference; the script path's control block is computed from
the tree the descriptor holds, through `taproot.input_script_sig`. That
last is the one capability `satisfy` has that `finalize_psbt` does not:
the finalizer must be *handed* a control block.

Three refusals, each a `BTClibValueError` and not the
`NotImplementedError` the parser raises for miniscript, because no later
release makes any of them spendable from the descriptor alone: `addr()`
and `raw()` name a script and not the key that spends it, and `combo()`
is four scripts, so which one is being spent is the caller's to say. A
signature short of what the script pops is an error too, and names the
keys that have not signed: a 2-of-3 holding one signature is a psbt
waiting for the second, and `PsbtIn.partial_sigs` is where that state
belongs.

`satisfy` assembles and does not verify. It has no transaction, so no
sig_hash to check a signature against — which is also the reason the
signatures are a parameter rather than something the module makes.

### How it is checked

Against `finalize_psbt`, which does have a transaction and does verify,
and which is the older and independently tested of the two: for nine
shapes both can express — `pk`, `pkh`, `wpkh`, `sh(wpkh)`, `multi`,
`sh(multi)`, `wsh(multi)`, `sh(wsh(multi))`, `wsh(sortedmulti)` — a
`PsbtIn` is built carrying the same signatures and the scripts the psbt
has to be told about, and the two constructions are compared byte for
byte. Real DER signatures throughout, since `PsbtIn` parses every
partial signature it is handed.

What the cross-check cannot cover is checked directly: each leaf of an
asymmetric three-leaf tree is satisfied and its control block put through
`taproot.check_output_pubkey`, the verifier's own side of BIP 341, so a
merkle path of one hash and one of two are both walked back to the tweak.
And the key order is tested where the two disagree — a descriptor naming
the keys C, B, A, a mapping offering them in a third order, and `multi()`
and `sortedmulti()` required to answer in opposite orders.

Coverage stays at 100%. `pre-commit run --all-files`, the full suite and
the `-W` docs build are green.

### One thing noticed and not changed

`_finalized_input` adds BIP 147's empty push only when it holds more than
one signature (`cmds = [b""] if len(sigs) > 1 else []`), which is a
reasonable guess at "is this a multisig" everywhere except a 1-of-n:
finalizing a `wsh(multi(1,…))` input builds a witness that OP_CHECKMULTISIG
will underflow. `MultiDescriptor` always prepends it, knowing it is a
multisig, so the two disagree there and the cross-check uses 2-of-3.
Left alone as a change to psbt behaviour that belongs in its own issue.

### Not in this PR

The BIP 174 **Updater** — descriptor to psbt input fields, so that
signers can fill `partial_sigs` at their own pace and the existing
finalizer assembles. Its shape is visible in the cross-check test, which
builds those fields by hand; #263's comment sets out the case for it as
the follow-up.

## Summary by Sourcery

Add support for constructing spending data from descriptors using provided signatures, and validate this behavior against existing PSBT finalization.

New Features:
- Expose Descriptor.satisfy to build scriptSig and witness for a descriptor output from a key-to-signature mapping, including support for taproot, multisig, and ranged descriptors.

Enhancements:
- Unify satisfaction logic across fragment classes via a shared stack abstraction and enforce clearer index validation on descriptor usage.
- Provide explicit errors for unsatisfiable descriptors such as addr(), raw(), combo(), and for missing or insufficient signatures.

Documentation:
- Extend descriptor module and changelog documentation to describe satisfaction semantics and limitations.

Tests:
- Add comprehensive tests ensuring Descriptor.satisfy matches PSBT finalization across supported descriptor forms, checks key/signature ordering and multiplicity, and covers taproot key and script paths as well as error cases.