### PR TITLE
base58.encode and decode, as bech32's are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3028,6 +3028,20 @@ edit.
   way `btclib.ecc` names `dsa`. The package docstring records both
   decisions, and `tests/all_test.py` pins the list and checks the nine are
   still where they are defined.
+- **`btclib.base58` exports `encode` and `decode`**, where it exported
+  `b58encode` and `b58decode`. The module name already carries the prefix,
+  and `btclib.bech32` — the sibling codec, `btclib.b32`'s bitcoin semantics
+  on top of it the same way `btclib.b58` sits on `base58` — defines `encode`
+  and `decode` with no prefix at all; `base58.b58encode` was the one pair
+  that stuttered. The two call sites where both codecs are in scope,
+  `btclib/b58.py` and `btclib/to_prv_key.py`, import the pair aliased —
+  `from btclib.base58 import decode as b58decode, encode as b58encode` —
+  so the distinction is spelled where it is needed rather than at every
+  use. `BIP32KeyData.b58encode`/`.b58decode`, `bms.Sig.b64encode`/
+  `.b64decode` and `Psbt.b64encode`/`.b64decode` are methods and keep
+  their prefix: on a class it says which encoding the object serializes
+  to, distinguishing it from `serialize`, rather than repeating the
+  module's own name (issue #335)
 
 ### Types
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -317,6 +317,13 @@ against the `v2023.7.12` tag.
   where they are defined. They are how one field of one psbt map is
   written and read; `Psbt`, `PsbtIn` and `PsbtOut` are where a caller
   reads and writes a psbt.
+- **`from btclib.base58 import b58encode, b58decode` is `encode,
+  decode`.** The two call sites that need both codecs in scope —
+  `btclib/b58.py` and `btclib/to_prv_key.py` — alias them back at the
+  import, `from btclib.base58 import decode as b58decode, encode as
+  b58encode`, so a caller doing the same keeps its own names.
+  `BIP32KeyData.b58encode`/`.b58decode`, `bms.Sig.b64encode`/`.b64decode`
+  and `Psbt.b64encode`/`.b64decode` are methods and are unaffected.
 
 Two changes are deliberately *not* on that list, because what they change
 stays compatible. The new `BTClibTypeError`, `NotAPrvKeyError` and

--- a/btclib/b58.py
+++ b/btclib/b58.py
@@ -25,7 +25,8 @@ from typing import Literal
 
 from btclib import b32
 from btclib.alias import Octets, ScriptType, String
-from btclib.base58 import b58decode, b58encode
+from btclib.base58 import decode as b58decode
+from btclib.base58 import encode as b58encode
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
 from btclib.network import NETWORKS, network_from_key_value

--- a/btclib/base58.py
+++ b/btclib/base58.py
@@ -40,7 +40,7 @@ https://github.com/keis/base58, with the following modifications:
 
 * type annotated Python3
 * using native Python3 int.from_bytes() and i.to_bytes()
-* added optional check on output size for b58decode()
+* added optional check on output size for decode()
 * interface mimics the native Python3 base64 interface, i.e.
   it supports encoding bytes-like objects to ASCII bytes,
   and decoding ASCII bytes-like objects or ASCII strings to bytes.
@@ -95,7 +95,7 @@ def _b58encode(v: bytes) -> bytes:
     return result
 
 
-def b58encode(v: Octets, in_size: int | None = None) -> bytes:
+def encode(v: Octets, in_size: int | None = None) -> bytes:
     """Encode a bytes-like object using Base58Check."""
     v = bytes_from_octets(v, in_size)
     h256 = hash256(v)
@@ -131,7 +131,7 @@ def _b58decode(v: bytes) -> bytes:
     return result
 
 
