### PR TITLE
btclib.curves exports CURVES, the catalogue secp256k1 came out of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2942,6 +2942,15 @@ edit.
   of the library rather than the four it named: a package added to btclib
   is a package it checks, and it is what found `btclib.script` outside the
   list.
+- **`btclib.curves` exports `CURVES`**, the catalogue every curve other
+  than secp256k1 is looked up in. `secp256k1` was exported by name and the
+  dictionary it comes from was not, so the package's own docstring named
+  the catalogued curves while a caller could reach exactly one of them
+  without importing `btclib.curves.curve` — which is where the test suite
+  takes `CURVES` from, that being the only place it was available. The
+  four catalogues it is the union of, `SEC2v1`, `SEC2v2`, `NIST` and
+  `Brainpool`, stay unexported: which standard a curve comes from is a
+  question about a curve, not a way of finding one.
 
 ### Types
 

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -22,8 +22,16 @@ The two names are easy to conflate -- everything in ecc is also about
 curves -- so the anchor is worth stating: `from btclib.curves import mult`,
 `from btclib.ecc import dsa`.
 
-What this package exports is the curve API: a Curve, the three scalar
-multiplications, and the SEC point codec. The other mult_* of
+What this package exports is the curve API: a Curve, the catalogue they
+are looked up in, the three scalar multiplications, and the SEC point
+codec. `CURVES` is what makes the catalogue reachable -- `secp256k1` is
+exported by name because nearly every caller wants that one, and every
+other curve is `CURVES["secp256r1"]` -- so exporting the name and not the
+dictionary left the paragraph above naming curves a caller could not get
+at without importing the module the name is defined in. The four
+catalogues it is the union of (SEC2v1, SEC2v2, NIST, Brainpool) stay
+where they are defined: which standard a curve comes from is a question
+about a curve, not a way of finding one. The other mult_* of
 btclib.curves.curve_group and btclib.curves.curve_group_2 -- mult_aff, mult_jac,
 mult_base_3, mult_mont_ladder, the two mult_recursive_*, the two
 mult_fixed_window*, mult_regular_window, mult_sliding_window, mult_w_NAF and
@@ -45,7 +53,14 @@ is, answered for secp256k1 out of the bindings' own serialization, without
 materializing the point (issue #127).
 """
 
-from btclib.curves.curve import Curve, double_mult, mult, multi_mult, secp256k1
+from btclib.curves.curve import (
+    CURVES,
+    Curve,
+    double_mult,
+    mult,
+    multi_mult,
+    secp256k1,
+)
 from btclib.curves.curve_group import CurveGroup
 from btclib.curves.curve_group_f import find_all_points, find_subgroup_points
 from btclib.curves.sec_point import (
@@ -55,6 +70,7 @@ from btclib.curves.sec_point import (
 )
 
 __all__ = [
+    "CURVES",
     "Curve",
     "CurveGroup",
     "bytes_from_point",

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -40,6 +40,7 @@ def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
     on the strength of its name -- gives up.
     """
     assert sorted(btclib.curves.__all__) == [
+        "CURVES",
         "Curve",
         "CurveGroup",
         "bytes_from_point",


### PR DESCRIPTION
## What this changes

`btclib.curves` exported `secp256k1` and not `CURVES`, the dictionary it
is looked up in. The package docstring already named "the catalogued
curves (secp256k1 among 26 others)", so it described a catalogue a caller
could reach exactly one entry of without importing
`btclib.curves.curve` — which is where the test suite takes `CURVES`
from, that being the only place it was available.

- `CURVES` is added to the import and to `__all__`
- the docstring paragraph on what the package exports says why, and says
  why `SEC2v1`, `SEC2v2`, `NIST` and `Brainpool` stay unexported: which
  standard a curve comes from is a question about a curve, not a way of
  finding one
- `tests/all_test.py` pins the export list by name, so the addition is
  one line there — that file exists because `__all__` had drifted once
  before, and it is written against names rather than counts

Purely additive: nothing that imported anything before imports less now.
Gates run locally: full suite (16858 passed), `pre-commit` on the changed
files, and the `-W` sphinx build.

## Renaming proposed for this module: none, and one not to make

This is the one module of the audit with nothing to rename, and it is
worth recording why the obvious candidate is not one:
`point_from_octets` beside `bytes_from_point` reads asymmetric and is
exact — `Octets` is the union the function accepts (hex `str` or
`bytes`), `bytes` is what the other hands back. Renaming either would
make the pair look symmetric and say less.

`bytes_from_prv_key_int` keeps its long name for the same reason: it is
the one of the three that takes a scalar rather than a point, and the
name is the whole of the distinction.

## How the finding was made

Every package's `__all__` compared against the public names its
submodules define:

```shell
./.venv/bin/python -c '
import btclib.curves as m, btclib.curves.curve as c
print(set(n for n in dir(c) if not n.startswith("_")) - set(m.__all__))'
```

Part of a per-module audit of `__all__`; the other modules get their own
pull requests, and the reasoning for all of them is collected in the
command-line proposal draft that prompted the audit.

## Summary by Sourcery

Export the CURVES catalogue from btclib.curves and document its availability while keeping underlying standard-specific catalogues unexported.

New Features:
- Expose the CURVES dictionary from btclib.curves alongside existing curve API exports.

Documentation:
- Document the export of the CURVES catalogue and the rationale for not exporting the underlying standard-specific catalogues.

Tests:
- Extend the export list pinning test to cover the new CURVES symbol in btclib.curves.__all__.