### PR TITLE
A taproot pub_key is 32 bytes, and check_validity reaches it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1966,6 +1966,19 @@ edit.
   every other nested field they build from a dict; the fingerprint is
   checked, as they are, by `assert_valid_hd_key_paths` inside
   `Psbt.assert_valid` (issue #264)
+- **`taproot_bip32_from_dict` checks a `pub_key` against 32 bytes**, where
+  it checked it against 4: `master_fingerprint`'s size, copied onto the
+  x-only key BIP371 gives as 32 bytes and
+  `assert_valid_taproot_bip32_derivation` already checked as 32. So
+  `PsbtOut.to_dict` wrote a `taproot_hd_key_paths` that
+  `PsbtOut.from_dict` refused with `invalid size: 32 bytes instead of 4`
+  — every real taproot output derivation, the json round trip being the
+  only path through the function; the binary one goes through
+  `parse_taproot_bip32` and was unaffected. It also takes
+  `check_validity` now, as `decode_from_bip32_derivs` does since #264, so
+  `PsbtOut.from_dict(d, check_validity=False)` defers both size checks to
+  `PsbtOut.assert_valid` rather than raising where nothing else in the
+  same dict does (issue #311)
 
 ### The public API and the module layout
 

--- a/btclib/psbt/psbt_out.py
+++ b/btclib/psbt/psbt_out.py
@@ -230,7 +230,10 @@ class PsbtOut:
         )
         taproot_hd_key_paths = cast(
             Mapping[Octets, tuple[list[bytes], BIP32KeyOrigin]],
-            taproot_bip32_from_dict(dict_["taproot_hd_key_paths"]),
+            # and the same for the taproot derivations (issue 311)
+            taproot_bip32_from_dict(
+                dict_["taproot_hd_key_paths"], check_validity=False
+            ),
         )
         return cls(
             script_from_dict(dict_["redeem_script"]),

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -345,14 +345,19 @@ def taproot_bip32_to_dict(
 
 def taproot_bip32_from_dict(
     taproot_hd_key_paths: list[dict[str, str]],
+    *,
+    check_validity: bool = True,
 ) -> dict[bytes, tuple[list[bytes], BIP32KeyOrigin]]:
     """Return a tap_bip32_derivation from its json representation."""
     return {
-        bytes_from_octets(bip32_deriv["pub_key"], 4): (
+        bytes_from_octets(bip32_deriv["pub_key"], 32 if check_validity else None): (
             [bytes_from_octets(x) for x in bip32_deriv["leaf_hashes"]],
             BIP32KeyOrigin(
-                bytes_from_octets(bip32_deriv["master_fingerprint"], 4),
+                bytes_from_octets(
+                    bip32_deriv["master_fingerprint"], 4 if check_validity else None
+                ),
                 indexes_from_der_path(bip32_deriv["path"]),
+                check_validity=check_validity,
             ),
         )
         for bip32_deriv in taproot_hd_key_paths

--- a/tests/psbt/psbt_out_test.py
+++ b/tests/psbt/psbt_out_test.py
@@ -11,11 +11,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from io import BytesIO
+from typing import Any, cast
 
 import pytest
 
 from btclib.alias import Octets
+from btclib.bip32 import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
 from btclib.psbt import (
     Psbt,
@@ -26,7 +29,7 @@ from btclib.psbt import (
     encode_dict_bytes_bytes,
     serialize_dict_bytes_bytes,
 )
-from btclib.psbt.psbt_utils import PSBT_SEPARATOR
+from btclib.psbt.psbt_utils import PSBT_SEPARATOR, taproot_bip32_from_dict
 from tests.conftest import JsonGolden
 
 
@@ -111,6 +114,48 @@ def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
     assert isinstance(psbt_out2, PsbtOut)
 
     assert psbt_out == psbt_out2
+
+
+def test_taproot_hd_key_paths_round_trips_through_dict() -> None:
+    """issue 311: a 32-byte pub_key used to be checked against 4 bytes.
+
+    `taproot_bip32_from_dict` copied `master_fingerprint`'s size check onto
+    `pub_key`, so no real taproot output derivation survived a
+    to_dict/from_dict round trip.
+    """
+    pub_key = "11" * 32
+    taproot_hd_key_paths: dict[Octets, tuple[list[bytes], BIP32KeyOrigin]] = {
+        pub_key: ([], BIP32KeyOrigin("d90c6a4f", "m/0"))
+    }
+    psbt_out = PsbtOut(taproot_hd_key_paths=taproot_hd_key_paths)
+
+    dict_ = psbt_out.to_dict()
+    assert dict_["taproot_hd_key_paths"]
+    assert PsbtOut.from_dict(dict_) == psbt_out
+
+
+def test_taproot_bip32_from_dict_check_validity() -> None:
+    # check_validity=False lets a malformed pub_key or master_fingerprint
+    # through, the way decode_from_bip32_derivs does for hd_key_paths
+    # (issue 264) -- deferred to PsbtOut.assert_valid rather than refused
+    # here
+    bip32_derivs: list[dict[str, Any]] = [
+        {
+            "pub_key": "11" * 4,
+            "leaf_hashes": [],
+            "master_fingerprint": "d90c6a4f",
+            "path": "m/0",
+        }
+    ]
+    with pytest.raises(BTClibValueError, match="invalid size: "):
+        taproot_bip32_from_dict(bip32_derivs)
+
+    taproot_hd_key_paths = cast(
+        "Mapping[Octets, tuple[list[bytes], BIP32KeyOrigin]]",
+        taproot_bip32_from_dict(bip32_derivs, check_validity=False),
+    )
+    with pytest.raises(BTClibValueError, match="invalid taproot bip32 derivation"):
+        PsbtOut(taproot_hd_key_paths=taproot_hd_key_paths)
 
 
 def test_scripts_are_rendered_as_asm_and_hex() -> None:


### PR DESCRIPTION
## Summary

Two things in `taproot_bip32_from_dict` (`psbt_utils.py`), the function
`PsbtOut.from_dict` builds `taproot_hd_key_paths` with.

- **The bug.** `pub_key` was checked against 4 bytes —
  `master_fingerprint`'s size, copied onto the x-only key BIP371 gives as
  32 and `assert_valid_taproot_bip32_derivation` already checks as 32. So
  `PsbtOut.to_dict` wrote a `taproot_hd_key_paths` that
  `PsbtOut.from_dict` refused with `invalid size: 32 bytes instead of 4`,
  for every real taproot output derivation. The json round trip is the
  only path through this function — the binary one goes through
  `parse_taproot_bip32` — which is why nothing caught it.
- **#264's question, same answer.** Both size checks now take
  `check_validity`, as `decode_from_bip32_derivs` does since #310, and
  `PsbtOut.from_dict` passes `check_validity=False` — matching every other
  nested field it builds from the same dict, and deferring to
  `PsbtOut.assert_valid`.

Resolves #311. Independent of #310: different function, no shared lines,
either can land first (the CHANGELOG bullet is `merge=union`).

## Test plan

- [x] `uv run pytest` (full suite, 16806 passed)
- [x] `uv run pre-commit run --all-files`
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html`
- [x] new test: a populated `taproot_hd_key_paths` round-trips through
      `to_dict`/`from_dict`, which is the case that used to raise
- [x] new test: `check_validity=False` lets a malformed `pub_key`
      through, and `PsbtOut.assert_valid` still catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix taproot PSBT JSON round-trip validation for taproot HD key paths and align taproot BIP32 derivation size checks with existing validity checks.

Bug Fixes:
- Correct taproot pub_key length validation in taproot_bip32_from_dict so 32-byte taproot keys no longer fail JSON round-trip through PsbtOut.to_dict/from_dict.
- Ensure malformed taproot BIP32 derivations are caught by PsbtOut.assert_valid rather than prematurely rejected when check_validity is disabled.

Enhancements:
- Add a check_validity flag to taproot_bip32_from_dict to mirror decode_from_bip32_derivs behavior and centralize validation in PsbtOut.assert_valid.

Documentation:
- Update CHANGELOG to document the taproot pub_key length fix and the new validation behavior for taproot BIP32 derivations.

Tests:
- Add tests verifying taproot_hd_key_paths round-trip through PsbtOut.to_dict/from_dict with a valid 32-byte pub_key.
- Add tests covering taproot_bip32_from_dict check_validity behavior and its interaction with PsbtOut.assert_valid.