### PR TITLE
The bindings pin has no ceiling, and says why where it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3851,6 +3851,24 @@ edit.
 
 ### Packaging, linting and CI
 
+- **the bindings dependency states its policy where the pin is** (issue
+  #325). `btclib_libsecp256k1>=0.7.1rc1` has no upper bound, and the
+  absence of a ceiling is now written down as the decision it is:
+  the bindings are a btclib-org project developed by the same people, so a
+  breaking change there is coordinated with the release here — which is
+  what a version ceiling substitutes for when it cannot be. `<0.8` would
+  cost a btclib release for every bindings minor, the ones that break
+  nothing included, and would make a published artifact refuse a version
+  it works with; `<1` constrains nothing, pre-1.0 semver putting the
+  breaking changes in the minor. CONTRIBUTING.md carries what the policy
+  does *not* cover — metadata is baked into every wheel already published,
+  so coordinating the two projects protects the supported pair and not an
+  artifact that went out before — and why the lower bound naming a release
+  candidate is not an opt-in to one: PEP 440 makes prereleases eligible
+  only when the specifier names one, and a resolver prefers a stable
+  release among the candidates, so the rc is installed only while nothing
+  stable satisfies the bound
+
 - **nine more mypy error codes**, surveyed the way the ruff sets were:
   every optional code `strict` leaves off, run over btclib and tests.
   These nine find nothing today, so each is a ratchet — and two carry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3863,11 +3863,13 @@ edit.
   breaking changes in the minor. CONTRIBUTING.md carries what the policy
   does *not* cover — metadata is baked into every wheel already published,
   so coordinating the two projects protects the supported pair and not an
-  artifact that went out before — and why the lower bound naming a release
-  candidate is not an opt-in to one: PEP 440 makes prereleases eligible
-  only when the specifier names one, and a resolver prefers a stable
-  release among the candidates, so the rc is installed only while nothing
-  stable satisfies the bound
+  artifact that went out before — and what the lower bound naming a release
+  candidate does: it opts this direct dependency into uv's default
+  `if-necessary-or-explicit` strategy, where packaging tools otherwise
+  generally exclude prereleases unless no final or post-release satisfies
+  the specifier or the user asks for them. A satisfying stable release
+  stays preferred, so publishing a final `0.7.1` makes it the selected
+  candidate without changing the bound
 
 - **nine more mypy error codes**, surveyed the way the ruff sets were:
   every optional code `strict` leaves off, run over btclib and tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,33 @@ pyproject.toml. They are compiled from source, so a C toolchain is required
 (cmake comes as a build dependency); the released btclib keeps depending on
 the plain btclib_libsecp256k1 wheels from PyPI.
 
+**The declared dependency is `btclib_libsecp256k1>=0.7.1rc1`, with no
+upper bound**, and the absence of a ceiling is a decision. The bindings are
+a btclib-org project developed by the same people, and their whole purpose
+is to be the bindings this library calls, so a breaking change there is
+coordinated with the release here — which is what a version ceiling
+substitutes for when it cannot be. A `<0.8` ceiling would cost a btclib
+release for every bindings minor, the ones that break nothing included, and
+would make a published artifact refuse a version it in fact works with; a
+`<1` ceiling constrains nothing, pre-1.0 semver putting the breaking
+changes in the minor.
+
+What the policy does not cover: dependency metadata is baked into every
+wheel already published, so coordinating the two projects protects the
+current pair and not an artifact that went out before. Only the latest
+release is supported (SECURITY.md) and nothing is backported, so the
+promise is about that pair — a bindings release keeps the runtime API the
+supported btclib needs, and an older btclib may one day stop installing or
+running against the newest bindings.
+
+The lower bound names a release candidate, and that is what makes
+prereleases of that package eligible at all: PEP 440 has pip exclude them
+unless the specifier itself names one, and uv's default strategy is the
+same. A resolver still prefers a stable release among the candidates, so
+the rc is installed only while nothing stable satisfies the bound — the day
+a final `0.7.1` is published, `>=0.7.1rc1` resolves to it with no edit
+here.
+
 **`pip install -e .` does not work here, and the error will not say why.**
 tool.uv.sources is uv-only metadata: pip does not read it, so it resolves
 btclib_libsecp256k1 from PyPI, where the newest release is older than the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,13 +62,16 @@ promise is about that pair — a bindings release keeps the runtime API the
 supported btclib needs, and an older btclib may one day stop installing or
 running against the newest bindings.
 
-The lower bound names a release candidate, and that is what makes
-prereleases of that package eligible at all: PEP 440 has pip exclude them
-unless the specifier itself names one, and uv's default strategy is the
-same. A resolver still prefers a stable release among the candidates, so
-the rc is installed only while nothing stable satisfies the bound — the day
-a final `0.7.1` is published, `>=0.7.1rc1` resolves to it with no edit
-here.
+The lower bound explicitly includes a prerelease, which opts this direct
+dependency into uv's default `if-necessary-or-explicit` strategy. Packaging
+tools otherwise generally exclude prereleases, except when no final or
+post-release satisfies the specifier or the user asks for them explicitly:
+see the
+[version-specifiers page](https://packaging.python.org/en/latest/specifications/version-specifiers/#handling-of-pre-releases)
+and
+[uv's prerelease handling](https://docs.astral.sh/uv/concepts/resolution/#pre-release-handling).
+A satisfying stable release remains preferred, so publishing a final
+`0.7.1` makes it the selected candidate without changing this bound.
 
 **`pip install -e .` does not work here, and the error will not say why.**
 tool.uv.sources is uv-only metadata: pip does not read it, so it resolves

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,12 @@ requires-python = ">=3.10"
 # breaking changes in the minor. CONTRIBUTING.md states the policy, and
 # what it costs an artifact that is no longer supported.
 #
-# The lower bound names a release candidate, which under PEP 440 is what
-# makes prereleases of this package eligible candidates at all. A resolver
-# still prefers a stable release among them, so the rc is what gets
-# installed only while nothing stable satisfies the bound
+# The lower bound explicitly includes a prerelease, which opts this direct
+# dependency into uv's default `if-necessary-or-explicit` strategy.
+# Packaging tools otherwise generally exclude prereleases, except when no
+# final or post-release satisfies the specifier or the user asks for them
+# explicitly. A satisfying stable release stays preferred, so publishing a
+# final 0.7.1 makes it the selected candidate without changing this bound
 dependencies = ["btclib_libsecp256k1>=0.7.1rc1"]
 keywords = [
     "bitcoin",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,20 @@ authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
 # 3.10 is also the oldest mypy can be aimed at (tool.mypy below), so the
 # floor and the type checker's target agree
 requires-python = ">=3.10"
+# No upper bound, and that is a decision rather than an omission (issue
+# 325). The bindings are a btclib-org project developed by the same people,
+# so a breaking change there is coordinated with the release here -- which
+# is what a version ceiling substitutes for when it cannot be. `<0.8` would
+# cost a btclib release for every bindings minor, including the ones that
+# break nothing, and would make a published artifact refuse a version it
+# works with; `<1` constrains nothing at all, pre-1.0 semver putting the
+# breaking changes in the minor. CONTRIBUTING.md states the policy, and
+# what it costs an artifact that is no longer supported.
+#
+# The lower bound names a release candidate, which under PEP 440 is what
+# makes prereleases of this package eligible candidates at all. A resolver
+# still prefers a stable release among them, so the rc is what gets
+# installed only while nothing stable satisfies the bound
 dependencies = ["btclib_libsecp256k1>=0.7.1rc1"]
 keywords = [
     "bitcoin",


### PR DESCRIPTION
The documentation half of #325. **Does not close it**: the issue stays open
for the RC-to-final edit, which waits on the bindings being published to
PyPI (same ground as #131).

The decision is written down twice, where each reader looks:

- `pyproject.toml`, beside the pin — the place a reader asks "why is there
  no upper bound?";
- `CONTRIBUTING.md`, after the paragraph on tracking the bindings under
  development, with the two things the decision costs.

The policy: no ceiling, because the bindings are a btclib-org project
developed by the same people and a breaking change there is coordinated
with the release here — which is what a ceiling substitutes for when it
cannot be. `<0.8` would cost a btclib release per bindings minor, the ones
that break nothing included, and would make a published artifact refuse a
version it works with; `<1` constrains nothing, pre-1.0 semver putting the
breaking changes in the minor.

What it does not cover, stated rather than implied: metadata is baked into
every wheel already published, so coordinating the two projects protects
the supported pair and not an artifact that went out before. Only the
latest release is supported and nothing is backported (SECURITY.md), which
is the boundary that makes the promise finite.

And the prerelease question, with the PEP 440 detail that shrinks it: the
lower bound naming an rc is what makes prereleases eligible at all, but a
resolver prefers a stable release among the candidates — measured on an
analogue, `django>=5.2rc1` resolves to `6.0.7` — so the rc is installed
only while nothing stable satisfies the bound. The day a final `0.7.1`
exists, this pin resolves to it with no edit here.

Gates: `pre-commit run --all-files`, `pytest` and the `-W` sphinx build,
all green. `uv.lock` is untouched — a comment in `pyproject.toml` is not
part of the resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the rationale for the btclib_libsecp256k1 dependency pin having no upper bound and for using a prerelease lower bound, and record this policy alongside the pin and in contributor-facing docs.

Build:
- Add explanatory comments next to the btclib_libsecp256k1 dependency in pyproject.toml describing the no-ceiling policy and the implications of the prerelease lower bound.

Documentation:
- Explain in CONTRIBUTING.md why the btclib_libsecp256k1 dependency has no upper version bound, what scenarios this policy does not cover, and how the prerelease lower bound affects resolver behavior.

Chores:
- Update CHANGELOG.md to record the documented policy for the btclib_libsecp256k1 dependency pin and its lack of an upper bound.