### PR TITLE
A live node is what says the recorded rpc replies are Core's (#377)

### DIFF
--- a/.github/scripts/rpc_smoke.py
+++ b/.github/scripts/rpc_smoke.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""The one claim recorded replies cannot make: a live node answers this way.
+
+`tests/fetch` exercises the whole of the request building, the status
+handling and the error mapping against replies recorded from Core, and
+opens no socket doing it. What it cannot establish is that Core sends
+those replies -- the recording *is* the thing being classified -- so this
+script starts a bitcoind of a stated version, on a regtest chain it
+generates itself, and asks it every question `btclib.fetch.bitcoin_core`
+answers.
+
+What it proves, and why each item is here rather than in the suite:
+
+- the protocol version the node speaks, read off the wire. The reply to
+  a request carrying the 2.0 marker is inspected before btclib
+  classifies it, because the shapes `_legacy_result` and `_v2_result`
+  read are exactly what a recording asserts without evidence: no
+  `jsonrpc` member and an rpc error under an HTTP 500 for 1.1, the marker
+  echoed and an rpc error under a 200 for 2.0;
+- a result and an error under that version, and then the same two through
+  `call`, which is btclib's classification of what was just read raw;
+- the cookie file the node wrote, at the path Core's layout puts it, one
+  ascii line with a colon in it;
+- the `/wallet/<name>` endpoint of a node with two wallets loaded, which
+  is the case where the endpoint is load-bearing: with two of them the
+  node refuses a wallet method that names neither;
+- the three fetcher answers against a chain generated here, so the
+  expected height is arithmetic rather than a recording, and the
+  transaction fetched is one whose id btclib recomputes from the bytes.
+
+The expected protocol version is an argument and not something derived
+from the version number: what the matrix pins is the claim that v27
+answers 1.1 and the current release answers 2.0, and a node that stopped
+doing so has to fail this rather than be accommodated by it.
+
+Run it against a node of your own with `--bitcoind`; CONTRIBUTING.md
+carries the command, and `.github/workflows/rpc-smoke.yml` the download
+that verifies which binary it is.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import closing, contextmanager
+from decimal import Decimal
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+
+from btclib import b32
+from btclib.exceptions import FetchError, HttpError, RpcError
+from btclib.fetch.bitcoin_core import (
+    COOKIE_USER,
+    BitcoinCoreFetcher,
+    BitcoinCoreRpcClient,
+    cookie_auth,
+)
+from btclib.fetch.transport import http_request
+
+# regtest, and the node is started with no -rpcport so that the port is
+# Core's own default for the chain rather than one this script chose:
+# `from_network` builds that number from Core's table, and a live node is
+# what says the two still agree
+NETWORK = "regtest"
+RPC_PORT = 18443
+
+# the subdirectory Core puts a regtest datadir in, which is where the
+# cookie is written. Spelled out rather than imported from the private
+# table in btclib.fetch.bitcoin_core: what is being checked is that btclib's
+# copy of Core's layout is Core's layout, and a check reading the value
+# under test proves nothing
+DATADIR_SUBDIR = "regtest"
+
+# 100 blocks of coinbase maturity plus the one that is spendable after
+# them: the height at which exactly one subsidy has matured, so the
+# wallet balance below is one subsidy exactly. Regtest halves every 150
+# blocks, so that subsidy is the full 50 BTC
+MATURITY_HEIGHT = 101
+SUBSIDY = Decimal(50)
+
+# a space and a plus, and both on purpose: a wallet is a directory and may
+# be called anything a filesystem accepts, so the endpoint has to
+# percent-encode the name. A space written into a url unencoded is a
+# malformed request line, and a plus is a space to anything reading the
+# path as a query string -- `for_wallet` is what this checks, and the two
+# characters are what would make it address a different endpoint or none
+WALLET = "btclib smoke+wallet"
+# the second one exists so that the first one has to be named: a node with
+# a single wallet loaded answers a wallet method on the bare endpoint too,
+# which would make the endpoint check pass without the endpoint
+OTHER_WALLET = "btclib-other"
+
+# the generator point as a compressed public key, i.e. the public key of
+# the private key 1: the one key in bitcoin published everywhere and
+# owned by nobody. What it is for is an address no wallet of this node
+# knows, so that the coinbase paid to it is a transaction only -txindex
+# can answer for -- and, incidentally, btclib's own address encoding put
+# in front of Core's parser
+FOREIGN_PUB_KEY = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+# what the fee estimator cannot supply on a chain with no fee history:
+# without it `sendtoaddress` fails rather than sending, and the
+# transaction to fetch is the whole point of sending one
+FALLBACK_FEE = "0.0002"
+
+# how long the node is given to open its rpc port, and how often it is
+# asked. bitcoind loads the block index before it answers, which on a
+# fresh regtest datadir is immediate and on a loaded runner is not
+STARTUP_TIMEOUT = 120.0
+STARTUP_POLL = 0.25
+
+# the id every raw probe below sends, and what the node has to echo. Fixed
+# rather than random, unlike `call`'s: there is one probe in flight at a
+# time here, and a constant is what makes the echo check readable
+PROBE_ID = "btclib-smoke-probe"
+
+# what is printed of the node's own log when a check fails: enough to
+# carry a refused bind or a wallet error, not the whole of a debug.log
+LOG_TAIL_LINES = 40
+
+
+class SmokeError(RuntimeError):
+    """A live node did not answer the way the recorded replies say it does."""
+
+
+def check(condition: bool, claim: str) -> None:
+    """Report a claim the node has just confirmed, or fail on it.
+
+    The claim is what is printed on success and what the exception names on
+    failure, so it is worded as the thing being asserted: the log of a
+    green run is the list of what a live node was actually asked.
+    """
+    if not condition:
+        raise SmokeError(f"a live node contradicts this: {claim}")
+    print(f"ok   {claim}")
+
+
+def port_is_free(port: int) -> bool:
+    """Say whether anything is listening on the loopback port."""
+    with closing(socket.socket()) as probe:
+        return probe.connect_ex(("127.0.0.1", port)) != 0
+
+
+@contextmanager
+def node(bitcoind: Path, datadir: Path) -> Iterator[BitcoinCoreRpcClient]:
+    """Run a regtest bitcoind on Core's own rpc port, and stop it after.
+
+    No `-rpcport` and no `-rpcuser`: the port, the datadir layout and the
+    cookie are the node's defaults, which is what makes `from_network` and
+    `cookie_auth` checkable at all. `-txindex` so `getrawtransaction`
+    answers for a transaction no wallet of this node knows, and `-listen=0`
+    because a smoke test has no peers.
+    """
+    if not port_is_free(RPC_PORT):
+        err_msg = f"something is already listening on {NETWORK} rpc port {RPC_PORT}:"
+        err_msg += " this script talks to Core's default port on purpose, so stop it"
+        raise SmokeError(err_msg)
+    command = [
+        str(bitcoind),
+        f"-{NETWORK}",
+        f"-datadir={datadir}",
+        "-txindex",
+        "-listen=0",
+        f"-fallbackfee={FALLBACK_FEE}",
+        # the node's own log stays in its datadir, where `print_log_tail`
+        # reads it when a check fails: on the console it interleaves with
+        # the checks, and what a green run is worth reading for is the
+        # checks
+        "-printtoconsole=0",
+    ]
+    # the client before the node, so that the `finally` below always has
+    # one to stop it with: the cookie is read at every call, so a client
+    # built before the file exists is a client that works once it does
+    client = BitcoinCoreRpcClient.from_network(
+        NETWORK, cookie_path=datadir / DATADIR_SUBDIR / ".cookie"
+    )
+    # S603: the executable is a path this script was handed, and every
+    # other word of the command line is a constant above; no shell is
+    # involved, so nothing here is parsed as anything but arguments
+    process = subprocess.Popen(command)  # noqa: S603
+    try:
+        wait_for_rpc(client, process)
+        yield client
+    finally:
+        stop(client, process)
+
+
+def wait_for_rpc(
+    client: BitcoinCoreRpcClient, process: subprocess.Popen[bytes]
+) -> None:
+    """Wait until the node answers, or say what it did instead.
+
+    Both failures on the way are the node not being up yet: no cookie file
+    and a refused connection arrive as `FetchError`, and the rpc error -28
+    is what it answers while it loads the block index. A node that exited
+    is not waited for -- its own output on the console says why.
+    """
+    deadline = time.monotonic() + STARTUP_TIMEOUT
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            err_msg = f"bitcoind exited with {process.returncode} before answering"
+            raise SmokeError(err_msg)
+        try:
+            client.call("getblockchaininfo")
+        except (FetchError, RpcError):
+            time.sleep(STARTUP_POLL)
+        else:
+            return
+    raise SmokeError(f"no rpc answer in {STARTUP_TIMEOUT} s")
+
+
+def stop(client: BitcoinCoreRpcClient, process: subprocess.Popen[bytes]) -> None:
+    """Ask the node to stop, and make sure it did.
+
+    Through the rpc, which is how a node is stopped without losing what it
+    has not flushed. A node that does not go down on its own is killed:
+    this runs in a `finally`, so the failure being reported is the one
+    worth keeping.
+    """
+    try:
+        client.call("stop")
+        process.wait(timeout=STARTUP_TIMEOUT)
+    except (FetchError, RpcError, subprocess.TimeoutExpired):
+        process.kill()
+        process.wait()
+
+
+def probe(
+    client: BitcoinCoreRpcClient, method: str, params: Sequence[Any]
+) -> tuple[int, Mapping[str, Any]]:
+    """Return the status and the json of a reply, before btclib reads it.
+
+    The same request `call` builds, the 2.0 marker included, sent through
+    the same transport -- and then neither classified nor validated, which
+    is the point: what the checks below read is the shape of the reply
+    itself, which is the thing every recorded fixture asserts.
+    """
+    body = json.dumps(
+        {"jsonrpc": "2.0", "id": PROBE_ID, "method": method, "params": list(params)}
+    ).encode()
+    status, payload = http_request(
+        client.url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": client.auth_header(),
+        },
+    )
+    reply = json.loads(payload)
+    check(reply.get("id") == PROBE_ID, "the node echoes the id the request carried")
+    return status, reply
+
+
+def check_legacy_reply(
+    status: int, reply: Mapping[str, Any], *, rpc_error: bool
+) -> None:
+    """Check a reply against Core's 1.1, the shape `_legacy_result` reads.
+
+    Two claims, and the second is the one that costs: the reply carries no
+    version marker at all, and an rpc error arrives as the body of an HTTP
+    500 -- so a routine "no such transaction" and a server fault have the
+    same status, and the error has to be read before the status is judged.
+    Both members are always present, one of them null, which is why the 2.0
+    rule of exactly one of them cannot be applied to a 1.1 reply.
+    """
+    check("jsonrpc" not in reply, "a 1.1 reply carries no jsonrpc member")
+    both = "result" in reply and "error" in reply
+    check(both, "a 1.1 reply carries both result and error, one of them null")
+    if rpc_error:
+        check(status == 500, "an rpc error under 1.1 arrives with an HTTP 500")
+        check(reply["result"] is None, "the 1.1 error reply has a null result")
+        check(reply["error"] is not None, "the 1.1 error reply has the error object")
+    else:
+        check(status == 200, "a result under 1.1 arrives with an HTTP 200")
+        check(reply["error"] is None, "the 1.1 result reply has a null error")
+
+
+def check_v2_reply(status: int, reply: Mapping[str, Any], *, rpc_error: bool) -> None:
+    """Check a reply against JSON-RPC 2.0, as `_v2_result` reads it.
+
+    The marker echoed, an HTTP 200 whatever the outcome -- which is what
+    lets a non-200 mean the exchange itself failed -- and exactly one of
+    `result` and `error` present rather than both with one null. That last
+    one is what tells a 2.0 reply from a 1.1 reply wearing the marker.
+    """
+    check(reply.get("jsonrpc") == "2.0", "a 2.0 reply echoes the 2.0 marker")
+    check(status == 200, "a 2.0 reply arrives with an HTTP 200, error or not")
+    if rpc_error:
+        check("error" in reply, "the 2.0 error reply has an error member")
+        check("result" not in reply, "the 2.0 error reply has no result member")
+    else:
+        check("result" in reply, "the 2.0 result reply has a result member")
+        check("error" not in reply, "the 2.0 result reply has no error member")
+
+
+def check_protocol(
+    client: BitcoinCoreRpcClient, protocol: str, unknown_tx_id: str
+) -> None:
+    """Read the two reply shapes off the wire, and then through `call`.
+
+    A result and an error under the version the node speaks: the minimum,
+    because the error path is where the two versions disagree and the one a
+    recording can least be trusted about. The `call` half is btclib
+    classifying the very replies just read.
+    """
+    check_reply = check_legacy_reply if protocol == "1.1" else check_v2_reply
+    status, reply = probe(client, "getblockcount", [])
+    check_reply(status, reply, rpc_error=False)
+    status, reply = probe(client, "getrawtransaction", [unknown_tx_id])
+    check_reply(status, reply, rpc_error=True)
+
+    height = client.call("getblockcount")
+    check(isinstance(height, int), f"call returns the result: a height of {height}")
+    try:
+        client.call("getrawtransaction", [unknown_tx_id])
+    except RpcError as e:
+        # -5 is RPC_INVALID_ADDRESS_OR_KEY, which is what Core answers for
+        # a transaction it cannot find, on both sides of the version
+        # boundary and whichever layer carried it
+        check(
+            e.code == -5, "call raises RpcError -5 for a transaction the node has not"
+        )
+    else:
+        raise SmokeError("an unknown transaction id was not an error")
+
+
+def check_cookie(cookie_path: Path) -> None:
+    """Check the credential in the file the node wrote.
+
+    At Core's own path for the chain, which is the other half of what
+    `from_network` computes. The first field is documentation -- the node
+    compares the whole line -- so what is checked about it is that it is
+    still what Core writes, a cookie whose first field is something else
+    being a valid one.
+    """
+    check(cookie_path.is_file(), f"the node wrote its cookie at {cookie_path}")
+    credential = cookie_auth(cookie_path)
+    user, _, password = credential.partition(":")
+    check(user == COOKIE_USER, f"the cookie names {COOKIE_USER} as the user")
+    check(bool(password), "the cookie carries a password after the colon")
+
+
+def check_credentials_refused(client: BitcoinCoreRpcClient) -> None:
+    """Check that a wrong credential is an HTTP failure with its status.
+
+    Which is what `HttpError.status` is for: a 401 is the node refusing
+    the credential and it will refuse it again, where a 503 from a full
+    work queue would not. Core answers a 401 with an empty body, so this
+    is also the live case for a status that arrives with nothing a parser
+    can read.
+    """
+    wrong = BitcoinCoreRpcClient(
+        client.url,
+        user="btclib",
+        # S106 and detect-secrets: a credential that is deliberately not
+        # the node's, which is the whole of what this checks
+        password="not the cookie",  # noqa: S106  # pragma: allowlist secret
+    )
+    try:
+        wrong.call("getblockcount")
+    except HttpError as e:
+        check(e.status == 401, "a wrong credential is an HttpError carrying a 401")
+    else:
+        raise SmokeError("the node accepted a credential that is not its cookie")
+
+
+def check_wallet_endpoint(client: BitcoinCoreRpcClient) -> None:
+    """Check `/wallet/<name>` against a node with two wallets loaded.
+
+    Two, because that is the case where the endpoint is load-bearing: a
+    node with one wallet loaded answers a wallet method on the bare
+    endpoint, so a single-wallet check would pass with no endpoint at all.
+    With two, the bare endpoint is an rpc error and each derived client
+    reaches the wallet it names -- through a name whose space and plus have
+    to survive the url.
+    """
+    try:
+        client.call("getwalletinfo")
+    except RpcError as e:
+        # -19 is RPC_WALLET_NOT_SPECIFIED, i.e. the node saying the request
+        # named no wallet and it will not choose one
+        check(e.code == -19, "a wallet method on the bare endpoint is an rpc error")
+    else:
+        raise SmokeError("a node with two wallets answered a wallet method unasked")
+    for name in (WALLET, OTHER_WALLET):
+        info = client.for_wallet(name).call("getwalletinfo")
+        check(info["walletname"] == name, f"the endpoint of the wallet named {name!r}")
+
+
+def check_named_params(client: BitcoinCoreRpcClient) -> None:
+    """Check both parameter structures Core accepts, against one method.
+
+    An array read positionally and an object read by name, plus Core's
+    `args` convention -- an object carrying the leading positional values
+    under one key. All three name the genesis block here, which is the one
+    hash a regtest chain has before anything is generated.
+    """
+    genesis = client.call("getblockhash", [0])
+    check(len(genesis) == 64, f"positional params: block 0 is {genesis}")
+    check(client.call("getblockhash", {"height": 0}) == genesis, "named params")
+    check(
+        client.call("getblockhash", {"args": [0]}) == genesis, "Core's args convention"
+    )
+
+
+def check_amount_is_decimal(wallet: BitcoinCoreRpcClient) -> None:
+    """Check that an amount arrives as a Decimal and is exact.
+
+    The reply is parsed with `parse_float=Decimal`, so a bitcoin amount
+    never transits binary floating point. One matured subsidy on a chain
+    generated here is an exact number, which is what makes the equality
+    below a check rather than a comparison with a tolerance.
+    """
+    balance = wallet.call("getbalance")
+    check(isinstance(balance, Decimal), f"an amount decodes as a Decimal: {balance!r}")
+    check(balance == SUBSIDY, f"the matured subsidy is exactly {SUBSIDY}")
+
+
+def generate_chain(client: BitcoinCoreRpcClient) -> tuple[int, str, str]:
+    """Generate the chain the fetcher answers are then checked against.
+
+    Returns the height it left, the id of a wallet transaction and the id
+    of a coinbase paid outside both wallets. The height is arithmetic and
+    not a reading: `MATURITY_HEIGHT` blocks to the wallet, one to the
+    foreign address, and one confirming the transaction sent in between.
+
+    The wallet is created here rather than by the workflow, so that the
+    whole of what a check needs is in one place, and so that a local run
+    against a bitcoind of one's own leaves nothing behind but the temporary
+    datadir.
+    """
+    for name in (WALLET, OTHER_WALLET):
+        client.call("createwallet", [name])
+    wallet = client.for_wallet(WALLET)
+    mine_to = wallet.call("getnewaddress")
+    client.call("generatetoaddress", [MATURITY_HEIGHT, mine_to])
+    check_amount_is_decimal(wallet)
+
+    # a coinbase neither wallet has any key for, which is the transaction
+    # that could only be answered from the index
+    foreign = b32.p2wpkh(FOREIGN_PUB_KEY, NETWORK)
+    block_id = client.call("generatetoaddress", [1, foreign])[0]
+    foreign_coinbase = client.call("getblock", [block_id, 1])["tx"][0]
+
+    # the amount goes out as a string, which Core reads as an amount and
+    # json carries exactly: `call` refuses a Decimal rather than rounding
+    # it through float, and a float is the thing being avoided
+    tx_id = wallet.call("sendtoaddress", [mine_to, "1.25"])
+    client.call("generatetoaddress", [1, foreign])
+    return MATURITY_HEIGHT + 2, tx_id, foreign_coinbase
+
+
+def check_fetcher(
+    client: BitcoinCoreRpcClient, height: int, tx_id: str, foreign_coinbase: str
+) -> None:
+    """Check the three fetcher answers against the generated chain.
+
+    The height is what was generated, so the expected value is arithmetic;
+    the tip hash is cross-checked against `getblockhash` at that height,
+    which is a second method answering the same question. Both transactions
+    come back as a serialization whose id btclib recomputes -- `get_tx`
+    raising is what a wrong one looks like -- and the second of them is a
+    coinbase no wallet knows, so `-txindex` is what answered it.
+    """
+    fetcher = BitcoinCoreFetcher(client, NETWORK)
+    check(
+        fetcher.get_block_count() == height, f"the tip of the generated chain: {height}"
+    )
+    tip = fetcher.get_best_block_id().hex()
+    check(tip == client.call("getblockhash", [height]), f"the tip hash: {tip}")
+    tx = fetcher.get_tx(tx_id)
+    check(tx.id.hex() == tx_id, f"a wallet transaction, its id recomputed: {tx_id}")
+    coinbase = fetcher.get_tx(foreign_coinbase)
+    check(
+        coinbase.vin[0].prev_out.is_coinbase(),
+        f"a coinbase only -txindex can answer for: {foreign_coinbase}",
+    )
+
+
+def check_version(client: BitcoinCoreRpcClient, core_version: str) -> None:
+    """Check that the node is the version this run is about.
+
+    What it catches is a download, an unpack or a `--bitcoind` naming
+    something other than what the caller thinks: every claim below is a
+    claim about a version, so the version is checked before them.
+    """
+    subversion = client.call("getnetworkinfo")["subversion"]
+    expected = f"/Satoshi:{core_version}."
+    check(subversion.startswith(expected), f"the node is Core {core_version}")
+
+
+def smoke(bitcoind: Path, datadir: Path, core_version: str, protocol: str) -> None:
+    """Ask a node of a stated version every question the client answers."""
+    with node(bitcoind, datadir) as client:
+        check_version(client, core_version)
+        check_cookie(datadir / DATADIR_SUBDIR / ".cookie")
+        check_credentials_refused(client)
+        check_named_params(client)
+        height, tx_id, foreign_coinbase = generate_chain(client)
+        # after the chain, so that the unknown transaction id is unknown to
+        # a node with an index and blocks in it: the id is the tip hash,
+        # which is a valid 32-byte id and no transaction of any chain
+        unknown_tx_id = client.call("getbestblockhash")
+        check_protocol(client, protocol, unknown_tx_id)
+        check_wallet_endpoint(client)
+        check_fetcher(client, height, tx_id, foreign_coinbase)
+
+
+def print_log_tail(datadir: Path) -> None:
+    """Print the end of the node's own log, a failure being about the node."""
+    log = datadir / DATADIR_SUBDIR / "debug.log"
+    if not log.is_file():
+        return
+    print(f"\nthe last {LOG_TAIL_LINES} lines of {log}:", file=sys.stderr)
+    lines = log.read_text(encoding="utf-8", errors="replace").splitlines()
+    for line in lines[-LOG_TAIL_LINES:]:
+        print(line, file=sys.stderr)
+
+
+def main() -> int:
+    """Run the checks against one node, and say which version answered."""
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--bitcoind", type=Path, required=True, help="the bitcoind to run"
+    )
+    parser.add_argument(
+        "--core-version", required=True, help="the version it has to report, e.g. 27.2"
+    )
+    parser.add_argument(
+        "--protocol",
+        required=True,
+        choices=("1.1", "2.0"),
+        help="the json-rpc version that node answers",
+    )
+    args = parser.parse_args()
+    with TemporaryDirectory(prefix="btclib-rpc-smoke-") as tmp:
+        datadir = Path(tmp)
+        try:
+            smoke(args.bitcoind, datadir, args.core_version, args.protocol)
+        except Exception:
+            print_log_tail(datadir)
+            raise
+    print(
+        f"\nCore {args.core_version} answered every check,"
+        f" over json-rpc {args.protocol}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/rpc-smoke.yml
+++ b/.github/workflows/rpc-smoke.yml
@@ -1,0 +1,166 @@
+---
+name: rpc-smoke
+
+# The one claim tests/fetch cannot make. Every reply under
+# tests/fetch/_data is Core's own and the suite classifies all of them
+# without opening a socket, which is the right shape for a test suite --
+# but a recording is the thing being classified, so nothing in it says
+# that a live bitcoind still answers this way. This workflow asks two of
+# them, and .github/scripts/rpc_smoke.py is the whole of what it asks:
+# the reply shapes read off the wire before btclib reads them, the cookie
+# the node wrote, the /wallet/<name> endpoint of a node with two wallets,
+# and the three fetcher answers against a regtest chain the script
+# generates, so the expected height is arithmetic rather than a recording.
+#
+# It gates a release rather than a commit, and issue #370 adopted it as
+# the last gate before the rpc client is described as production ready:
+# RELEASING.md dispatches it, and CONTRIBUTING.md carries the local
+# command.
+#
+# A workflow of its own and not a job in test.yml, whose matrix is
+# interpreters: this one is bitcoind versions, and two nodes plus two
+# downloads is minutes where that workflow is seconds. It therefore does
+# not appear in master's required checks, and must not -- that rule lives
+# outside the repository and names its checks as literal strings.
+
+on:
+  # the way a release asks for the answer, which is when the answer is
+  # wanted: hanging two node downloads off every commit would make every
+  # commit wait for them, which is the reason mutation.yml gives for the
+  # same choice
+  workflow_dispatch:
+  # so that a change to this file, or to the script it runs, is checked by
+  # the thing it configures -- as links.yml does for its own
+  # configuration. Not a path under btclib/fetch/: a change to the client
+  # is gated by the recorded suite, and re-validated against live nodes by
+  # the dispatch before a release
+  pull_request:
+    paths:
+      - .github/workflows/rpc-smoke.yml
+      - .github/scripts/rpc_smoke.py
+
+# least privilege for the GITHUB_TOKEN, and here it is also the point: a
+# job that exists to establish a security property files nothing and
+# publishes nothing, so read is the whole of what it needs. In particular
+# the download below is verified rather than trusted, which is the other
+# half of the same argument
+permissions:
+  contents: read
+
+# cancel superseded runs. Named literally rather than through
+# github.workflow, as everywhere else here: in a called workflow that
+# expression is the caller's name
+concurrency:
+  group: rpc-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  rpc-smoke:
+    name: Smoke the rpc client against Core ${{ matrix.core }}
+    runs-on: ubuntu-latest
+    # a download, a node and a hundred blocks of regtest, all of it local:
+    # a run past this is a node that never opened its rpc port
+    timeout-minutes: 20
+    strategy:
+      # both cells always run: which versions answer which protocol is the
+      # question, so the answer for one of them is not a reason to stop
+      # asking about the other
+      fail-fast: false
+      matrix:
+        # x86_64 linux only, that being the architecture the digests below
+        # are of. What the matrix buys here is bitcoind versions, and a
+        # second architecture would buy the same two protocols again.
+        #
+        # The rule for moving these pins, which is why it is written beside
+        # them: the older is the final release of the newest line that
+        # predates the 2.0 marker, and the newer is whatever is current.
+        #
+        # 27.2 is deliberately end of life. It is the last major that does
+        # not recognize the "jsonrpc": "2.0" marker at all, so what it pins
+        # is the compatibility boundary -- that a client sending the marker
+        # to a node which has never heard of it still reads the 1.1 reply
+        # that comes back, an rpc error under an HTTP 500 included. Nothing
+        # else in Core's supported range can demonstrate that, and this pin
+        # does not move again unless Core changes what v27 was.
+        #
+        # The digest is the SHA256SUMS entry of the release directory,
+        # written here rather than fetched beside the file it describes: a
+        # checksum file served by the host that served the archive is one
+        # host's statement about itself. SHA256SUMS.asc is the stronger
+        # link and is not taken -- it would make this job hold the builder
+        # keys and decide how many signatures are enough, which is a policy
+        # this repository has nowhere to state
+        include:
+          - core: "27.2"
+            protocol: "1.1"
+            digest: acc223af46c178064c132b235392476f66d486453ddbd6bca6f1f8411547da78
+          - core: "31.1"
+            protocol: "2.0"
+            digest: b80d9c3e04da78fb6f0569685673418cf686fadba9042d926d13fb87ff503f9e
+    steps:
+      # every action is pinned to a commit SHA, the tag in the comment: a
+      # tag, let alone a branch, is a name its owner can move
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # see the checkout of the test-py job in test.yml
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          # the bindings are compiled from source, from the git revision
+          # uv.lock pins: the cache is the difference between a couple of
+          # minutes and a couple of seconds
+          enable-cache: true
+      # the matrix values reach the shell as environment variables rather
+      # than as expressions interpolated into it, which is the convention
+      # zizmor enforces and the one that keeps a shell script readable as
+      # a shell script
+      - name: Download bitcoind and verify the archive
+        env:
+          CORE: ${{ matrix.core }}
+          DIGEST: ${{ matrix.digest }}
+        run: |
+          archive="bitcoin-${CORE}-x86_64-linux-gnu.tar.gz"
+          # an immutable versioned artifact, never a "latest" url, and no
+          # --location: the release url is https and direct, so a redirect
+          # is a change in what is being served rather than a hop to
+          # follow. The digest below would catch it either way; failing
+          # here says which of the two happened
+          curl --fail --silent --show-error --proto '=https' --tlsv1.2 \
+            --output "${archive}" \
+            "https://bitcoincore.org/bin/bitcoin-core-${CORE}/${archive}"
+          # fail closed, before the archive is unpacked and long before
+          # anything in it is executed
+          printf '%s  %s\n' "${DIGEST}" "${archive}" | sha256sum --check --strict -
+          # and the negative control, which is what says the check above is
+          # load-bearing rather than decorative: the same comparison
+          # against a digest that is not the file's has to fail. Every hex
+          # digit rotated, so the tampered digest is a well-formed one that
+          # no file is
+          tampered="$(printf '%s' "${DIGEST}" | tr '0123456789abcdef' '123456789abcdef0')"
+          if printf '%s  %s\n' "${tampered}" "${archive}" \
+              | sha256sum --check --status --strict -; then
+            echo "::error::sha256sum accepted a digest that is not the archive's"
+            exit 1
+          fi
+          # the daemon is the only member extracted; the other archive
+          # members are never unpacked or run. The archive itself is on
+          # disk, curl having written it, and verified before this line.
+          # tar fails the step if the member is not there, which is what a
+          # release changing its layout looks like from here
+          tar --extract --gzip --file "${archive}" "bitcoin-${CORE}/bin/bitcoind"
+      # --no-default-groups: the script imports btclib and starts a node,
+      # so what it needs installed is the project and its one dependency.
+      # --locked, as everywhere else, so the bindings are the revision
+      # uv.lock pins
+      - name: Smoke the rpc client against the node
+        env:
+          CORE: ${{ matrix.core }}
+          PROTOCOL: ${{ matrix.protocol }}
+        run: >
+          uv run --locked --no-default-groups
+          python .github/scripts/rpc_smoke.py
+          --bitcoind "bitcoin-${CORE}/bin/bitcoind"
+          --core-version "${CORE}"
+          --protocol "${PROTOCOL}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -356,14 +356,19 @@ repos:
   # leaves mypy type checking a stale environment and saying nothing about
   # it. The uv-lock hook below catches the stale lock in the same run, but
   # only after this one has already produced a verdict on the wrong
-  # environment, and the lint workflow runs this file, so CI inherits that
+  # environment, and the lint workflow runs this file, so CI inherits that.
+  # .github/scripts is in the scope because what lives there imports btclib
+  # and no test collects it: the smoke script needs a node, so a workflow
+  # dispatch is the only thing that runs it, and strict mode is the whole of
+  # what reads it in between. A bound method used as a truth value is what
+  # that buys -- in a script of checks, a check that cannot fail
   - repo: local
     hooks:
       - id: mypy
         name: mypy (strict, in the project environment)
         entry: >
           uv run --locked --no-default-groups --group lint --group test
-          mypy btclib tests
+          mypy btclib tests .github/scripts
         language: system
         types: [python]
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4553,6 +4553,43 @@ edit.
   noise. It is not a gate and is not among master's required checks: a
   mutant survives because a test is missing, so a red merge would stop
   whoever next touched the file for a hole somebody else left
+- an `rpc-smoke` workflow asks live bitcoinds what the recorded replies
+  under `tests/fetch/_data` claim, on demand and before a release (issue
+  #377). The suite classifies every one of those replies without opening a
+  socket, which is the right shape for it and leaves exactly one claim with
+  nothing behind it: the recording is the thing being classified.
+  `.github/scripts/rpc_smoke.py` is what the workflow runs — a node in a
+  temporary datadir on Core's own regtest rpc port, the reply shapes read
+  off the wire before btclib classifies them, and then the same result and
+  the same error through `call`. Two pins, with the rule for moving them
+  beside them: v27.2, end of life upstream and the final release of the
+  last major that does not recognize the `"jsonrpc": "2.0"` marker at all,
+  and v31.1, whatever is current. The first is the compatibility boundary —
+  a client sending the marker to a node that has never heard of it reads
+  back a 1.1 reply, an rpc error under an HTTP 500 included — and no
+  supported release can demonstrate that, v28 and later all knowing the
+  marker. The rest is what only a node can answer: the cookie file it
+  wrote, one ascii line at the path Core's layout puts it; a wrong
+  credential as a 401 with an empty body; the `/wallet/<name>` endpoint of
+  a node with *two* wallets loaded, one named with a space and a plus in
+  it, two being the case where the endpoint is load-bearing; an amount as
+  an exact `Decimal`; and the three fetcher answers against a chain the
+  script generates, so the expected height is arithmetic rather than a
+  recording, with a coinbase paid outside both wallets that only
+  `-txindex` can answer for. The download is verified rather than trusted:
+  an immutable versioned url and never a `latest` one,
+  the release SHA256SUMS digest written into the workflow instead of
+  fetched beside the file it describes, checked before the archive is
+  unpacked — and the same comparison against a rotated digest required to
+  fail in the same step, a verification nothing tests being decorative. A
+  workflow of its own and not a job in test.yml, whose matrix is
+  interpreters where this one is node versions, and it gates no commit:
+  RELEASING.md dispatches it, and CONTRIBUTING.md carries the command for
+  a bitcoind of one's own
+- mypy's scope grew by `.github/scripts`, where that script lives: no test
+  collects it, so a workflow dispatch would otherwise be the first thing to
+  read it — and in a script of checks, a bound method used as a truth value
+  is a check that cannot fail
 - a scheduled workflow runs the test suite against the *published*
   btclib_libsecp256k1, resolved from PyPI by the declared pin, where every
   other job follows tool.uv.sources to the bindings under development: what

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -163,7 +163,7 @@ These requirements are easily checked (and partially fixed) with:
 ```shell
 uv run ruff check --fix
 uv run ruff format
-uv run mypy btclib tests
+uv run mypy btclib tests .github/scripts
 uv run pytest
 ```
 
@@ -347,6 +347,45 @@ a `git status` in the middle is a working tree with a mutant in it.
 interrupting one costs only the mutant it was on. And the `.sqlite`
 sessions are the artifact the workflow uploads: `cr-report`, `cr-html` and
 `cr-rate` all read one, and a downloaded one can be finished locally.
+
+The `rpc-smoke` workflow, on demand and before a release, and the one job
+here that needs something uv cannot fetch: a bitcoind. It is what stands
+behind the recorded replies under `tests/fetch/_data` — the reply shapes of
+both protocol versions read off the wire, the cookie the node wrote, the
+`/wallet/<name>` endpoint, and the three fetcher answers against a regtest
+chain it generates. Two versions, and `rpc-smoke.yml` states the rule for
+moving the pins: the last v27 release for the JSON-RPC 1.1 path, whatever
+is current for 2.0.
+
+The node comes from the release directory of its version, verified against
+the digest that workflow carries — never a `latest` url, and verified
+before the archive is unpacked. `sha256sum` is coreutils, so on macOS the
+command is `shasum -a 256`:
+
+```shell
+core=27.2
+archive="bitcoin-$core-x86_64-linux-gnu.tar.gz"
+curl --fail --proto '=https' --tlsv1.2 --output "$archive" \
+    "https://bitcoincore.org/bin/bitcoin-core-$core/$archive"
+printf '%s  %s\n' "<the digest in rpc-smoke.yml>" "$archive" \
+    | sha256sum --check --strict -
+tar --extract --gzip --file "$archive" "bitcoin-$core/bin/bitcoind"
+```
+
+Then the command the workflow runs, verbatim, for that half of the matrix:
+
+```shell
+uv run --locked --no-default-groups python .github/scripts/rpc_smoke.py \
+    --bitcoind bitcoin-27.2/bin/bitcoind --core-version 27.2 --protocol 1.1
+```
+
+A bitcoind already on the machine does as well, `--core-version` being
+what says which one it has to be. The script starts it itself, in a
+temporary datadir, with no `-rpcport`: the port, the datadir layout and the
+cookie are then the node's own defaults, which is what makes them
+something to check rather than something to configure — and why it refuses
+to run while anything else is listening on regtest's rpc port. Both cells
+of the matrix are two runs of that command, with `31.1` and `2.0`.
 
 The documentation, which the `Build the documentation` job of `lint.yml`
 runs with this same command, as read the docs does. `-W` is what makes an

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -126,6 +126,18 @@ pyroma), build, wheel smoke test — and publishes to
    [documentation](https://btclib.readthedocs.io/en/latest/) render
    correctly.
 
+1. Dispatch the `rpc-smoke` workflow (Actions → rpc-smoke → Run workflow)
+   and see both cells green. It is the one job here that talks to a live
+   bitcoind: everything about the rpc client of `btclib.fetch` is otherwise
+   tested against recorded replies, which cannot say that Core still sends
+   them — so this asks the legacy compatibility boundary and current Core,
+   the last v27 release for the JSON-RPC 1.1 path and v31.1 for 2.0. That
+   first one is end of life upstream, which is what makes it the boundary:
+   it is the last major that does not know the 2.0 marker. Red here is a
+   release that must not describe that client as production ready.
+   CONTRIBUTING.md has the same command for a node of your own, and
+   `.github/workflows/rpc-smoke.yml` the rule for moving the two pins.
+
 1. Rehearse on TestPyPI (see above) from master.
 
 1. Tag the release commit and push the tag:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -571,6 +571,12 @@ ignore = [
 # prints are the interface, not a debugging leftover -- unlike a print
 # anywhere else in the library, which is deleted rather than ignored
 "btclib/mnemonic/entropy.py" = ["T201"]
+# the smoke script's output is the whole of what it produces: it runs a
+# bitcoind and prints, one line each, the claim every check confirmed, so
+# the log of a green run is the list of what a live node was actually
+# asked. T20 is selected for the library, which writes to no stream of its
+# own; a script whose caller is a workflow step is the case it is not about
+".github/scripts/rpc_smoke.py" = ["T201"]
 # the D rules are not here: a public test function, fixture or method
 # states what it verifies -- the property, the vector, the failure
 # mode -- under the same docstring gate as the library's public


### PR DESCRIPTION
Issue #377, the third step of #370's order and the last gate before the
rpc client can be described as production ready. #372 having landed, this
targets `dev` and its one commit is replayed onto it: the diff is the seven
files below and nothing of that pull request's.

`tests/fetch` classifies every reply under `tests/fetch/_data` and opens
no socket, which is the right shape for the suite — and leaves exactly one
claim with nothing behind it, the recording being the thing being
classified. This asks two live nodes instead.

## What it asks

`.github/scripts/rpc_smoke.py` starts a bitcoind in a temporary datadir
with **no `-rpcport`**, so the port, the datadir layout and the cookie are
Core's own defaults rather than something the script configured — which is
what makes `from_network` and `cookie_auth` checkable at all — and then:

- **the reply shapes read off the wire**, before btclib classifies them, a
  result and an error under each version. 1.1: no `jsonrpc` member, both
  members present with one null, the rpc error as the body of an HTTP 500.
  2.0: the marker echoed, an HTTP 200 either way, exactly one of `result`
  and `error` present. Those are the shapes `_legacy_result` and
  `_v2_result` read;
- **the same two through `call`**, i.e. btclib classifying the very replies
  just read raw;
- the cookie the node wrote, one ascii line naming `__cookie__`, and a
  wrong credential as an `HttpError` carrying a 401 with an empty body;
- the `/wallet/<name>` endpoint of a node with **two** wallets loaded, one
  named `btclib smoke+wallet`: with two of them the bare endpoint is an rpc
  error, which is what makes the endpoint load-bearing rather than
  incidental — a single-wallet check passes with no endpoint at all;
- both parameter structures Core takes and its `args` convention, and an
  amount arriving as an exact `Decimal`;
- **the three fetcher answers against a chain the script generates**: the
  height is arithmetic, the tip hash is cross-checked against
  `getblockhash`, and one of the two transactions fetched is a coinbase
  paid to an address outside both wallets, which only `-txindex` can answer
  for. That address is `b32.p2wpkh` of the generator point, so btclib's own
  encoder meets Core's parser on the way.

The expected protocol version is an argument, not something derived from
the version number: what the matrix pins is the claim that v27 answers 1.1
and the current release answers 2.0, so a node that stopped doing so fails
this rather than being accommodated by it.

## The pins and the download

v27.2, the final release of the last major that does not recognize the
marker at all, and v31.1, whatever is current. The rule for moving them is
written beside them, and the first does not move again unless Core changes
what v27 was.

The download is verified rather than trusted, this being the one job whose
purpose is a security property: an immutable versioned url and never a
`latest` one; the release `SHA256SUMS` digest written into the workflow
instead of taken from what the host serves beside the file it describes;
and the check before the archive is unpacked, let alone anything in it
executed. `bin/bitcoind` is the only member extracted, the other members
never being unpacked or run — the archive itself is on disk, curl having
written it, and verified before tar reads it. `SHA256SUMS.asc` is the
stronger link and is not
taken — it would make this job hold the builder keys and decide how many
signatures are enough, which is a policy this repository has nowhere to
state.

The same comparison against a **rotated digest has to fail in the same
step**: a verification nothing tests is decoration, and this is the half
of the definition of done that says the check is load-bearing. It runs on
every run rather than being a one-off experiment.

## Three decisions worth reviewing

1. **A `pull_request` trigger, restricted to this workflow and its
   script.** The issue asks for dispatch and before a release, and that is
   what the file says — but `workflow_dispatch` needs the workflow on the
   default branch, so nothing on a branch can dispatch it, and the
   definition of done asks for evidence that it is green. The paths filter
   is the precedent `links.yml` sets for its own configuration: a change to
   `btclib/fetch/` does *not* trigger it.
2. **mypy's scope grows by `.github/scripts`** (one word in the hook and in
   CONTRIBUTING.md). No test collects that script, so a dispatch would
   otherwise be the first thing to read it — and strict mode is what caught
   `prev_out.is_coinbase` used as a truth value, which in a script of
   checks is a check that cannot fail.
3. **REPOSITORY.md is unchanged, deliberately.** The job declares the
   read-only permissions every workflow here declares, files nothing,
   publishes nothing and gates no branch, so nothing in that file stops
   being true: its required-checks table and its statement that only
   `release.yml` asks for more than `contents: read` both still hold.

CONTRIBUTING.md carries the command verbatim, as it does for every other
job, with the verified download beside it; RELEASING.md requires the
dispatch before a release.

## Verification

Both cells run here, against the arm64 macOS builds of the same two
releases (the digests checked against upstream `SHA256SUMS`):

```shell
uv run --locked --no-default-groups python .github/scripts/rpc_smoke.py \
    --bitcoind bitcoin-27.2/bin/bitcoind --core-version 27.2 --protocol 1.1
# 30 checks, exit 0: "Core 27.2 answered every check, over json-rpc 1.1"
uv run --locked --no-default-groups python .github/scripts/rpc_smoke.py \
    --bitcoind bitcoin-31.1/bin/bitcoind --core-version 31.1 --protocol 2.0
# 29 checks, exit 0: "Core 31.1 answered every check, over json-rpc 2.0"
```

So the protocol claim is now measured rather than assumed: **27.2 sends no
marker and puts an rpc error under an HTTP 500; 31.1 echoes the marker and
answers 200 for a result and an error alike.** The suite's fixtures are
what a real node sends.

The negative controls, each red as it must be: 27.2 told to expect 2.0
(`a live node contradicts this: a 2.0 reply echoes the 2.0 marker`), and a
node told it is another version. The digest snippet run verbatim: the real
digest `OK`, the rotated one refused.

The gates, on the `dev` base and re-run after each rebase rather than
only before the first:

```shell
uv run --locked pre-commit run --all-files      # exit 0
uv run --locked --no-default-groups --group test pytest   # 17175 passed
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
```

## Summary by Sourcery

Introduce a new production-oriented Bitcoind JSON-RPC client and live Core integration checks, replacing the old AuthProxy-based design and enhancing error handling, parameter validation, and CI verification of recorded RPC fixtures against real nodes.

New Features:
- Add BitcoindRpcClient as a JSON-RPC 2.0 client for bitcoind, with support for positional and named parameters, wallet endpoints, and per-call timeouts.
- Introduce an rpc-smoke workflow and script that run live bitcoind instances to verify recorded RPC reply shapes, cookie handling, wallet routing, and fetcher behavior against pinned Core versions.
- Expose HttpError and extend RpcError to carry structured HTTP status and error data for downstream handling.

Bug Fixes:
- Ensure RPC replies with invalid JSON, mismatched IDs, malformed error objects, or inconsistent version markers are correctly rejected and surfaced with precise diagnostics.
- Prevent unintended use of environment proxies and invalid URL schemes when making RPC and HTTP requests, avoiding credential leakage and misrouted calls.

Enhancements:
- Refactor bitcoind fetcher to use the new BitcoindRpcClient, separating connection configuration from chain labelling and strengthening JSON parameter and reply validation, including Decimal handling and deep nesting checks.
- Tighten cookie file reading with size, encoding, and format validation to avoid misreads, binary files, or oversized inputs causing resource issues.
- Refine HTTP transport behavior to avoid redirects, enforce body size limits, and decouple transport-side allocation bounds from per-call limits.
- Strengthen Esplora fetcher error handling by using HttpError with status fields, simplifying caller retry and rate-limit logic.
- Extend tests extensively around RPC request construction, parameter encoding, timeout handling, reply correlation, error classification, and wallet endpoint behavior to match the new client semantics.
- Document the new RPC client, its error model, rpc-smoke workflow, and contributor guidance around running live Core verification and mypy coverage for scripts.

CI:
- Add the rpc-smoke GitHub workflow that downloads verified Core binaries, runs the smoke script against pinned Core versions, and is triggered on demand or when its own files change.
- Update pre-commit mypy hook configuration to include .github/scripts in strict type checking.

Documentation:
- Update CHANGELOG, CONTRIBUTING, RELEASING, CLI proposal, and fetch package docs to describe BitcoindRpcClient, its error model, cookie handling, rpc-smoke workflow, and contributor/release procedures.

Tests:
- Add comprehensive tests for BitcoindRpcClient covering URL validation, authentication modes, timeouts, parameter structures, Decimal and non-finite numbers, reply correlation, JSON-RPC 1.1 vs 2.0 behavior, and wallet endpoints.
- Add tests ensuring HTTP transport does not follow redirects or read environment proxies, and that Esplora failures surface structured HttpError statuses.
- Introduce tests validating per-call body size limits, custom transports, cookie file parsing, and fetcher network labelling behavior.

Chores:
- Adjust ruff configuration to allow intentional printing in the rpc_smoke script while keeping the library itself stream-free.
