### PR TITLE
Document the BIP324 transport boundary

### DIFF
--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -17,6 +17,17 @@ and what BIP324's v2 handshake needs of the keys it carries.
 
 https://github.com/bitcoin/bips/blob/master/bip-0324.mediawiki
 
+This module stops at ElligatorSwift key encoding and x-only ECDH. It does
+not implement BIP324's v2 transport: HKDF-SHA256, ChaCha20-Poly1305,
+forward-secure rekeying, length obfuscation, and packet framing are
+outside btclib's scope. Those belong beside a P2P client, which btclib
+does not provide. Shipping them here would either put a pure-Python cipher
+on a production network path or make a new cipher dependency mandatory for
+every installation; accepting a cipher from the caller would still
+leave a framing layer that is not useful on its own. A complete transport
+belongs in a separate optional package or extra, backed by an established
+cryptographic implementation and BIP324's packet vectors.
+
 `decode` is the map, and it is deterministic. `encode` and `create` are
 its inverse, and are not: up to eight (u, t) pairs decode to one
 x-coordinate, one of them is picked at random, and the randomness is the


### PR DESCRIPTION
Closes #303.

## What this changes

The `btclib.ecc.ellswift` module docstring now states the boundary chosen
in #303: the module provides ElligatorSwift key encoding and x-only ECDH,
but not the complete BIP324 v2 transport.

The new paragraph names the omitted layers and records why they do not fit
here. They belong beside a P2P client, while putting them in btclib would
either put a pure-Python cipher on a production network path or add a
mandatory cipher dependency for every installation. Supplying the cipher
from the caller would still leave framing that is not useful independently.
A complete transport therefore belongs in a separate optional package or
extra backed by established cryptography and the upstream packet vectors.

Sphinx already publishes this module docstring through
`docs/source/btclib.ecc.rst`. There is no runtime behavior change.

## How it was verified

- `uv run --locked --only-group lint pre-commit run --all-files --show-diff-on-failure`
- `uv run pytest` — 17070 passed
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`
- the generated HTML contains no unresolved `href="#./..."` links

## Checks

- [x] `uv run pre-commit run --all-files` is clean
- [x] `uv run pytest` passes
- [x] The existing ElligatorSwift entry in `CHANGELOG.md` already records
      the deliberate transport boundary; this PR adds no duplicate entry

## Anything the reviewer should know

`packet_encoding_test_vectors.csv` remains unvendored, as
`tests/_data/README.md` already documents.

## Summary by Sourcery

Documentation:
- Expand the btclib.ecc.ellswift module docstring to document that it covers key encoding and x-only ECDH but intentionally omits the full BIP324 v2 transport layers.