-def b58decode(v: String, out_size: int | None = None) -> bytes:
+def decode(v: String, out_size: int | None = None) -> bytes:
     """Decode a Base58Check encoded bytes-like object or ASCII string.
 
     Optionally, it also ensures required output size.

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -260,7 +260,7 @@ class BIP32KeyData:
     def b58encode(self, *, check_validity: bool = True) -> str:
         """Return the Base58Check text, the xprv/xpub spelling."""
         data_binary = self.serialize(check_validity=check_validity)
-        return base58.b58encode(data_binary).decode("ascii")
+        return base58.encode(data_binary).decode("ascii")
 
     @classmethod
     def parse(
@@ -297,7 +297,7 @@ class BIP32KeyData:
         if isinstance(address, str):
             address = address.strip()
 
-        xkey_bin = base58.b58decode(address)
+        xkey_bin = base58.decode(address)
         return cls.parse(xkey_bin, check_validity=check_validity)
 
 

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -12,7 +12,7 @@
 from __future__ import annotations
 
 from btclib.alias import String
-from btclib.base58 import b58decode
+from btclib.base58 import decode as b58decode
 from btclib.bip32 import BIP32Key, BIP32KeyData
 from btclib.curves import Curve, secp256k1
 from btclib.exceptions import (

--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -84,10 +84,9 @@ already maintains for its own reasons.
 Nothing is renamed for the shell, and no verb is invented. So the command
 line reads `btclib mnemonic bip39 mnemonic-from-entropy`, which is long;
 `btclib b58 wif-from-prv-key`, which is longer than `dumpprivkey`; and
-`btclib base58 b58encode`, which stutters, the function being `b58encode`
-in a module called `base58` — and which is the first of the renamings
-two sections below, since a stutter the mirror shows is a stutter the
-library has.
+`btclib base58 encode`, matching `base58.encode` — the first of the
+renamings two sections below, since a stutter the mirror once showed
+(`base58 b58encode`) is a stutter the library no longer has.
 
 That price is worth paying, for a reason the README states about the
 library: it "is often refactored for improved clarity, without care for
@@ -455,7 +454,7 @@ No key material, no network, no state. It is the half of the surface that
 can be written and reviewed without deciding anything about secrets.
 
 ```text
-base58        b58encode  b58decode
+base58        encode  decode
 bech32        encode  decode
 b58           wif-from-prv-key  address-from-h160  h160-from-address
               p2pkh  p2sh  p2wpkh-p2sh  p2wsh-p2sh

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -578,7 +578,7 @@ behind  0 revisions; that commit is the tip of the path
 Verdict: **identical**, 21 rows of `[hex, base58]`. Core's
 `EncodeBase58`/`DecodeBase58`, i.e. the codec with no checksum on it, so
 what reads them is `base58._b58encode`/`_b58decode` and not the checked
-`b58encode`/`b58decode` — one row is 256 bytes, 348 base58 characters,
+`encode`/`decode` — one row is 256 bytes, 348 base58 characters,
 which the checked decoder would refuse on `MAX_LENGTH` before looking at
 it.
 

--- a/tests/b58_test.py
+++ b/tests/b58_test.py
@@ -17,7 +17,7 @@ from hypothesis import strategies as st
 
 from btclib import b32, b58
 from btclib.alias import ScriptList, ScriptType
-from btclib.base58 import b58encode
+from btclib.base58 import encode as b58encode
 from btclib.bip32 import bip32, slip132
 from btclib.curves import bytes_from_point, point_from_octets, secp256k1
 from btclib.exceptions import (

--- a/tests/base58_test.py
+++ b/tests/base58_test.py
@@ -19,8 +19,8 @@ from btclib.base58 import (
     _b58decode_to_int,
     _b58encode,
     _b58encode_from_int,
-    b58decode,
-    b58encode,
+    decode,
+    encode,
 )
 from btclib.exceptions import BTClibValueError
 from tests import load, vector_id
@@ -29,7 +29,7 @@ from tests import load, vector_id
 # byte for byte; tests/_data/README.md pins the revision. A row is [hex,
 # base58], and the pair is Core's `EncodeBase58`/`DecodeBase58` -- the
 # codec with no checksum on it, which is `_b58encode`/`_b58decode` here
-# and not the `b58encode`/`b58decode` the rest of this module exercises
+# and not the `encode`/`decode` the rest of this module exercises
 CODEC_VECTORS = [
     pytest.param(hexed, encoded, id=vector_id(index, hexed[:16]))
     for index, (hexed, encoded) in enumerate(load("_data", "base58_encode_decode.json"))
@@ -41,7 +41,7 @@ def test_empty() -> None:
     assert _b58encode(b"") == b""
     assert _b58decode(_b58encode(b"")) == b""
 
-    assert b58decode(b58encode(b""), 0) == b""
+    assert decode(encode(b""), 0) == b""
 
 
 def test_hello_world() -> None:
@@ -51,7 +51,7 @@ def test_hello_world() -> None:
     assert _b58decode(_b58encode(b"hello world")) == b"hello world"
     assert _b58encode(_b58decode(b"StV1DL6CwTryKyV")) == b"StV1DL6CwTryKyV"
 
-    assert b58decode(b58encode(b"hello world"), 11) == b"hello world"
+    assert decode(encode(b"hello world"), 11) == b"hello world"
 
 
 def test_trailing_zeros() -> None:
@@ -61,7 +61,7 @@ def test_trailing_zeros() -> None:
     assert _b58decode(_b58encode(b"\x00\x00hello world")) == b"\x00\x00hello world"
     assert _b58encode(_b58decode(b"11StV1DL6CwTryKyV")) == b"11StV1DL6CwTryKyV"
 
-    assert b58decode(b58encode(b"\x00\x00hello world"), 13) == b"\x00\x00hello world"
+    assert decode(encode(b"\x00\x00hello world"), 13) == b"\x00\x00hello world"
 
 
 @pytest.mark.parametrize(("hexed", "encoded"), CODEC_VECTORS)
@@ -72,7 +72,7 @@ def test_core_codec_vectors(hexed: str, encoded: str) -> None:
     the empty string, leading zero bytes as leading '1' characters, the
     whole alphabet in order, the transitions at powers of 58, and a
     256-byte payload. That last one is 348 base58 characters, which
-    `b58decode` would refuse on MAX_LENGTH before looking at it -- the
+    `decode` would refuse on MAX_LENGTH before looking at it -- the
     cap is on the checked decoder, the codec under it being uncapped.
     What the set adds is that the answer is Core's, not btclib's.
     """
