### PR TITLE
A generic Bitcoin Core rpc client: BitcoinCoreRpcClient, contracted before release (#370)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,7 +278,7 @@ edit.
   bytes it has already read, so what `http_request` promises for one is
   that an oversized answer goes no further — a bound distinct from the
   one a transport of a caller's own applies to what it holds while
-  reading, which it alone can enforce. `BitcoindRpcClient.call` takes
+  reading, which it alone can enforce. `BitcoinCoreRpcClient.call` takes
   `max_body_size` too, for the caller invoking `getblock` on a large
   block. The body of an `HTTPError` is closed after that bounded read, a
   response left with octets in it being a `ResourceWarning` out of a
@@ -2378,7 +2378,7 @@ edit.
   bytes it was handed — the transaction with this id, the output an
   outpoint names, the chain tip — and it is implemented twice, so calling
   code takes a `Fetcher` and never branches on which one it got:
-  `BitcoindFetcher` over a full node's JSON-RPC, and `EsploraFetcher`
+  `BitcoinCoreFetcher` over a full node's JSON-RPC, and `EsploraFetcher`
   over a block explorer's HTTP api for anyone without a node. What comes
   back is `Tx` and `TxOut`, not the dicts the backends send, and the
   outputs are labelled with the fetcher's network, which `Tx.parse`
@@ -2392,7 +2392,7 @@ edit.
   reply from a node older than v28 is still read, and which of the two a
   reply is decides where an error may legitimately come from — under 2.0
   a non-200 is the HTTP exchange failing and never the node's answer.
-  `BitcoindRpcClient` calls any method, not only the three, and is an
+  `BitcoinCoreRpcClient` calls any method, not only the three, and is an
   implementation of the protocol rather than a port of
   python-bitcoinrpc's `AuthServiceProxy`, whose lineage is LGPL where
   btclib is MIT. It takes either of json-rpc's two parameter structures —
@@ -2413,7 +2413,7 @@ edit.
   `.cookie` — re-read at every call since a node restart rotates it,
   bounded, and required to be one ascii line — means there need be no
   password at all. The client holds no chain, so
-  `BitcoindFetcher(client, network=...)` owns btclib's label and a signet
+  `BitcoinCoreFetcher(client, network=...)` owns btclib's label and a signet
   of one's own is an explicit url rather than a name this package has to
   know. `FetchError`, `HttpError` with the HTTP status and `RpcError`
   with the node's code and optional `data` are in `btclib.exceptions`
@@ -3116,7 +3116,7 @@ edit.
 - **`btclib.fetch` states what it exports and what it keeps out.** The
   docstring explained the design of the package and said nothing about its
   public surface, where `btclib.curves` and `btclib.block` each record
-  theirs. `cookie_auth` stays out because `BitcoindRpcClient` takes a
+  theirs. `cookie_auth` stays out because `BitcoinCoreRpcClient` takes a
   `cookie_path` and reads that file at every call, the node rewriting the
   cookie whenever it restarts: a caller passes the path and never the
   credential, and a name for reading one is a way to hold it longer than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2402,7 +2402,11 @@ edit.
   for minutes. Amounts never pass through binary floating point: a number
   in a reply decodes as a `Decimal`, a `Decimal` parameter is refused
   rather than rounded, and `NaN` and `Infinity` are refused in both
-  directions. `for_wallet` is the `/wallet/<name>` endpoint of a
+  directions. The parameters are checked whole and not at the top level
+  only, because `json.dumps` *rewrites* a mapping key that is not a
+  string — `{1: "a"}` would reach the node as `{"1": "a"}` — and reports
+  a structure containing itself as the same kind of error a non-finite
+  number is. `for_wallet` is the `/wallet/<name>` endpoint of a
   multi-wallet node, percent-encoded. Credentials in the url are refused,
   as are a query, a fragment and a missing host; credentials and a cookie
   path are mutually exclusive rather than silently ranked; and bitcoind's
@@ -2417,7 +2421,9 @@ edit.
   its own — `call` carries any method, so it cannot know that re-sending
   one is safe, and a timeout is not a deadline — and a caller's policy
   for a 503 from a full work queue wants the number rather than a message
-  to match on. No endpoint is a
+  to match on. A body no parser can read keeps the status too: it cannot
+  be an rpc error, so what is reported is the 401 or the 503 rather than
+  the encoding of whatever answered instead of the node. No endpoint is a
   default: `BLOCKSTREAM_INFO` is a constant to pass, never a host btclib
   contacts on its own. Nothing here is tested against a live host —
   `HttpTransport` is the seam, and every test answers from a recorded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2421,9 +2421,11 @@ edit.
   its own — `call` carries any method, so it cannot know that re-sending
   one is safe, and a timeout is not a deadline — and a caller's policy
   for a 503 from a full work queue wants the number rather than a message
-  to match on. A body no parser can read keeps the status too: it cannot
-  be an rpc error, so what is reported is the 401 or the 503 rather than
-  the encoding of whatever answered instead of the node. No ambient proxy
+  to match on. A body that is no reply keeps the status too — one that no
+  parser can read, and one that parses into something which is not a
+  reply object — since neither can be an answer the node computed: what
+  is reported is the 401 or the 503, not the encoding of whatever
+  answered in its place. No ambient proxy
   is consulted either — `urllib` would otherwise route the request, and
   with it the `Basic` credential, through whatever host `HTTP_PROXY` names
   in a shell that set it for something else. No endpoint is a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -276,7 +276,9 @@ edit.
   positional arguments as before, which is why the limit is a keyword on
   `urlopen_transport` alone: a transport of a caller's own hands over
   bytes it has already read, so what `http_request` promises for one is
-  that an oversized answer goes no further. `AuthProxy.call` takes
+  that an oversized answer goes no further — a bound distinct from the
+  one a transport of a caller's own applies to what it holds while
+  reading, which it alone can enforce. `BitcoindRpcClient.call` takes
   `max_body_size` too, for the caller invoking `getblock` on a large
   block. The body of an `HTTPError` is closed after that bounded read, a
   response left with octets in it being a `ResourceWarning` out of a
@@ -2384,16 +2386,38 @@ edit.
   dependency: `urllib.request`, `json` and `base64` are the whole client,
   because a cryptography library that pulls `certifi`, `urllib3` and
   `idna` in for an optional convenience has charged every other user for
-  it. The
-  JSON-RPC is 2.0 rather than python-bitcoinrpc's 1.0, so that a routine
-  "no such transaction" is an HTTP 200 with an `error` member instead of
-  the 500 a real server fault also sends; a 1.0 reply from a node older
-  than v28 is still read. Credentials in the url are refused, and
-  bitcoind's `.cookie` — re-read at every call, since a node restart
-  rotates it — means there need be none. `AuthProxy` is the name the
-  request used, python-bitcoinrpc's, and it calls any method, not only
-  the three. `FetchError` and `RpcError`, the latter carrying the node's
-  code, are in `btclib.exceptions` with the rest. No endpoint is a
+  it. The JSON-RPC is 2.0 rather than the legacy 1.1 a node answers by
+  default, so that a routine "no such transaction" is an HTTP 200 with an
+  `error` member instead of the 500 a real server fault also sends; a 1.1
+  reply from a node older than v28 is still read, and which of the two a
+  reply is decides where an error may legitimately come from — under 2.0
+  a non-200 is the HTTP exchange failing and never the node's answer.
+  `BitcoindRpcClient` calls any method, not only the three, and is an
+  implementation of the protocol rather than a port of
+  python-bitcoinrpc's `AuthServiceProxy`, whose lineage is LGPL where
+  btclib is MIT. It takes either of json-rpc's two parameter structures —
+  a sequence positionally, a mapping by name, which covers Core's `args`
+  convention too — a distinct request id per call that the reply has to
+  echo back, and a `request_timeout` of its own for the methods that run
+  for minutes. Amounts never pass through binary floating point: a number
+  in a reply decodes as a `Decimal`, a `Decimal` parameter is refused
+  rather than rounded, and `NaN` and `Infinity` are refused in both
+  directions. `for_wallet` is the `/wallet/<name>` endpoint of a
+  multi-wallet node, percent-encoded. Credentials in the url are refused,
+  as are a query, a fragment and a missing host; credentials and a cookie
+  path are mutually exclusive rather than silently ranked; and bitcoind's
+  `.cookie` — re-read at every call since a node restart rotates it,
+  bounded, and required to be one ascii line — means there need be no
+  password at all. The client holds no chain, so
+  `BitcoindFetcher(client, network=...)` owns btclib's label and a signet
+  of one's own is an explicit url rather than a name this package has to
+  know. `FetchError`, `HttpError` with the HTTP status and `RpcError`
+  with the node's code and optional `data` are in `btclib.exceptions`
+  with the rest; the status is a field because btclib retries nothing on
+  its own — `call` carries any method, so it cannot know that re-sending
+  one is safe, and a timeout is not a deadline — and a caller's policy
+  for a 503 from a full work queue wants the number rather than a message
+  to match on. No endpoint is a
   default: `BLOCKSTREAM_INFO` is a constant to pass, never a host btclib
   contacts on its own. Nothing here is tested against a live host —
   `HttpTransport` is the seam, and every test answers from a recorded
@@ -3081,7 +3105,7 @@ edit.
 - **`btclib.fetch` states what it exports and what it keeps out.** The
   docstring explained the design of the package and said nothing about its
   public surface, where `btclib.curves` and `btclib.block` each record
-  theirs. `cookie_auth` stays out because `AuthProxy` takes a
+  theirs. `cookie_auth` stays out because `BitcoindRpcClient` takes a
   `cookie_path` and reads that file at every call, the node rewriting the
   cookie whenever it restarts: a caller passes the path and never the
   credential, and a name for reading one is a way to hold it longer than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2423,7 +2423,10 @@ edit.
   for a 503 from a full work queue wants the number rather than a message
   to match on. A body no parser can read keeps the status too: it cannot
   be an rpc error, so what is reported is the 401 or the 503 rather than
-  the encoding of whatever answered instead of the node. No endpoint is a
+  the encoding of whatever answered instead of the node. No ambient proxy
+  is consulted either — `urllib` would otherwise route the request, and
+  with it the `Basic` credential, through whatever host `HTTP_PROXY` names
+  in a shell that set it for something else. No endpoint is a
   default: `BLOCKSTREAM_INFO` is a constant to pass, never a host btclib
   contacts on its own. Nothing here is tested against a live host —
   `HttpTransport` is the seam, and every test answers from a recorded

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -158,7 +158,7 @@ used to teach and to prototype as much as to build:
     depend on the secret byte by byte; a caller wanting the same of the
     decryption should bring a cipher that gives it
 - **a `btclib.fetch` backend is trusted, and the two are trusted
-    differently.** `BitcoindFetcher` talks to a node that validated the
+    differently.** `BitcoinCoreFetcher` talks to a node that validated the
     chain it reports; `EsploraFetcher` talks to a host that says it did.
     Only one answer of the four is checked at all — the transaction, whose
     id is recomputed from the bytes that came back — so a height, a tip

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -15,7 +15,16 @@ failure it is, and adds nothing to it.
 
 So a caller is usually better off catching the regular ValueError,
 TypeError or RuntimeError, and does not lose anything by doing so.
+
+The exceptions to that are the few classes below carrying a field: what
+a peer got wrong, the node's rpc error code, an HTTP status. Those are
+values a caller acts on, and reading them back out of a message is what
+the field spares them.
 """
+
+from __future__ import annotations
+
+from typing import Any
 
 
 class BTClibValueError(ValueError):
@@ -116,6 +125,30 @@ class FetchError(BTClibRuntimeError):
     """
 
 
+class HttpError(FetchError):
+    """A backend failed at the HTTP layer, and `status` is what it said.
+
+    A field because acting on a status is the caller's job and btclib's
+    retries nothing: a 401 says the credentials are wrong and will stay
+    wrong until they are changed, while a 503 from bitcoind says its rpc
+    work queue is full and the same request works when the queue drains.
+    A caller writing that policy needs to recognise the status, and
+    matching on the text of a message is what a field spares them.
+
+    Not every FetchError carries one, and that is the distinction: a
+    refused connection, an expired timeout and a body that is not json
+    are failures with no status to report, and stay a plain FetchError.
+    The message states the status too -- an exception is a diagnostic
+    before it is a value.
+
+    A FetchError still, so code catching that keeps catching this.
+    """
+
+    def __init__(self, message: str, status: int) -> None:
+        self.status = status
+        super().__init__(message)
+
+
 class RpcError(FetchError):
     """bitcoind answered with a JSON-RPC error object, and this is it.
 
@@ -127,11 +160,18 @@ class RpcError(FetchError):
     the number, and parsing it back out of the message is what having a
     field avoids.
 
+    `data` is JSON-RPC's optional third member of an error object, kept
+    as it arrived. Core leaves it out today, so it is None for every
+    error a node sends; a method that starts sending one -- or a proxy
+    between the two adding its own -- would otherwise have it dropped
+    here, which is the one place it cannot be recovered from.
+
     A FetchError still, so code catching that keeps catching this.
     """
 
-    def __init__(self, message: str, code: int) -> None:
+    def __init__(self, message: str, code: int, data: Any = None) -> None:
         self.code = code
+        self.data = data
         super().__init__(f"{message} (rpc error code {code})")
 
 

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -136,10 +136,15 @@ class HttpError(FetchError):
     matching on the text of a message is what a field spares them.
 
     Not every FetchError carries one, and that is the distinction: a
-    refused connection, an expired timeout and a body that is not json
-    are failures with no status to report, and stay a plain FetchError.
-    The message states the status too -- an exception is a diagnostic
-    before it is a value.
+    refused connection and an expired timeout are failures of an exchange
+    that never produced a status, and stay a plain FetchError. So does a
+    body that is no answer -- not json, not utf-8, not a reply object --
+    when it arrived with an HTTP 200: there the status says nothing and
+    the shape of the body is the whole diagnosis. The same body under a
+    non-200 is this exception instead, carrying that status: it cannot be
+    an answer the backend computed, so what is left to report is the
+    status it came with. The message states the status too -- an exception
+    is a diagnostic before it is a value.
 
     A FetchError still, so code catching that keeps catching this.
     """

--- a/btclib/fetch/__init__.py
+++ b/btclib/fetch/__init__.py
@@ -13,7 +13,7 @@
 handed. This package is the one place that goes and asks: what
 transaction has this id, what output does this outpoint name, where is
 the chain tip. `Fetcher` is the interface, and it is implemented twice --
-`BitcoindFetcher` over a full node's JSON-RPC, `EsploraFetcher` over a
+`BitcoinCoreFetcher` over a full node's JSON-RPC, `EsploraFetcher` over a
 block explorer's HTTP api -- so that calling code takes a `Fetcher` and
 never branches on which one it got.
 
@@ -29,17 +29,18 @@ fetcher does not either: the first call is what opens a connection, and
 what raises if there is nothing to connect to.
 
 **What is exported, and what is not.** The two fetchers, the interface
-they implement, the rpc client a bitcoind one is reached through, and the
-transport seam: the timeout, the protocol a substitute has to satisfy and
-the one implementation of it that opens a socket. That last group is here
-because the seam is the supported way to test calling code without a node,
-which is not a detail of the two implementations.
+they implement, the rpc client a Bitcoin Core one is reached through, and
+the transport seam: the timeout, the protocol a substitute has to satisfy
+and the one implementation of it that opens a socket. That last group is
+here because the seam is the supported way to test calling code without a
+node, which is not a detail of the two implementations.
 
-`bitcoind.cookie_auth` is deliberately not here: `BitcoindRpcClient` takes
-a `cookie_path` and reads that file at every call -- the node rewrites the
-cookie whenever it restarts -- so a caller who wants cookie authentication
-passes the path and never the credential, and a name for reading it is one
-way to hold a credential longer than the node does. `fetcher.fetch_errors`,
+`bitcoin_core.cookie_auth` is deliberately not here:
+`BitcoinCoreRpcClient` takes a `cookie_path` and reads that file at every
+call -- the node rewrites the cookie whenever it restarts -- so a caller
+who wants cookie authentication passes the path and never the credential,
+and a name for reading it is one way to hold a credential longer than the
+node does. `fetcher.fetch_errors`,
 `tx_from_raw`, `tx_id_hex` and `tx_for_network` are not here either: they
 are what an implementation of the interface is built out of, and they are
 the answer to a third implementation rather than to a caller of the two --
@@ -51,7 +52,7 @@ is: `btclib.exceptions` holds every one of them together, which is what
 lets a caller see at a glance what the library raises.
 """
 
-from btclib.fetch.bitcoind import BitcoindFetcher, BitcoindRpcClient
+from btclib.fetch.bitcoin_core import BitcoinCoreFetcher, BitcoinCoreRpcClient
 from btclib.fetch.esplora import BLOCKSTREAM_INFO, EsploraFetcher
 from btclib.fetch.fetcher import Fetcher
 from btclib.fetch.transport import DEFAULT_TIMEOUT, HttpTransport, urlopen_transport
@@ -59,8 +60,8 @@ from btclib.fetch.transport import DEFAULT_TIMEOUT, HttpTransport, urlopen_trans
 __all__ = [
     "BLOCKSTREAM_INFO",
     "DEFAULT_TIMEOUT",
-    "BitcoindFetcher",
-    "BitcoindRpcClient",
+    "BitcoinCoreFetcher",
+    "BitcoinCoreRpcClient",
     "EsploraFetcher",
     "Fetcher",
     "HttpTransport",

--- a/btclib/fetch/__init__.py
+++ b/btclib/fetch/__init__.py
@@ -29,14 +29,14 @@ fetcher does not either: the first call is what opens a connection, and
 what raises if there is nothing to connect to.
 
 **What is exported, and what is not.** The two fetchers, the interface
-they implement, the endpoint a bitcoind one is reached through, and the
+they implement, the rpc client a bitcoind one is reached through, and the
 transport seam: the timeout, the protocol a substitute has to satisfy and
 the one implementation of it that opens a socket. That last group is here
 because the seam is the supported way to test calling code without a node,
 which is not a detail of the two implementations.
 
-`bitcoind.cookie_auth` is deliberately not here: `AuthProxy` takes a
-`cookie_path` and reads that file at every call -- the node rewrites the
+`bitcoind.cookie_auth` is deliberately not here: `BitcoindRpcClient` takes
+a `cookie_path` and reads that file at every call -- the node rewrites the
 cookie whenever it restarts -- so a caller who wants cookie authentication
 passes the path and never the credential, and a name for reading it is one
 way to hold a credential longer than the node does. `fetcher.fetch_errors`,
@@ -45,9 +45,13 @@ are what an implementation of the interface is built out of, and they are
 the answer to a third implementation rather than to a caller of the two --
 `from btclib.fetch.fetcher import fetch_errors` is that answer, and it says
 which layer it is reaching into.
+
+`FetchError`, `HttpError` and `RpcError` are not here because no exception
+is: `btclib.exceptions` holds every one of them together, which is what
+lets a caller see at a glance what the library raises.
 """
 
-from btclib.fetch.bitcoind import AuthProxy, BitcoindFetcher
+from btclib.fetch.bitcoind import BitcoindFetcher, BitcoindRpcClient
 from btclib.fetch.esplora import BLOCKSTREAM_INFO, EsploraFetcher
 from btclib.fetch.fetcher import Fetcher
 from btclib.fetch.transport import DEFAULT_TIMEOUT, HttpTransport, urlopen_transport
@@ -55,8 +59,8 @@ from btclib.fetch.transport import DEFAULT_TIMEOUT, HttpTransport, urlopen_trans
 __all__ = [
     "BLOCKSTREAM_INFO",
     "DEFAULT_TIMEOUT",
-    "AuthProxy",
     "BitcoindFetcher",
+    "BitcoindRpcClient",
     "EsploraFetcher",
     "Fetcher",
     "HttpTransport",

--- a/btclib/fetch/bitcoin_core.py
+++ b/btclib/fetch/bitcoin_core.py
@@ -7,12 +7,12 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""A JSON-RPC client against bitcoind, and the fetcher built on it.
+"""A JSON-RPC client against Bitcoin Core, and the fetcher built on it.
 
-`BitcoindRpcClient` invokes any one rpc method a node has, with
+`BitcoinCoreRpcClient` invokes any one rpc method a node has, with
 positional or named parameters: one HTTP POST per call, basic
 authentication, the result or an exception. Any method, and not only the
-three `BitcoindFetcher` asks for -- a caller with a node has every reason
+three `BitcoinCoreFetcher` asks for -- a caller with a node has every reason
 to ask it something else, and refusing that would only mean they write
 this class again. One method per call, though: a batch answers several at
 once and needs an api for correlating the answers and for partly failing,
@@ -46,8 +46,8 @@ deliberately.
     # credentials leave the url, which is what gets written into a
     # config file and printed in a traceback
     AuthServiceProxy(f"http://{user}:{password}@127.0.0.1:8332")
-    BitcoindRpcClient("http://127.0.0.1:8332", user=user, password=password)
-    BitcoindRpcClient.from_network("mainnet")  # or the node's cookie file
+    BitcoinCoreRpcClient("http://127.0.0.1:8332", user=user, password=password)
+    BitcoinCoreRpcClient.from_network("mainnet")  # or the node's cookie file
 
     # one wallet of a multi-wallet node, percent-encoded
     client.for_wallet("hot").call("getbalance")
@@ -588,8 +588,8 @@ def _v2_result(
     return reply["result"]
 
 
-class BitcoindRpcClient:
-    """One bitcoind JSON-RPC endpoint, and the credentials to reach it.
+class BitcoinCoreRpcClient:
+    """One Bitcoin Core JSON-RPC endpoint, and the credentials to reach it.
 
     Not a dataclass, and that is about the password: a generated
     `__repr__` prints every field, so the credential would appear in any
@@ -618,7 +618,7 @@ class BitcoindRpcClient:
     tunnel, is what keeps them off it.
 
     Nothing here asks the node which chain it is on. The url and the
-    cookie path say where to ask; `BitcoindFetcher`'s `network` says what
+    cookie path say where to ask; `BitcoinCoreFetcher`'s `network` says what
     the answers are labelled with, and holding the two together is the
     caller's -- `getblockchaininfo` through `call` is how it is checked.
     """
@@ -661,7 +661,7 @@ class BitcoindRpcClient:
         cookie_path: Path | str | None = None,
         timeout: float = DEFAULT_TIMEOUT,
         transport: HttpTransport = urlopen_transport,
-    ) -> BitcoindRpcClient:
+    ) -> BitcoinCoreRpcClient:
         """Return a client for the local node of one of Core's networks.
 
         The convenience of not writing out a loopback url, a port and a
@@ -672,7 +672,7 @@ class BitcoindRpcClient:
         with a `cookie_path`, which is the constructor.
 
         Nor is this the chain the answers get labelled with. That is
-        `BitcoindFetcher`'s `network`, and nothing here verifies that the
+        `BitcoinCoreFetcher`'s `network`, and nothing here verifies that the
         node agrees with either of them.
         """
         if network not in _RPC_PORT:
@@ -688,7 +688,7 @@ class BitcoindRpcClient:
             transport=transport,
         )
 
-    def for_wallet(self, wallet_name: str) -> BitcoindRpcClient:
+    def for_wallet(self, wallet_name: str) -> BitcoinCoreRpcClient:
         """Return a client for this node's `/wallet/<name>` endpoint.
 
         Which is how a node with several wallets loaded is told which one
@@ -702,7 +702,7 @@ class BitcoindRpcClient:
         several wallets builds one client and derives the rest.
         """
         url = f"{self.url.rstrip('/')}/wallet/{quote(wallet_name, safe='')}"
-        return BitcoindRpcClient(
+        return BitcoinCoreRpcClient(
             url,
             user=self.user,
             password=self._password,
@@ -817,7 +817,7 @@ class BitcoindRpcClient:
         return _v2_result(where, request_id, status, reply)
 
 
-class BitcoindFetcher(Fetcher):
+class BitcoinCoreFetcher(Fetcher):
     """The three questions, answered by a node over its rpc.
 
     The client is a constructor argument rather than a set of connection
@@ -835,7 +835,7 @@ class BitcoindFetcher(Fetcher):
     checked.
     """
 
-    def __init__(self, client: BitcoindRpcClient, network: str = "mainnet") -> None:
+    def __init__(self, client: BitcoinCoreRpcClient, network: str = "mainnet") -> None:
         super().__init__(network)
         self.client = client
 

--- a/btclib/fetch/bitcoind.py
+++ b/btclib/fetch/bitcoind.py
@@ -9,41 +9,74 @@
 # or distributed except according to the terms contained in the LICENSE file.
 """A JSON-RPC client against bitcoind, and the fetcher built on it.
 
-`AuthProxy` is python-bitcoinrpc's name for this, kept because it is the
-name the request that asked for it used, and it does what that one does:
-one HTTP POST per call, basic authentication, the result or an exception.
-What it does differently is the version and the credentials.
+`BitcoindRpcClient` invokes any one rpc method a node has, with
+positional or named parameters: one HTTP POST per call, basic
+authentication, the result or an exception. Any method, and not only the
+three `BitcoindFetcher` asks for -- a caller with a node has every reason
+to ask it something else, and refusing that would only mean they write
+this class again. One method per call, though: a batch answers several at
+once and needs an api for correlating the answers and for partly failing,
+which is a question of its own and not this one.
 
-**JSON-RPC 2.0, not 1.0.** Core answers 1.0 by default and 2.0 to a
-request carrying the `"jsonrpc": "2.0"` marker, and the difference is
-which layer reports a bitcoin error: under 1.0 an unknown transaction
+**Not python-bitcoinrpc's `AuthServiceProxy`, and not a port of it.**
+That class, and the copy of it Core's test framework maintains, carry the
+LGPL-2.1 of their python-jsonrpc ancestry, where btclib is MIT: this is
+an implementation of the protocol rather than a translation of theirs,
+and shares no line with either. It is not API-compatible with them
+either, and does not try to be -- `call("getblockcount")` against an
+attribute lookup that builds a method name is a different interface, and
+the explicit one is what makes an unknown method a value rather than a
+typo that becomes a request.
+
+**One call, one HTTP request, and no retry.** A 503 from bitcoind means
+its rpc work queue is full and the same request works once the queue
+drains, so a retry is the obvious convenience -- and it is the caller's
+to write, for two reasons. `call` carries any method, so this class
+cannot know whether re-sending one is safe. And a timeout is not a
+deadline: a node that stopped answering may still be executing the call,
+so a client re-sending a wallet command of its own accord can execute it
+twice. `HttpError.status` is what makes the caller's policy three lines
+rather than a match on the text of a message.
+
+**JSON-RPC 2.0, and 1.1 read back.** Core answers 1.1 by default and 2.0
+to a request carrying the `"jsonrpc": "2.0"` marker, and the difference
+is which layer reports a bitcoin error: under 1.1 an unknown transaction
 comes back as HTTP 500 with the error object in the body, so a genuine
 server fault and a routine "no such transaction" are the same status.
 Under 2.0 an rpc error is HTTP 200 with an `error` member, and a non-2xx
 means the HTTP exchange itself failed. Both are read here -- a node older
-than v28 does not know the marker and replies 1.0 to it -- but only one
+than v28 does not know the marker and replies 1.1 to it -- but only one
 of them can be told apart from a proxy in the way.
 
-**No credentials in the url.** python-bitcoinrpc takes a url with the
-userinfo part filled in -- the `<user>:<password>@` before the host --
-which puts a password in a string that ends up in configuration files,
-tracebacks and logs. Such a url is refused here; the password arrives
-as an argument, or, better,
-is never seen at all -- `.cookie` is what bitcoind writes for exactly
-this, rotated at every restart, readable by the user running the node and
-by nobody else.
+**No credentials in the url.** A url with the userinfo part filled in --
+the `<user>:<password>@` before the host -- puts a password in a string
+that ends up in configuration files, tracebacks and logs. Such a url is
+refused here; the password arrives as an argument, or, better, is never
+seen at all -- `.cookie` is what bitcoind writes for exactly this,
+rotated at every restart, readable by the user running the node and by
+nobody else.
 """
 
 from __future__ import annotations
 
 import json
 from base64 import b64encode
+from collections.abc import Mapping, Sequence
+from decimal import Decimal
+from math import isfinite
 from pathlib import Path
+from secrets import token_hex
 from typing import Any
-from urllib.parse import urlsplit
+from urllib.parse import quote, urlsplit
 
 from btclib.alias import Octets
-from btclib.exceptions import BTClibValueError, FetchError, RpcError
+from btclib.exceptions import (
+    BTClibTypeError,
+    BTClibValueError,
+    FetchError,
+    HttpError,
+    RpcError,
+)
 from btclib.fetch.fetcher import Fetcher, fetch_errors, tx_from_raw, tx_id_hex
 from btclib.fetch.transport import (
     DEFAULT_MAX_BODY_SIZE,
@@ -53,11 +86,14 @@ from btclib.fetch.transport import (
     urlopen_transport,
 )
 from btclib.tx import Tx
-from btclib.utils import bytes_from_octets
+from btclib.utils import bytes_from_octets, is_integer
 
 # the rpc port and the datadir subdirectory of each network, from Core's
 # `CreateBaseChainParams` in src/chainparamsbase.cpp. Mainnet's cookie is
-# in the datadir itself, which is the empty subdirectory below
+# in the datadir itself, which is the empty subdirectory below. Core's
+# chain names and not btclib's network registry, because what they index
+# here is a port and a directory: a chain btclib knows and Core has no
+# default port for is an explicit url, which is the constructor
 _RPC_PORT = {
     "mainnet": 8332,
     "testnet": 18332,
@@ -84,15 +120,26 @@ COOKIE_USER = "__cookie__"
 # %APPDATA%\Bitcoin. Guessing per platform would put two branches here
 # that no test on a third platform can reach, and a wrong guess fails
 # exactly as an absent file does; `cookie_path` is how a caller says
-# where it really is
+# where it really is, and the unreadable-cookie error names the file it
+# looked for, which is what tells a caller on either platform to pass one
 DEFAULT_DATADIR = Path.home() / ".bitcoin"
 
-# What goes in the request as `id`, and what the reply has to echo. Not a
-# counter: each call here is its own HTTP request and its own response,
-# so there is nothing to match up that the socket has not already
-# matched. Checking it back is worth the line anyway -- it is what
-# catches a caching proxy answering one call with another's reply
-_RPC_ID = "btclib"
+# what a cookie file may weigh. bitcoind writes one line of some seventy
+# octets, so a bound three orders of magnitude above that refuses nothing
+# a node wrote; what it refuses is holding a log, a core dump or a disk
+# image in memory whole because `cookie_path` pointed at one, only to
+# report a missing colon afterwards
+_MAX_COOKIE_SIZE = 4096
+
+# how many random bytes make the `id` of a request this call's. Random
+# per call rather than fixed or counted: the echo check exists to catch a
+# reply that answers another request -- a caching proxy in the way -- and
+# a value reused across calls cannot tell that reply from the right one.
+# Random rather than a counter because a counter is shared mutable state,
+# which is the one thing that would make a client unsafe to call from two
+# threads. Prefixed on the way out, so a node's debug log says whose call
+# it was
+_RPC_ID_BYTES = 8
 
 # what a reply that is a number or a hash may weigh: the json envelope
 # around `result`, `error` and `id`, and a value of a few dozen octets.
@@ -100,65 +147,397 @@ _RPC_ID = "btclib"
 # keeps the default of `call`
 _MAX_SMALL_REPLY = 1024
 
+# http and https, and nothing else, which is what a POST to an rpc
+# endpoint can be. `http_request` refuses any other scheme again before
+# it builds a request, that being the boundary where `urlopen` would
+# otherwise read a `file:` url off the local disk; this one is about
+# configuration, and refuses it where the caller who wrote it can still
+# see the line
+_SCHEMES = ("http", "https")
+
+
+def _rpc_id() -> str:
+    """Return the `id` of one request, distinct from every other."""
+    return f"btclib-{token_hex(_RPC_ID_BYTES)}"
+
+
+def _assert_valid_timeout(timeout: float, what: str) -> None:
+    """Refuse a timeout that is not a number of seconds to wait.
+
+    A bool is not a duration and `timeout=True` would be one second; a
+    zero or a negative one makes the socket give up before it connects;
+    an infinity or a nan is what `Infinity` in a json configuration
+    decodes to. All four reach the socket layer and fail there, out of
+    the standard library rather than through btclib's exception contract.
+    """
+    if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+        raise BTClibTypeError(f"non-numeric {what}: {timeout!r}")
+    if not isfinite(timeout) or timeout <= 0:
+        raise BTClibValueError(f"{what} is not a positive number of seconds: {timeout}")
+
+
+def _checked_url(url: str) -> str:
+    """Return the endpoint url, having refused what is not one.
+
+    Checked when the client is built and not at the first call, which is
+    where `urlopen` would refuse most of it: a url is configuration, and
+    configuration that cannot work is worth refusing while the caller who
+    supplied it is still looking at the line.
+    """
+    split = urlsplit(url)
+    if split.scheme not in _SCHEMES:
+        err_msg = f"invalid rpc url scheme: '{split.scheme}' instead of http(s)"
+        raise BTClibValueError(err_msg)
+    if split.username is not None or split.password is not None:
+        err_msg = "credentials in the rpc url:"
+        err_msg += " pass user and password, or use the cookie file"
+        raise BTClibValueError(err_msg)
+    if not split.hostname:
+        raise BTClibValueError(f"no host in the rpc url: {url}")
+    if split.query or split.fragment:
+        err_msg = f"query or fragment in the rpc url: {url}"
+        err_msg += " -- an rpc endpoint is a path, and the call is the body"
+        raise BTClibValueError(err_msg)
+    try:
+        # the port is parsed on access and not before, so this is what
+        # refuses `http://node:https` here rather than at the first call
+        _ = split.port
+    except ValueError as e:
+        raise BTClibValueError(f"invalid port in the rpc url: {url}") from e
+    return url
+
 
 def cookie_auth(cookie_path: Path) -> str:
     """Return the `user:password` bitcoind wrote in its cookie file.
 
     One line, `__cookie__:` and 32 random bytes in hex, rewritten at
     every start of the node. Read at each call rather than once at
-    construction: a proxy built when the node was up and used an hour
+    construction: a client built when the node was up and used an hour
     later would otherwise answer 401 for the rest of the process, the
     node having been restarted in between, and the cost of not doing so
     is one small local read against an HTTP round trip.
+
+    One line, ascii, and a bounded read. A path that is not a cookie file
+    is the ordinary mistake here, and a credential is the one value that
+    must not appear in the error reporting it: what the three checks buy
+    is that everything a wrong path produces -- a binary file, a log,
+    something enormous -- arrives as a FetchError naming the file, rather
+    than as a UnicodeDecodeError or as memory nobody agreed to.
     """
     try:
-        line = cookie_path.read_text(encoding="ascii").strip()
+        with cookie_path.open("rb") as file:
+            raw = file.read(_MAX_COOKIE_SIZE + 1)
     except OSError as e:
         raise FetchError(f"unreadable rpc cookie file {cookie_path}: {e}") from e
+    if len(raw) > _MAX_COOKIE_SIZE:
+        err_msg = f"oversized rpc cookie file {cookie_path}:"
+        err_msg += f" more than the {_MAX_COOKIE_SIZE} bytes one can be"
+        raise FetchError(err_msg)
+    try:
+        line = raw.decode("ascii").strip()
+    except UnicodeDecodeError as e:
+        raise FetchError(f"non-ascii rpc cookie file {cookie_path}: {e}") from e
+    if "\n" in line or "\r" in line:
+        raise FetchError(f"malformed rpc cookie file {cookie_path}: several lines")
     if ":" not in line:
         raise FetchError(f"malformed rpc cookie file {cookie_path}: no ':' in it")
     return line
 
 
-class AuthProxy:
+def _params_member(params: Sequence[Any] | Mapping[str, Any] | None) -> Any:
+    """Return what goes in the request as `params`, refusing what cannot.
+
+    JSON-RPC has two parameter structures and Core takes both: an array,
+    read positionally, and an object, read by name. Which of them a
+    method wants is the method's business, so both go through unchanged
+    -- Core's `args` convenience included, a named call carrying an array
+    of leading positional values, which is one key of a caller's mapping
+    and needs nothing here.
+
+    A str, bytes or bytearray is a Sequence and is never a list of
+    parameters: `call("getblock", block_id)` means one parameter, where
+    json would have sent sixty-four of them. Refused rather than wrapped,
+    since a caller who meant a sequence of one has `[block_id]` to say so
+    and nothing tells the two intentions apart from here.
+    """
+    if params is None:
+        return []
+    if isinstance(params, Mapping):
+        for name in params:
+            if not isinstance(name, str):
+                raise BTClibTypeError(f"non-string rpc parameter name: {name!r}")
+        return dict(params)
+    if isinstance(params, (str, bytes, bytearray)):
+        err_msg = f"rpc params is a {type(params).__name__} and not a sequence"
+        err_msg += " of parameters: pass [params] for a single positional one"
+        raise BTClibTypeError(err_msg)
+    if isinstance(params, Sequence):
+        return list(params)
+    err_msg = "rpc params is neither a sequence nor a mapping, but a"
+    err_msg += f" {type(params).__name__}"
+    raise BTClibTypeError(err_msg)
+
+
+def _refuse_param(value: Any) -> Any:
+    """Refuse a parameter no json value corresponds to.
+
+    Decimal by name, it being the one a caller has a reason to pass: an
+    amount is a decimal quantity, and `Decimal("0.1")` is the exact way
+    to hold one in Python. What json has no room for is exactly that --
+    the encoder renders a number through `float`, which rounds, and an
+    exact decimal literal would take an encoder of btclib's own. So an
+    amount goes the way the method documents it, satoshis as an int or
+    the string Core accepts for the field, and a Decimal is refused
+    rather than quietly narrowed to binary floating point.
+    """
+    if isinstance(value, Decimal):
+        err_msg = "Decimal rpc parameter: json carries no exact decimal, so"
+        err_msg += " pass what the method documents -- an int of satoshis,"
+        err_msg += " or the string it accepts -- rather than a rounded float"
+        raise BTClibTypeError(err_msg)
+    raise BTClibTypeError(f"rpc parameter that is not a json value: {value!r}")
+
+
+def _refuse_constant(name: str) -> Any:
+    """Refuse the three non-numbers Python's json decodes by default.
+
+    `NaN`, `Infinity` and `-Infinity` are what Python writes and reads
+    for floats json has no numbers for. A node does not send them; a
+    proxy or a stub in the way can, and a nan arriving as an amount
+    compares false against itself for the rest of its life.
+    """
+    raise FetchError(f"not a json number in the reply: {name}")
+
+
+def _http_error(where: str, status: int) -> HttpError:
+    """Turn a status that is itself the failure into the exception for it."""
+    if status == 401:
+        message = f"{where}: HTTP 401, the node refused the credentials"
+        return HttpError(message, status)
+    return HttpError(f"{where}: HTTP {status}", status)
+
+
+def _id_error(where: str, request_id: str, reply: Mapping[str, Any]) -> FetchError:
+    """Say that a reply answers some request other than this one."""
+    err_msg = f"{where}: reply id {reply.get('id')!r}"
+    err_msg += f" is not the {request_id!r} asked for"
+    return FetchError(err_msg)
+
+
+def _rpc_error(where: str, error: Any) -> FetchError:
+    """Turn what the node put in `error` into the exception for it."""
+    if not isinstance(error, Mapping) or not is_integer(error.get("code")):
+        return FetchError(f"{where}: unreadable rpc error {error!r}")
+    return RpcError(
+        f"{where}: {error.get('message', '')}", error["code"], error.get("data")
+    )
+
+
+def _reply_object(where: str, status: int, payload: bytes) -> Mapping[str, Any]:
+    """Return the json object a reply is, or say what arrived instead."""
+    try:
+        reply = json.loads(
+            payload, parse_float=Decimal, parse_constant=_refuse_constant
+        )
+    except UnicodeDecodeError as e:
+        raise FetchError(f"{where}: a reply that is not utf-8 ({e})") from e
+    except json.JSONDecodeError as e:
+        # a 401 is the common way to get here: Core answers an
+        # unauthorized request with the status and an empty body, so
+        # reporting "not json" would name the symptom and hide the cause
+        if status != 200:
+            raise _http_error(where, status) from e
+        raise FetchError(f"{where}: not json ({e})") from e
+    except RecursionError as e:
+        # json nested deeper than the interpreter's stack, which the
+        # bound on the body leaves ample room for: a megabyte of `[` is a
+        # recursion error out of the parser rather than an answer
+        raise FetchError(f"{where}: a reply nested too deeply to parse") from e
+    if not isinstance(reply, dict):
+        raise FetchError(f"{where}: not a json-rpc reply, but a {type(reply).__name__}")
+    return reply
+
+
+def _legacy_result(
+    where: str, request_id: str, status: int, reply: Mapping[str, Any]
+) -> Any:
+    """Return the `result` of a reply carrying no version marker.
+
+    Core's legacy JSON-RPC 1.1: what a node answers to a request without
+    the 2.0 marker, and what v27 and older answer to every request.
+    `result` and `error` are both present, one of them null, and an rpc
+    error arrives with an HTTP 500 -- so the error is read before the
+    status, or every "no such transaction" from an old node would be
+    reported as a server fault.
+
+    Before the status, but not before the id. A 500 from something in the
+    way, carrying an error object of its own or another call's, is a
+    failure of the HTTP exchange and not this call's rpc error.
+    """
+    ours = reply.get("id") == request_id
+    error = reply.get("error")
+    if ours and error is not None:
+        raise _rpc_error(where, error)
+    if status != 200:
+        raise _http_error(where, status)
+    if not ours:
+        raise _id_error(where, request_id, reply)
+    if "result" not in reply:
+        raise FetchError(f"{where}: a reply with neither result nor error")
+    return reply["result"]
+
+
+def _v2_result(
+    where: str, request_id: str, status: int, reply: Mapping[str, Any]
+) -> Any:
+    """Return the `result` of a JSON-RPC 2.0 reply.
+
+    The status is read first, and that is the whole gain of asking for
+    2.0: a non-200 is a failure of the HTTP exchange and never an rpc
+    error, Core answering 200 with an `error` member for those. So a 401
+    from the node, a 403 from something in front of it and a 503 from a
+    full work queue cannot be reported as anything the node computed,
+    however json-shaped the body beside them is.
+
+    Then exactly one of `result` and `error`, which is 2.0's own rule and
+    what tells a 2.0 reply from a 1.1 one wearing the marker.
+    """
+    if status != 200:
+        raise _http_error(where, status)
+    if reply.get("id") != request_id:
+        raise _id_error(where, request_id, reply)
+    error = reply.get("error")
+    if error is not None:
+        if "result" in reply:
+            raise FetchError(f"{where}: a 2.0 reply with both result and error")
+        raise _rpc_error(where, error)
+    if "result" not in reply:
+        raise FetchError(f"{where}: a reply with neither result nor error")
+    return reply["result"]
+
+
+class BitcoindRpcClient:
     """One bitcoind JSON-RPC endpoint, and the credentials to reach it.
 
     Not a dataclass, and that is about the password: a generated
     `__repr__` prints every field, so the credential would appear in any
-    traceback that renders the proxy, and in any log line that prints it.
+    traceback that renders the client, and in any log line that prints
+    it.
+
+    Credentials or a cookie path, and not both: each of the two says who
+    is calling, so a client given both would have to rank them, and a
+    caller who passed both has a mistaken idea of which one is in use.
+    `from_network` is the constructor that fills in a cookie path, along
+    with the port, from Core's own defaults.
+
+    **Concurrent calls are supported while the configuration is not
+    mutated.** `call` writes nothing on the client, opens its own
+    connection and takes its request id from no shared counter, so one
+    client serves any number of threads. What is not promised is a client
+    whose url, credentials or transport are reassigned while a call is in
+    flight, or a caller's transport that is not itself thread-safe --
+    that one is the transport's own contract.
+
+    **Basic authentication is cleartext over plain HTTP**, that being
+    what Core's rpc speaks. On loopback, which is what `from_network`
+    builds, the cleartext is between one process and the node beside it.
+    For a node anywhere else it is on the wire, and rpc credentials
+    authorise every wallet command that node has: an `https` url, or a
+    tunnel, is what keeps them off it.
+
+    Nothing here asks the node which chain it is on. The url and the
+    cookie path say where to ask; `BitcoindFetcher`'s `network` says what
+    the answers are labelled with, and holding the two together is the
+    caller's -- `getblockchaininfo` through `call` is how it is checked.
     """
 
     def __init__(
         self,
-        url: str = "",
+        url: str,
         *,
-        network: str = "mainnet",
         user: str | None = None,
         password: str | None = None,
         cookie_path: Path | str | None = None,
         timeout: float = DEFAULT_TIMEOUT,
         transport: HttpTransport = urlopen_transport,
     ) -> None:
-        if network not in _RPC_PORT:
-            raise BTClibValueError(f"unknown network: {network}")
-        self.network = network
-        self.url = url or f"http://127.0.0.1:{_RPC_PORT[network]}"
-        split = urlsplit(self.url)
-        if split.username is not None or split.password is not None:
-            err_msg = "credentials in the rpc url:"
-            err_msg += " pass user and password, or use the cookie file"
-            raise BTClibValueError(err_msg)
+        self.url = _checked_url(url)
         if (user is None) != (password is None):
             raise BTClibValueError("rpc user and password go together, or neither")
+        if user is not None and cookie_path is not None:
+            err_msg = "both rpc credentials and a cookie path:"
+            err_msg += " either of them says who is calling, so pass one"
+            raise BTClibValueError(err_msg)
+        if user is None and cookie_path is None:
+            err_msg = "no rpc credentials: pass user and password, or the"
+            err_msg += " path of the cookie file the node writes"
+            raise BTClibValueError(err_msg)
+        _assert_valid_timeout(timeout, "rpc timeout")
         self.user = user
         self._password = password
-        self.cookie_path = (
-            Path(cookie_path)
-            if cookie_path is not None
-            else DEFAULT_DATADIR / _DATADIR_SUBDIR[network] / ".cookie"
-        )
+        self.cookie_path = None if cookie_path is None else Path(cookie_path)
         self.timeout = timeout
         self.transport = transport
+
+    @classmethod
+    def from_network(
+        cls,
+        network: str = "mainnet",
+        *,
+        user: str | None = None,
+        password: str | None = None,
+        cookie_path: Path | str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        transport: HttpTransport = urlopen_transport,
+    ) -> BitcoindRpcClient:
+        """Return a client for the local node of one of Core's networks.
+
+        The convenience of not writing out a loopback url, a port and a
+        datadir: all three come from Core's own tables, and everything
+        else is the constructor's. The five names are Core's chain names,
+        because what they index here is a port and a directory -- a chain
+        btclib knows and Core has no default port for is an explicit url
+        with a `cookie_path`, which is the constructor.
+
+        Nor is this the chain the answers get labelled with. That is
+        `BitcoindFetcher`'s `network`, and nothing here verifies that the
+        node agrees with either of them.
+        """
+        if network not in _RPC_PORT:
+            raise BTClibValueError(f"unknown network: {network}")
+        if user is None and cookie_path is None:
+            cookie_path = DEFAULT_DATADIR / _DATADIR_SUBDIR[network] / ".cookie"
+        return cls(
+            f"http://127.0.0.1:{_RPC_PORT[network]}",
+            user=user,
+            password=password,
+            cookie_path=cookie_path,
+            timeout=timeout,
+            transport=transport,
+        )
+
+    def for_wallet(self, wallet_name: str) -> BitcoindRpcClient:
+        """Return a client for this node's `/wallet/<name>` endpoint.
+
+        Which is how a node with several wallets loaded is told which one
+        a wallet command is about. The name is percent-encoded, a wallet
+        being a directory and free to be called anything a filesystem
+        accepts: a space, a `#` or a `/` written into the path unencoded
+        addresses a different endpoint, or none.
+
+        The credentials, the timeout and the transport are this client's,
+        the endpoint being the only difference -- so a caller working on
+        several wallets builds one client and derives the rest.
+        """
+        url = f"{self.url.rstrip('/')}/wallet/{quote(wallet_name, safe='')}"
+        return BitcoindRpcClient(
+            url,
+            user=self.user,
+            password=self._password,
+            cookie_path=self.cookie_path,
+            timeout=self.timeout,
+            transport=self.transport,
+        )
 
     def auth_header(self) -> str:
         """Return the Basic credential, from the arguments or the cookie.
@@ -169,30 +548,70 @@ class AuthProxy:
         it is the choice that matches what a shell and a config file
         would have written.
         """
-        if self.user is None:
+        if self.cookie_path is not None:
             credential = cookie_auth(self.cookie_path)
         else:
             credential = f"{self.user}:{self._password}"
         return "Basic " + b64encode(credential.encode()).decode("ascii")
 
     def call(
-        self, method: str, *params: Any, max_body_size: int = DEFAULT_MAX_BODY_SIZE
+        self,
+        method: str,
+        params: Sequence[Any] | Mapping[str, Any] | None = None,
+        *,
+        request_timeout: float | None = None,
+        max_body_size: int = DEFAULT_MAX_BODY_SIZE,
     ) -> Any:
         """Invoke one rpc method, returning its `result`.
 
-        Any method, not only the three the fetcher needs: a caller with a
-        node has every reason to ask it something else, and refusing that
-        would only mean they write this class again.
+        `params` is one value, shaped as json-rpc shapes it: a sequence
+        for the positional form, a mapping for the named one. The
+        client's own controls are keyword-only for that reason --
+        `timeout` is a parameter of several Core methods, and a signature
+        mixing the two would have to decide which of them owns the name.
 
-        `max_body_size` is what the reply may weigh, and it defaults to the
-        widest answer a fetcher asks for -- a raw transaction, as hex
+        Amounts do not travel as binary floating point in either
+        direction: a number in the reply decodes as a Decimal, and a
+        Decimal parameter is refused rather than rounded through `float`.
+        `NaN` and `Infinity` are refused both ways, being what Python
+        writes for floats json has no numbers for.
+
+        `request_timeout` is this call's, defaulting to the client's.
+        What it is for is the handful of methods that legitimately run
+        long -- `rescanblockchain`, `scantxoutset`, `dumptxoutset` -- for
+        which the alternative is a second client whose wider timeout
+        applies to everything.
+
+        `max_body_size` is what the reply may weigh, and it defaults to
+        the widest answer a fetcher asks for -- a raw transaction, as hex
         inside a json envelope. A caller invoking something whose reply is
         a number tightens it; one invoking `getblock` on a large block
         widens it, this being their node and their memory.
+
+        There is no retry: one call is one HTTP request, whatever comes
+        back. `HttpError.status` is what a caller's own policy reads --
+        503 from a full work queue is worth another attempt, 401 never is
+        -- and the reason the policy is theirs is in this module's
+        docstring: any method may be carried here, and a timeout does not
+        say the node stopped executing one.
         """
-        body = json.dumps(
-            {"jsonrpc": "2.0", "id": _RPC_ID, "method": method, "params": list(params)}
-        ).encode()
+        request_id = _rpc_id()
+        timeout = self.timeout if request_timeout is None else request_timeout
+        _assert_valid_timeout(timeout, "rpc request_timeout")
+        request = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": _params_member(params),
+        }
+        try:
+            body = json.dumps(request, allow_nan=False, default=_refuse_param).encode()
+        except ValueError as e:
+            # allow_nan=False, i.e. a nan or an infinity among the
+            # parameters: Python writes those as the three bare words
+            # json has no numbers for, and a node parsing strictly
+            # rejects the whole request rather than the one parameter
+            raise BTClibValueError(f"not a json number in the rpc params: {e}") from e
         status, payload = http_request(
             self.url,
             data=body,
@@ -200,69 +619,49 @@ class AuthProxy:
                 "Content-Type": "application/json",
                 "Authorization": self.auth_header(),
             },
-            timeout=self.timeout,
+            timeout=timeout,
             max_body_size=max_body_size,
             transport=self.transport,
         )
-        return self._result(method, status, payload)
+        return self._result(method, request_id, status, payload)
 
-    def _result(self, method: str, status: int, payload: bytes) -> Any:
+    def _result(self, method: str, request_id: str, status: int, payload: bytes) -> Any:
         where = f"{method} at {self.url}"
-        try:
-            reply = json.loads(payload)
-        except json.JSONDecodeError as e:
-            # a 401 is the common way to get here: Core answers an
-            # unauthorized request with the status and an empty body, so
-            # reporting "not json" would name the symptom and hide the
-            # cause
-            if status != 200:
-                raise FetchError(f"{where}: {_http_reason(status)}") from e
-            raise FetchError(f"{where}: not json ({e})") from e
-
-        if not isinstance(reply, dict):
-            raise FetchError(f"{where}: not a json-rpc reply, but a {type(reply)}")
-
-        # before the status, because this is where a 1.0 reply keeps the
-        # error object it sends with its 500
-        error = reply.get("error")
-        if error is not None:
-            raise _rpc_error(where, error)
-
-        if status != 200:
-            raise FetchError(f"{where}: {_http_reason(status)}")
-        if reply.get("id") != _RPC_ID:
-            raise FetchError(f"{where}: reply id {reply.get('id')!r} is not ours")
-        if "result" not in reply:
-            raise FetchError(f"{where}: a reply with neither result nor error")
-        return reply["result"]
-
-
-def _http_reason(status: int) -> str:
-    """Say what a status means for a caller who has to act on it."""
-    if status == 401:
-        return "HTTP 401, the node refused the credentials"
-    return f"HTTP {status}"
-
-
-def _rpc_error(where: str, error: Any) -> FetchError:
-    """Turn what the node put in `error` into the exception for it."""
-    if not isinstance(error, dict) or not isinstance(error.get("code"), int):
-        return FetchError(f"{where}: unreadable rpc error {error!r}")
-    return RpcError(f"{where}: {error.get('message', '')}", error["code"])
+        reply = _reply_object(where, status, payload)
+        if "jsonrpc" not in reply:
+            # the member and not its value: `"jsonrpc": null` is a reply
+            # that names no protocol, which is not the same thing as a
+            # 1.1 reply, and it is the member's absence that means 1.1
+            return _legacy_result(where, request_id, status, reply)
+        marker = reply["jsonrpc"]
+        if marker != "2.0":
+            err_msg = f"{where}: json-rpc version {marker!r}, neither 2.0"
+            err_msg += " nor the legacy reply that carries no version at all"
+            raise FetchError(err_msg)
+        return _v2_result(where, request_id, status, reply)
 
 
 class BitcoindFetcher(Fetcher):
-    """The three questions, answered by a node over `AuthProxy`.
+    """The three questions, answered by a node over its rpc.
 
-    The proxy is a constructor argument rather than a set of connection
+    The client is a constructor argument rather than a set of connection
     arguments repeated here: one class owns the endpoint and the
     credentials, this one owns the mapping onto btclib types, and a
-    caller who already has a proxy does not build a second.
+    caller who already has a client does not build a second.
+
+    `network` is btclib's chain label and belongs to this class and not
+    to the connection: it is what the outputs of a fetched transaction
+    are labelled with, so that `ScriptPubKey.address` renders an address
+    of the right chain. The client knows a url and no chain, and nothing
+    here asks the node which one it serves -- a client pointed at a
+    testnet node under a fetcher labelling mainnet is a caller's mistake
+    to avoid, and `getblockchaininfo` through `call` is how it is
+    checked.
     """
 
-    def __init__(self, proxy: AuthProxy) -> None:
-        super().__init__(proxy.network)
-        self.proxy = proxy
+    def __init__(self, client: BitcoindRpcClient, network: str = "mainnet") -> None:
+        super().__init__(network)
+        self.client = client
 
     def get_tx(self, tx_id: Octets) -> Tx:
         """Return the transaction with this id.
@@ -278,16 +677,17 @@ class BitcoindFetcher(Fetcher):
         index the error is rpc code -5, and its message says so.
         """
         hex_ = tx_id_hex(tx_id)
-        raw = self.proxy.call("getrawtransaction", hex_)
+        raw = self.client.call("getrawtransaction", [hex_])
         return tx_from_raw(raw, hex_, self.network)
 
     def get_block_count(self) -> int:
         """Return the height of the node's best chain tip."""
         with fetch_errors("getblockcount"):
-            return int(self.proxy.call("getblockcount", max_body_size=_MAX_SMALL_REPLY))
+            reply = self.client.call("getblockcount", max_body_size=_MAX_SMALL_REPLY)
+            return int(reply)
 
     def get_best_block_id(self) -> bytes:
         """Return the hash of the node's best chain tip, display order."""
         with fetch_errors("getbestblockhash"):
-            reply = self.proxy.call("getbestblockhash", max_body_size=_MAX_SMALL_REPLY)
+            reply = self.client.call("getbestblockhash", max_body_size=_MAX_SMALL_REPLY)
             return bytes_from_octets(reply, 32)

--- a/btclib/fetch/bitcoind.py
+++ b/btclib/fetch/bitcoind.py
@@ -28,6 +28,44 @@ attribute lookup that builds a method name is a different interface, and
 the explicit one is what makes an unknown method a value rather than a
 typo that becomes a request.
 
+**Migrating from `AuthServiceProxy`.** A migration and not a drop-in
+replacement: four things change, and each of them is the difference
+deliberately.
+
+.. code-block:: python
+
+    # a method is an argument, not an attribute: an unknown one is a
+    # value that arrives at the node, not an AttributeError here
+    rpc.getblock(block_id, 2)
+    client.call("getblock", [block_id, 2])
+
+    # and the named form is the other structure Core takes, which no
+    # attribute lookup can express
+    client.call("getblock", {"blockhash": block_id, "verbosity": 2})
+
+    # credentials leave the url, which is what gets written into a
+    # config file and printed in a traceback
+    AuthServiceProxy(f"http://{user}:{password}@127.0.0.1:8332")
+    BitcoindRpcClient("http://127.0.0.1:8332", user=user, password=password)
+    BitcoindRpcClient.from_network("mainnet")  # or the node's cookie file
+
+    # one wallet of a multi-wallet node, percent-encoded
+    client.for_wallet("hot").call("getbalance")
+
+`JSONRPCException` becomes three exceptions, because it covered three
+things a caller acts on differently: `RpcError` when the node computed an
+error, with its `code`; `HttpError` when the exchange failed, with its
+`status`; `FetchError` when there was no answer to read at all. All three
+are `FetchError`, so one `except FetchError` is the equivalent of the one
+`except JSONRPCException` -- and the reason to catch them apart is that
+only the middle one is ever worth another attempt.
+
+Two things `AuthServiceProxy` does that this does not: `batch_`, and the
+notifications a request without an `id` makes. Both are named non-goals
+-- a batch needs an api for correlating several answers and for partly
+failing -- so code that uses either is a loop over `call` here, or stays
+where it is.
+
 **One call, one HTTP request, and no retry.** A 503 from bitcoind means
 its rpc work queue is full and the same request works once the queue
 drains, so a retry is the obvious convenience -- and it is the caller's
@@ -410,24 +448,29 @@ def _rpc_error(where: str, error: Any) -> FetchError:
     return RpcError(f"{where}: {message}", code, error.get("data"))
 
 
-def _unparsable(where: str, status: int, cause: Exception) -> FetchError:
-    """Say that a reply could not be read, the status first when it failed.
+def _no_reply(where: str, status: int, cause: Exception) -> FetchError:
+    """Say that no reply arrived, which on a non-200 is the status.
 
-    A body no parser can read cannot be a correlated rpc error, so on a
-    non-200 the status is the failure and the answer carries it: the
-    common case is the 401 with an empty body Core sends, and the next is
-    a 503 whose body is whatever is in front of the node. Reporting "not
-    json" for either would name the symptom and hide the cause.
+    One decision for every body that is not a json-rpc reply, whether the
+    parser refused it or read it into something else: none of them can be
+    a *correlated* answer, so none of them can be this call's rpc error,
+    and on a non-200 what is left is the status -- the 401 with the empty
+    body Core sends, or a 503 whose body is whatever stands in front of
+    the node. Reporting the encoding of an error page would name the
+    symptom and hide the cause.
 
-    On a 200 there is no status to report and what is left is that the
-    node answered something which is not a reply. The three shapes get
-    their own sentence, being three different things to go and look at,
-    and everything else -- a json integer longer than
-    `sys.get_int_max_str_digits` allows, and whatever a later Python adds
-    -- arrives as the parser refusing the reply, which is what happened.
+    On a 200 the status says nothing and the shape is the whole diagnosis,
+    so each shape keeps its own sentence: not utf-8, nested past the
+    stack, not json, not an object. Anything else -- a json integer longer
+    than `sys.get_int_max_str_digits` allows, and whatever a later Python
+    adds -- is the parser refusing the reply, which is what happened.
+    `_refuse_constant`'s own refusal is more precise than any of these and
+    is kept as it is.
     """
     if status != 200:
         return _http_error(where, status)
+    if isinstance(cause, FetchError):
+        return cause
     if isinstance(cause, UnicodeDecodeError):
         return FetchError(f"{where}: a reply that is not utf-8 ({cause})")
     if isinstance(cause, RecursionError):
@@ -443,15 +486,24 @@ def _reply_object(where: str, status: int, payload: bytes) -> Mapping[str, Any]:
         reply = json.loads(
             payload, parse_float=Decimal, parse_constant=_refuse_constant
         )
-    except (ValueError, RecursionError) as e:
-        # every way the parse can fail, under two types: JSONDecodeError
-        # and UnicodeDecodeError are both ValueError, the bare ValueError
-        # of the integer digit limit is a third, and json recurses. None
-        # of them is a distinction a caller acts on differently, and each
-        # of them on a non-200 has to keep the status -- see `_unparsable`
-        raise _unparsable(where, status, e) from e
+    except (ValueError, RecursionError, FetchError) as e:
+        # every way a body can fail to be a reply, under three types.
+        # JSONDecodeError and UnicodeDecodeError are both ValueError, the
+        # bare ValueError of the integer digit limit is a third, json
+        # recurses, and `_refuse_constant` raises a FetchError of its own
+        # for the three non-numbers Python would otherwise decode. What
+        # they have in common is the only thing that matters here: a
+        # caller acts on none of the distinctions, and every one of them
+        # on a non-200 has to keep the status -- see `_no_reply`
+        raise _no_reply(where, status, e) from e
     if not isinstance(reply, dict):
-        raise FetchError(f"{where}: not a json-rpc reply, but a {type(reply).__name__}")
+        # read, and not a reply: an array, a string or a number is no more
+        # a json-rpc answer than a page of html is, so it takes the same
+        # route -- a 503 whose body is `[1, 2, 3]` is a 503
+        cause = FetchError(
+            f"{where}: not a json-rpc reply, but a {type(reply).__name__}"
+        )
+        raise _no_reply(where, status, cause)
     return reply
 
 

--- a/btclib/fetch/bitcoind.py
+++ b/btclib/fetch/bitcoind.py
@@ -57,14 +57,26 @@ things a caller acts on differently: `RpcError` when the node computed an
 error, with its `code`; `HttpError` when the exchange failed, with its
 `status`; `FetchError` when there was no answer to read at all. All three
 are `FetchError`, so one `except FetchError` is the equivalent of the one
-`except JSONRPCException` -- and the reason to catch them apart is that
-only the middle one is ever worth another attempt.
+`except JSONRPCException`. What catching them apart buys is a policy on
+the status -- a 503 from a full work queue is the case where the same
+request works later, and a 401 is the case where it never will. It is not
+a rule about which failures are transient: a refused connection and an
+expired timeout arrive as a plain `FetchError` and can both clear on
+their own.
+Whether *this* call may be sent again is the caller's question and the
+method's, and this module's docstring says why -- a timeout is not a
+deadline.
 
-Two things `AuthServiceProxy` does that this does not: `batch_`, and the
-notifications a request without an `id` makes. Both are named non-goals
--- a batch needs an api for correlating several answers and for partly
-failing -- so code that uses either is a loop over `call` here, or stays
-where it is.
+``batch_`` is what a consumer loses: several calls in one request, which
+is a named non-goal here because a batch needs an api for correlating the
+answers and for partly failing. Core's maintained fork spells it `batch`.
+A loop over `call` is the replacement, at one HTTP request each.
+
+Notifications -- a request sent with no `id`, which a node does not answer
+-- are a non-goal too, and no `AuthServiceProxy` consumer is giving one
+up: both implementations count an `id` into every request they build, so
+sending one at all means reaching past the public interface into
+`_request`.
 
 **One call, one HTTP request, and no retry.** A 503 from bitcoind means
 its rpc work queue is full and the same request works once the queue
@@ -448,29 +460,18 @@ def _rpc_error(where: str, error: Any) -> FetchError:
     return RpcError(f"{where}: {message}", code, error.get("data"))
 
 
-def _no_reply(where: str, status: int, cause: Exception) -> FetchError:
-    """Say that no reply arrived, which on a non-200 is the status.
+def _unreadable(where: str, cause: Exception) -> FetchError:
+    """Say what shape a body was, for the 200 where the status says nothing.
 
-    One decision for every body that is not a json-rpc reply, whether the
-    parser refused it or read it into something else: none of them can be
-    a *correlated* answer, so none of them can be this call's rpc error,
-    and on a non-200 what is left is the status -- the 401 with the empty
-    body Core sends, or a 503 whose body is whatever stands in front of
-    the node. Reporting the encoding of an error page would name the
-    symptom and hide the cause.
+    Each shape gets its own sentence, being a different thing to go and
+    look at: not utf-8, nested past the interpreter's stack, not json.
+    Anything else -- a json integer longer than
+    `sys.get_int_max_str_digits` allows, and whatever a later Python adds
+    -- is the parser refusing the reply, which is what happened.
 
-    On a 200 the status says nothing and the shape is the whole diagnosis,
-    so each shape keeps its own sentence: not utf-8, nested past the
-    stack, not json, not an object. Anything else -- a json integer longer
-    than `sys.get_int_max_str_digits` allows, and whatever a later Python
-    adds -- is the parser refusing the reply, which is what happened.
-    `_refuse_constant`'s own refusal is more precise than any of these and
-    is kept as it is.
+    Only for a 200. Under any other status the shape is not the answer:
+    see `_reply_object`, which reaches this only after ruling that out.
     """
-    if status != 200:
-        return _http_error(where, status)
-    if isinstance(cause, FetchError):
-        return cause
     if isinstance(cause, UnicodeDecodeError):
         return FetchError(f"{where}: a reply that is not utf-8 ({cause})")
     if isinstance(cause, RecursionError):
@@ -481,29 +482,48 @@ def _no_reply(where: str, status: int, cause: Exception) -> FetchError:
 
 
 def _reply_object(where: str, status: int, payload: bytes) -> Mapping[str, Any]:
-    """Return the json object a reply is, or say what arrived instead."""
+    """Return the json object a reply is, or say what arrived instead.
+
+    One rule for every body that is not a json-rpc reply, whichever way it
+    is not one: none of them can be a *correlated* answer, so none can be
+    this call's rpc error, and on a non-200 what is left to report is the
+    status -- the 401 with the empty body Core sends, or a 503 whose body
+    is whatever stands in front of the node. Reporting the encoding of an
+    error page would name the symptom and hide the cause.
+
+    The status cannot be consulted before this, which is why the rule
+    lives here and not at the top of `_result`: a 1.1 error object
+    arriving with an HTTP 500 *is* a reply, and giving up on the status
+    first would report every "no such transaction" from an old node as a
+    server fault.
+    """
     try:
         reply = json.loads(
             payload, parse_float=Decimal, parse_constant=_refuse_constant
         )
-    except (ValueError, RecursionError, FetchError) as e:
-        # every way a body can fail to be a reply, under three types.
-        # JSONDecodeError and UnicodeDecodeError are both ValueError, the
-        # bare ValueError of the integer digit limit is a third, json
-        # recurses, and `_refuse_constant` raises a FetchError of its own
-        # for the three non-numbers Python would otherwise decode. What
-        # they have in common is the only thing that matters here: a
-        # caller acts on none of the distinctions, and every one of them
-        # on a non-200 has to keep the status -- see `_no_reply`
-        raise _no_reply(where, status, e) from e
+    except FetchError as e:
+        # `_refuse_constant`, i.e. one of the three non-numbers Python
+        # decodes by default. Its own sentence names which, so under a 200
+        # it is re-raised as it stands -- `raise _unreadable(...) from e`
+        # would hand back this very object and make the exception its own
+        # `__cause__`, which anything walking that chain follows in a loop
+        if status == 200:
+            raise
+        raise _http_error(where, status) from e
+    except (ValueError, RecursionError) as e:
+        # the rest of the ways a parse fails: JSONDecodeError and
+        # UnicodeDecodeError are both ValueError, the bare ValueError of
+        # the integer digit limit is a third, and json recurses
+        if status != 200:
+            raise _http_error(where, status) from e
+        raise _unreadable(where, e) from e
     if not isinstance(reply, dict):
-        # read, and not a reply: an array, a string or a number is no more
-        # a json-rpc answer than a page of html is, so it takes the same
-        # route -- a 503 whose body is `[1, 2, 3]` is a 503
-        cause = FetchError(
-            f"{where}: not a json-rpc reply, but a {type(reply).__name__}"
-        )
-        raise _no_reply(where, status, cause)
+        # read, and still not a reply: an array, a string or a number is
+        # no more a json-rpc answer than a page of html is, so a 503 whose
+        # body is `[1, 2, 3]` is a 503
+        if status != 200:
+            raise _http_error(where, status)
+        raise FetchError(f"{where}: not a json-rpc reply, but a {type(reply).__name__}")
     return reply
 
 

--- a/btclib/fetch/bitcoind.py
+++ b/btclib/fetch/bitcoind.py
@@ -709,11 +709,12 @@ class BitcoindRpcClient:
         try:
             body = json.dumps(request, allow_nan=False, default=_refuse_param).encode()
         except ValueError as e:
-            # the walk above refuses every value json refuses and says
-            # which one, so what is left for this to catch is whatever a
-            # later Python adds to the encoder's own refusals. It is still
-            # about the parameters, this being the only part of a request
-            # that is not built here
+            # an int of more digits than `sys.get_int_max_str_digits`
+            # allows, which is the mirror of the limit a *reply* holding
+            # one runs into: json has the number and this interpreter will
+            # not write it. The walk above refuses the types json has no
+            # rendering for, and this is a value of a type it does, so the
+            # encoder is where it surfaces
             raise BTClibValueError(f"rpc params json cannot carry: {e}") from e
         status, payload = http_request(
             self.url,

--- a/btclib/fetch/bitcoind.py
+++ b/btclib/fetch/bitcoind.py
@@ -141,6 +141,14 @@ _MAX_COOKIE_SIZE = 4096
 # it was
 _RPC_ID_BYTES = 8
 
+# how deep a parameter structure may nest. Both the encoder and the walk
+# that checks a structure before it recurse, so a bound is what turns
+# something too deep for either into a refusal that names the parameters
+# rather than a RecursionError out of the standard library. Core's own
+# methods nest a few levels -- the inputs of a psbt, the tree of a
+# descriptor -- so this is not a limit a call arrives at
+_MAX_PARAMS_DEPTH = 100
+
 # what a reply that is a number or a hash may weigh: the json envelope
 # around `result`, `error` and `id`, and a value of a few dozen octets.
 # `getrawtransaction` is the one answer here that is not small, and it
@@ -263,9 +271,6 @@ def _params_member(params: Sequence[Any] | Mapping[str, Any] | None) -> Any:
     if params is None:
         return []
     if isinstance(params, Mapping):
-        for name in params:
-            if not isinstance(name, str):
-                raise BTClibTypeError(f"non-string rpc parameter name: {name!r}")
         return dict(params)
     if isinstance(params, (str, bytes, bytearray)):
         err_msg = f"rpc params is a {type(params).__name__} and not a sequence"
@@ -278,23 +283,84 @@ def _params_member(params: Sequence[Any] | Mapping[str, Any] | None) -> Any:
     raise BTClibTypeError(err_msg)
 
 
-def _refuse_param(value: Any) -> Any:
-    """Refuse a parameter no json value corresponds to.
+def _assert_json_params(
+    value: Any, depth: int = 0, enclosing: tuple[int, ...] = ()
+) -> None:
+    """Refuse a parameter structure json cannot carry, before it is encoded.
 
-    Decimal by name, it being the one a caller has a reason to pass: an
-    amount is a decimal quantity, and `Decimal("0.1")` is the exact way
-    to hold one in Python. What json has no room for is exactly that --
-    the encoder renders a number through `float`, which rounds, and an
-    exact decimal literal would take an encoder of btclib's own. So an
-    amount goes the way the method documents it, satoshis as an int or
-    the string Core accepts for the field, and a Decimal is refused
-    rather than quietly narrowed to binary floating point.
+    Walked rather than left to the encoder, because most of what goes
+    wrong here is silent or unhelpful in it. A mapping keyed by anything
+    but a string is *rewritten*: `{1: "a"}` encodes as `{"1": "a"}`, so a
+    caller's value reaches the node changed rather than refused, and only
+    the outermost mapping is a name a caller wrote by hand. A structure
+    containing itself raises ValueError("Circular reference detected"),
+    which is the same type a non-finite number raises and means something
+    else entirely. One nested past the interpreter's stack raises
+    RecursionError from inside the encoder. And a Decimal or a `bytes`
+    reaches `default`, which cannot say where in the structure it was.
+
+    `enclosing` carries the ids of the containers this value sits inside,
+    which is what a cycle is: a container reached from within itself. No
+    depth bound tells that from a structure that is merely deep, and no
+    bound on a *reply* helps -- these are the caller's own objects.
+    """
+    if depth > _MAX_PARAMS_DEPTH:
+        err_msg = f"rpc params nested deeper than the {_MAX_PARAMS_DEPTH} allowed"
+        raise BTClibValueError(err_msg)
+    if _json_scalar(value):
+        return
+    if isinstance(value, Mapping):
+        _assert_no_cycle(value, enclosing)
+        for name, item in value.items():
+            if not isinstance(name, str):
+                raise BTClibTypeError(f"non-string rpc parameter name: {name!r}")
+            _assert_json_params(item, depth + 1, (*enclosing, id(value)))
+        return
+    if isinstance(value, Sequence):
+        _assert_no_cycle(value, enclosing)
+        for item in value:
+            _assert_json_params(item, depth + 1, (*enclosing, id(value)))
+        return
+    raise BTClibTypeError(f"rpc parameter that is not a json value: {value!r}")
+
+
+def _json_scalar(value: Any) -> bool:
+    """Say whether a value is a json scalar, refusing three that look like one.
+
+    A Decimal, a non-finite float and a `bytes` are each a value a caller
+    has a reason to pass and json has no rendering for, so each is refused
+    where what to pass instead can be named -- rather than reported as
+    "not a json value" from the end of the walk, or, for the `bytes`,
+    walked as the list of the ints of its octets.
     """
     if isinstance(value, Decimal):
         err_msg = "Decimal rpc parameter: json carries no exact decimal, so"
         err_msg += " pass what the method documents -- an int of satoshis,"
         err_msg += " or the string it accepts -- rather than a rounded float"
         raise BTClibTypeError(err_msg)
+    if isinstance(value, float) and not isfinite(value):
+        raise BTClibValueError(f"not a json number in the rpc params: {value}")
+    if isinstance(value, (bytes, bytearray)):
+        raise BTClibTypeError(f"rpc parameter that is not a json value: {value!r}")
+    return value is None or isinstance(value, (bool, int, float, str))
+
+
+def _assert_no_cycle(value: Any, enclosing: tuple[int, ...]) -> None:
+    """Refuse a container reached from inside itself, by the ids it is in."""
+    if id(value) in enclosing:
+        raise BTClibValueError("rpc params contains itself, so it has no json")
+
+
+def _refuse_param(value: Any) -> Any:
+    """Refuse a parameter the walk before the encoder did not anticipate.
+
+    The backstop, and every type it can be reached with today is one
+    `_assert_json_params` refuses first. What keeps it here is that
+    `json.dumps` calling this is the alternative to a TypeError from
+    inside the encoder: an object that is a `Sequence` of json values and
+    still has no json -- `range(3)` is one -- passes the walk and arrives
+    here.
+    """
     raise BTClibTypeError(f"rpc parameter that is not a json value: {value!r}")
 
 
@@ -325,12 +391,50 @@ def _id_error(where: str, request_id: str, reply: Mapping[str, Any]) -> FetchErr
 
 
 def _rpc_error(where: str, error: Any) -> FetchError:
-    """Turn what the node put in `error` into the exception for it."""
-    if not isinstance(error, Mapping) or not is_integer(error.get("code")):
+    """Turn what the node put in `error` into the exception for it.
+
+    An error object is a code that is an integer and a message that is a
+    string; a caller acts on the first and reads the second, so neither is
+    something to render whatever arrived. A missing message would become
+    an empty one and a list would be formatted into the exception, both of
+    which report the node as having said something it did not.
+    """
+    if not isinstance(error, Mapping):
         return FetchError(f"{where}: unreadable rpc error {error!r}")
-    return RpcError(
-        f"{where}: {error.get('message', '')}", error["code"], error.get("data")
-    )
+    # Any, both of them: every value of a reply is whatever the backend
+    # put there, which is what the two checks below are for
+    code: Any = error.get("code")
+    message: Any = error.get("message")
+    if not is_integer(code) or not isinstance(message, str):
+        return FetchError(f"{where}: unreadable rpc error {error!r}")
+    return RpcError(f"{where}: {message}", code, error.get("data"))
+
+
+def _unparsable(where: str, status: int, cause: Exception) -> FetchError:
+    """Say that a reply could not be read, the status first when it failed.
+
+    A body no parser can read cannot be a correlated rpc error, so on a
+    non-200 the status is the failure and the answer carries it: the
+    common case is the 401 with an empty body Core sends, and the next is
+    a 503 whose body is whatever is in front of the node. Reporting "not
+    json" for either would name the symptom and hide the cause.
+
+    On a 200 there is no status to report and what is left is that the
+    node answered something which is not a reply. The three shapes get
+    their own sentence, being three different things to go and look at,
+    and everything else -- a json integer longer than
+    `sys.get_int_max_str_digits` allows, and whatever a later Python adds
+    -- arrives as the parser refusing the reply, which is what happened.
+    """
+    if status != 200:
+        return _http_error(where, status)
+    if isinstance(cause, UnicodeDecodeError):
+        return FetchError(f"{where}: a reply that is not utf-8 ({cause})")
+    if isinstance(cause, RecursionError):
+        return FetchError(f"{where}: a reply nested too deeply to parse")
+    if isinstance(cause, json.JSONDecodeError):
+        return FetchError(f"{where}: not json ({cause})")
+    return FetchError(f"{where}: a reply the json parser refused ({cause})")
 
 
 def _reply_object(where: str, status: int, payload: bytes) -> Mapping[str, Any]:
@@ -339,20 +443,13 @@ def _reply_object(where: str, status: int, payload: bytes) -> Mapping[str, Any]:
         reply = json.loads(
             payload, parse_float=Decimal, parse_constant=_refuse_constant
         )
-    except UnicodeDecodeError as e:
-        raise FetchError(f"{where}: a reply that is not utf-8 ({e})") from e
-    except json.JSONDecodeError as e:
-        # a 401 is the common way to get here: Core answers an
-        # unauthorized request with the status and an empty body, so
-        # reporting "not json" would name the symptom and hide the cause
-        if status != 200:
-            raise _http_error(where, status) from e
-        raise FetchError(f"{where}: not json ({e})") from e
-    except RecursionError as e:
-        # json nested deeper than the interpreter's stack, which the
-        # bound on the body leaves ample room for: a megabyte of `[` is a
-        # recursion error out of the parser rather than an answer
-        raise FetchError(f"{where}: a reply nested too deeply to parse") from e
+    except (ValueError, RecursionError) as e:
+        # every way the parse can fail, under two types: JSONDecodeError
+        # and UnicodeDecodeError are both ValueError, the bare ValueError
+        # of the integer digit limit is a third, and json recurses. None
+        # of them is a distinction a caller acts on differently, and each
+        # of them on a non-200 has to keep the status -- see `_unparsable`
+        raise _unparsable(where, status, e) from e
     if not isinstance(reply, dict):
         raise FetchError(f"{where}: not a json-rpc reply, but a {type(reply).__name__}")
     return reply
@@ -400,19 +497,22 @@ def _v2_result(
     however json-shaped the body beside them is.
 
     Then exactly one of `result` and `error`, which is 2.0's own rule and
-    what tells a 2.0 reply from a 1.1 one wearing the marker.
+    what tells a 2.0 reply from a 1.1 one wearing the marker. Which member
+    is *present*, and not which is non-null: `"error": null` beside a
+    result is the 1.1 shape, and a reply that is 1.1 under a 2.0 marker is
+    one whose errors this function would look for in the wrong place.
     """
     if status != 200:
         raise _http_error(where, status)
     if reply.get("id") != request_id:
         raise _id_error(where, request_id, reply)
-    error = reply.get("error")
-    if error is not None:
-        if "result" in reply:
-            raise FetchError(f"{where}: a 2.0 reply with both result and error")
-        raise _rpc_error(where, error)
-    if "result" not in reply:
-        raise FetchError(f"{where}: a reply with neither result nor error")
+    has_result = "result" in reply
+    has_error = "error" in reply
+    if has_result == has_error:
+        both = "both result and error" if has_result else "neither result nor error"
+        raise FetchError(f"{where}: a 2.0 reply with {both}")
+    if has_error:
+        raise _rpc_error(where, reply["error"])
     return reply["result"]
 
 
@@ -598,20 +698,23 @@ class BitcoindRpcClient:
         request_id = _rpc_id()
         timeout = self.timeout if request_timeout is None else request_timeout
         _assert_valid_timeout(timeout, "rpc request_timeout")
+        params_member = _params_member(params)
+        _assert_json_params(params_member)
         request = {
             "jsonrpc": "2.0",
             "id": request_id,
             "method": method,
-            "params": _params_member(params),
+            "params": params_member,
         }
         try:
             body = json.dumps(request, allow_nan=False, default=_refuse_param).encode()
         except ValueError as e:
-            # allow_nan=False, i.e. a nan or an infinity among the
-            # parameters: Python writes those as the three bare words
-            # json has no numbers for, and a node parsing strictly
-            # rejects the whole request rather than the one parameter
-            raise BTClibValueError(f"not a json number in the rpc params: {e}") from e
+            # the walk above refuses every value json refuses and says
+            # which one, so what is left for this to catch is whatever a
+            # later Python adds to the encoder's own refusals. It is still
+            # about the parameters, this being the only part of a request
+            # that is not built here
+            raise BTClibValueError(f"rpc params json cannot carry: {e}") from e
         status, payload = http_request(
             self.url,
             data=body,

--- a/btclib/fetch/esplora.py
+++ b/btclib/fetch/esplora.py
@@ -38,7 +38,7 @@ renderings beside them carry the same values with more to disagree about
 from __future__ import annotations
 
 from btclib.alias import Octets
-from btclib.exceptions import FetchError
+from btclib.exceptions import HttpError
 from btclib.fetch.fetcher import Fetcher, fetch_errors, tx_from_raw, tx_id_hex
 from btclib.fetch.transport import (
     DEFAULT_MAX_BODY_SIZE,
@@ -110,6 +110,13 @@ class EsploraFetcher(Fetcher):
         `max_body_size` is what this particular answer may weigh; the
         default is the widest of the three, so a caller asking for
         something narrow says so.
+
+        A status that is not 200 is an `HttpError`, which carries it:
+        every answer here is a GET of an immutable value, so a 429 or a
+        503 from a public deployment is the one failure worth another
+        attempt, and telling it from a 404 without reading a message is
+        what the field is for. btclib retries nothing itself -- an
+        explorer's rate limit is the caller's budget to spend.
         """
         url = f"{self.base_url}{path}"
         status, payload = http_request(
@@ -120,7 +127,7 @@ class EsploraFetcher(Fetcher):
         )
         text = payload.decode("utf-8", errors="replace").strip()
         if status != 200:
-            raise FetchError(f"HTTP {status} from {url}: {text}")
+            raise HttpError(f"HTTP {status} from {url}: {text}", status)
         return text
 
     def get_tx(self, tx_id: Octets) -> Tx:

--- a/btclib/fetch/transport.py
+++ b/btclib/fetch/transport.py
@@ -50,7 +50,7 @@ from btclib.utils import is_integer
 # timeout in seconds, answering with the HTTP status and the response
 # body. A status rather than an exception, because a JSON-RPC error can
 # arrive with a 500 and its body is the error object -- see
-# btclib.fetch.bitcoind
+# btclib.fetch.bitcoin_core
 #
 # Two arguments and no more, which is what a caller's own transport is
 # owed and what it owes. What it is owed: a `Request` with its url, its
@@ -67,7 +67,7 @@ from btclib.utils import is_integer
 #   for the host it names -- `_OPENER` below is what does this for the
 #   default -- and a client library that follows a 30x sends that
 #   credential to whatever the `Location` says;
-# - its own thread-safety. `BitcoindRpcClient` promises that concurrent
+# - its own thread-safety. `BitcoinCoreRpcClient` promises that concurrent
 #   calls are safe while its configuration is not mutated, and the
 #   transport is part of that configuration: a session object that is not
 #   thread-safe makes the client not thread-safe, and only its author

--- a/btclib/fetch/transport.py
+++ b/btclib/fetch/transport.py
@@ -260,8 +260,8 @@ def http_request(
     them is a bitcoin error worth a type of its own.
 
     A non-2xx status is *not* a failure here. It comes back like any
-    other, because the body of a 500 is where bitcoind's JSON-RPC 1.0
-    reply puts its error object, and the body of a 404 is where an
+    other, because the body of a 500 is where bitcoind's legacy JSON-RPC
+    1.1 reply puts its error object, and the body of a 404 is where an
     explorer says what it could not find. Deciding what a status means is
     the backend's job, that being the layer that knows. A 30x is one of
     those statuses now rather than a second request: `urlopen_transport`

--- a/btclib/fetch/transport.py
+++ b/btclib/fetch/transport.py
@@ -36,7 +36,12 @@ from http.client import HTTPMessage
 from typing import IO, Any
 from urllib.error import HTTPError
 from urllib.parse import urlsplit
-from urllib.request import HTTPRedirectHandler, Request, build_opener
+from urllib.request import (
+    HTTPRedirectHandler,
+    ProxyHandler,
+    Request,
+    build_opener,
+)
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError, FetchError
 from btclib.utils import is_integer
@@ -46,6 +51,27 @@ from btclib.utils import is_integer
 # body. A status rather than an exception, because a JSON-RPC error can
 # arrive with a 500 and its body is the error object -- see
 # btclib.fetch.bitcoind
+#
+# Two arguments and no more, which is what a caller's own transport is
+# owed and what it owes. What it is owed: a `Request` with its url, its
+# method, its body and its headers already built, and a timeout in
+# seconds. What it owes, none of which this module can check for it:
+#
+# - *its own* bound on what it holds in memory while reading. It is handed
+#   no `max_body_size` -- there is nowhere in two arguments to pass one --
+#   and btclib's limit is a per-call number applied to the bytes it hands
+#   back, which is a refusal after the allocation and not instead of it.
+#   The two are different bounds, and a transport that reads a body of any
+#   size has already spent the memory btclib then declines to use;
+# - no redirect followed. The request already carries the `Authorization`
+#   for the host it names -- `_OPENER` below is what does this for the
+#   default -- and a client library that follows a 30x sends that
+#   credential to whatever the `Location` says;
+# - its own thread-safety. `BitcoindRpcClient` promises that concurrent
+#   calls are safe while its configuration is not mutated, and the
+#   transport is part of that configuration: a session object that is not
+#   thread-safe makes the client not thread-safe, and only its author
+#   knows which it is.
 HttpTransport = Callable[[Request, float], tuple[int, bytes]]
 
 # 30 seconds. Long enough for `getrawtransaction` against a node reading
@@ -143,10 +169,29 @@ class _NoRedirect(HTTPRedirectHandler):
 # does its own I/O, so what `requests` or `httpx` does with a 30x is
 # theirs.
 #
+# `ProxyHandler({})` is the second thing missing, and for the same reason
+# as the first. `build_opener` otherwise installs a `ProxyHandler` built
+# from `getproxies()`, i.e. from `HTTP_PROXY`, `HTTPS_PROXY` and the
+# system's proxy configuration -- so an rpc call to a node would be sent
+# to whatever host an environment variable named, carrying the `Basic`
+# credential btclib puts on every request before being asked for it.
+# Ambient configuration is exactly the wrong source for that decision: the
+# variable is set for a browser or a package manager and inherited by
+# everything in the shell, while the endpoint here is a node the caller
+# named. A caller who does want a proxy has `HttpTransport` and a client
+# that reads the environment if that is what they mean.
+#
+# An empty map does not install an inert handler, it installs none:
+# `ProxyHandler.__init__` sets one `<scheme>_open` method per entry,
+# `add_handler` keeps a handler only when it registered something, and
+# `build_opener` drops the default of a class it was handed an instance
+# of. So this argument is how the handler is *removed*, and the chain has
+# nothing in it that could proxy.
+#
 # `build_opener` and not `install_opener`: the default opener is process
 # wide, and a library that replaced it would decide this for every other
 # user of `urlopen` in the program
-_OPENER = build_opener(_NoRedirect)
+_OPENER = build_opener(_NoRedirect, ProxyHandler({}))
 
 
 def _assert_valid_max_body_size(max_body_size: int) -> None:

--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -184,11 +184,10 @@ the cause rather than the symptom: `ecc.bms` imports `b58` and `b32` the
 same way and `btclib.ecc` exports it without trouble, so what is wrong is
 narrower — `bip32` is the only package a lower layer imports *and* that
 holds a module belonging to a higher one. And `fetch.cookie_auth` is not
-missing: `AuthProxy`
-takes a `cookie_path` and reads the file at every call, the node
-rewriting the cookie when it restarts, so a caller passes a path and never
-a credential. In both cases what was missing was the statement of why, not
-the name.
+missing: `BitcoindRpcClient` takes a `cookie_path` and reads the file at
+every call, the node rewriting the cookie when it restarts, so a caller
+passes a path and never a credential. In both cases what was missing was
+the statement of why, not the name.
 
 **Too much.** Each of these is used nowhere outside its own package:
 

--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -184,7 +184,7 @@ the cause rather than the symptom: `ecc.bms` imports `b58` and `b32` the
 same way and `btclib.ecc` exports it without trouble, so what is wrong is
 narrower — `bip32` is the only package a lower layer imports *and* that
 holds a module belonging to a higher one. And `fetch.cookie_auth` is not
-missing: `BitcoindRpcClient` takes a `cookie_path` and reads the file at
+missing: `BitcoinCoreRpcClient` takes a `cookie_path` and reads the file at
 every call, the node rewriting the cookie when it restarts, so a caller
 passes a path and never a credential. In both cases what was missing was
 the statement of why, not the name.

--- a/docs/source/btclib.fetch.rst
+++ b/docs/source/btclib.fetch.rst
@@ -4,10 +4,10 @@ btclib.fetch package
 Submodules
 ----------
 
-btclib.fetch.bitcoind module
-----------------------------
+btclib.fetch.bitcoin_core module
+--------------------------------
 
-.. automodule:: btclib.fetch.bitcoind
+.. automodule:: btclib.fetch.bitcoin_core
    :members:
    :show-inheritance:
 

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -7,7 +7,7 @@
 #
 # No part of btclib including this file, may be copied, modified, propagated,
 # or distributed except according to the terms contained in the LICENSE file.
-"""Tests for btclib.fetch.bitcoind, against recorded replies.
+"""Tests for btclib.fetch.bitcoin_core, against recorded replies.
 
 Every client here is built with a transport, so no test reaches a node.
 The recorded bodies under `_data` are Core's, shape and newline included;
@@ -41,11 +41,11 @@ from btclib.exceptions import (
     HttpError,
     RpcError,
 )
-from btclib.fetch.bitcoind import (
+from btclib.fetch.bitcoin_core import (
     COOKIE_USER,
     DEFAULT_DATADIR,
-    BitcoindFetcher,
-    BitcoindRpcClient,
+    BitcoinCoreFetcher,
+    BitcoinCoreRpcClient,
     cookie_auth,
 )
 from btclib.fetch.transport import DEFAULT_MAX_BODY_SIZE, DEFAULT_TIMEOUT
@@ -105,9 +105,9 @@ class Echoing(Recorded):
 
 def client(
     *answers: tuple[int, bytes] | Exception, **kwargs: object
-) -> BitcoindRpcClient:
+) -> BitcoinCoreRpcClient:
     """Return a client over an id-echoing recording, credentials of no node."""
-    return BitcoindRpcClient(
+    return BitcoinCoreRpcClient(
         URL,
         user=RPC_USER,
         password=RPC_PASSWORD,
@@ -116,30 +116,30 @@ def client(
     )
 
 
-def verbatim(*answers: tuple[int, bytes] | Exception) -> BitcoindRpcClient:
+def verbatim(*answers: tuple[int, bytes] | Exception) -> BitcoinCoreRpcClient:
     """Return a client answering exactly these bodies, their id included."""
-    return BitcoindRpcClient(
+    return BitcoinCoreRpcClient(
         URL, user=RPC_USER, password=RPC_PASSWORD, transport=Recorded(*answers)
     )
 
 
 def fetcher(
     *answers: tuple[int, bytes] | Exception, **kwargs: object
-) -> BitcoindFetcher:
-    """Return a BitcoindFetcher over a recorded client."""
+) -> BitcoinCoreFetcher:
+    """Return a BitcoinCoreFetcher over a recorded client."""
     network = kwargs.pop("network", "mainnet")
     assert isinstance(network, str)
-    return BitcoindFetcher(client(*answers, **kwargs), network)
+    return BitcoinCoreFetcher(client(*answers, **kwargs), network)
 
 
-def recording(endpoint: BitcoindRpcClient) -> Recorded:
+def recording(endpoint: BitcoinCoreRpcClient) -> Recorded:
     """Return the recording a client was built with, as one."""
     transport = endpoint.transport
     assert isinstance(transport, Recorded)
     return transport
 
 
-def sent(endpoint: BitcoindRpcClient) -> dict[str, object]:
+def sent(endpoint: BitcoinCoreRpcClient) -> dict[str, object]:
     """Return the json request body a client's only call was sent with."""
     body = json.loads(recording(endpoint).body)
     assert isinstance(body, dict)
@@ -148,7 +148,7 @@ def sent(endpoint: BitcoindRpcClient) -> dict[str, object]:
 
 def test_from_network_is_the_local_node_of_that_network() -> None:
     """The rpc port and the datadir subdirectory of Core's chainparamsbase."""
-    from_network = BitcoindRpcClient.from_network
+    from_network = BitcoinCoreRpcClient.from_network
     assert from_network().url == "http://127.0.0.1:8332"
     assert from_network("testnet").url == "http://127.0.0.1:18332"
     assert from_network("testnet4").url == "http://127.0.0.1:48332"
@@ -166,7 +166,7 @@ def test_from_network_is_the_local_node_of_that_network() -> None:
 
 def test_from_network_takes_credentials_instead_of_a_cookie() -> None:
     """Credentials given, no cookie path derived: the two are exclusive."""
-    endpoint = BitcoindRpcClient.from_network(
+    endpoint = BitcoinCoreRpcClient.from_network(
         "regtest", user=RPC_USER, password=RPC_PASSWORD
     )
     assert endpoint.cookie_path is None
@@ -176,18 +176,18 @@ def test_from_network_takes_credentials_instead_of_a_cookie() -> None:
 def test_from_network_refuses_a_network_core_has_no_port_for() -> None:
     """The five names are Core's chainparamsbase, not btclib's registry."""
     with pytest.raises(BTClibValueError, match="unknown network: testnet5"):
-        BitcoindRpcClient.from_network("testnet5")
+        BitcoinCoreRpcClient.from_network("testnet5")
 
 
 def test_the_url_carries_no_network_and_no_registry() -> None:
     """A signet of one's own reaches the constructor, which asks no name.
 
     The connection is a url and credentials; which chain the node serves
-    is `BitcoindFetcher`'s label. A custom signet -- a network btclib can
+    is `BitcoinCoreFetcher`'s label. A custom signet -- a network btclib can
     be taught and Core has no default port for -- is exactly the case a
     client validating chain names would have refused.
     """
-    endpoint = BitcoindRpcClient(
+    endpoint = BitcoinCoreRpcClient(
         "http://node.example:39332", user=RPC_USER, password=RPC_PASSWORD
     )
     assert endpoint.url == "http://node.example:39332"
@@ -215,7 +215,7 @@ def test_an_endpoint_that_is_not_one_is_refused_at_construction(
     these -- by then the line that supplied it is somewhere else.
     """
     with pytest.raises(BTClibValueError, match=match):
-        BitcoindRpcClient(url, user=RPC_USER, password=RPC_PASSWORD)
+        BitcoinCoreRpcClient(url, user=RPC_USER, password=RPC_PASSWORD)
 
 
 @pytest.mark.parametrize(
@@ -233,7 +233,7 @@ def test_credentials_in_the_url_are_refused(url: str) -> None:
     disclosed before anybody meant to disclose it.
     """
     with pytest.raises(BTClibValueError, match="credentials in the rpc url"):
-        BitcoindRpcClient(url, cookie_path="/nowhere/.cookie")
+        BitcoinCoreRpcClient(url, cookie_path="/nowhere/.cookie")
 
 
 @pytest.mark.parametrize(("user", "password"), [(RPC_USER, None), (None, RPC_PASSWORD)])
@@ -242,7 +242,7 @@ def test_a_user_without_a_password_is_refused(
 ) -> None:
     """Refuse a user without a password, and the other way round."""
     with pytest.raises(BTClibValueError, match="go together"):
-        BitcoindRpcClient(URL, user=user, password=password)
+        BitcoinCoreRpcClient(URL, user=user, password=password)
 
 
 def test_credentials_and_a_cookie_path_together_are_refused() -> None:
@@ -254,7 +254,7 @@ def test_credentials_and_a_cookie_path_together_are_refused() -> None:
     nothing said which of the two was in use.
     """
     with pytest.raises(BTClibValueError, match="both rpc credentials and a cookie"):
-        BitcoindRpcClient(
+        BitcoinCoreRpcClient(
             URL,
             user=RPC_USER,
             password=RPC_PASSWORD,
@@ -265,21 +265,21 @@ def test_credentials_and_a_cookie_path_together_are_refused() -> None:
 def test_neither_credentials_nor_a_cookie_path_is_refused() -> None:
     """A client with no way to authenticate is refused where it is built."""
     with pytest.raises(BTClibValueError, match="no rpc credentials"):
-        BitcoindRpcClient(URL)
+        BitcoinCoreRpcClient(URL)
 
 
 @pytest.mark.parametrize("timeout", [0, -1, float("inf"), float("nan")])
 def test_a_timeout_that_is_no_duration_is_refused(timeout: float) -> None:
     """A zero, a negative, an infinity and a nan are not seconds to wait."""
     with pytest.raises(BTClibValueError, match="rpc timeout is not a positive"):
-        BitcoindRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD, timeout=timeout)
+        BitcoinCoreRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD, timeout=timeout)
 
 
 @pytest.mark.parametrize("timeout", [True, "30", None])
 def test_a_non_numeric_timeout_is_refused(timeout: object) -> None:
     """A bool is not a duration: `timeout=True` would be one second."""
     with pytest.raises(BTClibTypeError, match="non-numeric rpc timeout"):
-        BitcoindRpcClient(
+        BitcoinCoreRpcClient(
             URL,
             user=RPC_USER,
             password=RPC_PASSWORD,
@@ -289,14 +289,16 @@ def test_a_non_numeric_timeout_is_refused(timeout: object) -> None:
 
 def test_the_default_timeout_is_the_one_the_module_documents() -> None:
     """Verify a client with no timeout argument carries the module default."""
-    assert BitcoindRpcClient(URL, cookie_path="/nowhere/.cookie").timeout == (
+    assert BitcoinCoreRpcClient(URL, cookie_path="/nowhere/.cookie").timeout == (
         DEFAULT_TIMEOUT
     )
 
 
 def test_the_basic_credential_is_the_user_and_password_given() -> None:
     """Verify the Authorization header is Basic over user:password."""
-    header = BitcoindRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD).auth_header()
+    header = BitcoinCoreRpcClient(
+        URL, user=RPC_USER, password=RPC_PASSWORD
+    ).auth_header()
     scheme, encoded = header.split(" ")
     assert scheme == "Basic"
     assert b64decode(encoded).decode() == f"{RPC_USER}:{RPC_PASSWORD}"
@@ -305,7 +307,7 @@ def test_the_basic_credential_is_the_user_and_password_given() -> None:
 def test_a_non_ascii_password_is_utf_8() -> None:
     """What a shell and a bitcoin.conf would have written."""
     umlauts = "pässwörd"
-    header = BitcoindRpcClient(URL, user=RPC_USER, password=umlauts).auth_header()
+    header = BitcoinCoreRpcClient(URL, user=RPC_USER, password=umlauts).auth_header()
     assert b64decode(header.split(" ")[1]) == f"{RPC_USER}:{umlauts}".encode()
 
 
@@ -315,7 +317,7 @@ def test_the_cookie_file_is_the_credential_when_there_is_no_user(
     """Verify the cookie line becomes the Basic credential, no user given."""
     cookie = tmp_path / ".cookie"
     cookie.write_text(COOKIE_LINE)
-    header = BitcoindRpcClient(URL, cookie_path=cookie).auth_header()
+    header = BitcoinCoreRpcClient(URL, cookie_path=cookie).auth_header()
     assert b64decode(header.split(" ")[1]).decode() == COOKIE_LINE
 
 
@@ -330,7 +332,7 @@ def test_the_cookie_is_read_at_every_call_not_at_construction(
     should not raise FileNotFoundError.
     """
     cookie = tmp_path / ".cookie"
-    endpoint = BitcoindRpcClient(
+    endpoint = BitcoinCoreRpcClient(
         URL, cookie_path=cookie, transport=Echoing((200, b"{}"))
     )
     assert not cookie.exists()
@@ -1033,9 +1035,9 @@ def test_an_error_member_that_is_not_one(error: object) -> None:
 
 def test_a_wallet_endpoint_is_the_path_core_documents() -> None:
     """How a node with several wallets loaded is told which one is meant."""
-    endpoint = BitcoindRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD).for_wallet(
-        "hot"
-    )
+    endpoint = BitcoinCoreRpcClient(
+        URL, user=RPC_USER, password=RPC_PASSWORD
+    ).for_wallet("hot")
     assert endpoint.url == f"{URL}/wallet/hot"
     assert endpoint.user == RPC_USER
 
@@ -1058,7 +1060,7 @@ def test_a_wallet_name_is_percent_encoded(name: str, path: str) -> None:
     addresses a different endpoint or none -- and the caller who named
     the wallet is not the one who should have to know that.
     """
-    endpoint = BitcoindRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD)
+    endpoint = BitcoinCoreRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD)
     assert endpoint.for_wallet(name).url == f"{URL}/wallet/{path}"
 
 
@@ -1066,7 +1068,7 @@ def test_a_wallet_client_keeps_the_credentials_and_the_transport() -> None:
     """The endpoint is the only difference, so one client derives the rest."""
     cookie = Path("/nowhere/.cookie")
     transport = Echoing((200, recorded_body("getblockcount.json")))
-    endpoint = BitcoindRpcClient(
+    endpoint = BitcoinCoreRpcClient(
         URL, cookie_path=cookie, timeout=7.0, transport=transport
     ).for_wallet("hot")
     assert endpoint.cookie_path == cookie
@@ -1086,7 +1088,7 @@ def test_get_tx_parses_the_serialization_the_node_sent() -> None:
 def test_get_tx_asks_for_the_id_it_was_given() -> None:
     """Verify get_tx sends getrawtransaction with the hex id it was given."""
     endpoint = client((200, recorded_body("getrawtransaction.json")))
-    BitcoindFetcher(endpoint).get_tx(bytes.fromhex(TX_ID))
+    BitcoinCoreFetcher(endpoint).get_tx(bytes.fromhex(TX_ID))
     body = sent(endpoint)
     assert body["method"] == "getrawtransaction"
     assert body["params"] == [TX_ID]
@@ -1095,7 +1097,7 @@ def test_get_tx_asks_for_the_id_it_was_given() -> None:
 def test_get_tx_labels_the_outputs_for_the_fetchers_network() -> None:
     """The network is the fetcher's: the client knows a url and no chain."""
     endpoint = client((200, recorded_body("getrawtransaction.json")))
-    tx = BitcoindFetcher(endpoint, "testnet").get_tx(TX_ID)
+    tx = BitcoinCoreFetcher(endpoint, "testnet").get_tx(TX_ID)
     assert [out.script_pub_key.network for out in tx.vout] == ["testnet"] * 2
 
 
@@ -1106,8 +1108,8 @@ def test_the_fetchers_network_is_btclibs_registry_not_cores() -> None:
     has no port for -- neither of which is the question this label answers.
     """
     with pytest.raises(BTClibValueError, match="unknown network"):
-        BitcoindFetcher(
-            BitcoindRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD), "nowhere"
+        BitcoinCoreFetcher(
+            BitcoinCoreRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD), "nowhere"
         )
 
 
@@ -1173,7 +1175,7 @@ def test_a_small_reply_carries_a_small_limit() -> None:
     # and `call` itself keeps the wide default, being public and taking
     # any method: `getblock` on a large block is a legitimate call. The
     # timeout defaults to the client's, which is what None means here
-    defaults = BitcoindRpcClient.call.__kwdefaults__
+    defaults = BitcoinCoreRpcClient.call.__kwdefaults__
     assert defaults is not None
     assert defaults["max_body_size"] == DEFAULT_MAX_BODY_SIZE
     assert defaults["request_timeout"] is None

--- a/tests/fetch/bitcoind_test.py
+++ b/tests/fetch/bitcoind_test.py
@@ -29,6 +29,7 @@ import re
 from base64 import b64decode
 from decimal import Decimal
 from pathlib import Path
+from typing import Any
 from urllib.request import Request
 
 import pytest
@@ -492,6 +493,96 @@ def test_a_parameter_name_that_is_not_a_string() -> None:
         endpoint.call("getblock", {1: TX_ID})  # type: ignore[dict-item]
 
 
+def test_a_nested_parameter_name_that_is_not_a_string() -> None:
+    """The check is the whole structure, because the encoder rewrites keys.
+
+    `json.dumps` renders `{1: "a"}` as `{"1": "a"}`: an int, a float, a
+    bool or None as a key is silently turned into a string rather than
+    refused. Only the outermost mapping is a set of names a caller wrote
+    by hand, so a check that stopped there would let every nested value
+    reach the node changed from what was passed.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibTypeError, match="non-string rpc parameter name"):
+        endpoint.call("importdescriptors", [{"nested": {1: "value"}}])
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        [{"nested": {"amount": Decimal("0.1")}}],
+        [[[Decimal("0.1")]]],
+        {"outputs": [{"bc1qexample": Decimal("0.1")}]},
+    ],
+)
+def test_a_decimal_anywhere_in_the_parameters_is_refused(params: object) -> None:
+    """A Decimal is refused wherever it is, not only at the top level.
+
+    Which is where one would actually be passed: an amount belongs to an
+    output of `send`, an entry of `sendmany`, a field of a descriptor
+    request -- never to the array itself.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibTypeError, match="Decimal rpc parameter"):
+        endpoint.call("send", params)  # type: ignore[arg-type]
+
+
+def test_a_non_finite_number_nested_in_the_parameters_is_refused() -> None:
+    """The same walk, and the same diagnosis, for a nan inside a structure."""
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibValueError, match="not a json number in the rpc params"):
+        endpoint.call("send", [{"fee_rate": float("inf")}])
+
+
+def test_bytes_nested_in_the_parameters_are_not_a_list_of_octets() -> None:
+    """A `bytes` is a Sequence, and walking it would send the ints in it.
+
+    Refused as the value it is instead, which is the same answer the top
+    level gives: btclib takes hex where Core takes hex.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibTypeError, match="not a json value"):
+        endpoint.call("sendrawtransaction", [b"\x01\x00"])
+
+
+def test_parameters_that_contain_themselves_are_refused() -> None:
+    """A cycle is a ValueError out of the encoder, and not about a number.
+
+    `json.dumps` says "Circular reference detected" with the same
+    exception type a nan raises, so leaving it to the encoder would report
+    a structure that has no json as a number that is not one.
+    """
+    cyclic: list[Any] = [1]
+    cyclic.append(cyclic)
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibValueError, match="contains itself"):
+        endpoint.call("send", cyclic)
+
+
+def test_parameters_nested_deeper_than_the_bound_are_refused() -> None:
+    """Deep and acyclic, which no cycle check catches and json recurses on."""
+    deep: Any = "bottom"
+    for _ in range(200):
+        deep = [deep]
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibValueError, match="nested deeper than"):
+        endpoint.call("send", deep)
+
+
+def test_something_that_walks_as_json_and_has_none_is_still_refused() -> None:
+    """The backstop under the walk, reached by a Sequence json cannot write.
+
+    `range(3)` is a Sequence of three json numbers and has no json of its
+    own, so it passes a walk that checks what a structure contains and
+    fails in the encoder. What the backstop buys is that it fails as a
+    btclib refusal naming the value, rather than as a TypeError from
+    inside the standard library.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibTypeError, match="not a json value: range"):
+        endpoint.call("send", [range(3)])
+
+
 def test_a_decimal_parameter_is_refused_and_not_rounded() -> None:
     """An amount does not become binary floating point on the way out.
 
@@ -752,28 +843,6 @@ def test_a_redirect_is_refused_and_not_answered(code: int) -> None:
     assert transport.request.get_header("Authorization") == endpoint.auth_header()
 
 
-@pytest.mark.parametrize("code", [301, 302, 303, 307, 308])
-def test_a_redirect_is_refused_and_not_answered(code: int) -> None:
-    """An rpc call meeting a 30x fails; the credential stays on one url.
-
-    Nothing follows a redirect (issue #358), so a `Location` is a header on
-    a status like any other and the body beside it -- here the html of
-    whatever answered instead of the node -- is not a reply. What the
-    caller gets is the status, which is what says the endpoint is not the
-    node any more; the `Authorization` reached the url they wrote down and
-    no second one.
-    """
-    endpoint = proxy((code, b"<html><title>Moved</title></html>"))
-    with pytest.raises(FetchError, match=f"HTTP {code}"):
-        endpoint.call("getblockcount")
-
-    transport = endpoint.transport
-    assert isinstance(transport, Recorded)
-    assert len(transport.requests) == 1
-    assert transport.request.full_url == endpoint.url
-    assert transport.request.get_header("Authorization") == endpoint.auth_header()
-
-
 def test_a_body_that_is_not_json_says_so() -> None:
     """A proxy or a web server on the rpc port, answering 200 with html."""
     with pytest.raises(FetchError, match="not json"):
@@ -784,6 +853,43 @@ def test_a_body_that_is_not_utf_8_says_so() -> None:
     """Json is utf-8, and a body that is not is the backend's failure."""
     with pytest.raises(FetchError, match="not utf-8"):
         client((200, b'{"result": "\xff\xfe"}')).call("getblockcount")
+
+
+# a json number of more digits than `sys.get_int_max_str_digits` allows,
+# which `int` refuses with a bare ValueError that is not a
+# JSONDecodeError: valid json that this interpreter will not read
+_TOO_MANY_DIGITS = b'{"jsonrpc":"2.0","result":' + b"9" * 5000 + b',"id":"x"}'
+
+
+@pytest.mark.parametrize(
+    "body",
+    [b'{"result": "\xff\xfe"}', b"[" * 200_000 + b"]" * 200_000, _TOO_MANY_DIGITS],
+    ids=["not utf-8", "too deep", "too many digits"],
+)
+def test_a_status_survives_a_body_no_parser_can_read(body: bytes) -> None:
+    """An unreadable body cannot be a correlated rpc error, so the status wins.
+
+    Whatever is in front of a node explains itself in its own words, and
+    those words are not json-rpc: reporting "not utf-8" for a 503 would
+    name the symptom and lose the one thing a caller acts on. Every way
+    the parse can fail has to keep the status, and they are not one
+    exception type -- a decode error, a recursion error and the bare
+    ValueError of the integer digit limit.
+    """
+    with pytest.raises(HttpError) as exc:
+        client((503, body)).call("getblockcount")
+    assert exc.value.status == 503
+
+
+def test_a_number_too_long_for_this_interpreter_to_read() -> None:
+    """Valid json, and `int` refuses it: `sys.get_int_max_str_digits`.
+
+    Not a JSONDecodeError, so it escaped as a bare ValueError from
+    underneath the library rather than through btclib's contract, where a
+    caller catching FetchError would not see it at all.
+    """
+    with pytest.raises(FetchError, match="the json parser refused"):
+        client((200, _TOO_MANY_DIGITS)).call("getblockcount")
 
 
 def test_a_reply_nested_too_deeply_to_parse() -> None:
@@ -818,9 +924,17 @@ def test_a_version_marker_that_is_neither_2_0_nor_absent(marker: object) -> None
         client((200, body)).call("getblockcount")
 
 
-def test_a_2_0_reply_with_both_result_and_error() -> None:
-    """2.0 says exactly one of them, which is what tells it from 1.1."""
-    error = {"code": -5, "message": "not found"}
+@pytest.mark.parametrize(
+    "error", [{"code": -5, "message": "not found"}, None], ids=["error", "null"]
+)
+def test_a_2_0_reply_with_both_result_and_error(error: object) -> None:
+    """2.0 says exactly one of them, which is what tells it from 1.1.
+
+    Which member is *present*, and not which is non-null: `"error": null`
+    beside a result is the 1.1 shape, and a 1.1 reply wearing the 2.0
+    marker is one whose errors would be looked for in the wrong place --
+    under 2.0 they never arrive with a 500, and under 1.1 they do.
+    """
     body = json.dumps(
         {"jsonrpc": "2.0", "result": 1, "error": error, "id": "x"}
     ).encode()
@@ -843,14 +957,27 @@ def test_a_legacy_reply_with_neither_result_nor_error() -> None:
 
 
 @pytest.mark.parametrize(
-    "error", ["a string", {"message": "no code"}, {"code": "-5"}, {"code": True}, []]
+    "error",
+    [
+        "a string",
+        {"message": "no code"},
+        {"code": "-5"},
+        {"code": True},
+        [],
+        {"code": -1},
+        {"code": -1, "message": ["not", "a", "string"]},
+        {"code": -1, "message": None},
+    ],
 )
 def test_an_error_member_that_is_not_one(error: object) -> None:
-    """Not every non-null `error` carries a code to report.
+    """Not every non-null `error` carries a code and a message to report.
 
-    A bool among them, `true` being what a json `code` of one decodes to
-    and a bool not being another spelling of a number anywhere else in
-    the library.
+    A bool among the codes, `true` being what a json `code` of one decodes
+    to and a bool not being another spelling of a number anywhere else in
+    the library. And a message that is absent or is not a string: a caller
+    acts on the code and reads the message, so formatting a list into the
+    exception, or reporting an empty message, would have the node saying
+    something it did not say.
     """
     body = json.dumps({"jsonrpc": "2.0", "error": error, "id": "x"}).encode()
     with pytest.raises(FetchError, match="unreadable rpc error"):

--- a/tests/fetch/bitcoind_test.py
+++ b/tests/fetch/bitcoind_test.py
@@ -639,8 +639,18 @@ def test_a_non_number_in_a_reply_is_refused(constant: str) -> None:
     rest of its life, so it is refused where it decodes.
     """
     body = b'{"jsonrpc":"2.0","result":' + constant.encode() + b',"id":"x"}'
-    with pytest.raises(FetchError, match=f"not a json number in the reply: {constant}"):
+    with pytest.raises(
+        FetchError, match=f"not a json number in the reply: {constant}"
+    ) as exc:
         client((200, body)).call("getbalance")
+
+    # and it is not its own cause. This refusal is btclib's, raised from
+    # inside `json.loads` and re-raised as it stands, so a `from` here
+    # would have made `__cause__` point at the exception itself -- which
+    # anything walking that chain, a log formatter or a reporter, follows
+    # round for as long as it is willing to
+    assert exc.value.__cause__ is not exc.value
+    assert exc.value.__context__ is not exc.value
 
 
 def test_the_clients_timeout_reaches_the_transport() -> None:

--- a/tests/fetch/bitcoind_test.py
+++ b/tests/fetch/bitcoind_test.py
@@ -720,6 +720,19 @@ def test_an_error_for_someone_elses_request_is_refused() -> None:
     assert not isinstance(exc.value, RpcError)
 
 
+def test_a_legacy_reply_to_someone_elses_request_is_refused() -> None:
+    """The correlation is checked on the path that reads a 1.1 reply too.
+
+    A 200 rules out the status being the failure, so what is left to say
+    about a reply carrying another call's id is that it is not this call's
+    answer -- the same conclusion the 2.0 path reaches, by a different
+    route through the same two facts.
+    """
+    body = json.dumps({"result": 1, "error": None, "id": "another"}).encode()
+    with pytest.raises(FetchError, match="reply id 'another' is not the"):
+        verbatim((200, body)).call("getblockcount")
+
+
 def test_an_rpc_error_object_is_an_rpc_error_with_the_code() -> None:
     """Core's own message for a node without -txindex, and its code."""
     body = recorded_body("getrawtransaction_error.json")
@@ -879,6 +892,19 @@ def test_a_status_survives_a_body_no_parser_can_read(body: bytes) -> None:
     with pytest.raises(HttpError) as exc:
         client((503, body)).call("getblockcount")
     assert exc.value.status == 503
+
+
+def test_a_number_too_long_for_this_interpreter_to_write() -> None:
+    """The mirror of the reply-side limit, on the way out.
+
+    json has the number and Python will not render it, so this is a value
+    of a type json takes rather than one of a type it refuses -- which is
+    why the walk over the parameters cannot catch it and the encoder is
+    where it surfaces.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibValueError, match="rpc params json cannot carry"):
+        endpoint.call("send", [10**5000])
 
 
 def test_a_number_too_long_for_this_interpreter_to_read() -> None:

--- a/tests/fetch/bitcoind_test.py
+++ b/tests/fetch/bitcoind_test.py
@@ -876,18 +876,29 @@ _TOO_MANY_DIGITS = b'{"jsonrpc":"2.0","result":' + b"9" * 5000 + b',"id":"x"}'
 
 @pytest.mark.parametrize(
     "body",
-    [b'{"result": "\xff\xfe"}', b"[" * 200_000 + b"]" * 200_000, _TOO_MANY_DIGITS],
-    ids=["not utf-8", "too deep", "too many digits"],
+    [
+        b'{"result": "\xff\xfe"}',
+        b"[" * 200_000 + b"]" * 200_000,
+        _TOO_MANY_DIGITS,
+        b'{"jsonrpc":"2.0","result":NaN,"id":"x"}',
+        b"[1, 2, 3]",
+        b'"a string"',
+        b"",
+    ],
+    ids=["not utf-8", "too deep", "too many digits", "NaN", "array", "string", "empty"],
 )
-def test_a_status_survives_a_body_no_parser_can_read(body: bytes) -> None:
-    """An unreadable body cannot be a correlated rpc error, so the status wins.
+def test_a_status_survives_a_body_that_is_no_reply(body: bytes) -> None:
+    """A body that is no reply cannot be correlated, so the status wins.
 
-    Whatever is in front of a node explains itself in its own words, and
-    those words are not json-rpc: reporting "not utf-8" for a 503 would
-    name the symptom and lose the one thing a caller acts on. Every way
-    the parse can fail has to keep the status, and they are not one
-    exception type -- a decode error, a recursion error and the bare
-    ValueError of the integer digit limit.
+    Whatever stands in front of a node explains itself in its own words,
+    and those words are not json-rpc: reporting "not utf-8" for a 503, or
+    "not a json-rpc reply", would name the symptom and lose the one thing
+    a caller acts on. Every way a body can fail to be a reply keeps the
+    status, and they are not one exception type nor even all of them
+    failures of the parse -- a decode error, a recursion error, the bare
+    ValueError of the integer digit limit, btclib's own refusal of the
+    three non-numbers Python decodes, and a body that parses perfectly
+    into something that is not an object.
     """
     with pytest.raises(HttpError) as exc:
         client((503, body)).call("getblockcount")

--- a/tests/fetch/bitcoind_test.py
+++ b/tests/fetch/bitcoind_test.py
@@ -9,11 +9,17 @@
 # or distributed except according to the terms contained in the LICENSE file.
 """Tests for btclib.fetch.bitcoind, against recorded replies.
 
-Every AuthProxy here is built with a transport, so no test reaches a
-node. The recorded bodies under `_data` are Core's, shape and newline
-included; the failure bodies a node cannot be asked to produce on demand
--- a 401, a proxy's html -- are written inline, where what they are is
-visible beside the assertion.
+Every client here is built with a transport, so no test reaches a node.
+The recorded bodies under `_data` are Core's, shape and newline included;
+the failure bodies a node cannot be asked to produce on demand -- a 401,
+a proxy's html -- are written inline, where what they are is visible
+beside the assertion.
+
+The recorded bodies carry the id of the call they answered, and `call`
+sends a fresh one per request: `Echoing` puts the request's id in the
+reply the way a node does, so that a test about the *reply* is not also a
+test about the id. A test about the id builds its own body and uses
+`Recorded` directly, through `verbatim`.
 """
 
 from __future__ import annotations
@@ -21,19 +27,27 @@ from __future__ import annotations
 import json
 import re
 from base64 import b64decode
+from decimal import Decimal
 from pathlib import Path
+from urllib.request import Request
 
 import pytest
 
-from btclib.exceptions import BTClibValueError, FetchError, RpcError
+from btclib.exceptions import (
+    BTClibTypeError,
+    BTClibValueError,
+    FetchError,
+    HttpError,
+    RpcError,
+)
 from btclib.fetch.bitcoind import (
     COOKIE_USER,
     DEFAULT_DATADIR,
-    AuthProxy,
     BitcoindFetcher,
+    BitcoindRpcClient,
     cookie_auth,
 )
-from btclib.fetch.transport import DEFAULT_MAX_BODY_SIZE
+from btclib.fetch.transport import DEFAULT_MAX_BODY_SIZE, DEFAULT_TIMEOUT
 from btclib.tx import OutPoint
 from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
 
@@ -50,39 +64,157 @@ COOKIE_LINE = f"{COOKIE_USER}:" + "ab" * 32
 RPC_USER = "rpcuser"
 RPC_PASSWORD = "rpcpassword"  # noqa: S105  # pragma: allowlist secret
 
+# the endpoint the tests build against, written once. A url is required,
+# there being no network here to derive one from -- `from_network` is what
+# derives one, and has its own tests
+URL = "http://127.0.0.1:8332"
 
-def proxy(*answers: tuple[int, bytes] | Exception, **kwargs: object) -> AuthProxy:
-    """Return an AuthProxy over a recording, with credentials of no node."""
-    transport = Recorded(*answers)
-    return AuthProxy(
+
+def asked_id(request: Request) -> str:
+    """Return the json-rpc id a recorded request was sent with."""
+    data = request.data
+    assert isinstance(data, bytes)
+    request_id = json.loads(data)["id"]
+    assert isinstance(request_id, str)
+    return request_id
+
+
+def echoed(body: bytes, request_id: str) -> bytes:
+    """Return a recorded reply carrying the id of the request it answers."""
+    try:
+        reply = json.loads(body)
+    except (ValueError, RecursionError):
+        # not json, or not json anything can parse: both are what several
+        # tests are about, and a node would not have answered them either
+        return body
+    if not isinstance(reply, dict):
+        return body
+    reply["id"] = request_id
+    return json.dumps(reply).encode()
+
+
+class Echoing(Recorded):
+    """A Recorded answering with the request's own id, as a node does."""
+
+    def __call__(self, request: Request, timeout: float) -> tuple[int, bytes]:
+        """Answer the next scripted reply, with this request's id in it."""
+        status, body = super().__call__(request, timeout)
+        return status, echoed(body, asked_id(request))
+
+
+def client(
+    *answers: tuple[int, bytes] | Exception, **kwargs: object
+) -> BitcoindRpcClient:
+    """Return a client over an id-echoing recording, credentials of no node."""
+    return BitcoindRpcClient(
+        URL,
         user=RPC_USER,
         password=RPC_PASSWORD,
-        transport=transport,
+        transport=Echoing(*answers),
         **kwargs,  # type: ignore[arg-type]
     )
 
 
-def test_the_default_endpoint_is_the_local_node_of_that_network() -> None:
-    """The rpc port and the datadir subdirectory of Core's chainparamsbase."""
-    assert AuthProxy().url == "http://127.0.0.1:8332"
-    assert AuthProxy(network="testnet").url == "http://127.0.0.1:18332"
-    assert AuthProxy(network="testnet4").url == "http://127.0.0.1:48332"
-    assert AuthProxy(network="signet").url == "http://127.0.0.1:38332"
-    assert AuthProxy(network="regtest").url == "http://127.0.0.1:18443"
+def verbatim(*answers: tuple[int, bytes] | Exception) -> BitcoindRpcClient:
+    """Return a client answering exactly these bodies, their id included."""
+    return BitcoindRpcClient(
+        URL, user=RPC_USER, password=RPC_PASSWORD, transport=Recorded(*answers)
+    )
 
-    assert AuthProxy().cookie_path == DEFAULT_DATADIR / ".cookie"
-    assert AuthProxy(network="testnet").cookie_path == (
+
+def fetcher(
+    *answers: tuple[int, bytes] | Exception, **kwargs: object
+) -> BitcoindFetcher:
+    """Return a BitcoindFetcher over a recorded client."""
+    network = kwargs.pop("network", "mainnet")
+    assert isinstance(network, str)
+    return BitcoindFetcher(client(*answers, **kwargs), network)
+
+
+def recording(endpoint: BitcoindRpcClient) -> Recorded:
+    """Return the recording a client was built with, as one."""
+    transport = endpoint.transport
+    assert isinstance(transport, Recorded)
+    return transport
+
+
+def sent(endpoint: BitcoindRpcClient) -> dict[str, object]:
+    """Return the json request body a client's only call was sent with."""
+    body = json.loads(recording(endpoint).body)
+    assert isinstance(body, dict)
+    return body
+
+
+def test_from_network_is_the_local_node_of_that_network() -> None:
+    """The rpc port and the datadir subdirectory of Core's chainparamsbase."""
+    from_network = BitcoindRpcClient.from_network
+    assert from_network().url == "http://127.0.0.1:8332"
+    assert from_network("testnet").url == "http://127.0.0.1:18332"
+    assert from_network("testnet4").url == "http://127.0.0.1:48332"
+    assert from_network("signet").url == "http://127.0.0.1:38332"
+    assert from_network("regtest").url == "http://127.0.0.1:18443"
+
+    assert from_network().cookie_path == DEFAULT_DATADIR / ".cookie"
+    assert from_network("testnet").cookie_path == (
         DEFAULT_DATADIR / "testnet3" / ".cookie"
     )
-    assert AuthProxy(network="regtest").cookie_path == (
+    assert from_network("regtest").cookie_path == (
         DEFAULT_DATADIR / "regtest" / ".cookie"
     )
 
 
-def test_an_unknown_network_is_refused() -> None:
-    """Refuse a network name Core's chainparamsbase does not know."""
+def test_from_network_takes_credentials_instead_of_a_cookie() -> None:
+    """Credentials given, no cookie path derived: the two are exclusive."""
+    endpoint = BitcoindRpcClient.from_network(
+        "regtest", user=RPC_USER, password=RPC_PASSWORD
+    )
+    assert endpoint.cookie_path is None
+    assert endpoint.user == RPC_USER
+
+
+def test_from_network_refuses_a_network_core_has_no_port_for() -> None:
+    """The five names are Core's chainparamsbase, not btclib's registry."""
     with pytest.raises(BTClibValueError, match="unknown network: testnet5"):
-        AuthProxy(network="testnet5")
+        BitcoindRpcClient.from_network("testnet5")
+
+
+def test_the_url_carries_no_network_and_no_registry() -> None:
+    """A signet of one's own reaches the constructor, which asks no name.
+
+    The connection is a url and credentials; which chain the node serves
+    is `BitcoindFetcher`'s label. A custom signet -- a network btclib can
+    be taught and Core has no default port for -- is exactly the case a
+    client validating chain names would have refused.
+    """
+    endpoint = BitcoindRpcClient(
+        "http://node.example:39332", user=RPC_USER, password=RPC_PASSWORD
+    )
+    assert endpoint.url == "http://node.example:39332"
+    assert not hasattr(endpoint, "network")
+
+
+@pytest.mark.parametrize(
+    ("url", "match"),
+    [
+        ("ftp://127.0.0.1:8332", "invalid rpc url scheme"),
+        ("file:///etc/passwd", "invalid rpc url scheme"),
+        ("127.0.0.1:8332", "invalid rpc url scheme"),
+        ("http://", "no host in the rpc url"),
+        ("http://127.0.0.1:8332?wallet=hot", "query or fragment in the rpc url"),
+        ("http://127.0.0.1:8332#wallet", "query or fragment in the rpc url"),
+        ("http://127.0.0.1:https", "invalid port in the rpc url"),
+    ],
+)
+def test_an_endpoint_that_is_not_one_is_refused_at_construction(
+    url: str, match: str
+) -> None:
+    """A url is configuration: it is refused where it was written.
+
+    Not at the first call, which is where `urlopen` would refuse most of
+    these -- by then the line that supplied it is somewhere else.
+    """
+    with pytest.raises(BTClibValueError, match=match):
+        BitcoindRpcClient(url, user=RPC_USER, password=RPC_PASSWORD)
 
 
 @pytest.mark.parametrize(
@@ -93,14 +225,14 @@ def test_an_unknown_network_is_refused() -> None:
     ],
 )
 def test_credentials_in_the_url_are_refused(url: str) -> None:
-    """python-bitcoinrpc's spelling, and the reason for not taking it.
+    """The spelling python-bitcoinrpc requires, and the reason to refuse it.
 
     A url is the thing that gets written into a config file, printed in
     a traceback and pasted into an issue; a password in one has been
     disclosed before anybody meant to disclose it.
     """
     with pytest.raises(BTClibValueError, match="credentials in the rpc url"):
-        AuthProxy(url)
+        BitcoindRpcClient(url, cookie_path="/nowhere/.cookie")
 
 
 @pytest.mark.parametrize(("user", "password"), [(RPC_USER, None), (None, RPC_PASSWORD)])
@@ -109,12 +241,61 @@ def test_a_user_without_a_password_is_refused(
 ) -> None:
     """Refuse a user without a password, and the other way round."""
     with pytest.raises(BTClibValueError, match="go together"):
-        AuthProxy(user=user, password=password)
+        BitcoindRpcClient(URL, user=user, password=password)
+
+
+def test_credentials_and_a_cookie_path_together_are_refused() -> None:
+    """Either of them says who is calling, so both would have to be ranked.
+
+    Silently preferring one leaves a caller with a mistaken idea of which
+    credential the node is shown, which is the failure that costs an
+    afternoon: the cookie was rotated, the password was stale, and
+    nothing said which of the two was in use.
+    """
+    with pytest.raises(BTClibValueError, match="both rpc credentials and a cookie"):
+        BitcoindRpcClient(
+            URL,
+            user=RPC_USER,
+            password=RPC_PASSWORD,
+            cookie_path="/nowhere/.cookie",
+        )
+
+
+def test_neither_credentials_nor_a_cookie_path_is_refused() -> None:
+    """A client with no way to authenticate is refused where it is built."""
+    with pytest.raises(BTClibValueError, match="no rpc credentials"):
+        BitcoindRpcClient(URL)
+
+
+@pytest.mark.parametrize("timeout", [0, -1, float("inf"), float("nan")])
+def test_a_timeout_that_is_no_duration_is_refused(timeout: float) -> None:
+    """A zero, a negative, an infinity and a nan are not seconds to wait."""
+    with pytest.raises(BTClibValueError, match="rpc timeout is not a positive"):
+        BitcoindRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD, timeout=timeout)
+
+
+@pytest.mark.parametrize("timeout", [True, "30", None])
+def test_a_non_numeric_timeout_is_refused(timeout: object) -> None:
+    """A bool is not a duration: `timeout=True` would be one second."""
+    with pytest.raises(BTClibTypeError, match="non-numeric rpc timeout"):
+        BitcoindRpcClient(
+            URL,
+            user=RPC_USER,
+            password=RPC_PASSWORD,
+            timeout=timeout,  # type: ignore[arg-type]
+        )
+
+
+def test_the_default_timeout_is_the_one_the_module_documents() -> None:
+    """Verify a client with no timeout argument carries the module default."""
+    assert BitcoindRpcClient(URL, cookie_path="/nowhere/.cookie").timeout == (
+        DEFAULT_TIMEOUT
+    )
 
 
 def test_the_basic_credential_is_the_user_and_password_given() -> None:
     """Verify the Authorization header is Basic over user:password."""
-    header = AuthProxy(user=RPC_USER, password=RPC_PASSWORD).auth_header()
+    header = BitcoindRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD).auth_header()
     scheme, encoded = header.split(" ")
     assert scheme == "Basic"
     assert b64decode(encoded).decode() == f"{RPC_USER}:{RPC_PASSWORD}"
@@ -123,7 +304,7 @@ def test_the_basic_credential_is_the_user_and_password_given() -> None:
 def test_a_non_ascii_password_is_utf_8() -> None:
     """What a shell and a bitcoin.conf would have written."""
     umlauts = "pässwörd"
-    header = AuthProxy(user=RPC_USER, password=umlauts).auth_header()
+    header = BitcoindRpcClient(URL, user=RPC_USER, password=umlauts).auth_header()
     assert b64decode(header.split(" ")[1]) == f"{RPC_USER}:{umlauts}".encode()
 
 
@@ -133,7 +314,7 @@ def test_the_cookie_file_is_the_credential_when_there_is_no_user(
     """Verify the cookie line becomes the Basic credential, no user given."""
     cookie = tmp_path / ".cookie"
     cookie.write_text(COOKIE_LINE)
-    header = AuthProxy(cookie_path=cookie).auth_header()
+    header = BitcoindRpcClient(URL, cookie_path=cookie).auth_header()
     assert b64decode(header.split(" ")[1]).decode() == COOKIE_LINE
 
 
@@ -142,13 +323,15 @@ def test_the_cookie_is_read_at_every_call_not_at_construction(
 ) -> None:
     """Because a node restart rotates it.
 
-    A proxy built once and used for an hour would otherwise answer 401
+    A client built once and used for an hour would otherwise answer 401
     for the rest of the process. Constructing one touches no file at all,
     which is the other half of the same decision: building a client
     should not raise FileNotFoundError.
     """
     cookie = tmp_path / ".cookie"
-    endpoint = AuthProxy(cookie_path=cookie, transport=Recorded((200, b"{}")))
+    endpoint = BitcoindRpcClient(
+        URL, cookie_path=cookie, transport=Echoing((200, b"{}"))
+    )
     assert not cookie.exists()
 
     cookie.write_text(COOKIE_LINE)
@@ -158,7 +341,12 @@ def test_the_cookie_is_read_at_every_call_not_at_construction(
 
 
 def test_an_absent_cookie_file_says_which_file(tmp_path: Path) -> None:
-    """Verify the unreadable-cookie error names the missing file."""
+    """Verify the unreadable-cookie error names the missing file.
+
+    Which is also what tells a caller on macOS or Windows to pass a
+    `cookie_path`: the default is `~/.bitcoin`, Core's datadir on Linux
+    and on neither of those.
+    """
     absent = tmp_path / "no-such-datadir" / ".cookie"
     # escaped because `match` is a regex and a path is not: the windows
     # separator is a backslash, so a tmp_path under C:\Users carries an
@@ -172,73 +360,363 @@ def test_a_cookie_file_without_a_colon_is_not_one(tmp_path: Path) -> None:
     """Refuse a cookie file carrying no colon as malformed."""
     cookie = tmp_path / ".cookie"
     cookie.write_text("nonsense\n")
-    with pytest.raises(FetchError, match="malformed rpc cookie file"):
+    with pytest.raises(FetchError, match="no ':' in it"):
+        cookie_auth(cookie)
+
+
+def test_a_cookie_file_of_several_lines_is_not_one(tmp_path: Path) -> None:
+    """One line is what bitcoind writes, so more than one is another file."""
+    cookie = tmp_path / ".cookie"
+    cookie.write_text(f"{COOKIE_LINE}\nand a second line\n")
+    with pytest.raises(FetchError, match="several lines"):
+        cookie_auth(cookie)
+
+
+def test_a_cookie_file_that_is_not_ascii_is_not_one(tmp_path: Path) -> None:
+    """A binary file at the cookie path is a FetchError, not a decode error.
+
+    The wrong path is the ordinary mistake here, and everything it can
+    point at has to arrive through the same contract: naming the file,
+    and never rendering what was in it.
+    """
+    cookie = tmp_path / ".cookie"
+    cookie.write_bytes(b"\x80\x81:not ascii")
+    with pytest.raises(FetchError, match="non-ascii rpc cookie file"):
+        cookie_auth(cookie)
+
+
+def test_an_enormous_cookie_file_is_refused_rather_than_held(
+    tmp_path: Path,
+) -> None:
+    """The read is bounded, so a wrong path costs no memory.
+
+    A cookie is seventy octets; anything three orders of magnitude larger
+    is another file, and finding that out should not mean holding it.
+    """
+    cookie = tmp_path / ".cookie"
+    cookie.write_text(f"{COOKIE_LINE}\n" + "x" * 8192)
+    with pytest.raises(FetchError, match="oversized rpc cookie file"):
         cookie_auth(cookie)
 
 
 def test_the_request_is_a_json_rpc_2_0_post() -> None:
     """2.0, so that an rpc error is not an HTTP 500 like a real one."""
-    transport = Recorded((200, recorded_body("getblockcount.json")))
-    endpoint = AuthProxy(user=RPC_USER, password=RPC_PASSWORD, transport=transport)
+    endpoint = client((200, recorded_body("getblockcount.json")))
     assert endpoint.call("getblockcount") == TIP_HEIGHT
 
-    assert transport.request.get_method() == "POST"
-    assert transport.request.full_url == "http://127.0.0.1:8332"
-    assert transport.request.get_header("Content-type") == "application/json"
-    authorization = transport.request.get_header("Authorization")
+    request = recording(endpoint).request
+    assert request.get_method() == "POST"
+    assert request.full_url == URL
+    assert request.get_header("Content-type") == "application/json"
+    authorization = request.get_header("Authorization")
     assert authorization is not None
     assert authorization.startswith("Basic ")
-    assert json.loads(transport.body) == {
-        "jsonrpc": "2.0",
-        "id": "btclib",
-        "method": "getblockcount",
-        "params": [],
-    }
+
+    body = sent(endpoint)
+    assert body["jsonrpc"] == "2.0"
+    assert body["method"] == "getblockcount"
+    assert body["params"] == []
 
 
-def test_the_parameters_go_through_in_order() -> None:
-    """Positional, as Core takes them: `call` is any method, not three."""
-    transport = Recorded((200, recorded_body("getrawtransaction.json")))
-    endpoint = AuthProxy(user=RPC_USER, password=RPC_PASSWORD, transport=transport)
-    endpoint.call("getrawtransaction", TX_ID, 0, TIP_ID)
-    assert json.loads(transport.body)["params"] == [TX_ID, 0, TIP_ID]
+def test_positional_parameters_go_through_in_order() -> None:
+    """An array, which is one of json-rpc's two parameter structures."""
+    endpoint = client((200, recorded_body("getrawtransaction.json")))
+    endpoint.call("getrawtransaction", [TX_ID, 0, TIP_ID])
+    assert sent(endpoint)["params"] == [TX_ID, 0, TIP_ID]
 
 
-def test_the_timeout_reaches_the_transport() -> None:
-    """Verify the constructor's timeout is handed to the transport."""
-    transport = Recorded((200, recorded_body("getblockcount.json")))
-    AuthProxy(
-        user=RPC_USER, password=RPC_PASSWORD, timeout=2.5, transport=transport
-    ).call("getblockcount")
-    assert transport.timeouts == [2.5]
+def test_named_parameters_go_through_as_an_object() -> None:
+    """The other structure: Core reads an object by parameter name."""
+    endpoint = client((200, recorded_body("getrawtransaction.json")))
+    endpoint.call("getrawtransaction", {"txid": TX_ID, "verbosity": 0})
+    assert sent(endpoint)["params"] == {"txid": TX_ID, "verbosity": 0}
+
+
+def test_cores_args_convention_needs_nothing_here() -> None:
+    """A named call carrying an array of leading positional values.
+
+    Core accepts `args` in the object as the positional parameters before
+    the named ones, which is why btclib needs no third parameter form:
+    the convention is one key of the caller's mapping.
+    """
+    endpoint = client((200, recorded_body("getrawtransaction.json")))
+    endpoint.call("getrawtransaction", {"args": [TX_ID], "verbosity": 0})
+    assert sent(endpoint)["params"] == {"args": [TX_ID], "verbosity": 0}
+
+
+def test_a_parameter_named_like_a_control_reaches_the_node() -> None:
+    """`timeout` is a parameter of Core methods and a control of this one.
+
+    Keyword-only controls are what keep the two apart: `request_timeout`
+    is this client's and never leaves it, while a `timeout` in `params`
+    is the node's and goes through untouched. A signature spreading
+    parameters as keywords would have had to choose.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")), timeout=5.0)
+    endpoint.call("waitfornewblock", {"timeout": 1000}, request_timeout=2.5)
+    assert sent(endpoint)["params"] == {"timeout": 1000}
+    assert recording(endpoint).timeouts == [2.5]
+
+
+def test_a_string_is_not_a_sequence_of_parameters() -> None:
+    """`call("getblock", block_id)` means one parameter, not sixty-four.
+
+    A str satisfies `Sequence[Any]`, so this one is not even a type error
+    to a checker: it is a refusal at run time or a request with sixty-four
+    parameters in it.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibTypeError, match="not a sequence of parameters"):
+        endpoint.call("getblock", TX_ID)
+
+
+@pytest.mark.parametrize("params", [b"bytes", bytearray(b"bytes")])
+def test_bytes_are_not_a_sequence_of_parameters(params: object) -> None:
+    """Bytes are a Sequence too, and are a value and not a list of them."""
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibTypeError, match="not a sequence of parameters"):
+        endpoint.call("getblock", params)  # type: ignore[arg-type]
+
+
+def test_params_that_are_neither_a_sequence_nor_a_mapping() -> None:
+    """An int is not a parameter structure json-rpc has."""
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibTypeError, match="neither a sequence nor a mapping"):
+        endpoint.call("getblock", 481824)  # type: ignore[arg-type]
+
+
+def test_a_parameter_name_that_is_not_a_string() -> None:
+    """A json object is keyed by strings, and a mapping here may not be."""
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibTypeError, match="non-string rpc parameter name"):
+        endpoint.call("getblock", {1: TX_ID})  # type: ignore[dict-item]
+
+
+def test_a_decimal_parameter_is_refused_and_not_rounded() -> None:
+    """An amount does not become binary floating point on the way out.
+
+    Which is the whole policy: json carries no exact decimal, so a
+    Decimal cannot be sent as one -- and rounding it through `float`
+    silently is how a payment becomes a different payment. What the
+    method documents is what goes: satoshis as an int, or the string
+    Core accepts for the field.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibTypeError, match="Decimal rpc parameter"):
+        endpoint.call("sendtoaddress", ["bc1qexample", Decimal("0.1")])
+
+
+def test_a_parameter_json_cannot_carry_at_all() -> None:
+    """Anything else with no json rendering is refused by name."""
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibTypeError, match="not a json value"):
+        endpoint.call("sendtoaddress", [OutPoint(TX_ID, 0)])
+
+
+@pytest.mark.parametrize("number", [float("nan"), float("inf"), float("-inf")])
+def test_a_non_finite_number_is_not_a_json_number(number: float) -> None:
+    """`NaN` and `Infinity` are Python's spelling and json has neither.
+
+    Python writes them by default and a node parsing strictly rejects
+    the whole request for one, so the refusal belongs here, beside the
+    parameter that caused it.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibValueError, match="not a json number in the rpc params"):
+        endpoint.call("settxfee", [number])
+
+
+def test_a_number_in_a_reply_is_a_decimal_not_a_float() -> None:
+    """An amount arrives exact, which binary floating point cannot be.
+
+    0.1 is the standard demonstration: as a float it is a little more
+    than a tenth, and the difference is what accumulates over a wallet's
+    worth of outputs.
+    """
+    body = json.dumps({"jsonrpc": "2.0", "result": {"mine": 0.1}, "id": "x"}).encode()
+    amount = client((200, body)).call("getbalances")["mine"]
+    assert isinstance(amount, Decimal)
+    assert amount == Decimal("0.1")
+    assert amount != 0.1
+
+
+@pytest.mark.parametrize("constant", ["NaN", "Infinity", "-Infinity"])
+def test_a_non_number_in_a_reply_is_refused(constant: str) -> None:
+    """Python reads back what it writes, and a node sends none of it.
+
+    A nan arriving as an amount compares false against itself for the
+    rest of its life, so it is refused where it decodes.
+    """
+    body = b'{"jsonrpc":"2.0","result":' + constant.encode() + b',"id":"x"}'
+    with pytest.raises(FetchError, match=f"not a json number in the reply: {constant}"):
+        client((200, body)).call("getbalance")
+
+
+def test_the_clients_timeout_reaches_the_transport() -> None:
+    """Verify the constructor's timeout is what a call inherits."""
+    endpoint = client((200, recorded_body("getblockcount.json")), timeout=2.5)
+    endpoint.call("getblockcount")
+    assert recording(endpoint).timeouts == [2.5]
+
+
+def test_a_call_can_widen_the_timeout_for_itself() -> None:
+    """What `rescanblockchain` needs, and what nothing else should pay for.
+
+    The alternative is a second client whose wider timeout applies to
+    every call made through it, including the ones that should fail fast.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")), timeout=2.5)
+    endpoint.call("rescanblockchain", request_timeout=3600.0)
+    assert recording(endpoint).timeouts == [3600.0]
+    assert endpoint.timeout == 2.5
+
+
+@pytest.mark.parametrize("timeout", [0, -1, float("inf")])
+def test_a_per_call_timeout_that_is_no_duration_is_refused(timeout: float) -> None:
+    """The same check as the constructor's, at the other place it is set."""
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    with pytest.raises(BTClibValueError, match="request_timeout is not a positive"):
+        endpoint.call("getblockcount", request_timeout=timeout)
+
+
+def test_every_call_asks_with_an_id_of_its_own() -> None:
+    """Which is what makes the echo check able to catch anything.
+
+    A fixed id is echoed by the right reply and by a cached one alike, so
+    it cannot tell them apart -- and a counter would be shared mutable
+    state, the one thing that would make a client unsafe to call from two
+    threads.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    endpoint.call("getblockcount")
+    endpoint.call("getblockcount")
+    ids = [asked_id(request) for request in recording(endpoint).requests]
+    assert len(set(ids)) == 2
+    assert all(id_.startswith("btclib-") for id_ in ids)
+
+
+def test_a_call_writes_nothing_on_the_client() -> None:
+    """The other half of what makes concurrent calls safe.
+
+    No counter, no cached credential, no connection kept: the state after
+    a call is the configuration it started with, so two threads sharing a
+    client cannot interleave into each other's request.
+    """
+    endpoint = client((200, recorded_body("getblockcount.json")))
+    before = dict(vars(endpoint))
+    endpoint.call("getblockcount")
+    assert dict(vars(endpoint)) == before
+
+
+def test_a_reply_to_someone_elses_request_is_refused() -> None:
+    """What a caching proxy in the way looks like from here."""
+    body = json.dumps({"jsonrpc": "2.0", "result": 1, "id": "another call"}).encode()
+    with pytest.raises(FetchError, match="reply id 'another call' is not the"):
+        verbatim((200, body)).call("getblockcount")
+
+
+def test_an_error_for_someone_elses_request_is_refused() -> None:
+    """The correlation is checked on the error path too.
+
+    An error object arriving with another call's id is not this call's
+    answer, and reporting its code as this method's would attribute a
+    failure to a transaction that was never asked about.
+    """
+    error = {"code": -5, "message": "No such mempool transaction"}
+    body = json.dumps({"jsonrpc": "2.0", "error": error, "id": "another"}).encode()
+    with pytest.raises(FetchError, match="reply id 'another' is not the") as exc:
+        verbatim((200, body)).call("getrawtransaction", [TX_ID])
+    assert not isinstance(exc.value, RpcError)
 
 
 def test_an_rpc_error_object_is_an_rpc_error_with_the_code() -> None:
     """Core's own message for a node without -txindex, and its code."""
     body = recorded_body("getrawtransaction_error.json")
     with pytest.raises(RpcError, match="rpc error code -5") as exc:
