### PR TITLE
btclib.mnemonic names entropy and mnemonic, the modules under the schemes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3001,6 +3001,15 @@ edit.
   `Fetcher` is built out of, which is a third implementation's question
   rather than a caller's. The transport seam is in, and the reason is now
   written down: it is how calling code is tested without a node.
+- **`btclib.mnemonic` names `entropy` and `mnemonic`**, the two modules the
+  three schemes are built on: the first turns dice rolls, bytes, an int or
+  a bit string into the entropy a sentence encodes, the second is the word
+  list and the index codec over it. They were the two submodules of the
+  six that the list left out — `bip39`, `electrum`, `slip39` and
+  `dispatch` were named — so what they hold and the package does not
+  re-export flat, `WordLists` and `data_file` among it, had no named way
+  in. `tests/all_test.py` now finds the submodules rather than listing
+  them, so one added to the package is one it asks about.
 
 ### Types
 

--- a/btclib/mnemonic/__init__.py
+++ b/btclib/mnemonic/__init__.py
@@ -18,9 +18,18 @@ the submodule, which is why all three are named here.
 dispatch is exported beside them: it is the entry point that answers
 which scheme a sentence belongs to, and it is of no use to anyone who
 has to import it by name after already knowing.
+
+entropy and mnemonic are named too, being the two modules the three
+schemes are built on rather than schemes themselves: the first turns
+dice rolls, bytes, an int or a bit string into the entropy a sentence
+encodes, the second is the word list and the index codec over it. Their
+functions are also re-exported flat below, so naming the modules adds one
+thing -- what is *not* flat, WordLists and data_file among it, is reached
+as btclib.mnemonic.mnemonic, a module spelled like the package that holds
+it and easy to assume is the package.
 """
 
-from btclib.mnemonic import bip39, dispatch, electrum, slip39
+from btclib.mnemonic import bip39, dispatch, electrum, entropy, mnemonic, slip39
 from btclib.mnemonic.entropy import (
     BinStr,
     Entropy,
@@ -60,7 +69,9 @@ __all__ = [
     "collect_rolls",
     "dispatch",
     "electrum",
+    "entropy",
     "indexes_from_mnemonic",
+    "mnemonic",
     "mnemonic_from_indexes",
     "normalize_mnemonic",
     "slip39",

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -161,6 +161,29 @@ def test_mnemonic_exports_its_three_schemes() -> None:
         assert module.__name__ == f"btclib.mnemonic.{name}"
 
 
+def test_mnemonic_names_every_submodule_it_has() -> None:
+    """The schemes, the entry point, and the two modules under all of them.
+
+    `entropy` and `mnemonic` were the two the list left out, so what those
+    hold and does not come out flat -- `WordLists` and `data_file` -- had no
+    named way in. The submodules are found rather than listed: one added to
+    the package is one this asks about.
+    """
+    submodules = sorted(name for _, name, _ in iter_modules(btclib.mnemonic.__path__))
+    assert submodules == [
+        "bip39",
+        "dispatch",
+        "electrum",
+        "entropy",
+        "mnemonic",
+        "slip39",
+    ]
+    for name in submodules:
+        assert name in btclib.mnemonic.__all__, f"{name} is not exported"
+        module = getattr(btclib.mnemonic, name)
+        assert module.__name__ == f"btclib.mnemonic.{name}"
+
+
 def test_every_exported_name_exists() -> None:
     """An `__all__` entry that names nothing is a broken `import *`.
 


### PR DESCRIPTION
## What this changes

Four of the six submodules of `btclib.mnemonic` were named in `__all__` —
`bip39`, `electrum`, `slip39` and `dispatch`, each with a reason in the
package docstring — and the two the three schemes are built on were not:
`entropy`, which turns dice rolls, bytes, an int or a bit string into what
a sentence encodes, and `mnemonic`, the word list and the index codec over
it.

The consequence is small and real: what those two hold and the package
does not re-export flat — `WordLists` and `data_file` — had no named way
in, and `btclib.mnemonic.mnemonic` is a module spelled like the package
that holds it, which is exactly the name a reader assumes is the package.