@@ -82,27 +82,27 @@ def test_core_codec_vectors(hexed: str, encoded: str) -> None:
 
 
 def test_exceptions() -> None:
-    """Check the message of each way b58decode refuses an input."""
-    encoded = b58encode(b"hello world")
-    b58decode(encoded, 11)
+    """Check the message of each way decode refuses an input."""
+    encoded = encode(b"hello world")
+    decode(encoded, 11)
 
     wrong_length = len(encoded) - 1
     with pytest.raises(BTClibValueError, match="invalid decoded size: "):
-        b58decode(encoded, wrong_length)
+        decode(encoded, wrong_length)
 
     invalid_checksum = encoded[:-4] + b"1111"
     with pytest.raises(BTClibValueError, match="invalid checksum: "):
-        b58decode(invalid_checksum, 4)
+        decode(invalid_checksum, 4)
 
     # a character outside ascii is an invalid base58 character like any
     # other, not a UnicodeEncodeError
     err_msg = "non-ascii character in base58 string: "
     with pytest.raises(BTClibValueError, match=err_msg):
-        b58decode("hèllo world")
+        decode("hèllo world")
 
     err_msg = "not enough bytes for checksum, invalid base58 decoded size: "
     with pytest.raises(BTClibValueError, match=err_msg):
-        b58decode(_b58encode(b"123"))
+        decode(_b58encode(b"123"))
 
 
 def test_wif() -> None:
@@ -112,21 +112,21 @@ def test_wif() -> None:
 
     uncompressed_key = b"\x80" + prv.to_bytes(32, byteorder="big", signed=False)
     uncompressed_wif = b"5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTJ"
-    wif = b58encode(uncompressed_key)
+    wif = encode(uncompressed_key)
     assert wif == uncompressed_wif
-    key = b58decode(uncompressed_wif)
+    key = decode(uncompressed_wif)
     assert key == uncompressed_key
 
     compressed_key = b"\x80" + prv.to_bytes(32, byteorder="big", signed=False) + b"\x01"
     compressed_wif = b"KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617"
-    wif = b58encode(compressed_key)
+    wif = encode(compressed_key)
     assert wif == compressed_wif
-    key = b58decode(compressed_wif)
+    key = decode(compressed_wif)
     assert key == compressed_key
 
     # string
     compressed_wif = b"KwdMAjGmerYanjeui5SHS7JkmpZvVipYvB2LJGU1ZxJwYvP98617"
-    key = b58decode(compressed_wif)
+    key = decode(compressed_wif)
     assert key == compressed_key
 
 
