### PR TITLE
A percent that escapes nothing is not text: bip21 checks the syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2659,6 +2659,16 @@ edit.
   while a base58 one uppercased is a broken checksum. `label` and
   `message` are percent-decoded with `unquote` and not `unquote_plus`,
   a payment URI not being an HTML form, so `Alice+Bob` is two names.
+  The escapes are checked as syntax before they are decoded as text
+  (issue #362), which is a second fault and not the one `errors="strict"`
+  answers: that flag is the error handler of the utf-8 decode *after* the
+  unescaping, so it refuses `%FF` — an escape of an octet that is no text
+  — and says nothing about `%ZZ`, `%G0` or a trailing `%`, which `unquote`
+  leaves as literal text. Left as text they would not round trip, a
+  literal percent sign being written back as `%25`: `label=%ZZ` came out
+  as `label=%25ZZ`, two URIs meaning one request with only one of them
+  written. Every `%` must be followed by two hexadecimal digits, in a
+  parameter name as in a value.
   Along the way: **the address BIP21 prints in every one of its
   examples does not checksum.** Its payload is a sound mainnet p2pkh
   hash160 and hash256 of it begins `8a9c6111` where the address carries

--- a/btclib/bip21.py
+++ b/btclib/bip21.py
@@ -60,6 +60,21 @@ _AMOUNT = re.compile(r"\A(?:[0-9]+(?:\.[0-9]*)?|\.[0-9]+)\Z")
 # "?" and "#" are the delimiters and must stay encoded
 _SAFE = "/:@!$'()*+,;"
 
+# a `%` that is not RFC 3986's pct-encoded, i.e. not followed by exactly
+# two hexadecimal digits. `unquote` leaves such a `%` as literal text --
+# "%ZZ" decodes to "%ZZ" -- and `errors="strict"` does not see it, being
+# the error handler of the utf-8 decode that happens *after* the
+# unescaping. Malformed syntax is therefore not what that flag catches:
+# "%FF" is an escape of an octet that is no text and is refused by it,
+# where "%ZZ" is not an escape at all.
+#
+# Left as text, it would not round trip: serialize writes a literal
+# percent sign as "%25", so "label=%ZZ" would come back out as
+# "label=%25ZZ" -- two URIs meaning one request, with only one of them
+# written, which is the canonical-form rule the binary parsers of this
+# library are held to as well
+_MALFORMED_ESCAPE = re.compile("%(?![0-9A-Fa-f]{2})")
+
 
 def _network_from_address(address: str) -> str:
     """Return the network of an address, raising if it is not one."""
@@ -76,6 +91,11 @@ def _decode(value: str, what: str) -> str:
     -- a label of "Alice+Bob" is two names, and a space is "%20".
     """
     if "%" in value:
+        # the syntax first, and separately: a `%` that escapes nothing is a
+        # different fault from an escape of octets that are not utf-8, and
+        # only the second is what errors="strict" answers
+        if _MALFORMED_ESCAPE.search(value):
+            raise BTClibValueError(f"malformed percent escape in {what}")
         # errors="strict", because a mangled percent escape in a payment
         # request is not a label with a replacement character in it
         try:

--- a/tests/bip21_test.py
+++ b/tests/bip21_test.py
@@ -170,6 +170,36 @@ def test_percent_encoding() -> None:
         Bip21.parse(f"bitcoin:{ADDR}?label=%FF")
 
 
+def test_a_percent_that_escapes_nothing_is_not_text() -> None:
+    """Malformed syntax is a second fault, and `errors="strict"` misses it.
+
+    That flag is the error handler of the utf-8 decode that follows the
+    unescaping, so it answers `%FF` -- an escape of an octet that is not
+    text -- and says nothing about `%ZZ`, which is not an escape: `unquote`
+    leaves the percent sign as literal text. What makes that a defect and
+    not a leniency is the round trip, `serialize` writing a literal percent
+    sign as `%25`: `label=%ZZ` came back out as `label=%25ZZ`, two URIs
+    meaning one request with only one of them written.
+    """
+    for escape in ("%", "%2", "%G0", "%0G", "%ZZ", "%%41", "a%b"):
+        for query in (
+            f"label={escape}",
+            f"message={escape}",
+            f"foo={escape}",
+            f"{escape}=1",
+        ):
+            with pytest.raises(BTClibValueError, match="malformed percent escape"):
+                Bip21.parse(f"bitcoin:{ADDR}?{query}")
+
+    # and what the refusal must not take with it: either case of hex, the
+    # escape of a percent sign itself, and a multi-octet character
+    uri = Bip21.parse(f"bitcoin:{ADDR}?label=%2f%2F&message=100%25&foo=caff%C3%A8")
+    assert uri.label == "//"
+    assert uri.message == "100%"
+    assert uri.others == {"foo": "caffè"}
+    assert Bip21.parse(uri.serialize()) == uri
+
+
 def test_the_address_is_not_lowercased() -> None:
     """A bech32 address is legally uppercase; a base58 one is not."""
     bech32 = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"


### PR DESCRIPTION
Closes #362.

## What this changes

`btclib.bip21._decode` checks the escape syntax before decoding the text:
every `%` must be followed by exactly two hexadecimal digits, or the URI is
refused with a `BTClibValueError`. It is the one place both parameter names
and values pass through, so keys are covered by the same line.

## Why `errors="strict"` did not already do this

That flag is the error handler of the utf-8 decode that happens *after*
the unescaping. It answers `%FF` -- a valid escape of an octet that is not
text -- and says nothing about `%ZZ`, `%G0` or a trailing `%`, which
`unquote` leaves as a literal percent sign. Two different faults, and the
messages say which: `invalid percent-encoding in <what>` for the first,
`malformed percent escape in <what>` for the second.

What makes the leniency a defect is the round trip, since `serialize`
writes a literal percent sign as `%25`:

```python
>>> Bip21.parse(f"bitcoin:{ADDR}?label=%ZZ").serialize()
'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv2456?label=%25ZZ'
```

Two URIs meaning one request, with only one of them written back -- the
canonical-form rule #322 states for the binary parsers.

## What needs nothing

- the **amount**: `_valid_amount_field` holds it to BIP21's own grammar of
  digits and at most one dot, so `amount=%31` is refused without being
  decoded;
- the **address**: it is not percent-decoded at all, and the module
  docstring says why -- neither base58 nor bech32 has a character needing
  an escape, and decoding one would turn a string that is not an address
  into something that might be.

## Tests

`test_a_percent_that_escapes_nothing_is_not_text` runs seven malformed
escapes -- `%`, `%2`, `%G0`, `%0G`, `%ZZ`, `%%41`, `a%b` -- through a
`label`, a `message`, an unknown parameter and a parameter *name*, and then
checks what the refusal must not take with it: either case of hex digit,
`%25` for a percent sign, and the two octets of `caff%C3%A8`, with the
round trip.

## Gates

```
pytest                                             17026 passed
pre-commit run --files <the three>                 exit 0
sphinx-build -W --keep-going                       exit 0
```

Not a HISTORY.md entry: `btclib.bip21` is new in this unreleased version,
so there is no `v2023.7.12` behaviour to act on. The CHANGELOG.md bullet
for the module gains the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate percent-encoded syntax in BIP21 URI decoding to reject malformed escapes and ensure canonical round-tripping.

Bug Fixes:
- Reject BIP21 URIs whose query parameters contain malformed percent escapes before UTF-8 decoding, covering both parameter names and values.

Enhancements:
- Introduce a pre-decode check for RFC 3986-compliant percent-encoding in BIP21 URIs to distinguish malformed escapes from invalid UTF-8 sequences.

Documentation:
- Document in the changelog that BIP21 percent escapes are now syntactically validated before decoding, clarifying behavior for malformed escapes and round-trip guarantees.

Tests:
- Add tests covering multiple malformed percent-escape patterns across labels, messages, unknown parameters, and parameter names, and verifying correct decoding and round-trip behavior for valid escapes.