### PR TITLE
The primary checkout is the maintainer's, and a review keeps its commits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,27 @@ edit.
   `_config.yml`'s `exclude:` lists it beside CLAUDE.md and RELEASING.md,
   since a file in master's root is a URL under btclib.org otherwise, and a
   branch rule's app ids are not a page a visitor wants.
+- **The primary checkout is the maintainer's, and no session works in it.**
+  It is their window on the tree — what is open in their editor, what they
+  have half-staged, the branch they are looking at — and one working tree
+  has one index and one HEAD to lose, so an edit, a `git add`, a branch
+  switch, a rebase or a `pre-commit run` there is somebody else's work
+  being rewritten. CLAUDE.md now says so, and says that a worktree per
+  session is the whole of the alternative: reading the primary checkout
+  stays fine, `git fetch` included, since it writes refs and leaves the
+  work tree alone. What the advisory lock file it replaces could not do is
+  bind a session that never read the file it was described in.
+- **A pull request under review is corrected by a commit on top, never by
+  an amend, and is merged with "Squash and merge"** (CONTRIBUTING.md's
+  "Pull Request" section). An amend and a force-push replace the commits
+  the review is attached to: the reviewer loses the diff they read,
+  "changes since your last review" has nothing to compare against, and
+  every check restarts from a commit nobody has seen. The squash is what
+  makes that free — the branch lands as one commit whose subject is the
+  pull request title with its number, so `dev` keeps one commit per change
+  while the review keeps its own. The one force-push still right is the
+  one carrying no new work, a `git rebase origin/dev` on a branch whose
+  base has moved.
 
 ### Security
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,70 +69,50 @@ carries the same layout as a table, and each of the six modules states
 its own direction in its docstring — six places, if the direction ever
 changes.
 
-## The shared checkout
+## The primary checkout is the maintainer's
 
-**Take the lock before the first edit.** Working in the shared checkout
-is what lets the maintainer watch the edits as they happen, so it is not
-reserved for the awkward cases — but only one session can have it,
-because one working tree has one index and one HEAD: a plain `git commit`
-(or `git add -A`) there picks up whatever another session has staged, and
-`git rebase`, `git stash` and the `pre-commit` hooks that fix files in
-place rewrite or shelve files that are not this session's.
+**Never work in it.** No edit, no `git add`, no commit, no branch switch,
+no rebase, no `git stash`, no `pre-commit run` — the hooks fix files in
+place. It is the maintainer's window on the tree: whatever is open in
+their editor, whatever they have half-staged, and the branch they are
+looking at are theirs, and one working tree has one index and one HEAD to
+lose. Reading it is fine — `git log`, `git show`, `git diff`, `gh`, and a
+`git fetch`, which writes refs and leaves the work tree alone.
+
+**Every session works in a worktree**, its own, from the first edit:
 
 ```shell
-LOCK="$(git rev-parse --path-format=absolute \
-  --git-common-dir)/claude-shared-tree.lock"
-( set -C; printf 'session %s\npid %s\nsince %s\ntask %s\n' \
-  "$CLAUDE_CODE_SESSION_ID" "$CLAUDE_PID" "$(date -u +%FT%TZ)" \
-  "<the task, one line>" > "$LOCK" ) 2>/dev/null \
-  && echo "shared tree: mine" || cat "$LOCK"
+WT=<scratchpad>/wt<issue>
+git worktree add -b <branch> "$WT" origin/dev
+cd "$WT" && uv sync --locked          # a second venv, about a minute
+# edit, gate and commit here, then
+git push origin HEAD:refs/heads/<branch>
+git worktree remove --force "$WT"     # removing it is part of finishing
 ```
 
-`set -C` (noclobber) makes the redirection fail when the file is already
-there, so testing and taking are one atomic step. The path is the
-*common* dir because a file in the repository root would be per-worktree,
-i.e. invisible to exactly the sessions that have to see it; being outside
-the work tree it also needs no `.gitignore` entry. `rm "$LOCK"` when the
-work is pushed: releasing is part of finishing, like removing a worktree.
+The venv is the whole of the cost, and it buys the thing that matters: a
+commit cannot contain work that was never in it. Expect `origin/dev` to
+move while you work, so `git fetch && git rebase origin/dev` before
+pushing, resolving in favour of *both* sides (their change and yours,
+both CHANGELOG.md bullets).
 