-        proxy((200, body)).call("getrawtransaction", TX_ID)
+        client((200, body)).call("getrawtransaction", [TX_ID])
     assert exc.value.code == -5
+    assert exc.value.data is None
     assert "-txindex" in str(exc.value)
 
 
-def test_an_rpc_error_arriving_with_a_500_is_still_an_rpc_error() -> None:
-    """A node older than v28 does not know the 2.0 marker and answers 1.0.
+def test_the_data_member_of_an_error_object_is_kept() -> None:
+    """json-rpc's optional third member, which Core does not send today.
 
-    The 1.0 reply puts the error object in the body of an HTTP 500, so
+    A method that starts sending one, or a proxy adding its own, would
+    otherwise have it dropped where it cannot be recovered from.
+    """
+    error = {"code": -8, "message": "Invalid parameter", "data": {"field": "txid"}}
+    body = json.dumps({"jsonrpc": "2.0", "error": error, "id": "x"}).encode()
+    with pytest.raises(RpcError) as exc:
+        client((200, body)).call("getrawtransaction", [TX_ID])
+    assert exc.value.data == {"field": "txid"}
+
+
+def test_an_rpc_error_arriving_with_a_500_is_still_an_rpc_error() -> None:
+    """A node older than v28 does not know the 2.0 marker and answers 1.1.
+
+    The 1.1 reply puts the error object in the body of an HTTP 500, so
     the status has to be read after the body and not before it -- or
     every "no such transaction" from an old node would be reported as a
