### PR TITLE
btclib.fetch states what it exports and what it keeps out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2989,6 +2989,18 @@ edit.
   missing is the reason, which is now beside the list, with the
   observation that `btclib.bip44` has the same shape and lives at the top
   level for the same cause.
+- **`btclib.fetch` states what it exports and what it keeps out.** The
+  docstring explained the design of the package and said nothing about its
+  public surface, where `btclib.curves` and `btclib.block` each record
+  theirs. `cookie_auth` stays out because `AuthProxy` takes a
+  `cookie_path` and reads that file at every call, the node rewriting the
+  cookie whenever it restarts: a caller passes the path and never the
+  credential, and a name for reading one is a way to hold it longer than
+  the node does. `fetch_errors`, `tx_from_raw`, `tx_id_hex` and
+  `tx_for_network` stay out because they are what an implementation of
+  `Fetcher` is built out of, which is a third implementation's question
+  rather than a caller's. The transport seam is in, and the reason is now
+  written down: it is how calling code is tested without a node.
 
 ### Types
 

--- a/btclib/fetch/__init__.py
+++ b/btclib/fetch/__init__.py
@@ -27,6 +27,24 @@ socket.
 Importing the package does not connect to anything, and constructing a
 fetcher does not either: the first call is what opens a connection, and
 what raises if there is nothing to connect to.
+
+**What is exported, and what is not.** The two fetchers, the interface
+they implement, the endpoint a bitcoind one is reached through, and the
+transport seam: the timeout, the protocol a substitute has to satisfy and
+the one implementation of it that opens a socket. That last group is here
+because the seam is the supported way to test calling code without a node,
+which is not a detail of the two implementations.
+
+`bitcoind.cookie_auth` is deliberately not here: `AuthProxy` takes a
+`cookie_path` and reads that file at every call -- the node rewrites the
+cookie whenever it restarts -- so a caller who wants cookie authentication
+passes the path and never the credential, and a name for reading it is one
+way to hold a credential longer than the node does. `fetcher.fetch_errors`,
+`tx_from_raw`, `tx_id_hex` and `tx_for_network` are not here either: they
+are what an implementation of the interface is built out of, and they are
+the answer to a third implementation rather than to a caller of the two --
+`from btclib.fetch.fetcher import fetch_errors` is that answer, and it says
+which layer it is reaching into.
 """
 
 from btclib.fetch.bitcoind import AuthProxy, BitcoindFetcher


### PR DESCRIPTION
## What this changes

This is the second pull request of the series where the audit's finding
did not survive being checked, and the change is the reason written down.

`cookie_auth` looked missing from `btclib.fetch.__all__`: `AuthProxy` is
exported and building one against a bitcoind cookie seemed to need it.
Read, it does not — `AuthProxy(cookie_path=...)` takes the path and
`auth_header()` reads the file at **every call**, because the node
rewrites the cookie whenever it restarts. So a caller passes a path and
never a credential, and a name for reading one is a way to hold a
credential longer than the node does. That is a reason to keep it out, not
an oversight.

The same for `fetcher.fetch_errors`, `tx_from_raw`, `tx_id_hex` and
`tx_for_network`: they are what an *implementation* of `Fetcher` is built
out of — both of the two use all four — which is a third implementation's
question rather than a caller's, and
`from btclib.fetch.fetcher import fetch_errors` says which layer it
reaches into.

What was actually missing is the statement. `btclib.curves` has a
paragraph on what it exports and why the `mult_*` menu stays out;
`btclib.block` has the comment on `limits`. `btclib.fetch` explained its
design — the interface, the two implementations, the absence of a
dependency, the fact that importing connects to nothing — and said nothing
about its public surface. It does now, including why the transport seam
*is* exported: it is how calling code is tested without a node, which is
not a detail of either implementation.

No behaviour change. Gates run locally: full suite (16858 passed),
`pre-commit` on the changed files, `-W` sphinx build.

## Renaming proposed for this module: none

`Fetcher.get_tx`, `get_tx_out`, `get_block_count` and `get_best_block_id`
keep their names, and the `get_` prefix is worth defending rather than
trimming: every one of the four goes out to the network, and it is the one
package in btclib where a method call is an HTTP round trip. `tx()` reads
like an accessor; `get_tx()` reads like a request. Bitcoin Core's RPC
spells them `getrawtransaction`, `gettxout`, `getblockcount` and
`getbestblockhash`, so the prefix also lines up with the interface a reader
is holding in the other hand.

`BLOCKSTREAM_INFO` names an endpoint of a particular operator and is
correct as it is: it is not "the esplora url", it is one esplora instance,
and any other is a string a caller passes.

## The one thing worth deciding here

Should the implementer's toolkit be exported after all? The package
already exports `HttpTransport`, `urlopen_transport` and `DEFAULT_TIMEOUT`,
i.e. the seam for substituting the network — an extension point — so there
is a coherent case for `fetch_errors`, `tx_from_raw`, `tx_id_hex` and
`tx_for_network` joining it as the toolkit a third `Fetcher` is written
with. It would be additive. This pull request records the opposite
decision because nothing in the tree asks for it yet, and an exported name
is harder to withdraw than to add.

## How the finding was made

```shell
./.venv/bin/python -c '
import btclib.fetch as p, btclib.fetch.fetcher as f, btclib.fetch.bitcoind as b
print([n for n in list(vars(f)) + list(vars(b))
       if not n.startswith("_") and n not in p.__all__])'
```

Part of a per-module audit of `__all__`; the other modules get their own
pull requests.

## Summary by Sourcery

Documentation:
- Extend btclib.fetch’s module docstring and CHANGELOG to explain its exported API, the rationale for keeping certain helper functions and cookie_auth internal, and the role of the transport seam for testing without a node.