@@ -155,16 +155,16 @@ def test_max_length() -> None:
     """
     # the longest thing btclib encodes: a 78-byte BIP32 extended key,
     # here the one whose 112 characters no payload can exceed
-    longest = b58encode(b"\xff" * 78)
+    longest = encode(b"\xff" * 78)
     assert len(longest) == MAX_LENGTH
-    assert b58decode(longest, 78) == b"\xff" * 78
+    assert decode(longest, 78) == b"\xff" * 78
 
     err_msg = f"too many base58 characters: {MAX_LENGTH + 1}, max is {MAX_LENGTH}"
     with pytest.raises(BTClibValueError, match=err_msg):
-        b58decode(b"1" * (MAX_LENGTH + 1))
+        decode(b"1" * (MAX_LENGTH + 1))
     # str and bytes take the same path
     with pytest.raises(BTClibValueError, match=err_msg):
-        b58decode("1" * (MAX_LENGTH + 1))
+        decode("1" * (MAX_LENGTH + 1))
 
 
 @given(payload=st.binary(max_size=78))
@@ -176,9 +176,9 @@ def test_round_trip(payload: bytes) -> None:
     case the encoding writes as leading '1' characters rather than
     carrying through the base conversion, and has to count back.
     """
-    encoded = b58encode(payload)
+    encoded = encode(payload)
     assert len(encoded) <= MAX_LENGTH
-    assert b58decode(encoded) == payload
-    assert b58decode(encoded, len(payload)) == payload
+    assert decode(encoded) == payload
+    assert decode(encoded, len(payload)) == payload
     # str and bytes are the same string to the decoder
-    assert b58decode(encoded.decode("ascii")) == payload
+    assert decode(encoded.decode("ascii")) == payload

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -157,7 +157,7 @@ def test_serialization() -> None:
     xkey = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
     xkey_data = BIP32KeyData.b58decode(xkey)
 
-    decoded_key = base58.b58decode(xkey, 78)
+    decoded_key = base58.decode(xkey, 78)
     assert xkey_data.version == decoded_key[:4]
     assert xkey_data.depth == decoded_key[4]
     assert xkey_data.parent_fingerprint == decoded_key[5:9]
@@ -291,15 +291,15 @@ def test_derive_exceptions() -> None:
 
     rootxprv = "xprv9s21ZrQH143K2ZP8tyNiUtgoezZosUkw9hhir2JFzDhcUWKz8qFYk3cxdgSFoCMzt8E2Ubi1nXw71TLhwgCfzqFHfM5Snv4zboSebePRmLS"
 
-    temp = base58.b58decode(rootxprv)
-    bad_xprv = base58.b58encode(temp[:45] + b"\x02" + temp[46:], 78)
+    temp = base58.decode(rootxprv)
+    bad_xprv = base58.encode(temp[:45] + b"\x02" + temp[46:], 78)
     err_msg = "invalid private key prefix: "
     with pytest.raises(BTClibValueError, match=err_msg):
         derive(bad_xprv, 0x80000000)
 
     xpub = xpub_from_xprv(rootxprv)
-    temp = base58.b58decode(xpub)
-    bad_xpub = base58.b58encode(temp[:45] + b"\x00" + temp[46:], 78)
+    temp = base58.decode(xpub)
+    bad_xpub = base58.encode(temp[:45] + b"\x00" + temp[46:], 78)
     err_msg = r"invalid public key prefix not in \(0x02, 0x03\): "
     with pytest.raises(BTClibValueError, match=err_msg):
         derive(bad_xpub, 0x80000000)

--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -94,14 +94,14 @@ BINARY_PARSERS: dict[str, Callable[[bytes], Any]] = {
     "ssa.Sig.parse": ssa.Sig.parse,
     "bms.Sig.parse": bms.Sig.parse,
     "point_from_octets": point_from_octets,
-    "base58.b58decode": base58.b58decode,
+    "base58.decode": base58.decode,
     "bech32.decode": bech32.decode,
 }
 
 # The same contract, for what a user pastes rather than what a peer
 # sends: an address, a WIF, an extended key, a descriptor
 TEXT_PARSERS: dict[str, Callable[[str], Any]] = {
-    "base58.b58decode": base58.b58decode,
+    "base58.decode": base58.decode,
     "bech32.decode": bech32.decode,
     "b32.witness_from_address": b32.witness_from_address,
     "b58.h160_from_address": b58.h160_from_address,

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -105,7 +105,7 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     ("derivation index as a step", str_from_index_int),
     ("output size", lambda v: bytes_from_octets(b"x", v)),
     ("output size in an iterable", lambda v: bytes_from_octets(b"x", [v])),
-    ("base58 output size", lambda v: base58.b58decode(base58.b58encode(b"x"), v)),
+    ("base58 output size", lambda v: base58.decode(base58.encode(b"x"), v)),
 ]
 
 _IDS = [case[0] for case in _CASES]