-    server fault.
+    server fault. No `jsonrpc` member is what says the reply is 1.1.
     """
     body = json.dumps(
         {
             "result": None,
             "error": {"code": -5, "message": "No such mempool or blockchain"},
-            "id": "btclib",
+            "id": "x",
         }
     ).encode()
     with pytest.raises(RpcError, match="rpc error code -5"):
-        proxy((500, body)).call("getrawtransaction", TX_ID)
+        client((500, body)).call("getrawtransaction", [TX_ID])
+
+
+def test_a_legacy_reply_with_a_result_is_the_result() -> None:
+    """v27 and older answer every request this way: no marker, both members."""
+    body = json.dumps({"result": TIP_HEIGHT, "error": None, "id": "x"}).encode()
+    assert client((200, body)).call("getblockcount") == TIP_HEIGHT
+
+
+def test_a_500_from_something_in_the_way_is_not_an_rpc_error() -> None:
+    """A json body with somebody else's id does not make a 500 the node's.
+
+    Which is why the id is checked before the error object is believed: a
+    proxy answering 500 with an error object of its own would otherwise
+    be reported as a bitcoin error the node never computed.
+    """
+    error = {"code": -32603, "message": "upstream said no"}
+    body = json.dumps({"result": None, "error": error, "id": "proxy"}).encode()
+    with pytest.raises(HttpError, match="HTTP 500") as exc:
+        verbatim((500, body)).call("getblockcount")
+    assert exc.value.status == 500
+    assert not isinstance(exc.value, RpcError)
+
+
+def test_a_2_0_reply_on_a_non_200_is_an_http_failure() -> None:
+    """Under 2.0 an rpc error is a 200, so a 503 is the exchange failing.
+
+    A body shaped like an rpc error beside a 503 is something in front of
+    the node explaining itself, and reporting a full work queue as a
+    bitcoin error would send the caller looking at the wrong layer.
+    """
+    error = {"code": -32603, "message": "Work queue depth exceeded"}
+    body = json.dumps({"jsonrpc": "2.0", "error": error, "id": "x"}).encode()
+    with pytest.raises(HttpError, match="HTTP 503") as exc:
+        client((503, body)).call("getblockcount")
+    assert exc.value.status == 503
+    assert not isinstance(exc.value, RpcError)
+
+
+def test_the_status_of_a_full_work_queue_is_a_field() -> None:
+    """Which is what a caller's retry policy reads, btclib retrying nothing.
+
+    503 with an empty body is what a node whose `rpcworkqueue` is full
+    answers; the same request works when the queue drains, and telling it
+    from a 401 -- which never will -- is the whole use of the field.
+    """
+    with pytest.raises(HttpError) as exc:
+        client((503, b"")).call("getblockcount")
+    assert exc.value.status == 503
 
 
 def test_a_401_says_it_is_the_credentials() -> None:
@@ -247,8 +725,31 @@ def test_a_401_says_it_is_the_credentials() -> None:
     Reporting "not json" would name the symptom and hide the cause,
     which is the whole reason the status is consulted in the except.
     """
