### PR TITLE
The docstring gate is pydocstyle's public-interface boundary, and says so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4463,13 +4463,19 @@ edit.
 
 - **The tests are documented too, and the rendered pages show only what
   is documented.** The `tests/**` exemption from ruff's D rules is gone:
-  every test function, fixture and helper states what it verifies — the
-  property, the published vector, the failure mode — rather than leaving
-  the name to speak, under the same pydocstyle gate as the library. With
-  nothing left undocumented, the 92 `:undoc-members:` options are gone
-  from the `automodule` blocks: a member without a docstring no longer
-  renders as a bare signature, so `sphinx.ext.coverage` measures
-  something again instead of reporting 100% by construction (issue #290)
+  every public test function, fixture and method states what it
+  verifies — the property, the published vector, the failure mode —
+  rather than leaving the name to speak, under the same pydocstyle gate
+  as the library's public interface. With nothing left undocumented,
+  the 92 `:undoc-members:` options are gone from the `automodule`
+  blocks: a member without a docstring no longer renders as a bare
+  signature, so `sphinx.ext.coverage` measures something again instead
+  of reporting 100% by construction (issue #290). A private or nested
+  helper is not what the gate reaches — `D102`/`D103` stop at pydocstyle's
+  public-interface boundary, the one the library's own private helpers
+  already sit outside of — so one is documented the same way a private
+  library helper is: only where the name alone does not say what it
+  does (issue #349)
 - **One spelling per term, throughout the prose.** BIPnnn — no space, no
   hyphen — op code, segwit, merkle, sighash, x-only, and lowercase
   p2pkh/p2sh/p2wpkh/p2tr: each is the spelling already dominant in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -544,9 +544,13 @@ ignore = [
 # these two prints are the interface, not a debugging leftover -- unlike
 # the one print T20 found elsewhere, which is deleted rather than ignored
 "btclib/mnemonic/entropy.py" = ["T201"]
-# the D rules are not here: a test states what it verifies -- the
-# property, the vector, the failure mode -- under the same docstring
-# gate as the library (issue #290)
+# the D rules are not here: a public test function, fixture or method
+# states what it verifies -- the property, the vector, the failure
+# mode -- under the same docstring gate as the library's public
+# interface (issue #290). D102/D103 stop at that boundary, so a
+# private or nested helper is held to the same convention every
+# private helper in the library already is: undocumented unless the
+# name alone does not say what it does (issue #349)
 "tests/**" = [
     "S101",   # assert
     "S311",   # non-cryptographic random: fine in tests


### PR DESCRIPTION
Closes #349.

## What this changes

PR #331 removed the `tests/**` exemption from ruff's D rules, and both
CHANGELOG.md and the `pyproject.toml` comment beside it claimed "every
test function, fixture and helper states what it verifies". `D102`/
`D103` only enforce that at pydocstyle's public-interface boundary --
module-level and public -- so an AST walk still finds 36 non-magic
helpers without a docstring: 24 nested functions, 10 private module
helpers, 2 methods of private test classes. The gate stays green on
all of them, and stays green on the next one added.

This is option 2 of the two the issue lays out: narrow the claim
rather than add a second, custom AST-based check to cover what
pydocstyle's rules deliberately do not. The reasoning: that boundary
is already the rule for the library itself -- a private helper in
`btclib/` (e.g. `base58._b58encode_from_int`) carries no docstring
either, and nothing asks it to -- so holding test helpers to a
stricter standard than library helpers would be a new, bespoke rule
rather than an alignment, maintained by a hand-rolled linter instead
of the tool already doing the job.

Both spots are narrowed to say what the gate actually checks: "every
test function, fixture and helper" becomes "every public test
function, fixture and method", with a sentence pointing at the same
convention already governing private helpers in the library.

## Gates

Full suite (17025 passed), `pre-commit run --all-files` on the changed
files, and the `-W` sphinx build, all green locally. No code changes,
only the two prose spots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify how docstring linting applies to tests by aligning documentation and config comments with pydocstyle’s public-interface boundary.

Documentation:
- Update changelog text to state that only public test functions, fixtures, and methods are required to document what they verify, and to explain how private or nested helpers are treated.

Chores:
- Adjust pyproject.toml comments to accurately describe the scope of D-rule enforcement on tests and its alignment with the library’s public-interface docstring policy.