-**Locked out means worktree**, which is the cheap side of the trade:
-`git worktree add --detach <scratchpad>/wt<issue> dev`, `uv sync
---locked` in it (a second venv, about a minute), then edit, gate and
-commit *there*, `git push origin HEAD:dev`, and `git worktree remove
---force` at the end. Nothing destructive reaches a file the other session
-holds, and the commit cannot contain their work because their edits were
-never in it. Expect the push to be rejected — `origin/dev` moves while
-you work — so `git fetch && git rebase origin/dev` in the worktree,
-resolving in favour of *both* sides (their change and yours, both
-CHANGELOG.md bullets).
+**Never `git stash` in a worktree either: `refs/stash` is shared.** A
+worktree isolates files, not refs. The stash is a single ref in the
+common `.git`, so `git stash push` pushes onto the same stack every other
+session pops from — and on a clean tree it creates nothing, so the `git
+stash pop` that follows applies and *drops* whatever another session
+shelved. Commit to your own branch instead: a branch is per-worktree in
+the way the stash only looks to be. What is already lost is still in the
+object store — `git fsck --unreachable` names the commit and `git stash
+store <sha>` puts the ref back.
 
-Two things not to do while their lock is held. Do not move
-`refs/heads/dev`: `git update-ref` leaves their files alone but moves the
-base under them, and their next commit, built on the older copy, would
-revert what just landed. And if your change is already sitting in the
-shared tree, carry it out as a patch (`git diff -- <paths> | git -C
-<worktree> apply`), which refuses rather than clobbers if they have
-touched the same file.
-
-**Never `git stash` in a worktree: `refs/stash` is shared.** A worktree
-isolates files, not refs. The stash is a single ref in the common `.git`,
-so `git stash push` pushes onto the same stack every other session pops
-from — and on a clean tree it creates nothing, so the `git stash pop`
-that follows applies and *drops* whatever another session shelved. Commit
-to your own branch instead: a branch is per-worktree in the way the stash
-only looks to be. What is already lost is still in the object store —
-`git fsck --unreachable` names the commit and `git stash store <sha>`
-puts the ref back.
-
-**A stale lock is a dead pid, and that is testable.** The file records
-the holder's `CLAUDE_PID`, the Claude Code process itself and not the
-shell of one command, so `kill -0 <pid>` answers whether the holder still
-exists: dead, and the lock is yours to overwrite — say so; alive, and a
-worktree costs a venv while taking their tree costs their work. An idle
-session is not a dead one, and a pid can be recycled across a reboot, so
-the lock stays advisory: keep using `git add <paths>` rather than `git
-add -A`, since a session that never read this file cannot honour any of
-it.
+**Do not rewrite `refs/heads/dev`, or advance it with work that is not
+yours.** `git update-ref`, or a push carrying another session's commits,
+leaves every working tree's files alone and moves the base under them, so
+their next commit — built on the older copy — reverts what just landed.
+Your own branch is what you push, and the pull request is what moves
+`dev`: CONTRIBUTING.md's "Pull Request" section has how a branch under
+review is corrected and how it is merged.
 
 ## Non-obvious facts that will otherwise waste a session
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -592,6 +592,26 @@ When you're finished with the changes, create a pull request (PR).
   [git tutorial](https://github.com/skills/resolve-merge-conflicts)
   to help you resolve merge conflicts and other issues.
 
+**A correction is a commit of its own, never an amend.** Once a branch is
+pushed and under review, `git commit --amend` and a force-push replace the
+commits the review is attached to: the reviewer loses the diff they read,
+"changes since your last review" has nothing to compare against, and every
+check starts again from a commit nobody has seen. Add the fix on top, with
+a message saying what it fixes, and reply to the comment with the sha.
+
+Nothing is lost in `dev`'s history by doing so, because **every pull
+request is merged with "Squash and merge"**: the branch becomes one commit
+whose subject is the PR title with its number, so the review's commits are
+the record of the review and `dev` keeps one commit per landed change. A
+merge commit would put the branch's steps into `dev` and a rebase merge
+would replay them one by one — `dev` is linear by branch rule, and one
+change is one commit there.
+
+The one force-push that stays right is the one that carries no new work: a
+`git rebase origin/dev` on a branch whose base has moved, which is how a
+stale pull request is refreshed. Re-run the gates after it, never only
+before it, and say in the pull request that the head moved and why.
+
 ### Your PR is merged
 
 Congratulations :tada::tada: The btclib team thanks you :sparkles:.


### PR DESCRIPTION
Two process rules, asked for after PR #380 exercised both the hard way.

## The primary checkout is the maintainer's

CLAUDE.md's "shared checkout" section described a lock file: take it before
the first edit, and a session locked out uses a worktree. That is now
inverted — **no session works in the primary checkout at all**, from the
first edit, and a worktree per session is the whole of the alternative.

The lock could not do the one thing it existed for. A session that never
read the file the protocol was described in cannot honour it, so the tree
was only ever as safe as its least careful reader; and the tree is the
maintainer's window on the work, so what is open in their editor, what
they have half-staged and the branch they are looking at are not a shared
resource to take a turn with. A worktree needs nobody's cooperation.

Reading the primary checkout stays fine — `git log`, `git show`, `git
diff`, `gh`, and `git fetch`, which writes refs and leaves the work tree
alone. What the section keeps from before: never `git stash` in a worktree
either, `refs/stash` being shared, and never rewrite `refs/heads/dev` or
advance it with work that is not yours.

## A review keeps its commits, and the merge is a squash

**A correction on a pull request is a commit of its own, never an amend.**
An amend plus a force-push replaces the commits the review is attached to:
the reviewer loses the diff they read, "changes since your last review" has
nothing to compare against, and every check restarts from a commit nobody
has seen. The fix goes on top, with a message saying what it fixes, and the
review comment gets the sha in reply.

**Every pull request is merged with "Squash and merge"**, which is what
makes that free: the branch lands as one commit whose subject is the pull
request title with its number, so `dev` keeps one commit per change while
the review keeps its own. A merge commit would put the branch's steps into
`dev` and a rebase merge would replay them one at a time, where the branch
rule wants `dev` linear.

The one force-push that stays right is the one carrying **no new work**: a
`git rebase origin/dev` on a branch whose base has moved, with the gates
re-run after it rather than only before, and a word in the pull request
saying the head moved and why. Say so if you would rather that one went
too — it is the only reason a branch of mine has been force-pushed.

The pull-request half is in CONTRIBUTING.md, contributors reading that file
and not CLAUDE.md, which points at it; CHANGELOG.md's "Repository" group
records both.

## Verification

```shell
uv run --locked pre-commit run --all-files                 # exit 0
uv run --locked --no-default-groups --group test pytest    # 17175 passed
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
```

`tests/release_notes_test.py` and `tests/vendored_data_test.py` pass, so
the new CHANGELOG bullets state no count. Written in a worktree on
`origin/dev`, which is the rule this pull request is about.

## Summary by Sourcery

Clarify repository workflow rules around the primary checkout and pull request reviews.

Enhancements:
- Redefine the primary checkout as read-only for contributors and require each session to work in its own Git worktree and branch.
- Document that `refs/stash` is shared and must not be used in worktrees, reinforcing branch-based workflows for local changes.
- Establish that `refs/heads/dev` must not be rewritten or advanced with others' work, making pull requests the sole mechanism for updating `dev`.
- Specify that corrections to a PR must be new commits on top, never amends, and that all PRs are merged using GitHub's "Squash and merge" to keep `dev` linear and reviews intact.

Documentation:
- Update CLAUDE.md, CONTRIBUTING.md, and CHANGELOG.md to describe the new checkout, worktree, and review/merge policies for contributors and maintainers.