-    with pytest.raises(FetchError, match="HTTP 401, the node refused"):
-        proxy((401, b"")).call("getblockcount")
+    with pytest.raises(HttpError, match="HTTP 401, the node refused") as exc:
+        client((401, b"")).call("getblockcount")
+    assert exc.value.status == 401
+
+
+@pytest.mark.parametrize("code", [301, 302, 303, 307, 308])
+def test_a_redirect_is_refused_and_not_answered(code: int) -> None:
+    """An rpc call meeting a 30x fails; the credential stays on one url.
+
+    Nothing follows a redirect (issue #358), so a `Location` is a header on
+    a status like any other and the body beside it -- here the html of
+    whatever answered instead of the node -- is not a reply. What the
+    caller gets is the status, which is what says the endpoint is not the
+    node any more; the `Authorization` reached the url they wrote down and
+    no second one.
+    """
+    endpoint = client((code, b"<html><title>Moved</title></html>"))
+    with pytest.raises(HttpError, match=f"HTTP {code}") as exc:
+        endpoint.call("getblockcount")
+    assert exc.value.status == code
+
+    transport = recording(endpoint)
+    assert len(transport.requests) == 1
+    assert transport.request.full_url == endpoint.url
+    assert transport.request.get_header("Authorization") == endpoint.auth_header()
 
 
 @pytest.mark.parametrize("code", [301, 302, 303, 307, 308])
