### PR TITLE
An amount validator raises what this library raises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -909,9 +909,12 @@ edit.
   too; an infinity does compare, and the range check refuses it. Beside
   it, `valid_sats_amount` let `int()`'s own refusals out unchanged — a
   bare `ValueError` for `"abc"` and `b"\x01"`, a bare `TypeError` for a
-  list — and each is now this library's counterpart of the builtin it was,
-  so a caller catching `ValueError` or `TypeError` catches exactly what it
-  caught before
+  list, and a bare `OverflowError` for an infinity, which is an
+  `ArithmeticError` and so was never caught by `except ValueError` either
+  — and each is now this library's counterpart of the builtin it was, so
+  what a caller catches does not shrink. A NaN leaves `int()` as a
+  `ValueError` where an infinity leaves it as an `OverflowError`; the
+  asymmetry is `int()`'s, and both answer `invalid satoshi amount` now
 
 ### Immutability and shared state
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -892,6 +892,26 @@ edit.
   is pinned to its own reason at last: the case whose value is not its
   stated size now answers `39 bytes after the transaction` rather than the
   `Missing inputs` that was true of it and not what was wrong with it
+- **an amount validator raises what this library raises** (issue #339).
+  `valid_btc_amount` converted with `Decimal(str(amount))` and let
+  `decimal.InvalidOperation` out: an `ArithmeticError`, which `except
+  BTClibValueError` does not catch and which nobody writes `except
+  ArithmeticError` around an amount. The argument is `Any` on purpose, so
+  the leak was reachable from ordinary input — `valid_btc_amount("abc")`
+  and `valid_btc_amount("1,2")`, the way half the world writes a decimal.
+  It answers `invalid BTC amount` now, as `FeeRate.from_sats_per_vbyte`
+  already did for a rate. Catching the constructor is not the whole fix:
+  `Decimal("nan")` is valid syntax and constructs without a word, and what
+  raised for it was the *ordering comparison* in the range check, so every
+  spelling of a NaN — `float("nan")`, `"nan"`, `"sNaN"`, `Decimal("NaN")`
+  — left through the very line meant to bound the amount. `is_finite()`
+  refuses those, which is what that method is there for in the fee rate
+  too; an infinity does compare, and the range check refuses it. Beside
+  it, `valid_sats_amount` let `int()`'s own refusals out unchanged — a
+  bare `ValueError` for `"abc"` and `b"\x01"`, a bare `TypeError` for a
+  list — and each is now this library's counterpart of the builtin it was,
+  so a caller catching `ValueError` or `TypeError` catches exactly what it
+  caught before
 
 ### Immutability and shared state
 

--- a/btclib/amount.py
+++ b/btclib/amount.py
@@ -107,14 +107,17 @@ def sats_from_btc(amount: Decimal) -> int:
 def valid_sats_amount(amount: Any, dust: int = 0) -> int:
     """Return the satoshi amount as int, if valid and not less than dust."""
     # any input that can be converted to int is fine -- and int() refuses
-    # what it cannot convert with a bare ValueError ("abc", b"\x01") or a
-    # bare TypeError (a list), neither of which says that btclib refused
-    # anything. Each is answered with this library's counterpart of the
-    # very builtin it was, so a caller catching ValueError or TypeError
-    # catches exactly what it caught before
+    # what it cannot convert with a bare ValueError ("abc", b"\x01"), a
+    # bare TypeError (a list), or a bare OverflowError (an infinity, where
+    # a NaN is a ValueError: the asymmetry is int()'s, not this
+    # function's). None of the three says that btclib refused anything,
+    # and OverflowError is not even a ValueError -- it is an
+    # ArithmeticError, so a caller catching ValueError never caught it.
+    # Each is answered with this library's counterpart of the builtin it
+    # was, so what a caller catches does not shrink
     try:
         sats = 0 if amount is None else int(amount)
-    except ValueError as e:
+    except (ValueError, OverflowError) as e:
         raise BTClibValueError(f"invalid satoshi amount: {amount}") from e
     except TypeError as e:
         raise BTClibTypeError(f"non-integer satoshi amount: {amount}") from e

--- a/btclib/amount.py
+++ b/btclib/amount.py
@@ -22,7 +22,7 @@ Amounts are never negative, here as in the protocol.
 
 from __future__ import annotations
 
-from decimal import Decimal, FloatOperation, localcontext
+from decimal import Decimal, FloatOperation, InvalidOperation, localcontext
 from typing import Any
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -68,11 +68,31 @@ def valid_btc_amount(amount: Any, dust: Decimal = Decimal(0)) -> Decimal:
         ctx.traps[FloatOperation] = True
         # any input that can be converted to str is fine
         amount = "0" if amount is None else str(amount)
+        err_msg = f"invalid BTC amount: {amount}"
         # using str in the Decimal constructor avoids the
-        # FloatOperation exception trapped just above
-        btc = Decimal(amount)
+        # FloatOperation exception trapped just above.
+        #
+        # str() renders every object there is and Decimal refuses most of
+        # what it renders with an InvalidOperation -- an ArithmeticError,
+        # which nobody catches around an amount and which `except
+        # BTClibValueError` does not catch either. Accepting Any is what
+        # makes it reachable from ordinary input, "1,2" being how half the
+        # world writes a decimal, so the width of the argument has to be
+        # matched by one exception of this library's:
+        # FeeRate.from_sats_per_vbyte answers the same way
+        try:
+            btc = Decimal(amount)
+        except InvalidOperation as e:
+            raise BTClibValueError(err_msg) from e
+        # a NaN parses and is no amount, and the range check below is not
+        # what refuses it: an ordering comparison against a NaN raises
+        # InvalidOperation of its own, so "nan" would leave through the
+        # very line meant to bound it. An infinity does compare, and the
+        # range refuses it there
+        if not btc.is_finite():
+            raise BTClibValueError(err_msg)
         if not dust <= btc <= _MAX_BITCOIN:
-            raise BTClibValueError(f"invalid BTC amount: {amount}")
+            raise BTClibValueError(err_msg)
         if btc == btc.quantize(_BITCOIN_PER_SATOSHI):
             return btc
         raise BTClibValueError(f"too many decimals for a BTC amount: {amount}")
@@ -86,8 +106,18 @@ def sats_from_btc(amount: Decimal) -> int:
 
 def valid_sats_amount(amount: Any, dust: int = 0) -> int:
     """Return the satoshi amount as int, if valid and not less than dust."""
-    # any input that can be converted to int is fine
-    sats = 0 if amount is None else int(amount)
+    # any input that can be converted to int is fine -- and int() refuses
+    # what it cannot convert with a bare ValueError ("abc", b"\x01") or a
+    # bare TypeError (a list), neither of which says that btclib refused
+    # anything. Each is answered with this library's counterpart of the
+    # very builtin it was, so a caller catching ValueError or TypeError
+    # catches exactly what it caught before
+    try:
+        sats = 0 if amount is None else int(amount)
+    except ValueError as e:
+        raise BTClibValueError(f"invalid satoshi amount: {amount}") from e
+    except TypeError as e:
+        raise BTClibTypeError(f"non-integer satoshi amount: {amount}") from e
     if amount is not None and sats != amount:
         raise BTClibTypeError(f"non-integer satoshi amount: {amount}")
     if not dust <= sats <= _MAX_SATOSHI:

--- a/tests/amount_test.py
+++ b/tests/amount_test.py
@@ -161,3 +161,60 @@ def test_self_consistency() -> None:
                 btc = btc_from_sats(sats_from_btc(btc_amount))  # type: ignore[arg-type]
                 assert btc == exp_btc
                 assert str(btc) == str(exp_btc)
+
+
+@pytest.mark.parametrize(
+    "amount",
+    ["abc", "1,2", "", "0x10", object(), "nan", "sNaN", "-nan", "inf", "-Infinity"],
+)
+def test_what_is_no_decimal_number_is_refused_as_btclib_refuses_things(
+    amount: object,
+) -> None:
+    """The exception is this library's, not the decimal module's.
+
+    `str()` renders every object there is and `Decimal` refuses most of
+    what it renders with an `InvalidOperation` -- an `ArithmeticError`,
+    which `except BTClibValueError` does not catch and nobody writes
+    `except ArithmeticError` around an amount. The argument is `Any` on
+    purpose, so this is reachable from ordinary input rather than from
+    something exotic.
+    """
+    with pytest.raises(BTClibValueError, match="invalid BTC amount"):
+        valid_btc_amount(amount)
+
+
+def test_a_nan_does_not_leave_through_the_range_check() -> None:
+    """The NaNs are why `is_finite` is there and a `try` is not enough.
+
+    `Decimal("nan")` is valid syntax and constructs without a word: what
+    used to raise `InvalidOperation` was the *comparison* in the range
+    check, so catching the constructor alone would have left every
+    spelling of a NaN leaking an ArithmeticError out of a validator.
+    """
+    for nan in (float("nan"), "nan", "sNaN", Decimal("NaN")):
+        with pytest.raises(BTClibValueError, match="invalid BTC amount"):
+            valid_btc_amount(nan)
+
+    # an infinity does compare, so the range check is what refuses it,
+    # and that is the line the NaNs never reach
+    for infinity in (float("inf"), "-inf", Decimal("Infinity")):
+        with pytest.raises(BTClibValueError, match="invalid BTC amount"):
+            valid_btc_amount(infinity)
+
+
+def test_a_satoshi_amount_that_int_refuses_is_refused_in_kind() -> None:
+    """int()'s bare ValueError and TypeError become this library's own.
+
+    Each maps to btclib's counterpart of the very builtin it was --
+    BTClibValueError derives from ValueError, BTClibTypeError from
+    TypeError -- so a caller catching either of the builtins catches
+    exactly what it caught before, and one catching btclib's now sees
+    these too.
+    """
+    for amount in ("abc", "", b"\x01", "1,2"):
+        with pytest.raises(BTClibValueError, match="invalid satoshi amount"):
+            valid_sats_amount(amount)
+
+    for other in ([], {}, object()):
+        with pytest.raises(BTClibTypeError, match="non-integer satoshi amount"):
+            valid_sats_amount(other)

--- a/tests/amount_test.py
+++ b/tests/amount_test.py
@@ -218,3 +218,24 @@ def test_a_satoshi_amount_that_int_refuses_is_refused_in_kind() -> None:
     for other in ([], {}, object()):
         with pytest.raises(BTClibTypeError, match="non-integer satoshi amount"):
             valid_sats_amount(other)
+
+
+@pytest.mark.parametrize(
+    "amount",
+    [float("inf"), float("-inf"), Decimal("Infinity"), Decimal("-Infinity")],
+)
+def test_a_non_finite_satoshi_amount_is_refused_in_kind(amount: object) -> None:
+    """An infinity leaves int() as an OverflowError, which is no ValueError.
+
+    It is an ArithmeticError, like the InvalidOperation of the BTC
+    validator: a caller catching ValueError around a satoshi amount never
+    caught it. A NaN is a ValueError out of the same call, which is int()'s
+    asymmetry rather than this function's, and both answer the same way
+    now.
+    """
+    with pytest.raises(BTClibValueError, match="invalid satoshi amount"):
+        valid_sats_amount(amount)
+
+    for nan in (float("nan"), Decimal("NaN")):
+        with pytest.raises(BTClibValueError, match="invalid satoshi amount"):
+            valid_sats_amount(nan)


### PR DESCRIPTION
Closes #339. First of the numeric chain: #326 is stacked on this branch,
and #321 on that one, because all three edit the same two files.

`valid_btc_amount` let `decimal.InvalidOperation` out — an
`ArithmeticError`, which `except BTClibValueError` does not catch and
which nobody writes `except ArithmeticError` around an amount. The
argument is `Any` on purpose, so the leak was reachable from ordinary
input: `"abc"`, and the `"1,2"` half the world writes a decimal as.

**Catching the constructor is not the whole fix**, which is the correction
made on the issue: `Decimal("nan")` is valid syntax and constructs without
a word, and what raised for it was the *ordering comparison* in the range
check — `amount.py:74` — so every spelling of a NaN (`float("nan")`,
`"nan"`, `"sNaN"`, `Decimal("NaN")`) left through the very line meant to
bound the amount. `is_finite()` refuses those, as it already does in
`FeeRate.from_sats_per_vbyte`; an infinity does compare, and the range
check refuses it there.

Beside it, the sibling the issue did not name: `valid_sats_amount` let
`int()`'s own refusals out unchanged — a bare `ValueError` for `"abc"` and
`b"\x01"`, a bare `TypeError` for a list. Each is now this library's
counterpart of the builtin it was, so a caller catching `ValueError` or
`TypeError` catches exactly what it caught before, and one catching
btclib's sees these too.

Not source-breaking: `BTClibValueError` derives from `ValueError` and
`BTClibTypeError` from `TypeError`, so only `except ArithmeticError`
around an amount stops catching — and that was the defect.

Gates, all three green locally: `pre-commit run --all-files`, `pytest`,
and the `-W` sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align amount validators with btclib-specific exceptions and strengthen validation of non-finite and invalid numeric inputs.

Bug Fixes:
- Ensure valid_btc_amount converts decimal.InvalidOperation into BTClibValueError and rejects non-finite Decimal values like NaN and infinities.
- Ensure valid_sats_amount converts int()'s ValueError and TypeError into BTClibValueError and BTClibTypeError with clear error messages.

Documentation:
- Document the corrected amount validation and exception behavior in the changelog.

Tests:
- Add coverage to confirm invalid BTC inputs, NaNs, infinities, and invalid satoshi inputs raise the expected btclib-specific exceptions.