### PR TITLE
Recover a public key in libsecp256k1, arithmetic and enumeration (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2827,9 +2827,9 @@ edit.
   computed only to be discarded. Verification delegates the
   single-candidate `dsa.recover_pub_key` to `secp256k1_ecdsa_recover`,
   95 µs against 2330, so every caller of that function gains and not
-  only bms; the plural `recover_pub_keys` has no counterpart in the
-  bindings, stays Python whatever the curve, and is what the tests hold
-  the singular against. bms takes the sec octets the recovery answers
+  only bms; the plural `recover_pub_keys` has no single counterpart in the
+  bindings, an enumeration being btclib's own loop, and is what the tests
+  hold the singular against. bms takes the sec octets the recovery answers
   straight to `hash160`, an address being a hash of those bytes: no point
   is built on either side of the module any more, so the affine
   conversion of a recovered key and the multiplication behind
@@ -3202,6 +3202,49 @@ edit.
   gone with the branch: its only caller was that branch, and the search is
   now spelled in the tests, which is where a cross-check of the key_id
   belongs
+- **public key recovery multiplies in libsecp256k1** (issue #286): step
+  1.6.1 of SEC 1 v.2 section 4.1.6 held the last two
+  `double_mult_w_NAF` calls left in `ecc/`, one in each
+  `_recover_pub_key_`, and both are now the `_jac_double_mult` of issue
+  #281. ECDSA's is 2215 µs to 214 for one candidate and 6800 µs to 850
+  for the enumeration that runs one per key_id; BIP340's x-only recovery
+  3540 µs to 109. Then **`dsa.recover_pub_keys_` stops multiplying
+  altogether on secp256k1 with sha256**, and is four
+  `secp256k1_ecdsa_recover` calls: 83 µs against those 850. An
+  enumeration is btclib's loop and not a function the bindings have --
+  their recovery answers for the one recid it is given, which #282
+  delegated as `recover_pub_key_` because that is what bms asks for --
+  but every candidate in the loop *is* one of those recids, and a recid
+  is two bits, i.e. every candidate a curve of cofactor 1 has. So
+  `range(4)` there is the `range(2 * (ec.cofactor + 1))` of the Python
+  enumeration, in the same order, and the dropped candidates drop the
+  same way: `_libsecp256k1_recover_sec_` maps the bindings' refusal to
+  the `BTClibValueError` the loop already suppressed, so a high-s
+  signature under `lower_s` still enumerates to the empty list where the
+  singular raises. x-only recovery had no such option — libsecp256k1's
+  recovery module is ECDSA and its xonly module carries no recovery — so
+  BIP340's delegated multiplication is the whole of its gain.
+  What is left of a Python ECDSA candidate is the `_y_even` lift,
+  delegated already, and a `mod_inv`, which delegating the multiplication
+  has made measurable: 41 µs of the 214, where the same 41 sat inside
+  2215. Still not hoisted out of the loop, because the plural being
+  `_recover_pub_key_` over a range of key_ids and nothing else is what
+  keeps the two from disagreeing (issue #183), so the paths that reach it
+  pay 19% for the arithmetic being written once. On that Python path the
+  recovered point comes back as `jac_from_aff`, i.e. `z == 1`, where the
+  wNAF answered whatever projective representative its ladder reached:
+  the same point either way, and every caller converts it with
+  `aff_from_jac`. What the enumeration answers is now three
+  implementations' answer and asserted to be one list — the four recover
+  calls, the Python loop with its double_mult delegated, and the same
+  with `curves.curve`'s dispatch patched off as well — because the list
+  is dense and a position in it is what a caller reads a key_id from, so
+  two implementations dropping differently would disagree about a
+  recovery flag without disagreeing about any key. The `j = 1` pair that
+  no signature of secp256k1 can reach (`r + ec.n < ec.p`, some 2^-127 of
+  them) is asserted on a fabricated r instead: `r = 2` recovers all four
+  candidates, `r = 7` only the pair, whose key_ids are 2 and 3 while
+  their positions are 0 and 1
 
 ### Tests
 
@@ -3662,6 +3705,18 @@ edit.
   and that any other cut is refused. Whether the preimage is Bitcoin
   Core's is still the appendix vectors and #176's byte-slice property,
   and an independent oracle (#198) is what would settle it
+- **the two spellings of `dsa.recover_pub_keys` are held to being one
+  function.** `recover_pub_keys_` takes the hash the other reduces, and
+  `challenge_` does not hash it again, so the underscore spelling is the
+  one a caller holding a sig_hash has to reach for — and it had no test
+  naming it, only the lines the msg spelling covers through it. Nothing
+  in btclib calls either since bms began naming its own key_id (issue
+  #269), which is what makes the pairing the whole of their contract: the
+  same keys from both, the signature passed as a `Sig` and as DER octets,
+  under another hash function, and with the lower-s rule off. A high-s
+  signature enumerates to the empty list where the singular raises "not a
+  low s" — every candidate fails the rule and a failing candidate is
+  dropped rather than reported
 
 ### Supported interpreters and dependencies
 

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -45,7 +45,6 @@ from btclib.curves.curve import (
     _libsecp256k1_applicable,
     _y_even,
 )
-from btclib.curves.curve_group_2 import double_mult_w_NAF
 from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point_
 from btclib.ecc.rfc6979_nonce import _rfc6979_nonce_, challenge_
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
@@ -936,10 +935,15 @@ def _recover_pub_keys_(
 ) -> list[JacPoint]:
     # Private function provided for testing purposes only.
 
-    # libsecp256k1 has no counterpart to enumerate with -- its recover
-    # answers for a recid it is given -- so this is the Python path
-    # whatever the curve, and it is what the tests hold the delegated
-    # single-candidate recovery against.
+    # The Python enumeration: `recover_pub_keys_` above asks the bindings
+    # for each of the four recids instead, so what reaches here is every
+    # other curve, every other hash function, and the tests that patch the
+    # dispatch off -- where this is the implementation held against the
+    # bindings, they being the authority on the answer.
+    #
+    # The two have to answer the same list and not merely the same set,
+    # dropped candidates included, which is what those tests asserted
+    # before the delegation existed and assert of both paths now.
     #
     # every candidate is a key_id, so this is _recover_pub_key_ over the
     # whole range of them and nothing else: a j in [0, ec.cofactor] (step
@@ -948,9 +952,14 @@ def _recover_pub_keys_(
     # order key_id numbers them in, so range() is the loop.
     #
     # It costs a mod_inv per candidate rather than hoisting the
-    # precomputation out of the loop, and that is not measurable: each
-    # candidate also runs a double_mult_w_NAF, which on secp256k1 is some
-    # eighty times dearer (1970 us against 23.6 us, timeit).
+    # precomputation out of the loop, and delegating the double_mult below
+    # is what made that measurable: 41 us of the 214 a candidate takes on
+    # secp256k1 with the dispatch off, where the same 41 sat inside 2215.
+    # Still not hoisted, because the plural is `_recover_pub_key_` over a
+    # range of key_ids and nothing else -- issue 183 was the two
+    # disagreeing while each held its own copy of this arithmetic -- so the
+    # paths that reach this loop pay 19% for the singular staying the only
+    # place the arithmetic is written.
     keys: list[JacPoint] = []
     for key_id in range(2 * (ec.cofactor + 1)):
         # a candidate can fail either half of step 1.6: x_K may not be on
@@ -981,6 +990,28 @@ def recover_pub_keys_(
     # The message msg_hash: a hf_len array
     hf_len = hf().digest_size
     msg_hash = bytes_from_octets(msg_hash, hf_len)
+
+    # the enumeration is btclib's loop and not a function libsecp256k1
+    # has, but each candidate in it is a recid the bindings answer for, so
+    # what runs here is four `recover` calls: 83 us against 854 (issue
+    # 286). A recid is two bits, i.e. every candidate a curve of cofactor
+    # 1 has, and _libsecp256k1_applicable admits no other curve --
+    # secp256k1's cofactor is 1, so `range(4)` here is the
+    # `range(2 * (ec.cofactor + 1))` of the Python enumeration above, in
+    # the same order, key_id by key_id
+    if _libsecp256k1_applicable(sig.ec, hf):
+        keys: list[Point] = []
+        for key_id in range(4):
+            # a candidate that recovers nothing is dropped rather than
+            # reported, as in _recover_pub_keys_: the bindings' refusal
+            # arrives as the BTClibValueError _libsecp256k1_recover_sec_
+            # maps it to, and a high-s signature under lower_s enumerates
+            # to the empty list, every candidate failing the same rule
+            with contextlib.suppress(BTClibValueError, BTClibRuntimeError):
+                keys.append(
+                    _libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s)
+                )
+        return keys
 
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 
@@ -1036,7 +1067,20 @@ def _recover_pub_key_(
     y_K = ec.p - y if i else y
     KJ = x_K, y_K, 1  # 1.2, 1.3, and 1.4
     # 1.5 has been performed in the recover_pub_keys calling function
-    QJ = double_mult_w_NAF(r1s, KJ, r1e, ec.GJ, ec)  # 1.6.1
+    #
+    # delegated as the double_mult of _assert_as_valid_ below it is: this
+    # is the Python path of recovery -- the named candidate goes to
+    # secp256k1_ecdsa_recover instead, and the enumeration has no
+    # counterpart to go to at all -- but the arithmetic under it is
+    # libsecp256k1's for secp256k1 all the same, as the lift above is:
+    # 2215 us against 214 for the whole of this function, and 6800 against
+    # 850 for the enumeration that runs it once per candidate.
+    #
+    # It is the same point either way and not the same triple: what comes
+    # back is jac_from_aff, i.e. z == 1, where the wNAF answered whatever
+    # representative its ladder reached. Every caller converts with
+    # aff_from_jac, which is what a Jacobian coordinate is for
+    QJ = _jac_double_mult(r1s, KJ, r1e, ec.GJ, ec)  # 1.6.1
     _assert_as_valid_(c, QJ, r, s, lower_s, ec)  # 1.6.2
     return QJ
 
@@ -1091,6 +1135,26 @@ def _libsecp256k1_recover_sec_(
     return libsecp256k1_keys.serialize(libsecp256k1_keys.parse(sec), compressed=False)
 
 
+def _libsecp256k1_recover_point_(
+    key_id: int, msg_hash: bytes, sig: Sig, lower_s: bool
+) -> Point:
+    # Private function: the caller has asked _libsecp256k1_applicable
+    # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
+    #
+    # 0x04 || x || y (SEC 1 v.2, section 2.3.3), read rather than parsed
+    # through point_from_octets: this is a point libsecp256k1 has just
+    # created, and proving it on the curve again is work with a known
+    # answer. The two callers are the named candidate and the enumeration
+    # over all four of them, which is the only reason this is a function:
+    # bms wants the octets and never builds the point at all.
+    sec = _libsecp256k1_recover_sec_(key_id, msg_hash, sig, lower_s, compressed=False)
+    p_size = sig.ec.p_size
+    return (
+        int.from_bytes(sec[1 : 1 + p_size], byteorder="big", signed=False),
+        int.from_bytes(sec[1 + p_size :], byteorder="big", signed=False),
+    )
+
+
 def recover_pub_key_(
     key_id: int,
     msg_hash: Octets,
@@ -1121,18 +1185,7 @@ def recover_pub_key_(
     # x_K = r + ec.n - ec.p otherwise, which fails step 1.6.2 for every r
     # -- passing it would need ec.p ≡ 0 mod ec.n
     if _libsecp256k1_applicable(sig.ec, hf) and 0 <= key_id <= 3:
-        sec = _libsecp256k1_recover_sec_(
-            key_id, msg_hash, sig, lower_s, compressed=False
-        )
-        # 0x04 || x || y (SEC 1 v.2, section 2.3.3), read rather than
-        # parsed through point_from_octets: this is a point libsecp256k1
-        # has just created, and proving it on the curve again is work with
-        # a known answer
-        p_size = sig.ec.p_size
-        return (
-            int.from_bytes(sec[1 : 1 + p_size], byteorder="big", signed=False),
-            int.from_bytes(sec[1 + p_size :], byteorder="big", signed=False),
-        )
+        return _libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s)
 
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -83,7 +83,6 @@ from btclib.curves.curve import (
     mult,
     multi_mult,
 )
-from btclib.curves.curve_group_2 import double_mult_w_NAF
 from btclib.ecc.bip340_nonce import bip340_nonce_
 from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point_
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
@@ -610,8 +609,18 @@ def _recover_pub_key_(c: int, r: int, s: int, ec: Curve) -> int:
     KJ = r, _y_even(r, ec), 1
 
     e1 = mod_inv(c, ec.n)
-    QJ = double_mult_w_NAF(ec.n - e1, KJ, e1 * s, ec.GJ, ec)
-    # QJ = e1*(s*G - K) is INF whenever r is the x of s*G, y even
+    # libsecp256k1 recovers no x-only key -- its recovery module is ECDSA
+    # ("recover(msg, signature, recid)") and its xonly module has no
+    # recovery in it -- so the delegated double_mult is the whole of what
+    # there is to gain here, and it is all of the cost: 3540 us against
+    # 109 for this function. Which is also why this stays private, with no
+    # public spelling above it: BIP340 has no recovery flag to carry the
+    # candidate, x-only keys leaving nothing for one to disambiguate
+    QJ = _jac_double_mult(ec.n - e1, KJ, e1 * s, ec.GJ, ec)
+    # QJ = e1*(s*G - K) is INF whenever r is the x of s*G, y even, and
+    # that answer comes back from the bindings too: a libsecp256k1 pubkey
+    # is never the identity, so the sum is recognized from the coordinates
+    # in curves.curve and handed back as the z == 0 tested here
     if QJ[2] == 0:
         err_msg = "invalid (INF) key"
         raise BTClibRuntimeError(err_msg)

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -533,6 +533,14 @@ def _recovered(
         return None
 
 
+def _recovered_(key_id: int, msg_hash: bytes, sig: dsa.Sig) -> Point | None:
+    """The same, for a caller holding the hash rather than the message."""
+    try:
+        return dsa.recover_pub_key_(key_id, msg_hash, sig)
+    except (BTClibValueError, BTClibRuntimeError):
+        return None
+
+
 def test_libsecp256k1_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
     """`recover_pub_key` through secp256k1_ecdsa_recover.
 
@@ -543,8 +551,10 @@ def test_libsecp256k1_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
     recovery flag of a message signature carries a key_id from outside, so
     the number has to mean there what it means here.
 
-    `recover_pub_keys` beside them is the enumeration, which has no
-    counterpart in the bindings and stays Python whatever the curve.
+    `recover_pub_keys` beside them is the enumeration, which is these same
+    four recids on secp256k1 with sha256 and the Python loop everywhere
+    else; `test_recovery_multiplies_in_libsecp256k1` below is where the
+    three implementations of it are held to one list.
     """
     msg = b"Satoshi Nakamoto"
     for q in (0x1, 0x2, prv_key_int, secp256k1.n - 1):
@@ -576,6 +586,134 @@ def test_libsecp256k1_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
         with pytest.raises(BTClibValueError, match=err_msg):
             dsa.recover_pub_key(key_id ^ 1, msg, malleated)
         assert _recovered(key_id ^ 1, msg, malleated, lower_s=False) == Q
+
+
+def test_recover_pub_keys_takes_the_hash_that_recover_pub_keys_reduces() -> None:
+    """The two spellings of the enumeration are one function.
+
+    `challenge_` reduces a digest to an integer and does not hash it
+    again, so the underscore spelling is the one a caller holding a hash
+    -- a sig_hash, the `reduce_to_hlen(magic_message(msg))` of a message
+    signature -- has to reach for: the other would hash it a second time.
+    Nothing in btclib calls either, bms naming its own key_id since issue
+    269, so this is what holds the pairing that justifies both.
+
+    The malleated signature is the plural's answer where the singular
+    raises: a candidate that fails is dropped rather than reported, and
+    every candidate fails the lower-s rule at once, so the enumeration of
+    a high-s signature is empty and not an error. Both spellings say so on
+    both implementations -- sha256 here is the four recover calls, sha512
+    the Python loop -- the rule being btclib's either way, since the
+    recoverable parser takes any s in [1, n-1].
+    """
+    msg = b"Satoshi Nakamoto"
+    for q in (0x1, 0x2, prv_key_int, secp256k1.n - 1):
+        prv_key, Q = dsa.gen_keys(q)
+        # the hash function is the argument both spellings thread through
+        # to the challenge, and it is also what the dispatch reads: sha256
+        # enumerates through the bindings, sha512 through the Python loop
+        for hf in (sha256, sha512):
+            msg_hash = reduce_to_hlen(msg, hf)
+            sig = dsa.sign(msg, prv_key, hf=hf)
+            keys = dsa.recover_pub_keys(msg, sig, hf=hf)
+            assert Q in keys
+            assert dsa.recover_pub_keys_(msg_hash, sig, hf=hf) == keys
+            # the octets spelling of both arguments, which is the shape a
+            # caller of the public API is likelier to hold
+            assert dsa.recover_pub_keys_(msg_hash.hex(), sig.serialize(), hf=hf) == keys
+
+            malleated = dsa.Sig(sig.r, secp256k1.n - sig.s)
+            assert dsa.recover_pub_keys_(msg_hash, malleated, hf=hf) == []
+            assert Q in dsa.recover_pub_keys_(msg_hash, malleated, lower_s=False, hf=hf)
+
+
+def test_recovery_multiplies_in_libsecp256k1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The three implementations of the enumeration, and one answer (issue 286).
+
+    On secp256k1 with sha256 `recover_pub_keys` is four
+    `secp256k1_ecdsa_recover` calls: the enumeration is btclib's loop --
+    the bindings recover the one candidate a recid names -- but every
+    candidate in it is one of those recids. Patching `dsa`'s own dispatch
+    off reaches the Python enumeration, whose step 1.6.1 is still
+    libsecp256k1's; patching `curves.curve`'s off as well reaches the wNAF
+    under that.
+
+    The three have to answer the same *list* and not merely the same set:
+    a candidate that fails step 1.6 is dropped rather than reported, so
+    the position of a key in it is what a caller reads a key_id from, and
+    two implementations that drop differently would disagree about the
+    recovery flag of a message signature without disagreeing about any
+    key. Which is why `no_bindings` alone is not this test: it leaves
+    `dsa`'s dispatch on, and the comparison would be the bindings against
+    themselves.
+    """
+    msg = b"Satoshi Nakamoto"
+    for q in (0x1, 0x2, prv_key_int, secp256k1.n - 1):
+        prv_key, Q = dsa.gen_keys(q)
+        sig = dsa.sign(msg, prv_key)
+        # four recover calls, which is what production runs here
+        keys = dsa.recover_pub_keys(msg, sig)
+        assert Q in keys
+        key_ids = range(2 * (secp256k1.cofactor + 1))
+        # and the same, candidate by candidate, None where one recovers
+        # nothing: the enumeration is these four answers less the Nones
+        recovered = [_recovered(key_id, msg, sig) for key_id in key_ids]
+        assert [key for key in recovered if key is not None] == keys
+
+        with monkeypatch.context() as patch:
+            # the Python enumeration, its double_mult still delegated
+            patch.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            assert dsa.recover_pub_keys(msg, sig) == keys
+            assert [_recovered(key_id, msg, sig) for key_id in key_ids] == recovered
+
+            # and the same with the arithmetic under it patched off too
+            no_bindings(patch)
+            assert dsa.recover_pub_keys(msg, sig) == keys
+            assert [_recovered(key_id, msg, sig) for key_id in key_ids] == recovered
+
+
+@pytest.mark.parametrize(
+    ("r", "expected_key_ids"),
+    [(2, [0, 1, 2, 3]), (7, [2, 3])],
+    ids=["four-candidates", "the-j-one-pair-alone"],
+)
+def test_the_enumeration_asks_for_the_j_one_candidates(
+    r: int, expected_key_ids: list[int], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """key_id 2 and 3, which no signature of secp256k1 will produce.
+
+    They need `r + ec.n < ec.p`, some 2^-127 of signatures, so a signature
+    cannot reach them and the enumeration would answer the same list with
+    those two candidates never asked for. An r is fabricated instead: with
+    `r = 2` both r and `r + ec.n` are x-coordinates of the curve and all
+    four candidates recover, and with `r = 7` only `r + ec.n` is, so the
+    list is two keys long and their key_ids are 2 and 3 -- the dense-list
+    case, where an index into the list is not the key_id that produced it.
+
+    `(r, s)` is no signature anybody made, and does not have to be: step
+    1.6 is arithmetic on r and s, and the key it recovers satisfies the
+    equation by construction. What it pins is that the four `recover` calls
+    ask for the same candidates as the Python loop, in the same order, and
+    drop the same ones -- on the two key_ids the bindings and the Python
+    path arrive at differently, `recid & 2` against `(r + j*ec.n) % ec.p`.
+    """
+    msg_hash = reduce_to_hlen(b"Satoshi Nakamoto")
+    sig = dsa.Sig(r, 12345)
+
+    keys = dsa.recover_pub_keys_(msg_hash, sig)
+    candidates = [_recovered_(key_id, msg_hash, sig) for key_id in range(4)]
+    assert [
+        key_id for key_id, key in enumerate(candidates) if key is not None
+    ] == expected_key_ids
+    assert [key for key in candidates if key is not None] == keys
+
+    with monkeypatch.context() as patch:
+        patch.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+        assert dsa.recover_pub_keys_(msg_hash, sig) == keys
+        no_bindings(patch)
+        assert dsa.recover_pub_keys_(msg_hash, sig) == keys
 
 
 def _search_key_id(msg: bytes, sig: dsa.Sig, Q: Point, lower_s: bool = True) -> int:

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -759,14 +759,53 @@ def test_zero_challenge() -> None:
         ssa.challenge_(msg_hash, 1, 1, ec, hf)
 
 
-def test_recover_infinity_pub_key() -> None:
+def test_recover_infinity_pub_key(monkeypatch: pytest.MonkeyPatch) -> None:
     """The recovered Q = e1*(s*G - K) is INF whenever s*G equals K.
 
     G's y-coordinate is even, so r = G.x picks K = G, and s = 1 then
     makes the recovered key INF whatever the challenge. The
     low-cardinality loop can never get here: its s comes from a real
     signature, hence s*G - K = c*q*G with c and q both nonzero.
+
+    Both arithmetics answer it, which is what the delegated double_mult of
+    issue 286 turns on: a libsecp256k1 pubkey is never the identity, so
+    the sum is recognized from the coordinates in curves.curve and handed
+    back as the z == 0 this function tests -- u*H + v*Q with v*Q == -u*H
+    is exactly the case, u being n - e1 and v being e1 here.
     """
     err_msg = r"invalid \(INF\) key"
     with pytest.raises(BTClibRuntimeError, match=err_msg):
         ssa._recover_pub_key_(1, secp256k1.G[0], 1, secp256k1)
+
+    no_bindings(monkeypatch)
+    with pytest.raises(BTClibRuntimeError, match=err_msg):
+        ssa._recover_pub_key_(1, secp256k1.G[0], 1, secp256k1)
+
+
+def test_recovery_multiplies_in_libsecp256k1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """x-only recovery on both point arithmetics (issue 286).
+
+    Nothing in libsecp256k1 recovers an x-only key: its recovery module is
+    ECDSA -- `recover(msg, signature, recid)` -- and its xonly module has
+    no recovery in it, so the double_mult under this function is the whole
+    of what there is to delegate, and the Python arithmetic is reachable
+    only by patching the dispatch off. What this catches is the two
+    disagreeing about the recovered x_Q.
+
+    The low-cardinality loop asserts the same equality exhaustively, and
+    on the Python arithmetic alone: those curves are not secp256k1, so
+    nothing there reaches the bindings this compares against.
+    """
+    ec = secp256k1
+    for i in range(1, 5):
+        msg_hash = reduce_to_hlen(bytes([i]) * 32)
+        q, x_Q = ssa.gen_keys(i)
+        sig = ssa.sign_(msg_hash, q)
+        c = ssa.challenge_(msg_hash, x_Q, sig.r, ec, hf)
+
+        assert ssa._recover_pub_key_(c, sig.r, sig.s, ec) == x_Q
+        with monkeypatch.context() as patch:
+            no_bindings(patch)
+            assert ssa._recover_pub_key_(c, sig.r, sig.s, ec) == x_Q


### PR DESCRIPTION
Closes #286: both of its open options, in the order the issue put them.

## 1. The double_mult of both `_recover_pub_key_`

Step 1.6.1 of SEC 1 v.2 section 4.1.6 held the last two
`double_mult_w_NAF` calls left in `ecc/`, and both are now the
`_jac_double_mult` of #281. Measured over 40 random keys, one process,
with only step 1.6.1 substituted — so `_assert_as_valid_` and the
`_y_even` lift stay delegated on both sides of the pair:

| operation | before | after | |
| --- | --- | --- | --- |
| `dsa._recover_pub_key_`, one candidate | 2215 µs | 214 µs | 10.4× |
| `dsa._recover_pub_keys_`, all candidates | 6800 µs | 850 µs | 8.0× |
| `ssa._recover_pub_key_` | 3540 µs | 109 µs | 32.5× |

Nothing in libsecp256k1 recovers an x-only key — the recovery module is
ECDSA, the xonly module has no recovery in it — so for BIP340 that
multiplication is the whole of the gain, and there is nothing further to
decide about it.

## 2. And the enumeration itself, on secp256k1 with sha256

`recover_pub_keys_` now stops multiplying altogether there: four
`secp256k1_ecdsa_recover` calls, **83 µs against those 850**.

An enumeration is btclib's loop and not a function the bindings have —
their recovery answers for the one recid it is *given*, which #282
delegated as `recover_pub_key_` because that is what bms asks for — but
every candidate in the loop is one of those recids, and a recid is two
bits, i.e. every candidate a curve of cofactor 1 has, the only kind
`_libsecp256k1_applicable` admits. So `range(4)` is the
`range(2 * (ec.cofactor + 1))` of the Python enumeration, in the same
order, and the drops match: `_libsecp256k1_recover_sec_` already maps the
bindings' refusal to the `BTClibValueError` the loop suppresses, so a
high-s signature under `lower_s` still enumerates to the empty list where
the singular raises.

`_libsecp256k1_recover_point_` is the sec octets read as the point they
are, factored out of `recover_pub_key_` because the enumeration wants it
four times. bms is untouched: it takes the octets and builds no point.

## Three implementations, asserted to be one list

The four recover calls; the Python loop with its double_mult delegated;
the same with `curves.curve`'s dispatch off as well.

A **list** and not a set, because the list is dense — a candidate that
fails step 1.6 is dropped rather than reported — so a position in it is
what a caller reads a key_id from, and two implementations dropping
differently would disagree about the recovery flag of a message signature
without disagreeing about any key.

`no_bindings` alone would not have tested this: it patches
`curves.curve`'s dispatch, leaves `dsa`'s own on, and the comparison
would have been the bindings against themselves. That trap is now named
in the test's docstring.

**The `j = 1` candidates are fabricated rather than signed.** key_id 2
and 3 need `r + ec.n < ec.p`, some 2^-127 of signatures, so no signature
of secp256k1 reaches them and a loop asking for neither would pass every
other test in the suite. `r = 2` has both `r` and `r + ec.n` on the curve
and recovers all four; `r = 7` only the pair, whose key_ids are 2 and 3
while their positions are 0 and 1 — the dense-list case itself. `(r, s)`
is no signature anybody made and does not need to be: step 1.6 is
arithmetic on r and s.

Checked by mutation, each against the whole dsa suite:

| mutation of the recid loop | before this case existed | now |
| --- | --- | --- |
| `range(3)` | passed | 2 failed |
| `range(2)` | passed | 2 failed |
| `range(1, 4)` | 4 failed | 5 failed |
| `reversed(range(4))` | 1 failed | 3 failed |

## What the delegation surfaced

The `mod_inv` per Python candidate, 41 µs of the 214 where the same 41
sat inside 2215. It stays in the loop rather than hoisted: the plural is
`_recover_pub_key_` over a range of key_ids and nothing else, and #183
was those two disagreeing while each held its own copy of the arithmetic.
The comment says the 19% instead of the old "not measurable".

Also **#286's `y_even` bullet was stale** — #284 delegated that lift
before this branch existed, and it costs 6.0 µs, not the 73.8 µs the
issue quoted. Recorded in the issue.

## `dsa.recover_pub_keys_` gets the test it never had

Only the lines `recover_pub_keys` covers through it. It takes the hash
the other reduces, and `challenge_` does not hash it again, so it is the
spelling a caller holding a sig_hash has to reach for; nothing in btclib
calls either since bms began naming its own key_id (#269), which leaves
the pairing as the whole of their contract. Asserted through `Sig` and
through DER octets, with `lower_s` off, and under both hash functions —
sha256 being the delegated enumeration and sha512 the Python loop.

## Gates

```text
uv run --locked pytest                                    16810 passed
pytest --cov=btclib --cov=tests                           100.00%
uv run pre-commit run --files <the three>                 exit 0
sphinx-build -W --keep-going                              build succeeded
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