@@ -276,51 +777,128 @@ def test_a_redirect_is_refused_and_not_answered(code: int) -> None:
 def test_a_body_that_is_not_json_says_so() -> None:
     """A proxy or a web server on the rpc port, answering 200 with html."""
     with pytest.raises(FetchError, match="not json"):
-        proxy((200, b"<html><title>nginx</title></html>")).call("getblockcount")
+        client((200, b"<html><title>nginx</title></html>")).call("getblockcount")
+
+
+def test_a_body_that_is_not_utf_8_says_so() -> None:
+    """Json is utf-8, and a body that is not is the backend's failure."""
+    with pytest.raises(FetchError, match="not utf-8"):
+        client((200, b'{"result": "\xff\xfe"}')).call("getblockcount")
+
+
+def test_a_reply_nested_too_deeply_to_parse() -> None:
+    """A hundred thousand `[` is a recursion error out of the parser.
+
+    Which the bound on the body leaves ample room for, so it arrives as
+    the FetchError every other unusable answer does rather than as a
+    RecursionError from inside the standard library.
+    """
+    body = b"[" * 200_000 + b"]" * 200_000
+    with pytest.raises(FetchError, match="nested too deeply"):
+        client((200, body)).call("getblockcount")
 
 
 def test_a_json_body_that_is_not_a_reply_object() -> None:
     """Refuse a json body that is not a json-rpc reply object."""
