### PR TITLE
Record why ellswift's encode negates t, which no Python reference does

### DIFF
--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -216,7 +216,14 @@ def _ell_from_point(Q: Point, ec: Curve) -> bytes:
         if t is None:
             continue
         # _xswiftec_inv pins the x-coordinate alone, so t and p-t encode
-        # the two points of that x: the parity of t has to be the y's
+        # the two points of that x: the parity of t has to be the y's.
+        # Neither Python reference has this step and neither is wrong --
+        # BIP324's reference.py and Core's crypto/ellswift.py are x-only
+        # end to end, so no y ever reaches them -- while libsecp256k1
+        # wraps the same x-only map in the same condition, its
+        # elligatorswift_var over xelligatorswift_var. It is here because
+        # `decode` answers with a point; without it, half the encodings
+        # would decode to -Q
         if t % 2 != Q[1] % 2:
             t = p - t
         return u.to_bytes(size, "big") + t.to_bytes(size, "big")


### PR DESCRIPTION
Follow-up to #302 (issue #270). **Comment only — no behaviour change**, so
nothing for `CHANGELOG.md`.

## What was thin

`_ell_from_point` negates `t` when its parity is not the y's, and the
comment gave the mechanism without the provenance:

```python
# _xswiftec_inv pins the x-coordinate alone, so t and p-t encode
# the two points of that x: the parity of t has to be the y's
```

True, and not enough to keep the step alive. `_xswiftec_inv` pins an
x-coordinate, so `t` and `p-t` encode the two points sharing it; encoding
a *point* has to pick one. Anybody checking btclib against the references
#270 names finds no counterpart in either, with nothing on the page saying
that is expected — which is how a correct line gets deleted as a
divergence.

## Why the references look different

Measured against all three sources rather than assumed:

| source | has the step? | why |
| --- | --- | --- |
| `bip-0324/reference.py` | no | `xelligatorswift(x)` takes an x; `ellswift_create` hands it `(priv*G).x`, and `ellswift_decode` returns 32 x-only bytes |
| Core `test_framework/crypto/ellswift.py` | no | the same code and the same shape — `xswiftec`, `xswiftec_inv`, `xelligatorswift`, `ellswift_create`, `ellswift_ecdh_xonly`, x-only throughout |
| libsecp256k1 | **yes** | `secp256k1_ellswift_elligatorswift_var` wraps the x-only `xelligatorswift_var` with exactly this condition |

```c
if (secp256k1_fe_is_odd(t) != secp256k1_fe_is_odd(&p->y)) {
    secp256k1_fe_negate(t, t, 1);
}
```

Neither Python reference is wrong: being x-only end to end, no y ever
reaches them, so the question cannot arise. It arises in btclib because
`decode` answers with a `Point` — the library's own vocabulary, and what
makes `encode(decode(ell))` type-check — exactly as it arises in
libsecp256k1, which answers with a public key. btclib's structure already
mirrors the C's, `_ell_from_point` over `_xswiftec_inv`; only the comment
was missing.

Without the step, half the encodings decode to `-Q`. The suite catches it
either way — the round trip is asserted across both implementations — but
a comment that says so is cheaper than a red test to read.

## Symmetry

The decode side already carried this kind of note, naming what BIP324's
reference leaves out and what libsecp256k1 does instead. The encode side
did not, and it is the side where the divergence is visible. This makes
the two halves say the same thing.

## Gates

`pre-commit run --all-files` exit 0, and `pytest tests/ecc/ellswift_test.py`
194 passed, on `dev` at `8a8bfd61`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Expand the inline comment in `_ell_from_point` to explain why t is negated based on y-parity and how this differs from x-only Python references and matches libsecp256k1.