### PR TITLE
The license is an SPDX expression, before setuptools drops the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4458,6 +4458,23 @@ edit.
   ..., "hex": ...}`, seven identical markers), #173 (four unfinished PSBT
   behaviours — combining a witness, the Finalizer's sighash check, output
   merging, and a partial signature never checked against its key)
+- **the license is an SPDX expression** (issue #363). `license = "MIT"` and
+  `license-files = ["LICENSE", "AUTHORS.md"]` replace the TOML table
+  `license = { text = "MIT License" }`, the `License :: OSI Approved :: MIT
+  License` classifier is gone, and `[build-system] requires` is
+  `setuptools>=77`, the version that added both halves of the PEP 639 form.
+  The metadata field changes with it: the free-text `License: MIT License`
+  of a wheel becomes `License-Expression: MIT`, one machine-readable
+  statement where there were two spellings and a classifier. What prompted
+  it is a build that was already loud about it — three
+  `SetuptoolsDeprecationWarning`s per distribution, the table's naming
+  2027-02-18 as the date the legacy call goes — and `uv build` is now
+  silent on license metadata, with `twine check --strict`,
+  `check-wheel-contents`, `check-manifest` and pyroma at 10/10 unchanged.
+  `AUTHORS.md` is named beside `LICENSE` rather than dropped: setuptools'
+  default globs matched both, so both were already in
+  `dist-info/licenses/`, and the MIT notice names "Ferdinando M. Ametrano
+  and btclib contributors" with that file being where the list is kept
 
 ### Documentation and the website
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [build-system]
-requires = ["setuptools>=64"]
+# 77 is the floor for the PEP 639 metadata below, and for both halves of
+# it at once: the SPDX string form of `project.license` and
+# `project.license-files` arrived in setuptools 77.0.0, which is the
+# version the deprecation warning for the old table form names. An
+# isolated build resolving anything older fails on the syntax rather than
+# ignoring it, which is what the bound is for
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -12,7 +18,19 @@ name = "btclib"
 version = "2026.8"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
-license = { text = "MIT License" }
+# PEP 639: an SPDX expression, which becomes the `License-Expression`
+# metadata field, and the files it is carried by. The TOML-table form
+# setuptools deprecates wrote a free-text `License:` field instead, and
+# there is no license classifier below for the same reason -- one
+# machine-readable statement rather than three spellings of it.
+#
+# AUTHORS.md is named beside LICENSE rather than dropped: setuptools'
+# default globs match both, so both are in `dist-info/licenses/` today, and
+# the MIT notice this repository carries names "Ferdinando M. Ametrano and
+# btclib contributors" -- AUTHORS.md being where that list is kept.
+# `["LICENSE"]` alone would take the attribution out of every wheel
+license = "MIT"
+license-files = ["LICENSE", "AUTHORS.md"]
 authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
 # Python 3.9 is end-of-life since 2025-10, and keeping it out buys more
 # than one fewer column in the matrix: a fresh resolve at ">=3.9" splits
@@ -70,7 +88,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Education",
-    "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
Closes #363.

## What this changes

```toml
[build-system]
requires = ["setuptools>=77"]

[project]
license = "MIT"
license-files = ["LICENSE", "AUTHORS.md"]
```

and the `License :: OSI Approved :: MIT License` classifier is gone.

`>=77` is the floor for both halves at once -- the SPDX string form of
`project.license` and `project.license-files` arrived in setuptools
77.0.0, which is the version the deprecation warning names -- so an
isolated build cannot select a backend that ignores the syntax instead of
failing on it.

## What it measures, before and after

Before, `uv build` exits 0 and emits three `SetuptoolsDeprecationWarning`s
per distribution:

```
setuptools/config/_apply_pyprojecttoml.py:82: `project.license` as a TOML table is deprecated
        By 2027-Feb-18, you need to update your project and remove deprecated calls
setuptools/config/_apply_pyprojecttoml.py:61: License classifiers are deprecated.
setuptools/dist.py:765: License classifiers are deprecated.
```

After, `grep -ic deprecat` over the whole build log is `0`, and the
metadata field changes with the declaration:

| | before | after |
| --- | --- | --- |
| wheel METADATA | `License: MIT License` | `License-Expression: MIT` |

`Metadata-Version` was already 2.4, so nothing else in the metadata moves.

## AUTHORS.md, which is the one choice not in the issue's text

setuptools' default `license-files` globs match `LICENSE` and `AUTHORS*`,
so `dist-info/licenses/` carried both before this change. Writing
`license-files = ["LICENSE"]` would have taken `AUTHORS.md` out of every
wheel; it is named instead, because the MIT notice in `LICENSE` says
"Ferdinando M. Ametrano and btclib contributors" and `AUTHORS.md` is where
that list is kept. Both artifacts carry both files, as before.

## Gates

```
uv build                                          exit 0, no license warnings
twine check --strict dist/*                       PASSED, PASSED
check-wheel-contents dist/*.whl                   OK
check-manifest                                    lists of files ... match
pyroma dist/btclib-2026.8.tar.gz                  Final rating: 10/10
pre-commit run --files pyproject.toml CHANGELOG.md exit 0
pytest                                            17025 passed
sphinx-build -W --keep-going                       build succeeded
```

`uv.lock` is untouched: a build requirement is resolved at build time and
is not part of the resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adopt PEP 639-compliant license metadata and align packaging configuration with setuptools’ newer license handling.

Enhancements:
- Switch project license declaration to an SPDX expression with explicit license files to produce machine-readable license metadata and avoid deprecated setuptools fields.
- Remove the legacy MIT license classifier in favor of the new SPDX-based declaration and keep AUTHORS.md included for attribution in built artifacts.

Build:
- Raise the setuptools build requirement to >=77 to ensure support for SPDX-style license and license-files configuration.

Documentation:
- Document the licensing metadata change, including SPDX expression usage and build tooling implications, in the changelog.