-    with pytest.raises(FetchError, match="not a json-rpc reply"):
-        proxy((200, b"[1, 2, 3]")).call("getblockcount")
+    with pytest.raises(FetchError, match="not a json-rpc reply, but a list"):
+        client((200, b"[1, 2, 3]")).call("getblockcount")
 
 
-def test_a_non_200_with_no_error_object_reports_the_status() -> None:
-    """Verify a non-200 with no error object reports the status."""
-    body = json.dumps({"jsonrpc": "2.0", "result": None, "id": "btclib"}).encode()
-    with pytest.raises(FetchError, match="HTTP 503"):
-        proxy((503, body)).call("getblockcount")
+@pytest.mark.parametrize("marker", ["1.0", "1.1", "2", 2.0, None])
+def test_a_version_marker_that_is_neither_2_0_nor_absent(marker: object) -> None:
+    """Absent means 1.1 and `"2.0"` means 2.0; anything else is neither.
+
+    The two protocols differ on where an error is reported, so a marker
+    naming no protocol leaves nothing to decide that by. `null` is such a
+    marker: a reply carrying it is not the same as one with no member at
+    all, which is what says 1.1.
+    """
+    body = json.dumps({"jsonrpc": marker, "result": 1, "id": "x"}).encode()
+    with pytest.raises(FetchError, match="json-rpc version"):
+        client((200, body)).call("getblockcount")
 
 
-def test_a_reply_to_someone_elses_request_is_refused() -> None:
-    """What a caching proxy in the way looks like from here."""
-    body = json.dumps({"jsonrpc": "2.0", "result": 1, "id": "other"}).encode()
-    with pytest.raises(FetchError, match="reply id 'other' is not ours"):
-        proxy((200, body)).call("getblockcount")
+def test_a_2_0_reply_with_both_result_and_error() -> None:
+    """2.0 says exactly one of them, which is what tells it from 1.1."""
+    error = {"code": -5, "message": "not found"}
+    body = json.dumps(
+        {"jsonrpc": "2.0", "result": 1, "error": error, "id": "x"}
+    ).encode()
+    with pytest.raises(FetchError, match="both result and error"):
+        client((200, body)).call("getblockcount")
 
 
 def test_a_reply_with_neither_result_nor_error() -> None:
