### PR TITLE
CompactSize is an integer field: a bool is neither a count nor a cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1014,6 +1014,22 @@ edit.
   holds all of them to it, and holds the refusal to the numbers it must
   not take with it
 
+- **CompactSize is one of those integer fields too** (issue #361).
+  `var_int.serialize(True)` was the one-octet count one and
+  `var_int.serialize(False)` the length zero — the number saying how many
+  of something there are, taken from a value that says whether — and
+  `var_int.parse(..., max_size=True)` was a cap of one, so a caller who
+  meant "no cap" got a `var_int too big` refusal for every count above
+  one: a range error for what is a type error, and `true` is what a json
+  configuration decodes to. Both entry points go through the `is_integer`
+  of #326 and raise `BTClibTypeError`, which also puts a float, a string
+  and an arbitrary object inside the exception contract, where
+  `bytes([1.5])` and a comparison against a string used to answer from
+  underneath the library. An `IntEnum` is still a count, the negative and
+  overflow diagnostics are still `BTClibValueError` — both being about a
+  value and not a type — and the check on `parse` is on `max_size` alone,
+  the octets being read on the hottest path in the library
+
 - **a key derivation function does not answer with an empty key**
   (issue #321). `ansi_x9_63_kdf` checked only that the requested size was
   not above what the hash function can derive, so a negative size made the

--- a/btclib/var_int.py
+++ b/btclib/var_int.py
@@ -30,8 +30,8 @@ txids.
 from io import BytesIO
 
 from btclib.alias import BinaryData
-from btclib.exceptions import BTClibValueError
-from btclib.utils import bytesio_from_binarydata, hex_string
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.utils import bytesio_from_binarydata, hex_string, is_integer
 
 # The MAX_SIZE of Bitcoin Core (serialize.h), i.e. the range check its
 # ReadCompactSize applies by default. Every var_int btclib parses is a
@@ -56,8 +56,16 @@ def parse(stream: BinaryData, max_size: int = MAX_SIZE) -> int:
     """Return the variable-length integer read from a stream.
 
     max_size is the range check of Bitcoin Core's ReadCompactSize; raise
-    it only for a var_int that is neither a length nor a count.
+    it only for a var_int that is neither a length nor a count. It is an
+    integer and a bool is not one, `is_integer` being the same predicate
+    every integer field of the library is held to: `max_size=True` is a cap
+    of one, so a caller who meant "no cap" would get a `var_int too big`
+    for every count above one -- and `true` is what a json configuration
+    decodes to.
     """
+    if not is_integer(max_size):
+        raise BTClibTypeError(f"non-integer max_size: {max_size}")
+
     stream = bytesio_from_binarydata(stream)
 
     data = stream.read(1)
@@ -82,7 +90,18 @@ def parse(stream: BinaryData, max_size: int = MAX_SIZE) -> int:
 
 
 def serialize(i: int) -> bytes:
-    """Return the var_int bytes encoding of an integer."""
+    """Return the var_int bytes encoding of an integer.
+
+    An integer, and a bool is not one: `bytes([True])` is the single octet
+    one, so a boolean would encode as the count one or the length zero --
+    the number saying how many of something there are, taken from a value
+    that says whether. A float or a string leaves through the `TypeError`
+    of `bytes()` or of a comparison, from underneath the library rather
+    than through its exception contract, which is what `is_integer` is
+    here to answer instead.
+    """
+    if not is_integer(i):
+        raise BTClibTypeError(f"non-integer var_int: {i}")
     if i < 0x00:
         raise BTClibValueError(f"negative integer: {i}")
     if i < 0xFD:  # 1 byte

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -25,7 +25,7 @@ from typing import Any
 
 import pytest
 
-from btclib import base58
+from btclib import base58, var_int
 from btclib.amount import valid_sats_amount
 from btclib.bip32 import BIP32KeyData
 from btclib.bip32.der_path import (
@@ -106,6 +106,8 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     ("output size", lambda v: bytes_from_octets(b"x", v)),
     ("output size in an iterable", lambda v: bytes_from_octets(b"x", [v])),
     ("base58 output size", lambda v: base58.decode(base58.encode(b"x"), v)),
+    ("var_int", var_int.serialize),
+    ("var_int max_size", lambda v: var_int.parse(b"\x01", max_size=v)),
 ]
 
 _IDS = [case[0] for case in _CASES]
@@ -152,6 +154,8 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert bytes_from_octets(b"x", 1) == b"x"
     assert bytes_from_octets(b"xx", [1, 2]) == b"xx"
     assert base58.decode(base58.encode(b"x"), 1) == b"x"
+    assert var_int.serialize(1) == b"\x01"
+    assert var_int.parse(b"\x01", max_size=1) == 1
 
     # the str and bytes spellings of a path are untouched by any of it
     assert indexes_from_der_path("m/44h/0h") == [2147483692, 2147483648]
@@ -182,6 +186,12 @@ def test_what_is_no_integer_at_all_is_refused_the_same_way() -> None:
     with pytest.raises(BTClibTypeError, match="invalid output size type"):
         base58.decode(base58.encode(b"x"), 1.0)  # type: ignore[arg-type]
 
+    for not_a_count in (1.5, "1", object()):
+        with pytest.raises(BTClibTypeError, match="non-integer var_int"):
+            var_int.serialize(not_a_count)  # type: ignore[arg-type]
+        with pytest.raises(BTClibTypeError, match="non-integer max_size"):
+            var_int.parse(b"\x01", max_size=not_a_count)  # type: ignore[arg-type]
+
 
 def test_an_int_subclass_that_is_not_a_bool_is_still_an_integer() -> None:
     """`IntEnum` stays a number, which is why the predicate names bool.
@@ -207,6 +217,8 @@ def test_an_int_subclass_that_is_not_a_bool_is_still_an_integer() -> None:
     assert str_from_index_int(Sighash.ALL) == "1"
     assert bytes_from_octets(b"x", Sighash.ALL) == b"x"
     assert base58.decode(base58.encode(b"x"), Sighash.ALL) == b"x"
+    assert var_int.serialize(Sighash.ALL) == b"\x01"
+    assert var_int.parse(b"\x01", max_size=Sighash.ALL) == 1
 
     assert is_integer(0)
     assert is_integer(-1)

--- a/tests/var_int_test.py
+++ b/tests/var_int_test.py
@@ -14,7 +14,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from btclib import var_int
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 
 
 def test_var_int_conversion() -> None:
@@ -95,6 +95,29 @@ def test_var_int_max_size() -> None:
     # a caller can still raise it for a var_int that is neither a length
     # nor a count
     assert var_int.parse("fe00000004", max_size=0xFFFFFFFF) == 0x04000000
+
+
+def test_a_bool_is_neither_a_count_nor_a_cap() -> None:
+    """CompactSize is an integer field, and `is_integer` is the policy.
+
+    The cap is the case a caller cannot see failing: `max_size=True` is a
+    limit of one, so every count above one comes back as `var_int too
+    big` -- a range refusal for what is a type error, and `true` is what a
+    json configuration decodes to. Both entry points are in
+    tests/integer_policy_test.py's inventory too, with every other integer
+    field of the library.
+    """
+    for value in (True, False):
+        with pytest.raises(BTClibTypeError, match="non-integer var_int"):
+            var_int.serialize(value)
+        with pytest.raises(BTClibTypeError, match="non-integer max_size"):
+            var_int.parse(b"\x01", max_size=value)
+
+    # what the refusal must not take with it: the numbers those two are
+    # not, at the boundary of the one-byte encoding
+    assert var_int.serialize(0) == b"\x00"
+    assert var_int.serialize(1) == b"\x01"
+    assert var_int.parse(b"\x01", max_size=1) == 1
 
 
 def test_var_int_non_canonical() -> None:


### PR DESCRIPTION
Closes #361.

## What this changes

`var_int.serialize` and `var_int.parse`'s `max_size` go through
`btclib.utils.is_integer`, the predicate of #326, and raise
`BTClibTypeError`.

Before:

```python
>>> var_int.serialize(True), var_int.serialize(False)
(b'\x01', b'\x00')
>>> var_int.parse(b"\x01", max_size=True)
1
```

The count is the number saying how many of something there are, taken
from a value that says whether. The `max_size` half is the one a caller
cannot see failing: `True` is a cap of one, so every count above one comes
back as `var_int too big` -- a range refusal for what is a type error, and
`true` is what a json configuration decodes to.

A float, a string and an arbitrary object come inside the exception
contract with them, where `bytes([1.5])` and a comparison against a string
answered from underneath the library.

## What does not change

- an `IntEnum` is still a count, `is_integer` naming `bool` and not every
  `int` subclass;
- `negative integer`, `integer too big for var_int encoding`,
  `var_int too big`, `non-canonical var_int` and `not enough binary data`
  stay `BTClibValueError`, being about a value and not a type;
- `parse` checks `max_size` and not the octets it reads: that is the
  hottest path in the library, one call per script push and per field
  length, and the type of the buffer is `bytesio_from_binarydata`'s
  question already.

## Tests

Both entry points join `tests/integer_policy_test.py`'s inventory, so they
are held to the same three properties as every other integer field -- a
bool refused, a non-integer refused as a type, an `IntEnum` and a plain int
accepted. `tests/var_int_test.py` gains the case for the module, with the
`max_size` reasoning beside it.

## Gates

```
pytest                                  17030 passed
pre-commit run --files <the four>       exit 0
sphinx-build -W --keep-going            exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce consistent integer-only semantics for CompactSize var_int serialization and parsing and align their error handling with the library-wide integer policy.

Bug Fixes:
- Treat non-integer values, including bool, floats, strings, and arbitrary objects, passed to var_int.serialize and var_int.parse(max_size=...) as type errors with BTClibTypeError instead of silently accepting or leaking underlying Python errors.

Enhancements:
- Apply the shared is_integer predicate to CompactSize var_int arguments so they follow the same integer field policy as the rest of the library.
- Clarify var_int API documentation and changelog to describe the integer-only constraint and preserved value-error diagnostics.

Documentation:
- Update CHANGELOG to document CompactSize var_int’s integer-only policy and its revised type error handling.

Tests:
- Extend integer policy tests to cover var_int serialize/parse, including bool refusal, non-integer type refusal, and acceptance of IntEnum and plain int values.
- Add dedicated var_int tests ensuring bools are rejected as counts/caps and verifying boundary behavior remains unchanged.