### PR TITLE
btclib.fetch follows no redirect, so an rpc credential reaches one host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,32 @@ edit.
 
 ### Security
 
+- **`btclib.fetch` follows no redirect, so an rpc credential reaches one
+  host** (issue #358). `urlopen` uses urllib's default opener, whose
+  `HTTPRedirectHandler` answered a 30x before this module saw a response,
+  and it did three things nothing here asked for: `redirect_request`
+  copies every header but `content-length` and `content-type`, so the
+  `Authorization` built for a node travelled to whatever host the
+  `Location` named — a JSON-RPC POST arriving there as a GET; a redirect
+  target may be `http`, `https` or `ftp`, so an https request could be
+  answered with an http one and the scheme check covered only the first
+  url; and `fp.read()` with no argument read the whole intermediate body,
+  so `max_body_size` bounded the final response and not the exchange.
+  Measured against two local `http.server` instances, the second one
+  received the request with `Authorization: Basic YWxpY2U6c2VjcmV0` on
+  it verbatim. `urlopen_transport` now does its I/O through an opener
+  built without that handler, so a 30x arrives as the `HTTPError` any
+  other non-2xx does and comes back as a status with a bounded body,
+  which both fetchers already turn into a `FetchError` naming it —
+  `getblockcount at http://127.0.0.1:8332: HTTP 302`. Refused rather than
+  policed, and the reason is what a policy would have to be: stripping
+  credentials across origins, refusing a downgrade, bounding every
+  intermediate body and counting hops is a redirect implementation inside
+  a module whose subject is one bounded request, where what a same-origin
+  redirect would buy is a base url the caller fixes once. `build_opener`
+  and not `install_opener`, the default opener being process-wide: a
+  library replacing it would decide this for every other user of
+  `urlopen` in the program
 - **a sign-to-contract commitment reaches the nonce derivation, and not
   only the nonce.** `sign_to_contract` tweaked the nonce with the
   commitment and derived that nonce from the message and the key alone,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -174,4 +174,11 @@ used to teach and to prototype as much as to build:
     `127.0.0.1`, which is what bitcoind serves: a node on another host is
     reached over an ssh tunnel or a TLS proxy, not by trusting the
     network in between — the basic authentication this sends is a
-    base64 of the credential and nothing more
+    base64 of the credential and nothing more. With the default
+    `urlopen_transport` it reaches the url the caller wrote down and no
+    other: no redirect is followed, so a 30x is a status the backend
+    reports rather than a second request carrying the same `Authorization`
+    to wherever a `Location` header named. A transport of the caller's own
+    is supported and does its own I/O, so there the same guarantee is
+    theirs to provide — a client that follows redirects is one that
+    decides where the credential goes

--- a/btclib/fetch/transport.py
+++ b/btclib/fetch/transport.py
@@ -21,7 +21,7 @@ need it passes a transport of their own: that is what the `HttpTransport`
 alias below is for.
 
 The seam is deliberate, and it is what keeps the test suite off the
-network. `http_request` never calls `urlopen` itself; it calls whatever
+network. `http_request` opens no socket itself; it calls whatever
 callable it was handed, `urlopen_transport` by default. A test hands it a
 function answering from a recorded response, so the suite exercises the
 request building, the status handling and the error mapping while opening
@@ -32,10 +32,11 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping
 from contextlib import suppress
-from typing import Any
+from http.client import HTTPMessage
+from typing import IO, Any
 from urllib.error import HTTPError
 from urllib.parse import urlsplit
-from urllib.request import Request, urlopen
+from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError, FetchError
 from btclib.utils import is_integer
@@ -92,6 +93,60 @@ MAX_ERROR_BODY_SIZE = 64 * 1024
 # scheme here is what makes the `noqa` in `urlopen_transport` true rather
 # than hopeful
 _SCHEMES = ("http", "https")
+
+
+class _NoRedirect(HTTPRedirectHandler):
+    """The handler that does not follow a 30x, and answers None to say so.
+
+    `redirect_request` returning None means "not handled" to
+    `OpenerDirector.error`, which then reaches `HTTPDefaultErrorHandler`
+    and raises the `HTTPError` -- so a redirect arrives at `http_request`
+    as the status and the bounded body of any other non-2xx.
+    """
+
+    def redirect_request(
+        self,
+        req: Request,
+        fp: IO[bytes],
+        code: int,
+        msg: str,
+        headers: HTTPMessage,
+        newurl: str,
+    ) -> Request | None:
+        """Answer None: no redirect is followed, whatever it points at."""
+        return None
+
+
+# The one opener btclib does its I/O with, and what it is missing is the
+# point: urllib's default `HTTPRedirectHandler`, which follows a 30x
+# before any of this module sees a response. Three things it does that no
+# caller asked for, read off CPython's urllib/request.py:
+#
+# - `redirect_request` copies every request header except `content-length`
+#   and `content-type`, so an `Authorization` built for a node reaches
+#   whatever host the redirect names -- a JSON-RPC POST also arriving there
+#   as a GET;
+# - `http_error_302` admits `http`, `https`, `ftp` and the empty scheme, so
+#   an https request can be answered with an http target and the scheme
+#   check of `http_request` covers only the first url;
+# - it calls `fp.read()` with no argument before following, so the whole
+#   intermediate body is read whatever `max_body_size` says.
+#
+# Refused rather than policed, and that is a decision (issue #358): a
+# redirect policy is stripping credentials across origins, refusing a
+# downgrade, bounding every intermediate body and counting hops, which is
+# a redirect implementation inside a module whose subject is one bounded
+# request. What following a same-origin redirect would buy a caller -- an
+# endpoint that moved path -- is a base url they fix once, and both
+# fetchers turn the 30x into a FetchError naming the status and the url,
+# which is what tells them to. A caller passing a transport of their own
+# does its own I/O, so what `requests` or `httpx` does with a 30x is
+# theirs.
+#
+# `build_opener` and not `install_opener`: the default opener is process
+# wide, and a library that replaced it would decide this for every other
+# user of `urlopen` in the program
+_OPENER = build_opener(_NoRedirect)
 
 
 def _assert_valid_max_body_size(max_body_size: int) -> None:
@@ -176,10 +231,14 @@ def urlopen_transport(
     type. What a transport of someone else's returns is bytes it has
     already read, so all `http_request` can do for those is refuse to pass
     an oversized body on -- see its `max_body_size`.
+
+    No redirect is followed: `_OPENER` above says why, and what a 30x
+    arrives as is the `HTTPError` any other non-2xx status does.
     """
-    # what reaches urlopen is http or https: `http_request` is the only
-    # thing that builds a Request, and it checks the scheme first
-    with urlopen(request, timeout=timeout) as response:  # noqa: S310
+    # what reaches the opener is http or https: `http_request` is the only
+    # thing that builds a Request, it checks the scheme first, and a
+    # redirect cannot introduce a second url
+    with _OPENER.open(request, timeout=timeout) as response:
         body = _read_bounded(response, max_body_size, request.full_url)
         return response.status, body
 
@@ -204,7 +263,9 @@ def http_request(
     other, because the body of a 500 is where bitcoind's JSON-RPC 1.0
     reply puts its error object, and the body of a 404 is where an
     explorer says what it could not find. Deciding what a status means is
-    the backend's job, that being the layer that knows.
+    the backend's job, that being the layer that knows. A 30x is one of
+    those statuses now rather than a second request: `urlopen_transport`
+    follows no redirect, and `_OPENER` says why.
 
     `max_body_size` is what an *answer* may weigh, and the caller sets it
     from what it asked for: a tip height is a few octets and a raw

--- a/tests/fetch/bitcoind_test.py
+++ b/tests/fetch/bitcoind_test.py
@@ -251,6 +251,28 @@ def test_a_401_says_it_is_the_credentials() -> None:
         proxy((401, b"")).call("getblockcount")
 
 
+@pytest.mark.parametrize("code", [301, 302, 303, 307, 308])
+def test_a_redirect_is_refused_and_not_answered(code: int) -> None:
+    """An rpc call meeting a 30x fails; the credential stays on one url.
+
+    Nothing follows a redirect (issue #358), so a `Location` is a header on
+    a status like any other and the body beside it -- here the html of
+    whatever answered instead of the node -- is not a reply. What the
+    caller gets is the status, which is what says the endpoint is not the
+    node any more; the `Authorization` reached the url they wrote down and
+    no second one.
+    """
+    endpoint = proxy((code, b"<html><title>Moved</title></html>"))
+    with pytest.raises(FetchError, match=f"HTTP {code}"):
+        endpoint.call("getblockcount")
+
+    transport = endpoint.transport
+    assert isinstance(transport, Recorded)
+    assert len(transport.requests) == 1
+    assert transport.request.full_url == endpoint.url
+    assert transport.request.get_header("Authorization") == endpoint.auth_header()
+
+
 def test_a_body_that_is_not_json_says_so() -> None:
     """A proxy or a web server on the rpc port, answering 200 with html."""
     with pytest.raises(FetchError, match="not json"):

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -11,11 +11,21 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from types import TracebackType
+from http.client import HTTPMessage
+from io import BytesIO
+from types import SimpleNamespace, TracebackType
+from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.request import Request
+from urllib.request import (
+    HTTPHandler,
+    HTTPRedirectHandler,
+    OpenerDirector,
+    Request,
+    build_opener,
+)
+from urllib.response import addinfourl
 
 import pytest
 
@@ -31,6 +41,25 @@ from btclib.fetch.transport import (
 from tests.fetch import Recorded
 
 URL = "http://127.0.0.1:8332"
+# where a 30x would send the request, and the host that must receive
+# nothing: `.invalid` is reserved by RFC 2606, so a test that started
+# following redirects would fail on a resolution error rather than reach
+# somebody
+REDIRECT_URL = "http://elsewhere.invalid/"
+# the credential of the reproduction in issue #358, which is what the
+# redirected request carried verbatim: `alice:secret`
+CREDENTIAL = "Basic YWxpY2U6c2VjcmV0"
+
+
+def _opener(open_: Callable[..., Any]) -> SimpleNamespace:
+    """Return something with an `open`, which is all the transport uses.
+
+    `urlopen_transport` does its I/O through the module's own opener --
+    urllib's default one without the redirect handler -- so that is what a
+    test replaces, and `.open(request, timeout=...)` is the whole of the
+    interface it needs to offer.
+    """
+    return SimpleNamespace(open=open_)
 
 
 class FakeResponse:
@@ -99,12 +128,12 @@ def test_urlopen_transport_reads_status_and_body(
     seen: dict[str, object] = {}
     response = FakeResponse(200, b"body")
 
-    def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
+    def fake_open(request: Request, timeout: float) -> FakeResponse:
         seen["request"] = request
         seen["timeout"] = timeout
         return response
 
-    monkeypatch.setattr(transport_module, "urlopen", fake_urlopen)
+    monkeypatch.setattr(transport_module, "_OPENER", _opener(fake_open))
 
     request = Request(URL, method="GET")
     assert urlopen_transport(request, 12.5) == (200, b"body")
@@ -145,10 +174,10 @@ def test_urlopen_transport_does_not_swallow_an_http_error(
     """A non-2xx is urlopen's exception, and it goes up to http_request."""
     with http_error(500) as error:
 
-        def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
+        def fake_open(request: Request, timeout: float) -> FakeResponse:
             raise error
 
-        monkeypatch.setattr(transport_module, "urlopen", fake_urlopen)
+        monkeypatch.setattr(transport_module, "_OPENER", _opener(fake_open))
 
         with pytest.raises(HTTPError):
             urlopen_transport(Request(URL, method="GET"), DEFAULT_TIMEOUT)
@@ -169,10 +198,10 @@ def test_the_body_of_a_response_is_bounded(
     def serve(body: bytes) -> FakeResponse:
         response = FakeResponse(200, body)
 
-        def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
+        def fake_open(request: Request, timeout: float) -> FakeResponse:
             return response
 
-        monkeypatch.setattr(transport_module, "urlopen", fake_urlopen)
+        monkeypatch.setattr(transport_module, "_OPENER", _opener(fake_open))
         return response
 
     serve(b"a" * limit)
@@ -199,10 +228,10 @@ def test_a_chunked_body_is_read_to_the_limit_and_no_further(
     body = b"z" * limit
     response = FakeResponse(200, body, chunk_size=7)
 
-    def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
+    def fake_open(request: Request, timeout: float) -> FakeResponse:
         return response
 
-    monkeypatch.setattr(transport_module, "urlopen", fake_urlopen)
+    monkeypatch.setattr(transport_module, "_OPENER", _opener(fake_open))
 
     request = Request(URL, method="GET")
     assert urlopen_transport(request, DEFAULT_TIMEOUT, max_body_size=limit) == (
@@ -225,10 +254,10 @@ def test_an_announced_size_over_the_limit_is_refused_before_reading(
     request = Request(URL, method="GET")
 
     def serve(response: FakeResponse) -> None:
-        def fake_urlopen(req: Request, timeout: float) -> FakeResponse:
+        def fake_open(req: Request, timeout: float) -> FakeResponse:
             return response
 
-        monkeypatch.setattr(transport_module, "urlopen", fake_urlopen)
+        monkeypatch.setattr(transport_module, "_OPENER", _opener(fake_open))
 
     serve(FakeResponse(200, b"a" * 4, content_length=str(limit + 1)))
     with pytest.raises(FetchError, match=f"announced {limit + 1} bytes"):
@@ -273,10 +302,10 @@ def test_the_limit_reaches_the_read_of_the_default_transport(
     """
     response = FakeResponse(200, b"a" * 100)
 
-    def fake_urlopen(request: Request, timeout: float) -> FakeResponse:
+    def fake_open(request: Request, timeout: float) -> FakeResponse:
         return response
 
-    monkeypatch.setattr(transport_module, "urlopen", fake_urlopen)
+    monkeypatch.setattr(transport_module, "_OPENER", _opener(fake_open))
 
     with pytest.raises(FetchError, match="response larger than 64 bytes"):
         http_request(URL, max_body_size=64)
@@ -431,6 +460,167 @@ def test_an_http_error_is_a_status_and_a_body_not_an_exception() -> None:
             500,
             b'{"result":null,"error":{"code":-5}}',
         )
+
+
+def test_the_opener_does_not_follow_a_redirect() -> None:
+    """One redirect handler is installed, and it is the one that refuses.
+
+    The direct claim behind the exchange the next test measures, and worth
+    a test of its own for what it says when it fails: an opener carrying
+    urllib's own handler follows a 30x before this module sees a response,
+    and that is a fact about which object is in the chain.
+    """
+    # getattr with a default because typeshed does not declare `handlers`
+    # on OpenerDirector: the attribute is what add_handler appends to, and
+    # a plain access would be an attr-defined error rather than a test
+    handlers = getattr(transport_module._OPENER, "handlers", [])
+    redirect_handlers = [
+        handler for handler in handlers if isinstance(handler, HTTPRedirectHandler)
+    ]
+    assert len(redirect_handlers) == 1
+    assert isinstance(redirect_handlers[0], transport_module._NoRedirect)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        REDIRECT_URL,  # another origin, which is where the credential leaked
+        f"{URL}/moved",  # the same one, i.e. an endpoint that changed path
+        "https://elsewhere.invalid/",  # an upgrade
+        "ftp://elsewhere.invalid/tx",  # not http at all, and urllib admits it
+    ],
+)
+def test_no_redirect_target_is_followed(target: str) -> None:
+    """Cross-origin, same-origin, an upgrade and an ftp target alike.
+
+    urllib's own handler follows all four -- `http_error_302` admits http,
+    https, ftp and the empty scheme -- and a redirect policy would have had
+    to tell them apart: strip the credential across origins, refuse a
+    downgrade, bound the intermediate body, keep the rest. Answering None
+    before the target is read is what makes the four one case, and it is
+    why a downgrade needs no rule of its own: the scheme of the request is
+    not consulted either.
+    """
+    handlers = getattr(transport_module._OPENER, "handlers", [])
+    redirect = next(h for h in handlers if isinstance(h, HTTPRedirectHandler))
+    headers = HTTPMessage()
+    headers["Location"] = target
+
+    request = Request(URL, data=b"{}", headers={"Authorization": CREDENTIAL})
+    assert (
+        redirect.redirect_request(
+            request, BytesIO(b"moved"), 302, "Found", headers, target
+        )
+        is None
+    )
+
+
+class RecordedBody(BytesIO):
+    """A response body that remembers what was read of it.
+
+    Which is the half of the fix a status cannot show: urllib's redirect
+    handler calls `fp.read()` with no argument before following, so the
+    whole intermediate body was held whatever the caller's limit said. A
+    read of -1 in `reads` is that call.
+    """
+
+    def __init__(self, data: bytes) -> None:
+        super().__init__(data)
+        self.reads: list[int] = []
+
+    def read(self, size: int | None = -1, /) -> bytes:
+        """Record the size asked for, and answer as a BytesIO does."""
+        self.reads.append(-1 if size is None else size)
+        return super().read(size)
+
+
+class RecordedHTTP(HTTPHandler):
+    """The opener's socket, replaced by a scripted response in memory.
+
+    A handler and not a whole opener: what the redirect exchange runs
+    through is urllib's own chain -- the redirect handler, the error
+    processor, the default error handler -- and the only part of it that
+    would reach the network is this one. `Location` is set on every
+    response, so a handler that follows redirects has somewhere to go and
+    the test can tell that it went.
+    """
+
+    def __init__(self, code: int, body: bytes) -> None:
+        super().__init__()
+        self.code = code
+        self.body = RecordedBody(body)
+        self.requests: list[Request] = []
+
+    # typeshed types `http_open` by what urllib's own answers with, an
+    # `HTTPResponse` read off a socket; the chain downstream only takes a
+    # status, headers and bytes off it, which is what an `addinfourl` is --
+    # and what `FileHandler.file_open` beside it answers with
+    def http_open(self, req: Request) -> addinfourl:  # type: ignore[override]
+        """Record the request and answer the scripted response."""
+        self.requests.append(req)
+        headers = HTTPMessage()
+        headers["Location"] = REDIRECT_URL
+        response = addinfourl(self.body, headers, req.full_url, self.code)
+        # what `do_open` sets from the reason line and `HTTPErrorProcessor`
+        # reads off a response beside the status; addinfourl has no such
+        # attribute of its own, and typeshed says so
+        response.msg = "Found"  # type: ignore[attr-defined]
+        return response
+
+
+def _opener_over(handler: HTTPHandler) -> OpenerDirector:
+    """Return the module's own opener with `handler` in place of the socket.
+
+    The redirect handler is taken from `_OPENER` rather than named here,
+    and that is what makes a test built on this fail if urllib's own comes
+    back: the exchange would then be two requests instead of one, which is
+    the property under test rather than a spelling of it.
+    """
+    handlers = getattr(transport_module._OPENER, "handlers", [])
+    redirect = next(h for h in handlers if isinstance(h, HTTPRedirectHandler))
+    return build_opener(type(redirect), handler)
+
+
+@pytest.mark.parametrize("code", [301, 302, 303, 307, 308])
+def test_a_redirect_is_a_status_and_not_a_second_request(
+    monkeypatch: pytest.MonkeyPatch, code: int
+) -> None:
+    """The credential goes nowhere, and the 30x body is bounded.
+
+    urllib's default handler copies every header but the content ones onto
+    the redirected request, so an `Authorization` built for a node reached
+    whatever host the `Location` named -- and it read the whole 30x body
+    before following, whatever `max_body_size` said.
+
+    The whole chain runs here, socket excepted: `http_request` builds the
+    request, `urlopen_transport` hands it to the module's opener, and the
+    30x travels `OpenerDirector.error` -> the redirect handler ->
+    `HTTPDefaultErrorHandler` -> the `HTTPError` that `http_request`
+    answers with a status. What a caller gets is one request and one
+    response, which for both fetchers is a `FetchError` naming the status.
+    """
+    handler = RecordedHTTP(code, b"x" * (MAX_ERROR_BODY_SIZE + 10))
+    monkeypatch.setattr(transport_module, "_OPENER", _opener_over(handler))
+
+    status, body = http_request(
+        URL,
+        data=b'{"method":"getblockcount"}',
+        headers={"Authorization": CREDENTIAL},
+        max_body_size=64,
+    )
+
+    assert status == code
+    # bounded as any failure body is, by truncation rather than refusal
+    assert len(body) == MAX_ERROR_BODY_SIZE
+    # one request, to the url the caller asked for, carrying the credential
+    # exactly once and nowhere else
+    assert len(handler.requests) == 1
+    assert handler.requests[0].full_url == URL
+    assert handler.requests[0].get_header("Authorization") == CREDENTIAL
+    # and the body of the 30x was read to the bound and no further, which
+    # the `fp.read()` of a following handler would have done first
+    assert handler.body.reads == [MAX_ERROR_BODY_SIZE]
+    assert handler.body.closed
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #358.

## What this changes

`urlopen_transport` does its I/O through a module-private opener built
without urllib's `HTTPRedirectHandler`, so no redirect is followed. A 30x
then arrives as the `HTTPError` that `http_request` already has a path for:
the status and a bounded body, like any other non-2xx.

All three consequences the issue reports have one cause, and it is that
handler. Read off CPython 3.14.6's `urllib/request.py`:

- `redirect_request` copies every request header except `content-length`
  and `content-type`, so an `Authorization` built for a node reaches
  whatever host the `Location` names -- and a POST is rewritten as a GET;
- `http_error_302` admits `http`, `https`, `ftp` and the empty scheme, so
  an https request may be answered with an http target while
  `http_request`'s scheme check covers only the first url;
- it calls `fp.read()` with no argument before following, so the whole
  intermediate body is read whatever `max_body_size` says.

## Measured, before and after

Two `http.server` instances on 127.0.0.1: server A answers a POST carrying
`Authorization: Basic YWxpY2U6c2VjcmV0` with a 302 whose `Location` is
server B and whose body is 8 MiB.

| | before | after |
| --- | --- | --- |
| requests server B received | 1, as a GET, with the header verbatim | 0 |
| what the caller gets | the 200 from server B | `FetchError: getblockcount at http://127.0.0.1:…: HTTP 302` |
| octets of the 8 MiB body read | all of them | 64 KiB, `MAX_ERROR_BODY_SIZE` |

The "after" row is `BitcoindFetcher(AuthProxy(url, user=…, password=…))
.get_block_count()` against the same pair of servers, so it is the whole
path and not the handler in isolation.

## Refused rather than policed

That is the decision, and what a policy would have to be is the reason:
stripping credentials across origins, refusing a downgrade, bounding every
intermediate body and counting hops is a redirect implementation inside a
module whose subject is one bounded request, and each of those four rules
is a way to get it subtly wrong. What following a same-origin redirect
would buy a caller -- an endpoint that moved path -- is a `base_url` they
fix once, and both fetchers already turn a non-200 into a `FetchError`
naming the status and the url (`EsploraFetcher.text`,
`AuthProxy._result`), which is what tells them to.

So the issue's last acceptance criterion has no test: the same-origin
behaviour is not retained.

One promise this cannot make, and the docstring says so: a caller passing a
transport of their own does its own I/O, so what `requests` or `httpx` does
with a 30x is theirs.

`build_opener` and not `install_opener`: the default opener is process-wide,
and a library that replaced it would decide this for every other user of
`urlopen` in the program.

## Tests

The suite still opens no socket. `test_the_opener_does_not_follow_a_redirect`
reads the installed handler off the opener and checks
`redirect_request` answers None -- which is what makes
`OpenerDirector.error` fall through to `HTTPDefaultErrorHandler` -- and
`test_a_redirect_is_a_status_and_not_a_second_request` runs 301, 302, 303,
307 and 308 through `http_request` and asserts one request, to the url the
caller asked for, with the credential on it exactly once, and a body
bounded at `MAX_ERROR_BODY_SIZE`.

The six tests that replaced `transport_module.urlopen` now replace
`transport_module._OPENER`, which is the thing that does the I/O; the
`_opener` helper at the top of the file says why.

## Also

`SECURITY.md`'s "rpc credentials" bullet gains the sentence that follows
from this: the credential reaches the url the caller wrote down and no
other.

## Gates

```
pytest                                       17031 passed
pre-commit run --files <the four>            exit 0
sphinx-build -W --keep-going                 exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route all btclib.fetch HTTP I/O through a module-local opener that disables redirects so RPC credentials and bodies are never sent to redirected endpoints, and treat 3xx responses as normal statuses with bounded bodies surfaced to callers.

Bug Fixes:
- Prevent RPC Authorization headers from being forwarded to redirect targets and avoid unintended HTTP scheme downgrades or oversized intermediate bodies when using btclib.fetch.

Enhancements:
- Document redirect behavior and its security rationale in http_request/urlopen_transport docstrings and changelog, and clarify that btclib.fetch uses a process-local opener rather than the global default.
- Introduce an explicit opener abstraction and no-redirect handler to make transport behavior testable without network access.

Documentation:
- Update SECURITY.md to state that RPC credentials are only sent to the caller-specified URL and not to redirect targets.

Tests:
- Add tests verifying that the custom opener installs a no-redirect handler, that 3xx responses are surfaced as single-status responses with bounded bodies, and adjust existing transport tests to target the new opener rather than urlopen.