-    """Refuse a reply object with neither result nor error."""
-    body = json.dumps({"jsonrpc": "2.0", "id": "btclib"}).encode()
+    """Refuse a 2.0 reply object with neither result nor error."""
+    body = json.dumps({"jsonrpc": "2.0", "id": "x"}).encode()
     with pytest.raises(FetchError, match="neither result nor error"):
-        proxy((200, body)).call("getblockcount")
+        client((200, body)).call("getblockcount")
+
+
+def test_a_legacy_reply_with_neither_result_nor_error() -> None:
+    """The same refusal on the path that reads a reply with no marker."""
+    body = json.dumps({"id": "x"}).encode()
+    with pytest.raises(FetchError, match="neither result nor error"):
+        client((200, body)).call("getblockcount")
 
 
 @pytest.mark.parametrize(
-    "error", ["a string", {"message": "no code"}, {"code": "-5"}, []]
+    "error", ["a string", {"message": "no code"}, {"code": "-5"}, {"code": True}, []]
 )
 def test_an_error_member_that_is_not_one(error: object) -> None:
-    """Not every non-null `error` carries a code to report."""
-    body = json.dumps({"jsonrpc": "2.0", "error": error, "id": "btclib"}).encode()
+    """Not every non-null `error` carries a code to report.
+
+    A bool among them, `true` being what a json `code` of one decodes to
+    and a bool not being another spelling of a number anywhere else in
+    the library.
+    """
+    body = json.dumps({"jsonrpc": "2.0", "error": error, "id": "x"}).encode()
     with pytest.raises(FetchError, match="unreadable rpc error"):
