### PR TITLE
A boolean is not an integer quantity, anywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -952,11 +952,19 @@ edit.
   bool is the one thing they refuse instead. `isinstance(x, int) and not
   isinstance(x, bool)` rather than `type(x) is int`, so an `IntEnum` stays
   a number and issue #273 is not answered here in advance. The fields:
-  satoshi amounts, `FeeRate.sats_per_kvbyte`, virtual sizes, `OutPoint.vout`,
+  satoshi amounts and the dust threshold they are compared against,
+  `FeeRate.sats_per_kvbyte`, virtual sizes, `OutPoint.vout`,
   `TxIn.sequence`, `Tx.version` and `Tx.lock_time` — the last three
   type-checked before their range, as `BlockHeader.assert_valid` already
   checked its own two — a block header's version and nonce, a block
-  context's heights, and a bip32 key's depth and index. A BTC amount is a
+  context's heights, a bip32 key's depth and index, every derivation index
+  (`indexes_from_der_path` turned `True` into the index one and
+  `str_from_index_int` turned it into the path step `"True"`, `str()`
+  rendering a bool as a word), and the output sizes of `bytes_from_octets`
+  and `base58.b58decode`, where `out_size=True` accepted a single octet and
+  reported a size as checked. The derivation-path sequence is no longer
+  coerced with `int()` either: its contract is `Sequence[int]`, so a member
+  that is no integer is refused rather than converted. A BTC amount is a
   Decimal quote rather than an integer field, so `valid_btc_amount(True)`
   stays the value error it became in #339. `tests/integer_policy_test.py`
   holds all of them to it, and holds the refusal to the numbers it must

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -935,6 +935,32 @@ edit.
   the transaction rather than part of the signature, and stripping it is
   the caller's — `signature[:64]`, as `btclib.script.engine.tapscript`
   does once `get_hashtype` has read it
