### PR TITLE
The dummy BIP147 asks for is the script's, not the signatures' (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1718,6 +1718,25 @@ edit.
   the five are now finalized, extracted and run through the engine. A
   single-key input carrying more than one signature is refused rather
   than picked from (issue #249)
+- **`finalize_psbt` writes BIP147's empty push when the script pops one,
+  not when a second signature is there.** OP_CHECKMULTISIG pops one
+  element more than it reads, whatever the threshold, and BIP 147 is the
+  rule that the extra element be empty rather than the rule that it be
+  there: counting the signatures agreed with the script everywhere but a
+  1-of-n, where one signature is a full satisfaction and the witness came
+  out an element short of what the script consumes — bytes the psbt round
+  trip carries happily and no node accepts. The kind of the script decides
+  now, `is_p2ms` read over the witness script where the multisig is wrapped
+  in a p2wsh and over the spent script otherwise, which answers a p2pk
+  input carrying two signatures as well: that is caller error, and it used
+  to get a dummy on top of it. The count survives as the fallback where the
+  psbt says nothing, a bare multisig needing no script of its own to be
+  finalized, so a missing utxo leaves the number of signatures the only
+  evidence there is. All four positions a multisig script can sit in are
+  finalized, extracted and run through the engine at both thresholds; and
+  `Descriptor.satisfy`, which knows from the descriptor what the finalizer
+  had to guess, is now compared against it for a 1-of-3 too — the
+  disagreement that found this (issue #305)
 - **The difficulty retarget, the work behind a chain, the hash rate it
   implies, and a toy miner.** `btclib.block.proof_of_work` holds the first
   three as pure functions over the four `bits` bytes a header carries,

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -75,6 +75,7 @@ from btclib.psbt.psbt_utils import (
 )
 from btclib.script import (
     Witness,
+    is_p2ms,
     is_p2pkh,
     is_p2sh,
     is_p2tr,
@@ -1294,6 +1295,40 @@ def _single_key(psbt_in: PsbtIn) -> bytes:
     return next(iter(psbt_in.partial_sigs))
 
 
+def _bip147_dummy(psbt_in: PsbtIn) -> list[bytes]:
+    """Return the empty push OP_CHECKMULTISIG pops, or nothing.
+
+    OP_CHECKMULTISIG pops one element more than it reads, whatever the
+    threshold, and BIP 147 is the rule that the extra element be empty
+    rather than the rule that it be there:
+
+        https://github.com/bitcoin/bips/blob/master/bip-0147.mediawiki#motivation
+
+    So what decides the push is the kind of the script, not how many
+    signatures satisfy it. Counting them agrees everywhere but a 1-of-n,
+    where one signature is a full satisfaction and the element is popped
+    all the same, and on a p2pk carrying two signatures, which is caller
+    error and gets a dummy on top of it (issue #305).
+
+    The script to read is the witness script where the multisig is
+    wrapped in a p2wsh, `_spent_script` naming the p2wsh there rather
+    than what it commits to; and it is `_spent_script` itself for a bare
+    multisig and for a legacy p2sh, whose redeem script that already is.
+
+    The count survives as the fallback for an input that says nothing.
+    A bare multisig needs no script of its own to be finalized, so it
+    reaches here with a utxo missing the way `_assert_partial_sigs_verify`
+    lets an unverifiable signature through -- and the count is then the
+    only evidence there is. A bare 1-of-n without a utxo therefore stays
+    an element short, unknowably: one signature, no script, and nothing
+    to tell it from a p2pk.
+    """
+    script = psbt_in.witness_script or _spent_script(psbt_in)
+    if script:
+        return [b""] if is_p2ms(script) else []
+    return [b""] if len(psbt_in.partial_sigs) > 1 else []
+
+
 def _finalized_input(psbt_in: PsbtIn) -> tuple[bytes, Witness]:
     """Return the final script_sig and witness the input is spent with.
 
@@ -1315,9 +1350,7 @@ def _finalized_input(psbt_in: PsbtIn) -> tuple[bytes, Witness]:
     input" (issue #249).
     """
     sigs: list[bytes] = list(psbt_in.partial_sigs.values())
-    # https://github.com/bitcoin/bips/blob/master/bip-0147.mediawiki#motivation
-    cmds: list[bytes] = [b""] if len(sigs) > 1 else []
-    cmds += sigs
+    cmds: list[bytes] = _bip147_dummy(psbt_in) + sigs
     redeem_script: list[bytes] = (
         [psbt_in.redeem_script] if psbt_in.redeem_script else []
     )

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -869,6 +869,10 @@ SCHNORR = ssa.sign(bytes(32), 1).serialize().hex()
 
 MULTI = f"multi(2,{KEY_A},{KEY_B},{KEY_C})"
 SORTED_MULTI = f"sortedmulti(2,{KEY_A},{KEY_B},{KEY_C})"
+# the threshold the two constructions used to disagree about: one
+# signature is a full satisfaction and OP_CHECKMULTISIG pops the dummy
+# all the same, which the psbt finalizer decided by counting (issue #305)
+MULTI_1 = f"multi(1,{KEY_A},{KEY_B},{KEY_C})"
 
 
 def signatures_of(*keys: str) -> dict[Octets, Octets]:
@@ -897,6 +901,16 @@ FINALIZER_VECTORS = [
     ),
     pytest.param(
         f"wsh({SORTED_MULTI})", [KEY_A, KEY_C], "", SORTED_MULTI, id="wsh-sortedmulti"
+    ),
+    pytest.param(MULTI_1, [KEY_A], "", "", id="multi-1"),
+    pytest.param(f"sh({MULTI_1})", [KEY_A], MULTI_1, "", id="sh-multi-1"),
+    pytest.param(f"wsh({MULTI_1})", [KEY_A], "", MULTI_1, id="wsh-multi-1"),
+    pytest.param(
+        f"sh(wsh({MULTI_1}))",
+        [KEY_A],
+        f"wsh({MULTI_1})",
+        MULTI_1,
+        id="sh-wsh-multi-1",
     ),
 ]
 

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -1834,12 +1834,29 @@ _PRV_KEY = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF
 _PUB_KEY = bytes.fromhex(
     "02bb50e2d89a4ed70663d080659fe0ad4b9bc3e06c17a227433966cb59ceee020d"
 )
+# a second key, for the inputs that hold more than one signature
+_OTHER_PRV_KEY = _PRV_KEY + 1
+_OTHER_PUB_KEY = pub_keyinfo_from_prv_key(_OTHER_PRV_KEY)[0]
 
 
 def _p2pkh_script_code(pub_key_hash: bytes) -> bytes:
     return serialize(
         ["OP_DUP", "OP_HASH160", pub_key_hash, "OP_EQUALVERIFY", "OP_CHECKSIG"]
     )
+
+
+def _spending_tx(prev_out: TxOut) -> tuple[Tx, Tx]:
+    """Return the transaction spending an output, and the one holding it.
+
+    The previous transaction and not merely the output: a legacy input is
+    spent against the whole of it, and its id is the outpoint the
+    spending transaction names.
+    """
+    prev_tx = Tx(
+        2, 0, [TxIn(OutPoint("00" * 31 + "01", 0), b"", 0xFFFFFFFF)], [prev_out]
+    )
+    tx_in = TxIn(OutPoint(prev_tx.id, 0), b"", 0xFFFFFFFF)
+    return Tx(2, 0, [tx_in], [TxOut(90_000, ScriptPubKey.p2wpkh(_PUB_KEY))]), prev_tx
 
 
 def _single_key_psbt(kind: str) -> tuple[Psbt, list[TxOut]]:
@@ -1867,13 +1884,7 @@ def _single_key_psbt(kind: str) -> tuple[Psbt, list[TxOut]]:
     )
 
     prev_out = TxOut(100_000, script_pub_key)
-    # the previous transaction, not merely the output it holds: a legacy
-    # input is spent against the whole of it, and its id is the outpoint
-    prev_tx = Tx(
-        2, 0, [TxIn(OutPoint("00" * 31 + "01", 0), b"", 0xFFFFFFFF)], [prev_out]
-    )
-    tx_in = TxIn(OutPoint(prev_tx.id, 0), b"", 0xFFFFFFFF)
-    tx = Tx(2, 0, [tx_in], [TxOut(90_000, ScriptPubKey.p2wpkh(_PUB_KEY))])
+    tx, prev_tx = _spending_tx(prev_out)
 
     psbt = Psbt.from_tx(tx)
     psbt.inputs[0].redeem_script = redeem_script
@@ -1967,15 +1978,155 @@ def test_a_single_key_input_takes_one_signature() -> None:
     psbt, prev_outs = _single_key_psbt("p2wpkh")
     script_code = _p2pkh_script_code(hash160(_PUB_KEY))
     msg_hash = sig_hash.segwit_v0(script_code, psbt.tx, 0, 1, prev_outs[0].value)
-    other_prv_key = _PRV_KEY + 1
-    other_pub_key = pub_keyinfo_from_prv_key(other_prv_key)[0]
-    psbt.inputs[0].partial_sigs[other_pub_key] = (
-        dsa.sign_(msg_hash, other_prv_key).serialize() + b"\x01"
+    psbt.inputs[0].partial_sigs[_OTHER_PUB_KEY] = (
+        dsa.sign_(msg_hash, _OTHER_PRV_KEY).serialize() + b"\x01"
     )
 
     err_msg = "2 signatures for a single-key input"
     with pytest.raises(BTClibValueError, match=err_msg):
         finalize_psbt(psbt)
+
+
+# issue 305: the empty push BIP147 asks for is the script's, not the
+# signatures'
+
+
+def _multisig_psbt(threshold: int, kind: str) -> tuple[Psbt, list[TxOut]]:
+    """Build a one-input threshold-of-2 psbt, signed and not finalized.
+
+    `_single_key_psbt` one key further, and the four kinds are the four
+    places a multisig script can sit: the script_pub_key of a bare
+    multisig, the redeem script of a p2sh, the witness script of a p2wsh,
+    and the witness script of a p2sh-p2wsh, which is the only one the
+    redeem script does not name.
+
+    The signatures go in the order the script holds the keys, which
+    `lexicographic_sorting=False` makes the order given here:
+    OP_CHECKMULTISIG never goes back, so a witness ordered otherwise is
+    one the engine refuses whatever the dummy.
+    """
+    keys = [_PUB_KEY, _OTHER_PUB_KEY]
+    multisig = ScriptPubKey.p2ms(threshold, keys, lexicographic_sorting=False).script
+    witness_script = multisig if "wsh" in kind else b""
+    script_pub_key = {
+        "multi": ScriptPubKey(multisig),
+        "sh-multi": ScriptPubKey.p2sh(multisig),
+        "wsh-multi": ScriptPubKey.p2wsh(multisig),
+        "sh-wsh-multi": ScriptPubKey.p2sh(ScriptPubKey.p2wsh(multisig).script),
+    }[kind]
+    redeem_script = (
+        multisig
+        if kind == "sh-multi"
+        else ScriptPubKey.p2wsh(multisig).script
+        if kind == "sh-wsh-multi"
+        else b""
+    )
+
+    prev_out = TxOut(100_000, script_pub_key)
+    tx, prev_tx = _spending_tx(prev_out)
+
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].redeem_script = redeem_script
+    psbt.inputs[0].witness_script = witness_script
+    if witness_script:
+        psbt.inputs[0].witness_utxo = prev_out
+        msg_hash = sig_hash.segwit_v0(multisig, tx, 0, 1, prev_out.value)
+    else:
+        psbt.inputs[0].non_witness_utxo = prev_tx
+        # the script being spent, which for a p2sh input is its redeem
+        # script and for a bare multisig the script_pub_key: the same
+        # bytes either way here
+        msg_hash = sig_hash.legacy(multisig, tx, 0, 1)
+    prv_keys = [_PRV_KEY, _OTHER_PRV_KEY][:threshold]
+    psbt.inputs[0].partial_sigs = {
+        pub_keyinfo_from_prv_key(prv_key)[0]: dsa.sign_(msg_hash, prv_key).serialize()
+        + b"\x01"
+        for prv_key in prv_keys
+    }
+    return psbt, [prev_out]
+
+
+@pytest.mark.parametrize("kind", ["multi", "sh-multi", "wsh-multi", "sh-wsh-multi"])
+@pytest.mark.parametrize("threshold", [1, 2])
+def test_a_multisig_input_is_spent_with_the_element_the_script_pops(
+    threshold: int, kind: str
+) -> None:
+    """OP_CHECKMULTISIG pops one element more than it reads (issue #305).
+
+    Whatever the threshold: BIP147 is the rule that the extra element be
+    empty, not the rule that it be there. Counting the signatures to
+    decide, as the Finalizer did, is right for every threshold but a
+    1-of-n, where one signature is a full satisfaction and the element is
+    popped all the same -- and a witness one element short is what the
+    engine here refuses.
+
+    The 2-of-2 cases are what every psbt vector already covered, and they
+    are the control: the count and the script agree there, so what the
+    fix must not do is change them.
+    """
+    psbt, prev_outs = _multisig_psbt(threshold, kind)
+    psbt_in = psbt.inputs[0]
+    sigs = list(psbt_in.partial_sigs.values())
+    redeem_script = [psbt_in.redeem_script] if psbt_in.redeem_script else []
+    witness_script = psbt_in.witness_script
+
+    finalized = finalize_psbt(psbt)
+    verify_transaction(prev_outs, extract_tx(finalized, check_validity=False))
+
+    final = finalized.inputs[0]
+    if witness_script:
+        assert final.final_script_witness.stack == (b"", *sigs, witness_script)
+        assert final.final_script_sig == serialize([*redeem_script])
+    else:
+        assert final.final_script_sig == serialize([b"", *sigs, *redeem_script])
+        assert not final.final_script_witness
+
+
+def test_the_dummy_is_the_multisig_script_and_not_a_second_signature() -> None:
+    """A p2pk input holding two signatures gets no empty push (issue #305).
+
+    Two signatures for a script that checks one is caller error, the way
+    `_single_key` refuses the same thing for p2pkh and p2wpkh, and the
+    count gave that error a BIP147 dummy on top of it. Reading the script
+    answers it: a p2pk is not a p2ms, so nothing is pushed and the
+    script_sig is the two signatures the caller supplied.
+
+    Both signatures are real, over the same sig_hash: the Finalizer
+    verifies every partial signature before building anything.
+    """
+    p2pk = serialize([_PUB_KEY, "OP_CHECKSIG"])
+    prev_out = TxOut(100_000, ScriptPubKey(p2pk))
+    tx, prev_tx = _spending_tx(prev_out)
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    msg_hash = sig_hash.legacy(p2pk, tx, 0, 1)
+    sigs = {
+        pub_keyinfo_from_prv_key(prv_key)[0]: dsa.sign_(msg_hash, prv_key).serialize()
+        + b"\x01"
+        for prv_key in (_PRV_KEY, _OTHER_PRV_KEY)
+    }
+    psbt.inputs[0].partial_sigs = sigs
+
+    final_script_sig = finalize_psbt(psbt).inputs[0].final_script_sig
+    assert final_script_sig == serialize([*sigs.values()])
+
+
+def test_an_input_that_says_no_script_is_left_with_the_count() -> None:
+    """No script is no answer, and the count is the only evidence (issue #305).
+
+    A bare multisig needs no script of its own to be finalized, so it
+    reaches the Finalizer with the utxo missing the way any input whose
+    sig_hash is not computable does -- and there `is_p2ms` has nothing to
+    read where the number of signatures still says something. Two
+    signatures are a multisig in every case but the caller error the test
+    above names, so the empty push stays.
+    """
+    psbt, _ = _multisig_psbt(2, "multi")
+    sigs = list(psbt.inputs[0].partial_sigs.values())
+    psbt.inputs[0].non_witness_utxo = None
+
+    final = finalize_psbt(psbt).inputs[0]
+    assert final.final_script_sig == serialize([b"", *sigs])
 
 
 def _one_input_finalized_each() -> tuple[Psbt, Psbt]:


### PR DESCRIPTION
Closes #305, as decided in
https://github.com/btclib-org/btclib/issues/305#issuecomment-5170871306.

`_finalized_input` decided whether to write BIP 147's empty push by
counting the signatures it held. OP_CHECKMULTISIG pops one element more
than it reads, whatever the threshold, and BIP 147 is the rule that the
extra element be empty rather than the rule that it be there: the count
agreed with the script everywhere but a 1-of-n, where one signature is a
full satisfaction and the element is popped all the same. There the
finalizer wrote a witness one element short of what the script consumes —
serialized, combined and extracted without complaint, and refused by
consensus, which nothing in the suite ran it past.

`_bip147_dummy` reads the script instead: `is_p2ms` over the witness
script where the multisig is wrapped in a p2wsh, `_spent_script` naming
the p2wsh there rather than what it commits to, and over `_spent_script`
itself for a bare multisig and a legacy p2sh. A p2pk input carrying two
signatures is answered by the same check, that being caller error which
used to collect a dummy on top of it.

The count survives as the fallback for an input that says nothing, which
is the part the issue left to decide. A bare multisig needs no script of
its own to be finalized, so it reaches the finalizer with the utxo
missing the way any input whose sig_hash is not computable does, and the
number of signatures is then the only evidence there is. A bare 1-of-n
without a utxo therefore stays an element short, unknowably: one
signature, no script, and nothing to tell it from a p2pk.

### Tests

All four positions a multisig script can sit in — the script_pub_key of a
bare multisig, the redeem script of a p2sh, and the witness script of a
p2wsh and of a p2sh-p2wsh — are finalized, extracted and run through
btclib's own script engine at both thresholds, the 2-of-2 cases being the
control the fix must not change. Reverting `btclib/psbt/psbt.py` alone
fails the four 1-of-2 cases and the p2pk one, and nothing else.

`Descriptor.satisfy`, which knows from the descriptor what the finalizer
had to guess, is compared against it for a 1-of-3 too: that disagreement
is how this was found (#263).

### Gates

`pytest` (16826 passed), `pytest --cov` at 100.00%, `pre-commit run
--all-files`, and the `-W` sphinx build, all green in a clean worktree on
top of `2387a11f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust PSBT finalization to base BIP147 dummy element insertion on the spent script type rather than the number of signatures, ensuring multisig witnesses match OP_CHECKMULTISIG semantics and avoiding incorrect dummies for non-multisig scripts.

Bug Fixes:
- Fix PSBT finalization for 1-of-n multisig inputs so the empty BIP147 push is added when the script requires it, preventing witnesses that are one element short of script consumption.
- Ensure p2pk inputs carrying multiple signatures no longer receive an unintended BIP147 dummy element, treating this case purely as caller error.
- Provide a fallback that uses the signature count for inputs lacking script/utxo data so bare multisig inputs can still be finalized sensibly.

Enhancements:
- Introduce a dedicated helper to determine when to add the BIP147 dummy element by inspecting the spent script, simplifying and clarifying PSBT finalization logic.
- Extend descriptor-based tests to cover 1-of-3 multisig satisfaction cases and align PSBT finalization behavior with `Descriptor.satisfy`.
- Add comprehensive tests covering multisig scripts in all supported positions (bare, p2sh, p2wsh, p2sh-p2wsh) and script types with multiple signatures to validate the new finalization behavior.

Documentation:
- Update the changelog to document the corrected BIP147 dummy handling in PSBT finalization and its impact on multisig and descriptor-based flows.

Tests:
- Add new PSBT and descriptor tests to exercise BIP147 dummy handling across multisig variants, script placements, and edge cases like multi-signature p2pk inputs.