### PR TITLE
Thread check_validity through decode_from_bip32_derivs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1956,6 +1956,16 @@ edit.
   spend of two whole blocks turned back into the psbt it was signed
   from, where the estimate of an input is exactly what the input took
   with each of its signatures at 72 bytes (issue #209)
+- **`decode_from_bip32_derivs` takes `check_validity`**, which it used to
+  drop: its `master_fingerprint` size check ran unconditionally, so
+  `Psbt.from_dict(d, check_validity=False)` raised on a bad
+  `master_fingerprint` while every other malformed field of the same
+  `d` was accepted for the caller to inspect. `Psbt.from_dict`,
+  `PsbtIn.from_dict` and `PsbtOut.from_dict` now pass
+  `check_validity=False` into it, matching what they already pass into
+  every other nested field they build from a dict; the fingerprint is
+  checked, as they are, by `assert_valid_hd_key_paths` inside
+  `Psbt.assert_valid` (issue #264)
 
 ### The public API and the module layout
 

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -157,18 +157,28 @@ def encode_to_bip32_derivs(
 
 def _decode_from_bip32_deriv(
     bip32_deriv: Mapping[str, str],
+    *,
+    check_validity: bool = True,
 ) -> tuple[bytes, BIP32KeyOrigin]:
-    # issue 264: the size checks here cannot be switched off, so an invalid
-    # master_fingerprint or pub_key cannot be instantiated even deliberately
-    # -- a check_validity question, now that the flag is keyword-only
-    master_fingerprint = bytes_from_octets(bip32_deriv["master_fingerprint"], 4)
+    master_fingerprint = bytes_from_octets(
+        bip32_deriv["master_fingerprint"], 4 if check_validity else None
+    )
     der_path = indexes_from_der_path(bip32_deriv["path"])
-    key_origin = BIP32KeyOrigin(master_fingerprint, der_path)
+    key_origin = BIP32KeyOrigin(
+        master_fingerprint, der_path, check_validity=check_validity
+    )
     return bytes_from_octets(bip32_deriv["pub_key"]), key_origin
 
 
 def decode_from_bip32_derivs(
     bip32_derivs: Sequence[Mapping[str, str]],
+    *,
+    check_validity: bool = True,
 ) -> HdKeyPaths:
     """Return the dataclass element from its json representation."""
-    return dict(sorted([_decode_from_bip32_deriv(item) for item in bip32_derivs]))
+    return dict(
+        sorted(
+            _decode_from_bip32_deriv(item, check_validity=check_validity)
+            for item in bip32_derivs
+        )
+    )

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -793,7 +793,9 @@ class Psbt:
     ) -> Psbt:
         hd_key_paths = cast(
             Mapping[Octets, BIP32KeyOrigin],
-            decode_from_bip32_derivs(dict_["bip32_derivs"]),
+            # check_validity=False, as for every other element here (issue
+            # 264): Psbt.assert_valid below validates it as part of the whole
+            decode_from_bip32_derivs(dict_["bip32_derivs"], check_validity=False),
         )
         return cls(
             dict_["tx_version"],

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -745,11 +745,15 @@ class PsbtIn:
     ) -> PsbtIn:
         hd_key_paths = cast(
             Mapping[Octets, BIP32KeyOrigin],
-            decode_from_bip32_derivs(dict_["bip32_derivs"]),
+            # check_validity=False, as for every other element here (issue
+            # 264): PsbtIn.assert_valid below validates it as part of the whole
+            decode_from_bip32_derivs(dict_["bip32_derivs"], check_validity=False),
         )
         taproot_hd_key_paths = cast(
             Mapping[Octets, tuple[list[Octets], BIP32KeyOrigin]],
-            decode_from_bip32_derivs(dict_["taproot_hd_key_paths"]),
+            decode_from_bip32_derivs(
+                dict_["taproot_hd_key_paths"], check_validity=False
+            ),
         )
         return cls(
             Tx.from_dict(dict_["non_witness_utxo"], check_validity=False)

--- a/btclib/psbt/psbt_out.py
+++ b/btclib/psbt/psbt_out.py
@@ -224,7 +224,9 @@ class PsbtOut:
     ) -> PsbtOut:
         hd_key_paths = cast(
             Mapping[Octets, BIP32KeyOrigin],
-            decode_from_bip32_derivs(dict_["bip32_derivs"]),
+            # check_validity=False, as for every other element here (issue
+            # 264): PsbtOut.assert_valid below validates it as part of the whole
+            decode_from_bip32_derivs(dict_["bip32_derivs"], check_validity=False),
         )
         taproot_hd_key_paths = cast(
             Mapping[Octets, tuple[list[bytes], BIP32KeyOrigin]],

--- a/tests/bip32/key_origin_test.py
+++ b/tests/bip32/key_origin_test.py
@@ -131,3 +131,22 @@ def test_bip32_derivs() -> None:
         BTClibValueError, match="Duplicated key origin values in hd_key_paths"
     ):
         assert_valid_hd_key_paths(hd_key_paths)
+
+
+def test_bip32_derivs_check_validity() -> None:
+    # issue 264: check_validity=False lets a malformed master_fingerprint
+    # through decode_from_bip32_derivs, the way every other check_validity
+    # does -- deferred to assert_valid_hd_key_paths rather than refused here
+    bip32_derivs = [
+        {
+            "pub_key": "029583bf39ae0a609747ad199addd634fa6108559d6c5cd39b4c2183f1ab96e07f",
+            "master_fingerprint": "d90c6a",
+            "path": f"m/0{_HARDENING}/0/0",
+        },
+    ]
+    with pytest.raises(BTClibValueError, match="invalid size: "):
+        decode_from_bip32_derivs(bip32_derivs)
+
+    hd_key_paths = decode_from_bip32_derivs(bip32_derivs, check_validity=False)
+    with pytest.raises(BTClibValueError, match="invalid master fingerprint length: "):
+        assert_valid_hd_key_paths(hd_key_paths)


### PR DESCRIPTION
## Summary

- `_decode_from_bip32_deriv` built its `BIP32KeyOrigin` with an
  unconditional `master_fingerprint` size check, so
  `Psbt.from_dict(d, check_validity=False)` raised on a bad
  `master_fingerprint` while accepting every other malformed field of the
  same dict — the one flag in the library that meant something different
  here than everywhere else.
- `decode_from_bip32_derivs`/`_decode_from_bip32_deriv` now take
  `check_validity`. `Psbt.from_dict`, `PsbtIn.from_dict` and
  `PsbtOut.from_dict` pass `check_validity=False`, matching what they
  already pass to every other nested field built from the same dict, and
  defer the check to `assert_valid_hd_key_paths` inside their own
  `assert_valid` — same pattern, same place it was already checked.
- Resolves #264 by taking option 1 ("thread it") of the two the issue
  laid out.

## Test plan

- [x] `uv run pytest` (full suite, 16805 passed)
- [x] `uv run pre-commit run --all-files`
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html`
- [x] new test: `check_validity=False` lets a malformed
      `master_fingerprint` through `decode_from_bip32_derivs`, and
      `assert_valid_hd_key_paths` still catches it afterwards

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Thread the check_validity flag through BIP32 key origin decoding so PSBT deserialization can defer master fingerprint validation to the standard assert_valid path.

Bug Fixes:
- Ensure Psbt.from_dict, PsbtIn.from_dict, and PsbtOut.from_dict honor check_validity for BIP32 key origins instead of always enforcing master_fingerprint size checks.

Enhancements:
- Extend decode_from_bip32_derivs and its helper to accept a check_validity flag consistent with other decoding utilities, aligning validation behavior across PSBT components.

Documentation:
- Document the new check_validity behavior of decode_from_bip32_derivs and its interaction with PSBT validity checks in the changelog.

Tests:
- Add tests verifying that decode_from_bip32_derivs respects check_validity for malformed master_fingerprint values and that assert_valid_hd_key_paths still detects invalid fingerprints.