### PR TITLE
A response body weighs what the answer weighs, and no more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -252,8 +252,13 @@ edit.
   bytes it has already read, so what `http_request` promises for one is
   that an oversized answer goes no further. `AuthProxy.call` takes
   `max_body_size` too, for the caller invoking `getblock` on a large
-  block. A total request deadline is a different mechanism and is
-  deliberately not here
+  block. The body of an `HTTPError` is closed after that bounded read, a
+  response left with octets in it being a `ResourceWarning` out of a
+  deallocator later, and the limit itself is refused when it is no size: a
+  float would otherwise reach `read` and leave through a bare `TypeError`,
+  a negative one would report every body as too large, and zero is a limit
+  like any other -- it says that only an empty body is an answer. A total
+  request deadline is a different mechanism and is deliberately not here
 
 ### Consensus rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,34 @@ edit.
   `nlen` by `Curve`: it is a count and not a limit, a scalar above it
   being multiplied in the digits it needs
 
+- **a response body is bounded, and the bound is what the answer is**
+  (issue #324). `urlopen_transport` read every response with a bare
+  `response.read()`, and `EsploraFetcher`'s endpoint is allowed to be a
+  public explorer — a host on the internet that says it validated the
+  chain — so a malicious or misconfigured one decided how much memory this
+  process spent before any parser of btclib's could refuse the answer. The
+  socket timeout is no substitute: a peer delivering slowly but steadily
+  resets it with every packet. The read is incremental now and stops at
+  `max_body_size + 1`, which is the octet that tells a body at the limit
+  from one over it; `Content-Length` refuses an over-announced response
+  before a byte of it is read, and is never believed, the header being the
+  sender's claim about the sender. `DEFAULT_MAX_BODY_SIZE` is twice Core's
+  4,000,000-byte buffer bound on a serialized block plus room for a
+  proxy's newline, a raw transaction in hex being the widest answer a
+  fetcher asks for, and the narrow answers carry their own: 64 octets for
+  a tip height, 128 for a tip hash, 1024 for a JSON-RPC reply that is a
+  number or a hash. The body of a *failure* is bounded separately, by
+  `MAX_ERROR_BODY_SIZE` and by truncation rather than refusal — an
+  explorer explaining a 404 in a paragraph of html is worth reading even
+  when what was asked for was a height. `HttpTransport` is unchanged, two
+  positional arguments as before, which is why the limit is a keyword on
+  `urlopen_transport` alone: a transport of a caller's own hands over
+  bytes it has already read, so what `http_request` promises for one is
+  that an oversized answer goes no further. `AuthProxy.call` takes
+  `max_body_size` too, for the caller invoking `getblock` on a large
+  block. A total request deadline is a different mechanism and is
+  deliberately not here
+
 ### Consensus rules
 
 - **a block has a maximum size, and `Block.weight` is now the block's.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,7 +257,10 @@ edit.
   deallocator later, and the limit itself is refused when it is no size: a
   float would otherwise reach `read` and leave through a bare `TypeError`,
   a negative one would report every body as too large, and zero is a limit
-  like any other -- it says that only an empty body is an answer. A total
+  like any other -- it says that only an empty body is an answer. The check
+  is `is_integer`, the predicate of issue #326, so a bool is refused here
+  for the reason it is refused everywhere else rather than by a second
+  spelling of the rule. A total
   request deadline is a different mechanism and is deliberately not here
 
 ### Consensus rules

--- a/btclib/fetch/bitcoind.py
+++ b/btclib/fetch/bitcoind.py
@@ -46,6 +46,7 @@ from btclib.alias import Octets
 from btclib.exceptions import BTClibValueError, FetchError, RpcError
 from btclib.fetch.fetcher import Fetcher, fetch_errors, tx_from_raw, tx_id_hex
 from btclib.fetch.transport import (
+    DEFAULT_MAX_BODY_SIZE,
     DEFAULT_TIMEOUT,
     HttpTransport,
     http_request,
@@ -92,6 +93,12 @@ DEFAULT_DATADIR = Path.home() / ".bitcoin"
 # matched. Checking it back is worth the line anyway -- it is what
 # catches a caching proxy answering one call with another's reply
 _RPC_ID = "btclib"
+
+# what a reply that is a number or a hash may weigh: the json envelope
+# around `result`, `error` and `id`, and a value of a few dozen octets.
+# `getrawtransaction` is the one answer here that is not small, and it
+# keeps the default of `call`
+_MAX_SMALL_REPLY = 1024
 
 
 def cookie_auth(cookie_path: Path) -> str:
@@ -168,12 +175,20 @@ class AuthProxy:
             credential = f"{self.user}:{self._password}"
         return "Basic " + b64encode(credential.encode()).decode("ascii")
 
-    def call(self, method: str, *params: Any) -> Any:
+    def call(
+        self, method: str, *params: Any, max_body_size: int = DEFAULT_MAX_BODY_SIZE
+    ) -> Any:
         """Invoke one rpc method, returning its `result`.
 
         Any method, not only the three the fetcher needs: a caller with a
         node has every reason to ask it something else, and refusing that
         would only mean they write this class again.
+
+        `max_body_size` is what the reply may weigh, and it defaults to the
+        widest answer a fetcher asks for -- a raw transaction, as hex
+        inside a json envelope. A caller invoking something whose reply is
+        a number tightens it; one invoking `getblock` on a large block
+        widens it, this being their node and their memory.
         """
         body = json.dumps(
             {"jsonrpc": "2.0", "id": _RPC_ID, "method": method, "params": list(params)}
@@ -186,6 +201,7 @@ class AuthProxy:
                 "Authorization": self.auth_header(),
             },
             timeout=self.timeout,
+            max_body_size=max_body_size,
             transport=self.transport,
         )
         return self._result(method, status, payload)
@@ -268,9 +284,10 @@ class BitcoindFetcher(Fetcher):
     def get_block_count(self) -> int:
         """Return the height of the node's best chain tip."""
         with fetch_errors("getblockcount"):
-            return int(self.proxy.call("getblockcount"))
+            return int(self.proxy.call("getblockcount", max_body_size=_MAX_SMALL_REPLY))
 
     def get_best_block_id(self) -> bytes:
         """Return the hash of the node's best chain tip, display order."""
         with fetch_errors("getbestblockhash"):
-            return bytes_from_octets(self.proxy.call("getbestblockhash"), 32)
+            reply = self.proxy.call("getbestblockhash", max_body_size=_MAX_SMALL_REPLY)
+            return bytes_from_octets(reply, 32)

--- a/btclib/fetch/esplora.py
+++ b/btclib/fetch/esplora.py
@@ -41,6 +41,7 @@ from btclib.alias import Octets
 from btclib.exceptions import FetchError
 from btclib.fetch.fetcher import Fetcher, fetch_errors, tx_from_raw, tx_id_hex
 from btclib.fetch.transport import (
+    DEFAULT_MAX_BODY_SIZE,
     DEFAULT_TIMEOUT,
     HttpTransport,
     http_request,
@@ -58,6 +59,23 @@ BLOCKSTREAM_INFO = {
     "testnet": "https://blockstream.info/testnet/api",
     "signet": "https://blockstream.info/signet/api",
 }
+
+
+# What each answer may weigh, because each of the three is bounded by
+# what it is: a height is a decimal number, a tip hash is sixty-four hex
+# digits, and a raw transaction is hex of a transaction that fits in a
+# block -- DEFAULT_MAX_BODY_SIZE, which is that bound. The two small ones
+# leave room for the whitespace a deployment behind a proxy adds and for
+# nothing else: a host answering a height with a megabyte is answering
+# something that is not a height, and there is no reason to hold it in
+# order to find that out.
+#
+# The body of a *failure* is not bounded by these -- see
+# `MAX_ERROR_BODY_SIZE` -- so a 404 whose error page is longer than a
+# height still arrives as the diagnosis it is
+_MAX_HEIGHT_BODY = 64
+_MAX_HASH_BODY = 128
+_MAX_TX_BODY = DEFAULT_MAX_BODY_SIZE
 
 
 class EsploraFetcher(Fetcher):
@@ -80,7 +98,7 @@ class EsploraFetcher(Fetcher):
         self.timeout = timeout
         self.transport = transport
 
-    def text(self, path: str) -> str:
+    def text(self, path: str, max_body_size: int = DEFAULT_MAX_BODY_SIZE) -> str:
         """Return the body of a GET on `path`, as stripped text.
 
         Stripped because a deployment behind a proxy may add a newline
@@ -88,10 +106,17 @@ class EsploraFetcher(Fetcher):
         with `replace` rather than strictly: the body of a failure is an
         error page from whatever is in the way, and it is more use
         rendered imperfectly than swallowed by a UnicodeDecodeError.
+
+        `max_body_size` is what this particular answer may weigh; the
+        default is the widest of the three, so a caller asking for
+        something narrow says so.
         """
         url = f"{self.base_url}{path}"
         status, payload = http_request(
-            url, timeout=self.timeout, transport=self.transport
+            url,
+            timeout=self.timeout,
+            max_body_size=max_body_size,
+            transport=self.transport,
         )
         text = payload.decode("utf-8", errors="replace").strip()
         if status != 200:
@@ -101,14 +126,15 @@ class EsploraFetcher(Fetcher):
     def get_tx(self, tx_id: Octets) -> Tx:
         """Return the transaction, parsed and checked against its txid."""
         hex_ = tx_id_hex(tx_id)
-        return tx_from_raw(self.text(f"/tx/{hex_}/hex"), hex_, self.network)
+        raw = self.text(f"/tx/{hex_}/hex", _MAX_TX_BODY)
+        return tx_from_raw(raw, hex_, self.network)
 
     def get_block_count(self) -> int:
         """Return the height of the server's best chain tip."""
         with fetch_errors("blocks/tip/height"):
-            return int(self.text("/blocks/tip/height"))
+            return int(self.text("/blocks/tip/height", _MAX_HEIGHT_BODY))
 
     def get_best_block_id(self) -> bytes:
         """Return the hash of the server's best chain tip, display order."""
         with fetch_errors("blocks/tip/hash"):
-            return bytes_from_octets(self.text("/blocks/tip/hash"), 32)
+            return bytes_from_octets(self.text("/blocks/tip/hash", _MAX_HASH_BODY), 32)

--- a/btclib/fetch/transport.py
+++ b/btclib/fetch/transport.py
@@ -38,6 +38,7 @@ from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError, FetchError
+from btclib.utils import is_integer
 
 # What a fetcher does its I/O with: a callable taking the request and a
 # timeout in seconds, answering with the HTTP status and the response
@@ -101,8 +102,13 @@ def _assert_valid_max_body_size(max_body_size: int) -> None:
     exception contract; a negative limit makes the bounded read ask for
     nothing and then report every body as too large. Zero is a size and is
     left alone: it says that only an empty body is an answer.
+
+    `is_integer` and not a second spelling of it, so a bool is refused here
+    for the reason it is refused everywhere else: `max_body_size=True`
+    would be a limit of one octet, and `true` is what a json configuration
+    decodes to.
     """
-    if not isinstance(max_body_size, int):
+    if not is_integer(max_body_size):
         err_msg = f"non-integer max_body_size: {max_body_size}"
         raise BTClibTypeError(err_msg)
     if max_body_size < 0:

--- a/btclib/fetch/transport.py
+++ b/btclib/fetch/transport.py
@@ -37,7 +37,7 @@ from urllib.error import HTTPError
 from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
 
-from btclib.exceptions import BTClibValueError, FetchError
+from btclib.exceptions import BTClibTypeError, BTClibValueError, FetchError
 
 # What a fetcher does its I/O with: a callable taking the request and a
 # timeout in seconds, answering with the HTTP status and the response
@@ -93,6 +93,22 @@ MAX_ERROR_BODY_SIZE = 64 * 1024
 _SCHEMES = ("http", "https")
 
 
+def _assert_valid_max_body_size(max_body_size: int) -> None:
+    """Refuse a limit that is no size, before it is read as one.
+
+    A float reaches `read` and leaves through a bare `TypeError` about the
+    argument of a read, from underneath the library rather than through its
+    exception contract; a negative limit makes the bounded read ask for
+    nothing and then report every body as too large. Zero is a size and is
+    left alone: it says that only an empty body is an answer.
+    """
+    if not isinstance(max_body_size, int):
+        err_msg = f"non-integer max_body_size: {max_body_size}"
+        raise BTClibTypeError(err_msg)
+    if max_body_size < 0:
+        raise BTClibValueError(f"negative max_body_size: {max_body_size}")
+
+
 def _read_bounded(response: Any, max_body_size: int, where: str) -> bytes:
     """Return the body, having never held more than the limit of it.
 
@@ -108,6 +124,8 @@ def _read_bounded(response: Any, max_body_size: int, where: str) -> bytes:
     chunked response, so this loops until the limit is filled or the peer
     is done.
     """
+    _assert_valid_max_body_size(max_body_size)
+
     announced = response.headers.get("Content-Length")
     if announced is not None:
         # a header, so it can be anything: a value that is not a number
@@ -190,6 +208,8 @@ def http_request(
     octet over a caller's limit for a *height* is still the diagnosis of
     why there is no height.
     """
+    _assert_valid_max_body_size(max_body_size)
+
     scheme = urlsplit(url).scheme
     if scheme not in _SCHEMES:
         raise BTClibValueError(f"invalid url scheme: '{scheme}' instead of http(s)")
@@ -219,7 +239,17 @@ def http_request(
         # diagnosis the backend offered into a bare number -- bounded,
         # because an error page is written by whatever is in the way and
         # is not a size this library agreed to
-        return e.code, e.read(MAX_ERROR_BODY_SIZE)
+        try:
+            return e.code, e.read(MAX_ERROR_BODY_SIZE)
+        finally:
+            # an HTTPError is a response, and a bounded read leaves it with
+            # octets still in it: releasing the connection is nobody
+            # else's, and an unclosed one is a ResourceWarning out of a
+            # deallocator at whatever later moment the collector picks --
+            # which under `filterwarnings = ["error"]` fails an unrelated
+            # test. The `with` in `urlopen_transport` does this for the
+            # responses that are not errors
+            e.close()
     except OSError as e:
         # URLError and TimeoutError both derive from it, which is every
         # way urllib reports that the exchange did not happen

--- a/btclib/fetch/transport.py
+++ b/btclib/fetch/transport.py
@@ -31,6 +31,8 @@ no socket at all.
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
+from contextlib import suppress
+from typing import Any
 from urllib.error import HTTPError
 from urllib.parse import urlsplit
 from urllib.request import Request, urlopen
@@ -52,6 +54,37 @@ HttpTransport = Callable[[Request, float], tuple[int, bytes]]
 # is not a timeout
 DEFAULT_TIMEOUT = 30.0
 
+# How much of a response body btclib will hold in memory, and why there
+# is a number at all: `EsploraFetcher`'s endpoint is allowed to be a
+# public explorer -- a host on the internet that says it validated the
+# chain -- and `response.read()` with nothing in front of it lets that
+# host hand over as much as it likes before any parser of btclib's gets to
+# refuse it. The socket timeout is no substitute: a peer delivering data
+# slowly but steadily resets it with every packet.
+#
+# Eight megabytes and a little. The largest of the three answers a fetcher
+# asks for is a raw transaction, a transaction fits in a block, and Esplora
+# sends it as hex, so the bound is twice Core's 4,000,000-byte buffer bound
+# on a serialized block, plus room for the newline a proxy may add.
+# btclib/block/limits.py leaves that constant out on purpose, consensus
+# capping the weight rather than the size -- here a buffer bound is
+# precisely what is wanted, so it is spelled out rather than imported.
+# A caller fetching something larger through `http_request` says so with
+# max_body_size
+_MAX_BLOCK_SERIALIZED_SIZE = 4_000_000
+DEFAULT_MAX_BODY_SIZE = 2 * _MAX_BLOCK_SERIALIZED_SIZE + 1024
+
+# where a status stops being an answer and becomes a diagnosis: urlopen
+# raises HTTPError from 400 up, so this is the same line drawn for a
+# transport of a caller's own that catches its own errors and returns them
+_CLIENT_ERROR = 400
+
+# what is kept of the body of a failure: enough to carry whatever the
+# backend said with its status, and not the megabytes an error page from
+# something in the way can be. Truncated rather than refused, a diagnostic
+# being worth more incomplete than absent
+MAX_ERROR_BODY_SIZE = 64 * 1024
+
 # http and https, and nothing else. `urlopen` also speaks `file:` and
 # `data:`, so a base url taken from configuration could make a fetcher
 # read the local disk and report the bytes as a transaction. Refusing the
@@ -60,18 +93,71 @@ DEFAULT_TIMEOUT = 30.0
 _SCHEMES = ("http", "https")
 
 
-def urlopen_transport(request: Request, timeout: float) -> tuple[int, bytes]:
-    """Perform the request with urllib, reading the whole response.
+def _read_bounded(response: Any, max_body_size: int, where: str) -> bytes:
+    """Return the body, having never held more than the limit of it.
+
+    `Content-Length` first, when the response carries one: a server
+    announcing more than the limit is refused before a byte of it is
+    read. It is not believed, though -- it is the sender's claim about
+    the sender -- so the read is bounded as well, and by one octet more
+    than the limit, which is what tells a body *at* the limit from one
+    over it.
+
+    The reads are incremental because the point is not to hold the body:
+    `read(limit + 1)` may answer with less than was asked for on a
+    chunked response, so this loops until the limit is filled or the peer
+    is done.
+    """
+    announced = response.headers.get("Content-Length")
+    if announced is not None:
+        # a header, so it can be anything: a value that is not a number
+        # says nothing about the size and is left to the bounded read
+        with suppress(ValueError):
+            if int(announced) > max_body_size:
+                err_msg = f"{where}: announced {int(announced)} bytes,"
+                err_msg += f" more than the {max_body_size} allowed"
+                raise FetchError(err_msg)
+
+    chunks = []
+    remaining = max_body_size + 1
+    while remaining > 0:
+        chunk = response.read(remaining)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    body = b"".join(chunks)
+
+    if len(body) > max_body_size:
+        raise FetchError(f"{where}: response larger than {max_body_size} bytes")
+    return body
+
+
+def urlopen_transport(
+    request: Request,
+    timeout: float,
+    *,
+    max_body_size: int = DEFAULT_MAX_BODY_SIZE,
+) -> tuple[int, bytes]:
+    """Perform the request with urllib, reading a bounded response.
 
     The default `HttpTransport`, and the only function in btclib that
     opens a socket. It maps nothing and interprets nothing: the status
     and the bytes go back as they arrived, and `http_request` is where
     the failures become btclib errors.
+
+    Bounded, and this is the only place a bound can be incremental: the
+    limit is a keyword with a default, so this function still *is* an
+    `HttpTransport` and a caller's own transport still satisfies that
+    type. What a transport of someone else's returns is bytes it has
+    already read, so all `http_request` can do for those is refuse to pass
+    an oversized body on -- see its `max_body_size`.
     """
     # what reaches urlopen is http or https: `http_request` is the only
     # thing that builds a Request, and it checks the scheme first
     with urlopen(request, timeout=timeout) as response:  # noqa: S310
-        return response.status, response.read()
+        body = _read_bounded(response, max_body_size, request.full_url)
+        return response.status, body
 
 
 def http_request(
@@ -80,6 +166,7 @@ def http_request(
     data: bytes | None = None,
     headers: Mapping[str, str] | None = None,
     timeout: float = DEFAULT_TIMEOUT,
+    max_body_size: int = DEFAULT_MAX_BODY_SIZE,
     transport: HttpTransport = urlopen_transport,
 ) -> tuple[int, bytes]:
     """Return the status and body of a GET, or of a POST when data is given.
@@ -94,6 +181,14 @@ def http_request(
     reply puts its error object, and the body of a 404 is where an
     explorer says what it could not find. Deciding what a status means is
     the backend's job, that being the layer that knows.
+
+    `max_body_size` is what an *answer* may weigh, and the caller sets it
+    from what it asked for: a tip height is a few octets and a raw
+    transaction is megabytes, so one number for both would be the larger.
+    The body of a failure is bounded separately, by `MAX_ERROR_BODY_SIZE`
+    and by truncation rather than refusal -- an error page arriving one
+    octet over a caller's limit for a *height* is still the diagnosis of
+    why there is no height.
     """
     scheme = urlsplit(url).scheme
     if scheme not in _SCHEMES:
@@ -105,14 +200,45 @@ def http_request(
         url, data=data, headers=dict(headers or {}), method="POST" if data else "GET"
     )
     try:
-        return transport(request, timeout)
+        # the limit reaches the read itself for the transport of this
+        # module, which is the only one it can: `HttpTransport` is two
+        # positional arguments, so a caller's transport has nowhere to be
+        # told a limit and nothing to do with one it does not know about.
+        # Identity and not a subclass check because there is one such
+        # function, and the fetchers pass it explicitly
+        if transport is urlopen_transport:
+            status, body = urlopen_transport(
+                request, timeout, max_body_size=max_body_size
+            )
+        else:
+            status, body = transport(request, timeout)
     except HTTPError as e:
         # a subclass of URLError, so it has to be caught before the OSError
         # below. It is also a response: `read` gives the body the server
         # sent with the status, and discarding it would turn whatever
-        # diagnosis the backend offered into a bare number
-        return e.code, e.read()
+        # diagnosis the backend offered into a bare number -- bounded,
+        # because an error page is written by whatever is in the way and
+        # is not a size this library agreed to
+        return e.code, e.read(MAX_ERROR_BODY_SIZE)
     except OSError as e:
         # URLError and TimeoutError both derive from it, which is every
         # way urllib reports that the exchange did not happen
         raise FetchError(f"no answer from {url}: {e}") from e
+
+    # a failure, whether it arrived as an exception above or as a status
+    # from a transport that catches its own: the body is a diagnostic and
+    # not the answer, so it is bounded by truncation rather than held to
+    # the caller's limit for the answer. An explorer explaining a 404 in a
+    # paragraph of html is worth reading even when what was asked for was
+    # a tip height, sixty-four octets wide
+    if status >= _CLIENT_ERROR:
+        return status, body[:MAX_ERROR_BODY_SIZE]
+
+    # the transport of this module has already stopped reading at the
+    # limit; a caller's own has not, and cannot be made to, so this is
+    # what is left to promise for one: an oversized answer goes no further
+    if len(body) > max_body_size:
+        err_msg = f"{url}: response of {len(body)} bytes,"
+        err_msg += f" more than the {max_body_size} allowed"
+        raise FetchError(err_msg)
+    return status, body

--- a/tests/fetch/bitcoind_test.py
+++ b/tests/fetch/bitcoind_test.py
@@ -33,6 +33,7 @@ from btclib.fetch.bitcoind import (
     BitcoindFetcher,
     cookie_auth,
 )
+from btclib.fetch.transport import DEFAULT_MAX_BODY_SIZE
 from btclib.tx import OutPoint
 from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
 
@@ -374,3 +375,28 @@ def test_a_raw_transaction_that_is_not_one(result: object) -> None:
     body = json.dumps({"jsonrpc": "2.0", "result": result, "id": "btclib"}).encode()
     with pytest.raises(FetchError, match=f"transaction {TX_ID}:"):
         fetcher((200, body)).get_tx(TX_ID)
+
+
+def test_a_small_reply_carries_a_small_limit() -> None:
+    """A height and a tip hash are bounded by what they are.
+
+    `call` defaults to the widest answer a fetcher asks for, a raw
+    transaction as hex inside a json envelope, because it is public and
+    takes any method -- `getblock` on a large block is a legitimate call.
+    The two answers that are a number and a hash say so instead.
+    """
+    oversized = b'{"result":' + b"9" * 1100 + b',"error":null,"id":"btclib"}'
+    with pytest.raises(FetchError, match="more than the 1024 allowed"):
+        fetcher((200, oversized)).get_block_count()
+
+    # the recorded answers are well inside it, which is the other half of
+    # the claim
+    assert fetcher((200, recorded_body("getblockcount.json"))).get_block_count() == (
+        TIP_HEIGHT
+    )
+
+    # and `call` itself keeps the wide default, being public and taking
+    # any method: `getblock` on a large block is a legitimate call
+    defaults = AuthProxy.call.__kwdefaults__
+    assert defaults is not None
+    assert defaults["max_body_size"] == DEFAULT_MAX_BODY_SIZE

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -154,3 +154,38 @@ def test_a_tip_hash_that_is_not_one(body: bytes) -> None:
 def test_whitespace_around_an_answer_is_not_part_of_it() -> None:
     """A deployment behind a proxy that adds a newline is still readable."""
     assert fetcher((200, b"  481824\n")).get_block_count() == TIP_HEIGHT
+
+
+def test_each_answer_is_bounded_by_what_it_is() -> None:
+    """A height is not megabytes, and the limit says so per endpoint.
+
+    One limit for all three would have to be the widest of them -- a raw
+    transaction in hex -- so a host answering `blocks/tip/height` with a
+    transaction's worth of digits would be held in memory and only then
+    refused by `int`. The narrow answers carry narrow limits, with room
+    for the newline a proxy adds and for nothing else.
+    """
+    height = fetcher((200, b"9" * 65))
+    with pytest.raises(FetchError, match="response of 65 bytes, more than the 64"):
+        height.get_block_count()
+
+    tip = fetcher((200, b"a" * 129))
+    with pytest.raises(FetchError, match="response of 129 bytes, more than the 128"):
+        tip.get_best_block_id()
+
+    # and the recorded answers are inside their limits, which is the other
+    # half of the claim
+    assert fetcher((200, b"481824\n")).get_block_count() == TIP_HEIGHT
+    assert fetcher((200, TIP_ID.encode() + b"\n")).get_best_block_id().hex() == TIP_ID
+
+
+def test_the_body_of_a_failure_is_not_held_to_the_answer_limit() -> None:
+    """A 404 page is longer than a height, and is still the diagnosis.
+
+    The bound on an error body is `MAX_ERROR_BODY_SIZE` and truncation,
+    not the caller's limit for the answer that did not arrive: an explorer
+    saying "Block not found" in a paragraph of html is worth reading.
+    """
+    page = b"<html><body>Block not found, and here is why: " + b"x" * 200 + b"</body>"
+    with pytest.raises(FetchError, match="HTTP 404"):
+        fetcher((404, page)).get_block_count()

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -22,7 +22,9 @@ import pytest
 from btclib.exceptions import BTClibValueError, FetchError
 from btclib.fetch import transport as transport_module
 from btclib.fetch.transport import (
+    DEFAULT_MAX_BODY_SIZE,
     DEFAULT_TIMEOUT,
+    MAX_ERROR_BODY_SIZE,
     http_request,
     urlopen_transport,
 )
@@ -32,12 +34,31 @@ URL = "http://127.0.0.1:8332"
 
 
 class FakeResponse:
-    """What the real urlopen answers with, reduced to what is read of it."""
+    """What the real urlopen answers with, reduced to what is read of it.
 
-    def __init__(self, status: int, body: bytes) -> None:
+    `content_length` is what the response *claims*, which is a header and
+    so is the sender's claim about the sender: a test sets it apart from
+    the body on purpose. `chunk_size` caps every read, which is what a
+    chunked response does and what the bounded read has to loop over.
+    """
+
+    def __init__(
+        self,
+        status: int,
+        body: bytes,
+        *,
+        content_length: str | None = None,
+        chunk_size: int | None = None,
+    ) -> None:
         self.status = status
         self._body = body
         self.closed = False
+        self._offset = 0
+        self._chunk_size = chunk_size
+        self.reads: list[int | None] = []
+        self.headers: dict[str, str] = (
+            {} if content_length is None else {"Content-Length": content_length}
+        )
 
     def __enter__(self) -> FakeResponse:
         return self
@@ -50,9 +71,19 @@ class FakeResponse:
     ) -> None:
         self.closed = True
 
-    def read(self) -> bytes:
-        """Return the recorded body."""
-        return self._body
+    def read(self, amt: int | None = None) -> bytes:
+        """Return up to amt octets of the recorded body, as a socket would.
+
+        Every read is remembered, which is how a test checks that a
+        caller's limit reached the read rather than the check after it.
+        """
+        self.reads.append(amt)
+        size = len(self._body) - self._offset if amt is None else amt
+        if self._chunk_size is not None:
+            size = min(size, self._chunk_size)
+        chunk = self._body[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        return chunk
 
 
 def test_urlopen_transport_reads_status_and_body(
@@ -98,7 +129,8 @@ def http_error(status: int, body: bytes = b"") -> Iterator[HTTPError]:
     # HTTPError is a response as well as an exception, and this is what
     # the server sent with the status
     def read(n: int = -1) -> bytes:
-        return body
+        # as the real one does: -1 is the whole of it, a size is a size
+        return body if n < 0 else body[:n]
 
     error.read = read  # type: ignore[method-assign]
     try:
@@ -120,6 +152,160 @@ def test_urlopen_transport_does_not_swallow_an_http_error(
 
         with pytest.raises(HTTPError):
             urlopen_transport(Request(URL, method="GET"), DEFAULT_TIMEOUT)
+
+
+def test_the_body_of_a_response_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The bound is the point of the transport, not a courtesy of the peer.
+
+    An explorer is a host on the internet, and an unbounded `read()` lets
+    it decide how much memory this process spends before any parser gets
+    to refuse the answer. One octet over the limit is what tells a body at
+    the limit from one past it.
+    """
+    limit = 32
+
+    def serve(body: bytes) -> FakeResponse:
+        response = FakeResponse(200, body)
+
+        def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
+            return response
+
+        monkeypatch.setattr(transport_module, "urlopen", fake_urlopen)
+        return response
+
+    serve(b"a" * limit)
+    request = Request(URL, method="GET")
+    assert urlopen_transport(request, DEFAULT_TIMEOUT, max_body_size=limit) == (
+        200,
+        b"a" * limit,
+    )
+
+    serve(b"a" * (limit + 1))
+    with pytest.raises(FetchError, match=f"response larger than {limit} bytes"):
+        urlopen_transport(request, DEFAULT_TIMEOUT, max_body_size=limit)
+
+
+def test_a_chunked_body_is_read_to_the_limit_and_no_further(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """read(n) may answer with less than n, so the bounded read loops.
+
+    A single `read(limit + 1)` would take a chunked response for a short
+    one and hand back a truncated body as if the peer were done with it.
+    """
+    limit = 100
+    body = b"z" * limit
+    response = FakeResponse(200, body, chunk_size=7)
+
+    def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
+        return response
+
+    monkeypatch.setattr(transport_module, "urlopen", fake_urlopen)
+
+    request = Request(URL, method="GET")
+    assert urlopen_transport(request, DEFAULT_TIMEOUT, max_body_size=limit) == (
+        200,
+        body,
+    )
+
+
+def test_an_announced_size_over_the_limit_is_refused_before_reading(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Content-Length fails the request early, and is never believed.
+
+    Early because a server that says it is about to send a gigabyte can be
+    refused without reading one, and never believed because the header is
+    the sender's claim about the sender: the third case below announces a
+    single octet and sends more, and the bounded read is what catches it.
+    """
+    limit = 16
+    request = Request(URL, method="GET")
+
+    def serve(response: FakeResponse) -> None:
+        def fake_urlopen(req: Request, timeout: float) -> FakeResponse:
+            return response
+
+        monkeypatch.setattr(transport_module, "urlopen", fake_urlopen)
+
+    serve(FakeResponse(200, b"a" * 4, content_length=str(limit + 1)))
+    with pytest.raises(FetchError, match=f"announced {limit + 1} bytes"):
+        urlopen_transport(request, DEFAULT_TIMEOUT, max_body_size=limit)
+
+    # not a number: no claim about the size, so the read decides
+    serve(FakeResponse(200, b"a" * 4, content_length="banana"))
+    assert urlopen_transport(request, DEFAULT_TIMEOUT, max_body_size=limit) == (
+        200,
+        b"a" * 4,
+    )
+
+    serve(FakeResponse(200, b"a" * (limit + 1), content_length="1"))
+    with pytest.raises(FetchError, match=f"response larger than {limit} bytes"):
+        urlopen_transport(request, DEFAULT_TIMEOUT, max_body_size=limit)
+
+
+def test_an_oversized_body_from_a_caller_transport_goes_no_further() -> None:
+    """What is left to promise for a transport this module did not write.
+
+    A caller's transport hands over bytes it has already read, so nothing
+    here can keep it from having read them; refusing to pass the body on
+    is the whole of what remains, and it is what keeps a fetcher's own
+    limit meaningful whichever transport is underneath it.
+    """
+    transport = Recorded((200, b"a" * 40))
+    assert http_request(URL, max_body_size=40, transport=transport) == (200, b"a" * 40)
+
+    with pytest.raises(FetchError, match="response of 40 bytes, more than the 39"):
+        http_request(URL, max_body_size=39, transport=Recorded((200, b"a" * 40)))
+
+
+def test_the_limit_reaches_the_read_of_the_default_transport(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller's limit is incremental where it can be, i.e. here.
+
+    `HttpTransport` is two positional arguments, so a limit cannot be
+    handed to a transport this module did not write; the one it did write
+    takes it as a keyword, and `http_request` passes it -- otherwise a
+    request for a tip height would buffer megabytes before refusing them.
+    """
+    response = FakeResponse(200, b"a" * 100)
+
+    def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
+        return response
+
+    monkeypatch.setattr(transport_module, "urlopen", fake_urlopen)
+
+    with pytest.raises(FetchError, match="response larger than 64 bytes"):
+        http_request(URL, max_body_size=64)
+
+    # what the read asked for, and the whole of what it asked for: the
+    # limit and the one octet that tells a body at it from one over it
+    assert response.reads == [65]
+
+
+def test_the_body_of_a_failure_is_truncated_not_refused() -> None:
+    """An error page is bounded separately, and by truncation.
+
+    A backend's explanation of why there is no answer is worth having
+    even when it arrives longer than the answer would have been allowed to
+    be: a 404 page is not a 404-byte page. What it may not be is
+    unbounded, an error page being written by whatever is in the way.
+    """
+    with http_error(404, b"x" * (MAX_ERROR_BODY_SIZE + 10)) as error:
+        status, body = http_request(URL, max_body_size=64, transport=Recorded(error))
+    assert status == 404
+    assert len(body) == MAX_ERROR_BODY_SIZE
+
+
+def test_the_default_limit_is_a_transaction_in_hex() -> None:
+    """Twice Core's buffer bound on a block, plus room for a newline."""
+    assert DEFAULT_MAX_BODY_SIZE == 2 * 4_000_000 + 1024
+    defaults = http_request.__kwdefaults__
+    assert defaults is not None
+    assert defaults["max_body_size"] == DEFAULT_MAX_BODY_SIZE
 
 
 def test_the_default_transport_is_the_urllib_one() -> None:

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -325,13 +325,15 @@ def test_the_response_of_a_failure_is_closed() -> None:
         assert closed == [True]
 
 
-@pytest.mark.parametrize("max_body_size", [1.5, "64", None, 64.0])
+@pytest.mark.parametrize("max_body_size", [1.5, "64", None, 64.0, True, False])
 def test_a_limit_that_is_no_size_is_refused_as_such(max_body_size: object) -> None:
     """And refused before it is read as one.
 
     A float reaches `read` and leaves through a bare `TypeError` about the
     argument of a read: outside this library's exception contract, and out
-    of a function whose whole subject is what it refuses to read.
+    of a function whose whole subject is what it refuses to read. A bool
+    goes with it, through the `is_integer` of issue #326: `True` would be a
+    limit of one octet, and `true` is what a json configuration decodes to.
     """
     transport = Recorded((200, b"7"))
     with pytest.raises(BTClibTypeError, match="non-integer max_body_size"):

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -19,7 +19,7 @@ from urllib.request import Request
 
 import pytest
 
-from btclib.exceptions import BTClibValueError, FetchError
+from btclib.exceptions import BTClibTypeError, BTClibValueError, FetchError
 from btclib.fetch import transport as transport_module
 from btclib.fetch.transport import (
     DEFAULT_MAX_BODY_SIZE,
@@ -298,6 +298,58 @@ def test_the_body_of_a_failure_is_truncated_not_refused() -> None:
         status, body = http_request(URL, max_body_size=64, transport=Recorded(error))
     assert status == 404
     assert len(body) == MAX_ERROR_BODY_SIZE
+
+
+def test_the_response_of_a_failure_is_closed() -> None:
+    """A bounded read leaves octets in it, and nobody else will close it.
+
+    An HTTPError is a response as well as an exception, so releasing the
+    connection is this function's now that it stops reading early. Left
+    open, it is a ResourceWarning out of a deallocator at whatever later
+    moment the collector picks -- which under `filterwarnings = ["error"]`
+    fails whichever unrelated test is running then.
+    """
+    with http_error(500, b"x" * (MAX_ERROR_BODY_SIZE + 1)) as error:
+        closed: list[bool] = []
+        already = error.close
+
+        def close() -> None:
+            closed.append(True)
+            already()
+
+        error.close = close  # type: ignore[method-assign]
+        status, body = http_request(URL, transport=Recorded(error))
+
+        assert status == 500
+        assert len(body) == MAX_ERROR_BODY_SIZE
+        assert closed == [True]
+
+
+@pytest.mark.parametrize("max_body_size", [1.5, "64", None, 64.0])
+def test_a_limit_that_is_no_size_is_refused_as_such(max_body_size: object) -> None:
+    """And refused before it is read as one.
+
+    A float reaches `read` and leaves through a bare `TypeError` about the
+    argument of a read: outside this library's exception contract, and out
+    of a function whose whole subject is what it refuses to read.
+    """
+    transport = Recorded((200, b"7"))
+    with pytest.raises(BTClibTypeError, match="non-integer max_body_size"):
+        http_request(URL, max_body_size=max_body_size, transport=transport)  # type: ignore[arg-type]
+    assert transport.requests == []
+
+
+def test_a_negative_limit_is_no_limit_at_all() -> None:
+    """Where zero is a limit: only an empty body answers it."""
+    with pytest.raises(BTClibValueError, match="negative max_body_size: -1"):
+        http_request(URL, max_body_size=-1, transport=Recorded((200, b"")))
+
+    assert http_request(URL, max_body_size=0, transport=Recorded((200, b""))) == (
+        200,
+        b"",
+    )
+    with pytest.raises(FetchError, match="more than the 0 allowed"):
+        http_request(URL, max_body_size=0, transport=Recorded((200, b"7")))
 
 
 def test_the_default_limit_is_a_transaction_in_hex() -> None:


### PR DESCRIPTION
Closes #324. Independent of #341/#342 — no shared file.

The decision taken on the issue, implemented: `HttpTransport` keeps its
two positional arguments, the incremental bound lives in
`urlopen_transport` (the only place it can), and `http_request` carries
`max_body_size` for the answer it asked for.

- **incremental read**, stopping at `max_body_size + 1` — the octet that
  tells a body at the limit from one over it — and looping, since
  `read(n)` on a chunked response may answer with less than `n`;
- **`Content-Length` refuses early and is never believed**: an
  over-announced response costs no read, a lying one is caught by the
  bound;
- **one limit per answer**: 64 octets for a tip height, 128 for a tip
  hash, 1024 for a JSON-RPC reply that is a number or a hash,
  `DEFAULT_MAX_BODY_SIZE` (twice Core's 4,000,000-byte buffer bound on a
  serialized block, plus a proxy's newline) for a raw transaction in hex.
  `AuthProxy.call` keeps the wide default, being public and taking any
  method — `getblock` on a large block is a legitimate call;
- **the body of a failure is bounded separately**, by
  `MAX_ERROR_BODY_SIZE` and by truncation rather than refusal.

That last point is a correction the suite forced: a caller's transport
returns its own `(404, body)` where `urlopen` raises, so the answer limit
was refusing the diagnosis — an explorer explaining a 404 in a paragraph
of html is worth reading even when what was asked for was a height.

A caller's transport hands over bytes it has already read, so it cannot
be made to read incrementally; what `http_request` promises for one is
that an oversized answer goes no further. Stated in the docstrings.

The total request deadline is deliberately **not** here: different
mechanism, its own issue if wanted.

Tests: body at and over the limit, a chunked body read to the limit, an
over-announced and a lying `Content-Length`, a non-numeric one, the limit
reaching the read of the default transport (asserted on what the response
was asked for), truncation of an error body, and the per-endpoint limits
through both fetchers.

Gates, all three green locally: `pre-commit run --all-files`, `pytest`,
and the `-W` sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bound HTTP response bodies by request-specific size limits and enforce per-endpoint defaults for Esplora and bitcoind fetchers.

New Features:
- Introduce configurable maximum body size for HTTP responses with a library-wide default sized for raw transactions.
- Add per-endpoint body size limits for Esplora and bitcoind fetchers based on the expected shape of each answer.

Bug Fixes:
- Prevent unbounded memory usage from overly large or malicious HTTP responses by enforcing incremental, bounded reads.
- Ensure error responses are always delivered (truncated if necessary) instead of being rejected by normal answer size limits.

Enhancements:
- Treat Content-Length as an early refusal hint without trusting it for final size, and add stricter handling of oversized responses from custom transports.
- Extend tests and documentation to cover bounded reads, error body truncation, and the new per-endpoint limits for all HTTP-based fetchers.

Documentation:
- Document the new response body limits and behavior in the changelog, including default sizes and error-body handling semantics.