### PR TITLE
btclib.script exports both halves of every pair it exported one of

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2763,6 +2763,17 @@ edit.
   seeing which is the signer's, so the recoverable spelling publishes
   nothing the plain one keeps. `docs/source/guide.rst` has the round trip
   as a worked example, next to `sign` and `verify` (issue #285)
+- **`btclib.script` exports both halves of every pair it exports one of**:
+  `addresses` beside the `address` that was there, and `is_segwit` with
+  `assert_segwit`, which were the one missing pair of the nine
+  `script_pub_key` defines — the file already carries a comment recording
+  that this audit was run once, for `is_p2pkh`, and it caught eight of the
+  nine. `tests/all_test.py` now asserts the pairing itself rather than a
+  list of names, so a script type added to `script_pub_key` has to bring
+  both halves, and `test_every_exported_name_exists` walks every package
+  of the library rather than the four it named: a package added to btclib
+  is a package it checks, and it is what found `btclib.script` outside the
+  list.
 
 ### Types
 

--- a/btclib/script/__init__.py
+++ b/btclib/script/__init__.py
@@ -21,6 +21,7 @@ from btclib.script.script import (
 from btclib.script.script_pub_key import (
     ScriptPubKey,
     address,
+    addresses,
     assert_nulldata,
     assert_p2ms,
     assert_p2pk,
@@ -29,6 +30,7 @@ from btclib.script.script_pub_key import (
     assert_p2tr,
     assert_p2wpkh,
     assert_p2wsh,
+    assert_segwit,
     is_nulldata,
     is_p2ms,
     is_p2pk,
@@ -39,6 +41,7 @@ from btclib.script.script_pub_key import (
     is_p2tr,
     is_p2wpkh,
     is_p2wsh,
+    is_segwit,
     type_and_payload,
 )
 from btclib.script.sig_ops import sig_op_count
@@ -60,6 +63,7 @@ __all__ = [
     "TaprootScriptTree",
     "Witness",
     "address",
+    "addresses",
     "assert_nulldata",
     "assert_p2ms",
     "assert_p2pk",
@@ -68,6 +72,7 @@ __all__ = [
     "assert_p2tr",
     "assert_p2wpkh",
     "assert_p2wsh",
+    "assert_segwit",
     "check_output_pubkey",
     "input_script_sig",
     "is_nulldata",
@@ -78,6 +83,7 @@ __all__ = [
     "is_p2tr",
     "is_p2wpkh",
     "is_p2wsh",
+    "is_segwit",
     "op_int",
     "output_prvkey",
     "output_pubkey",

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -20,10 +20,16 @@ deliberate addition is one line here and an accidental one is a failure.
 
 from __future__ import annotations
 
+from importlib import import_module
+from pkgutil import iter_modules
+
+import btclib
 import btclib.curves
 import btclib.ecc
 import btclib.mnemonic
+import btclib.script
 from btclib.curves import curve_group, curve_group_2
+from btclib.script import script_pub_key
 
 
 def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
@@ -108,6 +114,25 @@ def test_ecc_exports_the_signature_schemes() -> None:
     assert btclib.ecc.bms.dsa is btclib.ecc.dsa  # type: ignore[attr-defined]
 
 
+def test_script_exports_both_halves_of_every_pair() -> None:
+    """`is_x` beside `assert_x`, and `address` beside `addresses`.
+
+    Written as the pairing rather than as the list of names, because the
+    pairing is the invariant: a script type added to `script_pub_key`
+    brings both halves, and exporting one of the two is what this catches.
+    """
+    for name in ("address", "addresses"):
+        assert name in btclib.script.__all__
+
+    types = sorted(n[3:] for n in vars(script_pub_key) if n.startswith("is_"))
+    assert types  # a typo in the prefix would otherwise pass silently
+    for script_type in types:
+        for prefix in ("is_", "assert_"):
+            name = f"{prefix}{script_type}"
+            assert hasattr(script_pub_key, name), f"{name} went missing"
+            assert name in btclib.script.__all__, f"{name} is not exported"
+
+
 def test_mnemonic_exports_its_three_schemes() -> None:
     for name in ("bip39", "electrum", "slip39"):
         assert name in btclib.mnemonic.__all__
@@ -116,7 +141,25 @@ def test_mnemonic_exports_its_three_schemes() -> None:
 
 
 def test_every_exported_name_exists() -> None:
-    """An `__all__` entry that names nothing is a broken `import *`."""
-    for package in (btclib.curves, btclib.ecc, btclib.mnemonic):
-        for name in package.__all__:
+    """An `__all__` entry that names nothing is a broken `import *`.
+
+    Every package of the library, found rather than listed: a package added
+    to btclib is a package this checks, where a list here would be one more
+    thing to keep true -- and it is what caught `btclib.script` being
+    outside the four names this used to hold. Nested packages are not
+    walked, `btclib.script.engine` being the only one; asking `pkgutil` to
+    walk them would import every module of the library, which
+    tests/imports_test.py already does deliberately and one module at a
+    time.
+    """
+    packages = [
+        import_module(f"btclib.{name}")
+        for _, name, is_package in iter_modules(btclib.__path__)
+        if is_package
+    ]
+    assert packages, "no package found under btclib"
+    for package in packages:
+        names = getattr(package, "__all__", None)
+        assert names, f"{package.__name__} declares no __all__"
+        for name in names:
             assert hasattr(package, name), f"{package.__name__}.{name} is not there"


### PR DESCRIPTION
## What this changes

`btclib.script` exported `address` and not `addresses`, and eight of the
nine `is_x`/`assert_x` pairs `script_pub_key` defines — `is_segwit` and
`assert_segwit` were the missing one. `script/__init__.py` already carries
a comment recording that this audit was run once ("is_p2pkh was the one
missing, where assert_p2pkh was not: the other seven assert/is pairs are
both here"), so the intent was completeness and the pass was
name-by-name.

- `addresses`, `is_segwit` and `assert_segwit` are added to the import and
  to `__all__`
- `tests/all_test.py` asserts the **pairing** rather than a list of names:
  every `is_x` in `script_pub_key` has to have its `assert_x`, and both
  have to be exported. A script type added later brings both halves or the
  test fails, which a 37-name literal would not have caught
- `test_every_exported_name_exists` walks every package of the library
  instead of the four it named. That is what found `btclib.script` outside
  the check, and it means no future pull request has to add a fifth name
  to that tuple. Nested packages are not walked — `btclib.script.engine`
  is the only one, and `tests/imports_test.py` already imports every
  module deliberately, one at a time

Purely additive on the library side. Gates run locally: full suite (16859
passed), `pre-commit` on the changed files, `-W` sphinx build.

## Renamings proposed for this module (decision needed)

1. **`taproot.output_pubkey` → `output_pub_key`,
   `output_prvkey` → `output_prv_key`,
   `check_output_pubkey` → `check_output_pub_key`, and the
   `internal_pubkey` parameter of the three → `internal_pub_key`.** The
   library writes `pub_key` with the underscore in 780 lines; `pubkey` as
   one word appears in btclib-owned names only here and in
   `ssa.point_from_bip340pub_key` (proposed in the `ecc` pull request of
   this series). Every other `pubkey` in the tree is a libsecp256k1 entry
   point — `ec_pubkey_parse`, `pubkey_tweak_add` — and must not move.
   Source-breaking, so it wants a HISTORY.md bullet, which is why it is
   not in this pull request.

## The open question this module raises, and does not answer

`sig_hash` and `engine` have no name in `btclib.script.__all__`, and
`from btclib.script import sig_hash` works anyway — as it does for every
submodule. Naming them, the way `btclib.ecc` names `dsa`, would collide:
`script.taproot` is a module and `sig_hash.taproot` is a function, and
`script` already exports `taproot`'s four functions flat. So the choice
for this package is a real one and not a copy of `ecc`'s:

- name the subsystems (`sig_hash`, `engine`, `taproot`) and stop
  flattening `taproot`'s functions, which is source-breaking; or
- leave them unnamed and say in the docstring that a subsystem is reached
  as a module, which is what happens today with nothing stating it.

Left for the decision rather than taken here.

## How the finding was made

```shell
./.venv/bin/python -c '
import btclib.script as m
from btclib.script import script_pub_key as s
print(sorted({n for n in vars(s) if n.startswith(("is_","assert_"))} - set(m.__all__)))'
```

Part of a per-module audit of `__all__`; the other modules get their own
pull requests. This branch and the others touch the same file
`tests/all_test.py`, so whichever lands second wants a trivial rebase.

## Summary by Sourcery

Ensure btclib.script exports a complete and consistent public API for script types and addresses, and tighten tests around package exports.

New Features:
- Export the addresses helper and the is_segwit/assert_segwit script type pair from btclib.script.

Enhancements:
- Add a test that enforces every script_pub_key is_x function has a matching assert_x and that both are exported by btclib.script.
- Generalize the export-existence test to automatically walk all btclib top-level packages rather than a hardcoded list.
- Document the btclib.script export changes and testing improvements in the changelog.