+- **a boolean is not an integer quantity, anywhere** (issue #326).
+  `bool` is a subclass of `int` in Python, so every field of this library
+  whose contract is a whole number took `True` for the number one:
+  `valid_sats_amount(True)` was 1, `FeeRate(sats_per_kvbyte=True)`
+  constructed a one-sat/kvB rate, `fee_from_vsize(True, rate)` charged a
+  virtual byte, and `int(True) == True` slipped through the
+  conversion-and-equality check the satoshi validator makes on top of
+  that. What makes it worth refusing rather than shrugging at is the json
+  boundary: `true` decodes to `True`, so a schema mistake became one
+  satoshi, one index or a one-sat/kvB fee rate instead of failing beside
+  the input that caused it. `btclib.utils.is_integer` is the decision,
+  stated once, and `int_from_json_number` is the same decision where a
+  field is coerced rather than checked — `BlockHeader` and `BIP32KeyData`
+  coerce, a whole number out of json being free to arrive as `1.0`, and a
+  bool is the one thing they refuse instead. `isinstance(x, int) and not
+  isinstance(x, bool)` rather than `type(x) is int`, so an `IntEnum` stays
+  a number and issue #273 is not answered here in advance. The fields:
+  satoshi amounts, `FeeRate.sats_per_kvbyte`, virtual sizes, `OutPoint.vout`,
+  `TxIn.sequence`, `Tx.version` and `Tx.lock_time` — the last three
+  type-checked before their range, as `BlockHeader.assert_valid` already
+  checked its own two — a block header's version and nonce, a block
+  context's heights, and a bip32 key's depth and index. A BTC amount is a
+  Decimal quote rather than an integer field, so `valid_btc_amount(True)`
+  stays the value error it became in #339. `tests/integer_policy_test.py`
+  holds all of them to it, and holds the refusal to the numbers it must
+  not take with it
 
 ### Immutability and shared state
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -964,7 +964,15 @@ edit.
   and `base58.b58decode`, where `out_size=True` accepted a single octet and
   reported a size as checked. The derivation-path sequence is no longer
   coerced with `int()` either: its contract is `Sequence[int]`, so a member
-  that is no integer is refused rather than converted. A BTC amount is a
+  that is no integer is refused rather than converted. Two things follow
+  from accepting an `IntEnum`, and both are in: `str_from_index_int`
+  normalizes with `int()` before formatting, `str()` of an `IntEnum` being
+  its *name* up to Python 3.10 — a path step of `"Sighash.ALL"` there and
+  `"1"` on every later interpreter, which is what the 3.10 cells of the
+  matrix caught — and `bytes_from_octets` tells a scalar size from an
+  iterable of them before taking `tuple()` of either, a float otherwise
+  answering "not iterable", which complains about the wrong thing and from
+  outside this library's exception contract. A BTC amount is a
   Decimal quote rather than an integer field, so `valid_btc_amount(True)`
   stays the value error it became in #339. `tests/integer_policy_test.py`
   holds all of them to it, and holds the refusal to the numbers it must

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -287,6 +287,14 @@ against the `v2023.7.12` tag.
   reading a transaction out of a block reads on as before. Parsing one
   object out of a longer buffer is `parse(BytesIO(buffer))` rather than
   `parse(buffer)`.
+- **a boolean is refused wherever a field is an integer quantity.**
+  `bool` being a subclass of `int`, `valid_sats_amount(True)` was 1,
+  `FeeRate(sats_per_kvbyte=True)` was a one-sat/kvB rate, and
+  `OutPoint(tx_id, True)` was output number one; all of them raise
+  `BTClibTypeError` now. This matters at a json boundary, where `true`
+  decodes to `True`: what used to be one satoshi is an error next to the
+  field that carried it. Only an actual boolean is affected — an `IntEnum`
+  or any other deliberate integer subclass is still an integer.
 
 - **`ssa.verify` answers False for a 65-byte taproot witness signature**,
   where it answered True: the 65th octet is BIP341's sighash type, not

--- a/btclib/amount.py
+++ b/btclib/amount.py
@@ -106,6 +106,13 @@ def sats_from_btc(amount: Decimal) -> int:
 
 def valid_sats_amount(amount: Any, dust: int = 0) -> int:
     """Return the satoshi amount as int, if valid and not less than dust."""
+    # a bool is an int in Python, so True reached the conversion below as
+    # the number one and `int(True) == True` let it through the equality
+    # check as well: refused by name, for the reason is_integer gives --
+    # and by name because this argument is Any, so a str and a Decimal are
+    # legitimate here and the predicate cannot be the gate
+    if isinstance(amount, bool):
+        raise BTClibTypeError(f"non-integer satoshi amount: {amount}")
     # any input that can be converted to int is fine -- and int() refuses
     # what it cannot convert with a bare ValueError ("abc", b"\x01"), a
     # bare TypeError (a list), or a bare OverflowError (an infinity, where

--- a/btclib/amount.py
+++ b/btclib/amount.py
@@ -26,6 +26,7 @@ from decimal import Decimal, FloatOperation, InvalidOperation, localcontext
 from typing import Any
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.utils import is_integer
 
 # The two functions below doing Decimal algebra trap FloatOperation in a
 # local context, not in the process-wide one at import time:
@@ -113,6 +114,11 @@ def valid_sats_amount(amount: Any, dust: int = 0) -> int:
     # legitimate here and the predicate cannot be the gate
     if isinstance(amount, bool):
         raise BTClibTypeError(f"non-integer satoshi amount: {amount}")
+    # and the threshold it is compared against: a bool passes the
+    # comparison below as zero or one, so `dust=True` is a dust level of
+    # one satoshi rather than a caller error
+    if not is_integer(dust):
+        raise BTClibTypeError(f"non-integer satoshi dust threshold: {dust}")
     # any input that can be converted to int is fine -- and int() refuses
     # what it cannot convert with a bare ValueError ("abc", b"\x01"), a
     # bare TypeError (a list), or a bare OverflowError (an infinity, where

--- a/btclib/base58.py
+++ b/btclib/base58.py
@@ -49,9 +49,9 @@ https://github.com/keis/base58, with the following modifications:
 from __future__ import annotations
 
 from btclib.alias import Octets, String
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash256
-from btclib.utils import bytes_from_octets
+from btclib.utils import bytes_from_octets, is_integer
 
 _ALPHABET = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 __BASE = len(_ALPHABET)
@@ -163,6 +163,13 @@ def b58decode(v: String, out_size: int | None = None) -> bytes:
     if checksum != h256[:4]:
         err_msg = f"invalid checksum: 0x{checksum.hex()} instead of 0x{h256[:4].hex()}"
         raise BTClibValueError(err_msg)
+
+    # the size policy of btclib/utils.py, at the boundary that does its own
+    # comparison rather than going through bytes_from_octets: a bool would
+    # accept a one-octet payload and call it a checked size
+    if out_size is not None and not is_integer(out_size):
+        err_msg = f"invalid output size type: {type(out_size).__name__}"
+        raise BTClibTypeError(err_msg)
 
     if out_size is None or len(result) == out_size:
         return result

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -54,6 +54,8 @@ from btclib.utils import (
     bytes_from_octets,
     bytesio_from_binarydata,
     hex_string,
+    int_from_json_number,
+    is_integer,
 )
 
 # secp256k1 is written out at each use rather than aliased to a module
@@ -185,15 +187,17 @@ class BIP32KeyData:
         check_validity: bool = True,
     ) -> None:
         self.version = bytes_from_octets(version)
-        # int(), where the annotation already says int, for the same reason
-        # bytes_from_octets is called on the four Octets fields: from_dict
-        # feeds this constructor a json object, where a whole number may
-        # arrive as a float. Coercing in assert_valid instead would rewrite
-        # the object it is asked to inspect -- and it is called by
-        # serialize() and to_dict(), so reading a key would mutate it
-        self.depth = int(depth)
+        # a coercion, where the annotation already says int, for the same
+        # reason bytes_from_octets is called on the four Octets fields:
+        # from_dict feeds this constructor a json object, where a whole
+        # number may arrive as a float. Coercing in assert_valid instead
+        # would rewrite the object it is asked to inspect -- and it is
+        # called by serialize() and to_dict(), so reading a key would
+        # mutate it. A bool is refused rather than coerced: `true` out of
+        # json is a schema error, not depth one
+        self.depth = int_from_json_number(depth, "depth")
         self.parent_fingerprint = bytes_from_octets(parent_fingerprint)
