### PR TITLE
btclib.psbt exports the format and the roles, not the file format's plumbing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3010,6 +3010,24 @@ edit.
   re-export flat, `WordLists` and `data_file` among it, had no named way
   in. `tests/all_test.py` now finds the submodules rather than listing
   them, so one added to the package is one it asks about.
+- **`btclib.psbt` exports the format and the roles, not the plumbing of
+  the file format.** Nine names came from `psbt_utils` —
+  `serialize_bytes`, `deserialize_int`, `deserialize_map`,
+  `deserialize_tx`, `encode_dict_bytes_bytes`, `decode_dict_bytes_bytes`,
+  `serialize_dict_bytes_bytes`, `serialize_hd_key_paths` and
+  `assert_valid_unknown` — which is how one field of one map is written and
+  read, called by `psbt_in`, `psbt_out` and `psbt` and by nothing outside
+  the package: there were more of them in `__all__` than there were names
+  for the psbt itself, `encode_dict_bytes_bytes` listed twice among them.
+  Each is still importable from `btclib.psbt.psbt_utils`, which is where
+  the test suite already took the other half of that module from — and one
+  test file was importing `serialize_hd_key_paths` from the package and
+  `deserialize_map` from the module, in the same import block.
+  Two names arrive: `prevouts`, the outputs a psbt spends, and `musig2`,
+  named as a module because BIP373 is a role rather than a function, the
+  way `btclib.ecc` names `dsa`. The package docstring records both
+  decisions, and `tests/all_test.py` pins the list and checks the nine are
+  still where they are defined.
 
 ### Types
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -309,6 +309,14 @@ against the `v2023.7.12` tag.
   byte at the call site — `ssa.verify(msg, pub_key, witness_sig[:64])`,
   which is what btclib's own script engine does after reading the sighash
   type off it.
+- **`btclib.psbt` no longer exports the nine `psbt_utils` names**:
+  `serialize_bytes`, `deserialize_int`, `deserialize_map`,
+  `deserialize_tx`, `encode_dict_bytes_bytes`, `decode_dict_bytes_bytes`,
+  `serialize_dict_bytes_bytes`, `serialize_hd_key_paths` and
+  `assert_valid_unknown` come from `btclib.psbt.psbt_utils`, which is
+  where they are defined. They are how one field of one psbt map is
+  written and read; `Psbt`, `PsbtIn` and `PsbtOut` are where a caller
+  reads and writes a psbt.
 
 Two changes are deliberately *not* on that list, because what they change
 stays compatible. The new `BTClibTypeError`, `NotAPrvKeyError` and

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -7,40 +7,49 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Partially signed bitcoin transactions and the BIP174/BIP370 roles."""
+"""Partially signed bitcoin transactions and the BIP174/BIP370 roles.
 
