### PR TITLE
Validate the coinbase transaction in Block.assert_valid

### DIFF
--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -482,6 +482,7 @@ class Block:
         self.assert_valid_length()
 
         self._assert_coinbase()
+        self.transactions[0].assert_valid()
 
         for transaction in self.transactions[1:]:
             # Bitcoin Core's bad-cb-multiple, asked immediately after the

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -585,6 +585,24 @@ def test_a_block_carries_one_coinbase() -> None:
         block.assert_valid()
 
 
+def test_assert_valid_checks_the_coinbase_transaction() -> None:
+    """Refuse an invalid coinbase before checking its changed txid.
+
+    Emptying the script_sig violates CheckTransaction's coinbase rule and
+    also changes the merkle root. The transaction rule comes first in
+    CheckBlock, so a merkle-root error would mean the coinbase itself was
+    skipped.
+    """
+    fname = "block_1.bin"
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        block = Block.parse(file_.read())
+
+    block.transactions[0].vin[0].script_sig = b""
+    with pytest.raises(BTClibValueError, match="Invalid coinbase script size"):
+        block.assert_valid()
+
+
 def test_assert_valid_does_not_rewrite_the_header() -> None:
     """A read is a read: assert_valid must not coerce nonce in place.
 


### PR DESCRIPTION
## What changed

`Block.assert_valid` now calls `assert_valid` on the first transaction after confirming that it is the coinbase, before validating the remaining transactions.

A regression test empties block 1's coinbase `script_sig` and verifies that the block is rejected with the coinbase transaction error before the changed txid reaches the merkle-root check.

## Root cause and impact

The existing loop starts at `transactions[1:]`, so it validates every non-coinbase transaction but never validates the coinbase transaction itself. `Block.assert_valid` therefore did not perform the complete per-transaction `CheckTransaction` pass it documents and that Bitcoin Core's `CheckBlock` performs.

## Verification

- `uv run pytest tests/block/block_test.py -q` — 31 passed
- `uv run pre-commit run --files btclib/block/block.py tests/block/block_test.py` — all hooks passed

## Summary by Sourcery

Validate the coinbase transaction as part of block validation and add regression coverage to ensure coinbase-specific errors surface before merkle root checks.

Bug Fixes:
- Ensure the coinbase transaction is validated during Block.assert_valid, preventing invalid coinbases from bypassing per-transaction checks.

Tests:
- Add a regression test confirming Block.assert_valid rejects a block with an invalid coinbase script_sig before failing on a mismatched merkle root.