### PR TITLE
No digit of a secret scalar is zero: a regular window (#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,46 @@ edit.
   whose iteration count is its input; and the wNAF loops skip the
   addition of a zero digit outright, which is the next thing to fix
   (issue #254)
+- **the scalar no longer decides how many additions a multiplication
+  makes, nor how many windows** (issue #254). Infinity had stopped costing
+  less than a point inside the group law, which closed the leak *in* the
+  addition; the loops above it still let the scalar say how many additions
+  to do at all. `mult_regular_window` is the fixed window with both
+  quantities taken away from it: `signed_odd_digits` recodes the scalar
+  into digits of `{±1, ±3, …, ±(2^w − 1)}` — the regular recoding of
+  Joye-Tunstall, which libsecp256k1's `ecmult_gen` uses too — so no digit
+  is zero and every window is one addition and `w` doublings, and there
+  are `ceil(ec.scalar_len / w)` windows whatever the scalar, where the
+  fixed window has `ceil(m.bit_length() / w)` and so runs one short for a
+  scalar one short. Measured over 200 random scalars on secp256k1: 71
+  additions and 253 doublings for every one of them, against 68 to 70 and
+  251 to 259, and 0.815 ms against 0.812 — uniformity for the price of
+  nothing, which is why `_mult` is this now and the plain fixed window
+  stays as the didactic one. `curves.mult` on secp256k1 goes through the
+  GLV endomorphism, whose two halves now feed
+  `double_mult_regular_window` rather than the interleaved wNAFs of
+  algorithm 3.77: 79 additions and 126 doublings for every scalar and
+  0.589 ms, against 51 to 64, 124 to 131 and 0.509 — 16% for a quarter of
+  the work stopping to be a property of the secret. The wNAFs are still
+  there and still the default of nothing but themselves: `double_mult`,
+  `dsa` and `ssa` verification and public key recovery reach
+  `double_mult_w_NAF` directly, their coefficients being a signature and a
+  message hash, and `mult_endomorphism_secp256k1(…, regular=False)` is
+  algorithm 3.77 as it is written. Two further consequences, one of them
+  the point: the accumulator starts at a table entry instead of at
+  infinity and no digit names infinity, so the identity is now unreachable
+  from the loops rather than merely uniform inside them, and `add_jac`'s
+  stand-ins have become belt and braces for callers rather than the thing
+  holding a multiplication together; and a scalar's *size* stops being
+  visible, which nothing addressed before. What is unchanged is the
+  memory access pattern: the table is indexed by a secret digit, which is
+  what the FLUSH+RELOAD recovery of OpenSSL's nonces read, and Python
+  offers nothing to hide it with — scanning the whole table per window is
+  the technique, and it costs the window. `SECURITY.md` said so and still
+  does. `CurveGroup` gained `scalar_len`, the bits a scalar of the group
+  can have, `p.bit_length() + 1` from Hasse's bound and narrowed to
+  `nlen` by `Curve`: it is a count and not a limit, a scalar above it
+  being multiplied in the digits it needs
 
 ### Consensus rules
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,16 +106,25 @@ used to teach and to prototype as much as to build:
     are opposite, do still branch — that case needs the accumulator to
     land on a table entry, 2^-250 on a curve with a real order, and a
     caller spelling out `P + P` knows it did.
+    Nor does the scalar decide how many additions there are, or how many
+    windows: `mult` recodes it into signed odd digits, none of them zero
+    and always `ceil(nlen / w)` of them, and starts the accumulator at a
+    table entry rather than at the identity, so every scalar of the curve
+    costs the same additions and the same doublings, and its size is
+    hidden as its bits are. Measured over 200 random scalars: 71 additions
+    and 253 doublings for every one of them, where the plain fixed window
+    makes 68 to 70 and 251 to 259; and on secp256k1, whose endomorphism
+    halves the doublings, 79 and 126 for every one of them, where the
+    interleaved wNAFs of the same decomposition make 51 to 64 and 124 to
+    131. Those wNAFs add on a nonzero digit and so once per unit of the
+    recoded weight of the coefficient, which is why they are not what
+    `mult` reaches for; they are what `double_mult` and signature
+    verification reach, where the coefficients are a signature and a
+    message hash rather than a secret.
 
     What is left is out of reach from pure Python, and is enough to
-    matter: the loop runs once per digit of the scalar, so the size of a
-    secret is not hidden, only its bits; the wNAF multiplications, which
-    are the ones `mult`, `double_mult` and verification reach, skip the
-    addition of a zero digit outright, so the _number_ of additions is
-    the recoded weight of the scalar (measured on secp256k1: 51 to 63
-    additions, 0.502 ms to 0.549 ms, over 200 random scalars);
-    the windowed multiplications index a table of precomputed multiples
-    with a secret digit, which is the memory access pattern the
+    matter: the windowed multiplications index a table of precomputed
+    multiples with a secret digit, which is the memory access pattern the
     FLUSH+RELOAD recovery of OpenSSL's nonces read; every reduction and
     multiplication takes the time its operand sizes ask for, and a
     residue is not always the full size; the affine group law and the

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -23,20 +23,21 @@ curves -- so the anchor is worth stating: `from btclib.curves import mult`,
 `from btclib.ecc import dsa`.
 
 What this package exports is the curve API: a Curve, the three scalar
-multiplications, and the SEC point codec. The eleven other mult_* of
+multiplications, and the SEC point codec. The other mult_* of
 btclib.curves.curve_group and btclib.curves.curve_group_2 -- mult_aff, mult_jac,
 mult_base_3, mult_mont_ladder, the two mult_recursive_*, the two
-mult_fixed_window*, mult_sliding_window, mult_w_NAF and
+mult_fixed_window*, mult_regular_window, mult_sliding_window, mult_w_NAF and
 mult_endomorphism_secp256k1 -- are deliberately not exported, nor are the
-multiples, cached_multiples and jac_from_aff they are built on.
+multiples, cached_multiples, odd_multiples and jac_from_aff they are built on.
 
 They are implementations of one operation, kept side by side to be measured
 against each other, and exporting them would make a menu out of a benchmark:
-a caller reading btclib.curves would find fourteen ways to multiply a point
-and nothing to say that mult is the one to use, that it dispatches to
-libsecp256k1 for secp256k1 and the generator, and that mult_jac is not the
-faster alternative its name suggests. Each is importable from the module
-that defines it, which is where the test suite takes them from.
+a caller reading btclib.curves would find every way of multiplying a point
+this package implements and nothing to say that mult is the one to use, that
+it dispatches to libsecp256k1 for secp256k1 and the generator, and that
+mult_jac is not the faster alternative its name suggests. Each is importable
+from the module that defines it, which is where the test suite takes them
+from.
 
 The codec has a third function, bytes_from_prv_key_int: the composition of
 a multiplication and an encoding that every private-to-public conversion

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -140,6 +140,14 @@ class Curve(CurveGroup):
         self.n = n
         self.nlen = n.bit_length()
         self.n_size = (self.nlen + 7) // 8
+        # a scalar here is reduced mod n and not mod the order of the whole
+        # curve, so nlen is a tighter bound than the plen + 1 CurveGroup
+        # took from Hasse -- one window less at w=4 on secp256k1, and
+        # log2(cofactor) bits less on a curve with a cofactor.
+        # mult_regular_window fixes its digit count to it, and reads it
+        # under this name rather than as nlen so that a CurveGroup, which
+        # has no n, can be multiplied in as well
+        self.scalar_len = self.nlen
 
         # 5. Check that n is prime.
         if not _is_prime(n):
@@ -516,9 +524,13 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
     # -- a zero scalar, or infinity -- and, with the dispatch
     # above patched off, every multiplication of the curve: that is the
     # reference implementation the test suite holds the bindings against,
-    # and the GLV endomorphism is its fastest form, 0.53 ms against the
-    # 0.84 of _mult, the decomposition being secp256k1's own lambda and
-    # beta. Not spelled as _libsecp256k1_applicable, though it is the same
+    # and the GLV endomorphism is its fastest form, 0.59 ms against the
+    # 0.82 of _mult, the decomposition being secp256k1's own lambda and
+    # beta. Both are regular: the number of point additions either makes
+    # is the same for every scalar, which is what a private key or a nonce
+    # arriving here needs and what issue 254 is about -- the endomorphism
+    # over interleaved wNAFs would be 0.51 ms and 51 to 64 additions.
+    # Not spelled as _libsecp256k1_applicable, though it is the same
     # test today: what decides here is whether the curve has that
     # endomorphism, so patching the bindings off must leave this arm --
     # python_path_test.py's pattern, which otherwise would compare the

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -103,6 +103,16 @@ class CurveGroup:
         self.p_is_3_mod_4 = p % 4 == 3
         self.p = p
 
+        # how many bits a scalar of this group has, which is what fixes
+        # the digit count of mult_regular_window below -- the quantity a
+        # loop running once per digit of the scalar in hand puts on the
+        # clock. Hasse bounds the order of the group by p + 1 + 2*sqrt(p),
+        # so a scalar reduced mod that order is under 2^(plen+1); Curve
+        # narrows it to nlen, the order of its subgroup being the bound
+        # there. It is a count and not a limit: a scalar above it is
+        # multiplied all the same, in the digits it needs
+        self.scalar_len = plen + 1
+
         # 2. check that a and b are integers in the interval [0, p−1]
         if a < 0:
             raise BTClibValueError(f"negative a: {a}")
@@ -734,6 +744,58 @@ def wNAF_of_m(m: int, w: int) -> list[int]:
     return M
 
 
+def signed_odd_digits(m: int, w: int, size: int) -> list[int]:
+    """Return the size signed odd base-2^w digits of an odd m.
+
+    Regular recoding, Joye-Tunstall: m = sum(digits[i] * 2^(w*i)) with
+    every digit odd and in {±1, ±3, ..., ±(2^w - 1)}, least significant
+    first, as wNAF_of_m returns its own. Two properties are what it is
+    for, and neither is the wNAF's:
+
+    - no digit is zero, so the multiplication that indexes them makes one
+      addition per digit whatever m is, where a wNAF adds on a nonzero
+      digit and so once per unit of the recoded weight
+    - the count is `size` and not the length of m, so a scalar's *size*
+      stops being visible too
+
+    The digits are signed, and that is what buys the first property: 2^w
+    odd values in -(2^w - 1)..2^w - 1 name 2^(w-1) points and their
+    opposites, and negating a Jacobian point is one modular subtraction.
+
+    m must be odd -- a sum of odd digits weighted by powers of 2 has the
+    parity of digits[0], so no even number has such a form at all -- and
+    must fit the size asked for, which is `m < 2^(w*size)`: the last digit
+    is what is left of m and is not reduced further.
+    """
+    if m < 0:
+        raise BTClibValueError(f"negative m: {hex(m)}")
+    # a number cannot be written in basis 1 (ie w=0)
+    if w <= 0:
+        raise BTClibValueError(f"non positive w: {w}")
+    if m % 2 == 0:
+        raise BTClibValueError(f"even m: {hex(m)}")
+    if size < 1:
+        raise BTClibValueError(f"size too low: {size}")
+    if m >> (w * size):
+        raise BTClibValueError(f"m does not fit {size} digits: {hex(m)}")
+
+    w2 = 1 << w
+    digits: list[int] = []
+    for _ in range(size - 1):
+        # the low w+1 bits of m read as a signed value: odd, since m is,
+        # and in -(2^w - 1)..2^w - 1
+        digit = (m % (2 * w2)) - w2
+        digits.append(digit)
+        # m - digit is 2^w times an odd number -- m - (m mod 2^(w+1)) is a
+        # multiple of 2^(w+1) and 2^w is added back to it -- so the next
+        # digit is odd in its turn, and the recoding never needs a zero
+        m = (m - digit) >> w
+    # what is left, which the bound above makes an odd digit of its own:
+    # positive, so the accumulator can start at the entry it names
+    digits.append(m)
+    return digits
+
+
 def odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
     """Return the odd multiples 1*Q, 3*Q, ..., (2^(w-1) - 1)*Q.
 
@@ -748,6 +810,25 @@ def odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
         for _ in range(2 ** (w - 2) - 1):
             T.append(ec.add_jac(T[-1], Q2))
     return T
+
+
+def signed_odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
+    """Return the 2^w multiples a signed odd width-w digit names.
+
+    -(2^w - 1)*Q first and (2^w - 1)*Q last, so the digit d of
+    signed_odd_digits picks entry (d + 2^w - 1) // 2 and nothing has to
+    test its sign, where the wNAF loops negate an entry of `odd_multiples`
+    on the fly under an `if`. Cheaper, too, and not only regular: 2^(w-1)
+    modular subtractions once -- 8 of them at w=4 -- against the one per
+    negative digit the loop would make, which is half of the 64 digits a
+    256-bit scalar has at that width.
+
+    The table it is built on is `odd_multiples(Q, ec, w + 1)`: a regular
+    digit reaches 2^w - 1 where a width-w NAF digit stops at 2^(w-1) - 1,
+    so the table is twice as long as that recoding's for the same window.
+    """
+    T = odd_multiples(Q, ec, w + 1)
+    return [ec.negate_jac(P) for P in reversed(T)] + T
 
 
 def mult_mont_ladder(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
@@ -886,7 +967,85 @@ def mult_fixed_window_cached(
     return R
 
 
-_mult = mult_fixed_window
+def mult_regular_window(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacPoint:
+    """Scalar multiplication using a regular window: no digit is zero.
+
+    The fixed window above, with the quantity the scalar still decided
+    taken away from it (issue 254). That one adds a table entry on every
+    digit, the infinity of T[0] included, so *which* digits a scalar has
+    does not change what it costs -- but how many it has does: the count
+    is ceil(m.bit_length() / w), and a scalar short of a full top window
+    runs one window less. Here the digits are the signed odd ones of
+    signed_odd_digits, none of them zero, and there are
+    ceil(ec.scalar_len / w) of them whatever m is: one addition and w
+    doublings per window, for every scalar of every size. Measured on
+    secp256k1 over 200 random scalars: 68 to 70 additions and 251 to 259
+    doublings for the fixed window, and 71 and 253 for this one on every
+    one of them.
+
+    Uniformity for free, in other words -- 0.815 ms against 0.812 over 30
+    random 256-bit scalars, best of five -- which is what makes this the
+    `_mult` the package reaches for rather than an option beside it. The
+    fixed window stays as what it is didactically, the plain one, and the
+    wNAF multiplications stay the fast irregular ones for coefficients
+    that are public: `double_mult_w_NAF` is what verification runs.
+
+    w=4 by measurement, as for the fixed window: 0.803 ms at w=5 and 0.831
+    at w=6, the window paying for a table twice the size of the NAF's at
+    the same width.
+
+    Two things follow for the group law underneath. The accumulator starts
+    at a table entry instead of at infinity and no digit names infinity, so
+    the identity is unreachable from the loop rather than merely uniform in
+    it; and the two special cases left in `add_jac`, a doubling and a sum
+    that is infinity, need the accumulator to land on a table entry or its
+    opposite, 2^-250 on a curve with a real order. On the toy curves of
+    the test suite they are reached constantly, an accumulator wrapping
+    around a group of eleven points, which is what holds them tested.
+
+    The input point is assumed to be on curve. m is *not* assumed to have
+    been reduced: a scalar above ec.scalar_len bits is multiplied in the
+    digits it needs, which is the one case where the count is the scalar's
+    own again -- and no entry point of the library forms one, each reducing
+    mod n first.
+    """
+    if m < 0:
+        raise BTClibValueError(f"negative m: {hex(m)}")
+
+    # a number cannot be written in basis 1 (ie w=0)
+    if w <= 0:
+        raise BTClibValueError(f"non positive w: {w}")
+
+    size = ceil(max(ec.scalar_len, m.bit_length()) / w)
+    # the recoding needs an odd scalar, and m | 1 is m for an odd one and
+    # m + 1 for an even one. The final addition below takes the 1 back
+    # rather than n being added to make m odd: n is not on CurveGroup at
+    # all, and m + n would be the same point only for a point whose order
+    # it is -- which the group this multiplies in cannot say
+    digits = signed_odd_digits(m | 1, w, size)
+    T = signed_odd_multiples(Q, ec, w)
+    offset = (1 << w) - 1
+
+    # a table entry, the top digit being positive, and never infinity
+    R = T[(digits[-1] + offset) // 2]
+    for digit in digits[-2::-1]:
+        # multiple 'double'
+        for _ in range(w):
+            R = ec.double_jac(R)
+        # and 'add', on every digit: there is no zero one to skip
+        R = ec.add_jac(R, T[(digit + offset) // 2])
+    # the parity correction, made whatever the parity so that it cannot be
+    # read off the clock: one addition of infinity, which by the same
+    # property costs what the addition of -Q costs. It is also what
+    # answers m == 0, whose recoding is that of 1
+    return ec.add_jac(R, (INFJ, ec.negate_jac(Q))[not m & 1])
+
+
+# what the rest of the package multiplies with, on every curve but
+# secp256k1, where curves.mult has the GLV endomorphism: the regular
+# window, whose cost is the same for every scalar of the curve, at the
+# cost of nothing measurable against the fixed window it recodes
+_mult = mult_regular_window
 
 
 def _double_mult(

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -14,9 +14,11 @@ The implemented algorithms are:
     - Montgomery Ladder
     - Scalar multiplication on basis 3
     - Fixed window
+    - Regular window, signed odd digits (Joye-Tunstall recoding)
     - Sliding window
     - w-ary non-adjacent form (wNAF)
     - Interleaved-wNAF double multiplication (HMV algorithm 3.51)
+    - Regular-window double multiplication
     - GLV endomorphism multiplication for secp256k1 (HMV algorithm 3.77)
 
 References:
@@ -25,6 +27,9 @@ References:
     - https://ecc2017.cs.ru.nl/slides/ecc2017school-castryck.pdf
     - https://cr.yp.to/bib/2003/joye-ladder.pdf
     - D. Hankerson, 'Guide to Elliptic Curve Cryptography' chapter 3
+    - M. Joye and M. Tunstall, 'Exponent Recoding and Regular
+      Exponentiation Algorithms', AFRICACRYPT 2009, for the signed odd
+      digits of a regular window
     - https://bitcointalk.org/index.php?topic=3238.msg45565#msg45565
     - https://medium.com/@CoinExChain/acceleration-of-ecdsa-verification-with-endomorphism-mapping-of-secp256k1-126e77a51dba
 
@@ -60,6 +65,8 @@ follow-ups; what is here is the rest:
 
 from __future__ import annotations
 
+from math import ceil
+
 from btclib.alias import INFJ, JacPoint
 
 # the wNAF recoding and the table of odd multiples it indexes live in
@@ -70,6 +77,8 @@ from btclib.curves.curve_group import (
     CurveGroup,
     convert_number_to_base,
     odd_multiples,
+    signed_odd_digits,
+    signed_odd_multiples,
     wNAF_of_m,
 )
 from btclib.exceptions import BTClibValueError
@@ -277,6 +286,77 @@ def double_mult_w_NAF(
     return R
 
 
+def double_mult_regular_window(
+    u: int,
+    HJ: JacPoint,
+    v: int,
+    QJ: JacPoint,
+    ec: CurveGroup,
+    w: int = 4,
+    scalar_len: int = 0,
+) -> JacPoint:
+    """Double scalar multiplication (u*H + v*Q), regular windows.
+
+    curve_group's mult_regular_window for two coefficients, sharing the
+    doublings as the interleaved wNAF above does: one recoding and one
+    table of signed odd multiples per coefficient, and a loop of w
+    doublings and two additions per window, both of them made whatever the
+    digits are. So the cost is the same for every pair (u, v) of a given
+    scalar_len -- 143 additions and 254 doublings on secp256k1, over 200
+    random pairs -- where double_mult_w_NAF's is the recoded weight of the
+    two coefficients and is 101 to 116 additions over the same pairs, and
+    0.996 ms against 1.11.
+
+    Which is mult_regular_window's trade, twice: a table of 2^(w-1) points
+    per coefficient, and their opposites, to make one addition per window
+    per coefficient -- where the wNAF builds half as many points and adds
+    on one digit in w+1. This function is therefore not what
+    `double_mult` runs -- verification's coefficients are public -- but
+    what mult_endomorphism_secp256k1 runs, whose two are halves of a
+    secret.
+
+    scalar_len is the bit count the digits are fixed to, ec.scalar_len by
+    default. It is a parameter because the caller that wants this function
+    has coefficients shorter than the group's by construction:
+    mult_endomorphism_secp256k1 splits a 256-bit scalar into two halves of
+    128 bits, and the group's own 256 would double the work for nothing.
+
+    The input points are assumed to be on curve, and the u and v
+    coefficients are assumed to have been reduced mod n if appropriate
+    (e.g. cyclic groups of order n).
+    """
+    if u < 0:
+        raise BTClibValueError(f"negative first coefficient: {hex(u)}")
+    if v < 0:
+        raise BTClibValueError(f"negative second coefficient: {hex(v)}")
+    # a number cannot be written in basis 1 (ie w=0)
+    if w <= 0:
+        raise BTClibValueError(f"non positive w: {w}")
+
+    # as in mult_regular_window: the count is the curve's, or the caller's,
+    # and a coefficient above it is multiplied in the digits it needs
+    bits = max(scalar_len or ec.scalar_len, u.bit_length(), v.bit_length())
+    size = ceil(bits / w)
+    us = signed_odd_digits(u | 1, w, size)
+    vs = signed_odd_digits(v | 1, w, size)
+
+    TH = signed_odd_multiples(HJ, ec, w)
+    TQ = signed_odd_multiples(QJ, ec, w)
+    offset = (1 << w) - 1
+
+    # the accumulator starts at the sum of two table entries, so infinity
+    # is out of the loop here too
+    R = ec.add_jac(TH[(us[-1] + offset) // 2], TQ[(vs[-1] + offset) // 2])
+    for du, dv in zip(us[-2::-1], vs[-2::-1], strict=True):
+        for _ in range(w):
+            R = ec.double_jac(R)
+        R = ec.add_jac(R, TH[(du + offset) // 2])
+        R = ec.add_jac(R, TQ[(dv + offset) // 2])
+    # and the two parity corrections, each made whatever the parity
+    R = ec.add_jac(R, (INFJ, ec.negate_jac(HJ))[not u & 1])
+    return ec.add_jac(R, (INFJ, ec.negate_jac(QJ))[not v & 1])
+
+
 # secp256k1 constants for the GLV endomorphism, all four functions of
 # them below being specific to that curve:
 # the group order,
@@ -330,18 +410,48 @@ def multiplier_decomposer(m: int) -> tuple[int, int]:
     return m1, m2
 
 
-def mult_endomorphism_secp256k1(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
+# the bits either half of the decomposition can have, and the digit count
+# double_mult_regular_window is fixed to below. It is the rounding error of
+# multiplier_decomposer and not a measurement: round-to-nearest leaves at
+# most half a basis vector of each, |m1| <= (|a1| + |a2|)/2 and
+# |m2| <= (|b1| + |b2|)/2, both of which are 128-bit numbers with the
+# constants above. libsecp256k1's scalar_split_lambda states the same 128
+_HALF_LEN = 128
+
+
+def mult_endomorphism_secp256k1(
+    m: int, Q: JacPoint, ec: CurveGroup, w: int = 4, regular: bool = True
+) -> JacPoint:
     """Scalar multiplication in Jacobian coordinates using endomorphism.
 
     Algorithm 3.77 of D. Hankerson, 'Guide to Elliptic Curve
     Cryptography': m*Q as m1*Q + m2*(lambda*Q), the halves coming from
-    multiplier_decomposer and the double multiplication interleaving
-    their wNAFs. Measured over 30 random 256-bit scalars: 0.53 ms at the
-    default w=4, against 0.80 ms feeding the same halves to curve_group's
-    _double_mult and 0.84 ms for the _mult this exists to beat -- the
-    fastest Python multiplication in the package, and the w=4 default is
-    that measurement, the same halves interleaved at w=3 giving 0.57 ms
-    and at w=5 0.52, which is the default's own noise.
+    multiplier_decomposer and a double multiplication sharing their
+    doublings. It is the fastest Python multiplication in the package and
+    what `curves.mult` runs for every secp256k1 point the bindings do not
+    take.
+
+    Which double multiplication is `regular`, and the two answer the same
+    point at different costs. Measured over 30 random 256-bit scalars,
+    best of five, at the default w=4:
+
+    - the regular windows of double_mult_regular_window, 0.589 ms, and 79
+      additions and 126 doublings for every one of 200 random scalars
+    - the interleaved wNAFs of double_mult_w_NAF, 0.509 ms, which is
+      algorithm 3.77 as it is written, and 51 to 64 additions and 124 to
+      131 doublings over the same scalars: a quarter more work for the
+      worst scalar than for the best, and which it is is a property of
+      the secret (issue 254)
+
+    The regular one is the default because the scalar of a `curves.mult`
+    is a private key or a nonce in every caller btclib has, and 16% of a
+    multiplication that libsecp256k1 answers in 13 us is not what this
+    path is for. Both stay: the wNAF is what verification wants, its
+    coefficients being public, and `double_mult` reaches it directly.
+
+    w=4 by measurement for both: the regular windows give 0.610 ms at
+    w=5, and the wNAFs 0.527 at w=3 and 0.510 at w=5, which is the
+    default's own noise.
     """
     if m < 0:
         raise BTClibValueError(f"negative m: {hex(m)}")
@@ -352,11 +462,14 @@ def mult_endomorphism_secp256k1(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint
 
     # the decomposition is signed on purpose -- balance is what makes the
     # halves short -- and the sign belongs to the point: -m1*Q is m1*(-Q),
-    # one modular negation of a y-coordinate
-    P = Q
-    if m1 < 0:
-        m1, P = -m1, ec.negate_jac(P)
-    if m2 < 0:
-        m2, K = -m2, ec.negate_jac(K)
+    # one modular negation of a y-coordinate. Negated whatever the sign and
+    # selected afterwards, rather than under an `if`: the sign of a half is
+    # a bit of the scalar, and a modular subtraction is what a branch on it
+    # would put on the clock
+    P = (Q, ec.negate_jac(Q))[m1 < 0]
+    K = (K, ec.negate_jac(K))[m2 < 0]
+    m1, m2 = abs(m1), abs(m2)
 
-    return double_mult_w_NAF(m1, P, m2, K, ec)
+    if regular:
+        return double_mult_regular_window(m1, P, m2, K, ec, w, _HALF_LEN)
+    return double_mult_w_NAF(m1, P, m2, K, ec, w)

--- a/tests/curves/curve_group_2_test.py
+++ b/tests/curves/curve_group_2_test.py
@@ -13,15 +13,17 @@ import secrets
 
 import pytest
 
-from btclib.alias import INFJ
+from btclib.alias import INFJ, JacPoint
 from btclib.curves import secp256k1
 from btclib.curves.curve_group import _double_mult, _mult
 
 # from the module that defines them: btclib.curves does not export the
 # individual multiplication implementations
 from btclib.curves.curve_group_2 import (
+    _HALF_LEN,
     _LAM,
     _N,
+    double_mult_regular_window,
     double_mult_w_NAF,
     mult_endomorphism_secp256k1,
     mult_sliding_window,
@@ -98,26 +100,37 @@ def test_mult_w_NAF() -> None:
             assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
-def test_mult_endomorphism_secp256k1() -> None:
+@pytest.mark.parametrize("regular", [True, False])
+def test_mult_endomorphism_secp256k1(regular: bool) -> None:
+    """Both double multiplications the endomorphism can be built on.
+
+    The regular windows of the default and the interleaved wNAFs of
+    algorithm 3.77 as it is written: the same points, at the costs the
+    function's docstring measures, so both answer every case here.
+    """
+
+    def mult(m: int, QJ: JacPoint) -> JacPoint:
+        return mult_endomorphism_secp256k1(m, QJ, secp256k1, regular=regular)
+
     ec = secp256k1
-    assert ec.jac_equality(mult_endomorphism_secp256k1(0, ec.GJ, ec), INFJ)
-    assert ec.jac_equality(mult_endomorphism_secp256k1(0, INFJ, ec), INFJ)
+    assert ec.jac_equality(mult(0, ec.GJ), INFJ)
+    assert ec.jac_equality(mult(0, INFJ), INFJ)
 
-    assert ec.jac_equality(mult_endomorphism_secp256k1(1, INFJ, ec), INFJ)
-    assert ec.jac_equality(mult_endomorphism_secp256k1(1, ec.GJ, ec), ec.GJ)
+    assert ec.jac_equality(mult(1, INFJ), INFJ)
+    assert ec.jac_equality(mult(1, ec.GJ), ec.GJ)
 
-    PJ = mult_endomorphism_secp256k1(2, ec.GJ, ec)
+    PJ = mult(2, ec.GJ)
     assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-    PJ = mult_endomorphism_secp256k1(ec.n - 1, ec.GJ, ec)
+    PJ = mult(ec.n - 1, ec.GJ)
     assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
 
-    assert ec.jac_equality(mult_endomorphism_secp256k1(ec.n - 1, INFJ, ec), INFJ)
+    assert ec.jac_equality(mult(ec.n - 1, INFJ), INFJ)
     assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-    assert ec.jac_equality(mult_endomorphism_secp256k1(ec.n, ec.GJ, ec), INFJ)
+    assert ec.jac_equality(mult(ec.n, ec.GJ), INFJ)
 
     with pytest.raises(BTClibValueError, match="negative m: "):
-        mult_endomorphism_secp256k1(-1, ec.GJ, ec)
+        mult(-1, ec.GJ)
 
 
 def test_mult_endomorphism_agrees_with_mult_above_2_127() -> None:
@@ -144,7 +157,9 @@ def test_mult_endomorphism_agrees_with_mult_above_2_127() -> None:
     ] + [secrets.randbelow(_N) for _ in range(8)]
     for m in scalars:
         expected = _mult(m, ec.GJ, ec)
-        assert ec.jac_equality(mult_endomorphism_secp256k1(m, ec.GJ, ec), expected)
+        for regular in (True, False):
+            got = mult_endomorphism_secp256k1(m, ec.GJ, ec, regular=regular)
+            assert ec.jac_equality(got, expected), (m, regular)
 
 
 def test_multiplier_decomposer() -> None:
@@ -174,10 +189,12 @@ def test_multiplier_decomposer() -> None:
         # congruent: m1 + m2*lambda is m mod n, which is the identity
         # making m1*Q + m2*(lambda*Q) equal m*Q
         assert (m1 + m2 * _LAM - m) % _N == 0
-        # short and signed: both halves fit 129 bits, sign included,
-        # against the 256 both reached when the results were % p
-        assert m1.bit_length() <= 129
-        assert m2.bit_length() <= 129
+        # short and signed: both halves fit _HALF_LEN bits, sign included,
+        # against the 256 both reached when the results were % p. That
+        # constant is the digit count of the regular double multiplication
+        # the endomorphism runs, so a half over it would cost a window
+        assert m1.bit_length() <= _HALF_LEN
+        assert m2.bit_length() <= _HALF_LEN
 
 
 def test_double_mult_w_NAF() -> None:
@@ -205,3 +222,38 @@ def test_double_mult_w_NAF() -> None:
         double_mult_w_NAF(1, ec.GJ, -1, ec.GJ, ec)
     with pytest.raises(BTClibValueError, match="non positive w: "):
         double_mult_w_NAF(1, ec.GJ, 1, ec.GJ, ec, 0)
+
+
+def test_double_mult_regular_window() -> None:
+    """Regular windows against the Shamir-Strauss double mult.
+
+    The same exhaustive pairs test_double_mult_w_NAF runs, the two
+    functions being interchangeable: a zero coefficient, whose recoding is
+    that of 1 with the correction taking it back, and w of 1, where each
+    table is the point and its opposite and every digit is +-1.
+    """
+    for ec in (low_card_curves["ec13_11"], ec23_31):
+        HJ = ec.GJ
+        QJ = _mult(3, ec.GJ, ec)
+        for w in (1, 2, 4):
+            for u in range(ec.n):
+                for v in range(ec.n):
+                    expected = _double_mult(u, HJ, v, QJ, ec)
+                    got = double_mult_regular_window(u, HJ, v, QJ, ec, w)
+                    assert ec.jac_equality(got, expected), (u, v, w)
+
+    ec = secp256k1
+    # the scalar_len the endomorphism passes, and coefficients that need
+    # more digits than it asks for: the count is fixed, not a limit
+    for u, v in ((0, 0), (1, _N - 1), (_N - 1, 1), (_N - 1, _N - 2)):
+        expected = _double_mult(u, ec.GJ, v, ec.GJ, ec)
+        for scalar_len in (0, _HALF_LEN):
+            got = double_mult_regular_window(u, ec.GJ, v, ec.GJ, ec, 4, scalar_len)
+            assert ec.jac_equality(got, expected), (u, v, scalar_len)
+
+    with pytest.raises(BTClibValueError, match="negative first coefficient: "):
+        double_mult_regular_window(-1, ec.GJ, 1, ec.GJ, ec)
+    with pytest.raises(BTClibValueError, match="negative second coefficient: "):
+        double_mult_regular_window(1, ec.GJ, -1, ec.GJ, ec)
+    with pytest.raises(BTClibValueError, match="non positive w: "):
+        double_mult_regular_window(1, ec.GJ, 1, ec.GJ, ec, 0)

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -16,8 +16,8 @@ import pytest
 from btclib.alias import INF, INFJ, JacPoint
 from btclib.curves import Curve, CurveGroup, secp256k1
 
-# the eight mult_* variants under test, and the helpers they are built on,
-# come from the module that defines them: btclib.curves exports mult,
+# the mult_* variants under test, and the helpers they are built on, come
+# from the module that defines them: btclib.curves exports mult,
 # double_mult and multi_mult, not a menu of implementations
 from btclib.curves.curve_group import (
     BOS_COSTER_THRESHOLD,
@@ -37,7 +37,10 @@ from btclib.curves.curve_group import (
     mult_mont_ladder,
     mult_recursive_aff,
     mult_recursive_jac,
+    mult_regular_window,
     multiples,
+    signed_odd_digits,
+    signed_odd_multiples,
 )
 from btclib.ecc import second_generator
 from btclib.exceptions import BTClibValueError
@@ -314,6 +317,162 @@ def test_mult_fixed_window() -> None:
             assert ec.jac_equality(K1, mult_jac(k1, ec.GJ, ec))
 
 
+def test_signed_odd_digits() -> None:
+    """The regular recoding against hand-computed digits, and its errors.
+
+    Vectors first, digit by digit and small enough to be checked on paper,
+    because the round trip below cannot fail on a recoding that is wrong
+    in a way its own reconstruction shares: -5 + 3*16 is 43 whether or not
+    -5 is the digit the algorithm should have produced.
+    """
+    assert signed_odd_digits(43, 4, 2) == [-5, 3]
+    assert signed_odd_digits(5, 1, 3) == [-1, 1, 1]
+    assert signed_odd_digits(255, 2, 4) == [3, 3, 3, 3]
+    # a scalar of one digit, padded out to three: the low digits go as
+    # negative as they can and the top one carries the whole value
+    assert signed_odd_digits(1, 4, 3) == [-15, -15, 1]
+    assert signed_odd_digits(1, 4, 1) == [1]
+
+    err_msg = "negative m: "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        signed_odd_digits(-1, 4, 2)
+    with pytest.raises(BTClibValueError, match="non positive w: "):
+        signed_odd_digits(1, 0, 2)
+    with pytest.raises(BTClibValueError, match="even m: "):
+        signed_odd_digits(4, 4, 2)
+    with pytest.raises(BTClibValueError, match="size too low: "):
+        signed_odd_digits(1, 4, 0)
+    with pytest.raises(BTClibValueError, match="does not fit 1 digits: "):
+        signed_odd_digits(17, 4, 1)
+
+
+def test_signed_odd_digits_properties() -> None:
+    """The three properties the multiplication is built on, over a spread.
+
+    Every digit odd and inside the window, the count exactly the one
+    asked for whatever the scalar, and the digits summing back to m --
+    the last one against the definition of a base-2^w expansion, which is
+    not how signed_odd_digits computes them.
+    """
+    rnd = random.Random(0x5164ED)
+    for w in range(1, 7):
+        for size in range(1, 6):
+            scalars = [1, (1 << (w * size)) - 1] + [
+                rnd.randrange(1 << (w * size)) | 1 for _ in range(20)
+            ]
+            for m in scalars:
+                digits = signed_odd_digits(m, w, size)
+                assert len(digits) == size, (m, w, size)
+                assert all(d % 2 for d in digits), (m, w, size)
+                assert all(0 < abs(d) < 2**w for d in digits), (m, w, size)
+                # positive, which is what lets the accumulator start there
+                assert digits[-1] > 0, (m, w, size)
+                assert sum(d << (w * i) for i, d in enumerate(digits)) == m
+
+
+def test_signed_odd_multiples() -> None:
+    """The table against the multiplications of the digits that index it."""
+    for ec in (ec23_31, secp256k1):
+        for w in range(1, 6):
+            T = signed_odd_multiples(ec.GJ, ec, w)
+            assert len(T) == 2**w
+            for d in range(-(2**w - 1), 2**w, 2):
+                expected = mult_jac(d % ec.n, ec.GJ, ec)
+                assert ec.jac_equality(T[(d + 2**w - 1) // 2], expected), (d, w)
+
+
+class _CountingGroup(CurveGroup):
+    """secp256k1's group, counting the point additions it is asked for.
+
+    The number of additions is what the scalar used to decide (issue 254),
+    and counting them is how the test below says it no longer does: a
+    timing at 0.8 ms a multiplication is noise against a spread of one
+    addition in seventy.
+    """
+
+    def __init__(self) -> None:
+        # secp256k1's own p, a and b, which is the curve every measurement
+        # in curve_group's docstrings is taken on
+        super().__init__(secp256k1.p, 0, 7)
+        self.additions = 0
+
+    def add_jac(self, Q: JacPoint, R: JacPoint) -> JacPoint:
+        self.additions += 1
+        return super().add_jac(Q, R)
+
+
+def test_regular_window_addition_count_is_the_same_for_every_scalar() -> None:
+    """Issue 254, as the property it is: one count, not a range of them.
+
+    The fixed window over the same scalars is the control, and what varies
+    for it is the *size* of the scalar: its digit count is
+    ceil(m.bit_length() / w), so it makes one addition and w doublings
+    fewer for every window the scalar is short of a full one. Hence the
+    scalars of distant sizes here beside the full-length random ones --
+    over 256-bit scalars alone the control would be constant too, a
+    quarter of the 20 the seed picks being needed to reach a shorter
+    digit count at all.
+    """
+    ec = _CountingGroup()
+    rnd = random.Random(0x9EC0DE)
+    scalars = [rnd.randrange(secp256k1.n) for _ in range(10)]
+    scalars += [0, 1, 2, 3, 1 << 100, secp256k1.n >> 17, secp256k1.n - 1]
+
+    regular = set()
+    fixed = set()
+    for m in scalars:
+        ec.additions = 0
+        mult_regular_window(m, secp256k1.GJ, ec)
+        regular.add(ec.additions)
+        ec.additions = 0
+        mult_fixed_window(m, secp256k1.GJ, ec)
+        fixed.add(ec.additions)
+
+    assert len(regular) == 1, regular
+    assert len(fixed) > 1, fixed
+
+
+def test_mult_regular_window() -> None:
+    for w in range(1, MAX_W):
+        for ec in low_card_curves.values():
+            assert ec.jac_equality(mult_regular_window(0, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(mult_regular_window(0, INFJ, ec, w), INFJ)
+
+            assert ec.jac_equality(mult_regular_window(1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(mult_regular_window(1, ec.GJ, ec, w), ec.GJ)
+
+            PJ = mult_regular_window(2, ec.GJ, ec, w)
+            assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
+
+            PJ = mult_regular_window(ec.n - 1, ec.GJ, ec, w)
+            assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
+            assert ec.jac_equality(mult_regular_window(ec.n - 1, INFJ, ec, w), INFJ)
+
+            assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
+            assert ec.jac_equality(mult_regular_window(ec.n, ec.GJ, ec, w), INFJ)
+
+            with pytest.raises(BTClibValueError, match="negative m: "):
+                mult_regular_window(-1, ec.GJ, ec, w)
+
+            with pytest.raises(BTClibValueError, match="non positive w: "):
+                mult_regular_window(1, ec.GJ, ec, -w)
+
+    ec = ec23_31
+    for w in range(1, 10):
+        for k1 in range(ec.n):
+            K1 = mult_regular_window(k1, ec.GJ, ec, w)
+            assert ec.jac_equality(K1, mult_jac(k1, ec.GJ, ec))
+
+    # a scalar of more bits than the group has, which is the one case where
+    # the digit count is the scalar's own again: the answer is still the
+    # multiplication, the recoding being asked for the digits it needs
+    ec = secp256k1
+    for m in (ec.n, ec.n + 1, 2 * ec.n, 1 << 300):
+        assert ec.jac_equality(
+            mult_regular_window(m, ec.GJ, ec), mult_jac(m, ec.GJ, ec)
+        ), m
+
+
 def test_mult_fixed_window_cached() -> None:
     for _ in range(1, MAX_W):
         for ec in low_card_curves.values():
@@ -418,10 +577,10 @@ def test_mult_on_a_characteristic_7_curve() -> None:
     other operand (issue 171). Before it was fixed, mult_jac answered
     wrong for 6 of the 13 scalars here, the ladder and mult_recursive_jac
     for 12 of 13, and _double_mult for 100 of the 169 coefficient pairs;
-    _mult and the cached fixed window happened not to, every scalar of a
-    curve this small fitting in one base-16 digit -- which is why the
-    reference here is mult_aff, the one multiplication that forms no
-    Jacobian point at all.
+    the two fixed windows happened not to, every scalar of a curve this
+    small fitting in one base-16 digit -- which is why the reference here
+    is mult_aff, the one multiplication that forms no Jacobian point at
+    all.
     """
     ec = Curve(7, 0, 3, (1, 2), 13, 1, False)
     variants = (
@@ -432,6 +591,7 @@ def test_mult_on_a_characteristic_7_curve() -> None:
         mult_base_3,
         mult_fixed_window,
         mult_fixed_window_cached,
+        mult_regular_window,
     )
     for k in range(ec.n):
         expected = mult_aff(k, ec.G, ec)


### PR DESCRIPTION
Closes #254.

`add_jac` no longer lets the scalar decide what an addition costs; the
loops above it still decided how many additions to make at all. This
recodes the scalar so that no digit is zero and fixes the digit count to
the curve's, on the two multiplications `curves.mult` can reach.

## What is new

- **`signed_odd_digits(m, w, size)`** — the regular recoding of
  Joye-Tunstall: an odd `m` into `size` digits of
  `{±1, ±3, …, ±(2^w − 1)}`, none of them zero, least significant first
  as `wNAF_of_m` returns its own.
- **`signed_odd_multiples(Q, ec, w)`** — the table those digits index,
  the odd multiples and their opposites, so digit `d` is entry
  `(d + 2^w − 1) // 2` and no sign is tested inside a loop. Cheaper as
  well as regular: `2^(w-1)` negations once (8 at w=4) against one per
  negative digit, which is half of a 256-bit scalar's 64.
- **`mult_regular_window(m, Q, ec, w=4)`** — `ceil(ec.scalar_len / w)`
  windows of one addition and `w` doublings, the accumulator starting at
  a table entry rather than at infinity. `_mult` is this now.
- **`double_mult_regular_window(u, HJ, v, QJ, ec, w=4, scalar_len=0)`** —
  the same for two coefficients, sharing the doublings.
- **`mult_endomorphism_secp256k1(…, regular=True)`** — the halves of the
  GLV decomposition feed the regular double multiplication by default,
  and `regular=False` is algorithm 3.77 as it is written. Its sign
  handling stopped branching too: both negations are made and one is
  selected, a half's sign being a bit of the scalar.
- **`CurveGroup.scalar_len`** — the bits a scalar of the group can have,
  `p.bit_length() + 1` from Hasse's bound, narrowed to `nlen` by `Curve`.
  A count and not a limit: a scalar above it is multiplied in the digits
  it needs.

## Measured

secp256k1, 200 random scalars for the counts, 30 for the times, best of
five, Python 3.14 on macOS arm64.

| | additions | doublings | ms |
|---|---|---|---|
| `mult_fixed_window` | 68 to 70 | 251 to 259 | 0.812 |
| `mult_regular_window` | **71** | **253** | 0.815 |
| endomorphism, wNAFs | 51 to 64 | 124 to 131 | 0.509 |
| endomorphism, regular | **79** | **126** | 0.589 |
| `double_mult_w_NAF` | 101 to 116 | 253 to 259 | 0.996 |
| `double_mult_regular_window` | **143** | **254** | 1.11 |

The single-scalar window is uniformity for the price of nothing, which
is why `_mult` is it. The endomorphism costs 16%, and that is the one
policy decision in here: `curves.mult`'s scalar is a private key or a
nonce in every caller btclib has, and on secp256k1 that path is what the
bindings decline rather than what production takes. The wNAFs stay and
stay the default of nothing but themselves — `double_mult`, `dsa` and
`ssa` verification and public key recovery reach `double_mult_w_NAF`
directly, their coefficients being a signature and a message hash.

The parity is handled without the group order: `m | 1` recodes, and a
final addition of `-Q` or of infinity takes the 1 back, made whatever
the parity so it cannot be read off the clock. Adding `n` instead would
need an order the group cannot state, and `mult_fixed_window` takes a
`CurveGroup`.

## What it does not buy

The table is still indexed by a secret digit, which is the memory access
pattern the FLUSH+RELOAD recovery of OpenSSL's nonces read, and Python
offers nothing to hide it with. `SECURITY.md` said so and still does,
with its two measurements brought up to date.

## Tests

The recoding against hand-computed digits, not against its own
reconstruction (`-5 + 3*16` is 43 whether or not `-5` is the digit the
algorithm owed); its properties over a spread of widths and sizes; the
table against the multiplications of the digits that index it; both new
multiplications exhaustively over the low-cardinality curves and on the
characteristic-7 curve of issue 171; both sides of `regular`; and the
addition count as the count it is — one value for the regular window
over scalars of distant sizes, more than one for the fixed window.

`uv run pytest` 16858 passed, coverage 100.00%, `pre-commit run
--all-files` clean, and the `-W` sphinx build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce regular-window scalar multiplication with Joye–Tunstall signed odd digit recoding to make point addition counts and window counts independent of secret scalar size, and adopt it as the default multiplication strategy.

New Features:
- Add signed_odd_digits and signed_odd_multiples helpers implementing Joye–Tunstall regular signed odd digit recoding and its lookup table.
- Add mult_regular_window as a regular-window scalar multiplication variant and wire it in as the default _mult implementation.
- Add double_mult_regular_window as a regular double scalar multiplication and integrate it into mult_endomorphism_secp256k1 with a regular/non-regular switch.
- Expose scalar_len on CurveGroup and Curve to fix recoding window digit counts independently of the specific scalar value.

Enhancements:
- Refine secp256k1 GLV endomorphism multiplication to optionally use regular-window double multiplication with constant addition count and branch-free sign handling.
- Clarify curve API exports and documentation around the available mult_* implementations and their intended use as internal benchmarks rather than public options.

Documentation:
- Update CHANGELOG and SECURITY notes to document the new regular window recoding, its constant-time cost properties, and remaining side-channel considerations.

Tests:
- Add property-based and correctness tests for signed_odd_digits and signed_odd_multiples, including error cases and reconstruction checks.
- Add exhaustive and behavioral tests for mult_regular_window across low-cardinality curves, secp256k1, and varying scalar sizes, including addition-count uniformity checks.
- Extend endomorphism and double multiplication tests to cover both regular-window and wNAF-based variants and validate bounds implied by the decomposition constants.
- Add tests for double_mult_regular_window to ensure agreement with Shamir–Strauss double multiplication and correct handling of scalar_len constraints and error cases.