### PR TITLE
Update a psbt from a descriptor: the Updater of BIP 174 (#306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2029,6 +2029,31 @@ edit.
   against; the test suite checks it against `finalize_psbt`, which does
   have one, and the two build the same bytes for every shape both can
   express (issue #263)
+- **`Descriptor.update_psbt` is BIP 174's Updater**: it returns the psbt
+  with one input told what the descriptor knows — the redeem script of a
+  `sh()`, the witness script of a `wsh()`, the internal key, merkle root
+  and leaf scripts of a `tr()`, and the origin of every key that carries
+  one, which is what `KeyExpression.origin` is kept for and what nothing
+  carried into a psbt before. A copy, the psbt handed in left alone, as
+  `finalize_psbt` returns one. That completes the pipeline BIP 174
+  describes with a btclib call for each role: the descriptor updates,
+  signers fill `partial_sigs` in any order and at their own pace, and
+  `finalize_psbt` assembles — so a 2-of-3 waiting for its second
+  signature is handled without `satisfy` having to answer with bytes that
+  do not spend. The taproot half is the one an Updater is needed for
+  rather than convenient: a control block holds the merkle path from its
+  leaf to the root, so a psbt handed one leaf cannot work out another,
+  and `TrDescriptor.taproot_leaf_scripts` and
+  `TrDescriptor.taproot_merkle_root` are public for the same reason. The
+  three `satisfy` refuses are refused here too, for a reason of their
+  own: `addr()` and `raw()` hold no key and no script below the one the
+  utxo already carries, so an Updater over either would fill nothing and
+  report that it had, and `combo()` is four scripts of which only one is
+  being spent. A key with no origin is skipped rather than refused, the
+  field being keyed by key. `taproot.leaf_hash` is new beside it, the
+  BIP 341 tapleaf hash that `tree_helper`, `check_output_pubkey` and the
+  psbt's own `leaf_script` each used to compute for themselves (issue
+  #306)
 - **`btclib.fetch` is new, and is the one package that goes out to the
   network.** `Fetcher` is three questions the library cannot answer from
   bytes it was handed — the transaction with this id, the output an

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -25,6 +25,14 @@ the signatures are a parameter rather than something this module makes.
 `psbt.finalize_psbt` does have one and does check, and builds the same
 bytes from a psbt carrying the same signatures.
 
+`update_psbt` is the third answer, and the one for a spend the signers
+do not make all at once: BIP 174's Updater, writing the scripts and the
+key origins into a psbt input, for signers to fill in at their own pace
+and `psbt.finalize_psbt` to assemble. This module imports `psbt` for it
+and nothing there imports back, which is the direction of the layering:
+a psbt is a transaction being built, and a descriptor is what a wallet
+knows about the outputs it holds.
+
 BIP 380: https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki
 
 The grammar read is BIP 380 to BIP 386 and BIP 389, minus miniscript:
@@ -57,6 +65,7 @@ from __future__ import annotations
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import cast
 
@@ -65,9 +74,11 @@ from btclib.bip32.bip32 import BIP32KeyData, derive
 from btclib.bip32.der_path import int_from_index_str
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
+from btclib.psbt.psbt import Psbt
+from btclib.psbt.psbt_in import PsbtIn
 from btclib.script.script import serialize
 from btclib.script.script_pub_key import ScriptPubKey
-from btclib.script.taproot import input_script_sig
+from btclib.script.taproot import input_script_sig, leaf_hash, tree_helper
 from btclib.script.witness import Witness
 from btclib.to_pub_key import point_from_pub_key, pub_keyinfo_from_key
 from btclib.utils import bytes_from_octets
@@ -306,6 +317,23 @@ def _required_signature(signatures: Mapping[bytes, bytes], sec: bytes) -> bytes:
     return signature
 
 
+def _derived_origin(key: KeyExpression, index: int) -> BIP32KeyOrigin | None:
+    """Return the origin of the key at `index`, None for a key without one.
+
+    `KeyExpression.origin` is the path down to the extended key the
+    descriptor holds, and what BIP 174 carries is the path down to the
+    key itself: the derivation the descriptor then does, the wildcard
+    step at `index` included, appended to it. A signer given the shorter
+    path would derive the wrong key from it.
+    """
+    if key.origin is None:
+        return None
+    der_path = [*key.origin.der_path, *key.der_path]
+    if key.wildcard is not None:
+        der_path.append(key.wildcard + index)
+    return BIP32KeyOrigin(key.origin.master_fingerprint, der_path)
+
+
 @dataclass(frozen=True, kw_only=True)
 class Descriptor(ABC):
     """A parsed output descriptor: the scripts it describes, on demand.
@@ -433,6 +461,69 @@ class Descriptor(ABC):
         """
         return serialize(cast(ScriptList, self._stack(signatures, index))), Witness()
 
+    def update_psbt(self, psbt: Psbt, vin_i: int, index: int = 0) -> Psbt:
+        """Return the psbt with input `vin_i` told what the descriptor knows.
+
+        BIP 174's Updater, for the one input this descriptor describes:
+        the redeem script of a ``sh()``, the witness script of a
+        ``wsh()``, the internal key, merkle root and leaf scripts of a
+        ``tr()``, and the origin of every key that carries one -- which is
+        what a hardware signer needs, and what `KeyExpression.origin` is
+        kept for. `psbt.finalize_psbt` then assembles the same bytes
+        `satisfy` does, from the signatures the signers filled in at
+        their own pace: that pipeline is what a psbt is for, and what
+        `satisfy` cannot answer, refusing a partial satisfaction rather
+        than returning bytes that do not spend.
+
+        A copy, the psbt handed in being left alone, and the fields of
+        the copy mutated in place: `finalize_psbt` is the same
+        construction, and BIP 174's roles read as steps that update a
+        psbt rather than as functions that return a field at a time.
+
+        What is not filled is what a descriptor does not know: the utxo,
+        the sighash type, the signatures. Nor is the script checked
+        against the output being spent -- an input may not carry it yet,
+        and `Psbt.assert_signable` asks that question for every input at
+        once, being the role after this one.
+        """
+        self._assert_index(index)
+        # an IndexError out of a public method is not an answer, and a
+        # negative index would quietly update the input at the other end
+        if not 0 <= vin_i < len(psbt.inputs):
+            raise BTClibValueError(f"invalid input index: {vin_i}")
+        psbt = deepcopy(psbt)
+        self._update(psbt.inputs[vin_i], index)
+        psbt.assert_valid()
+        return psbt
+
+    def _update(self, psbt_in: PsbtIn, index: int) -> None:
+        """Fill the key origins, which is what every fragment knows.
+
+        And the whole of what ``pk()``, ``pkh()``, ``wpkh()`` and
+        ``multi()`` know: their script is the script_pub_key, which the
+        psbt has from the utxo rather than from here. The fragments that
+        embed one of those add their scripts to this.
+
+        The mapping is added to and not replaced: BIP 174 keys it by
+        public key, so a psbt already carrying another signer's key keeps
+        it, and this descriptor's entry wins for a key held by both.
+        """
+        psbt_in.hd_key_paths = {**psbt_in.hd_key_paths, **self._hd_key_paths(index)}
+
+    def _hd_key_paths(self, index: int) -> dict[bytes, BIP32KeyOrigin]:
+        """Return the origin of each key that has one, keyed by public key.
+
+        A key with no origin is skipped and not refused: a descriptor may
+        name one key as plain hex and the next with an origin, the field
+        is keyed by key, and what is missing is one entry of it.
+        """
+        hd_key_paths: dict[bytes, BIP32KeyOrigin] = {}
+        for key in self.key_expressions:
+            origin = _derived_origin(key, index)
+            if origin is not None:
+                hd_key_paths[key.sec(index, self.network)] = origin
+        return hd_key_paths
+
 
 @dataclass(frozen=True)
 class PkDescriptor(Descriptor):
@@ -532,6 +623,17 @@ class ShDescriptor(Descriptor):
         redeem_script = self.inner.redeem_script(index)
         return script_sig + serialize(cast(ScriptList, [redeem_script])), witness
 
+    def _update(self, psbt_in: PsbtIn, index: int) -> None:
+        """Fill the redeem script, and let the argument fill its own fields.
+
+        Delegated rather than dispatched on: the argument of a
+        ``sh(wsh())`` is what knows there is a witness script below the
+        redeem script, and it is the same method that fills it for a
+        native ``wsh()``.
+        """
+        self.inner._update(psbt_in, index)
+        psbt_in.redeem_script = self.inner.redeem_script(index)
+
 
 @dataclass(frozen=True)
 class WshDescriptor(Descriptor):
@@ -558,6 +660,16 @@ class WshDescriptor(Descriptor):
         """
         stack = self.inner._stack(signatures, index)
         return b"", Witness([*stack, self.inner.redeem_script(index)])
+
+    def _update(self, psbt_in: PsbtIn, index: int) -> None:
+        """Fill the witness script; the redeem script is ``sh()``'s to fill.
+
+        Which is the whole difference between a native ``wsh()`` and a
+        wrapped one, in the psbt as in the spend: the same witness script,
+        and a redeem script only where something wraps it.
+        """
+        self.inner._update(psbt_in, index)
+        psbt_in.witness_script = self.inner.redeem_script(index)
 
 
 @dataclass(frozen=True)
@@ -658,6 +770,18 @@ class ComboDescriptor(Descriptor):
         err_msg = "combo() is four scripts: satisfy the one being spent"
         raise BTClibValueError(err_msg)
 
+    def _update(self, psbt_in: PsbtIn, index: int) -> None:
+        """Refuse: the four scripts are updated into an input differently.
+
+        One of them is p2sh and wants a redeem script, the other three
+        want none, and the input is spending one output: an Updater that
+        wrote the key origin and left the script to the caller would have
+        filled in the half that is the same for all four and hidden the
+        half that is not.
+        """
+        err_msg = "combo() is four scripts: update the psbt with the one spent"
+        raise BTClibValueError(err_msg)
+
 
 @dataclass(frozen=True)
 class AddrDescriptor(Descriptor):
@@ -683,6 +807,15 @@ class AddrDescriptor(Descriptor):
         descriptor does not carry.
         """
         raise BTClibValueError("addr() cannot be satisfied: it holds no key")
+
+    def _update(self, psbt_in: PsbtIn, index: int) -> None:
+        """Refuse: there is nothing of an address to write into an input.
+
+        No key, so no origin; no script below the address, so no redeem or
+        witness script. Returning the input untouched would be an Updater
+        that ran and a caller told it had been updated.
+        """
+        raise BTClibValueError("addr() cannot update a psbt: it holds no key")
 
 
 @dataclass(frozen=True)
@@ -710,6 +843,15 @@ class RawDescriptor(Descriptor):
         """
         raise BTClibValueError("raw() cannot be satisfied: it holds no key")
 
+    def _update(self, psbt_in: PsbtIn, index: int) -> None:
+        """Refuse, for the reason ``addr()`` does: bytes hold no key origin.
+
+        Those bytes may be the script an input spends, and they are then
+        its script_pub_key, which the psbt has from the utxo; what a
+        descriptor is asked here is what the utxo does not say.
+        """
+        raise BTClibValueError("raw() cannot update a psbt: it holds no key")
+
 
 @dataclass(frozen=True)
 class TrDescriptor(Descriptor):
@@ -732,6 +874,84 @@ class TrDescriptor(Descriptor):
         )
         internal_key = self.internal_key.sec(index, self.network)
         return [ScriptPubKey.p2tr(internal_key, script_tree).script]
+
+    def _leaf(
+        self, script_tree: TaprootScriptTree, index: int, leaf: int
+    ) -> tuple[bytes, bytes]:
+        """Return one leaf's serialized script and its control block.
+
+        The one place either is built, a spend and an update of the same
+        leaf wanting the same bytes. The tree is a parameter because both
+        callers have computed it already -- and because a ``tr()`` with no
+        tree has no leaf, which they answer for themselves.
+        """
+        internal_key = self.internal_key.sec(index, self.network)
+        script, control_block = input_script_sig(internal_key, script_tree, leaf)
+        return serialize(script), control_block
+
+    def taproot_merkle_root(self, index: int = 0) -> bytes:
+        """Return the root the output key commits to, b"" where there is none.
+
+        BIP 371's PSBT_IN_TAP_MERKLE_ROOT, and empty is how that field
+        says "key path only": a ``tr(KEY)`` tweaks its internal key with
+        no tree, which is not the same as tweaking it with an empty one.
+        """
+        self._assert_index(index)
+        if self.tree is None:
+            return b""
+        return tree_helper(_taproot_script_tree(self.tree, index, self.network))[1]
+
+    def taproot_leaf_scripts(self, index: int = 0) -> dict[bytes, tuple[bytes, int]]:
+        """Return every leaf script and its version, keyed by control block.
+
+        The shape of BIP 371's PSBT_IN_TAP_LEAF_SCRIPT, and the field an
+        Updater is needed for rather than convenient: a control block
+        holds the merkle path from its leaf to the root, which is the
+        whole tree seen from that leaf, and a psbt carrying one leaf's
+        script has no way to compute another's.
+        """
+        self._assert_index(index)
+        if self.tree is None:
+            return {}
+        script_tree = _taproot_script_tree(self.tree, index, self.network)
+        leaf_scripts: dict[bytes, tuple[bytes, int]] = {}
+        for leaf in range(len(_tree_keys(self.tree))):
+            script, control_block = self._leaf(script_tree, index, leaf)
+            leaf_scripts[control_block] = (script, _TAPSCRIPT_LEAF_VERSION)
+        return leaf_scripts
+
+    def _taproot_hd_key_paths(
+        self, index: int
+    ) -> dict[bytes, tuple[list[bytes], BIP32KeyOrigin]]:
+        """Return each key's origin and leaf hashes, keyed by x-only key.
+
+        BIP 371 gives a taproot key a field of its own, keyed by the 32
+        bytes a tapscript holds and carrying the tapleaf hash of every
+        leaf the key appears in: none for a key that is only the internal
+        one, no leaf committing to it, and one entry naming each of them
+        for a key written into several, the field being keyed by key.
+
+        Named once each: a key in two leaves of the same script is in two
+        places of the tree and in one leaf of it, the tapleaf hash being
+        of the script, and what a signer reads here is which scripts it
+        has to sign for.
+        """
+        leaf_hashes: dict[bytes, list[bytes]] = {}
+        for script, leaf_version in self.taproot_leaf_scripts(index).values():
+            # a leaf of this module's own making is a push of the key and
+            # OP_CHECKSIG, `pk()` being the only leaf BIP 386 reads here,
+            # so the key is what the push holds
+            hashes = leaf_hashes.setdefault(script[1:-1], [])
+            if (hash_ := leaf_hash(leaf_version, script)) not in hashes:
+                hashes.append(hash_)
+        hd_key_paths: dict[bytes, tuple[list[bytes], BIP32KeyOrigin]] = {}
+        for key in self.key_expressions:
+            origin = _derived_origin(key, index)
+            if origin is None:
+                continue
+            x_only = key.sec(index, self.network)[1:]
+            hd_key_paths[x_only] = (leaf_hashes.get(x_only, []), origin)
+        return hd_key_paths
 
     def _satisfy(
         self, signatures: Mapping[bytes, bytes], index: int
@@ -771,12 +991,30 @@ class TrDescriptor(Descriptor):
                 signatures, key.sec(index, self.network), x_only=True
             )
             if signature is not None:
-                script, control_block = input_script_sig(
-                    internal_key, script_tree, leaf
-                )
-                return b"", Witness([signature, serialize(script), control_block])
+                script, control_block = self._leaf(script_tree, index, leaf)
+                return b"", Witness([signature, script, control_block])
         err_msg = "no signature for the tr() internal key or for any of its leaves"
         raise BTClibValueError(err_msg)
+
+    def _update(self, psbt_in: PsbtIn, index: int) -> None:
+        """Fill the four taproot fields: internal key, root, leaves, origins.
+
+        This replaces the base method rather than adding to it: a taproot
+        key origin belongs in `taproot_hd_key_paths`, keyed by the x-only
+        key, and a 33-byte entry in `hd_key_paths` beside it would be the
+        same key twice in two spellings, for a signer that signs with
+        neither.
+        """
+        psbt_in.taproot_internal_key = self.internal_key.sec(index, self.network)[1:]
+        psbt_in.taproot_merkle_root = self.taproot_merkle_root(index)
+        psbt_in.taproot_leaf_scripts = {
+            **psbt_in.taproot_leaf_scripts,
+            **self.taproot_leaf_scripts(index),
+        }
+        psbt_in.taproot_hd_key_paths = {
+            **psbt_in.taproot_hd_key_paths,
+            **self._taproot_hd_key_paths(index),
+        }
 
 
 def _split_arguments(arguments: str) -> list[str]:

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -39,7 +39,6 @@ from io import BytesIO
 from math import ceil
 from typing import Any, TypeVar, cast
 
-from btclib import var_bytes
 from btclib.alias import BinaryData, Octets, ScriptList, String
 from btclib.bip32 import (
     BIP32KeyOrigin,
@@ -51,7 +50,7 @@ from btclib.bip32 import (
 )
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
-from btclib.hashes import hash160, sha256, tagged_hash
+from btclib.hashes import hash160, sha256
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
 from btclib.psbt.psbt_size import estimated_input_sizes
@@ -82,6 +81,7 @@ from btclib.script import (
     is_p2wsh,
     serialize,
     sig_hash,
+    taproot,
     type_and_payload,
 )
 from btclib.script.sig_hash import DEFAULT
@@ -1412,8 +1412,7 @@ def leaf_script(psbt_in: PsbtIn, leaf_hash: Octets) -> tuple[bytes, bytes]:
     """
     leaf_hash = bytes_from_octets(leaf_hash, LEAF_HASH_SIZE)
     for control_block, (script, leaf_version) in psbt_in.taproot_leaf_scripts.items():
-        preimage = leaf_version.to_bytes(1, "big") + var_bytes.serialize(script)
-        if tagged_hash(b"TapLeaf", preimage) == leaf_hash:
+        if taproot.leaf_hash(leaf_version, script) == leaf_hash:
             return script, control_block
     raise BTClibValueError(f"no leaf script for tapleaf hash {leaf_hash.hex()}")
 

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -120,6 +120,19 @@ def parse(stream: BinaryData, exit_on_op_success: bool = False) -> ScriptList:
     return r
 
 
+def leaf_hash(leaf_version: int, script: bytes) -> bytes:
+    """Return the BIP341 tapleaf hash of a serialized leaf script.
+
+    What names a leaf everywhere but in the control block: the merkle
+    path is built from these, a BIP342 signature commits to one, and
+    BIP371's psbt fields key their taproot data by one. `script` is the
+    leaf script already serialized, which is the form all three of those
+    hold it in.
+    """
+    preimage = leaf_version.to_bytes(1, "big") + var_bytes.serialize(script)
+    return tagged_hash(b"TapLeaf", preimage)
+
+
 def tree_helper(script_tree: TaprootScriptTree) -> tuple[TaprootLeafPaths, bytes]:
     if len(script_tree) == 1:
         return _tree_helper(script_tree)
@@ -137,9 +150,7 @@ def tree_helper(script_tree: TaprootScriptTree) -> tuple[TaprootLeafPaths, bytes
 def _tree_helper(script_tree: TaprootScriptTree) -> tuple[TaprootLeafPaths, bytes]:
     leaf_version, script = cast("TaprootLeaf", script_tree[0])
     leaf_version = leaf_version & 0xFE
-    preimage = leaf_version.to_bytes(1, "big")
-    preimage += var_bytes.serialize(serialize(script))
-    h = tagged_hash(b"TapLeaf", preimage)
+    h = leaf_hash(leaf_version, serialize(script))
     return ([((leaf_version, script), b"")], h)
 
 
@@ -250,9 +261,7 @@ def check_output_pubkey(
     m = (len(control) - 33) // 32
     if len(control) != 33 + 32 * m:
         raise BTClibValueError("invalid control block length")
-    leaf_version = control[0] & 0xFE
-    preimage = leaf_version.to_bytes(1, "big") + var_bytes.serialize(script)
-    k = tagged_hash(b"TapLeaf", preimage)
+    k = leaf_hash(control[0] & 0xFE, script)
     for j in range(m):
         e = control[33 + 32 * j : 65 + 32 * j]
         if k < e:

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -37,6 +37,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from btclib.alias import Octets
+from btclib.bip32 import BIP32KeyOrigin
 from btclib.descriptors import (
     AddrDescriptor,
     ComboDescriptor,
@@ -58,14 +59,19 @@ from btclib.descriptors import (
 )
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
-from btclib.psbt.psbt import _finalized_input
+from btclib.psbt.psbt import (
+    Psbt,
+    _finalized_input,
+    finalize_psbt,
+    taproot_sig_hash,
+)
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.script import taproot
 from btclib.script.script import serialize
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.script.witness import Witness
 from btclib.to_pub_key import pub_keyinfo_from_key
-from btclib.tx.tx_out import TxOut
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests import load, vector_id
 
 DOC_DESCRIPTORS = [
@@ -1073,3 +1079,273 @@ def test_only_a_script_is_embeddable() -> None:
     inner = parse(f"tr({XONLY_A})")
     with pytest.raises(BTClibValueError, match="TrDescriptor is not a script"):
         WshDescriptor(inner).satisfy({XONLY_A: SCHNORR})
+
+
+def psbt_spending(descriptor: Descriptor, index: int = 0) -> Psbt:
+    """Return a one-input psbt spending what the descriptor describes.
+
+    The whole previous transaction as the utxo, rather than the spent
+    output alone: a witness_utxo beside a legacy input is what
+    `Psbt.assert_signable` refuses as "script type not in ('p2wpkh',
+    'p2wsh')", and these vectors are of every kind.
+    """
+    script_pub_key = descriptor.script_pub_key(index)
+    prev_tx = Tx(
+        vin=[TxIn(OutPoint(b"\x02" * 32, 0))], vout=[TxOut(1000, script_pub_key)]
+    )
+    psbt = Psbt.from_tx(
+        Tx(vin=[TxIn(OutPoint(prev_tx.id, 0))], vout=[TxOut(900, script_pub_key)])
+    )
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    return psbt
+
+
+@pytest.mark.parametrize(
+    ("descriptor", "signing_keys", "redeem", "witness"), FINALIZER_VECTORS
+)
+def test_the_updater_fills_what_the_finalizer_dispatches_on(
+    descriptor: str, signing_keys: list[str], redeem: str, witness: str
+) -> None:
+    """The vectors above, with the two scripts written by the descriptor.
+
+    Which is the whole of issue 306 for a legacy input: the test beside
+    this one hands the psbt the redeem and witness scripts by parsing a
+    second descriptor of each, and here nothing is handed to it. That the
+    same signatures then finalize to the same spend says the fields are
+    the ones the Finalizer needs, and `assert_signable` says each script
+    is the one the output being spent commits to.
+    """
+    parsed = parse(descriptor)
+    psbt = parsed.update_psbt(psbt_spending(parsed), 0)
+    psbt.assert_signable()
+
+    psbt_in = psbt.inputs[0]
+    assert psbt_in.redeem_script == (parse(redeem).redeem_script() if redeem else b"")
+    assert psbt_in.witness_script == (
+        parse(witness).redeem_script() if witness else b""
+    )
+    psbt_in.partial_sigs = {
+        bytes.fromhex(key): bytes.fromhex(SIGNATURES[key]) for key in signing_keys
+    }
+    assert parsed.satisfy(signatures_of(*signing_keys)) == _finalized_input(psbt_in)
+
+
+def test_the_updater_carries_the_key_origin_of_the_derived_key() -> None:
+    """The path down to the key itself, and not down to the xpub above it.
+
+    What BIP 174 carries is what a signer derives with, so the origin of
+    a ranged descriptor's key is the origin written in it, the steps the
+    descriptor derives, and the index -- three pieces the psbt sees as
+    one path.
+    """
+    descriptor = parse(f"wpkh([d34db33f/84h/0h/0h]{XPUB}/0/*)")
+    key = descriptor.key_expressions[0]
+    for index in (0, 7):
+        psbt = descriptor.update_psbt(psbt_spending(descriptor, index), 0, index)
+        hd_key_paths = psbt.inputs[0].hd_key_paths
+        assert list(hd_key_paths) == [key.sec(index)]
+        assert (
+            hd_key_paths[key.sec(index)].description == f"d34db33f/84h/0h/0h/0/{index}"
+        )
+
+
+def test_a_key_without_an_origin_is_skipped_rather_than_refused() -> None:
+    """A descriptor may name one key as hex and the next with an origin.
+
+    The field is keyed by public key, so what a key with nothing to say
+    about where it came from costs is its own entry and not the field.
+    """
+    descriptor = parse(f"wsh(multi(2,[d34db33f/0h]{XPUB}/0,{KEY_B},{KEY_C}))")
+    psbt = descriptor.update_psbt(psbt_spending(descriptor), 0)
+    hd_key_paths = psbt.inputs[0].hd_key_paths
+    assert list(hd_key_paths) == [descriptor.key_expressions[0].sec()]
+    assert hd_key_paths[descriptor.key_expressions[0].sec()].description == (
+        "d34db33f/0h/0"
+    )
+
+
+def test_the_updater_adds_to_what_the_psbt_already_carries() -> None:
+    """An Updater is a role a psbt passes through, and not the first one.
+
+    Another signer's key origin is left where it is, and the entry for a
+    key this descriptor names too is this one: what the descriptor knows
+    is knowledge about its own keys.
+    """
+    descriptor = parse(f"wsh(multi(2,[d34db33f/0h]{XPUB}/0,{KEY_B},{KEY_C}))")
+    key = descriptor.key_expressions[0].sec()
+    psbt = psbt_spending(descriptor)
+    psbt.inputs[0].hd_key_paths = {
+        bytes.fromhex(KEY_A): BIP32KeyOrigin("ffffffff", "m/1"),
+        key: BIP32KeyOrigin("ffffffff", "m/2"),
+    }
+    hd_key_paths = descriptor.update_psbt(psbt, 0).inputs[0].hd_key_paths
+    assert hd_key_paths[bytes.fromhex(KEY_A)].description == "ffffffff/1"
+    assert hd_key_paths[key].description == "d34db33f/0h/0"
+
+
+def test_the_updater_leaves_the_psbt_it_was_given_alone() -> None:
+    """A copy, as `finalize_psbt` returns one."""
+    descriptor = parse(f"sh({MULTI})")
+    psbt = psbt_spending(descriptor)
+    assert descriptor.update_psbt(psbt, 0).inputs[0].redeem_script
+    assert not psbt.inputs[0].redeem_script
+
+
+def test_the_updater_refuses_an_index_that_names_no_input() -> None:
+    """An IndexError out of a public method is not an answer.
+
+    A negative one least of all: it is the input at the other end of the
+    psbt, updated with the fields of an output it does not spend.
+    """
+    descriptor = parse(f"wpkh({KEY_A})")
+    psbt = psbt_spending(descriptor)
+    for vin_i in (-1, 1):
+        with pytest.raises(BTClibValueError, match="invalid input index"):
+            descriptor.update_psbt(psbt, vin_i)
+    with pytest.raises(BTClibValueError, match="not a ranged descriptor"):
+        descriptor.update_psbt(psbt, 0, 1)
+
+
+def taproot_leaf_of(psbt_in: PsbtIn, x_only: str) -> tuple[bytes, bytes]:
+    """Return the leaf script a key is the whole of, and its control block."""
+    return next(
+        (script, control_block)
+        for control_block, (script, _) in psbt_in.taproot_leaf_scripts.items()
+        if script[1:-1] == bytes.fromhex(x_only)
+    )
+
+
+def test_the_updater_fills_the_taproot_fields() -> None:
+    """The internal key, the merkle root, and every leaf of the tree.
+
+    A control block is the field an Updater is needed for rather than
+    convenient: it holds the merkle path from its leaf to the root, which
+    is the whole tree seen from that leaf, so a psbt handed one leaf
+    cannot work out another. `check_output_pubkey` is the verifier's own
+    side of BIP 341 and says each of them is the path and the parity bit
+    that leaf needs.
+    """
+    descriptor = parse(f"tr({XONLY_A},{{pk({XONLY_B}),pk({XONLY_C})}})")
+    assert isinstance(descriptor, TrDescriptor)
+    psbt_in = descriptor.update_psbt(psbt_spending(descriptor), 0).inputs[0]
+
+    assert psbt_in.taproot_internal_key == bytes.fromhex(XONLY_A)
+    assert psbt_in.taproot_merkle_root == descriptor.taproot_merkle_root()
+    output_key = descriptor.script_pub_key().script[2:]
+    for leaf_key in (XONLY_B, XONLY_C):
+        script, control_block = taproot_leaf_of(psbt_in, leaf_key)
+        assert script == serialize([bytes.fromhex(leaf_key), "OP_CHECKSIG"])
+        assert taproot.check_output_pubkey(output_key, script, control_block)
+    # 0xc0 is the leaf version of every BIP 386 tree, and what the
+    # control block's first byte carries beside the parity bit
+    assert {version for _, version in psbt_in.taproot_leaf_scripts.values()} == {0xC0}
+
+
+def test_a_taproot_key_path_descriptor_has_no_root_and_no_leaf() -> None:
+    """Which is not the same as a tree that is empty.
+
+    `tr(KEY)` tweaks its internal key with no tree at all, and BIP 371
+    says so by leaving PSBT_IN_TAP_MERKLE_ROOT out.
+    """
+    descriptor = parse(f"tr({XONLY_A})")
+    assert isinstance(descriptor, TrDescriptor)
+    assert descriptor.taproot_merkle_root() == b""
+    assert descriptor.taproot_leaf_scripts() == {}
+
+    psbt_in = descriptor.update_psbt(psbt_spending(descriptor), 0).inputs[0]
+    assert psbt_in.taproot_internal_key == bytes.fromhex(XONLY_A)
+    assert not psbt_in.taproot_merkle_root
+    assert not psbt_in.taproot_leaf_scripts
+
+
+def test_a_taproot_key_origin_names_the_leaves_it_is_in() -> None:
+    """BIP 371 keys the field by x-only key and carries the tapleaf hashes.
+
+    None for the internal key, which no leaf commits to, and one per leaf
+    for a key in the tree. `hd_key_paths` stays empty: the same key in
+    its 33-byte spelling there would be a second entry for a signer that
+    signs with neither.
+    """
+    internal = f"[d34db33f/86h]{XPUB}/0"
+    left, right = f"[aabbccdd/1]{XPUB}/1", f"[11223344/2]{XPUB}/2"
+    # the left key is in two leaves, at two depths, so its two control
+    # blocks are two entries of `taproot_leaf_scripts` -- and one leaf
+    # hash here, the two leaves being the same script
+    descriptor = parse(f"tr({internal},{{pk({left}),{{pk({right}),pk({left})}}}})")
+    psbt_in = descriptor.update_psbt(psbt_spending(descriptor), 0).inputs[0]
+
+    assert not psbt_in.hd_key_paths
+    # the left key twice among the key expressions, and once here
+    keys = list(dict.fromkeys(key.sec()[1:] for key in descriptor.key_expressions))
+    assert len(descriptor.key_expressions) == len(keys) + 1
+    assert list(psbt_in.taproot_hd_key_paths) == keys
+    assert len(psbt_in.taproot_leaf_scripts) == 3
+    leaf_hashes, origin = psbt_in.taproot_hd_key_paths[keys[0]]
+    assert leaf_hashes == []
+    assert origin.description == "d34db33f/86h/0"
+    for key, description in zip(
+        keys[1:], ("aabbccdd/1/1", "11223344/2/2"), strict=True
+    ):
+        leaf_hashes, origin = psbt_in.taproot_hd_key_paths[key]
+        script = taproot_leaf_of(psbt_in, key.hex())[0]
+        assert leaf_hashes == [taproot.leaf_hash(0xC0, script)]
+        assert origin.description == description
+
+
+def test_a_taproot_script_path_is_finalizable_only_after_the_updater() -> None:
+    """The gap issue 306 names: a psbt cannot invent a leaf script.
+
+    The Finalizer builds the witness of a script path spend out of the
+    leaf script and the control block the input carries, and until now
+    nothing wrote them there from a descriptor. With them, the psbt
+    finalizes to the very bytes `satisfy` builds from the same signature.
+    """
+    descriptor = parse(f"tr({XONLY_A},{{pk({XONLY_B}),pk({XONLY_C})}})")
+    psbt = descriptor.update_psbt(psbt_spending(descriptor), 0)
+    script, control_block = taproot_leaf_of(psbt.inputs[0], XONLY_B)
+
+    # sign_ and not sign: what BIP 341 signs is the hash BIP 342 makes of
+    # the transaction, and the Finalizer checks it with verify_
+    leaf_hash = taproot.leaf_hash(0xC0, script)
+    msg_hash = taproot_sig_hash(psbt, 0, leaf_hash=leaf_hash)
+    signature = ssa.sign_(msg_hash, 2).serialize()
+    key_data = bytes.fromhex(XONLY_B) + leaf_hash
+    psbt.inputs[0].taproot_script_spend_signatures = {key_data: signature}
+
+    witness = Witness([signature, script, control_block])
+    assert finalize_psbt(psbt).inputs[0].final_script_witness == witness
+    assert descriptor.satisfy({XONLY_B: signature}) == (b"", witness)
+
+    # the same signature in a psbt the descriptor never updated: the
+    # leaf it names is one that input says nothing about
+    not_updated = psbt_spending(descriptor)
+    not_updated.inputs[0].taproot_script_spend_signatures = {key_data: signature}
+    with pytest.raises(BTClibValueError, match="no leaf script for tapleaf hash"):
+        finalize_psbt(not_updated)
+
+
+# what cannot update a psbt, and what says so. The three `satisfy`
+# refuses as well, for reasons of their own: an Updater has nothing to
+# choose between, and these have nothing to write
+UNUPDATABLE = [
+    (f"combo({KEY_A})", "combo\\(\\) is four scripts"),
+    ("addr(1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH)", "addr\\(\\) cannot update a psbt"),
+    ("raw(76a914000000000000000000000000000000000000000088ac)", "raw\\(\\) cannot"),
+]
+
+
+@pytest.mark.parametrize(
+    ("descriptor", "message"),
+    [
+        pytest.param(descriptor, message, id=vector_id(index, descriptor))
+        for index, (descriptor, message) in enumerate(UNUPDATABLE)
+    ],
+)
+def test_what_cannot_update_a_psbt(descriptor: str, message: str) -> None:
+    parsed = parse(descriptor)
+    # combo() is four scripts and script_pub_key refuses to pick one, so
+    # the psbt is built around the p2pkh of the same key: what is being
+    # tested is the refusal, and it comes before anything reads the utxo
+    psbt = psbt_spending(parse(f"pkh({KEY_A})"))
+    with pytest.raises(BTClibValueError, match=message):
+        parsed.update_psbt(psbt, 0)


### PR DESCRIPTION
Closes #306, in the shape the [comment on the
issue](https://github.com/btclib-org/btclib/issues/306#issuecomment-5170892286)
proposed: the four open decisions answered, and the two things that
comment added.

### The four

- **A `Descriptor` method, so the import runs `descriptors` → `psbt`.**
  `descriptors` is the last name of CLAUDE.md's layering, not below
  `psbt`, and the dispatch per fragment is needed either way: this is
  `satisfy`'s own shape, a public method over a `_update` each fragment
  overrides, rather than the `isinstance` chain a function outside the
  hierarchy would need.
- **Updates *and* returns**, as `finalize_psbt` does: `deepcopy`, mutate
  the input's fields in place, return the copy.
- **The output is a second issue.** `PsbtOut` shares four of the six
  fields but has no `taproot_merkle_root` and holds the tree as
  `taproot_tree` triples where `PsbtIn` wants `taproot_leaf_scripts`
  keyed by control block, so what the two share is the easy half. The
  key-origin helper is written here for both to use.
- **`combo()`, `addr()` and `raw()` are refused**, as `satisfy` refuses
  them. The first two would fill nothing and report that they had; the
  third is four scripts of which one is being spent.

### The two the issue did not list

`TrDescriptor` exposed none of what an Updater needs: `_satisfy`
computed `(script, control_block)` for the one leaf a signature was
offered for, inside the loop, and never computed the merkle root. So the
work was the accessors — `taproot_leaf_scripts` and
`taproot_merkle_root`, both public, the control block being the thing a
psbt cannot work out for itself — after which the Updater is four
assignments, and `_satisfy` builds its one leaf through the same helper
rather than keeping a second copy of the walk.

And a key with no `origin` is skipped rather than refused: the field is
keyed by public key, and a descriptor may name one key as plain hex and
the next with an origin. What is carried for a key that has one is the
whole path down to the derived key — `origin.der_path`, the descriptor's
own steps, and the wildcard at `index` — since the shorter path is one a
signer would derive the wrong key from.

### Beside it

`taproot.leaf_hash` is the BIP 341 tapleaf hash that `tree_helper`,
`check_output_pubkey` and the psbt's own `leaf_script` each computed for
themselves; this needed a fourth, so it is one function and three call
sites now.

### Tests

The issue calls `test_satisfy_matches_the_psbt_finalizer` the prototype.
It is weaker than that — it builds `redeem_script` and `witness_script`
only, by re-parsing a sub-descriptor string carried in the vector, and
has no taproot vector — so it stays as the independent check and the
same nine vectors run through the Updater beside it, with
`assert_signable` saying each script is the one the spent output commits
to.

The taproot half gets what it had no prototype for: every control block
checked with `check_output_pubkey`, the verifier's own side of BIP 341;
the leaf hashes of a key in two leaves at two depths; and a script path
spend signed, finalized, and compared to `satisfy` byte for byte — which
the same psbt without the Updater cannot do, `finalize_psbt` answering
"no leaf script for tapleaf hash".

Suite green, coverage at 100%, `sphinx -W` builds. `check-manifest`
fails in my working tree on an untracked `REPOSITORY.md` that is another
session's, and passes with `--ignore REPOSITORY.md`; nothing in this
branch touches the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a descriptor-driven PSBT updater that populates inputs with script and key-origin data, including full taproot metadata, enabling proper multi-step signing and finalization per BIP 174 and related taproot BIPs.

New Features:
- Add Descriptor.update_psbt to update a specified PSBT input with redeem/witness scripts, key origins, and taproot fields based on the descriptor, returning a copied PSBT.
- Expose TrDescriptor.taproot_merkle_root and taproot_leaf_scripts helpers to provide merkle root and leaf script/control block data for taproot descriptors.
- Add taproot.leaf_hash utility for computing BIP341 tapleaf hashes shared across tree construction, verification, and PSBT lookups.

Enhancements:
- Refine descriptor hierarchy with fragment-specific _update implementations, including taproot-specific key path handling that uses taproot_hd_key_paths instead of generic hd_key_paths.
- Ensure descriptors refuse PSBT updating for addr(), raw(), and combo() shapes, aligning updater behavior with satisfy semantics and avoiding misleading no-op updates.

Documentation:
- Document Descriptor.update_psbt and taproot helper behavior in the changelog, describing the full PSBT pipeline of updater, signing, and finalization and clarifying taproot-specific fields and constraints.

Tests:
- Extend descriptor tests to cover PSBT updating behavior, key-origin propagation, taproot metadata population, and script-path finalization parity with satisfy, including negative cases for unsupported descriptors and invalid indices.