-        self.index = int(index)
+        self.index = int_from_json_number(index, "index")
         self.chain_code = bytes_from_octets(chain_code)
         self.key = bytes_from_octets(key)
 
@@ -227,7 +231,7 @@ class BIP32KeyData:
         # to_bytes and leave through an AttributeError
         for key in ("depth", "index"):
             value_ = getattr(self, key)
-            if not isinstance(value_, int):
+            if not is_integer(value_):
                 err_msg = f"invalid {key} type: {type(value_).__name__}"
                 raise BTClibTypeError(err_msg)
 

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -64,11 +64,16 @@ def str_from_index_int(i: int, hardening: str = _HARDENING) -> str:
     # path step of a boolean would be a path nothing derives
     if not is_integer(i):
         raise BTClibTypeError(f"invalid derivation index type: {type(i).__name__}")
-    if not 0 <= i <= 0xFFFFFFFF:
-        raise BTClibValueError(f"invalid index: {i}")
-    if i < _HARDENED_OFFSET:
-        return str(i)
-    return str(i - _HARDENED_OFFSET) + hardening
+    # int() of an int, because an IntEnum is one and str() of an IntEnum is
+    # its *name* up to Python 3.10 -- "Sighash.ALL" where a path step wants
+    # "1". Accepting a deliberate integer subclass, which is what
+    # is_integer above is for, means answering with the number it is
+    index = int(i)
+    if not 0 <= index <= 0xFFFFFFFF:
+        raise BTClibValueError(f"invalid index: {index}")
+    if index < _HARDENED_OFFSET:
+        return str(index)
+    return str(index - _HARDENED_OFFSET) + hardening
 
 
 def _indexes_from_der_path_str(der_path: str, skip_m: bool = True) -> list[int]:

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from btclib.alias import Octets
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.utils import is_integer
 
 # default hardening symbol among the possible ones: "h", "H", "'"
 _HARDENING = "h"
@@ -59,6 +60,10 @@ def str_from_index_int(i: int, hardening: str = _HARDENING) -> str:
     """Return one index as a path step, the chosen symbol for hardened."""
     if hardening not in ("'", "h", "H"):
         raise BTClibValueError(f"invalid hardening symbol: {hardening}")
+    # reachable without indexes_from_der_path, and str(True) is "True": a
+    # path step of a boolean would be a path nothing derives
+    if not is_integer(i):
+        raise BTClibTypeError(f"invalid derivation index type: {type(i).__name__}")
     if not 0 <= i <= 0xFFFFFFFF:
         raise BTClibValueError(f"invalid index: {i}")
     if i < _HARDENED_OFFSET:
@@ -93,6 +98,9 @@ def indexes_from_der_path(der_path: DerPath) -> list[int]:
         return _indexes_from_der_path_str(der_path)
 
     if isinstance(der_path, int):
+        if not is_integer(der_path):
+            err_msg = f"invalid derivation index type: {type(der_path).__name__}"
+            raise BTClibTypeError(err_msg)
         return [der_path]
 
     if isinstance(der_path, bytes):
@@ -104,8 +112,15 @@ def indexes_from_der_path(der_path: DerPath) -> list[int]:
             for n in range(0, len(der_path), 4)
         ]
 
-    # an iterable of int
-    return [int(i) for i in der_path]
+    # an iterable of int, and of int alone: int() here would coerce a bool
+    # into the index one, where the annotation already says Sequence[int]
+    # and a bool is no index -- `True` is not the first child of anything
+    indexes = list(der_path)
+    for index in indexes:
+        if not is_integer(index):
+            err_msg = f"invalid derivation index type: {type(index).__name__}"
+            raise BTClibTypeError(err_msg)
+    return indexes
 
 
 def _str_from_der_path(der_path: DerPath, hardening: str = _HARDENING) -> str:

--- a/btclib/block/block_context.py
+++ b/btclib/block/block_context.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.utils import is_integer
 
 # Core's chainparams: 227,931 on mainnet, 21,111 on testnet3, and 1 on
 # testnet4, signet and regtest. Mainnet is the default, as it is
