### PR TITLE
A psbt uint32 is four octets: the global version and the sighash type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -692,6 +692,21 @@ edit.
   when the maps it is handed are not one per input and one per output.
   A version 2 psbt whose count and maps disagree is refused by the
   parse instead, for the map that is missing or the bytes left over
+- **the last two psbt integer fields read without their width now have
+  it** (issue #360). `PSBT_GLOBAL_VERSION` and `PSBT_IN_SIGHASH_TYPE` are
+  both a little-endian uint32 in BIP174 and were both read by an unsized
+  `deserialize_int`, so a value of no octets, one, two, three or four
+  deserialized to the same number and was written back as four: one psbt
+  with five encodings, which is the malleability every fixed-width field of
+  BIP370 was already held away from and the canonical-serialization rule of
+  #322 one level up. `deserialize_sized_int(..., 4)` reads them now, the
+  length is refused whatever `check_validity` says — a width is not an
+  opinion about what the psbt means — and `_serialize_sig_hash_type` is
+  gone, `_serialize_uint32` beside it having written the same four octets
+  all along. `psbt_utils.deserialize_int` goes with them: every call site it
+  ever had was a fixed-width field read without its width, and the BIPs
+  define no psbt integer field that has none, the two counts of BIP370
+  being compact size and having `deserialize_count`
 - **a version 0 psbt carrying a PSBT v2 field is refused, by name**
   (issue #265). BIP370 lists 0 under "Versions Requiring Exclusion" for
   each of the twelve fields it defines, and btclib filed all twelve

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -50,6 +50,17 @@ against the `v2023.7.12` tag.
   `btclib.psbt.musig2` writes for a MuSig2 session and what any taproot
   signer writes; an input carrying neither answers "missing taproot
   signature".
+- **a psbt whose global version or input sighash type is not four octets
+  wide is refused.** BIP174 defines both as a little-endian uint32, and
+  both were read at whatever length they arrived at and written back at
+  four: `PSBT_GLOBAL_VERSION` of `02` in one octet was version 2, and
+  `PSBT_IN_SIGHASH_TYPE` of `01` in one octet was SIGHASH_ALL. Both now
+  answer `invalid global version length: 1 bytes instead of 4` and
+  `invalid sig_hash type length: 1 bytes instead of 4`. What this breaks is
+  a psbt written by something that padded neither field to its width; write
+  the four octets. `psbt_utils.deserialize_int` is gone with the last of
+  its call sites — `deserialize_sized_int` is the one to use, with the
+  width of the field.
 - **a psbt whose MuSig2 fields are malformed is refused**, where all four
   type bytes BIP373 defines were filed under `unknown` and round-tripped:
   input `0x1a`, `0x1b` and `0x1c`, output `0x08`. They are fields now, so

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -16,8 +16,8 @@ an unsigned psbt spends, and the size estimation a fee rate is applied to.
 function, the way btclib.ecc names dsa.
 
 btclib.psbt.psbt_utils is not exported, and this is where that decision is
-recorded: serialize_bytes, deserialize_int, deserialize_map,
-deserialize_tx, the encode/decode_dict_bytes_bytes pair,
+recorded: serialize_bytes, deserialize_map, deserialize_tx,
+the encode/decode_dict_bytes_bytes pair,
 serialize_dict_bytes_bytes, serialize_hd_key_paths and
 assert_valid_unknown are how one field of one map is written and read.
 They are called by psbt_in, psbt_out and psbt itself and by nothing

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -60,7 +60,6 @@ from btclib.psbt.psbt_utils import (
     assert_valid_unknown,
     decode_dict_bytes_bytes,
     deserialize_count,
-    deserialize_int,
     deserialize_map,
     deserialize_sized_int,
     deserialize_tx,
@@ -147,11 +146,15 @@ def _global_version(global_map: Mapping[bytes, bytes]) -> int:
     """Return PSBT_GLOBAL_VERSION, or 0 for a map that does not carry it.
 
     BIP174 makes the field optional and its absence version 0, which is
-    what a psbt written before BIP370 looks like.
+    what a psbt written before BIP370 looks like. Present, it is four
+    octets and no other number of them: the BIP calls it a little-endian
+    uint32, and a value read without its width makes one psbt out of five
+    encodings -- an empty value, one octet, two, three and four all
+    deserialize to a version this writes back as four.
     """
     for k, v in global_map.items():
         if k[:1] == PSBT_GLOBAL_VERSION:
-            return deserialize_int(k, v, "global version")
+            return deserialize_sized_int(k, v, "global version", 4)
     return 0
 
 

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -53,7 +53,6 @@ from btclib.psbt.psbt_utils import (
     decode_musig2_participant_pub_keys,
     decode_taproot_bip32,
     deserialize_bytes,
-    deserialize_int,
     deserialize_map,
     deserialize_sized_int,
     deserialize_tx,
@@ -212,14 +211,6 @@ def _serialize_witness_utxo(type_: bytes, tx_out: TxOut) -> bytes:
     return serialize_bytes(type_, tx_out.serialize())
 
 
-def _serialize_sig_hash_type(type_: bytes, sig_hash_type: int) -> bytes:
-    """Return the binary representation of the dataclass element."""
-    # BIP174: four bytes, little endian, unsigned
-    return serialize_bytes(
-        type_, sig_hash_type.to_bytes(4, byteorder="little", signed=False)
-    )
-
-
 def _serialize_final_script_witness(type_: bytes, witness: Witness) -> bytes:
     """Return the binary representation of the dataclass element."""
     return serialize_bytes(type_, witness.serialize())
@@ -282,7 +273,7 @@ _SERIALIZED_FIELDS: list[tuple[bytes, str, _Serializer]] = [
     (PSBT_IN_NON_WITNESS_UTXO, "non_witness_utxo", _serialize_non_witness_utxo),
     (PSBT_IN_WITNESS_UTXO, "witness_utxo", _serialize_witness_utxo),
     (PSBT_IN_PARTIAL_SIG, "partial_sigs", serialize_dict_bytes_bytes),
-    (PSBT_IN_SIG_HASH_TYPE, "sig_hash_type", _serialize_sig_hash_type),
+    (PSBT_IN_SIG_HASH_TYPE, "sig_hash_type", _serialize_uint32),
     (PSBT_IN_REDEEM_SCRIPT, "redeem_script", serialize_bytes),
     (PSBT_IN_WITNESS_SCRIPT, "witness_script", serialize_bytes),
     (PSBT_IN_BIP32_DERIVATION, "hd_key_paths", serialize_hd_key_paths),
@@ -407,7 +398,7 @@ _WHOLE_VALUE_FIELDS: dict[bytes, tuple[str, str, _Deserializer]] = {
         deserialize_tx,
     ),
     PSBT_IN_WITNESS_UTXO: ("witness_utxo", "witness-utxo", _deserialize_witness_utxo),
-    PSBT_IN_SIG_HASH_TYPE: ("sig_hash_type", "sig_hash type", deserialize_int),
+    PSBT_IN_SIG_HASH_TYPE: ("sig_hash_type", "sig_hash type", _deserialize_uint32),
     PSBT_IN_REDEEM_SCRIPT: ("redeem_script", "redeem script", deserialize_bytes),
     PSBT_IN_WITNESS_SCRIPT: ("witness_script", "witness script", deserialize_bytes),
     PSBT_IN_FINAL_SCRIPTSIG: (

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -117,25 +117,23 @@ def serialize_hd_key_paths(
     )
 
 
-def deserialize_int(k: bytes, v: bytes, type_: str) -> int:
-    """Return the dataclass element from its binary representation."""
-    if len(k) != 1:
-        err_msg = f"invalid {type_} key length: {len(k)}"
-        raise BTClibValueError(err_msg)
-    return int.from_bytes(v, byteorder="little", signed=False)
-
-
 def deserialize_sized_int(
     k: bytes, v: bytes, type_: str, size: int, *, signed: bool = False
 ) -> int:
     """Return the int of a little-endian value of exactly `size` octets.
 
-    The size check is what deserialize_int does not make, and every
-    BIP370 field needs it: a four-byte field written in five octets
-    deserializes to the same integer and serializes back to four, which
-    is one psbt with two encodings -- the malleability `read_exactly`
-    refuses a level down, where the length is the map's rather than the
-    field's.
+    The size is what makes the value one encoding of one number, and every
+    fixed-width field of BIP174 and BIP370 needs it: a four-byte field
+    written in five octets, or in one, deserializes to the same integer and
+    serializes back to four, which is one psbt with several encodings --
+    the malleability `read_exactly` refuses a level down, where the length
+    is the map's rather than the field's.
+
+    There is no unsized counterpart, and that is deliberate: the BIPs
+    define no psbt integer field without a width, the two counts of BIP370
+    being compact size and having `deserialize_count`. A helper reading a
+    value of any length is a field boundary left to whoever writes the
+    bytes.
 
     signed=True for the two values the BIPs define as signed, the
     transaction version and an output's amount.

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -214,7 +214,6 @@ def test_psbt_exports_the_format_not_its_plumbing() -> None:
     for name in (
         "assert_valid_unknown",
         "decode_dict_bytes_bytes",
-        "deserialize_int",
         "deserialize_map",
         "deserialize_tx",
         "encode_dict_bytes_bytes",

--- a/tests/psbt/psbt_in_test.py
+++ b/tests/psbt/psbt_in_test.py
@@ -54,6 +54,30 @@ def test_parse_reads_one_input_from_the_stream() -> None:
     assert stream.read() == b"the outputs"
 
 
+def test_the_sig_hash_type_is_four_octets_and_no_other_number_of_them() -> None:
+    """BIP174 calls PSBT_IN_SIGHASH_TYPE a 32-bit unsigned integer.
+
+    The width is the field, and read without it a one-octet `01` is the
+    same SIGHASH_ALL that serializes back as four -- one input with several
+    encodings, which is what the rest of the fixed-width fields of the
+    format are held away from. `_serialize_uint32` is what writes it, so
+    the two directions now agree on the number of octets rather than only
+    on the number.
+    """
+    canonical = bytes.fromhex("01030401000000") + PSBT_SEPARATOR
+    psbt_in = PsbtIn.parse(canonical)
+    assert psbt_in.sig_hash_type == 1
+    assert psbt_in.serialize() == canonical
+
+    for size in (0, 1, 2, 3, 5):
+        value = (1).to_bytes(max(size, 4), "little")[:size]
+        raw = bytes.fromhex("0103") + bytes([size]) + value + PSBT_SEPARATOR
+        err_msg = f"invalid sig_hash type length: {size} bytes instead of 4"
+        for check_validity in (True, False):
+            with pytest.raises(BTClibValueError, match=err_msg):
+                PsbtIn.parse(raw, check_validity=check_validity)
+
+
 def test_compatibility() -> None:
     """Check the compatibility property `sig_hash` defaults to zero."""
     psbt_in = PsbtIn()

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -38,6 +38,7 @@ from btclib.psbt.psbt import (
     HAS_SIG_HASH_SINGLE,
     INPUTS_MODIFIABLE,
     OUTPUTS_MODIFIABLE,
+    PSBT_GLOBAL_VERSION,
     _sig_hash_from_psbt_in,
     _sort_or_shuffle,
     leaf_script,
@@ -46,6 +47,7 @@ from btclib.psbt.psbt import (
 from btclib.psbt.psbt_in import _V2_FIELDS as _V2_INPUT_FIELDS
 from btclib.psbt.psbt_in import LOCK_TIME_THRESHOLD
 from btclib.psbt.psbt_out import _V2_FIELDS as _V2_OUTPUT_FIELDS
+from btclib.psbt.psbt_utils import PSBT_SEPARATOR
 from btclib.script import ScriptPubKey, Witness, serialize, sig_hash
 from btclib.script.engine import verify_transaction
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
@@ -842,6 +844,36 @@ def test_a_v2_field_of_the_wrong_size_is_refused() -> None:
     )
     with pytest.raises(BTClibValueError, match="invalid tx version key length: 2"):
         Psbt.parse(keyed_version)
+
+
+def test_the_global_version_is_four_octets_and_no_other_number_of_them() -> None:
+    """BIP174 calls it a little-endian uint32, so five values are not one.
+
+    Read without its width, the field made one psbt out of five encodings:
+    an empty value, one octet, two, three and four all deserialize to a
+    version this writes back as four -- the malleability every other
+    fixed-width field of the format is held away from.
+
+    A length is not an opinion about what the psbt means, so it is refused
+    with either value of `check_validity`; and it is refused ahead of the
+    version being one of the two that exist, which is what a value of `00`
+    in one octet would otherwise have been.
+    """
+    header = "70736274ff" + "01020402000000" + "01040100" + "01050100"
+    canonical = f"{header}01fb040200000000"
+
+    psbt = Psbt.parse(canonical)
+    assert psbt.version == 2
+    assert psbt.serialize().hex() == canonical
+
+    for size in (0, 1, 2, 3, 5):
+        value = (2).to_bytes(max(size, 4), "little")[:size]
+        field = bytes([1]) + PSBT_GLOBAL_VERSION + bytes([size]) + value
+        raw = bytes.fromhex(header) + field + PSBT_SEPARATOR
+        err_msg = f"invalid global version length: {size} bytes instead of 4"
+        for check_validity in (True, False):
+            with pytest.raises(BTClibValueError, match=err_msg):
+                Psbt.parse(raw, check_validity=check_validity)
 
 
 # the cases below are btclib's own, and btclib_test_vectors.json is where


### PR DESCRIPTION
Closes #360.

## What this changes

`PSBT_GLOBAL_VERSION` and `PSBT_IN_SIGHASH_TYPE` are read with
`deserialize_sized_int(..., 4)` instead of the unsized `deserialize_int`.

Both are a little-endian uint32 in BIP174, and both took a value of any
length. The issue reports the first; the second is the same defect, found
by following the helper's remaining call site:

```python
>>> raw = bytes.fromhex("0103" "01" "01" "00")   # sighash type: 01 in one octet
>>> PsbtIn.parse(raw).sig_hash_type
1
>>> PsbtIn.parse(raw).serialize().hex()
'0103040100000000'
```

One octet in, four out. Five distinct value lengths mapped to one object,
and only one of them was ever written back.

The width is refused whatever `check_validity` says, a length not being an
opinion about what the psbt means -- so for the global version it is
refused ahead of "one of the two versions that exist", which a value of
`00` in one octet would otherwise have been.

`_serialize_sig_hash_type` is gone: `_serialize_uint32` beside it wrote the
same four little-endian octets, so the field is now one table entry in each
direction, like every other uint32 of the format.

## `deserialize_int` is deleted, which is the one decision beyond the issue

It has no call site left, and this is why it gets no new one rather than
being kept for a caller: every site it ever had was a fixed-width field
read without its width, and the BIPs define no psbt integer field that has
none -- the two counts of BIP370 are compact size and have
`deserialize_count`. A helper that reads a value of any length is a field
boundary left to whoever writes the bytes, so keeping it is keeping the
trap the next field falls into. `deserialize_sized_int`'s docstring now says
that, where the comparison against `deserialize_int` used to be.

It is not in `btclib.psbt.__all__` and the package docstring already
records it as plumbing, but it is importable from
`btclib.psbt.psbt_utils` and was at `v2023.7.12` (`git show
v2023.7.12:btclib/psbt/psbt_utils.py`), so it costs a CHANGELOG.md entry
and a bullet in HISTORY.md's breaking-changes list. Say the word and it
stays.

## Tests

Two, one per field, each checking the canonical four-octet form
round-trips byte for byte and that lengths 0, 1, 2, 3 and 5 are refused
with either value of `check_validity`. The existing suite is what says the
fix breaks no vector: all of BIP174's, BIP370's, BIP371's and BIP373's
write both fields at their declared width.

## Gates

```
pytest                                  17027 passed
pre-commit run --files <the nine>       exit 0
sphinx-build -W --keep-going            exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce canonical four-octet encoding for PSBT global version and input sighash type and remove the legacy unsized integer deserialization helper.

Bug Fixes:
- Prevent malleable encodings of PSBT global version and input sighash type by requiring little-endian uint32 values to be exactly four octets wide during parsing.

Enhancements:
- Align sig_hash_type serialization with the common uint32 serializer to keep PSBT integer field handling consistent.
- Update psbt utilities documentation to reflect the deliberate absence of an unsized integer deserializer and the requirement for fixed-width fields.

Documentation:
- Document the stricter length validation for PSBT global version and sighash type, and note the removal of the generic integer deserializer as a breaking change in CHANGELOG and HISTORY.

Tests:
- Add regression tests ensuring PSBT global version and input sighash type round-trip in their canonical four-octet form and that non-four-octet lengths are rejected regardless of validity checks.

Chores:
- Remove the unused deserialize_int helper from psbt utilities and clean up related imports and export tests.