### PR TITLE
btclib.bip32 records why slip132 is not in its __all__

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2976,6 +2976,19 @@ edit.
   written from the BIP, which is what having to reach into
   `btclib.block.block` for it invited. The comment recording why
   `btclib.block.limits` stays out now records this too.
+- **`btclib.bip32` records why `slip132` is not in its `__all__`.** It is
+  the one submodule of that package that sits *above* the address
+  encodings — it imports `b58` and `b32`, which import `to_pub_key`, which
+  imports `btclib.bip32` — so naming it there means importing it there,
+  and that is a cycle: every caller then gets `cannot import name
+  'BIP32Key' from partially initialized module 'btclib.bip32'`, which
+  `tests/imports_test.py` reports by importing each module with nothing
+  else in `sys.modules`. `from btclib.bip32 import slip132` works
+  regardless — a submodule does not need its parent's `__all__` to be
+  importable — and is what every caller in the tree writes. What was
+  missing is the reason, which is now beside the list, with the
+  observation that `btclib.bip44` has the same shape and lives at the top
+  level for the same cause.
 
 ### Types
 

--- a/btclib/bip32/__init__.py
+++ b/btclib/bip32/__init__.py
@@ -35,6 +35,20 @@ from btclib.bip32.key_origin import (
     encode_to_bip32_derivs,
 )
 
+# btclib.bip32.slip132 is not here, and cannot be: it is the one submodule
+# of this package that sits *above* the address encodings -- it imports
+# btclib.b58 and btclib.b32, which import btclib.to_pub_key, which imports
+# this package -- so an import of it in this file is a cycle, and
+# `cannot import name 'BIP32Key' from partially initialized module
+# 'btclib.bip32'` is what every caller then gets. tests/imports_test.py,
+# which imports each module of the library with nothing else in sys.modules,
+# is what reports it.
+# `from btclib.bip32 import slip132` works regardless, a submodule not
+# needing its parent's __all__ to be importable, and is what every caller in
+# the tree writes. What the absence from this list costs is that nothing
+# states the layering it comes from, which is what this comment is for:
+# btclib.bip44 has the same shape -- bip32 plus both address encodings --
+# and lives at the top level for that very reason
 __all__ = [
     "BIP32Key",
     "BIP32KeyData",


### PR DESCRIPTION
## What this changes

This is the pull request of the series where the audit was **wrong**, and
the code change is the reason written down.

`btclib.bip32` flattens `der_path` and `key_origin` whole and names no
submodule, so `slip132` looked like the one gap: neither flattened nor
named, while the package docstring says "and SLIP132 versions". It cannot
be either, and that was measured rather than argued — adding
`from btclib.bip32 import slip132` to the package and running the suite:

```
73 failed, 16745 passed
E ImportError: cannot import name 'BIP32Key' from partially initialized
  module 'btclib.bip32' (most likely due to a circular import)
```

`slip132` is the one submodule of that package that sits *above* the
address encodings: it imports `b58` and `b32`, which import `to_pub_key`,
which imports `btclib.bip32`. Naming it in `__all__` means importing it in
`__init__.py`, and that closes the cycle for every caller.
`tests/imports_test.py` — each module imported with nothing else in
`sys.modules` — is what reports it.

Also measured, so that nobody has to try it twice: pointing
`to_prv_key` and `to_pub_key` at `btclib.bip32.bip32` instead of the
package does **not** open the road (`52 failed`); the cycle then closes
one step further out, at `btclib.b32` importing a partially initialized
`to_pub_key`.

So the change is a comment beside `__all__` stating the layering, the
error it produces, the test that reports it, and the fact that
`from btclib.bip32 import slip132` works anyway — a submodule needing no
entry in its parent's `__all__` — which is what every caller in the tree
already writes.

No behaviour change. Gates run locally: full suite (16858 passed),
`pre-commit` on the changed files, `-W` sphinx build.

## Proposal 1: move `slip132` up, beside `bip44` (decision needed)

`btclib/bip44.py` has exactly `slip132`'s shape — it imports `b32`, `b58`,
`bip32.bip32` and `to_pub_key` — and it lives at the top level for exactly
this reason; the README says so: "`bip44` is up there as well, and for the
same reason". `btclib/bip32/slip132.py` is the same module one directory
too low, and moving it to `btclib/slip132.py` would:

- put the cycle out of reach by construction, rather than by a comment
- make `btclib.bip32` a package whose submodules are all *below* the
  address encodings, which is a rule instead of an exception
- cost `from btclib.bip32 import slip132` → `from btclib import slip132`
  at three test files and one line of `docs/source/btclib.bip32.rst`

Source-breaking, so it wants a HISTORY.md bullet and a pull request of its
own.

## Proposal 2: one name for the master extended key (decision needed)

`bip32.rootxprv_from_seed` against `mnemonic.bip39.mxprv_from_mnemonic`,
`mnemonic.electrum.mxprv_from_mnemonic` and
`mnemonic.slip39.mxprv_from_mnemonics`: two names for one object, and not
a stray — 53 occurrences of `rootxprv` against 51 of `mxprv` over library
and tests.

`mxprv` is the one to keep: it is the spelling of three modules against
one, and the `m` is the `m/...` of every derivation path in the library.
So `rootxprv_from_seed` → `mxprv_from_seed`. Source-breaking, and it is
the kind of rename worth landing with the other five of this audit in one
release rather than spread over months, so HISTORY.md carries one entry a
reader acts on once.

## How the finding was made

```shell
./.venv/bin/python -c '
import btclib.bip32 as p
print("slip132" in p.__all__, hasattr(p, "slip132"))'
```

Part of a per-module audit of `__all__`; the other modules get their own
pull requests.

## Summary by Sourcery

Document the rationale for excluding the slip132 submodule from btclib.bip32.__all__ without changing runtime behavior.

Documentation:
- Add explanatory comments in btclib.bip32.__init__ describing the import cycle that would result from exposing slip132 via __all__ and how it relates to address-encoding modules.
- Update the changelog to record the reasoning and context for keeping slip132 out of btclib.bip32.__all__ while remaining directly importable.