@@ -106,10 +107,11 @@ class BlockContext:
         """
         for key in ("height", "bip34_height"):
             value = getattr(self, key)
-            # a float here would compare fine and read as a height, so the
-            # type is checked rather than coerced -- and bool is an int,
-            # which no comparison below can be confused by
-            if not isinstance(value, int):
+            # a float here would compare fine and read as a height, so
+            # the type is checked rather than coerced -- and a bool is not
+            # an integer for this purpose either, `true` out of json being
+            # how a height becomes one
+            if not is_integer(value):
                 err_msg = f"invalid {key} type: {type(value).__name__}"
                 raise BTClibTypeError(err_msg)
             if value < 0:

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -25,6 +25,8 @@ from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    int_from_json_number,
+    is_integer,
 )
 
 _HF = hash256
@@ -122,18 +124,20 @@ class BlockHeader:
         *,
         check_validity: bool = True,
     ) -> None:
-        # int(), where the annotation already says int, for the same reason
-        # bytes_from_octets is called on the Octets fields: from_dict feeds
-        # this constructor a json object, where a whole number may arrive
-        # as a float. Coercing in assert_valid instead would rewrite the
-        # object it is asked to inspect -- and it is called by serialize()
-        # and to_dict(), so reading a header would mutate it
-        self.version = int(version)
+        # a coercion, where the annotation already says int, for the same
+        # reason bytes_from_octets is called on the Octets fields:
+        # from_dict feeds this constructor a json object, where a whole
+        # number may arrive as a float. Coercing in assert_valid instead
+        # would rewrite the object it is asked to inspect -- and it is
+        # called by serialize() and to_dict(), so reading a header would
+        # mutate it. A bool is the one thing not coerced but refused,
+        # `true` out of json being a schema error rather than version 1
+        self.version = int_from_json_number(version, "version")
         self.previous_block_hash = bytes_from_octets(previous_block_hash)
         self.merkle_root = bytes_from_octets(merkle_root)
         self.time = time
         self.bits = bytes_from_octets(bits)
-        self.nonce = int(nonce)
+        self.nonce = int_from_json_number(nonce, "nonce")
 
         if check_validity:
             self.assert_valid()
@@ -250,7 +254,7 @@ class BlockHeader:
         # to_bytes and leave the library through an AttributeError
         for key in ("version", "nonce"):
             value = getattr(self, key)
-            if not isinstance(value, int):
+            if not is_integer(value):
                 err_msg = f"invalid {key} type: {type(value).__name__}"
                 raise BTClibTypeError(err_msg)
 

--- a/btclib/fee.py
+++ b/btclib/fee.py
@@ -42,7 +42,7 @@ from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.script.limits import MAX_SCRIPT_SIZE
 from btclib.script.script import BYTE_FROM_OP_CODE_NAME
 from btclib.script.script_pub_key import is_segwit
-from btclib.utils import bytes_from_octets
+from btclib.utils import bytes_from_octets, is_integer
 
 # the kilo in sat/kvB, i.e. how many virtual bytes a rate is quoted over
 _VBYTES_PER_KVBYTE = 1000
@@ -78,7 +78,7 @@ class FeeRate:
     sats_per_kvbyte: int
 
     def __post_init__(self) -> None:
-        if not isinstance(self.sats_per_kvbyte, int):
+        if not is_integer(self.sats_per_kvbyte):
             raise BTClibTypeError(
                 f"non-integer sat/kvB fee rate: {self.sats_per_kvbyte}"
             )
@@ -170,7 +170,7 @@ def fee_from_vsize(vsize: int, fee_rate: FeeRate) -> int:
     # the one function whose contract is that no float ever stands
     # between a rate and the satoshi it owes. A str fails instead, but on
     # the comparison below and with a bare TypeError naming '<'
-    if not isinstance(vsize, int):
+    if not is_integer(vsize):
         raise BTClibTypeError(f"non-integer virtual size: {vsize}")
     if vsize < 0:
         raise BTClibValueError(f"negative virtual size: {vsize}")

--- a/btclib/tx/out_point.py
+++ b/btclib/tx/out_point.py
@@ -16,11 +16,12 @@ from dataclasses import dataclass
 from typing import Any
 
 from btclib.alias import BinaryData, Octets
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    is_integer,
     read_exactly,
 )
 
@@ -81,6 +82,11 @@ class OutPoint:
             err_msg = f"invalid OutPoint tx_id: {len(self.tx_id)}"
             err_msg += " instead of 32 bytes"
             raise BTClibValueError(err_msg)
+        # a bool is an int and would read as vout 0 or 1, which the range
+        # check below cannot tell from an index: `from_dict` reads json
+        if not is_integer(self.vout):
+            err_msg = f"invalid vout type: {type(self.vout).__name__}"
+            raise BTClibTypeError(err_msg)
         # must be a 4-bytes int
         if not 0 <= self.vout <= 0xFFFFFFFF:
             raise BTClibValueError(f"invalid vout: {self.vout}")

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -21,13 +21,18 @@ from typing import Any
 from btclib import var_int
 from btclib.alias import BinaryData
 from btclib.amount import _MAX_SATOSHI
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash256
 from btclib.script.sig_ops import sig_op_count as script_sig_op_count
 from btclib.script.witness import Witness
 from btclib.tx.tx_in import TX_IN_COMPARES_WITNESS, TxIn
 from btclib.tx.tx_out import TxOut
-from btclib.utils import assert_no_trailing, bytesio_from_binarydata, read_exactly
+from btclib.utils import (
+    assert_no_trailing,
+    bytesio_from_binarydata,
+    is_integer,
+    read_exactly,
+)
 
 _SEGWIT_MARKER = b"\x00\x01"
 
@@ -258,6 +263,16 @@ class Tx:
         and btclib refused both (issue 170).
         """
         _assert_valid_coinbase(self.vin, is_coinbase=self.is_coinbase())
