### PR TITLE
Cover the key_id search's fallthrough, which #285 left at 99.99%

### DIFF
--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -768,6 +768,31 @@ def _search_key_id(magic_msg: bytes, dsa_sig: dsa.Sig, q: int) -> int:
     raise AssertionError("no key_id recovers the public key")
 
 
+def test_the_key_id_search_reports_a_key_it_cannot_reach() -> None:
+    """The helper above raises rather than answer, and this is why it can.
+
+    The counterpart of `test_a_key_id_that_recovers_nothing` below: that
+    one is a candidate recovering *no* key, this one is every candidate
+    recovering a key that is not the one asked for. Untested, the
+    fallthrough would be the single line of the cross-check that never
+    runs -- and a search answering 0 for a key it never found would make
+    the callers above agree with the recovery flag for the wrong reason.
+    """
+    msg = b"a message"
+    wif, _addr = bms.gen_keys()
+    bms_sig = bms.sign(msg, wif)
+    magic_msg = magic_message(msg)
+
+    # somebody else's private key: the signature is valid, and none of its
+    # candidates recovers this q's public key
+    other_wif, _other_addr = bms.gen_keys()
+    other_q = prv_keyinfo_from_prv_key(other_wif)[0]
+
+    err_msg = "no key_id recovers the public key"
+    with pytest.raises(AssertionError, match=err_msg):
+        _search_key_id(magic_msg, bms_sig.dsa_sig, other_q)
+
+
 def test_a_key_id_that_recovers_nothing() -> None:
     """The dropped candidate, which is why the helper above returns None.
 

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -591,6 +591,28 @@ def _search_key_id(msg: bytes, sig: dsa.Sig, Q: Point, lower_s: bool = True) -> 
     raise AssertionError("no key_id recovers the public key")
 
 
+def test_the_key_id_search_reports_a_key_it_cannot_reach() -> None:
+    """The helper above raises rather than answer, and this is why it can.
+
+    Its loop returns the first key_id that recovers Q, so a Q no candidate
+    recovers has to leave it with nothing to return. Untested, that
+    fallthrough would be the one line of the cross-check that never runs --
+    and a search that answered 0 for a key it never found would make every
+    caller above agree with `sign_recoverable` for the wrong reason.
+    """
+    msg = b"a message"
+    prv_key, _Q = dsa.gen_keys()
+    sig = dsa.sign(msg, prv_key)
+
+    # a key of somebody else: the signature is valid, and none of its
+    # candidates is this point
+    _other_prv_key, other_Q = dsa.gen_keys()
+
+    err_msg = "no key_id recovers the public key"
+    with pytest.raises(AssertionError, match=err_msg):
+        _search_key_id(msg, sig, other_Q)
+
+
 def test_sign_recoverable_is_sign_plus_the_key_id_a_search_would_find(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
**`dev` is red on a required check.** `coverage-py` fails at 99.99%
against the `fail_under` of 100, which fails `tests-passed` with it —
[run 30839959009](https://github.com/btclib-org/btclib/actions/runs/30839959009),
29 jobs green of 31, and all 16802 tests passing. This is the two lines.

## What is uncovered, and since when

```text
tests/ecc/bms_test.py     532      1  99.81%   768
tests/ecc/dsa_test.py     467      1  99.79%   591
```

Both are the same line — the `raise AssertionError("no key_id recovers the
public key")` that ends a `_search_key_id` helper — and both arrived with
#285 (`8f367a73`).

Not from the ellswift work, which is what the failure was first seen on:
checked out `8f367a73` and ran coverage there, before that commit, and it
is already 99.99% with exactly these two lines.

**Why it surfaced late.** `test.yml`'s concurrency group is
`test-${{ github.ref }}` with cancel-in-progress, so #285's own dev run
was `cancelled` by the next push and never reported. The first completed
dev run after it is the one that went red, and in between the failure
appeared on an unrelated pull request that had inherited it from its base.
That is the cancelled-is-not-green trap costing a bisect: `cancelled`
hides a real `failure` as readily as it hides nothing.

## A test each, not a pragma

The line is reachable, and what reaches it is worth asserting, so this
covers it rather than exempting it.

The search returns the first `key_id` that recovers the point it was asked
about — so the case with nothing to return is a point none of the
candidates recovers: somebody else's public key, against a signature that
is otherwise perfectly valid. In `bms_test` that is the counterpart of the
`test_a_key_id_that_recovers_nothing` right below it: that one is a
candidate recovering *no* key, this one is every candidate recovering a key
that is not the one asked for.

A `pragma: no cover` would have left the single line of a cross-check that
never runs — and a search silently answering `0` for a key it never found
would make every caller agree with `sign_recoverable` for the wrong
reason, which is precisely the failure the helper exists to rule out.

**Checked by mutation** rather than by the coverage number alone: with the
`raise` replaced by `return 0`, the new test fails. Without that check a
green `pytest.raises` proves only that *something* raised.

This is the shape `vendored_data_test.py::test_the_patterns_still_match`
already keeps for the same hazard — an assertion written in the negative
passes for free until something proves it can fail.

## Gates

`pytest --cov=btclib --cov=tests` → **100.00%, 0 missed, 16804 passed**,
and `pre-commit run --all-files` exit 0, on `dev` at `4465863c`.

Tests only, no behaviour change, so nothing for `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add tests to cover the key_id search helper’s assertion when no candidate recovers the requested public key, restoring full test coverage.

Tests:
- Add bms tests ensuring _search_key_id raises when all candidate keys correspond to a different public key than the one requested.
- Add dsa tests ensuring _search_key_id raises when no candidate recovers the specified point despite a valid signature.