@@ -151,7 +151,7 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert str_from_index_int(1) == "1"
     assert bytes_from_octets(b"x", 1) == b"x"
     assert bytes_from_octets(b"xx", [1, 2]) == b"xx"
-    assert base58.b58decode(base58.b58encode(b"x"), 1) == b"x"
+    assert base58.decode(base58.encode(b"x"), 1) == b"x"
 
     # the str and bytes spellings of a path are untouched by any of it
     assert indexes_from_der_path("m/44h/0h") == [2147483692, 2147483648]
@@ -180,7 +180,7 @@ def test_what_is_no_integer_at_all_is_refused_the_same_way() -> None:
     with pytest.raises(BTClibTypeError, match="invalid output size type"):
         bytes_from_octets(b"x", [1.5])  # type: ignore[list-item]
     with pytest.raises(BTClibTypeError, match="invalid output size type"):
-        base58.b58decode(base58.b58encode(b"x"), 1.0)  # type: ignore[arg-type]
+        base58.decode(base58.encode(b"x"), 1.0)  # type: ignore[arg-type]
 
 
 def test_an_int_subclass_that_is_not_a_bool_is_still_an_integer() -> None:
@@ -206,7 +206,7 @@ def test_an_int_subclass_that_is_not_a_bool_is_still_an_integer() -> None:
     assert indexes_from_der_path([Sighash.ALL]) == [1]
     assert str_from_index_int(Sighash.ALL) == "1"
     assert bytes_from_octets(b"x", Sighash.ALL) == b"x"
-    assert base58.b58decode(base58.b58encode(b"x"), Sighash.ALL) == b"x"
+    assert base58.decode(base58.encode(b"x"), Sighash.ALL) == b"x"
 
     assert is_integer(0)
     assert is_integer(-1)

--- a/tests/to_key_test.py
+++ b/tests/to_key_test.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import copy
 
 from btclib.alias import INF
-from btclib.base58 import b58encode
+from btclib.base58 import encode as b58encode
 from btclib.bip32 import BIP32KeyData
 from btclib.curves import mult, secp256k1
 

--- a/tests/to_prv_key_test.py
+++ b/tests/to_prv_key_test.py
@@ -15,7 +15,7 @@ import pytest
 # Library imports
 from btclib.alias import INF
 from btclib.b58 import wif_from_prv_key
-from btclib.base58 import b58encode
+from btclib.base58 import encode as b58encode
 from btclib.curves.curve import CURVES
 from btclib.exceptions import (
     BTClibValueError,


### PR DESCRIPTION
Closes #335.

## What this changes

`btclib.base58` renames `b58encode`/`b58decode` to `encode`/`decode`.
The module name already carries the prefix, and the sibling codec does
it the other way: `btclib.bech32` defines `encode`/`decode` with no
prefix, so `base58.b58encode` was the one pair that stuttered.

The two call sites where both codecs are in scope, `btclib/b58.py` and
`btclib/to_prv_key.py`, import the pair aliased --
`from btclib.base58 import decode as b58decode, encode as b58encode`
-- so the distinction is spelled where it is needed rather than at
every use, matching what the issue proposed.

## What keeps its prefix, and why

`BIP32KeyData.b58encode`/`.b58decode`, `bms.Sig.b64encode`/
`.b64decode` and `Psbt.b64encode`/`.b64decode` are methods and are
unaffected: on a class the prefix does not repeat the module name, it
says *which* encoding the object serializes to, distinguishing
`b58encode` from `serialize`.

## Cost

Source-breaking: `b58encode`/`b58decode` were the spellings at
`v2023.7.12` -- checked against the tag -- so HISTORY.md's
breaking-changes list gets a bullet and CHANGELOG.md the detail.

## Gates

Full suite (17022 passed), `pre-commit run --all-files` on the changed
files, and the `-W` sphinx build, all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename the public base58 codec API to use generic encode/decode names consistent with the bech32 module, and update callers and docs accordingly.

Enhancements:
- Standardize btclib.base58 public functions to export encode and decode instead of b58encode and b58decode for a cleaner, less stuttered API.
- Alias base58.encode/decode at call sites that need both base58 and bech32 codecs in scope to preserve existing naming in those modules.

Documentation:
- Document the base58 API rename and its rationale in CHANGELOG.md, HISTORY.md, and the base58-related test data README.

Tests:
- Update all base58-related tests and fuzz entry points to use the new encode/decode names and to reflect the updated API semantics.