+
+        # the type before the range, as BlockHeader.assert_valid checks its
+        # own two int fields: a bool passes every comparison below as one or
+        # zero, and `to_dict`/`from_dict` is a json boundary -- `true` there
+        # would be version 1 rather than a schema error
+        for key in ("version", "lock_time"):
+            value = getattr(self, key)
+            if not is_integer(value):
+                err_msg = f"invalid {key} type: {type(value).__name__}"
+                raise BTClibTypeError(err_msg)
 
         # must be a 4-bytes integer
         if not 0 <= self.version <= 0xFFFFFFFF:

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -17,13 +17,14 @@ from typing import Any
 
 from btclib import var_bytes
 from btclib.alias import BinaryData, Octets
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.script import Witness, script_from_dict, script_to_dict
 from btclib.tx.out_point import OutPoint
 from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
     bytesio_from_binarydata,
+    is_integer,
     read_exactly,
 )
 
@@ -110,6 +111,13 @@ class TxIn:
         carries the reasoning.
         """
         self.prev_out.assert_valid()
+
+        # as everywhere an int field is range-checked: True would be a
+        # sequence of one, and a sequence is where a locktime-enabled
+        # input is told from a final one
+        if not is_integer(self.sequence):
+            err_msg = f"invalid sequence type: {type(self.sequence).__name__}"
+            raise BTClibTypeError(err_msg)
 
         # script_sig is deliberately not looked at, and the marker asking
         # for a check (issue 183) is answered by where the answers already

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -58,7 +58,18 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
     if out_size is None:
         return octets
 
-    sizes = (out_size,) if isinstance(out_size, int) else tuple(out_size)
+    # one size or an iterable of them, and nothing else: `tuple()` on
+    # whatever is left would refuse a float with a bare TypeError about
+    # iteration -- a complaint about the wrong thing, and from underneath
+    # the library rather than through its exception contract
+    if isinstance(out_size, int):
+        sizes: tuple[int, ...] = (out_size,)
+    elif isinstance(out_size, Iterable):
+        sizes = tuple(out_size)
+    else:
+        err_msg = f"invalid output size type: {type(out_size).__name__}"
+        raise BTClibTypeError(err_msg)
+
     for size in sizes:
         if not is_integer(size):
             err_msg = f"invalid output size type: {type(size).__name__}"

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -35,7 +35,6 @@ one; that check is unconditional for the same reason.
 from __future__ import annotations
 
 from collections.abc import Iterable
-from collections.abc import Iterable as IterableCollection
 from io import BytesIO
 from typing import Any
 
@@ -49,16 +48,23 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
     """Return bytes from a hex-string, stripping leading/trailing spaces.
 
     If the input is not a string, then it goes untouched. Optionally, it
-    also ensures required output size.
+    also ensures required output size: one size, or any iterable of them,
+    and a bool is neither -- `out_size=True` would accept a single octet
+    and say it had checked a size.
     """
     if isinstance(octets, str):  # hex string
         octets = bytes.fromhex(octets)
 
-    if (
-        out_size is None
-        or (isinstance(out_size, int) and len(octets) == out_size)
-        or (isinstance(out_size, IterableCollection) and len(octets) in out_size)
-    ):
+    if out_size is None:
+        return octets
+
+    sizes = (out_size,) if isinstance(out_size, int) else tuple(out_size)
+    for size in sizes:
+        if not is_integer(size):
+            err_msg = f"invalid output size type: {type(size).__name__}"
+            raise BTClibTypeError(err_msg)
+
+    if len(octets) in sizes:
         return octets
 
     err_msg = f"invalid size: {len(octets)} bytes instead of {out_size}"
@@ -120,6 +126,7 @@ def assert_no_trailing(data: BinaryData, stream: BytesIO, what: str) -> None:
     trailing = stream.read()
     if trailing:
         raise BTClibValueError(f"{len(trailing)} bytes after the {what}")
+
 
 def is_integer(value: Any) -> bool:
     """Return whether the value is an integer, a bool not being one.

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -37,9 +37,10 @@ from __future__ import annotations
 from collections.abc import Iterable
 from collections.abc import Iterable as IterableCollection
 from io import BytesIO
+from typing import Any
 
 from btclib.alias import BinaryData, Integer, Octets
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 
 NoneOneOrMoreInt = int | Iterable[int] | None
 
@@ -119,6 +120,47 @@ def assert_no_trailing(data: BinaryData, stream: BytesIO, what: str) -> None:
     trailing = stream.read()
     if trailing:
         raise BTClibValueError(f"{len(trailing)} bytes after the {what}")
