### PR TITLE
A key derivation function does not answer with an empty key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -978,6 +978,19 @@ edit.
   holds all of them to it, and holds the refusal to the numbers it must
   not take with it
 
+- **a key derivation function does not answer with an empty key**
+  (issue #321). `ansi_x9_63_kdf` checked only that the requested size was
+  not above what the hash function can derive, so a negative size made the
+  loop empty and the final negative slice returned `b""` — keying material
+  the caller never got, reported as success. Zero is refused with it: SEC 1
+  3.6.1 states keydatalen as a positive integer, and a caller asking for no
+  octets of key has a bug rather than an empty key. A size that is no
+  integer reached that same slice and left through a bare `TypeError`
+  about slice indices, from underneath the library rather than through its
+  own exception contract; it is a `BTClibTypeError` now, `bool` included,
+  through the `is_integer` of #326. The bound above is unchanged and its
+  message with it
+
 ### Immutability and shared state
 
 - a default-constructed `TxIn` no longer shares its `prev_out` and

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -27,7 +27,8 @@ from btclib_libsecp256k1 import keys as libsecp256k1_keys
 from btclib.alias import HashF, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1
 from btclib.curves.curve import _libsecp256k1_applicable
-from btclib.exceptions import BTClibRuntimeError, BTClibValueError
+from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
+from btclib.utils import is_integer
 
 
 def ansi_x9_63_kdf(z: bytes, size: int, hf: HashF, shared_info: bytes | None) -> bytes:
@@ -36,9 +37,28 @@ def ansi_x9_63_kdf(z: bytes, size: int, hf: HashF, shared_info: bytes | None) ->
     Return a keying data octet sequence of the requested size according
     to ANSI-X9.63-KDF specifications for the key derivation function.
 
+    `size` is a positive number of octets, SEC 1's keydatalen: a
+    BTClibTypeError if it is no integer, a BTClibValueError if it is zero,
+    negative, or above what the hash function can derive.
+
     http://www.secg.org/sec1-v2.pdf,
     section 3.6.1
     """
+    # the range is checked before the loop bound is computed from it, and
+    # the type before the range. Unchecked, a negative size made the loop
+    # empty and the final negative slice returned b"" -- an empty key
+    # where the caller asked for keying material, which is the one answer
+    # a key derivation function must never invent (issue 321). A float
+    # went further still and reached that slice, leaving through a bare
+    # TypeError from underneath the library rather than through its own
+    # exception contract
+    if not is_integer(size):
+        raise BTClibTypeError(f"non-integer keying data size: {size}")
+    # zero and not merely negative: SEC 1 3.6.1 states keydatalen as a
+    # positive integer, and a caller asking for no octets of key is a
+    # caller with a bug rather than one with an empty key
+    if size <= 0:
+        raise BTClibValueError(f"invalid keying data size: {size}")
     hf_size = hf().digest_size
     max_size = hf_size * (2**32 - 1)
     if size > max_size:

--- a/tests/ecc/dh_test.py
+++ b/tests/ecc/dh_test.py
@@ -16,7 +16,11 @@ import pytest
 from btclib.curves import bytes_from_point, mult
 from btclib.curves.curve import CURVES
 from btclib.ecc import ansi_x9_63_kdf, dh, diffie_hellman, dsa
-from btclib.exceptions import BTClibRuntimeError, BTClibValueError
+from btclib.exceptions import (
+    BTClibRuntimeError,
+    BTClibTypeError,
+    BTClibValueError,
+)
 
 
 def test_ecdh() -> None:
@@ -57,6 +61,47 @@ def test_ecdh() -> None:
     size = max_size + 1
     with pytest.raises(BTClibValueError, match="cannot derive a key larger than "):
         ansi_x9_63_kdf(z, size, hf, None)
+
+
+@pytest.mark.parametrize("size", [-1, 0, -(2**32)])
+def test_a_key_of_no_octets_is_no_key(size: int) -> None:
+    """A size below one is refused, where a negative one used to answer b"".
+
+    The loop bound is computed from the size, so a negative one made the
+    loop empty and the final negative slice returned nothing at all: a key
+    derivation function answering with an empty key is the one answer it
+    must never invent. Zero is refused with it -- SEC 1 3.6.1 states
+    keydatalen as a positive integer, and a caller asking for no octets of
+    keying material has a bug rather than an empty key (issue 321).
+    """
+    with pytest.raises(BTClibValueError, match="invalid keying data size"):
+        ansi_x9_63_kdf(b"z", size, sha256, None)
+
+
+@pytest.mark.parametrize("size", [1.5, 32.0, "32", None, True, False])
+def test_a_size_that_is_no_integer_is_refused_as_such(size: object) -> None:
+    """And refused as this library's TypeError, not as a slice's.
+
+    A float reached the final slice and left through a bare `TypeError`
+    about slice indices -- outside the exception contract of
+    btclib/exceptions.py, which is the contract tests/fuzz_test.py holds
+    every parser to. A bool is refused for the reason
+    `btclib.utils.is_integer` gives: `True` would have derived a
+    one-octet key.
+    """
+    with pytest.raises(BTClibTypeError, match="non-integer keying data size"):
+        ansi_x9_63_kdf(b"z", size, sha256, None)  # type: ignore[arg-type]
+
+
+def test_the_smallest_key_a_size_can_ask_for() -> None:
+    """One octet, which is what the refusal above must not have taken.
+
+    The upper bound is checked without being reached: max_size octets of
+    sha256 output is a hundred and thirty-seven gigabytes, so what is
+    tested is that the number is refused one past it, above.
+    """
+    assert len(ansi_x9_63_kdf(b"z", 1, sha256, None)) == 1
+    assert len(ansi_x9_63_kdf(b"z", 32, sha256, None)) == 32
 
 
 def test_gec_2() -> None:


### PR DESCRIPTION
Closes #321. **Stacked on the #326 branch**, which is stacked on #344 —
this is the last of the numeric chain, and it is last because it reuses
`is_integer` rather than inventing a second predicate for the same
question.

`ansi_x9_63_kdf` checked only the upper bound, so:

- a **negative** size made the loop empty and the final negative slice
  returned `b""` — keying material the caller never got, reported as
  success;
- **zero** did the same, and is refused with it: SEC 1 3.6.1 states
  keydatalen as a positive integer, and a caller asking for no octets of
  key has a bug rather than an empty key;
- a size that is **no integer** reached that same slice and left through a
  bare `TypeError` about slice indices — outside the exception contract of
  `btclib/exceptions.py`, which is what `tests/fuzz_test.py` holds every
  parser to. It is a `BTClibTypeError` now, `bool` included.

The upper bound and its message are unchanged.

Tests: `-1`, `0`, `-2**32`; `1.5`, `32.0`, `"32"`, `None`, `True`, `False`;
and `1` and `32` so the refusals cannot pass by refusing everything. The
upper bound is exercised one past it, as the issue asked — `max_size`
octets of sha256 output is 137 GB, and no test allocates that.

Gates, all three green locally: `pre-commit run --all-files`, `pytest`,
and the `-W` sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate key derivation output length for ansi_x9_63_kdf and document the new behavior.

Bug Fixes:
- Prevent ansi_x9_63_kdf from returning an empty key for zero or negative sizes by rejecting non-positive key lengths.
- Normalize errors for non-integer key sizes in ansi_x9_63_kdf to raise BTClibTypeError instead of raw TypeError from slicing.

Enhancements:
- Clarify ansi_x9_63_kdf API behavior and constraints on key size in its docstring.

Documentation:
- Document the corrected ansi_x9_63_kdf size validation and error behavior in the changelog.

Tests:
- Add tests covering non-positive key sizes, non-integer size arguments, and valid minimal and typical key sizes for ansi_x9_63_kdf.