### PR TITLE
descriptors: checksum and from_address, where add_checksum and strip_checksum already drop the prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3042,6 +3042,16 @@ edit.
   their prefix: on a class it says which encoding the object serializes
   to, distinguishing it from `serialize`, rather than repeating the
   module's own name (issue #335)
+- **`btclib.descriptors` exports `checksum` and `from_address`**, where it
+  exported `descriptor_checksum` and `descriptor_from_address`. The
+  inconsistency was inside the one file: `add_checksum` and
+  `strip_checksum` already take a descriptor and return one without
+  repeating "descriptor" in their names, while the function that computes
+  the checksum did. Qualified, the four now read `descriptors.checksum`,
+  `descriptors.add_checksum`, `descriptors.strip_checksum`,
+  `descriptors.from_address` — one vocabulary instead of two.
+  `strip_checksum`'s local variable holding the parsed checksum is
+  `given_checksum` now, `checksum` being the function's name (issue #336)
 
 ### Types
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -324,6 +324,10 @@ against the `v2023.7.12` tag.
   b58encode`, so a caller doing the same keeps its own names.
   `BIP32KeyData.b58encode`/`.b58decode`, `bms.Sig.b64encode`/`.b64decode`
   and `Psbt.b64encode`/`.b64decode` are methods and are unaffected.
+- **`descriptors.descriptor_checksum` and `.descriptor_from_address` are
+  `checksum` and `from_address`.** Both spellings were already there at
+  `v2023.7.12` — checked against the tag. `add_checksum` and
+  `strip_checksum` keep their names.
 
 Two changes are deliberately *not* on that list, because what they change
 stays compatible. The new `BTClibTypeError`, `NotAPrvKeyError` and

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -119,11 +119,11 @@ def __descsum_expand(descriptor_string: str) -> list[int]:
     return symbols
 
 
-def descriptor_checksum(descriptor: str) -> str:
+def checksum(descriptor: str) -> str:
     """Compute the descriptor checksum."""
     symbols = [*__descsum_expand(descriptor), 0, 0, 0, 0, 0, 0, 0, 0]
-    checksum = __descsum_polymod(symbols) ^ 1
-    return "".join(CHECKSUM_CHARSET[(checksum >> (5 * (7 - i))) & 31] for i in range(8))
+    polymod = __descsum_polymod(symbols) ^ 1
+    return "".join(CHECKSUM_CHARSET[(polymod >> (5 * (7 - i))) & 31] for i in range(8))
 
 
 def strip_checksum(descriptor: str) -> str:
@@ -134,15 +134,15 @@ def strip_checksum(descriptor: str) -> str:
     require it. What is never accepted is a checksum that does not match,
     which is what the eight characters are there for.
     """
-    body, separator, checksum = descriptor.partition("#")
-    if "#" in checksum:
+    body, separator, given_checksum = descriptor.partition("#")
+    if "#" in given_checksum:
         raise BTClibValueError(f"more than one '#' in the descriptor: {descriptor}")
     # computed before the comparison, and whether or not there is one to
     # compare against: it is also what refuses a character outside
     # INPUT_CHARSET, which is an error in a descriptor with no checksum
-    expected = descriptor_checksum(body)
-    if separator and checksum != expected:
-        err_msg = f"invalid descriptor checksum: {checksum}, {expected} expected"
+    expected = checksum(body)
+    if separator and given_checksum != expected:
+        err_msg = f"invalid descriptor checksum: {given_checksum}, {expected} expected"
         raise BTClibValueError(err_msg)
     return body
 
@@ -150,10 +150,10 @@ def strip_checksum(descriptor: str) -> str:
 def add_checksum(descriptor: str) -> str:
     """Return the descriptor with its checksum, verifying a present one."""
     body = strip_checksum(descriptor)
-    return f"{body}#{descriptor_checksum(body)}"
+    return f"{body}#{checksum(body)}"
 
 
-def descriptor_from_address(address: str) -> str:
+def from_address(address: str) -> str:
     """Return the addr() descriptor of the address, checksummed."""
     return add_checksum(f"addr({address})")
 

--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -470,8 +470,8 @@ block         parse  to-dict  bip34-commitment
 block proof-of-work
               target-from-bits  bits-from-target  block-work
               chain-work  hash-rate  next-bits
-descriptors   descriptor-checksum  add-checksum  strip-checksum
-              descriptor-from-address  address  addresses
+descriptors   checksum  add-checksum  strip-checksum
+              from-address  address  addresses
               script-pub-key
 amount        btc-from-sats  sats-from-btc  valid-btc-amount
 fee           fee-from-vsize  dust-threshold

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -51,8 +51,8 @@ from btclib.descriptors import (
     WshDescriptor,
     __descsum_expand,
     add_checksum,
-    descriptor_checksum,
-    descriptor_from_address,
+    checksum,
+    from_address,
     multipath_descriptors,
     parse,
     strip_checksum,
@@ -93,10 +93,10 @@ CHECKSUM_VECTORS = [
 
 # descriptors taken from https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
 # checksum calculated using https://docs.rs/bdk/latest/bdk/descriptor/checksum/fn.get_checksum.html
-@pytest.mark.parametrize(("descriptor", "checksum"), CHECKSUM_VECTORS)
-def test_checksum(descriptor: str, checksum: str) -> None:
+@pytest.mark.parametrize(("descriptor", "expected_checksum"), CHECKSUM_VECTORS)
+def test_checksum(descriptor: str, expected_checksum: str) -> None:
     """Reproduce the checksum of each descriptor of Core's descriptors.md."""
-    assert descriptor_checksum(descriptor) == checksum
+    assert checksum(descriptor) == expected_checksum
 
 
 def test_invalid_charset() -> None:
@@ -109,7 +109,7 @@ def test_addr() -> None:
     """Build a checksummed addr() descriptor from an address."""
     address = "bc1qnehtvnd4fedkwjq6axfgsrxgllwne3k58rhdh0"
     descriptor = "addr(bc1qnehtvnd4fedkwjq6axfgsrxgllwne3k58rhdh0)#s2y3vepm"
-    assert descriptor_from_address(address) == descriptor
+    assert from_address(address) == descriptor
 
 
 def test_add_and_strip_checksum() -> None:
@@ -146,7 +146,7 @@ DESCRIPTOR = st.text(alphabet=DESCRIPTOR_CHARS, min_size=1, max_size=60)
 @given(descriptor=DESCRIPTOR)
 def test_checksum_is_eight_characters(descriptor: str) -> None:
     """Verify the checksum is eight characters whatever the input."""
-    assert len(descriptor_checksum(descriptor)) == 8
+    assert len(checksum(descriptor)) == 8
 
 
 @given(
@@ -167,7 +167,7 @@ def test_a_changed_character_changes_the_checksum(
     mutated = descriptor[:i] + replacement + descriptor[i + 1 :]
     if mutated == descriptor:
         return
-    assert descriptor_checksum(mutated) != descriptor_checksum(descriptor)
+    assert checksum(mutated) != checksum(descriptor)
 
 
 # Bitcoin Core's descriptor_test: the private spelling, the public one

--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -107,7 +107,7 @@ TEXT_PARSERS: dict[str, Callable[[str], Any]] = {
     "b58.h160_from_address": b58.h160_from_address,
     "BIP32KeyData.b58decode": BIP32KeyData.b58decode,
     "bms.Sig.b64decode": bms.Sig.b64decode,
-    "descriptors.descriptor_checksum": descriptors.descriptor_checksum,
+    "descriptors.checksum": descriptors.checksum,
 }
 
 


### PR DESCRIPTION
Closes #336.

## What this changes

`btclib.descriptors` renames `descriptor_checksum` to `checksum` and
`descriptor_from_address` to `from_address`. `add_checksum` and
`strip_checksum` are unchanged.

The inconsistency was inside the one file: `add_checksum` and
`strip_checksum` already take a descriptor and return one without
repeating "descriptor" in their names, while the function that
computes the checksum did. Qualified, the four now read
`descriptors.checksum`, `descriptors.add_checksum`,
`descriptors.strip_checksum`, `descriptors.from_address` -- one
vocabulary instead of two.

`strip_checksum`'s local variable holding the parsed checksum is
renamed to `given_checksum`, `checksum` now being the module function's
own name at that call site.

## Cost, measured rather than assumed

The issue's own text says these two names are recent and "no
`v2023.7.12` spelling is involved". That is not what the tag holds:
`git show v2023.7.12:btclib/descriptors.py` has both
`descriptor_checksum` and `descriptor_from_address` already, so this
*is* source-breaking against the released version, and HISTORY.md's
breaking-changes list gets a bullet accordingly, alongside the
CHANGELOG.md detail.

## Gates

Full suite (17022 passed), `pre-commit run --all-files` on the changed
files, and the `-W` sphinx build, all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align descriptor helper naming in btclib.descriptors and update tests and documentation to reflect the new public API.

Enhancements:
- Rename descriptor_checksum to checksum and descriptor_from_address to from_address for consistent descriptor helper naming.
- Adjust strip_checksum internals to avoid naming conflicts with the renamed checksum function.

Documentation:
- Document the descriptor helper renames and their breaking nature in CHANGELOG.md and HISTORY.md.

Tests:
- Update descriptor-related tests and fuzz harness to use the new checksum and from_address API.