### PR TITLE
Sixty-four octets are a BIP340 signature, and no other number is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -893,6 +893,26 @@ edit.
   stated size now answers `39 bytes after the transaction` rather than the
   `Missing inputs` that was true of it and not what was wrong with it
 
+- **a BIP340 signature is sixty-four octets, and no other number**
+  (issue #323). `ssa.Sig.parse` read `r` and `s` with two 32-byte reads
+  and checked nothing, so sixty-three octets parsed into a signature of
+  their own — an `s` read out of thirty-one bytes is below the order, so
+  it is a valid scalar — and sixty-five into the signature of the first
+  sixty-four, the last byte read as part of nothing. `Sig.parse(b"")`
+  under `check_validity=False` answered the `Sig` of `(0, 0)`: a
+  signature out of no bytes at all. The length is now checked as
+  `bms.Sig.parse` checks its own, whatever `check_validity` says, and
+  `bms.Sig.parse` gains the trailing-octets half of the same rule, so
+  sixty-six octets are no longer the signature of the first sixty-five.
+  The one parser left with a flag in front of that rule is
+  `dsa.Sig.parse`, whose `strict` is Core's own
+  `IsValidSignatureEncoding` and is documented as the exception it is
+  (issue #129). The 65-octet shape this refuses is the one a taproot
+  witness carries: BIP341 appends the sighash type, which is a fact about
+  the transaction rather than part of the signature, and stripping it is
+  the caller's — `signature[:64]`, as `btclib.script.engine.tapscript`
+  does once `get_hashtype` has read it
+
 ### Immutability and shared state
 
 - a default-constructed `TxIn` no longer shares its `prev_out` and

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -288,6 +288,15 @@ against the `v2023.7.12` tag.
   object out of a longer buffer is `parse(BytesIO(buffer))` rather than
   `parse(buffer)`.
 
+- **`ssa.verify` answers False for a 65-byte taproot witness signature**,
+  where it answered True: the 65th octet is BIP341's sighash type, not
+  part of the BIP340 signature, and `Sig.parse` read the first sixty-four
+  octets and dropped the rest. `ssa.Sig.parse` and `ssa.assert_as_valid`
+  raise `BTClibValueError` on it, as they do on a truncation. Strip the
+  byte at the call site — `ssa.verify(msg, pub_key, witness_sig[:64])`,
+  which is what btclib's own script engine does after reading the sighash
+  type off it.
+
 Two changes are deliberately *not* on that list, because what they change
 stays compatible. The new `BTClibTypeError`, `NotAPrvKeyError` and
 `InvalidPrvKeyError` all derive from what was raised before, so `except

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -128,7 +128,7 @@ from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import hash160, magic_message, reduce_to_hlen
 from btclib.network import NETWORKS
 from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
-from btclib.utils import bytesio_from_binarydata
+from btclib.utils import assert_no_trailing, bytesio_from_binarydata
 
 _REQUIRED_LENGTH = 65
 
@@ -206,6 +206,7 @@ class Sig:
             err_msg = f"invalid decoded length: {len(sig_bin)}"
             err_msg += f" instead of {_REQUIRED_LENGTH}"
             raise BTClibValueError(err_msg)
+        assert_no_trailing(data, stream, "signature")
 
         rf = sig_bin[0]
         ec = secp256k1

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -284,7 +284,12 @@ class Sig:
         # LOW_S and not otherwise, and fix_signature parses with
         # strict=False for exactly the flags Core leaves it out for. A
         # stream is held to the same rule as a bytes buffer, no caller in
-        # this library parsing a signature out of the middle of one
+        # this library parsing a signature out of the middle of one.
+        #
+        # This is the one parser in btclib with a flag in front of that
+        # rule, and the flag is Core's: btclib/utils.py states the rule
+        # everything else follows, where a complete octet string is one
+        # whole object and nothing may follow it
         if strict and stream.read(1) != b"":
             raise BTClibValueError("trailing bytes after the DER sequence")
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -84,6 +84,7 @@ from btclib.number_theory import mod_inv
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import point_from_pub_key
 from btclib.utils import (
+    assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
     hex_string,
@@ -99,6 +100,11 @@ from btclib.utils import (
 # a different scheme, and every signature already made would stop opening
 _S2C_POINT_TAG = b"s2c/bip340/point"
 _S2C_DATA_TAG = b"s2c/bip340/data"
+
+# BIP340 serializes a signature as thirty-two octets of r and thirty-two
+# of s, on secp256k1 and by that BIP alone: a Sig on another curve has no
+# encoding here to be a length of
+_REQUIRED_LENGTH = 64
 
 
 @dataclass(frozen=True, init=False)
@@ -161,11 +167,31 @@ class Sig:
         The serialization does not name its curve, so parse reads the
         one BIP340 is defined over; a Sig on another curve is built
         directly.
+
+        Sixty-four octets exactly, and a witness signature is not one:
+        BIP341 appends the sighash type to it, which is a byte about the
+        transaction and not part of the signature. Stripping it is the
+        caller's, `signature[:64]`, as btclib's own script engine does
+        after reading it.
         """
         stream = bytesio_from_binarydata(data)
+        sig_bin = stream.read(_REQUIRED_LENGTH)
+
+        # the length is checked whatever check_validity says, as
+        # bms.Sig.parse checks its own: it is not an opinion about the
+        # signature but what makes the two slices below mean anything.
+        # Skipped, sixty-three octets would yield a Sig whose s is a
+        # thirty-one-byte integer -- below the order, so valid -- and no
+        # bytes at all would yield the Sig of (0, 0)
+        if len(sig_bin) != _REQUIRED_LENGTH:
+            err_msg = f"invalid decoded length: {len(sig_bin)}"
+            err_msg += f" instead of {_REQUIRED_LENGTH}"
+            raise BTClibValueError(err_msg)
+        assert_no_trailing(data, stream, "BIP340 signature")
+
         ec = secp256k1
-        r = int.from_bytes(stream.read(ec.p_size), byteorder="big", signed=False)
-        s = int.from_bytes(stream.read(ec.n_size), byteorder="big", signed=False)
+        r = int.from_bytes(sig_bin[: ec.p_size], byteorder="big", signed=False)
+        s = int.from_bytes(sig_bin[ec.p_size :], byteorder="big", signed=False)
         return cls(r, s, ec, check_validity=check_validity)
 
 

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -931,6 +931,13 @@ def test_parse_length_is_not_a_validity_opinion() -> None:
             with pytest.raises(BTClibValueError, match=err_msg):
                 bms.Sig.parse(sig_bin[:length], check_validity=check_validity)
 
+    # and the other half of the same rule: octets are one whole
+    # signature, so what follows it in them is refused rather than
+    # dropped -- 66 bytes would otherwise be the signature of the 65
+    for check_validity in (True, False):
+        with pytest.raises(BTClibValueError, match="1 bytes after the signature"):
+            bms.Sig.parse(sig_bin + b"\x00", check_validity=check_validity)
+
 
 def test_b64decode_rejects_what_is_not_base64() -> None:
     """Guard against b64decode discarding what is not in the alphabet.

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -152,6 +152,55 @@ def test_bip340_vectors(row: list[str]) -> None:
         assert not ssa.verify_(m, pub_key, sig)
 
 
+@pytest.mark.parametrize("check_validity", [True, False], ids=["checked", "unchecked"])
+@pytest.mark.parametrize("length", [0, 1, 31, 32, 33, 63, 65, 68])
+def test_parse_takes_64_bytes_and_no_other_number(
+    length: int, *, check_validity: bool
+) -> None:
+    """A BIP340 signature is sixty-four octets, and the length says so.
+
+    Sixty-three of them used to parse into a signature of their own -- an
+    s read out of thirty-one bytes is below the order, so it is a valid
+    scalar -- and sixty-five into the signature of the first sixty-four,
+    the last byte read as part of nothing. Both are one object with two
+    encodings, and the second is the shape a taproot witness signature
+    arrives in.
+    """
+    sig_bin = ssa.sign(b"parse contract", 1).serialize()
+    assert len(sig_bin) == 64
+
+    truncated_or_extended = (sig_bin + sig_bin)[:length]
+    err_msg = f"invalid decoded length: {min(length, 64)} instead of 64"
+    if length > 64:
+        err_msg = f"{length - 64} bytes after the BIP340 signature"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        ssa.Sig.parse(truncated_or_extended, check_validity=check_validity)
+
+
+def test_the_sighash_type_of_a_witness_signature_is_the_callers() -> None:
+    """BIP341's 65-byte witness signature is not a BIP340 signature.
+
+    The 65th octet is the sighash type, a fact about the transaction
+    rather than part of the signature, and it used to reach `verify` as
+    part of one: True came back with the byte still attached, the first
+    sixty-four read and the rest dropped. Stripping it is the caller's,
+    which is what btclib's own script engine does with `signature[:64]`
+    once `get_hashtype` has read it.
+    """
+    prv_key, pub_key = ssa.gen_keys(1)
+    msg = b"witness signature"
+    sig_bin = ssa.sign(msg, prv_key).serialize()
+
+    # an encoding that is not a signature is False, as any other invalid
+    # one is, and assert_as_valid is where the reason comes out
+    assert not ssa.verify(msg, pub_key, sig_bin + b"\x01")
+    with pytest.raises(BTClibValueError, match="1 bytes after the BIP340 signature"):
+        ssa.assert_as_valid(msg, pub_key, sig_bin + b"\x01")
+
+    assert ssa.verify(msg, pub_key, (sig_bin + b"\x01")[:64])
+    assert ssa.verify(msg, pub_key, sig_bin)
+
+
 def test_point_from_bip340pub_key() -> None:
     """Verify every accepted pub_key representation yields the point."""
     q, x_Q = ssa.gen_keys()

--- a/tests/parse_contract_test.py
+++ b/tests/parse_contract_test.py
@@ -28,6 +28,7 @@ import pytest
 
 from btclib.bip32 import BIP32KeyData
 from btclib.block import Block, BlockHeader
+from btclib.ecc import bms, ssa
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
@@ -69,6 +70,8 @@ _CASES: list[tuple[str, Callable[..., Any], bytes]] = [
     ("block_header", BlockHeader.parse, _block_1()[:80]),
     ("block", Block.parse, _block_1()),
     ("bip32_key", BIP32KeyData.parse, BIP32KeyData.b58decode(_XPRV).serialize()),
+    ("ssa_sig", ssa.Sig.parse, ssa.sign(b"parse contract", 1).serialize()),
+    ("bms_sig", bms.Sig.parse, bms.sign(b"parse contract", 1).serialize()),
 ]
 
 _IDS = [case[0] for case in _CASES]


### PR DESCRIPTION
Closes #323. **Stacked on #341** — review that one first; this branch
targets it, so the diff here is the second commit alone.

`ssa.Sig.parse` read `r` and `s` with two 32-byte reads and checked
nothing:

- 63 octets parsed into a signature of their own, an `s` read out of 31
  bytes being below the order and so a valid scalar;
- 65 octets parsed into the signature of the first 64;
- `Sig.parse(b"", check_validity=False)` answered the `Sig` of `(0, 0)` —
  a signature out of no bytes at all.

The length is now checked as `bms.Sig.parse` checks its own, whatever
`check_validity` says, and `bms.Sig.parse` gains the trailing-octets half
of the rule from #341. `dsa.Sig.parse` keeps its `strict` flag and now
says why it is the exception: that flag is Core's
`IsValidSignatureEncoding`, called for DERSIG, STRICTENC and LOW_S and
not otherwise (issue #129).

**The 65-octet shape this refuses is what a taproot witness carries**, so
`ssa.verify` answers False where it answered True and
`ssa.assert_as_valid` raises. The internal call sites were never at risk —
`verify_key_path` and `op_checksig` pass `signature[:64]`, `get_hashtype`
having read the byte already — but a caller verifying a witness signature
by hand is, so HISTORY.md carries a bullet naming the remedy.

Tests: lengths 0, 1, 31, 32, 33, 63, 65 and 68 under both values of
`check_validity`; the witness-signature case end to end; and both
signature encodings join `tests/parse_contract_test.py`.

Gates, all three green locally: `pre-commit run --all-files`, `pytest`,
and the `-W` sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce strict 64-byte length and no trailing data for BIP340 and related signatures, and document and test the updated parsing and witness verification behaviour.

Bug Fixes:
- Reject truncated, extended, or empty BIP340 signatures in ssa.Sig.parse, including 65-byte taproot witness encodings with an in-band sighash byte.
- Ensure BMS signatures reject trailing bytes instead of silently dropping them, preventing multiple encodings of the same signature.

Enhancements:
- Clarify that DSA signature parsing is the only parser allowed to relax no-trailing-bytes rules and document its relationship to Core's IsValidSignatureEncoding.
- Extend the generic parse contract tests to cover ssa and bms signature parsing contracts for valid encodings.

Documentation:
- Describe the new BIP340/BIP341 signature length and trailing-byte rules in CHANGELOG and HISTORY, including the new behaviour of ssa.verify on taproot witness signatures.

Tests:
- Add parametrized tests ensuring BIP340 signature parsing only accepts exactly 64 bytes and rejects all other lengths, regardless of validity checks.
- Add tests confirming 65-byte taproot witness signatures must be stripped before verification and that assert_as_valid raises for overlong inputs.
- Add tests verifying BMS signature parsing rejects trailing bytes and include ssa/bms signature parsers in the shared parse contract suite.