-from btclib.psbt.psbt import Psbt, combine_psbts, extract_tx, finalize_psbt, join_psbts
+What this package exports is the format and the roles: the three maps a
+psbt is made of, the Combiner, the Finalizer, the Extractor, the outputs
+an unsigned psbt spends, and the size estimation a fee rate is applied to.
+`musig2` is named as a module, being the BIP373 role rather than one
+function, the way btclib.ecc names dsa.
+
+btclib.psbt.psbt_utils is not exported, and this is where that decision is
+recorded: serialize_bytes, deserialize_int, deserialize_map,
+deserialize_tx, the encode/decode_dict_bytes_bytes pair,
+serialize_dict_bytes_bytes, serialize_hd_key_paths and
+assert_valid_unknown are how one field of one map is written and read.
+They are called by psbt_in, psbt_out and psbt itself and by nothing
+outside this package, and there were more of them in __all__ than there
+were names for the format -- so a caller reading btclib.psbt was offered
+the plumbing of a file format ahead of the psbt. Each is importable from
+the module that defines it, which is where the test suite takes the other
+half of that module from already.
+"""
+
+from btclib.psbt import musig2
+from btclib.psbt.psbt import (
+    Psbt,
+    combine_psbts,
+    extract_tx,
+    finalize_psbt,
+    join_psbts,
+    prevouts,
+)
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
 from btclib.psbt.psbt_size import estimated_input_sizes
-from btclib.psbt.psbt_utils import (
-    assert_valid_unknown,
-    decode_dict_bytes_bytes,
-    deserialize_int,
-    deserialize_map,
-    deserialize_tx,
-    encode_dict_bytes_bytes,
-    serialize_bytes,
-    serialize_dict_bytes_bytes,
-    serialize_hd_key_paths,
-)
 
 __all__ = [
     "Psbt",
     "PsbtIn",
     "PsbtOut",
-    "assert_valid_unknown",
     "combine_psbts",
-    "decode_dict_bytes_bytes",
-    "deserialize_int",
-    "deserialize_map",
-    "deserialize_tx",
-    "encode_dict_bytes_bytes",
     "estimated_input_sizes",
     "extract_tx",
     "finalize_psbt",
     "join_psbts",
-    "serialize_bytes",
-    "serialize_dict_bytes_bytes",
-    "serialize_hd_key_paths",
+    "musig2",
+    "prevouts",
 ]

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -27,8 +27,10 @@ import btclib
 import btclib.curves
 import btclib.ecc
 import btclib.mnemonic
+import btclib.psbt
 import btclib.script
 from btclib.curves import curve_group, curve_group_2
+from btclib.psbt import psbt_utils
 from btclib.script import script_pub_key
 
 
@@ -182,6 +184,46 @@ def test_mnemonic_names_every_submodule_it_has() -> None:
         assert name in btclib.mnemonic.__all__, f"{name} is not exported"
         module = getattr(btclib.mnemonic, name)
         assert module.__name__ == f"btclib.mnemonic.{name}"
+
+
+def test_psbt_exports_the_format_not_its_plumbing() -> None:
+    """The maps and the roles, not how one field of one map is written.
+
+    The list it replaces held more names from psbt_utils than names for the
+    psbt itself, `encode_dict_bytes_bytes` twice among them, so a caller
+    reading `btclib.psbt` was offered the plumbing of a file format ahead
+    of the format.
+    """
+    assert sorted(btclib.psbt.__all__) == [
+        "Psbt",
+        "PsbtIn",
+        "PsbtOut",
+        "combine_psbts",
+        "estimated_input_sizes",
+        "extract_tx",
+        "finalize_psbt",
+        "join_psbts",
+        "musig2",
+        "prevouts",
+    ]
+
+    # BIP373 is a role, so the module is the name, as btclib.ecc.dsa is
+    assert btclib.psbt.musig2.__name__ == "btclib.psbt.musig2"
+
+    # the plumbing is still there, in the module that defines it
+    for name in (
+        "assert_valid_unknown",
+        "decode_dict_bytes_bytes",
+        "deserialize_int",
+        "deserialize_map",
+        "deserialize_tx",
+        "encode_dict_bytes_bytes",
+        "serialize_bytes",
+        "serialize_dict_bytes_bytes",
+        "serialize_hd_key_paths",
+    ):
+        assert hasattr(psbt_utils, name), f"psbt_utils.{name} went missing"
+        assert name not in btclib.psbt.__all__
 
 
 def test_every_exported_name_exists() -> None:

--- a/tests/psbt/psbt_out_test.py
+++ b/tests/psbt/psbt_out_test.py
@@ -20,16 +20,16 @@ import pytest
 from btclib.alias import Octets
 from btclib.bip32 import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
-from btclib.psbt import (
-    Psbt,
-    PsbtOut,
+from btclib.psbt import Psbt, PsbtOut
+from btclib.psbt.psbt_utils import (
+    PSBT_SEPARATOR,
     assert_valid_unknown,
     decode_dict_bytes_bytes,
     deserialize_map,
     encode_dict_bytes_bytes,
     serialize_dict_bytes_bytes,
+    taproot_bip32_from_dict,
 )
-from btclib.psbt.psbt_utils import PSBT_SEPARATOR, taproot_bip32_from_dict
 from tests.conftest import JsonGolden
 
 

--- a/tests/psbt/psbt_utils_test.py
+++ b/tests/psbt/psbt_utils_test.py
@@ -15,10 +15,10 @@ import pytest
 
 from btclib.bip32 import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
-from btclib.psbt import serialize_hd_key_paths
 from btclib.psbt.psbt_utils import (
     deserialize_map,
     parse_taproot_bip32,
+    serialize_hd_key_paths,
     serialize_taproot_bip32,
 )
 


### PR DESCRIPTION
## What this changes

Nine of the seventeen names in `btclib.psbt.__all__` came from
`psbt_utils`: `serialize_bytes`, `deserialize_int`, `deserialize_map`,
`deserialize_tx`, `encode_dict_bytes_bytes`, `decode_dict_bytes_bytes`,
`serialize_dict_bytes_bytes`, `serialize_hd_key_paths` and
`assert_valid_unknown`. That is how one field of one map is written and
read; measured, each is called by `psbt_in`, `psbt_out` and `psbt`, and by
nothing outside the package. So `__all__` held more names for the plumbing
of the file format than for the psbt — `encode_dict_bytes_bytes` listed
twice among them, which is what an unmaintained list looks like.

- the nine go; each is still importable from `btclib.psbt.psbt_utils`,
  where it is defined and where the suite already took the other half of
  that module from. `tests/psbt/psbt_utils_test.py` was importing
  `serialize_hd_key_paths` from the package and `deserialize_map` from the
  module in the same block, and `tests/psbt/psbt_out_test.py` was split
  the same way; both are now one import from the module
- `prevouts` arrives: the outputs a psbt spends, a function over the
  `Psbt` the package does export
- `musig2` arrives as a module, BIP373 being a role rather than a
  function, the way `btclib.ecc` names `dsa`. `tests/psbt/psbt_test.py`
  already did `from btclib.psbt import musig2 as psbt_musig2`
- the package docstring records both decisions, which is what was missing:
  the exclusion of `psbt_utils` is a choice, and nothing said so
- `tests/all_test.py` pins the new list and asserts the nine are still
  reachable from `psbt_utils`

**Source-breaking**: all nine were exported at `v2023.7.12` — checked
against the tag. HISTORY.md's breaking-changes list gets a bullet,
CHANGELOG.md the detail.

Gates run locally: full suite (16859 passed), `pre-commit` on the changed
files, `-W` sphinx build.

## Renamings proposed for this module (decision needed)

1. **`combine_psbts` → `combine`, `join_psbts` → `join`,
   `finalize_psbt` → `finalize`.** At package level the suffix stutters:
   `psbt.combine_psbts(...)`, `psbt.finalize_psbt(...)`. The flat import
   loses a noun — `from btclib.psbt import combine` — which is what the
   `as` clause is for, and it is the same trade `bech32.encode` already
   makes against `base58.b58encode`.
2. **`extract_tx` keeps its name.** It is the one of the four that says
   what comes *out*, and `psbt.extract_tx()` reads as the Extractor of
   BIP174 rather than as a stutter.
3. The sibling case in a package whose `__all__` needs no change:
   **`tx.join_txs` → `tx.join`**. It is listed here rather than in a pull
   request of its own because `btclib.tx` exports exactly the five names
   it should, so there is nothing to correct there.

All three are source-breaking, so each wants a HISTORY.md bullet, which
is why none is in this pull request.

## How the finding was made

```shell
for n in serialize_bytes deserialize_int deserialize_map deserialize_tx \
         encode_dict_bytes_bytes decode_dict_bytes_bytes \
         serialize_dict_bytes_bytes serialize_hd_key_paths \
         assert_valid_unknown; do
  echo "$n: $(grep -rn "\b$n\b" --include='*.py' btclib \
      | grep -vc '^btclib/psbt/') uses outside btclib/psbt/"
done
```

Part of a per-module audit of `__all__`; the other modules get their own
pull requests. Several of them touch `tests/all_test.py`, in different
functions, so whichever lands second may want a trivial rebase.

## Summary by Sourcery

Restrict the btclib.psbt package exports to PSBT data structures and high-level roles while documenting this boundary, and add coverage to ensure the new public API surface and helper locations remain correct.

New Features:
- Expose prevouts from btclib.psbt.psbt as part of the btclib.psbt public API to provide access to the outputs a PSBT spends.
- Export the musig2 module from btclib.psbt as the BIP373 role interface.

Enhancements:
- Refine btclib.psbt.__all__ to focus on PSBT types, role functions, size estimation, and the musig2 module instead of low-level psbt_utils helpers.
- Update the btclib.psbt package docstring to describe the intended public surface and explicitly record the decision not to re-export psbt_utils internals.

Documentation:
- Document the btclib.psbt export changes and rationale in CHANGELOG.md and mark the removal of psbt_utils symbols from btclib.psbt as a source-breaking change in HISTORY.md.

Tests:
- Add tests asserting the exact btclib.psbt.__all__ contents, that musig2 is exposed as a module, and that psbt_utils helper functions remain available only from their defining module.
- Adjust PSBT-related tests to import low-level helpers directly from btclib.psbt.psbt_utils instead of via the btclib.psbt package.