-        proxy((200, body)).call("getblockcount")
+        client((200, body)).call("getblockcount")
 
 
-def fetcher(
-    *answers: tuple[int, bytes] | Exception, **kwargs: object
-) -> BitcoindFetcher:
-    """Return a BitcoindFetcher over a recorded AuthProxy."""
-    return BitcoindFetcher(proxy(*answers, **kwargs))
+def test_a_wallet_endpoint_is_the_path_core_documents() -> None:
+    """How a node with several wallets loaded is told which one is meant."""
+    endpoint = BitcoindRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD).for_wallet(
+        "hot"
+    )
+    assert endpoint.url == f"{URL}/wallet/hot"
+    assert endpoint.user == RPC_USER
+
+
+@pytest.mark.parametrize(
+    ("name", "path"),
+    [
+        ("my wallet", "my%20wallet"),
+        ("a/b", "a%2Fb"),
+        ("#1", "%231"),
+        ("100%", "100%25"),
+        ("cold?", "cold%3F"),
+        ("", ""),
+    ],
+)
+def test_a_wallet_name_is_percent_encoded(name: str, path: str) -> None:
+    """A wallet is a directory and may be called anything a filesystem takes.
+
+    Written into the path unencoded, a space, a `/`, a `#` or a `?`
+    addresses a different endpoint or none -- and the caller who named
+    the wallet is not the one who should have to know that.
+    """
+    endpoint = BitcoindRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD)
+    assert endpoint.for_wallet(name).url == f"{URL}/wallet/{path}"
+
+
+def test_a_wallet_client_keeps_the_credentials_and_the_transport() -> None:
+    """The endpoint is the only difference, so one client derives the rest."""
+    cookie = Path("/nowhere/.cookie")
+    transport = Echoing((200, recorded_body("getblockcount.json")))
+    endpoint = BitcoindRpcClient(
+        URL, cookie_path=cookie, timeout=7.0, transport=transport
+    ).for_wallet("hot")
+    assert endpoint.cookie_path == cookie
+    assert endpoint.timeout == 7.0
+    assert endpoint.transport is transport
+    assert endpoint.user is None
 
 
 def test_get_tx_parses_the_serialization_the_node_sent() -> None:
@@ -333,22 +911,30 @@ def test_get_tx_parses_the_serialization_the_node_sent() -> None:
 
 def test_get_tx_asks_for_the_id_it_was_given() -> None:
     """Verify get_tx sends getrawtransaction with the hex id it was given."""
-    transport = Recorded((200, recorded_body("getrawtransaction.json")))
-    endpoint = AuthProxy(user=RPC_USER, password=RPC_PASSWORD, transport=transport)
+    endpoint = client((200, recorded_body("getrawtransaction.json")))
     BitcoindFetcher(endpoint).get_tx(bytes.fromhex(TX_ID))
-    assert json.loads(transport.body) == {
-        "jsonrpc": "2.0",
-        "id": "btclib",
-        "method": "getrawtransaction",
-        "params": [TX_ID],
-    }
+    body = sent(endpoint)
+    assert body["method"] == "getrawtransaction"
+    assert body["params"] == [TX_ID]
 
 
-def test_get_tx_labels_the_outputs_for_the_proxies_network() -> None:
-    """The network is the proxy's, so a fetcher cannot disagree with it."""
-    endpoint = proxy((200, recorded_body("getrawtransaction.json")), network="testnet")
-    tx = BitcoindFetcher(endpoint).get_tx(TX_ID)
+def test_get_tx_labels_the_outputs_for_the_fetchers_network() -> None:
+    """The network is the fetcher's: the client knows a url and no chain."""
+    endpoint = client((200, recorded_body("getrawtransaction.json")))
+    tx = BitcoindFetcher(endpoint, "testnet").get_tx(TX_ID)
     assert [out.script_pub_key.network for out in tx.vout] == ["testnet"] * 2
+
+
+def test_the_fetchers_network_is_btclibs_registry_not_cores() -> None:
+    """Which is the point of the split: `Fetcher` validates against NETWORKS.
+
+    The client refuses no name at all, and `from_network` refuses one Core
+    has no port for -- neither of which is the question this label answers.
+    """
+    with pytest.raises(BTClibValueError, match="unknown network"):
+        BitcoindFetcher(
+            BitcoindRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD), "nowhere"
+        )
 
 
 def test_get_tx_out_reads_one_output_of_the_previous_transaction() -> None:
@@ -368,25 +954,18 @@ def test_get_block_count_and_get_best_block_id() -> None:
     assert tip.hex() == TIP_ID
 
 
-@pytest.mark.parametrize(
-    ("result", "match"),
-    [
-        ("not a number", "getblockcount:"),
-        (None, "getblockcount:"),
-        ([1], "getblockcount:"),
-    ],
-)
-def test_a_height_that_is_not_one(result: object, match: str) -> None:
+@pytest.mark.parametrize("result", ["not a number", None, [1]])
+def test_a_height_that_is_not_one(result: object) -> None:
     """Refuse a getblockcount result that is not an int."""
-    body = json.dumps({"jsonrpc": "2.0", "result": result, "id": "btclib"}).encode()
-    with pytest.raises(FetchError, match=match):
+    body = json.dumps({"jsonrpc": "2.0", "result": result, "id": "x"}).encode()
+    with pytest.raises(FetchError, match="getblockcount:"):
         fetcher((200, body)).get_block_count()
 
 
 @pytest.mark.parametrize("result", ["", "00" * 31, 481824, None])
 def test_a_tip_hash_that_is_not_one(result: object) -> None:
     """Refuse a getbestblockhash result that is not a block id."""
-    body = json.dumps({"jsonrpc": "2.0", "result": result, "id": "btclib"}).encode()
+    body = json.dumps({"jsonrpc": "2.0", "result": result, "id": "x"}).encode()
     with pytest.raises(FetchError, match="getbestblockhash:"):
         fetcher((200, body)).get_best_block_id()
 
@@ -394,7 +973,7 @@ def test_a_tip_hash_that_is_not_one(result: object) -> None:
 @pytest.mark.parametrize("result", ["not hex", "", None, 170, {"hex": "0100"}])
 def test_a_raw_transaction_that_is_not_one(result: object) -> None:
     """Refuse a getrawtransaction result that is not a hex tx."""
-    body = json.dumps({"jsonrpc": "2.0", "result": result, "id": "btclib"}).encode()
+    body = json.dumps({"jsonrpc": "2.0", "result": result, "id": "x"}).encode()
     with pytest.raises(FetchError, match=f"transaction {TX_ID}:"):
         fetcher((200, body)).get_tx(TX_ID)
 
@@ -407,7 +986,7 @@ def test_a_small_reply_carries_a_small_limit() -> None:
     takes any method -- `getblock` on a large block is a legitimate call.
     The two answers that are a number and a hash say so instead.
     """
-    oversized = b'{"result":' + b"9" * 1100 + b',"error":null,"id":"btclib"}'
+    oversized = b'{"result":' + b"9" * 1100 + b',"error":null,"id":"x"}'
     with pytest.raises(FetchError, match="more than the 1024 allowed"):
         fetcher((200, oversized)).get_block_count()
 
@@ -418,7 +997,28 @@ def test_a_small_reply_carries_a_small_limit() -> None:
     )
 
     # and `call` itself keeps the wide default, being public and taking
-    # any method: `getblock` on a large block is a legitimate call
-    defaults = AuthProxy.call.__kwdefaults__
+    # any method: `getblock` on a large block is a legitimate call. The
+    # timeout defaults to the client's, which is what None means here
+    defaults = BitcoindRpcClient.call.__kwdefaults__
     assert defaults is not None
     assert defaults["max_body_size"] == DEFAULT_MAX_BODY_SIZE
+    assert defaults["request_timeout"] is None
+
+
+def test_a_custom_transport_owns_its_allocation_bound() -> None:
+    """The two bounds are not one bound, and this is the one btclib keeps.
+
+    A transport of a caller's own is handed the request and a timeout and
+    nothing else: it cannot see what this call allowed, so what it holds
+    in memory before answering is its own bound to set. What btclib
+    promises for one is the per-call limit applied afterwards -- an
+    oversized answer goes no further, having already been read.
+    """
+    body = b'{"jsonrpc":"2.0","result":"' + b"a" * 2048 + b'","id":"x"}'
+    endpoint = client((200, body))
+    with pytest.raises(FetchError, match="more than the 1024 allowed"):
+        endpoint.call("getblockcount", max_body_size=1024)
+
+    # and the same answer is fine when the call allows its weight, which
+    # is what says the limit is the caller's and not the transport's
+    assert len(endpoint.call("getblockcount", max_body_size=4096)) == 2048

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import pytest
 
-from btclib.exceptions import BTClibValueError, FetchError
+from btclib.exceptions import BTClibValueError, FetchError, HttpError
 from btclib.fetch.esplora import BLOCKSTREAM_INFO, EsploraFetcher
 from btclib.tx import OutPoint
 from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
@@ -125,6 +125,20 @@ def test_a_404_carries_what_the_explorer_said() -> None:
     """Esplora answers an unknown txid with a status and a sentence."""
     with pytest.raises(FetchError, match="HTTP 404 .*: Transaction not found"):
         fetcher((404, b"Transaction not found")).get_tx(TX_ID)
+
+
+@pytest.mark.parametrize("status", [404, 429, 503])
+def test_the_status_of_a_failure_is_a_field(status: int) -> None:
+    """Which is what tells a rate limit from a missing transaction.
+
+    Every answer here is a GET of an immutable value, so a 429 or a 503
+    from a public deployment is worth another attempt and a 404 is not.
+    btclib retries neither -- an explorer's rate limit is the caller's
+    budget to spend -- so the status has to reach them as a value.
+    """
+    with pytest.raises(HttpError) as exc:
+        fetcher((status, b"no")).get_tx(TX_ID)
+    assert exc.value.status == status
 
 
 def test_a_body_that_is_not_utf_8_is_still_reported() -> None:

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -483,7 +483,7 @@ def test_the_opener_does_not_follow_a_redirect() -> None:
     assert isinstance(redirect_handlers[0], transport_module._NoRedirect)
 
 
-@pytest.mark.parametrize("variable", ["http_proxy", "HTTPS_PROXY", "ALL_PROXY"])
+@pytest.mark.parametrize("variable", ["http_proxy", "HTTPS_PROXY"])
 def test_no_proxy_is_taken_from_the_environment(
     variable: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -506,6 +506,14 @@ def test_no_proxy_is_taken_from_the_environment(
     Measured against what the default opener does with the same
     environment, which is the other half of the claim: a handler that
     would have proxied is there, and in btclib's opener it is not.
+
+    These two variables and not `ALL_PROXY`, which is the case that looks
+    like a wildcard and is not one: `getproxies_environment` maps it to
+    the key `all`, `ProxyHandler` registers `all_open` from that, and
+    `OpenerDirector` dispatches an http request through the `http` chain
+    alone. So an `ALL_PROXY` handler is installed and never proxies
+    either scheme, which would make this a test that a handler exists
+    rather than one about where a credential goes.
     """
     monkeypatch.setenv(variable, "http://proxy.invalid:3128")
     assert getproxies_environment()  # the environment does name one

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -456,7 +456,7 @@ def test_only_http_and_https_are_opened(url: str) -> None:
 
 
 def test_an_http_error_is_a_status_and_a_body_not_an_exception() -> None:
-    """Where bitcoind's 1.0 error object and Esplora's 404 text come from."""
+    """Where bitcoind's 1.1 error object and Esplora's 404 text come from."""
     with http_error(500, b'{"result":null,"error":{"code":-5}}') as error:
         assert http_request(URL, transport=Recorded(error)) == (
             500,

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -22,8 +22,10 @@ from urllib.request import (
     HTTPHandler,
     HTTPRedirectHandler,
     OpenerDirector,
+    ProxyHandler,
     Request,
     build_opener,
+    getproxies_environment,
 )
 from urllib.response import addinfourl
 
@@ -479,6 +481,40 @@ def test_the_opener_does_not_follow_a_redirect() -> None:
     ]
     assert len(redirect_handlers) == 1
     assert isinstance(redirect_handlers[0], transport_module._NoRedirect)
+
+
+@pytest.mark.parametrize("variable", ["http_proxy", "HTTPS_PROXY", "ALL_PROXY"])
+def test_no_proxy_is_taken_from_the_environment(
+    variable: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A variable set for a browser does not get btclib's rpc credential.
+
+    `build_opener` installs a `ProxyHandler` built from `getproxies()` by
+    default, so without the empty one this module passes it, a call to a
+    node on loopback would be sent to whatever host `HTTP_PROXY` names --
+    with the `Basic` header btclib puts on every request before being
+    asked for one. The environment is inherited by everything in a shell
+    and is nobody's statement about which host holds the node.
+
+    There is no proxy handler in the chain at all, which is what passing
+    an empty map achieves: `ProxyHandler.__init__` sets one `<scheme>_open`
+    method per entry, `add_handler` appends a handler only when it
+    registered something, and `build_opener` skips the default of a class
+    it was handed an instance of. So the empty one takes the place of
+    urllib's and then declines to be in the chain.
+
+    Measured against what the default opener does with the same
+    environment, which is the other half of the claim: a handler that
+    would have proxied is there, and in btclib's opener it is not.
+    """
+    monkeypatch.setenv(variable, "http://proxy.invalid:3128")
+    assert getproxies_environment()  # the environment does name one
+
+    default = getattr(build_opener(), "handlers", [])
+    assert [h for h in default if isinstance(h, ProxyHandler)]
+
+    handlers = getattr(transport_module._OPENER, "handlers", [])
+    assert [h for h in handlers if isinstance(h, ProxyHandler)] == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The API pass of issue #370, whose body carries the adopted contract.
Nothing here is in a released tag, so every change is free today and
source-breaking after the first release.

**The client is named for the interface it implements.**
`BitcoinCoreRpcClient` in `btclib/fetch/bitcoin_core.py`, with
`BitcoinCoreFetcher` beside it. `bitcoind` names one executable; the
contract is Bitcoin Core's JSON-RPC interface, and the module name
mirrors the product's the way `esplora.py` already does. It is not
python-bitcoinrpc's `AuthServiceProxy`, whose lineage is LGPL-2.1 where
btclib is MIT, and not API-compatible with it — the module docstring
carries a migration section for consumers arriving from there.

**`call` mirrors the json-rpc envelope.**

```python
call(method, params=None, *, request_timeout=None, max_body_size=...)
```

One `params` value, a sequence or a mapping — exactly the two parameter
structures Core accepts, so its `args` convention is one key of a
caller's mapping. `str` and `bytes` are refused as positional sequences,
and the controls are keyword-only so a Core parameter called `timeout`
cannot collide with the client's.

**Amounts never transit binary floating point.** Replies decode with
`parse_float=Decimal`; a `Decimal` parameter is refused rather than
rounded. The parameters are walked whole before they are encoded, because
`json.dumps` *rewrites* a mapping key that is not a string — `{1: "a"}`
would reach the node as `{"1": "a"}` — and reports a structure containing
itself as the same kind of error a non-finite number is. `NaN` and
`Infinity` are refused in both directions, and so is an int longer than
`sys.get_int_max_str_digits` allows, in both directions.

**Response classification is version-aware.** No `jsonrpc` member is
Core's legacy 1.1, where a correlated error legitimately arrives with an
HTTP 500. `"2.0"` requires a 200 before any result or error is read, and
exactly one of the two *present* — `"error": null` beside a result is the
1.1 shape. Anything else names no protocol. The id is checked before an
error is treated as this call's.

**`HttpError(FetchError)` carries `.status`**, raised by both fetchers
wherever the status is the failure — including every body that is not a
reply, whether no parser could read it or it parsed into something that
is not an object. btclib retries nothing: `call` carries any method, so
it cannot know that re-sending one is safe, and a timeout is not a
deadline. What the field buys is the policy on a status, not a rule about
which failures are transient.

**A distinct request id per call**, verified on result and error replies
alike, random rather than counted so no shared mutable state appears and
the scoped thread-safety promise holds.

**The connection does not own btclib's chain label.** The constructor
validates no network name; `from_network` derives Core's port and cookie
path; `BitcoinCoreFetcher(client, network=...)` owns the label, which
unblocks a custom signet from btclib's registry. Nothing verifies which
chain the node serves, and the docstrings say so.

**Endpoint, authentication and transport.** `for_wallet` percent-encodes
a wallet name onto `/wallet/<name>`. The url is validated at construction
— scheme, host, port, no query or fragment. Credentials and a cookie path
are mutually exclusive. The cookie read is bounded and must be one ascii
line. The default opener follows no redirect (issue #358, PR #369) and
consults no ambient proxy: `ProxyHandler({})` removes the handler
`build_opener` would have built from `HTTP_PROXY`, so the pre-emptive
`Basic` credential reaches only the configured host.

**The decisions taken against something are in the tree**, as
present-tense prose rather than only in the issue: no retry and its two
reasons, no async, no batch, no notifications, no chain verification, the
Decimal policy, the scoped thread-safety promise, the three obligations a
caller's own transport carries — its own allocation bound, distinct from
btclib's per-call `max_body_size`; redirects off; its own thread-safety —
and Basic auth being cleartext over plain HTTP.

**Corrected**: the pre-v28 protocol is JSON-RPC **1.1**, not 1.0, per
Core's `doc/JSON-RPC-interface.md`.

## Verification

```shell
uv run pytest --cov=btclib --cov=tests   # 17,175 passed, 100.00%
uv run pre-commit run --all-files        # exit 0
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
```

All three run after the final rebase, which is how the duplicate-test
failure of the first round is not repeated.

The tests cover the acceptance list of #370: both parameter forms with
Core's `args` convention and a control-name collision; the Decimal result
and the input refusal at any depth; non-finite and over-long numbers both
ways; nested non-string keys, cycles and excessive depth; the inherited
and per-call timeout with validation; wallet-path encoding; distinct ids
and a mismatched id on a result and on an error reply, under both
protocol versions; 1.1 against 2.0 status and error semantics; the
structured 401 and 503; a status surviving seven kinds of non-reply body;
invalid markers and invalid error objects; the per-call limit through the
custom-transport contract; and no proxy taken from the environment.

## Not in this PR

The live smoke matrix — Core v27.2 for the 1.1 path and v31.1 for 2.0,
with integrity-pinned downloads verified against the release SHA256SUMS
and read-only job permissions — is issue #377, and the last release gate
before the client can be called production ready. Whether the client
should also be vendorable as a single standard-library-only file is issue
#378.
