### PR TITLE
Document the public interface, and one voice for the prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4086,6 +4086,35 @@ edit.
 
 ### Documentation and the website
 
+- **Every public class, method and function has a docstring, and ruff
+  now fails one that arrives without.** The members autodoc rendered as
+  bare signatures state their contract: the script engine's op codes
+  carry the stack effect, the refusals and the consensus rule each
+  comes from; the trailing-underscore variants (`ssa.assert_as_valid_`,
+  `dsa.crack_prv_key_`, ...) say what the suffix means — the input
+  enters already prepared, unvalidated; the core types say what
+  `to_dict`/`from_dict`, `serialize`/`parse` and `assert_valid` each
+  validate, mutate and preserve; and the `is_p2*`/`assert_p2*` family
+  says which raises and which answers a bool. `D101`, `D102` and `D103`
+  moved out of `pyproject.toml`'s ruff `ignore`, so the finished state
+  is a lint gate rather than a convention; `D107` stays ignored,
+  `__init__` being documented by its class (issue #290)
+- **One voice throughout the prose: neutral, factual, dry, and no
+  history.** Docstrings, comments, the sphinx pages and the top-level
+  markdown are reviewed to the same register — the reasoning with its
+  negative results, the authority cited, no unchecked numbers, one fact
+  in one place — and comments that told the story of what the code used
+  to be now state the same reasoning in the present tense, history
+  staying in this file and HISTORY.md. `amount.py` and `fee.py` drop
+  their `Args:`/`Returns:` sections for the pep257 prose the rest of
+  the tree uses (issue #290)
+- **CONTRIBUTING.md states the documentation style, and CLAUDE.md
+  points at it.** The tone of voice, the house style and the no-history
+  rule were readable only by inference from the files a contributor
+  happened to open; a new "Documentation and comments" section under
+  "Make Changes" states them where a contributor reads, and it is the
+  single statement — CLAUDE.md references it rather than repeating it
+  (issue #290)
 - **The documentation has a page that is not the API reference.** Issue
   #120 asked for worked examples for beginners — "sending transactions,
   deriving wallets, etc." — against fifteen pages of `automodule` stanzas

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,10 +187,12 @@ it.
   `persist-credentials: false`; uv commands pass `--locked`, never
   `--frozen`. `actionlint` and `zizmor` are hooks, and both must stay at
   zero findings.
-- **Comments carry the reasoning, including the negative results** — why
-  *not* the obvious alternative. That is the house style throughout the
-  workflows and pre-commit config, and it is what makes those files
-  reviewable; match it rather than trimming it.
+- **The prose style — tone, comments, docstrings, no history — is
+  CONTRIBUTING.md's "Documentation and comments" section**, stated once
+  there because contributors read that file and not this one. It
+  governs the workflows and the pre-commit config too: the reasoning
+  with its negative results is what makes those files reviewable, so
+  match it rather than trimming it.
 - **Markdown wraps at 80 columns**, tables included (MD013 is on), so
   long commands go in fenced blocks split with `\`.
 - pytest is strict: a warning is an error, an unregistered marker is an
@@ -213,15 +215,11 @@ it.
       btclib/mnemonic/_data/wordlist.txt | grep -cv 'README.md'
   ```
 
-  A stated count is a line every open branch has to edit, so with this
-  many branches open it is the one conflict a pull request is guaranteed
-  to have — and worse, two branches moving it to the same new number
-  merge without a conflict into a number that is wrong. Nothing states a
-  count now, and three tests keep it that way:
-  `tests/release_notes_test.py` for CHANGELOG.md and HISTORY.md,
-  `tests/vendored_data_test.py` for `tests/_data/README.md`, whose
-  summary used to open with a total and count each of its lists. They
-  fail on a stated count rather than on a wrong one.
+  The why is in CONTRIBUTING.md's "Documentation and comments"; what
+  this file adds is that nothing states a count now and tests keep it
+  that way — `tests/release_notes_test.py` for CHANGELOG.md and
+  HISTORY.md, `tests/vendored_data_test.py` for `tests/_data/README.md`
+  — failing on a stated count rather than on a wrong one.
 - **CHANGELOG.md and HISTORY.md are `merge=union`**, which is what
   `.gitattributes` is for: the insertion point conflicts too — two
   branches appending a bullet to the same group — and union keeps both

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,6 +450,52 @@ Work locally on your fork of btclib,
 until you are satisfied. Ensure that pre-commit and pytest
 have no issue with your modified codebase.
 
+#### Documentation and comments
+
+What "satisfied" means for the prose — docstrings, comments, the
+sphinx pages, a pull request reply — is written down here, because a
+hook can check that a docstring exists but not what it says.
+
+**Tone of voice: neutral, factual, dry.** The same register
+everywhere: no wit, no salesmanship, no emphasis where the fact is
+enough. Explanatory detail is wanted; decoration is not.
+
+**A docstring states the contract.** What the function takes, what it
+returns or raises, and the rule the behaviour comes from — not a
+restatement of the name. Most readers of a docstring here are new to
+btclib: write for them.
+
+**A comment carries the reasoning, including the negative result.**
+Say why the code is as it is and why *not* the obvious alternative —
+the second half is what stops the next reader from "fixing" a
+deliberate choice, and it is what makes a file reviewable rather than
+merely readable.
+
+**Cite the authority.** Where behaviour comes from a BIP, an RFC or a
+Bitcoin Core function, name it, rather than asserting the behaviour
+as if btclib had decided it. Where btclib deviates, say so and say
+why.
+
+**Measure, don't assert.** A number in prose comes from a command,
+and the command belongs beside it, so the next reader can re-measure
+instead of trusting a figure whose date they cannot see. Never state
+a count that nothing checks — an unchecked number drifts into a false
+claim — and never state how many of anything a file holds: a stated
+total is a line every open branch has to edit, and two branches
+moving it to the same wrong number merge without a conflict.
+
+**One fact in one place.** Two files stating the same thing become
+two files disagreeing about it; the second one points at the first.
+
+**No history in the prose.** Comments and docstrings say why the code
+is as it is, in the present tense; they do not tell the story of what
+it used to be. "This is here rather than X because X breaks Y" stays,
+whatever prompted it; "this used to be X, until Z" goes — unless the
+old spelling is something a caller can still encounter (a deprecated
+alias, a wire format), in which case it is not history but the
+present. History has two files of its own, `CHANGELOG.md` and
+`HISTORY.md`, and it is complete there.
+
 ### Commit your update
 
 Commit the changes to your fork once you are happy with them.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Python3 [type annotated](https://docs.python.org/3/library/typing.html)
 library intended for teaching, learning, and using bitcoin;
 the focus is on elliptic curve cryptography and bitcoin's blockchain.
 
-It is rigorously and extensively tested: the test suite covers
-virtually the whole code base, a floor the build enforces, and
-reproduces results from both informal and major reference sources.
+The test suite covers virtually the whole code base — a coverage
+floor the build enforces — and reproduces the published vectors of
+the BIPs, of RFC 6979, and of Bitcoin Core.
 
 Originally developed for the
 _[Bitcoin and Blockchain Technology](https://www.ametrano.net/bbt/)_

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -256,14 +256,26 @@ BIP44ScriptType = Literal["p2pkh", "p2wpkh-p2sh", "p2wpkh", "p2tr"]
 # Not hashlib._Hash, which is what typeshed calls it: a private name, and
 # structural typing is the right tool for "whatever hashlib.new returns"
 class HashObject(Protocol):
-    @property
-    def digest_size(self) -> int: ...
+    """The slice of a hashlib object this library reads, as a Protocol.
+
+    Structural: anything hashlib.new returns satisfies it, and the
+    members carry hashlib's own meanings.
+    """
 
     @property
-    def block_size(self) -> int: ...
+    def digest_size(self) -> int:
+        """Return the digest length in bytes."""
+        ...
 
     @property
-    def name(self) -> str: ...
+    def block_size(self) -> int:
+        """Return the internal block length in bytes."""
+        ...
+
+    @property
+    def name(self) -> str:
+        """Return the name hashlib.new would accept."""
+        ...
 
     # Any, alone in this Protocol, and not for want of trying: hmac.new
     # takes a digestmod whose update() accepts typeshed's ReadableBuffer,
@@ -273,13 +285,21 @@ class HashObject(Protocol):
     # hmac.new eight times. The two members that are actually read,
     # digest() and digest_size, stay exact, which is the point of the
     # Protocol
-    def update(self, data: Any, /) -> None: ...
+    def update(self, data: Any, /) -> None:
+        """Absorb more data, as hashlib's update does."""
+        ...
 
-    def digest(self) -> bytes: ...
+    def digest(self) -> bytes:
+        """Return the digest of everything absorbed so far."""
+        ...
 
-    def hexdigest(self) -> str: ...
+    def hexdigest(self) -> str:
+        """Return the digest as a hex string."""
+        ...
 
-    def copy(self) -> HashObject: ...
+    def copy(self) -> HashObject:
+        """Return a clone that can absorb independently."""
+        ...
 
 
 # Hash digest constructor: it may be any name suitable to hashlib.new().

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -7,9 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Aliases.
-
-mypy aliases, documenting also coding input conventions.
+"""The type aliases of the public API, and the input conventions they name.
 
 Octets and String below are both `bytes | str`, so mypy cannot tell
 one from the other: passing a text string where a hex-string is expected

--- a/btclib/amount.py
+++ b/btclib/amount.py
@@ -7,23 +7,17 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Proper handling of monetary amounts.
+"""Monetary amounts: satoshi ints and BTC Decimals, never floats.
 
-A BTC monetary amount can be expressed
-as number of satoshis (1 BTC is 100_000_000) or
-as Python Decimal with up to 8 digits, e.g. Decimal("0.12345678").
+A BTC amount is an int number of satoshi (1 BTC is 100_000_000) or a
+Decimal with up to 8 decimals, e.g. Decimal("0.12345678"). Not a
+float: binary floating point cannot hold most decimal fractions
+exactly (1.1 + 2.2 != 3.3), so a float between a rate and the satoshi
+it owes is a rounding error waiting for money to measure it. The
+functions here convert between the two spellings and refuse what no
+output can carry.
 
-Because of floating-point conversion issues
-(e.g. with floats 1.1 + 2.2 != 3.3)
-algebra with bitcoin amounts should never involve floats.
-
-The provided functions handle conversion between
-satoshi amounts (sats) and Decimal/float values.
-
-Amounts cannot be a negative value:
-the Bitcoin protocol and this library do not deal with negative amounts.
-The functions in this module could be easily amended
-(in a backward compatible way) in the future if such a need arises.
+Amounts are never negative, here as in the protocol.
 """
 
 from __future__ import annotations

--- a/btclib/amount.py
+++ b/btclib/amount.py
@@ -63,20 +63,12 @@ _MAX_BITCOIN = Decimal(21_000_000)
 
 
 def valid_btc_amount(amount: Any, dust: Decimal = Decimal(0)) -> Decimal:
-    """Return the BTC amount as Decimal, if valid and not less than dust.
+    """Return the BTC amount as a Decimal, refusing what no output holds.
 
-    Args:
-        amount (Any): The BTC amount. Assumed to be zero if None.
-        dust (Decimal, optional): The minimum threshold for a valid amount.
-                                  Defaults to Decimal("0").
-
-    Raises:
-        BTClibValueError: If the amount is below dust or above max
-                          number of bitcoin ever available.
-        BTClibValueError: If the amount has too many (>8) decimals.
-
-    Returns:
-        Decimal: The BTC amount converted to Decimal.
+    None reads as zero, and anything str() renders as a decimal number
+    is accepted. Refused: an amount below `dust` or above the 21
+    million cap, and one with more than 8 decimals, no output being
+    able to carry a fraction of a satoshi.
     """
     with localcontext() as ctx:
         ctx.traps[FloatOperation] = True

--- a/btclib/b32.py
+++ b/btclib/b32.py
@@ -65,6 +65,11 @@ from btclib.utils import bytes_from_octets
 
 
 def has_segwit_prefix(addr: String) -> bool:
+    """Answer whether the string starts as a bech32 address of any network.
+
+    The prefix alone -- hrp and the 1 separator -- is read; whether the
+    rest decodes is witness_from_address's answer.
+    """
     str_addr = addr.strip().lower() if isinstance(addr, str) else addr.decode("ascii")
     return any(str_addr.startswith(f"{net.hrp}1") for net in NETWORKS.values())
 
@@ -102,6 +107,11 @@ def power_of_2_base_conversion(
 
 
 def check_witness(wit_ver: int, wit_prg: Octets) -> bytes:
+    """Return the witness program, refusing what BIP141 does not define.
+
+    A version outside 0..16, a program outside 2..40 bytes, or a v0
+    program that is neither 20 nor 32 bytes is refused.
+    """
     if not 0 <= wit_ver < 17:
         err_msg = "invalid witness version: "
         err_msg += f"{wit_ver} not in 0..16"

--- a/btclib/bech32.py
+++ b/btclib/bech32.py
@@ -146,6 +146,11 @@ def _decode(bech: String) -> tuple[str, list[int], list[int]]:
 
 
 def decode(bech: String, m: int | None = None) -> tuple[str, list[int]]:
+    """Return (hrp, data) from a bech32 string, verifying its checksum.
+
+    `m` picks bech32 or bech32m; None reads it off the first data
+    value, the witness version choosing the constant per BIP350.
+    """
     hrp, data, checksum = _decode(bech)
     m = _m_from_wit_ver(data) if m is None else m
     if _verify_checksum(hrp, data + checksum, m):

--- a/btclib/bip21.py
+++ b/btclib/bip21.py
@@ -136,6 +136,7 @@ class Bip21:
             self.assert_valid()
 
     def assert_valid(self) -> None:
+        """Refuse a URI without a decodable address, or a bad amount."""
         if not isinstance(self.address, str) or not self.address:
             raise BTClibValueError("missing address in the bip21 URI")
         # the decoders *are* the validation, and each says what is wrong

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -7,19 +7,14 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""BIP32 Hierarchical Deterministic Wallet functions.
+"""BIP32 hierarchical deterministic wallet functions.
 
-A deterministic wallet is a hash-chain of private/public key pairs that
-derives from a single root, which is the only element requiring backup.
-Moreover, there are schemes where public keys can be calculated without
-accessing private keys.
+https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 
-A hierarchical deterministic wallet is a tree of multiple hash-chains,
-derived from a single root, allowing for selective sharing of keypair
-chains.
-
-Here, the HD wallet is implemented according to BIP32 bitcoin standard
-https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki.
+A deterministic wallet derives every key pair from a single root, the
+one element requiring backup; BIP32 makes the derivation a tree, so a
+branch of keys can be shared without the rest, and public derivation
+computes child public keys with no private key at hand.
 
 A BIP32 extended key is 78 bytes:
 

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -120,6 +120,15 @@ def _assert_valid_key(version: bytes, key: bytes) -> None:
 
 @dataclass
 class BIP32KeyData:
+    """A BIP32 extended key, decoded into its six fields.
+
+    What one xprv/xpub string holds: version, depth, parent
+    fingerprint, index, chain code and the 33-byte key, private keys
+    carrying their 0x00 prefix. The wire form is the 78-byte serialize
+    and parse; b58encode and b58decode add the customary Base58Check
+    spelling. repr masks the key material of a private one.
+    """
+
     version: bytes
     depth: int
     parent_fingerprint: bytes
@@ -130,6 +139,7 @@ class BIP32KeyData:
 
     @property
     def is_private(self) -> bool:
+        """Answer whether the key is private, by its 0x00 prefix."""
         return self.key[0] == 0
 
     def __repr__(self) -> str:
@@ -151,10 +161,12 @@ class BIP32KeyData:
 
     @property
     def is_hardened(self) -> bool:
+        """Answer whether the index is in the hardened range."""
         return self.index >= _HARDENED_OFFSET
 
     @property
     def is_root(self) -> bool:
+        """Answer whether this is a master key: no depth, index, parent."""
         return (
             self.depth == 0
             and self.index == 0
@@ -189,6 +201,13 @@ class BIP32KeyData:
             self.assert_valid()
 
     def assert_valid(self) -> None:
+        """Refuse what no valid extended key can hold.
+
+        Field types and sizes, a depth consistent with index and
+        parent fingerprint, a known version, and a key that parses --
+        as a scalar in 1..n-1 or as a point of the curve, whichever
+        the version demands.
+        """
         for key, size in _KEY_SIZE:
             # bytes() is the type check, not a coercion: it raises
             # TypeError for a field rebound to a str, which would otherwise
@@ -219,6 +238,7 @@ class BIP32KeyData:
         _assert_valid_key(self.version, self.key)
 
     def serialize(self, *, check_validity: bool = True) -> bytes:
+        """Return the 78-byte serialization, BIP32's."""
         if check_validity:
             self.assert_valid()
 
@@ -234,6 +254,7 @@ class BIP32KeyData:
         )
 
     def b58encode(self, *, check_validity: bool = True) -> str:
+        """Return the Base58Check text, the xprv/xpub spelling."""
         data_binary = self.serialize(check_validity=check_validity)
         return base58.b58encode(data_binary).decode("ascii")
 
@@ -264,6 +285,7 @@ class BIP32KeyData:
     def b58decode(
         cls: type[BIP32KeyData], address: String, *, check_validity: bool = True
     ) -> BIP32KeyData:
+        """Build a BIP32KeyData from its xprv/xpub Base58Check text."""
         if isinstance(address, str):
             address = address.strip()
 
@@ -680,6 +702,14 @@ def derive_from_account(
 
 
 def crack_prv_key(parent_xpub: BIP32Key, child_xprv: BIP32Key) -> str:
+    """Return the parent xprv from a parent xpub and a non-hardened child.
+
+    The known break BIP32 warns about: a non-hardened child's private
+    key minus the derivation offset -- computable from the xpub -- is
+    the parent's, so leaking one child xprv beside the account xpub
+    leaks the account. A hardened child is refused, its offset not
+    being computable.
+    """
     if isinstance(parent_xpub, BIP32KeyData):
         p = copy.copy(parent_xpub)
     else:

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -38,6 +38,11 @@ _HARDENED_OFFSET = 0x80000000
 
 
 def int_from_index_str(s: str) -> int:
+    """Return one path step as its index: "0h" is 0x80000000.
+
+    Any of the three hardening symbols is read; an index at or above
+    the hardened offset must be spelled with one, not as the number.
+    """
     s.strip().lower()
     hardened = False
     if s[-1] in ("'", "h"):
@@ -51,6 +56,7 @@ def int_from_index_str(s: str) -> int:
 
 
 def str_from_index_int(i: int, hardening: str = _HARDENING) -> str:
+    """Return one index as a path step, the chosen symbol for hardened."""
     if hardening not in ("'", "h", "H"):
         raise BTClibValueError(f"invalid hardening symbol: {hardening}")
     if not 0 <= i <= 0xFFFFFFFF:
@@ -77,6 +83,12 @@ DerPath = str | Sequence[int] | int | bytes
 
 
 def indexes_from_der_path(der_path: DerPath) -> list[int]:
+    """Return the path as a list of indexes, whatever spelling it came in.
+
+    The DerPath spellings of the module docstring are all read: a
+    string with or without the leading m, a single int, the 4-byte
+    little-endian concatenation, or any iterable of ints.
+    """
     if isinstance(der_path, str):
         return _indexes_from_der_path_str(der_path)
 
@@ -106,6 +118,11 @@ def str_from_der_path(
     master_fingerprint: Octets | None = None,
     hardening: str = _HARDENING,
 ) -> str:
+    """Return the path as text, led by m or by the master fingerprint.
+
+    With a fingerprint this is the key-origin spelling a descriptor
+    brackets; without, the m/ path BIP32 writes.
+    """
     result = _str_from_der_path(der_path, hardening)
     if master_fingerprint:
         if isinstance(master_fingerprint, str):
@@ -122,6 +139,7 @@ def str_from_der_path(
 
 
 def bytes_from_der_path(der_path: DerPath) -> bytes:
+    """Return the path as bytes: each index in 4 bytes, little-endian."""
     indexes = indexes_from_der_path(der_path)
     result = [i.to_bytes(4, byteorder="little", signed=False) for i in indexes]
     return b"".join(result)

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -27,11 +27,20 @@ from btclib.utils import bytes_from_octets
 
 @dataclass(frozen=True)
 class BIP32KeyOrigin:
+    """Where a key comes from: master fingerprint and derivation path.
+
+    What BIP174's bip32_derivs and a descriptor's [fingerprint/path]
+    prefix carry; the path is held as indexes, hardened ones offset
+    by 0x80000000. The wire form is serialize and parse, the bracketed
+    text form description and from_description.
+    """
+
     master_fingerprint: bytes
     der_path: Sequence[int]
 
     @property
     def description(self) -> str:
+        """Return the descriptor spelling: fingerprint/path, h for hardened."""
         return str_from_der_path(self.der_path, self.master_fingerprint)
 
     def __init__(
@@ -53,6 +62,11 @@ class BIP32KeyOrigin:
         return len(self.der_path)
 
     def assert_valid(self) -> None:
+        """Refuse a fingerprint not of 4 bytes, a path too long or out of range.
+
+        The bounds are the serialization's: at most 255 indexes, each
+        in 4 bytes.
+        """
         if len(self.master_fingerprint) != 4:
             err_msg = "invalid master fingerprint length: "
             err_msg += f"{len(self.master_fingerprint)}"
@@ -63,6 +77,7 @@ class BIP32KeyOrigin:
             raise BTClibValueError("invalid der_path element")
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, str]:
+        """Return {"master_fingerprint", "path"} as hex and m/ text."""
         if check_validity:
             self.assert_valid()
 
@@ -78,6 +93,7 @@ class BIP32KeyOrigin:
         *,
         check_validity: bool = True,
     ) -> BIP32KeyOrigin:
+        """Build a BIP32KeyOrigin from the dict shape to_dict writes."""
         return cls(
             dict_["master_fingerprint"],
             dict_["path"],
@@ -85,6 +101,7 @@ class BIP32KeyOrigin:
         )
 
     def serialize(self, *, check_validity: bool = True) -> bytes:
+        """Return BIP174's key-origin bytes: fingerprint, then the indexes."""
         if check_validity:
             self.assert_valid()
 
@@ -105,6 +122,7 @@ class BIP32KeyOrigin:
     def from_description(
         cls: type[BIP32KeyOrigin], data: str, *, check_validity: bool = True
     ) -> BIP32KeyOrigin:
+        """Build a BIP32KeyOrigin from its fingerprint/path spelling."""
         data = data.strip()
         return cls(data[:8], data[9:], check_validity=check_validity)
 

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -7,10 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Block dataclass.
-
-Dataclass encapsulating BlockHeader and list[Tx].
-"""
+"""The Block dataclass and its rules; the class docstring has the contract."""
 
 from __future__ import annotations
 

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -94,11 +94,19 @@ def bip34_commitment(height: int) -> bytes:
 
 @dataclass
 class Block:
+    """A block: its header and the transactions the header commits to.
+
+    assert_valid is Core's CheckBlock -- what the bytes answer for
+    themselves, proof-of-work included; the rules that need a height
+    or a clock are assert_valid_contextual, taking a BlockContext.
+    """
+
     header: BlockHeader
     transactions: list[Tx]
 
     @property
     def size(self) -> int:
+        """Return the serialized size, witnesses included."""
         return len(self.serialize(check_validity=False))
 
     @property
@@ -128,6 +136,7 @@ class Block:
 
     @property
     def vsize(self) -> int:
+        """Return the virtual size: the weight over four, rounded up."""
         return ceil(self.weight / 4)
 
     @property
@@ -183,6 +192,11 @@ class Block:
             self.assert_valid()
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, Any]:
+        """Return the block as a dict of json-friendly values.
+
+        The header and each transaction as their own to_dict render
+        them; from_dict reads the same shape back.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -197,6 +211,7 @@ class Block:
     def from_dict(
         cls: type[Block], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> Block:
+        """Build a Block from the dict shape to_dict writes."""
         return cls(
             BlockHeader.from_dict(dict_["header"], check_validity=False),
             [Tx.from_dict(tx, check_validity=False) for tx in dict_["transactions"]],
@@ -204,6 +219,7 @@ class Block:
         )
 
     def has_segwit_tx(self) -> bool:
+        """Answer whether any transaction carries a witness."""
         return any(tx.is_segwit() for tx in self.transactions)
 
     def _assert_coinbase(self) -> None:
@@ -293,6 +309,11 @@ class Block:
             raise BTClibValueError(err_msg)
 
     def assert_valid_merkle_root(self) -> None:
+        """Refuse a header whose merkle root is not the transactions'.
+
+        The CVE-2012-2459 mutation flag is refused too, as Core's
+        bad-txns-duplicate; the comment below carries the reasoning.
+        """
         merkle_root_, mutated = merkle_root_and_mutated_from_transactions(
             self.transactions
         )
@@ -438,6 +459,13 @@ class Block:
             self.assert_valid_coinbase_height(context.height)
 
     def assert_valid(self) -> None:
+        """Refuse what Core's CheckBlock refuses, in Core's order.
+
+        The header and its proof-of-work, the size bounds, exactly one
+        coinbase and it first, every transaction on its own, the sigop
+        bound, the merkle root, the witness commitment, the weight.
+        Height and clock rules are assert_valid_contextual's.
+        """
         self.header.assert_valid()
         # the header alone does not assert this: a header being mined is
         # structurally valid and has no proof-of-work yet, so requiring one
@@ -490,6 +518,11 @@ class Block:
     def serialize(
         self, include_witness: bool = True, *, check_validity: bool = True
     ) -> bytes:
+        """Return the wire serialization: header, count, transactions.
+
+        `include_witness` False gives the block as a legacy node
+        relays it, every witness stripped.
+        """
         if check_validity:
             self.assert_valid()
 

--- a/btclib/block/block_context.py
+++ b/btclib/block/block_context.py
@@ -53,6 +53,13 @@ BIP34_HEIGHT = 227_931
 
 @dataclass(frozen=True)
 class BlockContext:
+    """What Block.assert_valid_contextual reads: a height and a clock.
+
+    The two facts a block cannot answer for itself, supplied by the
+    caller; bip34_height is the chain's activation height, defaulting
+    to mainnet's.
+    """
+
     # the height the block is being accepted at, i.e. Core's
     # pindexPrev->nHeight + 1
     height: int
@@ -92,6 +99,11 @@ class BlockContext:
             self.assert_valid()
 
     def assert_valid(self) -> None:
+        """Refuse a negative or non-int height, or a now that is no datetime.
+
+        Naive-datetime refusal is assert_valid_time's, the reader of
+        the clock being where the comparison happens.
+        """
         for key in ("height", "bip34_height"):
             value = getattr(self, key)
             # a float here would compare fine and read as a height, so the

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -47,6 +47,16 @@ _EPOCH = datetime.fromtimestamp(0, timezone.utc)
 
 @dataclass
 class BlockHeader:
+    """The eighty bytes a block is identified and mined by.
+
+    Version, previous block hash, merkle root, time, bits, nonce; the
+    hashes and bits are held in display order and reversed on the
+    wire, the time as an aware datetime. assert_valid answers for the
+    eighty bytes alone -- proof-of-work and clock checks are the
+    explicit assert_valid_pow and assert_valid_time, a header being
+    mined having neither yet.
+    """
+
     # 4 bytes, _signed_ little endian
     version: int
     # _HF_LEN bytes, little endian
@@ -129,6 +139,12 @@ class BlockHeader:
             self.assert_valid()
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, int | float | str]:
+        """Return the header as a dict of json-friendly values.
+
+        The time is ISO 8601; target and difficulty are derived for
+        the reader and ignored by from_dict, which recomputes them
+        from bits.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -147,6 +163,7 @@ class BlockHeader:
     def from_dict(
         cls: type[BlockHeader], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> BlockHeader:
+        """Build a BlockHeader from the dict shape to_dict writes."""
         return cls(
             dict_["version"],
             dict_["previous_block_hash"],
@@ -218,6 +235,14 @@ class BlockHeader:
             raise BTClibValueError(err_msg)
 
     def assert_valid(self) -> None:
+        """Refuse a header the eighty bytes could not hold.
+
+        Field types, the version and nonce ranges, the timestamp
+        between genesis and the last four-byte instant, the field
+        sizes. Nothing here reads a clock or checks the work: those
+        are assert_valid_time and assert_valid_pow, whose docstrings
+        say why they are separate.
+        """
         # the type check the bytes fields get from bytes() below, for the
         # two int ones. Not a coercion, which would repair the mistake by
         # rewriting the header being inspected (__init__ coerces, this

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -7,11 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""BlockHeader dataclass.
-
-Dataclass encapsulating version, previous block hash, merkle root, time,
-bits, and nonce.
-"""
+"""The BlockHeader dataclass; the class docstring has the contract."""
 
 from __future__ import annotations
 

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -228,7 +228,11 @@ class CurveGroup:
         raise BTClibTypeError("not a Jacobian point")
 
     def aff_from_jac(self, Q: JacPoint) -> Point:
-        # point is assumed to be on curve
+        """Return the affine point: two modular inversions.
+
+        The input point is assumed to be on the curve; infinity comes
+        back as INF, its affine spelling.
+        """
         if Q[2] == 0:  # Infinity point in Jacobian coordinates
             return INF
 
@@ -238,7 +242,11 @@ class CurveGroup:
         return x % self.p, y % self.p
 
     def x_aff_from_jac(self, Q: JacPoint) -> int:
-        # point is assumed to be on curve
+        """Return the affine x alone: one modular inversion, not two.
+
+        The input point is assumed to be on the curve; infinity has no
+        x and is refused.
+        """
         if Q[2] == 0:  # Infinity point in Jacobian coordinates
             raise BTClibValueError("INF has no x-coordinate")
 
@@ -246,7 +254,11 @@ class CurveGroup:
         return (Q[0] * mod_inv(Z2, self.p)) % self.p
 
     def y_aff_from_jac(self, Q: JacPoint) -> int:
-        # point is assumed to be on curve
+        """Return the affine y alone: one modular inversion, not two.
+
+        The input point is assumed to be on the curve; infinity has no
+        y and is refused.
+        """
         if Q[2] == 0:  # Infinity point in Jacobian coordinates
             raise BTClibValueError("INF has no y-coordinate")
 
@@ -281,8 +293,12 @@ class CurveGroup:
         return self.add_aff(Q1, Q2)
 
     def add_jac(self, Q: JacPoint, R: JacPoint) -> JacPoint:
-        # points are assumed to be on curve
+        """Return the sum of two Jacobian points, branch-free.
 
+        The input points are assumed to be on the curve. One sequence
+        of operations whatever the operands -- infinity and doubling
+        included, the comment below saying why that is load-bearing.
+        """
         # the group law has four special cases, and they are of two kinds
         # that want opposite treatment. An operand at infinity is
         # bookkeeping rather than geometry: infinity is the identity, so
@@ -382,7 +398,7 @@ class CurveGroup:
         return ((X, Y, Z), R, Q, INFJ)[(Q[2] == 0) + 2 * (R[2] == 0)]
 
     def double_jac(self, Q: JacPoint) -> JacPoint:
-        # point is assumed to be on curve
+        """Return twice the Jacobian point, assumed to be on the curve."""
         return self._double_jac_helper(Q, Q[2] * Q[2] % self.p)
 
     def _double_jac_helper(self, Q: JacPoint, QZ2: int) -> JacPoint:
@@ -404,8 +420,11 @@ class CurveGroup:
         return X, Y, Z
 
     def add_aff(self, Q: Point, R: Point) -> Point:
-        # points are assumed to be on curve
+        """Return the sum of two affine points, assumed on the curve.
 
+        One modular inversion; the special cases are branched on, the
+        comment below saying why affine coordinates leave no choice.
+        """
         # infinity is a special case here and cannot stop being one: an
         # affine point is two field elements and the group has one point
         # more than any pair of them can name, so INF is spelled y == 0
@@ -444,7 +463,7 @@ class CurveGroup:
         return x, y
 
     def double_aff(self, Q: Point) -> Point:
-        # point is assumed to be on curve
+        """Return twice the affine point, assumed to be on the curve."""
         if Q[1] == 0:  # Infinity point in affine coordinates
             return INF
 
@@ -649,6 +668,11 @@ MAX_W = 5
 
 @functools.lru_cache  # results are cached to increase efficiency
 def cached_multiples(Q: JacPoint, ec: CurveGroup) -> list[JacPoint]:
+    """Return the multiples 0..(2^MAX_W - 1) of Q, memoized on (Q, ec).
+
+    The table the fixed-window ladder indexes when asked to cache; the
+    memoization pays because the generator is the Q of most calls.
+    """
     T = [INFJ, Q]
     for i in range(3, 2**MAX_W, 2):
         T.append(ec.double_jac(T[(i - 1) // 2]))

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -320,10 +320,11 @@ class CurveGroup:
         # answers for it, and an addition with no infinity in it pays two
         # comparisons: 1.02x to 1.03x on every multiplication in the
         # package, and 1.22x on _double_mult, whose Shamir-Strauss loop
-        # adds the infinity of a zero digit pair a quarter of the time and
-        # used to get those additions free. Without the stand-ins,
-        # dropping the early return was not enough: P + INFJ still cost
-        # 1.8 us against 5.4, and mult_jac was still 25% faster on a
+        # adds the infinity of a zero digit pair a quarter of the time --
+        # the additions an early return answers for free, at the price of
+        # putting their count on the clock. Dropping the early return
+        # without the stand-ins is not enough: P + INFJ still costs
+        # 1.8 us against 5.4, and mult_jac is still 25% faster on a
         # scalar with 128 low zero bits
         QS = (Q, self._stand_in_q)[Q[2] == 0]
         RS = (R, self._stand_in_r)[R[2] == 0]
@@ -956,9 +957,9 @@ def _double_mult(
         # entry it names is infinity: one addition per step, whatever the
         # coefficients. Which is where an add_jac that does not shortcut
         # infinity is dearest -- a quarter of the pairs are 0 on average,
-        # and adding infinity used to be free -- and it is the one place
-        # in the package that measures 22% slower for it, against the 2%
-        # to 3% everywhere else
+        # each an addition a shortcut would answer for free -- and it is
+        # the one place in the package that measures 22% slower for it,
+        # against the 2% to 3% everywhere else
         R = ec.add_jac(R, T[i])
     return R
 

--- a/btclib/curves/curve_group_f.py
+++ b/btclib/curves/curve_group_f.py
@@ -7,10 +7,11 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""CurveGroup explorer functions.
+"""CurveGroup explorer functions, for low-cardinality didactic curves.
 
-These functions are meant to explore low-cardinality CurveGroup, for
-didactic (and fun) reason only.
+Enumerating the points of a group is feasible only when the group is
+tiny, which is what makes these useful in teaching and useless -- and
+never used -- in the rest of the library.
 """
 
 from __future__ import annotations

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -154,6 +154,7 @@ def add_checksum(descriptor: str) -> str:
 
 
 def descriptor_from_address(address: str) -> str:
+    """Return the addr() descriptor of the address, checksummed."""
     return add_checksum(f"addr({address})")
 
 
@@ -241,6 +242,7 @@ class KeyExpression:
 
     @property
     def is_ranged(self) -> bool:
+        """Answer whether the key has a wildcard to derive at an index."""
         return self.wildcard is not None
 
     @property
@@ -533,6 +535,7 @@ class PkDescriptor(Descriptor):
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return the one KEY expression, as the base class's tuple."""
         return (self.key,)
 
     def _scripts(self, index: int) -> list[bytes]:
@@ -552,6 +555,7 @@ class PkhDescriptor(Descriptor):
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return the one KEY expression, as the base class's tuple."""
         return (self.key,)
 
     def _scripts(self, index: int) -> list[bytes]:
@@ -572,6 +576,7 @@ class WpkhDescriptor(Descriptor):
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return the one KEY expression, as the base class's tuple."""
         return (self.key,)
 
     def _scripts(self, index: int) -> list[bytes]:
@@ -601,6 +606,7 @@ class ShDescriptor(Descriptor):
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return the wrapped SCRIPT's KEY expressions."""
         return self.inner.key_expressions
 
     def _scripts(self, index: int) -> list[bytes]:
@@ -643,6 +649,7 @@ class WshDescriptor(Descriptor):
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return the wrapped SCRIPT's KEY expressions."""
         return self.inner.key_expressions
 
     def _scripts(self, index: int) -> list[bytes]:
@@ -685,6 +692,7 @@ class MultiDescriptor(Descriptor):
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return the KEY expressions, in descriptor order."""
         return self.keys
 
     def _pub_keys(self, index: int) -> list[bytes]:
@@ -744,6 +752,7 @@ class ComboDescriptor(Descriptor):
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return the one KEY expression, as the base class's tuple."""
         return (self.key,)
 
     def _scripts(self, index: int) -> list[bytes]:
@@ -791,6 +800,7 @@ class AddrDescriptor(Descriptor):
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return no KEY expression, the descriptor fixing none."""
         return ()
 
     def _scripts(self, index: int) -> list[bytes]:
@@ -826,6 +836,7 @@ class RawDescriptor(Descriptor):
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return no KEY expression, the descriptor fixing none."""
         return ()
 
     def _scripts(self, index: int) -> list[bytes]:
@@ -862,6 +873,7 @@ class TrDescriptor(Descriptor):
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return the internal key and every leaf key, in tree order."""
         if self.tree is None:
             return (self.internal_key,)
         return (self.internal_key, *_tree_keys(self.tree))

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -7,60 +7,26 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Bitcoin message signing (BMS).
+"""Bitcoin message signing (BMS): address-based signatures over text.
 
-Bitcoin uses a P2PKH address-based scheme for message signature: such
-a signature does prove the control of the private key corresponding to
-the address and, consequently, of the associated bitcoins (if any).
-Message signature adopts a custom compact 65-bytes (fixed size)
-serialization format (i.e. not the ASN.1 DER format used for
-transactions, which would results in 71-bytes average signature).
+A BMS signature proves control of the private key behind an address.
+The scheme is ECDSA under an envelope: the message is prefixed by the
+magic "Bitcoin Signed Message:\\n" string -- so that a signed message
+can never double as a transaction signature -- and the hash of the
+envelope is what is signed. The serialization is the compact 65-byte
+[1-byte recovery flag][32-byte r][32-byte s], customarily exchanged
+as base64 text, not the DER of transaction signatures.
 
-One should never sign a vague statement that could be reused
-out of the context it was intended for. Always include at least:
+A vague statement can be replayed out of the context it was signed
+for, so a message worth signing names its signer, its date, its
+addressee, and its purpose.
 
-- name (nickname, customer id, e-mail, etc.)
-- date and time
-- who the message is intended for (name, business name, e-mail, etc.)
-- specific purpose of the message
-
-To mitigate the risk of signing a possibly deceiving message,
-for any given message a *magic* "Bitcoin Signed Message:\\n" prefix is
-added, then the hash of the resulting message is signed.
-
-This BMS scheme relies on ECDSA,
-i.e. it works with private/public key pairs, not addresses:
-the address is only used to identify a key pair.
-At signing time, a wallet infrastructure is required to access
-the private key corresponding to a given address;
-alternatively, the private key must be provided explicitly.
-
-To verify the ECDSA signature the public key is not needed
-because (EC)DSA allows public key recovery:
-public keys that correctly verify the signature
-can be implied from the signature itself.
-In the case of the Bitcoin secp256k1 curve,
-two public keys are recovered
-(up to four with non-zero but negligible probability);
-at verification time the address must match
-that public key in the recovery set
-marked as the right one at signature time.
-
-The (r, s) DSA signature is serialized as
-[1-byte recovery flag][32-bytes r][32-bytes s],
-in a compact 65-bytes (fixed-size) encoding.
-
-The serialized signature is then base64-encoded to transport it
-across channels that are designed to deal with textual data.
-Base64-encoding uses 10 digits, 26 lowercase characters, 26 uppercase
-characters, '+' (plus sign), and '/' (forward slash).
-The equal sign '=' is used as encoding end marker.
-
-The recovery flag is used
-at verification time to discriminate among recovered
-public keys (and among address types in the case
-of scheme extension beyond P2PKH).
-Explicitly, the recovery flag value is:
+The scheme works on key pairs, the address only identifying one: the
+signer needs the private key behind the address, from a wallet or
+supplied directly. The verifier needs no public key at all, ECDSA
+allowing recovery: the candidate keys are implied by the signature,
+and the recovery flag says which candidate -- and which address type
+-- the signer meant. Explicitly, the recovery flag value is:
 
     key_id + (4 if compressed else 0) + 27
 
@@ -310,12 +276,12 @@ def sign(msg: Octets, prv_key: PrvKey, addr: String | None = None) -> Sig:
 
     # signing and naming the key_id are one call, not two, and this module
     # has no dispatch of its own for it: `dsa.sign_recoverable` answers the
-    # key_id whichever implementation signs, the recid libsecp256k1 reports
-    # being the very thing the Python signer computed and used to throw
-    # away -- the parity of the nonce's point and how far its x-coordinate
-    # ran past the group order. So the search this used to run, one
-    # recovery per candidate until one was the signer's own key, does not
-    # get faster: it is gone from both paths (issue 285)
+    # key_id whichever implementation signs, the recid libsecp256k1
+    # reports being the very thing the Python signer computes anyway --
+    # the parity of the nonce's point and how far its x-coordinate runs
+    # past the group order. Not a search over the four candidates, one
+    # recovery each until one is the signer's own key: that recomputes
+    # what the signer already knows, on either path (issue 285)
     dsa_sig, key_id = dsa.sign_recoverable(magic_msg, q)
 
     # bytes_from_prv_key_int, not bytes_from_point(mult(q)): the address

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -171,6 +171,14 @@ _REQUIRED_LENGTH = 65
 
 @dataclass(frozen=True, init=False)
 class Sig:
+    """A Bitcoin Message Signature: recovery flag and ECDSA signature.
+
+    The flag, 27 to 42, carries the recovery key id and the address
+    type the signer claims; the signature is an ordinary dsa.Sig on
+    secp256k1. The wire form is the 65-byte compact serialization,
+    customarily exchanged as base64 (b64encode/b64decode).
+    """
+
     # 1 byte
     rf: int
     dsa_sig: dsa.Sig
@@ -187,6 +195,7 @@ class Sig:
             self.assert_valid()
 
     def assert_valid(self) -> None:
+        """Refuse a flag outside 27..42, a curve that is not secp256k1."""
         if self.rf < 27 or self.rf > 42:
             raise BTClibValueError(f"invalid recovery flag: {self.rf}")
         self.dsa_sig.assert_valid()
@@ -194,6 +203,7 @@ class Sig:
             raise BTClibValueError(f"invalid curve: {self.dsa_sig.ec.name}")
 
     def serialize(self, *, check_validity: bool = True) -> bytes:
+        """Return the 65-byte compact form: flag, then r, then s."""
         if check_validity:
             self.assert_valid()
 
@@ -219,6 +229,7 @@ class Sig:
 
     @classmethod
     def parse(cls: type[Sig], data: BinaryData, *, check_validity: bool = True) -> Sig:
+        """Build a Sig from the 65-byte compact serialization."""
         stream = bytesio_from_binarydata(data)
         sig_bin = stream.read(_REQUIRED_LENGTH)
 
@@ -386,8 +397,13 @@ def _assert_p2wpkh_p2sh(addr: String, rf: int, pub_key: bytes, h160: bytes) -> N
 def assert_as_valid(
     msg: Octets, addr: String, sig: Sig | String, lower_s: bool = True
 ) -> None:
-    # Private function for test/dev purposes
-    # It raises Errors, while verify should always return True or False
+    """Refuse a signature that does not open to the address.
+
+    The public key is recovered from the signature under the magic
+    message envelope, then rendered as the address type the recovery
+    flag claims; anything short of a match is an error, verify being
+    the boolean answer.
+    """
     if isinstance(sig, Sig):
         sig.assert_valid()
     else:

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -205,8 +205,12 @@ def assert_as_valid(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
 ) -> None:
-    # Private function for test/dev purposes
-    # It raises Errors, while verify should always return True or False
+    """Refuse an invalid borromean ring signature.
+
+    The rings are walked forward from e0 and must close on the e0 they
+    started from; errors carry the reason, verify being the boolean
+    answer.
+    """
     msg, m, e = _initialize(msg, pubk_rings, ec, hf)
     e0bytes = m
 

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -7,15 +7,14 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Diffie-Hellman elliptic curve key agreement scheme.
+"""Diffie-Hellman elliptic curve key agreement, per SEC 1 v.2.
 
-Implementation of the Diffie-Hellman key agreement scheme using elliptic
-curve cryptography. A key agreement scheme is used by two entities to
-establish shared keying data, which will be later utilized e.g. in
-symmetric cryptographic scheme.
-
-The two entities must agree on the elliptic curve and key derivation
-function to use.
+Two parties, each holding the other's public key, compute the same
+shared secret -- their key pair times the other's public point -- and
+derive symmetric keying data from it through a key derivation
+function. The curve and the KDF are the two things the parties must
+agree on beforehand; ansi_x9_63_kdf is SEC 1's KDF, and
+diffie_hellman is the agreement built on it.
 """
 
 from __future__ import annotations

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -184,6 +184,7 @@ class Sig:
             self.assert_valid()
 
     def assert_valid(self) -> None:
+        """Refuse an r or s outside 1..n-1, or an r no x is congruent to."""
         # r is a scalar, fail if r is not in [1, n-1]
         if not 0 < self.r < self.ec.n:
             err_msg = "scalar r not in 1..n-1: "
@@ -677,9 +678,15 @@ def assert_as_valid_(
     commit_hash: Octets | None = None,
     receipt: Point | None = None,
 ) -> None:
-    # Private function for test/dev purposes
-    # It raises Errors, while verify should always return True or False
-    #
+    """Refuse an invalid ECDSA signature over a message hash.
+
+    The message enters already reduced -- msg_hash, not the message --
+    which is what the trailing underscore says; assert_as_valid is the
+    spelling that reduces with hf first. Errors carry the reason,
+    ``verify_`` being the boolean answer; lower_s asks for the BIP62 rule
+    that refuses the malleable high-s twin. With commit_hash and
+    receipt the sign-to-contract commitment is opened as well.
+    """
     # key is a PubKey, not a Key: verification is where a private key
     # accepted for a public one does real harm, silently checking a
     # signature against a public key derived from the very secret handed
@@ -735,8 +742,7 @@ def assert_as_valid(
     commit: Octets | None = None,
     receipt: Point | None = None,
 ) -> None:
-    # Private function for test/dev purposes
-    # It raises Errors, while verify should always return True or False
+    """Refuse an invalid ECDSA signature, reducing the message with hf."""
     msg_hash = reduce_to_hlen(msg, hf)
     commit_hash = None if commit is None else reduce_to_hlen(commit, hf)
     assert_as_valid_(
@@ -1216,6 +1222,12 @@ def crack_prv_key_(
     sig2: Sig | Octets,
     hf: HashF = sha256,
 ) -> tuple[int, int]:
+    """Return (private key, nonce) from two signatures sharing a nonce.
+
+    The classic nonce-reuse break: two signatures with one r over two
+    message hashes are two linear equations in the nonce and the key.
+    The messages enter already reduced; crack_prv_key reduces first.
+    """
     if isinstance(sig1, Sig):
         sig1.assert_valid()
     else:
@@ -1249,6 +1261,10 @@ def crack_prv_key(
     sig2: Sig | Octets,
     hf: HashF = sha256,
 ) -> tuple[int, int]:
+    """Return (private key, nonce) from two signatures sharing a nonce.
+
+    As ``crack_prv_key_``, with each message reduced by hf first.
+    """
     msg_hash1 = reduce_to_hlen(msg1, hf)
     msg_hash2 = reduce_to_hlen(msg2, hf)
 

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -930,7 +930,7 @@ def anti_exfil_host_verify(
 
     receipt is the R of step 2, what libsecp256k1 calls the opening.
     False and not an exception for everything that fails, as ``verify_``
-    answers: a rho of the wrong size is simply a rho this commitment does
+    answers: a rho of the wrong size is a rho this commitment does
     not open to.
     """
     return verify_(msg_hash, key, sig, lower_s, hf, commit_hash=rho, receipt=receipt)

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -101,8 +101,11 @@ def commit(r: int, v: int, ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
 def assert_as_valid(
     r: int, v: int, commitment: Point, ec: Curve = secp256k1, hf: HashF = sha256
 ) -> None:
-    # Private function for test/dev purposes
-    # It raises Errors, while verify should always return True or False
+    """Refuse a commitment that (r, v) does not open.
+
+    The commitment is recomputed and compared; verify is the boolean
+    answer.
+    """
     if commitment != commit(r, v, ec, hf):
         raise BTClibRuntimeError("commitment verification failed")
 

--- a/btclib/ecc/rfc6979_nonce.py
+++ b/btclib/ecc/rfc6979_nonce.py
@@ -50,6 +50,12 @@ from btclib.utils import bytes_from_octets, int_from_bits
 def challenge_(
     msg_hash: Octets, ec: Curve = secp256k1, hf: HashF = hashlib.sha256
 ) -> int:
+    """Return the ECDSA challenge scalar from a message hash.
+
+    Bits2int of SEC 1 and RFC6979: the leftmost nlen bits of the hash,
+    reduced mod n. The message enters already reduced -- a digest of
+    hf's size, which is what the trailing underscore says.
+    """
     # the message msg_hash: a hf_len array
     hf_len = hf().digest_size
     msg_hash = bytes_from_octets(msg_hash, hf_len)

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -13,13 +13,11 @@ This implementation is according to BIP340-Schnorr:
 
 https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki
 
-The BIP340-Schnorr scheme uses as public key the x-coordinate (field element)
-of the curve point associated to the private key 0 < q < n.
-Therefore, for sepcp256k1 the public key size is 32 bytes.
-Arguably, the knowledge of q as the discrete logarithm of Q
-also implies the knowledge of n-q as discrete logarithm of -Q.
-As such, {q, n-q} can be considered a single private key and
-{Q, -Q} the associated public key characterized by the shared x_Q.
+The public key is the x-coordinate -- a field element -- of the curve
+point associated to the private key 0 < q < n, so on secp256k1 a
+public key is 32 bytes. Knowing q as the discrete logarithm of Q is
+knowing n-q as the discrete logarithm of -Q, so {q, n-q} acts as one
+private key and {Q, -Q} as the public key their shared x_Q names.
 
 The dropped 02/03 prefix is implicit, not lost: verification needs an
 unambiguous Y, so BIP340 fixes it as even, and the x-only key is the
@@ -29,17 +27,16 @@ breaks the full key at the price of a negation -- and taking the bare
 x as the key refuses a malleability: a verifier that accepted a point
 and negated its odd Y would make every signature valid for two keys.
 
-Also, BIP340 advocates its own SHA256 modification as hash function:
-TaggedHash(tag, x) = SHA256(SHA256(tag)||SHA256(tag)||x)
-The rationale is to make BIP340 signatures invalid for anything else
-but Bitcoin and vice versa.
+The hash function is BIP340's tagged SHA256,
+TaggedHash(tag, x) = SHA256(SHA256(tag)||SHA256(tag)||x),
+which makes a BIP340 hash invalid under any other tag and any other
+scheme; the challenge uses tag 'BIP0340/challenge', the deterministic
+nonce 'BIP0340/aux' and 'BIP0340/nonce'.
 
-TaggedHash is used for both the challenge (with tag 'BIP0340/challenge')
-and the deterministic nonce (with tag 'BIP0340/aux').
-
-To allow for secure batch verification of multiple signatures,
-BIP340-Schnorr uses a challenge that prevents public key recovery
-from signature: c = TaggedHash('BIP0340/challenge', x_k||x_Q||msg).
+The challenge commits to the public key as well as to the nonce
+point, c = TaggedHash('BIP0340/challenge', x_k||x_Q||msg), which
+rules out public key recovery and is what makes batch verification
+sound.
 
 The challenge commits to the nonce point as well, and that dependency
 is the Fiat-Shamir transform itself: hashing the commitment x_k
@@ -48,18 +45,14 @@ only after receiving the commitment. Were c and the nonce chosen
 independently, no private key would be needed: K = s*G - c*Q
 satisfies verification for any Q.
 
-A custom algorithm for the ephemeral key (nonce)
-is used for signing, instead of the RFC6979 standard:
+The deterministic nonce is BIP340's own, not RFC6979's:
 
 nonce = TaggedHash('BIP0340/nonce', t||x_Q||msg)
 with t = q xor TaggedHash('BIP0340/aux', a), a the auxiliary randomness
 
-Finally, BIP340-Schnorr adopts a robust [r][s] custom serialization
-format, instead of the loosely specified ASN.1 DER standard.
-The signature size is p-size*n-size, where p-size is the field element
-(curve point coordinate) byte size and n-size is the scalar
-(curve point multiplication coefficient) byte size.
-For sepcp256k1 the resulting signature size is 64 bytes.
+The serialization is the fixed-size [r][s] -- p-size plus n-size
+bytes, 64 on secp256k1 -- not the loosely specified ASN.1 DER of
+ECDSA.
 """
 
 from __future__ import annotations
@@ -110,12 +103,11 @@ _S2C_DATA_TAG = b"s2c/bip340/data"
 
 @dataclass(frozen=True, init=False)
 class Sig:
-    """BIP340-Schnorr signature.
+    """A BIP340-Schnorr signature: (r, s).
 
-    - r is an x-coordinate _field_element_, 0 <= r < ec.p
-    - s is a scalar, 0 <= s < ec.n (yes, for BIP340-Schnorr it can be zero)
-
-    (ec.p is the field prime, ec.n is the curve order)
+    r is a field element, 0 <= r < ec.p, the x-coordinate of the nonce
+    point; s is a scalar, 0 <= s < ec.n, and zero is valid here where
+    dsa.Sig refuses it, BIP340 placing no lower bound.
     """
 
     # 32 bytes x-coordinate field element

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -137,6 +137,7 @@ class Sig:
             self.assert_valid()
 
     def assert_valid(self) -> None:
+        """Refuse an r that is no x-coordinate, or an s outside 0..n-1."""
         # r is a field element, fail if r is not a valid x-coordinate.
         # Asking for the y is how that is asked, and the y is discarded:
         # BIP340 fixes it even, and verification recomputes the point from
@@ -153,6 +154,7 @@ class Sig:
             raise BTClibValueError(err_msg)
 
     def serialize(self, *, check_validity: bool = True) -> bytes:
+        """Return BIP340's fixed-size r || s, 64 bytes on secp256k1."""
         if check_validity:
             self.assert_valid()
 
@@ -162,6 +164,12 @@ class Sig:
 
     @classmethod
     def parse(cls: type[Sig], data: BinaryData, *, check_validity: bool = True) -> Sig:
+        """Build a Sig from BIP340's r || s bytes, on secp256k1.
+
+        The serialization does not name its curve, so parse reads the
+        one BIP340 is defined over; a Sig on another curve is built
+        directly.
+        """
         stream = bytesio_from_binarydata(data)
         ec = secp256k1
         r = int.from_bytes(stream.read(ec.p_size), byteorder="big", signed=False)
@@ -223,6 +231,13 @@ def gen_keys(prv_key: PrvKey | None = None, ec: Curve = secp256k1) -> tuple[int,
 
 
 def challenge_(msg: Octets, x_Q: int, x_K: int, ec: Curve, hf: HashF) -> int:
+    """Return the BIP340 challenge scalar over a prepared message.
+
+    TaggedHash(BIP0340/challenge, x_K || x_Q || msg), reduced mod n.
+    The message enters as it is, of any size, which is what the
+    trailing underscore says throughout this module: no reduction by
+    hf happens here.
+    """
     # the message, of any size ("Messages of Arbitrary Size" in BIP340):
     # the tagged hash below absorbs any length unambiguously, x_K and x_Q
     # being fixed at p_size each
@@ -486,8 +501,14 @@ def assert_as_valid_(
     commit_hash: Octets | None = None,
     receipt: Point | None = None,
 ) -> None:
-    # Private function for test/dev purposes
-    # It raises Errors, while verify should always return True or False
+    """Refuse an invalid BIP340 signature over a prepared message.
+
+    The message enters as it is, of any size; assert_as_valid is the
+    spelling that reduces with hf first. Errors carry the reason,
+    ``verify_`` being the boolean answer. With commit_hash and receipt the
+    sign-to-contract commitment is opened as well, an independent
+    check of the same r.
+    """
     if isinstance(sig, Sig):
         sig.assert_valid()
     else:
@@ -638,6 +659,14 @@ def assert_batch_as_valid_(
     sigs: Sequence[Sig],
     hf: HashF = sha256,
 ) -> None:
+    """Refuse an invalid signature in a batch of prepared messages.
+
+    BIP340's batch verification: one multi-scalar equation over
+    random coefficients, cheaper than one verification per signature
+    -- and which signature failed is not in the answer, only that one
+    did. Messages enter as they are; every signature must share one
+    curve.
+    """
     batch_size = len(Qs)
     if batch_size == 0:
         raise BTClibValueError("no signatures provided")
@@ -701,6 +730,7 @@ def assert_batch_as_valid(
     sigs: Sequence[Sig],
     hf: HashF = sha256,
 ) -> None:
+    """Refuse an invalid signature in a batch, reducing each message."""
     msgs = [reduce_to_hlen(msg, hf) for msg in ms]
     return assert_batch_as_valid_(msgs, Qs, sigs, hf)
 
@@ -711,6 +741,12 @@ def batch_verify_(
     sigs: Sequence[Sig],
     hf: HashF = sha256,
 ) -> bool:
+    """Answer whether every signature in the batch verifies.
+
+    Messages enter prepared, as in ``assert_batch_as_valid_``; a failed
+    verification and a malformed input are both False, a caller error
+    still raises.
+    """
     # ValueError and BTClibRuntimeError, not Exception: an input that is not
     # a valid signature is False, and so is a verification that failed, but
     # a TypeError is neither -- an hf passed as sha256() instead of sha256

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -19,7 +19,7 @@ TypeError or RuntimeError, and does not lose anything by doing so.
 
 
 class BTClibValueError(ValueError):
-    pass
+    """A value no valid input could carry; the library's usual refusal."""
 
 
 class ScriptError(BTClibValueError):
@@ -64,11 +64,11 @@ class InvalidPrvKeyError(BTClibValueError):
 
 
 class BTClibTypeError(TypeError):
-    pass
+    """An input of a type no conversion accepts: a caller error."""
 
 
 class BTClibRuntimeError(RuntimeError):
-    pass
+    """A check that failed on valid inputs, e.g. a failed verification."""
 
 
 class InvalidContributionError(BTClibRuntimeError):

--- a/btclib/fee.py
+++ b/btclib/fee.py
@@ -94,23 +94,15 @@ class FeeRate:
 
     @classmethod
     def from_sats_per_vbyte(cls, sats_per_vbyte: Any) -> FeeRate:
-        """Return the fee rate quoted in satoshi per virtual byte.
+        """Return the same rate in sat/kvB from a sat/vB quote.
 
-        Args:
-            sats_per_vbyte (Any): The rate in sat/vB: a Decimal, an int,
-                a string, or anything else str() renders as a decimal
-                number. A float is read through its repr, so 1.1 is the
-                1.1 that was written rather than the binary fraction
-                nearest to it.
-
-        Raises:
-            BTClibValueError: If the rate does not read as a decimal
-                number, if it is not finite, or if it is not a whole
-                number of millisatoshi per virtual byte -- i.e. if
-                sat/kvB could not hold it exactly.
-
-        Returns:
-            FeeRate: The same rate, in sat/kvB.
+        The quote is a Decimal, an int, a string, or anything else
+        str() renders as a decimal number; a float is read through
+        its repr, so 1.1 is the 1.1 that was written rather than the
+        binary fraction nearest to it. Refused: what does not read as
+        a decimal number, is not finite, or is not a whole number of
+        millisatoshi per virtual byte -- what sat/kvB cannot hold
+        exactly.
         """
         err_msg = f"invalid sat/vB fee rate: {sats_per_vbyte}"
         # str() renders every object there is, and Decimal refuses most
@@ -169,18 +161,8 @@ def fee_from_vsize(vsize: int, fee_rate: FeeRate) -> int:
 
     Rounded up, which is what Core's `CFeeRate::GetFee` does and the
     reason it does it: a fee one satoshi short of the rate is a fee below
-    the rate, and a transaction paying it does not relay.
-
-    Args:
-        vsize (int): The virtual size, in virtual bytes.
-        fee_rate (FeeRate): The rate the fee is owed at.
-
-    Raises:
-        BTClibTypeError: If the virtual size is not an integer.
-        BTClibValueError: If the virtual size is negative.
-
-    Returns:
-        int: The fee, in satoshi.
+    the rate, and a transaction paying it does not relay. A virtual
+    size that is not an int, or is negative, is refused.
     """
     # checked for the reason FeeRate checks its own field: a float does
     # not fail this arithmetic, it passes through it, and
@@ -254,14 +236,9 @@ def dust_threshold(
     An unspendable output has no input to pay for, so its threshold is
     zero and no value is dust.
 
-    Args:
-        script_pub_key (Octets): The output script.
-        fee_rate (FeeRate, optional): The dust relay fee rate. Defaults
-            to DUST_RELAY_FEE_RATE, Core's 3000 sat/kvB.
-
-    Returns:
-        int: The threshold, in satoshi. An output is dust when its value
-        is below this; an output worth exactly this is not.
+    `fee_rate` is the dust relay rate, defaulting to Core's 3000
+    sat/kvB. An output is dust when its value is below the returned
+    satoshi; one worth exactly it is not.
     """
     script_pub_key = bytes_from_octets(script_pub_key)
 

--- a/btclib/fetch/bitcoind.py
+++ b/btclib/fetch/bitcoind.py
@@ -266,9 +266,11 @@ class BitcoindFetcher(Fetcher):
         return tx_from_raw(raw, hex_, self.network)
 
     def get_block_count(self) -> int:
+        """Return the height of the node's best chain tip."""
         with fetch_errors("getblockcount"):
             return int(self.proxy.call("getblockcount"))
 
     def get_best_block_id(self) -> bytes:
+        """Return the hash of the node's best chain tip, display order."""
         with fetch_errors("getbestblockhash"):
             return bytes_from_octets(self.proxy.call("getbestblockhash"), 32)

--- a/btclib/fetch/esplora.py
+++ b/btclib/fetch/esplora.py
@@ -99,13 +99,16 @@ class EsploraFetcher(Fetcher):
         return text
 
     def get_tx(self, tx_id: Octets) -> Tx:
+        """Return the transaction, parsed and checked against its txid."""
         hex_ = tx_id_hex(tx_id)
         return tx_from_raw(self.text(f"/tx/{hex_}/hex"), hex_, self.network)
 
     def get_block_count(self) -> int:
+        """Return the height of the server's best chain tip."""
         with fetch_errors("blocks/tip/height"):
             return int(self.text("/blocks/tip/height"))
 
     def get_best_block_id(self) -> bytes:
+        """Return the hash of the server's best chain tip, display order."""
         with fetch_errors("blocks/tip/hash"):
             return bytes_from_octets(self.text("/blocks/tip/hash"), 32)

--- a/btclib/hashes.py
+++ b/btclib/hashes.py
@@ -104,6 +104,12 @@ def hash256(octets: Octets) -> bytes:
 
 
 def reduce_to_hlen(msg: Octets, hf: HashF = hashlib.sha256) -> bytes:
+    """Return the message digested by hf, one digest long.
+
+    Step 4 of SEC 1 v.2 section 4.1.3: what the un-underscored
+    signing and verifying spellings do to a message before handing it
+    to their trailing-underscore twins.
+    """
     msg = bytes_from_octets(msg)
     # Step 4 of SEC 1 v.2 section 4.1.3
     h = hf()
@@ -112,6 +118,13 @@ def reduce_to_hlen(msg: Octets, hf: HashF = hashlib.sha256) -> bytes:
 
 
 def magic_message(msg: Octets) -> bytes:
+    """Return the hash BMS signs: the message in Core's magic envelope.
+
+    Both the "Bitcoin Signed Message:" magic and the message enter
+    var_int-length-prefixed, then hash256 of the whole; the envelope
+    is what keeps a signed message from being a valid transaction
+    signature.
+    """
     msg = bytes_from_octets(msg)
     # Both strings are length-prefixed as var_int (CompactSize), as Core
     # does by serializing them with CDataStream; the 0x18 prefix of the
@@ -259,6 +272,11 @@ def merkle_root_from_branch(
 
 
 def tagged_hash(tag: bytes, m: bytes, hf: HashF = hashlib.sha256) -> bytes:
+    """Return BIP340's tagged hash: hf(hf(tag) || hf(tag) || m).
+
+    The doubled tag digest is what makes a hash under one tag invalid
+    under every other.
+    """
     # libsecp256k1 computes exactly this in hashes.tagged_sha256, and the
     # binding is not called because it is slower at every size: 0.53 us
     # against 0.44 on an empty message, 0.63 against 0.44 on 64 bytes,

--- a/btclib/mnemonic/entropy.py
+++ b/btclib/mnemonic/entropy.py
@@ -148,6 +148,7 @@ def bin_str_entropy_from_bytes(
 
 
 def bytes_entropy_from_str(bin_str_entropy: BinStr) -> bytes:
+    """Return the binary-string entropy as bytes, left-padded to whole ones."""
     n_bits = len(bin_str_entropy)
     if n_bits not in _bits:
         err_msg = f"invalid number of bits: {n_bits} instead of {_bits}"
@@ -231,6 +232,13 @@ def bin_str_entropy_from_str(str_entropy: str, bits: OneOrMoreInt = _bits) -> Bi
 
 
 def collect_rolls(bits: int) -> tuple[int, list[int]]:
+    """Prompt for dice rolls until they carry `bits` of entropy.
+
+    Interactive on purpose, input() and print() being its interface:
+    the caller gets (dice sides, the rolls that count). Rolls beyond
+    a power of two are discarded and asked again, carrying no whole
+    bits.
+    """
     automate = False
     dice_sides = 0
     _dice_sides = (4, 6, 8, 12, 20, 24, 30, 48, 60, 120)

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -44,6 +44,16 @@ _KEY_SIZE: list[tuple[NetworkField, int]] = [
 
 @dataclass(frozen=True)
 class Network:
+    """The encoding table of one network: prefixes, versions, magic.
+
+    What tells a mainnet spelling from a test one -- wif and address
+    prefixes, the bech32 hrp, the BIP32 and SLIP132 version bytes --
+    plus the wire magic and the genesis block hash. No consensus
+    parameter lives here; NETWORKS holds the built-in instances, and
+    the ``*_from_network`` and ``*_from_xkeyversion`` functions below
+    are the lookups.
+    """
+
     curve: Curve
 
     # "main" or "test": see NetworkType in alias.py for why this is the
@@ -161,6 +171,7 @@ class Network:
             self.assert_valid()
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, str | None]:
+        """Return the network as a dict of hex strings and names."""
         if check_validity:
             self.assert_valid()
 
@@ -189,6 +200,7 @@ class Network:
     def from_dict(
         cls: type[Network], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> Network:
+        """Build a Network from the dict shape to_dict writes."""
         return cls(
             CURVES[dict_["curve"]],
             dict_["magic_bytes"],
@@ -214,6 +226,7 @@ class Network:
         )
 
     def assert_valid(self) -> None:
+        """Refuse a field of the wrong type, size, or network_type value."""
         # no check on self.curve
 
         # the hrp is the human-readable part of every bech32 address of this
@@ -346,6 +359,7 @@ def network_type_from_network(network: str = "mainnet") -> NetworkType:
 
 
 def xpubversions_from_network(network: str = "mainnet") -> list[bytes]:
+    """Return every xpub version of the network, BIP32 and SLIP132."""
     network = network.strip().lower()
     return [
         NETWORKS[network].bip32_pub,
@@ -357,6 +371,7 @@ def xpubversions_from_network(network: str = "mainnet") -> list[bytes]:
 
 
 def xprvversions_from_network(network: str = "mainnet") -> list[bytes]:
+    """Return every xprv version of the network, BIP32 and SLIP132."""
     network = network.strip().lower()
     return [
         NETWORKS[network].bip32_prv,
@@ -418,5 +433,6 @@ def network_type_from_xkeyversion(xkeyversion: bytes) -> NetworkType:
 
 
 def curve_from_xkeyversion(xkeyversion: bytes) -> Curve:
+    """Return the curve of the network the version bytes belong to."""
     network = network_from_xkeyversion(xkeyversion)
     return NETWORKS[network].curve

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -514,6 +514,15 @@ def _assert_input_signable(psbt_in: PsbtIn) -> None:
 
 @dataclass
 class Psbt:
+    """A partially signed bitcoin transaction, BIP174 and BIP370.
+
+    Both versions are held BIP370's way -- the transaction's fields
+    live in the psbt and `tx` computes the unsigned transaction; the
+    module docstring says why. The global fields are here, each input's
+    and output's in its PsbtIn or PsbtOut; the wire form is serialize
+    and parse, the customary text form b64encode and b64decode.
+    """
+
     tx_version: int
     inputs: list[PsbtIn]
     outputs: list[PsbtOut]
@@ -764,6 +773,12 @@ class Psbt:
             _assert_input_signable(psbt_in)
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, Any]:
+        """Return the psbt as a dict of json-friendly values.
+
+        The "tx" entry is derived for the reader and ignored by
+        from_dict, the comment on it saying why; everything else
+        round-trips.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -792,6 +807,7 @@ class Psbt:
     def from_dict(
         cls: type[Psbt], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> Psbt:
+        """Build a Psbt from the dict shape to_dict writes."""
         hd_key_paths = cast(
             Mapping[Octets, BIP32KeyOrigin],
             # check_validity=False, as for every other element here (issue
@@ -962,6 +978,7 @@ class Psbt:
         )
 
     def b64encode(self, *, check_validity: bool = True) -> str:
+        """Return the serialization as base64 text, BIP174's file form."""
         psbt_bin = self.serialize(check_validity=check_validity)
         return base64.b64encode(psbt_bin).decode("ascii")
 
@@ -969,6 +986,7 @@ class Psbt:
     def b64decode(
         cls: type[Psbt], psbt_str: String, *, check_validity: bool = True
     ) -> Psbt:
+        """Build a Psbt from its base64 text, stripping whitespace."""
         if isinstance(psbt_str, str):
             psbt_str = psbt_str.strip()
 

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -1183,9 +1183,10 @@ def _combined_tx_modifiable(psbts: Sequence[Psbt]) -> int | None:
 
 
 def combine_psbts(psbts: Sequence[Psbt]) -> Psbt:
-    """Merge Psbt data from multiple Psbts of one transaction.
+    """Merge the data of several psbts of one transaction: the Combiner.
 
-    Basically used to merge signatures.
+    BIP174's Combiner role, whose ordinary use is merging the partial
+    signatures different signers added to copies of one psbt.
 
     Which psbts are of one transaction is a question the two versions
     answer differently, and each is asked its own: a version 0 psbt is
@@ -1199,7 +1200,8 @@ def combine_psbts(psbts: Sequence[Psbt]) -> Psbt:
     The versions must match, and are not converted here: `to_v0` and
     `to_v2` are that, and doing it silently would decide for the caller
     which of the two the combined psbt is -- and, from v0 to v2, hand
-    back a psbt whose lock time no longer comes from where it did.
+    back a psbt whose lock time comes from the fallback rather than
+    from the unsigned transaction the caller wrote it into.
     """
     final_psbt = psbts[0]
     version = final_psbt.version
@@ -1795,9 +1797,9 @@ def _sort_or_shuffle(
 ) -> list[TypeA]:
     """Return the sequence sorted by ordering_func, or shuffled.
 
-    One sequence, where the two of a psbt's inputs used to be sorted
-    together: an input's outpoint and sequence are the input's own now,
-    so there is no second list to keep in step with the first.
+    One sequence only: an input's outpoint and sequence are fields of
+    the input itself, so there is no second list to keep in step with
+    the first.
     """
     items = list(sequence)
     if ordering_func is None:
@@ -1851,7 +1853,7 @@ def join_psbts(
     """Join multiple psbts into a single one by merging inputs and outputs.
 
     inputs/outputs are shuffled by default. If shuffle_{in|out}=False,
-    they are simply concatenated in the same order as psbts are
+    they are concatenated in the same order as psbts are
     specified. A specific ordering can be specified via sort_{inp|out},
     which overwrite shuffle when present.
 

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -481,6 +481,15 @@ _KEY_DATA_FIELDS: dict[bytes, tuple[str, Callable[[bytes], Any]]] = {
 
 @dataclass
 class PsbtIn:
+    """The per-input map of a psbt: one field per BIP174/BIP370 key type.
+
+    What each role fills in for one input on its way to a signature --
+    the spent output or the transaction holding it, scripts, hd paths,
+    partial and taproot signatures, preimages, the finalized script or
+    witness -- with what no key type names kept in `unknown`. A field
+    a psbt does not carry is None, or empty for the collection types.
+    """
+
     non_witness_utxo: Tx | None
     witness_utxo: TxOut | None
     partial_sigs: dict[bytes, bytes]
@@ -695,6 +704,11 @@ class PsbtIn:
         assert_valid_unknown(self.unknown)
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, Any]:
+        """Return the input map as a dict of json-friendly values.
+
+        Keys are hex, hd paths are BIP174's bip32_derivs shape;
+        from_dict reads the same shape back.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -743,6 +757,7 @@ class PsbtIn:
     def from_dict(
         cls: type[PsbtIn], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> PsbtIn:
+        """Build a PsbtIn from the dict shape to_dict writes."""
         hd_key_paths = cast(
             Mapping[Octets, BIP32KeyOrigin],
             # check_validity=False, as for every other element here (issue

--- a/btclib/psbt/psbt_out.py
+++ b/btclib/psbt/psbt_out.py
@@ -132,6 +132,14 @@ def _serialized_taproot_fields(psbt_out: PsbtOut) -> list[bytes]:
 
 @dataclass
 class PsbtOut:
+    """The per-output map of a psbt: one field per BIP174/BIP370 key type.
+
+    The scripts and hd paths that let a wallet recognize an output as
+    its own, BIP370's amount and script_pub_key of the output being
+    built, and what no key type names in `unknown`. A field a psbt
+    does not carry is None, or empty for the collection types.
+    """
+
     redeem_script: bytes
     witness_script: bytes
     hd_key_paths: HdKeyPaths
@@ -200,6 +208,11 @@ class PsbtOut:
         assert_valid_unknown(self.unknown)
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, Any]:
+        """Return the output map as a dict of json-friendly values.
+
+        Keys are hex, hd paths are BIP174's bip32_derivs shape;
+        from_dict reads the same shape back.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -222,6 +235,7 @@ class PsbtOut:
     def from_dict(
         cls: type[PsbtOut], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> PsbtOut:
+        """Build a PsbtOut from the dict shape to_dict writes."""
         hd_key_paths = cast(
             Mapping[Octets, BIP32KeyOrigin],
             # check_validity=False, as for every other element here (issue

--- a/btclib/script/engine/__init__.py
+++ b/btclib/script/engine/__init__.py
@@ -60,6 +60,14 @@ __all__ = [
 def taproot_unwrap_script(
     script: bytes, stack: list[bytes]
 ) -> tuple[bytes, list[bytes], int]:
+    """Take a script-path spend apart: (tapscript, stack, leaf version).
+
+    The last two witness elements are the control block and the script,
+    per BIP341; the control block must prove the script was committed
+    to by the output key, and check_output_pubkey is what verifies that
+    Merkle proof. Returns the stack without the two, leaving the
+    caller's list untouched.
+    """
     pub_key = type_and_payload(script)[1]
     script_bytes = stack[-2]
     control = stack[-1]
@@ -73,6 +81,12 @@ def taproot_unwrap_script(
 
 
 def taproot_get_annex(witness: Witness) -> tuple[bytes, list[bytes]]:
+    """Split the annex off a taproot witness stack: (annex, the rest).
+
+    BIP341 makes the annex the last element of a stack of at least two
+    whose first byte is 0x50; the empty bytes mean there is none, no
+    annex being distinguishable from an empty one by construction.
+    """
     # the trimmed stack is returned, never written back: a get_ function must
     # not write, and verifying a transaction must not rewrite it. A list in
     # either branch, the stack being popped by the script interpreter.
@@ -425,6 +439,12 @@ def verify_input(
 
 
 def verify_amounts(prevouts: list[TxOut], tx: Tx) -> None:
+    """Refuse a transaction whose outputs exceed the outputs it spends.
+
+    The difference is the fee, and a negative fee is money printed;
+    script validation never reads the amounts except through the
+    sig_hash, so this is a check of its own rather than a flag.
+    """
     if sum(x.value for x in tx.vout) > sum(x.value for x in prevouts):
         raise BTClibValueError("Invalid transaction amounts")
 

--- a/btclib/script/engine/__init__.py
+++ b/btclib/script/engine/__init__.py
@@ -7,7 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Bitcoin Script engine."""
+"""The script engine: transaction verification against the consensus rules."""
 
 from __future__ import annotations
 

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -7,7 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Bitcoin Script engine."""
+"""The legacy and segwit v0 interpreter loop of the script engine."""
 
 from __future__ import annotations
 

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -97,6 +97,15 @@ def fix_signature(signature: bytes, flags: ScriptFlag) -> bytes:
 
 
 def check_pub_key(pub_key: bytes, segwit: bool, flags: ScriptFlag) -> bool:
+    """Answer whether the public key is well-formed enough to verify with.
+
+    Core's CheckPubKeyEncoding, split the way Core splits it: a wrong
+    length or prefix returns False, which op_checksig turns into a
+    failed signature check rather than a script error, while the two
+    flags that make the encoding itself the offence raise -- STRICTENC
+    for a hybrid 0x06/0x07 prefix, WITNESS_PUBKEYTYPE for an
+    uncompressed key in a segwit script.
+    """
     if not pub_key:
         return False
     if pub_key[0] in [4, 6, 7]:
@@ -197,6 +206,21 @@ def op_checksig(
     segwit: bool,
     precomputed: PrecomputedTxData | None = None,
 ) -> bool:
+    """Verify one ECDSA signature over the script code it commits to.
+
+    Returns the boolean the op code pushes rather than raising: an
+    empty signature, one that fails to verify, or a key or encoding
+    refused under lax rules are all False, and an error only where a
+    flag makes the encoding the offence -- DERSIG/LOW_S/STRICTENC for
+    the signature, STRICTENC/WITNESS_PUBKEYTYPE for the key.
+
+    `signatures` is what FindAndDelete removes from a pre-segwit
+    script code: the whole set under check when called from
+    OP_CHECKMULTISIG, the signature itself otherwise. The message hash
+    is BIP143's for a segwit v0 input and the legacy per-input
+    serialization for the rest; tapscript signatures never reach here,
+    tapscript.py verifying BIP340 on its own.
+    """
     if not signature:
         return False
     try:
@@ -280,6 +304,11 @@ def check_signature_num(signature_num: int, pub_key_num: int) -> None:
 
 
 def script_op_count(count: int, increment: int) -> int:
+    """Add to the op code count, bounded by MAX_OPS_PER_SCRIPT.
+
+    Core's accounting: pushes are free, every other op code costs one,
+    and OP_CHECKMULTISIG adds its public key count on top.
+    """
     count += increment
     if count > MAX_OPS_PER_SCRIPT:
         raise BTClibValueError(f"more than {MAX_OPS_PER_SCRIPT} op codes: {count}")
@@ -341,6 +370,11 @@ def check_not_disabled(op_code: int) -> None:
 
 
 def prepare_script(script: ScriptList, flags: ScriptFlag, segwit: bool) -> None:
+    """Refuse OP_CODESEPARATOR in a legacy script under CONST_SCRIPTCODE.
+
+    Only legacy: BIP143 keeps the op code meaningful in segwit v0, so
+    the pre-segwit script code is the one the flag freezes.
+    """
     if (
         "OP_CODESEPARATOR" in script
         and ScriptFlag.CONST_SCRIPTCODE in flags
@@ -424,6 +458,16 @@ def verify_script(  # noqa: C901
     final: bool = False,
     precomputed: PrecomputedTxData | None = None,
 ) -> None:
+    """Execute the script over the caller's stack, as Core's EvalScript.
+
+    The stack is mutated in place, which is how the callers chain
+    scripts: script_sig leaves what script_pub_key then reads. Any
+    refusal -- a BTClibValueError out of an op code, an IndexError out
+    of a pop on a short stack -- is re-raised as ScriptError carrying
+    the index of the failing command and the stack depth. With `final`
+    the script must end on a non-empty stack with a true top element,
+    which is the caller saying no script runs after this one.
+    """
     if len(script_bytes) > MAX_SCRIPT_SIZE:
         err_msg = f"script longer than {MAX_SCRIPT_SIZE} bytes: {len(script_bytes)}"
         raise BTClibValueError(err_msg)

--- a/btclib/script/engine/script_op_codes.py
+++ b/btclib/script/engine/script_op_codes.py
@@ -5,7 +5,23 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Bitcoin Script legacy op codes."""
+"""Bitcoin Script legacy op codes.
+
+One function per op code, each the matching case of Core's EvalScript;
+script.py and tapscript.py hold the interpreter loops that dispatch
+them. Two contracts are shared by every function here rather than
+restated on each:
+
+- an operand read as a number is a CScriptNum: at most 4 bytes on
+  input, minimally encoded where MINIMALDATA asks, while a result may
+  be pushed at 5 bytes and is refused only when an op code consumes it
+  again -- Core's asymmetry, kept deliberately
+- a pop from a stack too short raises IndexError, which the loop
+  reports as a stack underflow, and every other refusal is a
+  BTClibValueError; the loop turns both into a ScriptError carrying
+  the index of the failing command. The op codes that check the depth
+  themselves do so only where popping would not fail on its own.
+"""
 
 from __future__ import annotations
 
@@ -161,6 +177,15 @@ def op_if(
     flags: ScriptFlag,
     segwit_version: int,
 ) -> None:
+    """Pop the condition and open a branch that executes on true.
+
+    Inside an unexecuted outer branch nothing is popped and False is
+    appended, so nesting is tracked without evaluating anything. The
+    minimal-condition rule -- the empty element or 0x01, nothing else
+    -- is consensus in tapscript per BIP342 and opt-in through the
+    MINIMALIF flag in segwit v0; a legacy script takes any element as
+    its condition.
+    """
     if not all(condition_stack):
         condition_stack.append(False)
         return
@@ -181,6 +206,11 @@ def op_notif(
     flags: ScriptFlag,
     segwit_version: int,
 ) -> None:
+    """Pop the condition and open a branch that executes on false.
+
+    The unexecuted-branch behaviour and the minimal-condition rule are
+    op_if's; only the sense of the popped condition is inverted.
+    """
     if not all(condition_stack):
         condition_stack.append(False)
         return
@@ -196,12 +226,19 @@ def op_notif(
 
 
 def op_else(condition_stack: list[bool]) -> None:
+    """Toggle the innermost open branch, refusing one never opened.
+
+    A toggle rather than a one-shot alternative: Core flips
+    vfExec.back(), so a second OP_ELSE in the same branch turns it
+    back on, and this keeps that.
+    """
     if len(condition_stack) == 1:
         raise BTClibValueError("OP_ELSE without OP_IF or OP_NOTIF")
     condition_stack[-1] = not condition_stack[-1]
 
 
 def op_endif(condition_stack: list[bool]) -> None:
+    """Close the innermost open branch, refusing one never opened."""
     # Core's SCRIPT_ERR_UNBALANCED_CONDITIONAL on `vfExec.empty()`, which is
     # this list holding the sentinel alone. Popping the sentinel instead
     # leaves `all([])` True, so an OP_ENDIF arriving before its OP_IF let the
@@ -229,47 +266,68 @@ def check_balanced_if(condition_stack: list[bool]) -> None:
 
 
 def op_nop(flags: ScriptFlag) -> None:
+    """Do nothing, or refuse to under DISCOURAGE_UPGRADABLE_NOPS.
+
+    Serves OP_NOP1 and OP_NOP4..OP_NOP10, the op codes reserved for
+    soft forks to redefine; the flag is the policy that keeps them out
+    of scripts until a fork gives one a meaning, as BIP65 and BIP112
+    did to OP_NOP2 and OP_NOP3.
+    """
     if ScriptFlag.DISCOURAGE_UPGRADABLE_NOPS in flags:
         raise BTClibValueError("upgradable NOP")
 
 
 def op_dup(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Push a copy of the top stack element."""
     stack.append(stack[-1])
 
 
 def op_2dup(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Push copies of the top two stack elements, keeping their order."""
     if len(stack) < 2:
         raise BTClibValueError("OP_2DUP on a stack of less than 2 elements")
     stack.extend(stack[-2:])
 
 
 def op_drop(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop the top stack element."""
     stack.pop()
 
 
 def op_2drop(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop the top two stack elements."""
     stack.pop()
     stack.pop()
 
 
 def op_swap(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Exchange the top two stack elements."""
     stack[-1], stack[-2] = stack[-2], stack[-1]
 
 
 def op_1negate(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Push the number -1."""
     stack.append(_from_num(-1))
 
 
 def op_verify(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop the top element and fail the script if it is false."""
     if not _to_bool(stack.pop()):
         raise BTClibValueError("false top stack element")
 
 
 def op_return(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Fail the script unconditionally, leaving the stack as it is."""
     raise BTClibValueError("OP_RETURN")
 
 
 def op_equal(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop two elements and push whether they are byte-equal.
+
+    Byte equality, not numeric: 0x00 and the empty element are both
+    false to op_verify yet unequal here, which op_numequal answers
+    the other way.
+    """
     a = stack.pop()
     b = stack.pop()
     if a == b:
@@ -281,66 +339,86 @@ def op_equal(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> No
 def op_equalverify(
     stack: list[bytes], altstack: list[bytes], flags: ScriptFlag
 ) -> ScriptList:
+    """Expand to OP_EQUAL followed by OP_VERIFY.
+
+    The ``*VERIFY`` op codes are the pair they contract: the interpreter
+    loop re-serializes the returned commands in front of the unread
+    script and winds its counters back, so the pair runs without being
+    counted twice.
+    """
     return ["OP_EQUAL", "OP_VERIFY"]
 
 
 def op_checksigverify(
     stack: list[bytes], altstack: list[bytes], flags: ScriptFlag
 ) -> ScriptList:
+    """Expand to OP_CHECKSIG followed by OP_VERIFY, as op_equalverify."""
     return ["OP_CHECKSIG", "OP_VERIFY"]
 
 
 def op_checkmultisigverify(
     stack: list[bytes], altstack: list[bytes], flags: ScriptFlag
 ) -> ScriptList:
+    """Expand to OP_CHECKMULTISIG and OP_VERIFY, as op_equalverify."""
     return ["OP_CHECKMULTISIG", "OP_VERIFY"]
 
 
 def op_size(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Push the byte length of the top element, leaving it in place."""
     stack.append(_from_num(len(stack[-1])))
 
 
 def op_ripemd160(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop the top element and push its RIPEMD160 digest."""
     stack.append(ripemd160(stack.pop()))
 
 
 def op_sha1(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop the top element and push its SHA1 digest."""
     stack.append(sha1(stack.pop()))
 
 
 def op_sha256(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop the top element and push its SHA256 digest."""
     stack.append(sha256(stack.pop()))
 
 
 def op_hash160(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop the top element and push RIPEMD160 of its SHA256 digest."""
     stack.append(hash160(stack.pop()))
 
 
 def op_hash256(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop the top element and push its double SHA256 digest."""
     stack.append(hash256(stack.pop()))
 
 
 def op_1add(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop a number and push it incremented by one."""
     a = _to_num(stack.pop(), flags)
     stack.append(_from_num(a + 1))
 
 
 def op_1sub(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop a number and push it decremented by one."""
     a = _to_num(stack.pop(), flags)
     stack.append(_from_num(a - 1))
 
 
 def op_negate(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop a number and push its negation."""
     a = _to_num(stack.pop(), flags)
     stack.append(_from_num(-a))
 
 
 def op_abs(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop a number and push its absolute value."""
     a = _to_num(stack.pop(), flags)
     stack.append(_from_num(abs(a)))
 
 
 def op_not(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop a number and push whether it is zero."""
     if _to_num(stack.pop(), flags) == 0:
         stack.append(b"\x01")
     else:
@@ -348,6 +426,7 @@ def op_not(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None
 
 
 def op_0notequal(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop a number and push whether it is non-zero."""
     a = _to_num(stack.pop(), flags)
     if a == 0:
         stack.append(b"")
@@ -356,18 +435,21 @@ def op_0notequal(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -
 
 
 def op_add(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop two numbers and push their sum."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     stack.append(_from_num(a + b))
 
 
 def op_sub(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop two numbers and push the deeper one minus the top one."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     stack.append(_from_num(a - b))
 
 
 def op_booland(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop two numbers and push whether both are non-zero."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     if a != 0 and b != 0:
@@ -377,6 +459,7 @@ def op_booland(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> 
 
 
 def op_boolor(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop two numbers and push whether either is non-zero."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     if a != 0 or b != 0:
@@ -386,6 +469,11 @@ def op_boolor(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> N
 
 
 def op_numequal(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop two numbers and push whether they are equal.
+
+    Numeric equality, not byte equality: without MINIMALDATA, 0x00
+    equals the empty element here and not in op_equal.
+    """
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     if a == b:
@@ -397,12 +485,14 @@ def op_numequal(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) ->
 def op_numequalverify(
     stack: list[bytes], altstack: list[bytes], flags: ScriptFlag
 ) -> ScriptList:
+    """Expand to OP_NUMEQUAL followed by OP_VERIFY, as op_equalverify."""
     return ["OP_NUMEQUAL", "OP_VERIFY"]
 
 
 def op_numnotequal(
     stack: list[bytes], altstack: list[bytes], flags: ScriptFlag
 ) -> None:
+    """Pop two numbers and push whether they differ."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     if a != b:
@@ -412,6 +502,7 @@ def op_numnotequal(
 
 
 def op_lessthan(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop two numbers and push whether the deeper is below the top."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     if a < b:
@@ -423,6 +514,7 @@ def op_lessthan(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) ->
 def op_greaterthan(
     stack: list[bytes], altstack: list[bytes], flags: ScriptFlag
 ) -> None:
+    """Pop two numbers and push whether the deeper is above the top."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     if a > b:
@@ -434,6 +526,7 @@ def op_greaterthan(
 def op_lessthanorequal(
     stack: list[bytes], altstack: list[bytes], flags: ScriptFlag
 ) -> None:
+    """Pop two numbers and push whether the deeper is at most the top."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     if a <= b:
@@ -445,6 +538,7 @@ def op_lessthanorequal(
 def op_greaterthanorequal(
     stack: list[bytes], altstack: list[bytes], flags: ScriptFlag
 ) -> None:
+    """Pop two numbers and push whether the deeper is at least the top."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     if a >= b:
@@ -454,18 +548,24 @@ def op_greaterthanorequal(
 
 
 def op_min(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop two numbers and push the smaller."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     stack.append(_from_num(min(a, b)))
 
 
 def op_max(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop two numbers and push the larger."""
     b = _to_num(stack.pop(), flags)
     a = _to_num(stack.pop(), flags)
     stack.append(_from_num(max(a, b)))
 
 
 def op_within(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop max, min and x, and push whether min <= x < max.
+
+    Left-closed and right-open, which is Core's comparison.
+    """
     M = _to_num(stack.pop(), flags)
     m = _to_num(stack.pop(), flags)
     x = _to_num(stack.pop(), flags)
@@ -476,16 +576,19 @@ def op_within(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> N
 
 
 def op_toaltstack(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Move the top stack element onto the altstack."""
     altstack.append(stack.pop())
 
 
 def op_fromaltstack(
     stack: list[bytes], altstack: list[bytes], flags: ScriptFlag
 ) -> None:
+    """Move the top altstack element back onto the stack."""
     stack.append(altstack.pop())
 
 
 def op_ifdup(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Push a copy of the top element only if it is true."""
     # Core's `if (CastToBool(vch))`, not a test for the empty element: a
     # one-byte zero and a negative zero are false without being empty, so
     # `<00> OP_IFDUP` duplicates here and does not there, and every op code
@@ -495,20 +598,28 @@ def op_ifdup(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> No
 
 
 def op_depth(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Push the number of elements on the stack."""
     stack.append(_from_num(len(stack)))
 
 
 def op_nip(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Remove the element below the top, leaving the top in place."""
     x = stack.pop()
     stack.pop()
     stack.append(x)
 
 
 def op_over(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Push a copy of the element below the top."""
     stack.append(stack[-2])
 
 
 def op_pick(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop a depth n and push a copy of the element n deep.
+
+    Zero is the top; a negative depth is refused, one past the stack
+    underflows.
+    """
     n = _to_num(stack.pop(), flags)
     if n < 0:
         raise BTClibValueError(f"negative OP_PICK depth: {n}")
@@ -516,6 +627,11 @@ def op_pick(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> Non
 
 
 def op_roll(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Pop a depth n and move the element n deep to the top.
+
+    Zero is the top and leaves the stack as it is; a negative depth or
+    one past the stack is refused.
+    """
     n = _to_num(stack.pop(), flags)
     if n < 0:
         raise BTClibValueError(f"negative OP_ROLL depth: {n}")
@@ -529,6 +645,7 @@ def op_roll(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> Non
 
 
 def op_rot(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Rotate the top three elements, the third-deep going on top."""
     x3 = stack.pop()
     x2 = stack.pop()
     x1 = stack.pop()
@@ -538,6 +655,7 @@ def op_rot(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None
 
 
 def op_tuck(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Insert a copy of the top element below the one under it."""
     x2 = stack.pop()
     x1 = stack.pop()
     stack.append(x2)
@@ -546,18 +664,21 @@ def op_tuck(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> Non
 
 
 def op_3dup(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Push copies of the top three stack elements, keeping their order."""
     if len(stack) < 3:
         raise BTClibValueError("OP_3DUP on a stack of less than 3 elements")
     stack.extend(stack[-3:])
 
 
 def op_2over(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Push copies of the third and fourth elements, keeping their order."""
     if len(stack) < 4:
         raise BTClibValueError("OP_2OVER on a stack of less than 4 elements")
     stack.extend(stack[-4:-2])
 
 
 def op_2rot(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Move the fifth and sixth elements to the top, keeping their order."""
     if len(stack) < 6:
         raise BTClibValueError("OP_2ROT on a stack of less than 6 elements")
     x6 = stack.pop()
@@ -575,6 +696,7 @@ def op_2rot(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> Non
 
 
 def op_2swap(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
+    """Exchange the top pair of elements with the pair below it."""
     stack[-1], stack[-3] = stack[-3], stack[-1]
     stack[-2], stack[-4] = stack[-4], stack[-2]
 
@@ -582,6 +704,16 @@ def op_2swap(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> No
 def op_checklocktimeverify(
     stack: list[bytes], tx: Tx, i: int, flags: ScriptFlag
 ) -> None:
+    """Refuse to spend before the absolute lock time on the stack, BIP65.
+
+    Reads the top element without popping it, as a number of up to 5
+    bytes. The refusals are BIP65's: an empty stack, a negative lock
+    time, a type mismatch -- block height against timestamp, the two
+    sides of the 500000000 threshold -- a lock time the transaction's
+    has not reached, and a final input sequence, which would let the
+    transaction bypass its own lock_time. A NOP when the flag is off,
+    the op code being a redefined OP_NOP2.
+    """
     if ScriptFlag.CHECKLOCKTIMEVERIFY not in flags:
         return
     if not stack:
@@ -611,6 +743,16 @@ def op_checklocktimeverify(
 def op_checksequenceverify(
     stack: list[bytes], tx: Tx, i: int, flags: ScriptFlag
 ) -> None:
+    """Refuse to spend before the relative lock time on the stack, BIP112.
+
+    Reads the top element without popping it, as a number of up to 5
+    bytes. An operand with bit 31 set asks for nothing, per BIP112;
+    otherwise the refusals are an empty stack, a negative operand, a
+    transaction version below BIP68's 2, an input sequence with the
+    disable bit set, a unit mismatch on bit 22 -- blocks against time
+    -- and a relative lock time above the input's. A NOP when the flag
+    is off, the op code being a redefined OP_NOP3.
+    """
     if ScriptFlag.CHECKSEQUENCEVERIFY not in flags:
         return
     if not stack:

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -7,7 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Bitcoin Script engine."""
+"""The tapscript interpreter loop of the script engine, per BIP342."""
 
 from __future__ import annotations
 

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -49,6 +49,12 @@ def ssa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:
 
 
 def get_hashtype(signature: bytes) -> int:
+    """Read the sig hash type off a taproot signature, per BIP341.
+
+    A 64-byte signature is SIGHASH_DEFAULT; a 65th byte carries the
+    type and must not spell the default explicitly, the two encodings
+    of one meaning being a malleability.
+    """
     sighash_type = 0  # all
     if len(signature) == 65:
         sighash_type = signature[-1]
@@ -62,6 +68,14 @@ def get_hashtype(signature: bytes) -> int:
 def op_checksigadd(
     stack: list[bytes], altstack: list[bytes], flags: ScriptFlag
 ) -> ScriptList:
+    """Expand OP_CHECKSIGADD to OP_CHECKSIG OP_ADD, per BIP342.
+
+    The op code pops signature, n and public key, and pushes n plus
+    the check's result; the swap puts n out of OP_CHECKSIG's way, and
+    the returned pair is re-run by the loop as the ``*VERIFY``
+    expansions are. BIP342 defines it as this composition,
+    batch-verifiable where the CHECKMULTISIGs it replaces are not.
+    """
     stack[-2], stack[-3] = stack[-3], stack[-2]
     return ["OP_CHECKSIG", "OP_ADD"]
 
@@ -75,6 +89,13 @@ def verify_key_path(
     annex: bytes,
     precomputed: PrecomputedTxData | None = None,
 ) -> None:
+    """Verify a taproot key-path spend, per BIP341.
+
+    The single witness element is a BIP340 signature by the output key
+    itself over the taproot sig_hash with no script committed to; a
+    signature that does not verify is the only refusal, get_hashtype's
+    aside.
+    """
     sighash_type = get_hashtype(stack[0])
     signature = stack[0][:64]
     pub_key = type_and_payload(script_pub_key)[1]
@@ -98,6 +119,19 @@ def op_checksig(
     flags: ScriptFlag,
     precomputed: PrecomputedTxData | None = None,
 ) -> int:
+    """Verify one BIP340 signature in a script path: BIP342's OP_CHECKSIG.
+
+    Pops public key and signature, pushes the result, and returns what
+    is left of the sigops budget, every non-empty signature costing 50
+    whether or not it verifies. The refusals are BIP342's: an empty
+    public key, an exhausted budget, and a non-empty signature that
+    does not verify -- where the legacy op code pushes False, tapscript
+    fails the script, its NULLFAIL being consensus. A key neither empty
+    nor 32 bytes verifies nothing and succeeds, which is the upgrade
+    room, refused only under DISCOURAGE_UPGRADABLE_PUBKEYTYPE. The
+    message hash commits to the tapleaf and to the last executed
+    OP_CODESEPARATOR through the BIP341 extension.
+    """
     pub_key = stack.pop()
     signature = stack.pop()
     if len(pub_key) == 0:
@@ -203,6 +237,16 @@ def verify_script_path_vc0(  # noqa: C901
     flags: ScriptFlag,
     precomputed: PrecomputedTxData | None = None,
 ) -> None:
+    """Execute a leaf-version-0xc0 tapscript, per BIP342.
+
+    The loop is the legacy engine's with BIP342's differences: no op
+    code count and no script size limit, a sigops budget spent by
+    signature instead, an OP_SUCCESSx that ends validation with
+    success before anything runs, MINIMALIF as consensus, and the
+    CHECKMULTISIGs gone in favour of OP_CHECKSIGADD. Refusals leave as
+    ScriptError, as they do from the legacy loop, and the script must
+    end with exactly one true element on the stack.
+    """
     if any(len(x) > MAX_SCRIPT_ELEMENT_SIZE for x in stack):
         err_msg = f"witness stack element longer than {MAX_SCRIPT_ELEMENT_SIZE} bytes"
         raise BTClibValueError(err_msg)

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -300,6 +300,12 @@ ERROR_COMMAND = "[error]"
 
 
 def op_int(i: int) -> str:
+    """Name the one-byte op code that pushes the number i, -1 to 16.
+
+    OP_0..OP_16 and OP_1NEGATE are the only numbers with an op code of
+    their own; any other integer is refused, a caller wanting it pushed
+    passing the integer itself to serialize.
+    """
     # Short 1-byte op_codes exist
     # to push numbers in [-1, 16]
     if i == -1:
@@ -367,6 +373,15 @@ def _pushdata(i: int, length: int, out: list[bytes]) -> None:
 
 
 def serialize(script: Sequence[Command]) -> bytes:
+    """Serialize a script from its commands.
+
+    An integer is encoded as the number it pushes -- with a warning
+    where a one-byte op code means the same -- a string is an op code
+    name, an UNKNOWN_OP_CODE_n byte, or hex data, and bytes are data;
+    data is always the minimal push, per BIP62. What parse returns
+    round-trips, ERROR_COMMAND excepted, that marker being a place in
+    the bytes rather than an instruction.
+    """
     r: list[bytes] = []
     for command in script:
         if isinstance(command, int):
@@ -580,6 +595,14 @@ def op_code_spans(script: bytes) -> Iterator[tuple[int, int, int]]:
 # condition
 @dataclass(frozen=True)
 class Script:
+    """A Bitcoin script, held as its bytes.
+
+    The bytes are the script -- assert_valid asks nothing else of them
+    -- and `asm` is their parse, computed on first read and cached.
+    Immutable, so a Script can be shared and concatenated (`+`) without
+    aliasing surprises; ScriptPubKey extends it with a network.
+    """
+
     # Bitcoin script expressed as ScriptList
     # e.g. [OP_HASH160, script_h160, OP_EQUAL]
     # or Octets of its byte-encoded representation

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -616,8 +616,8 @@ class Script:
         57.9 us for a 16.5 kB script, for a value that cannot change.
         Cached, a second read is 0.02 us.
 
-        Nothing warms the cache: construction no longer parses at all,
-        and __init__ filling it in would be the wrong trade anyway --
+        Nothing warms the cache: construction does not parse, and
+        __init__ filling the cache in would be the wrong trade --
         measured on that 16.5 kB script, an instance holding the parse
         costs 55.4 kB against 0.2 kB without it, 277 times the script's
         own bytes, and nothing inside the library reads .asm.
@@ -639,21 +639,21 @@ class Script:
     def assert_valid(self) -> None:
         """Assert that the script is bytes, which is all a script is.
 
-        There is no other question to ask, and asking one was the bug:
-        Bitcoin Core has no validity notion for a script either -- a
-        CScript is a vector of bytes, and the only script-level predicate
-        it offers is IsUnspendable(), for pruning the UTXO set. Whether a
-        script can be *executed* is the interpreter's answer, given by
-        executing it, and the limits it enforces depend on the sigversion
-        the script is spent under: in tapscript an OP_SUCCESSx makes a
-        script valid however malformed the rest of it is, so no predicate
-        on the bytes alone could answer for both.
+        There is no other question to ask: Bitcoin Core has no validity
+        notion for a script either -- a CScript is a vector of bytes,
+        and the only script-level predicate it offers is
+        IsUnspendable(), for pruning the UTXO set. Whether a script can
+        be *executed* is the interpreter's answer, given by executing
+        it, and the limits it enforces depend on the sigversion the
+        script is spent under: in tapscript an OP_SUCCESSx makes a
+        script valid however malformed the rest of it is, so no
+        predicate on the bytes alone could answer for both.
 
-        This used to parse, and refuse what the parse refused: a push
-        over 520 bytes, a truncated push, an op code no table names.
-        Those are five transactions in blocks 251718 to 299571 that
-        Tx.parse could not read (issue #123), and a `.asm` that raised
-        for the scripts an explorer prints.
+        Not a parse, refusing what the parse refuses -- a push over 520
+        bytes, a truncated push, an op code no table names: five
+        transactions in blocks 251718 to 299571 carry such scripts, so
+        that predicate leaves Tx.parse unable to read them and `.asm`
+        raising for the scripts an explorer prints (issue #123).
 
         The coercion is the check, as it is in Witness.assert_valid: a
         Script built through __init__ has been through bytes_from_octets

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -7,7 +7,17 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""ScriptPubKey class and functions."""
+"""ScriptPubKey and the classification of the standard script shapes.
+
+Every standard shape has an assert_* function, raising
+BTClibValueError on bytes that are not it, and an is_* companion
+answering the same test as a bool: False means "not this shape", while
+a caller error -- None, a list, anything no bytes can be read from --
+raises through both, a TypeError not being an answer to "is this a
+p2sh". The assert functions test shape, not spendability: any 20 bytes
+are a pub_key hash to assert_p2pkh, and only assert_p2pk parses its
+key, the script being the one place the key itself sits.
+"""
 
 from __future__ import annotations
 
@@ -101,6 +111,11 @@ def _is_funct(assert_funct: Callable[[Octets], None], script_pub_key: Octets) ->
 
 
 def assert_p2pk(script_pub_key: Octets) -> None:
+    """Refuse bytes that are not p2pk: a pushed pub_key, OP_CHECKSIG.
+
+    The key must parse as a curve point, so a well-shaped script
+    pushing 33 or 65 bytes that are not one is refused too.
+    """
     script_pub_key = bytes_from_octets(script_pub_key, (35, 67))
     # p2pk: pub_key OP_CHECKSIG
     # 0x41{65-byte pub_key}AC
@@ -126,10 +141,16 @@ def assert_p2pk(script_pub_key: Octets) -> None:
 
 
 def is_p2pk(script_pub_key: Octets) -> bool:
+    """Answer whether the bytes are a p2pk script_pub_key."""
     return _is_funct(assert_p2pk, script_pub_key)
 
 
 def assert_p2pkh(script_pub_key: Octets) -> None:
+    """Refuse bytes that are not p2pkh.
+
+    The shape is OP_DUP OP_HASH160, a 20-byte push, OP_EQUALVERIFY
+    OP_CHECKSIG; the hash is any 20 bytes.
+    """
     script_pub_key = bytes_from_octets(script_pub_key, 25)
     # p2pkh [OP_DUP, OP_HASH160, pub_key hash, OP_EQUALVERIFY, OP_CHECKSIG]
     # 0x76A914{20-byte pub_key_hash}88AC
@@ -144,10 +165,16 @@ def assert_p2pkh(script_pub_key: Octets) -> None:
 
 
 def is_p2pkh(script_pub_key: Octets) -> bool:
+    """Answer whether the bytes are a p2pkh script_pub_key."""
     return _is_funct(assert_p2pkh, script_pub_key)
 
 
 def assert_p2sh(script_pub_key: Octets) -> None:
+    """Refuse bytes that are not p2sh, per BIP16.
+
+    The shape is OP_HASH160, a 20-byte push, OP_EQUAL; the hash is any
+    20 bytes.
+    """
     script_pub_key = bytes_from_octets(script_pub_key, 23)
     # p2sh [OP_HASH160, redeem_script hash, OP_EQUAL]
     # 0xA914{20-byte redeem_script hash}87
@@ -162,14 +189,22 @@ def assert_p2sh(script_pub_key: Octets) -> None:
 
 
 def is_p2sh(script_pub_key: Octets) -> bool:
+    """Answer whether the bytes are a p2sh script_pub_key."""
     return _is_funct(assert_p2sh, script_pub_key)
 
 
 def assert_p2ms(script_pub_key: Octets) -> None:
+    """Refuse bytes that are not p2ms: m, the pushed keys, n, OP_CHECKMULTISIG.
+
+    The bounds are checked -- 0 < m <= n < 17 -- and each key is read
+    as a push of the declared length; the keys are not checked to be
+    curve points.
+    """
     addresses(script_pub_key)
 
 
 def is_p2ms(script_pub_key: Octets) -> bool:
+    """Answer whether the bytes are a p2ms script_pub_key."""
     return _is_funct(assert_p2ms, script_pub_key)
 
 
@@ -229,11 +264,17 @@ def assert_nulldata(script_pub_key: Octets) -> None:
 
 
 def is_nulldata(script_pub_key: Octets) -> bool:
+    """Answer whether the bytes are a standard nulldata script_pub_key."""
     return _is_funct(assert_nulldata, script_pub_key)
 
 
 def assert_segwit(script_pub_key: Octets) -> None:
-    # doesn't check if script_pub_key is a valid script
+    """Refuse bytes that are not a witness program, per BIP141.
+
+    The shape every segwit output shares, whatever its version: one
+    version op code -- OP_0 or OP_1..OP_16 -- and one push of 2 to 40
+    bytes. Shape only; the program is not interpreted.
+    """
     script_pub_key = bytes_from_octets(script_pub_key)
     # an empty script has no version byte to read: script_pub_key[0] would
     # answer it with an IndexError, from outside the exception contract
@@ -252,10 +293,12 @@ def assert_segwit(script_pub_key: Octets) -> None:
 
 
 def is_segwit(script_pub_key: Octets) -> bool:
+    """Answer whether the bytes are a witness program of any version."""
     return _is_funct(assert_segwit, script_pub_key)
 
 
 def assert_p2wpkh(script_pub_key: Octets) -> None:
+    """Refuse bytes that are not p2wpkh: OP_0, a 20-byte push, per BIP141."""
     script_pub_key = bytes_from_octets(script_pub_key, 22)
     # p2wpkh [OP_0, pub_key hash]
     # 0x0014{20-byte pub_key hash}
@@ -270,10 +313,12 @@ def assert_p2wpkh(script_pub_key: Octets) -> None:
 
 
 def is_p2wpkh(script_pub_key: Octets) -> bool:
+    """Answer whether the bytes are a p2wpkh script_pub_key."""
     return _is_funct(assert_p2wpkh, script_pub_key)
 
 
 def assert_p2wsh(script_pub_key: Octets) -> None:
+    """Refuse bytes that are not p2wsh: OP_0, a 32-byte push, per BIP141."""
     script_pub_key = bytes_from_octets(script_pub_key, 34)
     # p2wsh [OP_0, redeem_script hash]
     # 0x0020{32-byte redeem_script hash}
@@ -288,10 +333,17 @@ def assert_p2wsh(script_pub_key: Octets) -> None:
 
 
 def is_p2wsh(script_pub_key: Octets) -> bool:
+    """Answer whether the bytes are a p2wsh script_pub_key."""
     return _is_funct(assert_p2wsh, script_pub_key)
 
 
 def assert_p2tr(script_pub_key: Octets) -> None:
+    """Refuse bytes that are not p2tr: OP_1, a 32-byte push, per BIP341.
+
+    The 32 bytes are not checked to be a valid x-only key: the shape is
+    the classification, and an output key off the curve is found by the
+    spender, not by the classifier.
+    """
     script_pub_key = bytes_from_octets(script_pub_key, 34)
     # p2wtr [OP_1, redeem_script hash]
     # 0x0120{32-byte redeem_script hash}
@@ -306,6 +358,7 @@ def assert_p2tr(script_pub_key: Octets) -> None:
 
 
 def is_p2tr(script_pub_key: Octets) -> bool:
+    """Answer whether the bytes are a p2tr script_pub_key."""
     return _is_funct(assert_p2tr, script_pub_key)
 
 
@@ -413,10 +466,21 @@ def type_and_payload(script_pub_key: Octets) -> tuple[ScriptType, bytes]:
 # object.__setattr__, as Network's and the three Sig classes' do
 @dataclass(init=False, eq=False, frozen=True)
 class ScriptPubKey(Script):
+    """A Script with the network its addresses render on.
+
+    The script bytes and their validation are Script's; the network
+    enters `address`, `addresses` and the equality test, two
+    ScriptPubKey being equal when their scripts match and their
+    networks are of one type -- mainnet against the rest -- rather
+    than of one name. The classmethods build the standard shapes, one
+    per type the classifier names.
+    """
+
     network: str
 
     @property
     def type(self) -> ScriptType:
+        """Return the script type, as type_and_payload names it."""
         return type_and_payload(self.script)[0]
 
     @property
@@ -484,6 +548,7 @@ class ScriptPubKey(Script):
         super().__init__(script, check_validity=check_validity)
 
     def assert_valid(self) -> None:
+        """Run Script's checks, then refuse a network name not in NETWORKS."""
         super().assert_valid()
         if self.network not in NETWORKS:
             raise BTClibValueError(f"unknown network: {self.network}")

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -66,6 +66,11 @@ SIG_HASH_TYPES = frozenset(
 
 
 def assert_valid_hash_type(hash_type: int) -> None:
+    """Refuse a hash type outside SIG_HASH_TYPES.
+
+    The set is the seven combinations the BIPs define; ANYONECANPAY
+    with DEFAULT is not among them, BIP341 leaving 0x80 undefined.
+    """
     if hash_type not in SIG_HASH_TYPES:
         raise BTClibValueError(f"invalid sig_hash type: {hex(hash_type)}")
 
@@ -138,6 +143,15 @@ def _without_op_codeseparators(script_code: bytes) -> bytes:
 
 
 def taproot_annex_and_ext(tx: Tx, vin_i: int) -> tuple[bytes, bytes]:
+    """Read (annex, sig_hash extension) off one input's witness stack.
+
+    What `taproot` needs beyond the transaction: the annex, per
+    BIP341's "last element whose first byte is 0x50", and -- for a
+    stack that is a script path -- BIP342's message extension, the
+    tapleaf hash with key version 0 and no OP_CODESEPARATOR executed.
+    A signer past a separator computes its own extension; the caller's
+    transaction is never rewritten.
+    """
     # a local name, never assigned back: computing a hash must not rewrite
     # the caller's Tx, and the annex is dropped by rebinding it below
     stack = tx.vin[vin_i].script_witness.stack
@@ -228,6 +242,16 @@ def _zero_other_sequences(new_tx: Tx, vin_i: int) -> None:
 
 
 def legacy(script_code: Octets, tx: Tx, vin_i: int, hash_type: int) -> bytes:
+    """Return the pre-segwit hash one input's signature commits to.
+
+    Satoshi's SignatureHash: the transaction is copied, every other
+    script_sig blanked, the signed input's replaced by the script code
+    with its OP_CODESEPARATORs elided, and outputs and sequences
+    dropped as NONE, SINGLE and ANYONECANPAY ask; hash256 of that
+    serialization and the four hash-type bytes is the answer. The
+    SINGLE bug is kept, being consensus: an input with no matching
+    output signs the constant 1, not an error.
+    """
     # the legacy preimage commits to the script code with its
     # OP_CODESEPARATORs elided, and Core does that here rather than to the
     # script code itself: SerializeScriptCode is part of the serializer,
@@ -376,6 +400,14 @@ def segwit_v0(
     amount: int,
     precomputed: PrecomputedTxData | None = None,
 ) -> bytes:
+    """Return the BIP143 hash one segwit v0 input's signature commits to.
+
+    The preimage commits to the amount being spent -- the point of
+    BIP143 -- and to the script code whole, OP_CODESEPARATORs included.
+    `precomputed`, when given, must describe this very transaction; a
+    single call leaves it None and hashes only what its hash type
+    commits to.
+    """
     script_code = bytes_from_octets(script_code)
 
     # precomputed, when given, must describe this very tx: it is the
@@ -442,6 +474,15 @@ def taproot(
     message_extension: bytes,
     precomputed: PrecomputedTxData | None = None,
 ) -> bytes:
+    """Return the BIP341 hash one taproot input's signature commits to.
+
+    BIP341's SigMsg under the TapSighash tag: the whole-transaction
+    hashes enter as their single-sha256 forms, the spent amounts and
+    script_pub_keys are always committed to, and `ext_flag` with
+    `message_extension` carry BIP342's tapleaf commitment for a script
+    path -- empty for the key path. SIGHASH_SINGLE with no matching
+    output is an error here, per BIP341, where legacy keeps the bug.
+    """
     if hashtype not in SIG_HASH_TYPES:
         raise BTClibValueError(f"Unknown hash type: {hashtype}")
     if hashtype & 0x03 == SINGLE and input_index >= len(transaction.vout):

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -7,11 +7,15 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Transaction hashes to be signed and their hash types.
+"""The hashes a transaction signature commits to, one per era.
 
-- https://medium.com/@bitaps.com/exploring-bitcoin-signature-hash-types-15427766f0a9
-- https://raghavsood.com/blog/2018/06/10/bitcoin-signature-types-sighash
-- https://wiki.bitcoinsv.io/index.php/SIGHASH_flags
+Three preimages for one question -- what does this input's signature
+sign: `legacy` is Satoshi's SignatureHash, `segwit_v0` is BIP143's,
+which adds the amount being spent, and `taproot` is BIP341's SigMsg,
+which commits to every spent output. The hash types -- ALL, NONE,
+SINGLE, each with or without ANYONECANPAY, and taproot's DEFAULT --
+choose how much of the transaction each preimage covers, and
+`from_tx` dispatches an input to the preimage its script demands.
 """
 
 from __future__ import annotations

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -42,6 +42,13 @@ from btclib.utils import bytes_from_octets, bytesio_from_binarydata
 
 
 def serialize(script: ScriptList) -> bytes:
+    """Serialize a tapscript from its commands.
+
+    The tapscript twin of script.serialize, differing where BIP342
+    differs: the OP_SUCCESSx names exist here, and one must be followed
+    by exactly one bytes command, appended raw -- what follows an
+    OP_SUCCESS need not be a script, so it round-trips unparsed.
+    """
     r: list[bytes] = []
     script = script[::-1]
     while script:
@@ -86,6 +93,16 @@ def _read_push_data(s: BytesIO, i: int) -> bytes:
 
 
 def parse(stream: BinaryData, exit_on_op_success: bool = False) -> ScriptList:
+    """Parse a tapscript into its commands, per BIP342.
+
+    An unknown op code is refused, data pushes come back as hex
+    strings, and an OP_SUCCESSx ends the parse: what follows one is
+    returned as raw bytes, BIP342 not requiring it to be a script --
+    or, with `exit_on_op_success`, the whole answer is the single
+    marker ["OP_SUCCESS"], which is Core's pre-scan. An element over
+    520 bytes is refused only by a parse that meets no OP_SUCCESSx,
+    one anywhere making the script valid.
+    """
     s = bytesio_from_binarydata(stream)
     r: ScriptList = []  # initialize the result list
     invalid_element_size = False
@@ -134,6 +151,12 @@ def leaf_hash(leaf_version: int, script: bytes) -> bytes:
 
 
 def tree_helper(script_tree: TaprootScriptTree) -> tuple[TaprootLeafPaths, bytes]:
+    """Walk a script tree: (every leaf with its merkle path, root hash).
+
+    BIP341's taproot_tree_helper: the leaves come back in tree order,
+    each with the control-block path that proves it, and the root is
+    what the output key commits to.
+    """
     if len(script_tree) == 1:
         return _tree_helper(script_tree)
     # a branch: both elements are subtrees, and the alias says only that
@@ -173,6 +196,14 @@ def output_pubkey(
     script_tree: TaprootScriptTree | None = None,
     ec: Curve = secp256k1,
 ) -> tuple[bytes, int]:
+    """Return a taproot output key and its parity, per BIP341.
+
+    The x-only internal key is tweaked by the script tree's root hash,
+    an empty tree contributing empty bytes -- key path only -- and a
+    missing internal key replaced by BIP341's unspendable point, script
+    path only. The parity bit is the tweaked point's, needed by the
+    control block and never serialized in the output.
+    """
     if not internal_pubkey and not script_tree:
         raise BTClibValueError("missing data")
     if internal_pubkey:
@@ -206,6 +237,13 @@ def output_prvkey(
     script_tree: TaprootScriptTree | None = None,
     ec: Curve = secp256k1,
 ) -> int:
+    """Return the private key of the taproot output key, per BIP341.
+
+    The private counterpart of output_pubkey: the internal key is
+    negated where its public point has an odd y, then tweaked by the
+    script tree's root hash, so its public point is the output key
+    exactly.
+    """
     internal_prvkey: int = int_from_prv_key(prv_key)
     if script_tree:
         _, h = tree_helper(script_tree)
@@ -237,6 +275,13 @@ def output_prvkey(
 def input_script_sig(
     internal_pubkey: Key | None, script_tree: TaprootScriptTree, script_num: int
 ) -> tuple[ScriptList, bytes]:
+    """Return (leaf script, control block) for a script-path spend.
+
+    `script_num` picks the leaf in tree order, as tree_helper returns
+    them; the control block is BIP341's -- parity bit plus leaf
+    version, then the x-only internal key, then the merkle path -- and
+    a missing internal key is the unspendable point output_pubkey uses.
+    """
     parity_bit = output_pubkey(internal_pubkey, script_tree)[1]
     if internal_pubkey:
         pub_key_bytes = pub_keyinfo_from_key(internal_pubkey, compressed=True)[0][1:]
@@ -253,6 +298,14 @@ def input_script_sig(
 def check_output_pubkey(
     q: Octets, script: Octets, control: Octets, ec: Curve = secp256k1
 ) -> bool:
+    """Answer whether the control block proves the script against the key.
+
+    BIP341's control-block verification: the leaf hash is folded up
+    the merkle path in the control block, and the internal key tweaked
+    by the result must equal the output key q, parity included. A
+    malformed control block or an internal key that is not a point is
+    refused rather than answered False, either being no proof at all.
+    """
     q = bytes_from_octets(q)
     script = bytes_from_octets(script)
     control = bytes_from_octets(control)
@@ -300,5 +353,11 @@ def check_output_pubkey(
 
 
 def assert_valid_control_block(control_block: bytes) -> None:
+    """Refuse a control block whose size no leaf depth can produce.
+
+    Size only, and only its residue: one leading byte plus a multiple
+    of 32, which BIP341's 33 + 32m sizes all satisfy. Proving the
+    block against an output key is check_output_pubkey's.
+    """
     if (len(control_block) - 1) % 32 != 0:
         raise BTClibValueError("invalid control block size")

--- a/btclib/script/witness.py
+++ b/btclib/script/witness.py
@@ -7,7 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Witness (tuple[bytes, ...]) class."""
+"""The Witness dataclass; the class docstring has the contract."""
 
 from __future__ import annotations
 

--- a/btclib/script/witness.py
+++ b/btclib/script/witness.py
@@ -29,6 +29,14 @@ from btclib.utils import bytes_from_octets, bytesio_from_binarydata
 # and then read, so the interpreter's popping is done on a list of its own
 @dataclass(frozen=True)
 class Witness:
+    """The witness stack of one transaction input, per BIP141.
+
+    A tuple of byte strings, bottom of the stack first, exactly as
+    serialized after the input count; a non-segwit input has an empty
+    one. Immutable throughout, so a Witness can be shared and hashed;
+    the script interpreter pops a list copy of its own.
+    """
+
     stack: tuple[bytes, ...]
 
     def __init__(
@@ -48,10 +56,21 @@ class Witness:
         return len(self.stack)
 
     def assert_valid(self) -> None:
+        """Refuse a stack element that does not read as bytes.
+
+        Any elements are a valid witness -- what they must mean is the
+        spending script's business -- so readability is the whole
+        check.
+        """
         for stack_element in self.stack:
             bytes(stack_element)
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, list[str]]:
+        """Return the witness as a dict of hex strings, for json.
+
+        from_dict reads the same shape back, and the round trip is
+        exact, hex being a spelling of the bytes and nothing less.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -64,6 +83,7 @@ class Witness:
         *,
         check_validity: bool = True,
     ) -> Witness:
+        """Build a Witness from the dict shape to_dict writes."""
         return cls(dict_["stack"], check_validity=check_validity)
 
     def serialize(self, *, check_validity: bool = True) -> bytes:

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -285,6 +285,13 @@ def _prv_keyinfo_from_xprvwif(
 def prv_keyinfo_from_prv_key(
     prv_key: PrvKey, network: str | None = None, compressed: bool | None = None
 ) -> PrvkeyInfo:
+    """Return (int key, network, compressed) from any private key spelling.
+
+    A WIF or an xprv carries its own network and compression, and a
+    contradicting argument is refused rather than overridden; an int
+    or octets carry neither, so the arguments -- mainnet, compressed
+    -- fill in.
+    """
     compr = True if compressed is None else compressed
     net = "mainnet" if network is None else network
     ec = NETWORKS[net].curve

--- a/btclib/tx/out_point.py
+++ b/btclib/tx/out_point.py
@@ -29,6 +29,15 @@ from btclib.utils import bytes_from_octets, bytesio_from_binarydata
 # __init__ already went through object.__setattr__, in wait for this
 @dataclass(frozen=True)
 class OutPoint:
+    """The output a transaction input spends: (tx_id, vout).
+
+    tx_id is held in the byte order hex explorers print, reversed on
+    the wire by serialize and back by parse. Frozen and hashable, so
+    an OutPoint can key the dict a utxo set is; the default instance
+    is the coinbase marker, all-zero tx_id and 0xFFFFFFFF vout, and
+    assert_valid refuses a half-coinbase mix of the two.
+    """
+
     tx_id: bytes
     vout: int
 
@@ -56,9 +65,16 @@ class OutPoint:
             self.assert_valid()
 
     def is_coinbase(self) -> bool:
+        """Answer whether this is the coinbase marker, spending nothing."""
         return self.tx_id == b"\x00" * 32 and self.vout == 0xFFFFFFFF
 
     def assert_valid(self) -> None:
+        """Refuse a tx_id not of 32 bytes, a vout no 4 bytes hold, a mix.
+
+        The mix is an all-zero tx_id with a real vout or the reverse:
+        the coinbase marker is both fields at their sentinel or
+        neither.
+        """
         if len(self.tx_id) != 32:
             err_msg = f"invalid OutPoint tx_id: {len(self.tx_id)}"
             err_msg += " instead of 32 bytes"
@@ -71,6 +87,11 @@ class OutPoint:
             raise BTClibValueError("invalid OutPoint")
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, str | int]:
+        """Return {"txid", "vout"}, the keys Bitcoin Core's RPC uses.
+
+        The txid is hex in display order; from_dict reads the same
+        shape back and the round trip is exact.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -80,6 +101,7 @@ class OutPoint:
     def from_dict(
         cls: type[OutPoint], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> OutPoint:
+        """Build an OutPoint from the dict shape to_dict writes."""
         return cls(dict_["txid"], dict_["vout"], check_validity=check_validity)
 
     def serialize(self, *, check_validity: bool = True) -> bytes:

--- a/btclib/tx/out_point.py
+++ b/btclib/tx/out_point.py
@@ -7,10 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""OutPoint dataclass.
-
-Dataclass encapsulating tx_id and vout.
-"""
+"""The OutPoint dataclass; the class docstring has the contract."""
 
 from __future__ import annotations
 
@@ -23,7 +20,7 @@ from btclib.exceptions import BTClibValueError
 from btclib.utils import bytes_from_octets, bytesio_from_binarydata
 
 
-# frozen, as the FIXME here asked: both fields are immutable, so this one
+# frozen: both fields are immutable, so this one
 # is frozen all the way down, and the generated __hash__ makes an OutPoint
 # usable as the dict key or set member an utxo set wants it to be.
 # __init__ already went through object.__setattr__, in wait for this

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -71,6 +71,17 @@ def _assert_valid_coinbase(vin: Sequence[TxIn], *, is_coinbase: bool) -> None:
 
 @dataclass
 class Tx:
+    """A Bitcoin transaction: version, lock time, inputs, outputs.
+
+    Mutable, being what a builder and a signer edit in place; `id` and
+    `hash` are computed from the current state on every read, so they
+    follow the edits. assert_valid checks what CheckTransaction checks
+    of a lone transaction -- field ranges, the inputs and outputs one
+    by one, the coinbase script size, the MAX_MONEY bound on the
+    output sum; whether it spends what it claims needs the prevouts,
+    which is script.engine.verify_transaction's question.
+    """
+
     # 4 bytes, _signed_ little endian
     version: int
     # 0	Not locked
@@ -126,6 +137,7 @@ class Tx:
 
     @property
     def weight(self) -> int:
+        """Return the BIP141 weight: 3x the stripped size plus the size."""
         no_wit = len(self.serialize(include_witness=False, check_validity=False)) * 3
         wit = len(self.serialize(include_witness=True, check_validity=False))
         return no_wit + wit
@@ -147,13 +159,19 @@ class Tx:
 
     @property
     def vwitness(self) -> list[Witness]:
+        """Return the witnesses, one per input and in input order."""
         return [tx_in.script_witness for tx_in in self.vin]
 
     def is_segwit(self) -> bool:
-        # refer to tx_in, not tx_out
+        """Answer whether any input carries a witness.
+
+        The inputs and not the outputs: paying to a segwit script does
+        not make the paying transaction segwit, spending one does.
+        """
         return any(tx_in.is_segwit() for tx_in in self.vin)
 
     def is_coinbase(self) -> bool:
+        """Answer whether this is a coinbase: one input, spending nothing."""
         return len(self.vin) == 1 and self.vin[0].is_coinbase()
 
     def __init__(
@@ -191,6 +209,12 @@ class Tx:
     def to_dict(
         self, *, check_validity: bool = True
     ) -> dict[str, str | int | list[Any]]:
+        """Return the transaction as a dict of json-friendly values.
+
+        The keys are Bitcoin Core's decoderawtransaction ones; txid,
+        hash, size, vsize and weight are derived for the reader and
+        ignored by from_dict, which recomputes them.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -210,6 +234,7 @@ class Tx:
     def from_dict(
         cls: type[Tx], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> Tx:
+        """Build a Tx from the dict shape to_dict writes."""
         return cls(
             dict_["version"],
             dict_["locktime"],
@@ -219,6 +244,12 @@ class Tx:
         )
 
     def assert_standard(self) -> None:
+        """Refuse what assert_valid refuses, plus a non-standard version.
+
+        Standardness reads the version as the signed int Core relays
+        on, so zero and anything above 0x7FFFFFFF fail here and not in
+        assert_valid, negative-as-signed versions being in blocks.
+        """
         self.assert_valid()
 
         # should be a 4-bytes __signed__ integer
@@ -271,6 +302,13 @@ class Tx:
             raise BTClibValueError(f"invalid total output amount: {total}")
 
     def serialize(self, include_witness: bool, *, check_validity: bool = True) -> bytes:
+        """Return the wire serialization, BIP144's where a witness rides.
+
+        `include_witness` False gives the stripped serialization, what
+        the txid is computed over; True adds the marker and the
+        witnesses only if some input has one, a marker over empty
+        witnesses not being what the wire writes.
+        """
         if check_validity:
             self.assert_valid()
 

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -7,21 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Transaction (Tx) class.
-
-Dataclass encapsulating version, lock_time,
-vin (list[TxIn]), and vout (list[TxOut]).
-
-- https://en.bitcoin.it/wiki/Transaction
-- https://learnmeabitcoin.com/guide/coinbase-transaction
-- https://bitcoin.stackexchange.com/questions/20721/what-is-the-format-of-the-coinbase-transaction
-
-For TxIn.sequence and TX.lock_time see:
-- https://developer.bitcoin.org/devguide/transactions.html
-- https://medium.com/summa-technology/bitcoins-time-locks-27e0c362d7a1
-- https://bitcoin.stackexchange.com/questions/40764/is-my-understanding-of-locktime-correct
-- https://en.bitcoin.it/wiki/Timelock
-"""
+"""The Tx dataclass and join_txs; the class docstring has the contract."""
 
 from __future__ import annotations
 

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -31,6 +31,16 @@ TX_IN_COMPARES_WITNESS = True
 
 @dataclass
 class TxIn:
+    """One input of a transaction.
+
+    The outpoint it spends, the script_sig, the sequence, and the
+    witness -- which serialize omits and parse leaves empty, the wire
+    placing all witnesses after the inputs: Tx.serialize and Tx.parse
+    are what write and read them. Mutable, a transaction being built
+    input by input; TxIn() is the placeholder a builder starts from,
+    its prev_out the coinbase marker.
+    """
+
     prev_out: OutPoint
     script_sig: bytes
     # If all TxIns have final (0xffffffff) sequence numbers
@@ -85,13 +95,25 @@ class TxIn:
             self.assert_valid()
 
     def is_segwit(self) -> bool:
+        """Answer whether the input carries a witness.
+
+        The input alone can only answer for what it holds: whether the
+        spent output demands a witness is written in that output's
+        script_pub_key, which is not here.
+        """
         # self.prev_out has no segwit information
         return bool(self.script_witness.stack)
 
     def is_coinbase(self) -> bool:
+        """Answer whether the input is a coinbase, spending nothing."""
         return self.prev_out.is_coinbase()
 
     def assert_valid(self) -> None:
+        """Refuse an invalid prev_out, sequence, or witness.
+
+        The script_sig is deliberately not judged; the comment below
+        carries the reasoning.
+        """
         self.prev_out.assert_valid()
 
         # script_sig is deliberately not looked at, and the marker asking
@@ -125,6 +147,12 @@ class TxIn:
             self.script_witness.assert_valid()
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, Any]:
+        """Return the input as a dict of json-friendly values.
+
+        The script_sig enters as script_to_dict renders it -- asm and
+        hex -- and from_dict reads the same shape back; validation runs
+        once here, not again in the fields.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -139,6 +167,7 @@ class TxIn:
     def from_dict(
         cls: type[TxIn], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> TxIn:
+        """Build a TxIn from the dict shape to_dict writes."""
         return cls(
             OutPoint.from_dict(dict_["prev_out"], check_validity=False),
             script_from_dict(dict_["scriptSig"]),
@@ -148,6 +177,11 @@ class TxIn:
         )
 
     def serialize(self, *, check_validity: bool = True) -> bytes:
+        """Return the wire serialization: prev_out, script_sig, sequence.
+
+        The witness is not here, the wire putting every input's
+        witness after the outputs: Tx.serialize writes them there.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -160,6 +194,11 @@ class TxIn:
     def parse(
         cls: type[TxIn], data: BinaryData, *, check_validity: bool = True
     ) -> TxIn:
+        """Build a TxIn by parsing its wire serialization.
+
+        The witness comes back empty, sitting elsewhere on the wire;
+        Tx.parse fills it in.
+        """
         stream = bytesio_from_binarydata(data)
         prev_out = OutPoint.parse(stream, check_validity=check_validity)
         script_sig = var_bytes.parse(stream)

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -7,11 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Transaction Input (TxIn) dataclass.
-
-Dataclass encapsulating prev_out, script_sig, sequence, and
-script_witness.
-"""
+"""The TxIn dataclass; the class docstring has the contract."""
 
 from __future__ import annotations
 
@@ -43,17 +39,11 @@ class TxIn:
 
     prev_out: OutPoint
     script_sig: bytes
-    # If all TxIns have final (0xffffffff) sequence numbers
-    # then Tx lock_time is irrelevant.
-    #
-    # Set to 0xFFFFFFFE to enables nLocktime (e.g. to discourage fee sniping)
-    # and disables Replace-By-Fee (RBF).
-    #
-    # RBF txs typically have the sequence of each input set to 0xFFFFFFFD.
-    #
-    # Because sequence locks require that the sequence field be set
-    # lower than 0xFFFFFFFD to be meaningful,
-    # all sequence locked transactions are opting into RBF.
+    # 0xFFFFFFFF (final) on every input makes Tx.lock_time irrelevant;
+    # 0xFFFFFFFE enables the lock time (e.g. against fee sniping) while
+    # opting out of Replace-By-Fee, whose customary opt-in is 0xFFFFFFFD.
+    # BIP68 relative lock times need a sequence below 0xFFFFFFFD, so every
+    # sequence-locked transaction is also opting into RBF.
     sequence: int
     script_witness: Witness = field(compare=TX_IN_COMPARES_WITNESS)
 

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -33,6 +33,14 @@ from btclib.utils import bytes_from_octets, bytesio_from_binarydata
 # raise TypeError, so a frozen TxOut is not a hashable one
 @dataclass(frozen=True)
 class TxOut:
+    """One output of a transaction: an amount and who can spend it.
+
+    The value is in satoshi; the script_pub_key is a ScriptPubKey,
+    built from bytes when the caller passes them. assert_valid judges
+    the amount and not the script, a script_pub_key on chain not
+    having to parse.
+    """
+
     # 8 bytes, unsigned little endian
     value: int  # denominated in satoshi
     script_pub_key: ScriptPubKey
@@ -64,12 +72,20 @@ class TxOut:
             self.assert_valid()
 
     def assert_valid(self) -> None:
+        """Refuse a value that is not a valid satoshi amount."""
         valid_sats_amount(self.value)
         # the amount and not the script: a script_pub_key on chain need
         # not parse, and validating it here would refuse transactions
         # that are in blocks -- bitcoin/bitcoin#320, and issue #123
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, Any]:
+        """Return the output as a dict of json-friendly values.
+
+        The value is a BTC string, not satoshi; type, addresses and
+        network are derived for the reader and ignored by from_dict,
+        which rebuilds them from the script -- network excepted, read
+        back with mainnet as its default.
+        """
         if check_validity:
             self.assert_valid()
 
@@ -95,6 +111,7 @@ class TxOut:
     def from_dict(
         cls: type[TxOut], dict_: Mapping[str, Any], *, check_validity: bool = True
     ) -> TxOut:
+        """Build a TxOut from the dict shape to_dict writes."""
         value = sats_from_btc(dict_["value"])
         script_bin = script_from_dict(dict_["scriptPubKey"])
         network = dict_.get("network", "mainnet")
@@ -103,6 +120,7 @@ class TxOut:
         )
 
     def serialize(self, *, check_validity: bool = True) -> bytes:
+        """Return the wire serialization: the value, then the script."""
         if check_validity:
             self.assert_valid()
 
@@ -117,6 +135,11 @@ class TxOut:
         *,
         check_validity: bool = True,
     ) -> TxOut:
+        """Build a TxOut by parsing its wire serialization.
+
+        The network is mainnet, the wire not carrying one; the script
+        is taken as it comes, scripts on chain not having to parse.
+        """
         stream = bytesio_from_binarydata(data)
         value = int.from_bytes(stream.read(8), byteorder="little", signed=False)
         script = var_bytes.parse(stream)
@@ -130,5 +153,6 @@ class TxOut:
 
     @classmethod
     def from_address(cls: type[TxOut], value: int, address: String) -> TxOut:
+        """Build a TxOut paying the address, network included."""
         script_pub_key = ScriptPubKey.from_address(address)
         return cls(value, script_pub_key)

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -7,11 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Transaction Output (TxOut) dataclass.
-
-Dataclass encapsulating value and script_pub_key (and network to convert
-script_pub_key to and from address).
-"""
+"""The TxOut dataclass; the class docstring has the contract."""
 
 from __future__ import annotations
 
@@ -26,7 +22,7 @@ from btclib.script import ScriptPubKey, script_from_dict, script_to_dict
 from btclib.utils import bytes_from_octets, bytesio_from_binarydata
 
 
-# frozen, as the FIXME here asked. Shallow: `value` is immutable, but
+# frozen, but only shallowly: `value` is immutable, while
 # ScriptPubKey extends the plain dataclass Script, so `script_pub_key.script`
 # can still be rebound through a frozen TxOut. Freezing Script is a change
 # of its own. Its being unhashable also makes the generated TxOut.__hash__

--- a/btclib/var_int.py
+++ b/btclib/var_int.py
@@ -9,19 +9,13 @@
 # or distributed except according to the terms contained in the LICENSE file.
 """Varint encoding and decoding functions.
 
-A var_int (variable integer) is variable-length quantity that uses an
-arbitrary number of binary octets (eight-bit bytes) to represent an
-arbitrarily large integer.
-It is usually a base-128 (7 bits) representation of an unsigned integer
-with the addition of the eighth bit to mark continuation of bytes;
-it is used to save additional space for a resource constrained system.
+Bitcoin's variable-length integer, Core's CompactSize: what the wire
+uses to say how many fields follow or how long the next field is.
+Not the base-128 varint of other protocols -- the encoding is its
+own.
 
-This is the slightly different Bitcoin implementation, used in transaction
-data to indicate the number of upcoming fields or the length of the
-upcoming field.
-
-Up to 0xfc, a var_int is just 1 byte; however, if the integer is greater than
-0xfc, then it is expanded as [1 byte prefix][number]:
+Up to 0xfc, a var_int is 1 byte; a greater integer is expanded as
+[1 byte prefix][number]:
 
 * prefix 0xfd marks the next two bytes as the number;
 * prefix 0xfe marks the next four bytes as the number;

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -7,10 +7,10 @@ does this function take". This page answers the question before it,
 rather than by which module the code lives in.
 
 Every example below is executed by btclib's own test suite, in
-``tests/docs_examples_test.py``. What you see after a ``>>>`` prompt is
-what the library answered, not what somebody expected it to answer, and
-an example that stops being true fails a test rather than sitting here
-misleading you. So type them in: they work.
+``tests/docs_examples_test.py``. What follows a ``>>>`` prompt is what
+the library answered, not what somebody expected it to answer, and an
+example that stops being true fails a test rather than sitting here
+misleading.
 
 .. contents:: On this page
    :local:
@@ -33,13 +33,13 @@ particular btclib does **not**:
   spent, the example supplies it
 - choose coins, estimate a fee, or pick a change amount. A fee is the
   difference between what the inputs are worth and what the outputs are
-  worth, and that arithmetic is yours; btclib will happily build a
-  transaction that pays a thousand-bitcoin fee
+  worth, and that arithmetic is yours: btclib builds a transaction
+  that pays a thousand-bitcoin fee without objection
 - protect your secrets from the machine they are on. Read the
   `limitations section of SECURITY.md <security_link.html>`_ before you
   use it with a key that holds value: private keys live in ordinary,
-  immutable python objects that are never zeroized, and — this is the
-  one most people miss — **not every operation reaches the constant-time
+  immutable python objects that are never zeroized, and — the least
+  obvious limitation — **not every operation reaches the constant-time
   C library**. secp256k1 signing and generator multiplication are
   delegated to the libsecp256k1 bindings; another curve, another hash
   function, a nonce of your own, or a message that is not 32 bytes takes
@@ -78,13 +78,13 @@ Which type to pass
 ------------------
 
 Most of the public API takes "anything convertible" rather than one
-type, which is friendly once you know the rules and baffling until then.
+type, so the rules of the conversion are worth learning first.
 There are four aliases, all in :mod:`btclib.alias`, and one rule matters
 more than the rest.
 
 **A ``str`` is hexadecimal, not text.** Anywhere the signature says
 ``Octets`` — a message to sign, a script, a hash — a ``str`` is parsed
-with ``bytes.fromhex``. This is the single most common first mistake:
+with ``bytes.fromhex``. Passing text where hex is expected fails:
 
 >>> from btclib.ecc import dsa
 >>> dsa.sign("hello world", 1)
@@ -92,7 +92,7 @@ Traceback (most recent call last):
 ValueError: non-hexadecimal number found in fromhex() arg at position 0
 
 Pass ``bytes`` when you mean text, and let the hex spelling be for
-things that really are bytes:
+things that are bytes:
 
 >>> sig = dsa.sign(b"hello world", 1)
 >>> type(sig).__name__

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,9 +1,7 @@
-.. btclib documentation master file.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
+.. btclib documentation master file: the root `toctree`.
 
-Welcome to btclib's documentation
-=================================
+btclib documentation
+====================
 
 .. toctree::
    :maxdepth: 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -478,10 +478,11 @@ select = [
     "W",    # pycodestyle warnings
 ]
 ignore = [
-    # docstrings: only modules and public classes/functions are documented
-    "D101", # undocumented-public-class
-    "D102", # undocumented-public-method
-    "D103", # undocumented-public-function
+    # docstrings: every public module, class, method and function must
+    # carry one -- D100/D104 and the D101/D102/D103 left out of this
+    # list enforce exactly that (issue #290). The two still ignored are
+    # the ones pep257 does not ask for: __init__ is documented by its
+    # class, and a magic method by the data model it implements
     "D105", # undocumented-magic-method
     "D107", # undocumented-public-init
     "D203", # incorrect-blank-line-before-class (conflicts with D211)


### PR DESCRIPTION
Closes #290, in its three parts and in three commits.

## 1. The public interface, documented in full

Every public class, method and function has a docstring — 262 were
missing, measured with `uv run ruff check --select D101,D102,D103
btclib/` before the first commit and zero after it. The issue's four
groups, each documented as it asked:

- the script engine's op codes carry the stack effect, the failure
  modes and the consensus rule or BIP each comes from; the two
  contracts they all share (CScriptNum operands, underflow via
  IndexError re-raised as ScriptError) are stated once, in the module
  docstring
- the trailing-underscore variants (`ssa.assert_as_valid_`,
  `dsa.crack_prv_key_`, `challenge_`, ...) say what the suffix means:
  the input enters already prepared, unvalidated — with `sign_`'s
  existing wording as the model
- the core types say what `to_dict`/`from_dict`, `serialize`/`parse`
  and `assert_valid` each validate, mutate and preserve — including
  what a dict round-trip derives for the reader and ignores on the way
  back
- the `is_p2*`/`assert_p2*` family says which raises and which answers
  a bool, with the family contract (False is "not this shape", a
  caller error still raises) stated once in the module docstring

`amount.py` and `fee.py` drop their `Args:`/`Returns:` sections for
the pep257 prose the rest of the tree uses.

## 2. One voice, and no history in the prose

Docstrings, comments, `docs/source/` and the top-level markdown are
reviewed to one register — neutral, factual, dry. Comments that told
the story of what the code used to be ("this used to parse...", "the
search this used to run...", "as the FIXME here asked") state the same
reasoning in the present tense; module docstrings that restated their
class or leaned on third-party blog links state their own fact and
cite the BIP or the Core function; chatty emphasis in `guide.rst` and
the README is flattened; two `sepcp256k1` typos are gone.

## 3. CONTRIBUTING.md states all of it

A new `#### Documentation and comments` under `### Make Changes`
states the tone, the house style and the no-history rule where a
contributor reads them; CLAUDE.md points at that section rather than
repeating it. As the issue asked, it does not restate the 80-column
rule nor the D-rules, both being enforced by hooks.

## The gate

The last commit moves `D101`, `D102` and `D103` out of
`pyproject.toml`'s ruff `ignore` — the whole tree at once, no
`per-file-ignores` staging being needed — and rewrites the comment
above the list, which described a policy the configuration did not
apply. `D107` (and `D105`) stay ignored, pep257 not asking for either.

Verified locally on every commit: `uv run pre-commit run --all-files`,
`uv run pytest` (16851 passed), and the sphinx `-W` build. The only
red hook is `check-manifest`, tripped by an untracked
`docs/proposals/cli.md` another session left in the shared checkout —
absent from this branch and from CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the public Python API, enforce docstring presence with ruff, and standardize documentation tone and style across code comments and user docs.

Enhancements:
- Improve inline comments and explanations around consensus rules, script execution, sig-hash computation, ECC group operations, and transaction/block validation to aid maintainability.
- Document internal "assert_*" vs "verify" conventions, trailing-underscore variants, and type aliases to clarify caller expectations and input conventions.
- Refine descriptor, BIP21, entropy/mnemonic, fee/amount, fetch, and network helpers with clearer contracts and error semantics.

Build:
- Enable ruff D101/D102/D103 checks by removing them from the ignore list, keeping only magic method and __init__ docstring rules ignored.
- Adjust ruff configuration comments to reflect the new docstring policy enforced across the project.

Documentation:
- Add or expand docstrings for all public classes, functions, and methods across scripting, transactions, keys, PSBT, and other core modules.
- Clarify behavioural contracts in docstrings for script opcodes, Script/ScriptPubKey, Tx/TxIn/TxOut/Block, BIP32, PSBT, hashing, ECC primitives, networking, and helper types.
- Revise module, class, and function prose to a neutral, factual style, removing historical narrative and aligning comments and docs with house style.
- Update CONTRIBUTING.md with explicit guidelines for documentation tone, contracts, reasoning in comments, and no-history rule, and reference this from CLAUDE.md.
- Tidy top-level documentation and README wording, fixing minor typos and aligning descriptions of tests and examples with current behaviour.

Chores:
- Note documentation and style changes, and the new docstring enforcement gate, in CHANGELOG.md under the documentation section.