### PR TITLE
Octets are one whole object for the witness and the two psbt maps too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -921,13 +921,35 @@ edit.
   `var_int` and `var_bytes` read one element out of the middle of a
   buffer, which is how `Block.height` reads the BIP34 height out of a
   coinbase script that carries an extranonce after it.
-  `tests/parse_contract_test.py` holds seven parsers to the rule — every
+  `tests/parse_contract_test.py` holds the parsers to the rule — every
   truncation of an encoding refused at every offset, under either
   `check_validity`, octets with anything after them refused, and a stream
   left on the byte after the object — and one BIP174 invalid-psbt vector
   is pinned to its own reason at last: the case whose value is not its
   stated size now answers `39 bytes after the transaction` rather than the
   `Missing inputs` that was true of it and not what was wrong with it
+- **the three parsers the contract had missed are held to it, and the
+  inventory now fails when one is left out** (issue #359).
+  `Witness.parse(b"\x00junk")` was an empty witness and dropped the four
+  octets, and `PsbtIn.parse` and `PsbtOut.parse` did the same with
+  anything after their map's separator — one map with as many encodings as
+  a caller cares to append to it, while `Psbt.parse` one level up refused
+  exactly that. All three take the stream themselves now and call
+  `assert_no_trailing`, so octets are one whole object and a stream is
+  still the caller's, which is what leaves `Psbt.parse` reading its maps in
+  sequence and a transaction reading a witness per input.
+  `BIP32KeyOrigin.parse` requires its four fingerprint octets whatever
+  `check_validity` says, the other half of that boundary having been
+  unconditional already — `indexes_from_der_path` refuses a remainder that
+  is not a whole number of 4-octet indexes. And the test file now walks
+  `btclib` for every public class with a `parse` and fails unless each is
+  either in the inventory or in a table of exclusions with the reason:
+  `Bip21` is text rather than octets, `dsa.Sig` puts Bitcoin Core's
+  `strict` flag in front of the rule and says so where it does it,
+  `Envelope` writes BIE1's ciphertext between fixed offsets with no length
+  in front of it, and `BIP32KeyOrigin` has a valid four-octet prefix and no
+  length of its own, so two of the three properties are false of it by
+  design
 - **an amount validator raises what this library raises** (issue #339).
   `valid_btc_amount` converted with `Decimal(str(amount))` and let
   `decimal.InvalidOperation` out: an `ArithmeticError`, which `except

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -285,13 +285,16 @@ against the `v2023.7.12` tag.
   `Tx.parse(raw[:-1])` and `Tx.parse(raw + b"junk")` both raise
   `BTClibValueError`, where the first answered a transaction with a
   shorter lock time and the second answered the transaction of `raw`. The
-  same holds for `TxIn`, `TxOut`, `OutPoint`, `Block`, `BlockHeader` and
-  `BIP32KeyData`, and whatever `check_validity` says — the length is what
+  same holds for `TxIn`, `TxOut`, `OutPoint`, `Block`, `BlockHeader`,
+  `BIP32KeyData`, `Witness`, `PsbtIn` and `PsbtOut`, and whatever
+  `check_validity` says — the length is what
   makes the fields mean anything, not an opinion about what they hold. A
   stream is unaffected, what follows the object in it being the caller's:
   reading a transaction out of a block reads on as before. Parsing one
   object out of a longer buffer is `parse(BytesIO(buffer))` rather than
-  `parse(buffer)`.
+  `parse(buffer)`. `BIP32KeyOrigin.parse` goes with them for the width of
+  its master fingerprint, which `check_validity=False` used to defer: four
+  octets, or it is not a key origin.
 - **a boolean is refused wherever a field is an integer quantity.**
   `bool` being a subclass of `int`, `valid_sats_amount(True)` was 1,
   `FeeRate(sats_per_kvbyte=True)` was a one-sat/kvB rate, and

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
+from io import BytesIO
 
 from btclib.alias import Octets
 from btclib.bip32.der_path import (
@@ -22,7 +23,7 @@ from btclib.bip32.der_path import (
     str_from_der_path,
 )
 from btclib.exceptions import BTClibValueError
-from btclib.utils import bytes_from_octets
+from btclib.utils import bytes_from_octets, read_exactly
 
 
 @dataclass(frozen=True)
@@ -111,10 +112,20 @@ class BIP32KeyOrigin:
     def parse(
         cls: type[BIP32KeyOrigin], data: Octets, *, check_validity: bool = True
     ) -> BIP32KeyOrigin:
-        """Return a BIP32KeyOrigin by parsing binary data."""
+        """Return a BIP32KeyOrigin by parsing binary data.
+
+        The four fingerprint octets are the encoding's boundary and not an
+        opinion about what it means, so they are required whatever
+        `check_validity` says: a slice of a shorter buffer answers with
+        whatever is there, and the object serializes back longer than what
+        it was parsed from. The other half of the same boundary is already
+        unconditional -- `indexes_from_der_path` refuses a remainder that is
+        not a whole number of 4-octet indexes.
+        """
         data = bytes_from_octets(data)
-        master_fingerprint = data[:4]
-        der_path = indexes_from_der_path(data[4:])
+        stream = BytesIO(data)
+        master_fingerprint = read_exactly(stream, 4, "master fingerprint")
+        der_path = indexes_from_der_path(stream.read())
 
         return cls(master_fingerprint, der_path, check_validity=check_validity)
 

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -75,7 +75,11 @@ from btclib.psbt.psbt_utils import (
 from btclib.script import Witness, script_from_dict, script_to_dict
 from btclib.script.sig_hash import assert_valid_hash_type
 from btclib.tx import OutPoint, Tx, TxOut
-from btclib.utils import bytes_from_octets
+from btclib.utils import (
+    assert_no_trailing,
+    bytes_from_octets,
+    bytesio_from_binarydata,
+)
 
 PSBT_IN_NON_WITNESS_UTXO = b"\x00"
 PSBT_IN_WITNESS_UTXO = b"\x01"
@@ -854,8 +858,15 @@ class PsbtIn:
         decides whether a BIP370 type byte is a field of this input or
         one this version must not carry; an input read on its own is read
         as version 0, the version BIP174 defines.
+
+        Octets are one whole input and a stream is the caller's, as they
+        are for the psbt these maps make: `Psbt.parse` threads one stream
+        through the inputs and the outputs, and what follows an input in it
+        is the next one.
         """
-        input_map = deserialize_map(data)
+        stream = bytesio_from_binarydata(data)
+        input_map = deserialize_map(stream)
+        assert_no_trailing(data, stream, "psbt input")
         # the init keywords the map fills; whatever it does not carry keeps
         # the default __init__ gives it, which is what makes the two tables
         # above the whole of the mapping

--- a/btclib/psbt/psbt_out.py
+++ b/btclib/psbt/psbt_out.py
@@ -62,7 +62,11 @@ from btclib.psbt.psbt_utils import (
     taproot_bip32_to_dict,
 )
 from btclib.script import script_from_dict, script_to_dict
-from btclib.utils import bytes_from_octets
+from btclib.utils import (
+    assert_no_trailing,
+    bytes_from_octets,
+    bytesio_from_binarydata,
+)
 
 PSBT_OUT_REDEEM_SCRIPT = b"\x00"
 PSBT_OUT_WITNESS_SCRIPT = b"\x01"
@@ -334,8 +338,15 @@ class PsbtOut:
         decides whether a BIP370 type byte is a field of this output or
         one this version must not carry; an output read on its own is
         read as version 0, the version BIP174 defines.
+
+        Octets are one whole output and a stream is the caller's, as they
+        are for the psbt these maps make: `Psbt.parse` threads one stream
+        through the inputs and the outputs, and what follows an output in it
+        is the next one.
         """
-        output_map = deserialize_map(data)
+        stream = bytesio_from_binarydata(data)
+        output_map = deserialize_map(stream)
+        assert_no_trailing(data, stream, "psbt output")
         redeem_script = b""
         witness_script = b""
         hd_key_paths: dict[Octets, BIP32KeyOrigin] = {}

--- a/btclib/script/witness.py
+++ b/btclib/script/witness.py
@@ -16,7 +16,11 @@ from dataclasses import dataclass
 
 from btclib import var_bytes, var_int
 from btclib.alias import BinaryData, Octets
-from btclib.utils import bytes_from_octets, bytesio_from_binarydata
+from btclib.utils import (
+    assert_no_trailing,
+    bytes_from_octets,
+    bytesio_from_binarydata,
+)
 
 
 # frozen, and a tuple rather than a list of bytes, which makes a Witness
@@ -99,8 +103,16 @@ class Witness:
     def parse(
         cls: type[Witness], data: BinaryData, *, check_validity: bool = True
     ) -> Witness:
-        """Return a Witness by parsing binary data."""
-        data = bytesio_from_binarydata(data)
-        n = var_int.parse(data)
-        stack = [var_bytes.parse(data) for _ in range(n)]
+        """Return a Witness by parsing binary data.
+
+        Octets are one whole witness and a stream is the caller's:
+        btclib/utils.py states the rule both halves of this contract read.
+        The stream case is what a transaction is parsed with -- one witness
+        per input, out of the stream the transaction is read from -- and the
+        octet case is what a PSBT_IN_FINAL_SCRIPTWITNESS value is.
+        """
+        stream = bytesio_from_binarydata(data)
+        n = var_int.parse(stream)
+        stack = [var_bytes.parse(stream) for _ in range(n)]
+        assert_no_trailing(data, stream, "witness")
         return cls(stack, check_validity=check_validity)

--- a/tests/parse_contract_test.py
+++ b/tests/parse_contract_test.py
@@ -15,10 +15,18 @@ complete octet string is one whole object, and a caller's stream is the
 caller's. What the tests hold every parser to is that none of the three
 depends on `check_validity`, which is an opinion about what the bytes
 mean and not about where they end.
+
+The inventory at the top is what those tests run over, and the last test
+is what makes it a promise rather than a list: it walks the package for
+every public class carrying a `parse` and fails unless each one is either
+in the inventory or in a table of exclusions naming its reason. A parser
+added to btclib and forgotten here would otherwise be held to nothing.
 """
 
 from __future__ import annotations
 
+import importlib
+import pkgutil
 from collections.abc import Callable
 from io import BytesIO
 from os import path
@@ -26,10 +34,13 @@ from typing import Any
 
 import pytest
 
-from btclib.bip32 import BIP32KeyData
+import btclib
+from btclib.bip32 import BIP32KeyData, BIP32KeyOrigin
 from btclib.block import Block, BlockHeader
 from btclib.ecc import bms, ssa
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
+from btclib.psbt import Psbt, PsbtIn, PsbtOut
+from btclib.script import Witness
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
 # what btclib promises to raise, and the whole of it: a truncated buffer
@@ -60,22 +71,33 @@ def _tx() -> Tx:
     )
 
 
+def _psbt() -> Psbt:
+    """Return the psbt of the transaction above, maps and all."""
+    return Psbt.from_tx(_tx())
+
+
 # every object with a fixed-width field in it or a length of its own,
-# with the parser to read it back: (name, parse, serialization)
-_CASES: list[tuple[str, Callable[..., Any], bytes]] = [
-    ("outpoint", OutPoint.parse, OutPoint(_TX_ID, 0).serialize()),
-    ("tx_in", TxIn.parse, TxIn(OutPoint(_TX_ID, 0), b"", 0xFFFFFFFF).serialize()),
-    ("tx_out", TxOut.parse, TxOut(1, b"").serialize()),
-    ("tx", Tx.parse, _tx().serialize(include_witness=True)),
-    ("block_header", BlockHeader.parse, _block_1()[:80]),
-    ("block", Block.parse, _block_1()),
-    ("bip32_key", BIP32KeyData.parse, BIP32KeyData.b58decode(_XPRV).serialize()),
-    ("ssa_sig", ssa.Sig.parse, ssa.sign(b"parse contract", 1).serialize()),
-    ("bms_sig", bms.Sig.parse, bms.sign(b"parse contract", 1).serialize()),
+# with the class whose `parse` reads it back: (name, class, serialization).
+# The class and not the bound method, so that the inventory says which
+# parsers are covered -- see the completeness test at the end of this file
+_CASES: list[tuple[str, type[Any], bytes]] = [
+    ("outpoint", OutPoint, OutPoint(_TX_ID, 0).serialize()),
+    ("tx_in", TxIn, TxIn(OutPoint(_TX_ID, 0), b"", 0xFFFFFFFF).serialize()),
+    ("tx_out", TxOut, TxOut(1, b"").serialize()),
+    ("tx", Tx, _tx().serialize(include_witness=True)),
+    ("block_header", BlockHeader, _block_1()[:80]),
+    ("block", Block, _block_1()),
+    ("bip32_key", BIP32KeyData, BIP32KeyData.b58decode(_XPRV).serialize()),
+    ("ssa_sig", ssa.Sig, ssa.sign(b"parse contract", 1).serialize()),
+    ("bms_sig", bms.Sig, bms.sign(b"parse contract", 1).serialize()),
+    ("witness", Witness, Witness([b"\x51", b"\x52\x53"]).serialize()),
+    ("psbt", Psbt, _psbt().serialize()),
+    ("psbt_in", PsbtIn, PsbtIn(redeem_script=b"\x51").serialize()),
+    ("psbt_out", PsbtOut, PsbtOut(redeem_script=b"\x51").serialize()),
 ]
 
 _IDS = [case[0] for case in _CASES]
-_PARSE_AND_BYTES = [(case[1], case[2]) for case in _CASES]
+_PARSE_AND_BYTES = [(case[1].parse, case[2]) for case in _CASES]
 
 
 @pytest.mark.parametrize(("parse", "serialization"), _PARSE_AND_BYTES, ids=_IDS)
@@ -191,3 +213,109 @@ def test_a_truncation_does_not_round_trip() -> None:
     assert Tx.parse(tx_bytes) == tx
     with pytest.raises(BTClibValueError, match="4 bytes after the transaction"):
         Tx.parse(tx_bytes + b"junk")
+
+
+def test_a_key_origin_is_a_fingerprint_and_then_indexes() -> None:
+    """The fingerprint is four octets wide, whatever the origin means.
+
+    Deferred to `check_validity`, a slice of a shorter buffer answered with
+    whatever was there and the object serialized back longer than what it
+    was parsed from. The remainder was already unconditional:
+    `indexes_from_der_path` refuses what is not a whole number of 4-octet
+    indexes, whatever `check_validity` says, so this is the other half of
+    one boundary.
+
+    Its own test rather than a line in the inventory above, because none of
+    the three generic properties applies to a key origin, and that is worth
+    saying once: four octets are a valid key origin with an empty path, so
+    a prefix of a longer encoding *is* an object; the record carries no
+    length and consumes the whole buffer, so nothing can trail it -- four
+    junk octets are one more index; and `parse` takes `Octets` rather than
+    `BinaryData`, so there is no stream to leave alone.
+    """
+    for check_validity in (True, False):
+        for raw in (b"", b"\x00", b"\x00\x00\x00"):
+            err_msg = "not enough data for the master fingerprint"
+            with pytest.raises(BTClibValueError, match=err_msg):
+                BIP32KeyOrigin.parse(raw, check_validity=check_validity)
+
+    # and what the refusal must not take with it: the shortest key origin
+    # there is, and one with a path
+    assert BIP32KeyOrigin.parse(b"\xde\xad\xbe\xef").description == "deadbeef"
+    key_origin = BIP32KeyOrigin("deadbeef", "m/44h/0h")
+    assert BIP32KeyOrigin.parse(key_origin.serialize()) == key_origin
+
+
+# what a parser of this library is *not* held to, and why. A name here is
+# a decision, which is the difference between an exclusion and an
+# oversight -- the test below fails on either
+_EXCLUDED = {
+    "btclib.bip21.Bip21": (
+        "a bitcoin: URI is text and not octets: it has no fixed-width"
+        " field, nothing can follow it in a stream, and its own grammar"
+        " is what tests/bip21_test.py holds it to"
+    ),
+    "btclib.bip32.key_origin.BIP32KeyOrigin": (
+        "a four-octet prefix of it is a valid key origin with an empty"
+        " path, and the record has no length of its own, so two of the"
+        " three properties are false of it by design; the boundary it does"
+        " owe its caller is the test above"
+    ),
+    "btclib.ecc.dsa.Sig": (
+        "the one parser here with a flag in front of the rule, and the flag"
+        " is Bitcoin Core's: trailing octets are refused under `strict`"
+        " alone, where IsValidSignatureEncoding is called, and refused in a"
+        " stream as well -- no caller in this library reads a signature out"
+        " of the middle of one. Sig.parse says so where it does it"
+    ),
+    "btclib.ecc.ecies.Envelope": (
+        "BIE1 writes the ciphertext between fixed offsets with no length in"
+        " front of it, so what would trail the envelope is ciphertext and a"
+        " truncation of it is a shorter message: the size rule it can be"
+        " held to is the minimum one it checks"
+    ),
+}
+
+
+def _public_parsers() -> set[str]:
+    """Return every public btclib class offering a `parse`, module included.
+
+    Found rather than listed, which is the whole point: a parser added to
+    the library has to appear in the inventory above or be named an
+    exclusion, and a class the walk cannot reach is one no caller can
+    import either.
+
+    The module is part of the name because three classes are called `Sig`.
+    A private class is skipped, the contract being about what a caller can
+    reach -- `_BIP32KeyData` is the one such today, and its public
+    subclass is in the inventory.
+    """
+    module_names = [
+        "btclib",
+        *(module.name for module in pkgutil.walk_packages(btclib.__path__, "btclib.")),
+    ]
+    parsers = set()
+    for module_name in module_names:
+        module = importlib.import_module(module_name)
+        for obj in vars(module).values():
+            if not isinstance(obj, type):
+                continue
+            if not getattr(obj, "__module__", "").startswith("btclib"):
+                continue
+            if obj.__qualname__.startswith("_"):
+                continue
+            if callable(getattr(obj, "parse", None)):
+                parsers.add(f"{obj.__module__}.{obj.__qualname__}")
+    return parsers
+
+
+def test_every_parser_is_covered_or_named_an_exclusion() -> None:
+    """The inventory is a promise only if omission is what fails.
+
+    A parser added to btclib and forgotten here is the failure this
+    catches: the tests above would go on passing on the parsers they were
+    given, and the new one would be held to nothing.
+    """
+    covered = {f"{cls.__module__}.{cls.__qualname__}" for _, cls, _ in _CASES}
+    assert not covered & _EXCLUDED.keys()
+    assert _public_parsers() == covered | _EXCLUDED.keys()


### PR DESCRIPTION
Closes #359.

## What this changes

Both reproductions in the issue, plus two more of the same defect that the
audit it asks for turned up.

```python
>>> Witness.parse(b"\x00junk").serialize()      # four octets dropped
b'\x00'
>>> PsbtIn.parse(PsbtIn().serialize() + b"junk").serialize()
b'\x00'
```

`PsbtOut.parse` behaves like `PsbtIn.parse`, and the cause is the one
`Witness.parse` had: `deserialize_map` was handed the octets, stopped at
the separator and returned the map, so the parser never held the stream the
rule is asked of -- while `Psbt.parse` one level up already called
`assert_no_trailing`. The container obeyed the contract; the maps it is
made of did not, and reading one on its own is where it showed.

- `Witness.parse`, `PsbtIn.parse` and `PsbtOut.parse` take the stream
  themselves and call `assert_no_trailing`. A stream is still the caller's,
  which is what leaves `Psbt.parse` reading its maps in sequence and
  `Tx.parse` reading one witness per input -- both pass a `BytesIO`, so
  nothing there changes.
- `BIP32KeyOrigin.parse` requires its four fingerprint octets whatever
  `check_validity` says, through the same `read_exactly` every other
  parser reports a truncation with. The other half of that boundary was
  unconditional already: `indexes_from_der_path` refuses a remainder that
  is not a whole number of 4-octet indexes.

## The inventory now fails when a parser is left out

`tests/parse_contract_test.py` gains `witness`, `psbt_in`, `psbt_out` and
`psbt` -- the last one was obeying the contract untested -- and a final test
walks `btclib` for every public class carrying a `parse`, asserting the set
equals the inventory plus a table of exclusions. Four are excluded, each
with its reason in the table:

| parser | why not |
| --- | --- |
| `Bip21` | a URI is text, not octets: no fixed-width field, nothing can follow it in a stream |
| `dsa.Sig` | the one parser with a flag in front of the rule, and the flag is Core's: trailing octets are refused under `strict` alone, and in a stream too, which `Sig.parse` says where it does it |
| `Envelope` | BIE1 writes the ciphertext between fixed offsets with no length in front of it, so what would trail an envelope is ciphertext |
| `BIP32KeyOrigin` | a four-octet prefix is a valid key origin with an empty path, and the record has no length of its own, so two of the three properties are false of it by design |

The `_CASES` inventory now holds the class rather than its bound `parse`,
which is what lets the completeness test name what is covered without a
second list to keep in sync.

`BIP32KeyOrigin`'s own boundary is tested beside the exclusion, with the
reasoning for why it is not in the generic run.

## One thing measured on the way

The CHANGELOG paragraph on #322 claimed the file "holds seven parsers to
the rule". It held nine before this PR and holds thirteen after; the
sentence no longer states a number, which is what CLAUDE.md asks of a count
nothing checks.

## Gates

```
pytest                                  17047 passed
pre-commit run --files <the seven>      exit 0
sphinx-build -W --keep-going            exit 0
```

Every BIP174, BIP370, BIP371 and BIP373 vector passes unchanged, including
the `PSBT_IN_FINAL_SCRIPTWITNESS` values that now go through a
trailing-octet check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce strict trailing-byte checks and boundary handling for witness, PSBT input/output, and BIP32 key origin parsing, and extend the parse contract tests to cover all public parsers via an explicit inventory and exclusions list.

Bug Fixes:
- Ensure Witness.parse rejects trailing bytes and treats provided octets as a single complete witness object.
- Ensure PsbtIn.parse and PsbtOut.parse reject trailing bytes and do not silently drop data after their respective maps.
- Require BIP32KeyOrigin.parse to always read exactly four fingerprint bytes, raising on truncation instead of accepting partial data.

Enhancements:
- Have Witness.parse, PsbtIn.parse, and PsbtOut.parse operate on caller-owned streams while asserting no trailing data when given octets.
- Refine BIP32KeyOrigin parsing to use explicit, length-checked reads and document the boundary semantics.
- Add a reflective test that walks btclib for all public classes exposing parse and enforces that each is either covered by the parse-contract inventory or explicitly excluded with rationale.
- Extend parse-contract coverage to Witness, Psbt, PsbtIn, and PsbtOut, and store classes rather than bound parse methods in the inventory for clearer coverage reporting.
- Document the expanded set of parsers covered by the parse contract and clarify the behavior in CHANGELOG and HISTORY entries.

Tests:
- Expand parse contract tests to include Witness, Psbt, PsbtIn, and PsbtOut using class-based inventory entries.
- Introduce a completeness test that discovers all public btclib classes with a parse method and asserts they are either in the inventory or in an explicit exclusions table with documented reasons.
- Add targeted tests for BIP32KeyOrigin parsing boundaries, including truncated fingerprints and valid minimal encodings.