+
+def is_integer(value: Any) -> bool:
+    """Return whether the value is an integer, a bool not being one.
+
+    `isinstance(x, int)` is True for `True` and `False`, `bool` being a
+    subclass of `int` -- so every field of this library whose contract is
+    an integer quantity accepted a boolean as the number one or zero, and
+    `int(True) == True` slips through a conversion-and-equality check as
+    well. What makes that worth a refusal rather than a shrug is the json
+    boundary: `true` decodes to `True`, so a schema mistake became one
+    satoshi, one virtual byte, one index or a one-sat/kvB fee rate instead
+    of failing next to the input that caused it.
+
+    A boolean is not another spelling of a number, which is the difference
+    from the strings and bytes much of this library accepts: "1" is a
+    number written down, `True` is a different type that Python's
+    inheritance makes indistinguishable from one.
+
+    `isinstance` and not `type(value) is int`, so an `IntEnum` -- what
+    issue #273 asks about for the sighash types -- and any other
+    deliberate integer subclass stay integers. `bool` is the one
+    subclass excluded, and by name.
+    """
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def int_from_json_number(value: Any, what: str) -> int:
+    """Return the int of a whole number out of json, a bool not being one.
+
+    `from_dict` feeds a constructor a json object, where a whole number
+    may arrive as a float -- 1.0 for 1 -- which is why the int fields of
+    the dataclasses coerce rather than refuse. A boolean is not one of
+    those numbers: `true` decodes to `True`, `int(True)` is 1, and a
+    schema mistake would become a version, a depth or an index instead of
+    an error beside the input that caused it.
+
+    `is_integer` is the same decision where there is nothing to coerce.
+    """
+    if isinstance(value, bool):
+        raise BTClibTypeError(f"invalid {what} type: {type(value).__name__}")
+    return int(value)
 
 
 def int_from_bits(octets: Octets, nlen: int) -> int:

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -25,14 +25,21 @@ from typing import Any
 
 import pytest
 
+from btclib import base58
 from btclib.amount import valid_sats_amount
 from btclib.bip32 import BIP32KeyData
+from btclib.bip32.der_path import (
+    bytes_from_der_path,
+    indexes_from_der_path,
+    str_from_der_path,
+    str_from_index_int,
+)
 from btclib.block import BlockHeader
 from btclib.block.block_context import BlockContext
 from btclib.exceptions import BTClibTypeError
 from btclib.fee import FeeRate, fee_from_vsize
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
-from btclib.utils import is_integer
+from btclib.utils import bytes_from_octets, is_integer
 
 _TX_ID = "01" * 32
 _RATE = FeeRate(sats_per_kvbyte=1000)
@@ -90,6 +97,15 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
             b"\x04\x88\xad\xe4", 0, b"\x00" * 4, v, b"\x00" * 32, b"\x00" * 33
         ),
     ),
+    ("dust threshold", lambda v: valid_sats_amount(1, dust=v)),
+    ("derivation index", indexes_from_der_path),
+    ("derivation index in a sequence", lambda v: indexes_from_der_path([v])),
+    ("derivation path as bytes", bytes_from_der_path),
+    ("derivation path as text", str_from_der_path),
+    ("derivation index as a step", str_from_index_int),
+    ("output size", lambda v: bytes_from_octets(b"x", v)),
+    ("output size in an iterable", lambda v: bytes_from_octets(b"x", [v])),
+    ("base58 output size", lambda v: base58.b58decode(base58.b58encode(b"x"), v)),
 ]
 
 _IDS = [case[0] for case in _CASES]
@@ -127,6 +143,18 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert _tx(version=1, lock_time=1).lock_time == 1
     assert _header(nonce=1).nonce == 1
     assert BlockContext(1, _NOW).height == 1
+    assert valid_sats_amount(1, dust=1) == 1
+    assert indexes_from_der_path(1) == [1]
+    assert indexes_from_der_path([1, 2]) == [1, 2]
+    assert bytes_from_der_path(1).hex() == "01000000"
+    assert str_from_der_path([1]) == "m/1"
+    assert str_from_index_int(1) == "1"
+    assert bytes_from_octets(b"x", 1) == b"x"
+    assert bytes_from_octets(b"xx", [1, 2]) == b"xx"
+    assert base58.b58decode(base58.b58encode(b"x"), 1) == b"x"
+
+    # the str and bytes spellings of a path are untouched by any of it
+    assert indexes_from_der_path("m/44h/0h") == [2147483692, 2147483648]
 
 
 def test_an_int_subclass_that_is_not_a_bool_is_still_an_integer() -> None:
@@ -142,6 +170,11 @@ def test_an_int_subclass_that_is_not_a_bool_is_still_an_integer() -> None:
     assert is_integer(Sighash.ALL)
     assert valid_sats_amount(Sighash.ALL) == 1
     assert FeeRate(sats_per_kvbyte=Sighash.ALL).sats_per_kvbyte == 1
