### PR TITLE
btclib.block exports the merkle root a header commits to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2966,6 +2966,16 @@ edit.
   — so `from btclib.ecc import bip340_nonce_` is now
   `from btclib.ecc.bip340_nonce import bip340_nonce_`, which is where the
   rest of the tree already took it from.
+- **`btclib.block` exports
+  `merkle_root_and_mutated_from_transactions`**, beside the
+  `bip34_commitment` defined next to it: both are what a header commits
+  to, and this one is the single implementation the builder and the
+  validator share — `mining.candidate_block_header` builds a header from
+  it and `Block.assert_valid` compares the header against it. A caller
+  checking a block by hand needs that function and not a second one
+  written from the BIP, which is what having to reach into
+  `btclib.block.block` for it invited. The comment recording why
+  `btclib.block.limits` stays out now records this too.
 
 ### Types
 

--- a/btclib/block/__init__.py
+++ b/btclib/block/__init__.py
@@ -10,20 +10,31 @@
 """Blocks: header and block, their rules, proof of work, merkle proofs."""
 
 from btclib.block import merkle_proof, mining, proof_of_work
-from btclib.block.block import Block, bip34_commitment
+from btclib.block.block import (
+    Block,
+    bip34_commitment,
+    merkle_root_and_mutated_from_transactions,
+)
 from btclib.block.block_context import BlockContext
 from btclib.block.block_header import BlockHeader
 
 # btclib.block.limits is not here, as btclib.script.limits is not in
 # btclib.script: a caller reading a consensus constant names the module it
 # comes from, which is what says the number is Core's and not this
-# library's
+# library's.
+# merkle_root_and_mutated_from_transactions is, beside the bip34_commitment
+# defined next to it: both are what a header commits to, and this one is
+# the single implementation the builder and the validator share -- mining
+# builds a candidate header from it and Block.assert_valid compares the
+# header against it -- so a caller checking a block by hand needs the same
+# function rather than a second one written from the BIP
 __all__ = [
     "Block",
     "BlockContext",
     "BlockHeader",
     "bip34_commitment",
     "merkle_proof",
+    "merkle_root_and_mutated_from_transactions",
     "mining",
     "proof_of_work",
 ]


### PR DESCRIPTION
## What this changes

`btclib.block` exported `bip34_commitment` and not
`merkle_root_and_mutated_from_transactions`, which is defined next to it
in the same module. Both are what a block header commits to, and the
second is the single implementation the builder and the validator share:
`mining.candidate_block_header` builds a header from it, and
`Block.assert_valid` compares the header at hand against it — the
function's own docstring says why there is one of it.

A caller checking a block by hand needs that function, not a second one
written from the BIP, which is what having to reach into
`btclib.block.block` for it invited.

- the name is added to the import and to `__all__`
- the comment recording why `btclib.block.limits` stays out now records
  why this one comes in: the two decisions belong next to each other

Purely additive. Gates run locally: full suite (16858 passed),
`pre-commit` on the changed files, `-W` sphinx build.

## Renamings proposed for this module (decision needed)

None, and this is the module where the long name is the right one:
`merkle_root_and_mutated_from_transactions` returns two values, and the
second — the CVE-2012-2459 mutation flag — is the one a caller forgets to
look at. `merkle_root_from_transactions` would name half the return.

Worth recording as *not* a rename either: `btclib.hashes` holds
`merkle_root_and_mutated` and `merkle_root_and_mutated_from_hashes`
beside it. Those take hashes, this one takes transactions, and the
suffixes say exactly that.

## How the finding was made

```shell
./.venv/bin/python -c '
import btclib.block as p, btclib.block.block as m
print([n for n in vars(m) if not n.startswith("_") and n not in p.__all__])'
```

Part of a per-module audit of `__all__`; the other modules get their own
pull requests.

## Summary by Sourcery

Export the shared merkle root computation helper from btclib.block and update accompanying comments and changelog to reflect its availability.

New Features:
- Export merkle_root_and_mutated_from_transactions from btclib.block alongside Block and bip34_commitment for direct caller use.

Enhancements:
- Clarify inline documentation in btclib.block about which symbols are exported and why limits remains excluded.

Documentation:
- Document the new btclib.block export of merkle_root_and_mutated_from_transactions in the changelog.