- `entropy` and `mnemonic` are added to the import line and to `__all__`
- the docstring says what the two are for, and that their functions come
  out flat as well, so the module names add only what is *not* flat
- `tests/all_test.py` finds the submodules with `pkgutil` rather than
  listing them: a submodule added to the package is one the test asks
  about

Purely additive and declarative — both modules were already imported by
this `__init__`, so the names were already attributes. Gates run locally:
full suite (16859 passed), `pre-commit` on the changed files, `-W` sphinx
build.

## Proposal: the twelve flattened helpers should go down (decision needed)

This is the module where the audit found the opposite problem too, and
this pull request does **not** act on it.

`mnemonic.__all__` re-exports twelve functions flat from those same two
modules — the seven `bin_str_entropy_from_*`, `bytes_entropy_from_str`,
`wordlist_indexes_from_bin_str_entropy`, `collect_rolls`,
`indexes_from_mnemonic`, `mnemonic_from_indexes` and `normalize_mnemonic`
— and measured, **none of them is used anywhere outside
`btclib/mnemonic/`**:

```shell
for n in bin_str_entropy_from_rolls collect_rolls normalize_mnemonic \
         wordlist_indexes_from_bin_str_entropy; do
  echo "$n: $(grep -rn "\b$n\b" --include='*.py' btclib \
      | grep -vc '^btclib/mnemonic/') uses outside btclib/mnemonic/"
done
```

The flattening is also what makes the names long:
`bin_str_entropy_from_wordlist_indexes` has to carry "entropy" because the
module that said it was dropped. Under the module names this pull request
adds, the same functions read `entropy.bin_str_from_rolls` and
`entropy.bin_str_from_wordlist_indexes`.

Against demoting them: `collect_rolls` and `bin_str_entropy_from_random`
are *features* a caller asks for, not plumbing, and "used only inside the
package" is weaker evidence here than it was for `btclib.psbt`'s field
serializers — this is a teaching library, and generating entropy from dice
is one of the things it teaches. Which is why the decision is left open
rather than taken: both halves are source-breaking, and they should land
together or not at all.

## Renaming proposed for this module (decision needed)

**`mnemonic.dispatch` should not be called `dispatch`.** The name says how
the module works — a dispatch table over the three schemes — where every
other module here is named after what it answers. Its two functions are
`seed_type_from_mnemonic` and `all_seed_types_from_mnemonic`, so
`seed_type` is the name that matches them, and
`from btclib.mnemonic import seed_type` reads as the question a caller has.

Not the export, which the docstring already defends ("it is the entry
point that answers which scheme a sentence belongs to, and it is of no use
to anyone who has to import it by name after already knowing"): only the
name. Source-breaking, so it wants a HISTORY.md bullet and is not in this
pull request.

## How the finding was made

```shell
./.venv/bin/python -c '
from pkgutil import iter_modules
import btclib.mnemonic as p
print([n for _, n, _ in iter_modules(p.__path__) if n not in p.__all__])'
```

Part of a per-module audit of `__all__`; the other modules get their own
pull requests. Several touch `tests/all_test.py`, in different functions,
so whichever lands second may want a trivial rebase.

## Summary by Sourcery

Name the entropy and mnemonic submodules in btclib.mnemonic and ensure tests dynamically verify all mnemonic submodules are exported.

Enhancements:
- Expose the entropy and mnemonic foundational modules as named exports from btclib.mnemonic, alongside the existing scheme modules.
- Update the mnemonic package docstring to describe the roles of the entropy and mnemonic modules and clarify their relationship to flattened helpers.

Documentation:
- Add a CHANGELOG entry documenting that btclib.mnemonic now names its entropy and mnemonic submodules and that tests auto-discover future submodules.

Tests:
- Extend tests/all_test.py to discover btclib.mnemonic submodules via pkgutil and assert each one is listed in __all__ and correctly importable.