+    assert indexes_from_der_path(Sighash.ALL) == [1]
+    assert indexes_from_der_path([Sighash.ALL]) == [1]
+    assert str_from_index_int(Sighash.ALL) == "1"
+    assert bytes_from_octets(b"x", Sighash.ALL) == b"x"
+    assert base58.b58decode(base58.b58encode(b"x"), Sighash.ALL) == b"x"
 
     assert is_integer(0)
     assert is_integer(-1)

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Tests for the one policy on integer fields: a bool is not a number.
+
+One file rather than a case per module, because the decision is one and
+`btclib.utils.is_integer` states it. What makes it worth a refusal is the
+json boundary: `true` decodes to `True`, and a schema mistake used to
+become one satoshi, one virtual byte, one index or a one-sat/kvB fee rate
+instead of failing beside the input that caused it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+from enum import IntEnum
+from typing import Any
+
+import pytest
+
+from btclib.amount import valid_sats_amount
+from btclib.bip32 import BIP32KeyData
+from btclib.block import BlockHeader
+from btclib.block.block_context import BlockContext
+from btclib.exceptions import BTClibTypeError
+from btclib.fee import FeeRate, fee_from_vsize
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
+from btclib.utils import is_integer
+
+_TX_ID = "01" * 32
+_RATE = FeeRate(sats_per_kvbyte=1000)
+_NOW = datetime(2026, 8, 4, tzinfo=timezone.utc)
+
+
+def _tx(version: Any = 1, lock_time: Any = 0) -> Tx:
+    return Tx(
+        version,
+        lock_time,
+        [TxIn(OutPoint(_TX_ID, 0), b"", 0xFFFFFFFF)],
+        [TxOut(1, b"")],
+    )
+
+
+def _header(version: Any = 1, nonce: Any = 1) -> BlockHeader:
+    return BlockHeader(
+        version,
+        "00" * 32,
+        "11" * 32,
+        datetime(2009, 1, 9, tzinfo=timezone.utc),
+        "1d00ffff",
+        nonce,
+    )
+
+
+# every field whose contract is an integer quantity, with the shortest
+# call that reaches its validator
+_CASES: list[tuple[str, Callable[[Any], object]]] = [
+    ("satoshi amount", valid_sats_amount),
+    ("fee rate", lambda v: FeeRate(sats_per_kvbyte=v)),
+    ("virtual size", lambda v: fee_from_vsize(v, _RATE)),
+    ("output value", lambda v: TxOut(v, b"")),
+    ("outpoint vout", lambda v: OutPoint(_TX_ID, v)),
+    (
+        "outpoint vout from a dict",
+        lambda v: OutPoint.from_dict({"txid": _TX_ID, "vout": v}),
+    ),
+    ("input sequence", lambda v: TxIn(OutPoint(_TX_ID, 0), b"", v)),
+    ("transaction version", _tx),
+    ("transaction lock time", lambda v: _tx(lock_time=v)),
+    ("header version", _header),
+    ("header nonce", lambda v: _header(nonce=v)),
+    ("block height", lambda v: BlockContext(v, _NOW)),
+    ("bip34 height", lambda v: BlockContext(1, _NOW, v)),
+    (
+        "bip32 depth",
+        lambda v: BIP32KeyData(
+            b"\x04\x88\xad\xe4", v, b"\x00" * 4, 0, b"\x00" * 32, b"\x00" * 33
+        ),
+    ),
+    (
+        "bip32 index",
+        lambda v: BIP32KeyData(
+            b"\x04\x88\xad\xe4", 0, b"\x00" * 4, v, b"\x00" * 32, b"\x00" * 33
+        ),
+    ),
+]
+
+_IDS = [case[0] for case in _CASES]
+_CALLS = [case[1] for case in _CASES]
+
+
+@pytest.mark.parametrize("call", _CALLS, ids=_IDS)
+@pytest.mark.parametrize("value", [True, False], ids=["true", "false"])
+def test_a_bool_is_not_an_integer_field(
+    call: Callable[[Any], object], *, value: bool
+) -> None:
+    """Every integer field refuses a boolean, and refuses it as a type.
+
+    `isinstance(True, int)` is what let each of these through as one or
+    zero, and `int(True) == True` is what let the satoshi amount through a
+    conversion-and-equality check on top of that.
+    """
+    with pytest.raises(BTClibTypeError):
+        call(value)
+
+
+def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
+    """The same calls with a number, which is what the refusal is around.
+
+    A test that only checks refusals passes just as well when the field
+    refuses everything.
+    """
+    assert valid_sats_amount(1) == 1
+    assert FeeRate(sats_per_kvbyte=1).sats_per_kvbyte == 1
+    assert fee_from_vsize(1, _RATE) == 1
+    assert TxOut(1, b"").value == 1
+    assert OutPoint(_TX_ID, 1).vout == 1
+    assert OutPoint.from_dict({"txid": _TX_ID, "vout": 1}).vout == 1
+    assert TxIn(OutPoint(_TX_ID, 0), b"", 1).sequence == 1
+    assert _tx(version=1, lock_time=1).lock_time == 1
+    assert _header(nonce=1).nonce == 1
+    assert BlockContext(1, _NOW).height == 1
+
+
+def test_an_int_subclass_that_is_not_a_bool_is_still_an_integer() -> None:
+    """`IntEnum` stays a number, which is why the predicate names bool.
+
+    Issue #273 asks whether the sighash types should become an `IntEnum`;
+    `type(value) is int` would have answered it in advance, and with a no.
+    """
+
+    class Sighash(IntEnum):
+        ALL = 1
+
+    assert is_integer(Sighash.ALL)
+    assert valid_sats_amount(Sighash.ALL) == 1
+    assert FeeRate(sats_per_kvbyte=Sighash.ALL).sats_per_kvbyte == 1
+
+    assert is_integer(0)
+    assert is_integer(-1)
+    assert not is_integer(True)
+    assert not is_integer(False)
+    assert not is_integer(1.0)
+    assert not is_integer("1")
+    assert not is_integer(None)

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -157,11 +157,43 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert indexes_from_der_path("m/44h/0h") == [2147483692, 2147483648]
 
 
+def test_what_is_no_integer_at_all_is_refused_the_same_way() -> None:
+    """The policy is about integers, and a bool is only its sharpest case.
+
+    These boundaries used to convert what they were handed -- a derivation
+    path through `int()`, a dust threshold through a comparison -- or to
+    complain about the wrong thing: an output size that is neither a number
+    nor an iterable of them met `tuple()` and answered "not iterable", from
+    underneath the library rather than through its exception contract.
+    """
+    with pytest.raises(BTClibTypeError, match="non-integer satoshi dust"):
+        valid_sats_amount(1, dust=1.0)  # type: ignore[arg-type]
+
+    with pytest.raises(BTClibTypeError, match="invalid derivation index type"):
+        indexes_from_der_path([2.0])  # type: ignore[list-item]
+    with pytest.raises(BTClibTypeError, match="invalid derivation index type"):
+        str_from_index_int(1.0)  # type: ignore[arg-type]
+
+    for out_size in (1.5, object(), "1"):
+        with pytest.raises(BTClibTypeError, match="invalid output size type"):
+            bytes_from_octets(b"x", out_size)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="invalid output size type"):
+        bytes_from_octets(b"x", [1.5])  # type: ignore[list-item]
+    with pytest.raises(BTClibTypeError, match="invalid output size type"):
+        base58.b58decode(base58.b58encode(b"x"), 1.0)  # type: ignore[arg-type]
+
+
 def test_an_int_subclass_that_is_not_a_bool_is_still_an_integer() -> None:
     """`IntEnum` stays a number, which is why the predicate names bool.
 
     Issue #273 asks whether the sighash types should become an `IntEnum`;
     `type(value) is int` would have answered it in advance, and with a no.
+
+    The path step is the case that has to be *answered* with a number and
+    not merely accepted as one: `str()` of an `IntEnum` is its name up to
+    Python 3.10, so a derivation path of one would have read
+    "Sighash.ALL" there and "1" on every later interpreter -- which the
+    3.10 cells of the matrix caught and this assertion now pins.
     """
 
     class Sighash(IntEnum):


### PR DESCRIPTION
Closes #326. **Stacked on #344** (issue #339) — same two files, so the
chain is sequential rather than parallel. #321 is stacked on this one.

`bool` is a subclass of `int`, so every field whose contract is a whole
number took `True` for the number one, and `int(True) == True` slipped
through the conversion-and-equality check the satoshi validator makes on
top of that. The json boundary is what makes it worth refusing: `true`
decodes to `True`, so a schema mistake became one satoshi, one index or a
one-sat/kvB fee rate instead of failing beside the field that carried it.

- `btclib.utils.is_integer` states the decision once —
  `isinstance(x, int) and not isinstance(x, bool)`, never `type(x) is int`,
  so an `IntEnum` stays a number and **#273 is not answered here in
  advance**;
- `int_from_json_number` is the same decision where a field is *coerced*
  rather than checked. That is what the tests found: `BlockHeader` and
  `BIP32KeyData` coerce with `int()` — a whole number out of json is free
  to arrive as `1.0` — so the `isinstance` check in their `assert_valid`
  was unreachable for a bool, the constructor having already made it one
  or zero. The coercion refuses a bool and coerces everything else as
  before;
- the fields: satoshi amounts, `FeeRate.sats_per_kvbyte`, virtual sizes,
  `OutPoint.vout`, `TxIn.sequence`, `Tx.version`, `Tx.lock_time`, a block
  header's version and nonce, a block context's two heights, and a bip32
  key's depth and index.

`block_context`'s comment reverses with this: a bool was noted there as
"an int which no comparison below can be confused by", and `true` out of
json is exactly how a height becomes one.

A BTC amount is a Decimal quote rather than an integer field, so
`valid_btc_amount(True)` stays the value error #344 made it.

`tests/integer_policy_test.py` is new: every field × `True`/`False`, the
same fields with a number so the refusal cannot pass by refusing
everything, and `IntEnum` staying an integer.

Source-breaking in principle, so HISTORY.md carries a bullet; in practice
it breaks code that was passing a boolean where a number belonged.

Gates, all three green locally: `pre-commit run --all-files`, `pytest`,
and the `-W` sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce a consistent policy that booleans are not accepted as integer quantities across the library, especially at JSON boundaries, and document this source-compatible but behavior-changing decision.

Bug Fixes:
- Prevent booleans from being silently accepted and coerced as integer values for amounts, indices, fee rates, sizes, and protocol fields, raising BTClibTypeError instead.

Enhancements:
- Introduce shared utilities to detect integer values excluding bool and to coerce JSON numeric fields while rejecting booleans.
- Tighten type validation on integer fields in BIP32 key data, block headers, block context heights, transactions, inputs, outputs, outpoints, and fee-related functions to use the new integer policy.

Documentation:
- Document the new integer-field boolean refusal policy and its impact in CHANGELOG and HISTORY, including affected fields and error types.

Tests:
- Add a dedicated integer policy test suite covering all integer fields to ensure booleans are rejected, legitimate integers remain accepted, and IntEnum subclasses continue to be treated as integers.