### PR TITLE
A mutation profile for the wire format, and the boundaries it found unchecked

### DIFF
--- a/.github/mutation/engine.toml
+++ b/.github/mutation/engine.toml
@@ -31,7 +31,8 @@ test-command = """python -m pytest -x -q -n0 -p no:randomly \
   --ignore=tests/script_engine/python_path_test.py"""
 
 # seconds of wall clock, against a 7.2 s cpu baseline, and wide for the
-# reason sig_hash.toml measures: a timeout is a verdict of its own, so
+# reason sig_hash.toml measures: a timeout is answered KILLED, so a tight
+# one turns a loaded machine's slow mutant into a kill nobody earned, while
 # slack costs only the mutants that really do loop for ever -- and this
 # directory is where they live, the engine being a loop over opcodes with
 # a stack and a mutated bound the way to stop it ending

--- a/.github/mutation/parsers.toml
+++ b/.github/mutation/parsers.toml
@@ -76,9 +76,9 @@ excluded-modules = []
 # -- `Sequence[TxIn] >> None` and ten more -- none of which any test can
 # reach. Measured rather than argued: eight such `|` on seven lines, 88
 # mutants of the 1034, and an unfiltered session over the same scope
-# reports 118 survivors, every one of those 88 among them. Filtered it
-# reports the other 30, which is the difference between a list somebody
-# reads and one nobody does -- 88 against 30 -- and it spends minutes less
+# reports 110 survivors, every one of those 88 among them. Filtered it
+# reports the other 22, which is the difference between a list somebody
+# reads and one nobody does -- 88 against 22 -- and it spends minutes less
 # doing it, a survivor costing the whole test command where most kills cost
 # a fraction of one.
 #

--- a/.github/mutation/parsers.toml
+++ b/.github/mutation/parsers.toml
@@ -71,11 +71,11 @@ excluded-modules = []
 # -- `Sequence[TxIn] >> None` and ten more -- none of which any test can
 # reach. Measured rather than argued: eight such `|` on seven lines, 88
 # mutants of the 1035, and an unfiltered session over the same scope
-# reports 144 survivors, every one of those 88 among them. Filtered it
-# reports the other 56, which is the difference between a list somebody
-# reads and one nobody does, and it spends minutes less doing it -- a
-# survivor costs the whole test command, where most kills cost a fraction
-# of one.
+# reports 122 survivors, every one of those 88 among them. Filtered it
+# reports the other 34, which is the difference between a list somebody
+# reads and one nobody does -- 88 against 34 -- and it spends minutes less
+# doing it, a survivor costing the whole test command where most kills cost
+# a fraction of one.
 #
 # Excluded by operator here rather than with `# pragma: no mutate`, and
 # seven lines of library source against one line in this file is not what

--- a/.github/mutation/parsers.toml
+++ b/.github/mutation/parsers.toml
@@ -64,11 +64,11 @@ excluded-modules = []
 # an unevaluated string, and cosmic-ray mutates the `|` in it eleven ways
 # -- `Sequence[TxIn] >> None` and ten more -- none of which any test can
 # reach. Measured rather than argued: 88 mutants of the 1035, and an
-# unfiltered session over the same scope reports 142 survivors, every one
-# of those 88 among them. Filtered it reports the other 54, which is the
+# unfiltered session over the same scope reports 144 survivors, every one
+# of those 88 among them. Filtered it reports the other 56, which is the
 # difference between a list somebody reads and one nobody does, and it
-# spends two minutes less doing it -- a survivor costs the whole test
-# command.
+# spends minutes less doing it -- a survivor costs the whole test command,
+# where most kills cost a fraction of one.
 #
 # Excluded by operator here rather than with `# pragma: no mutate` on 37
 # lines of source, which is what sig_hash.toml refused for six of them:

--- a/.github/mutation/parsers.toml
+++ b/.github/mutation/parsers.toml
@@ -75,10 +75,10 @@ excluded-modules = []
 # an unevaluated string, and cosmic-ray mutates the `|` in it eleven ways
 # -- `Sequence[TxIn] >> None` and ten more -- none of which any test can
 # reach. Measured rather than argued: eight such `|` on seven lines, 88
-# mutants of the 1035, and an unfiltered session over the same scope
-# reports 122 survivors, every one of those 88 among them. Filtered it
-# reports the other 34, which is the difference between a list somebody
-# reads and one nobody does -- 88 against 34 -- and it spends minutes less
+# mutants of the 1034, and an unfiltered session over the same scope
+# reports 118 survivors, every one of those 88 among them. Filtered it
+# reports the other 30, which is the difference between a list somebody
+# reads and one nobody does -- 88 against 30 -- and it spends minutes less
 # doing it, a survivor costing the whole test command where most kills cost
 # a fraction of one.
 #

--- a/.github/mutation/parsers.toml
+++ b/.github/mutation/parsers.toml
@@ -56,11 +56,16 @@ test-command = """python -m pytest -x -q -n0 -p no:randomly \
 # it: `run_tests` catches `subprocess.TimeoutExpired` and answers KILLED,
 # so a mutant cut short is *reported as dead* on a busy machine. That is
 # the direction to be afraid of -- a survivor counted as a kill is the
-# failure mode a stale test command has, the one that looks like good news
-# -- and every second of slack costs only the mutants that really do not
-# end, `var_int.parse` reading a length it then allocates being where one
-# would be. Zero timeouts in the sessions measured so far, against a test
-# command of about a second
+# failure mode a stale test command has, the one that looks like good news.
+#
+# What the width is not guarding is a loop in this scope. There is no
+# unbounded one to find: the counts and lengths a mutant could uncap are
+# read from a stream that ends, so `Tx.parse`'s `range(n)` stops at the
+# first `read_exactly`, and `var_bytes.parse` asks `stream.read(i)` for
+# whatever is left and then refuses the short answer. Against a test
+# command of about a second, every session measured here has finished with
+# zero timeouts, so the number is slack for a loaded runner and nothing
+# else
 timeout = 300
 
 excluded-modules = []
@@ -78,14 +83,21 @@ excluded-modules = []
 # a fraction of one.
 #
 # Excluded by operator here rather than with `# pragma: no mutate`, and
-# seven lines of library source against one line in this file is not what
-# settles that: `cr-filter-pragma` skips whatever mutation *ends* on a
-# marked line, and every one of the seven is a signature, so the pragma
-# would take the `check_validity: bool = True` and the keyword-only `*` on
-# the same line with it -- mutants this profile's survivor list is about.
-# The price of doing it by operator is the other way round: a real `a | b`
-# added to one of these modules would be skipped in silence, so the claim
-# behind it is a grep:
+# the collateral of a pragma is not the argument: grouped by the line
+# `cr-filter-pragma` reads -- the one a mutation *ends* on -- six of the
+# seven hold nothing but that annotation's eleven mutants, the multiline
+# signatures putting the `*` and the `check_validity` default on lines of
+# their own. `out_point.py:97` is the exception and the only signature
+# written on one line, where a pragma would also skip the ten mutants of
+# the keyword-only `*` and the one of its default, both of which
+# tests/check_validity_test.py answers.
+#
+# What settles it is where the decision lives. One line here, in the file
+# that already says what is mutated and what judges it, against a marker in
+# each of seven library lines and again in every module a later
+# `module-path` adds. The price is the same either way and is paid here
+# instead of there: a real `a | b` added to one of these modules would be
+# skipped in silence, so the claim behind it is a grep:
 #
 #   grep -n ' | ' btclib/tx/*.py btclib/var_int.py btclib/var_bytes.py
 #

--- a/.github/mutation/parsers.toml
+++ b/.github/mutation/parsers.toml
@@ -88,10 +88,12 @@ excluded-modules = []
 # seven hold nothing but that annotation's eleven mutants, the multiline
 # signatures putting the `*` and the `check_validity` default on lines of
 # their own. `OutPoint.to_dict` is the exception, being the only one of the
-# seven written on a single line: a pragma there would also skip the ten
-# mutants of its keyword-only `*` and the one of its default, both of which
-# tests/check_validity_test.py answers. Named rather than numbered, a line
-# number here rotting on the next insertion above it.
+# seven written on a single line: 23 mutations end there, and a pragma would
+# skip 12 the filter does not -- eleven replacements of its keyword-only `*`,
+# `Mul_BitOr` among them and so past this exclusion's anchored pattern, and
+# the one of its `check_validity` default. tests/check_validity_test.py
+# answers both. Named rather than numbered, a line number here rotting on
+# the next insertion above it.
 #
 # What settles it is where the decision lives. One line here, in the file
 # that already says what is mutated and what judges it, against a marker in

--- a/.github/mutation/parsers.toml
+++ b/.github/mutation/parsers.toml
@@ -1,0 +1,96 @@
+# The wire format, mutated: the transaction encodings and the two
+# length-prefix codecs under them. Issue #327 asks for this scope after
+# five defects were found in code measuring 100% statement coverage, two
+# of them here -- fixed-width fields that took a truncated read and
+# normalized it on serialization, and octet parsers that ignored trailing
+# bytes (#322) -- which is #219's question again on a different boundary:
+# every statement ran, and nothing checked where the field ended.
+#
+# Its own configuration and its own job rather than a third session beside
+# the consensus ones: sig_hash.toml and engine.toml already spend 90
+# minutes each, so a session added there would either take from them or
+# push the job past its ceiling. mutation.yml runs the two jobs in
+# parallel and each carries its own budget.
+
+[cosmic-ray]
+# a list, which cosmic-ray reads as well as a single path: the scope is
+# four modules of one package and two files beside it, and one test
+# command judges all six. btclib/tx alone would leave var_int and
+# var_bytes -- the length prefix of every list and every script in a
+# transaction -- to a profile of their own, for 195 mutants
+module-path = [
+  "btclib/tx",
+  "btclib/var_int.py",
+  "btclib/var_bytes.py",
+]
+
+# tests/tx first, where most mutants die, and then the two files for the
+# codecs. The three after them are what makes this a parser profile
+# rather than a directory of unit tests, and each one answers a class of
+# mutant the first three cannot:
+#
+# - parse_contract_test.py holds every parse in btclib to the truncation,
+#   trailing-bytes and caller's-stream rules, under check_validity both
+#   ways, so it is what a mutated field boundary has to get past
+# - integer_policy_test.py is the type half of the same surface, refusing
+#   a bool as a satoshi amount, an index or a sequence (#326): without it
+#   those statements run in no test of this command
+# - check_validity_test.py is the rule about the signatures, and it is
+#   here for a mutant nothing else sees: cosmic-ray turns the `*` of a
+#   keyword-only marker into `/`, which moves `check_validity` into a
+#   positional slot, and the ast walk in that file is what fails on it.
+#   Fourteen mutants of this scope, killed by a file costing a tenth of a
+#   second
+#
+# -n0 overrides the `-n auto` of tool.pytest.ini_options, xdist's worker
+# per core being startup paid once per mutant; -p no:randomly makes the
+# collection order fixed, which with -x is what decides both the killing
+# test and the runtime. No --cov, for the reason sig_hash.toml gives
+test-command = """python -m pytest -x -q -n0 -p no:randomly \
+  tests/tx tests/var_int_test.py tests/var_bytes_test.py \
+  tests/parse_contract_test.py tests/integer_policy_test.py \
+  tests/check_validity_test.py"""
+
+# seconds of wall clock, as in the other two configurations and for the
+# same reason: a timeout is neither killed nor survived, so slack costs
+# only the mutants that really do not end -- and `var_int.parse` reading a
+# length it then allocates is where one would be
+timeout = 300
+
+excluded-modules = []
+
+# what a mutant of `Sequence[TxIn] | None` is: nothing. All four modules
+# open with `from __future__ import annotations`, so every annotation is
+# an unevaluated string, and cosmic-ray mutates the `|` in it eleven ways
+# -- `Sequence[TxIn] >> None` and ten more -- none of which any test can
+# reach. Measured rather than argued: 88 mutants of the 1035, and an
+# unfiltered session over the same scope reports 142 survivors, every one
+# of those 88 among them. Filtered it reports the other 54, which is the
+# difference between a list somebody reads and one nobody does, and it
+# spends two minutes less doing it -- a survivor costs the whole test
+# command.
+#
+# Excluded by operator here rather than with `# pragma: no mutate` on 37
+# lines of source, which is what sig_hash.toml refused for six of them:
+# the pragma filter needs a line in the library for the benefit of a
+# weekly report, and this one needs a line in this file. Its price is that
+# a real `a | b` added to one of these modules would be skipped in
+# silence, so the claim behind it is a grep:
+#
+#   grep -n ' | ' btclib/tx/*.py btclib/var_int.py btclib/var_bytes.py
+#
+# Every hit is an annotation today. Note also what a skipped mutant does
+# to the one number the workflow prints: `cr-rate` counts a result that
+# is not SURVIVED as a kill, and a skip is one, so the rate it reports is
+# over the whole session and the honest denominator is what
+# `cosmic-ray exec` actually ran.
+#
+# BitOr and not the other operators of that family: `^` is what
+# OutPoint.assert_valid uses to catch a half-coinbase outpoint, and a
+# mutant of that one is a test question
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
+# one mutant at a time, in this working tree: see sig_hash.toml
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/parsers.toml
+++ b/.github/mutation/parsers.toml
@@ -51,10 +51,16 @@ test-command = """python -m pytest -x -q -n0 -p no:randomly \
   tests/parse_contract_test.py tests/integer_policy_test.py \
   tests/check_validity_test.py"""
 
-# seconds of wall clock, as in the other two configurations and for the
-# same reason: a timeout is neither killed nor survived, so slack costs
-# only the mutants that really do not end -- and `var_int.parse` reading a
-# length it then allocates is where one would be
+# seconds of wall clock, as in the other two configurations, and wide
+# because of what cosmic-ray does with a timeout rather than in spite of
+# it: `run_tests` catches `subprocess.TimeoutExpired` and answers KILLED,
+# so a mutant cut short is *reported as dead* on a busy machine. That is
+# the direction to be afraid of -- a survivor counted as a kill is the
+# failure mode a stale test command has, the one that looks like good news
+# -- and every second of slack costs only the mutants that really do not
+# end, `var_int.parse` reading a length it then allocates being where one
+# would be. Zero timeouts in the sessions measured so far, against a test
+# command of about a second
 timeout = 300
 
 excluded-modules = []
@@ -63,26 +69,30 @@ excluded-modules = []
 # open with `from __future__ import annotations`, so every annotation is
 # an unevaluated string, and cosmic-ray mutates the `|` in it eleven ways
 # -- `Sequence[TxIn] >> None` and ten more -- none of which any test can
-# reach. Measured rather than argued: 88 mutants of the 1035, and an
-# unfiltered session over the same scope reports 144 survivors, every one
-# of those 88 among them. Filtered it reports the other 56, which is the
-# difference between a list somebody reads and one nobody does, and it
-# spends minutes less doing it -- a survivor costs the whole test command,
-# where most kills cost a fraction of one.
+# reach. Measured rather than argued: eight such `|` on seven lines, 88
+# mutants of the 1035, and an unfiltered session over the same scope
+# reports 144 survivors, every one of those 88 among them. Filtered it
+# reports the other 56, which is the difference between a list somebody
+# reads and one nobody does, and it spends minutes less doing it -- a
+# survivor costs the whole test command, where most kills cost a fraction
+# of one.
 #
-# Excluded by operator here rather than with `# pragma: no mutate` on 37
-# lines of source, which is what sig_hash.toml refused for six of them:
-# the pragma filter needs a line in the library for the benefit of a
-# weekly report, and this one needs a line in this file. Its price is that
-# a real `a | b` added to one of these modules would be skipped in
-# silence, so the claim behind it is a grep:
+# Excluded by operator here rather than with `# pragma: no mutate`, and
+# seven lines of library source against one line in this file is not what
+# settles that: `cr-filter-pragma` skips whatever mutation *ends* on a
+# marked line, and every one of the seven is a signature, so the pragma
+# would take the `check_validity: bool = True` and the keyword-only `*` on
+# the same line with it -- mutants this profile's survivor list is about.
+# The price of doing it by operator is the other way round: a real `a | b`
+# added to one of these modules would be skipped in silence, so the claim
+# behind it is a grep:
 #
 #   grep -n ' | ' btclib/tx/*.py btclib/var_int.py btclib/var_bytes.py
 #
-# Every hit is an annotation today. Note also what a skipped mutant does
-# to the one number the workflow prints: `cr-rate` counts a result that
-# is not SURVIVED as a kill, and a skip is one, so the rate it reports is
-# over the whole session and the honest denominator is what
+# Seven hits today, every one an annotation. Note also what a skipped
+# mutant does to the one number the workflow prints: `cr-rate` counts a
+# result that is not SURVIVED as a kill, and a skip is one, so the rate it
+# reports is over the whole session and the honest denominator is what
 # `cosmic-ray exec` actually ran.
 #
 # BitOr and not the other operators of that family: `^` is what

--- a/.github/mutation/parsers.toml
+++ b/.github/mutation/parsers.toml
@@ -87,10 +87,11 @@ excluded-modules = []
 # `cr-filter-pragma` reads -- the one a mutation *ends* on -- six of the
 # seven hold nothing but that annotation's eleven mutants, the multiline
 # signatures putting the `*` and the `check_validity` default on lines of
-# their own. `out_point.py:97` is the exception and the only signature
-# written on one line, where a pragma would also skip the ten mutants of
-# the keyword-only `*` and the one of its default, both of which
-# tests/check_validity_test.py answers.
+# their own. `OutPoint.to_dict` is the exception, being the only one of the
+# seven written on a single line: a pragma there would also skip the ten
+# mutants of its keyword-only `*` and the one of its default, both of which
+# tests/check_validity_test.py answers. Named rather than numbered, a line
+# number here rotting on the next insertion above it.
 #
 # What settles it is where the decision lives. One line here, in the file
 # that already says what is mutated and what judges it, against a marker in

--- a/.github/mutation/sig_hash.toml
+++ b/.github/mutation/sig_hash.toml
@@ -49,9 +49,13 @@ test-command = """python -m pytest -x -q -n0 -p no:randomly \
 
 # seconds of wall clock, against a baseline of 9.2 s of cpu: what this
 # guards is a mutant that turns a bound into a loop with no exit, and
-# nothing else. Wide rather than tight, because a timeout is a verdict of
-# its own -- neither killed nor survived -- so every second of slack a
-# loaded machine needs is a survivor not reported as noise. Measured, and
+# nothing else. Wide rather than tight, because of what cosmic-ray does
+# with a timeout: `run_tests` catches `subprocess.TimeoutExpired` and
+# answers KILLED, so a mutant cut short on a loaded machine is reported
+# dead rather than reported as noise -- a survivor counted as a kill, which
+# is the one failure mode of a mutation run that looks like good news.
+# Every second of slack a loaded machine needs buys against that. Measured,
+# and
 # this is why the number is 300 and not 60: at 60 s `cosmic-ray baseline`
 # failed with `>>> timeout` on the *unmutated* tree, on a developer machine
 # at load 120, where the same command takes 9.2 s of cpu and 74 s of wall.

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -102,12 +102,12 @@ jobs:
           # the transaction encodings and the length prefixes under them,
           # measured before this budget was written: 1035 mutants, 88 of
           # them skipped by the operator filter that configuration
-          # explains, and the 947 left take under five minutes of cpu. So
-          # unlike the engine this profile finishes, which is what makes its
-          # survival rate comparable with the week before -- and the budget
-          # is minutes rather than hours: 30 is six times what it takes on
-          # the machine that measured it, and a runner is slower than that
-          # but not by six
+          # explains, and the 947 left take five to seven minutes of cpu
+          # depending on what else the machine is doing. So unlike the engine
+          # this profile finishes, which is what makes its survival rate
+          # comparable with the week before -- and the budget is minutes
+          # rather than hours: 30 is several times the measurement, and a
+          # runner is slower than that machine but not by several
           - profile: the wire-format parsers
             slug: parsers
             ceiling: 45

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -102,12 +102,14 @@ jobs:
           # the transaction encodings and the length prefixes under them,
           # measured before this budget was written: 1035 mutants, 88 of
           # them skipped by the operator filter that configuration
-          # explains, and the 947 left take five to seven minutes of cpu
-          # depending on what else the machine is doing. So unlike the engine
-          # this profile finishes, which is what makes its survival rate
-          # comparable with the week before -- and the budget is minutes
-          # rather than hours: 30 is several times the measurement, and a
-          # runner is slower than that machine but not by several
+          # explains, and the 947 left take five to seven minutes of wall
+          # clock depending on what else the machine is doing -- elapsed and
+          # not cpu, which is what `timeout` below and this ceiling both
+          # count. So unlike the engine this profile finishes, which is what
+          # makes its survival rate comparable with the week before, and the
+          # budget is minutes rather than hours: 30 is several times the
+          # measurement, and a runner is slower than that machine but not by
+          # several
           - profile: the wire-format parsers
             slug: parsers
             ceiling: 45

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -100,9 +100,9 @@ jobs:
               sig_hash.toml 90m
               engine.toml 90m
           # the transaction encodings and the length prefixes under them,
-          # measured before this budget was written: 1035 mutants, 88 of
+          # measured before this budget was written: 1034 mutants, 88 of
           # them skipped by the operator filter that configuration
-          # explains, and the 947 left take five to seven minutes of wall
+          # explains, and the 946 left take five to seven minutes of wall
           # clock depending on what else the machine is doing -- elapsed and
           # not cpu, which is what `timeout` below and this ceiling both
           # count. So unlike the engine this profile finishes, which is what

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -4,8 +4,9 @@ name: mutation
 # Coverage answers "was this line executed"; this answers "would the suite
 # notice if it were wrong". The gap is not theoretical here -- issue #219
 # lists three defects found inside a 100% covered tree, all three in the
-# consensus code this workflow is scoped to -- and a surviving mutant names
-# one line of it at a time.
+# consensus code, and issue #327 five more on the input boundaries, two of
+# them in the transaction parsers -- and a surviving mutant names one line
+# of it at a time.
 #
 # It gates nothing, and that is the design rather than a caution. A gate
 # needs a number nobody has measured yet, and a survival rate is not a
@@ -60,13 +61,58 @@ concurrency:
 
 jobs:
   mutation:
-    name: Mutate the consensus code
+    name: Mutate ${{ matrix.profile }}
     runs-on: ubuntu-latest
-    # the two budgets below add up to 180, and the rest is what it takes to
-    # install the environment, take the baseline and write the reports. A
-    # job that reaches this ceiling has hung somewhere other than in a
-    # session, both of those being cut by `timeout` on their own
-    timeout-minutes: 200
+    # the profiles run in parallel, each under its own ceiling, which is
+    # what keeps a scope added here from spending the budget of the ones
+    # already measured (issue #327): another session inside the consensus
+    # job would have to come out of its 180 minutes or push it past the
+    # ceiling
+    timeout-minutes: ${{ matrix.ceiling }}
+    strategy:
+      # one profile's runner dying is not a reason to take the other's
+      # numbers with it
+      fail-fast: false
+      matrix:
+        include:
+          # `sessions` is one `<configuration> <budget>` line per session,
+          # in the order they run; the budget is what `timeout` is given,
+          # and the ceiling is the sum of them plus what it takes to
+          # install the environment, take the baselines and write the
+          # reports. A job that reaches its ceiling has hung somewhere
+          # other than in a session, each of those being cut on its own
+          - profile: the consensus code
+            slug: consensus
+            ceiling: 200
+            # 90 minutes each, and the asymmetry is in what they buy rather
+            # than in the number: the sighash session is half an hour of
+            # cpu -- 727 mutants, each costing between the 1.1 s of one the
+            # sighash vectors kill and the 9.2 s of one that reaches the
+            # end of the command -- and finishes inside the budget with
+            # room for a runner slower than the machine that measured it,
+            # while the engine's five and a half hours (2768 mutants at
+            # 7.2 s) cannot finish in any budget this workflow is worth and
+            # is sampled instead. A sample of the same slice every week is
+            # worth more than it sounds: the verdicts in it are stable, so
+            # one that changes is a test that stopped checking what it used
+            # to
+            sessions: |
+              sig_hash.toml 90m
+              engine.toml 90m
+          # the transaction encodings and the length prefixes under them,
+          # measured before this budget was written: 1035 mutants, 88 of
+          # them skipped by the operator filter that configuration
+          # explains, and the 947 left take under five minutes of cpu. So
+          # unlike the engine this profile finishes, which is what makes its
+          # survival rate comparable with the week before -- and the budget
+          # is minutes rather than hours: 30 is six times what it takes on
+          # the machine that measured it, and a runner is slower than that
+          # but not by six
+          - profile: the wire-format parsers
+            slug: parsers
+            ceiling: 45
+            sessions: |
+              parsers.toml 30m
     steps:
       # every action is pinned to a commit SHA, the tag in the comment: a
       # tag, let alone a branch, is a name its owner can move
@@ -85,43 +131,46 @@ jobs:
       # unmutated tree. Without this a stale path or a renamed test file
       # fails every mutant identically, and the session reports a perfect
       # kill rate -- the one failure mode of a mutation run that looks like
-      # good news
+      # good news.
+      #
+      # The matrix value reaches the shell through the environment rather
+      # than through a `${{ }}` inside the script, which would be text
+      # pasted into it: the value is this file's own, and the habit is what
+      # zizmor's template-injection rule is asking for
       - name: Check the baselines
+        env:
+          SESSIONS: ${{ matrix.sessions }}
         run: |
-          for config in .github/mutation/*.toml; do
+          while read -r config _; do
+            [ -n "$config" ] || continue
             uv run --locked --no-default-groups --group test --group mutation \
-              cosmic-ray baseline "$config"
-          done
-      # init enumerates the mutants and exec runs them, one at a time, in
-      # this working tree: the local distributor writes each mutation into
-      # the file itself and restores it afterwards, so the two sessions run
-      # in sequence and nothing else may read the source while they do.
+              cosmic-ray baseline ".github/mutation/$config"
+          done <<< "$SESSIONS"
+      # init enumerates the mutants, the filter marks as skipped whatever
+      # the configuration excludes by operator -- a no-op for one that
+      # excludes none, so the decision stays in the toml -- and exec runs
+      # the rest, one at a time, in this working tree: the local
+      # distributor writes each mutation into the file itself and restores
+      # it afterwards, so the sessions run in sequence and nothing else may
+      # read the source while they do.
       #
       # `timeout` and not the job's timeout-minutes, which would cancel the
       # job and take the reports and the artifact with it: what is wanted
       # is the numbers for the mutants that did run. 124 is what timeout
       # exits with when it cuts a session, and a session is resumable --
       # `cosmic-ray exec` runs the jobs still pending -- so a partial run
-      # is a partial answer rather than a lost one.
-      #
-      # 90 minutes each, and the asymmetry is in what they buy rather than
-      # in the number: the sighash session is half an hour of cpu -- 727
-      # mutants, each costing between the 1.1 s of one the sighash vectors
-      # kill and the 9.2 s of one that reaches the end of the command --
-      # and finishes inside the budget with room for a runner slower than
-      # the machine that measured it, while the engine's five and a half
-      # hours (2768 mutants at 7.2 s) cannot
-      # finish in any budget this workflow is worth and is sampled instead.
-      # .github/mutation/engine.toml carries that arithmetic. A sample of
-      # the same slice every week is worth more than it sounds: the
-      # verdicts in it are stable, so one that changes is a test that
-      # stopped checking what it used to
+      # is a partial answer rather than a lost one
       - name: Run the mutation sessions
+        env:
+          SESSIONS: ${{ matrix.sessions }}
         run: |
           run_session() {
-            local config="$1" session="$2" budget="$3" status=0
+            local config=".github/mutation/$1" session="${1%.toml}.sqlite"
+            local budget="$2" status=0
             uv run --locked --no-default-groups --group test --group mutation \
               cosmic-ray init "$config" "$session"
+            uv run --locked --no-default-groups --group test --group mutation \
+              cr-filter-operators "$session" "$config"
             timeout "$budget" \
               uv run --locked --no-default-groups --group test --group mutation \
               cosmic-ray exec "$config" "$session" || status=$?
@@ -132,15 +181,21 @@ jobs:
               echo "::notice::$config: cut at $budget, see the report"
             fi
           }
-          run_session .github/mutation/sig_hash.toml sig_hash.sqlite 90m
-          run_session .github/mutation/engine.toml engine.sqlite 90m
+          while read -r config budget; do
+            [ -n "$config" ] || continue
+            run_session "$config" "$budget"
+          done <<< "$SESSIONS"
       # always(), because the reports are the whole product: a session cut
       # short, or one whose exec died, still holds every verdict reached
       # before that, and those are what somebody reads on Monday
       - name: Write the reports
         if: always()
+        env:
+          SESSIONS: ${{ matrix.sessions }}
         run: |
-          for session in sig_hash engine; do
+          while read -r config _; do
+            [ -n "$config" ] || continue
+            session="${config%.toml}"
             [ -f "$session.sqlite" ] || continue
             # --surviving-only with the diff, which is the whole of what
             # anybody acts on: a killed mutant is the suite working, and
@@ -154,19 +209,25 @@ jobs:
               cr-html "$session.sqlite" > "$session-report.html"
             # the one line worth reading in the log rather than in the
             # artifact. Never with --fail-over: a survival rate is not a
-            # thing this workflow is allowed to be red about
+            # thing this workflow is allowed to be red about. It is taken
+            # over the whole session, a mutant the filter skipped counting
+            # as a kill, so what compares between weeks is that rate
+            # against the completed count in the report beside it
             uv run --locked --no-default-groups --group test --group mutation \
               cr-rate "$session.sqlite" | sed "s/^/$session survival rate: /"
-          done
+          done <<< "$SESSIONS"
       # the sessions as well as the reports: a .sqlite is what `cr-report`
       # and `cr-html` are re-run against, and what a later `cosmic-ray
       # exec` resumes, so downloading one is how the engine's remaining
-      # two thirds get finished on somebody's machine
+      # two thirds get finished on somebody's machine.
+      # One artifact per profile, the profiles being parallel jobs: two
+      # uploads under one name is an error, and the slug is what tells the
+      # consensus sessions from the parser ones in the Actions tab
       - name: Upload the sessions and the reports
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: mutation-sessions
+          name: mutation-${{ matrix.slug }}-sessions
           path: |
             *.sqlite
             *-survivors.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3959,6 +3959,42 @@ edit.
 
 ### Tests
 
+- **the boundaries the first parser mutation session found unconstrained
+  are tests now** (issue #327). Every one was a check the suite executed
+  without pinning, so a wrong version of it would have gone unnoticed: a
+  tx_id length refused from below only, where 33 bytes are an outpoint that
+  serializes back to 37; the largest number a two- or four-byte `var_int`
+  holds, which a canonical minimum one short of its value accepts;
+  `MAX_SIZE`'s value, every test around the cap holding for whatever the
+  constant is; the non-canonical message naming the width the number was
+  written in; the four-byte range of a version, a lock time and a sequence
+  at both ends rather than at one; the version window `assert_standard`
+  reads as signed, whose corners answer differently from `assert_valid`'s
+  range; the coinbase script_sig's 2 to 100 bytes, both included;
+  `assert_valid` asking every input and every output, which only a
+  transaction whose sums are fine can reach; the legacy sigop count being
+  the sum of both lists rather than a bitwise mix of them, one sigop on
+  each side being the case that tells those apart; and an output value read
+  as unsigned, the octets that tell the two readings apart being refused
+  before the conversion sees them
+- **three assertions that could not fail say something now.** `assert
+  tx_in.nSequence == tx_in.nSequence` compared the property with itself in
+  three places, so the alias it is there to check was never read; `assert
+  tx_in == tx_in2 or TX_IN_COMPARES_WITNESS` passes whichever way that flag
+  is set, and the two halves are now separate assertions; and a
+  non-shuffled `join` was held to equalling *another* non-shuffled join,
+  which two shuffled ones satisfy every other attempt with two inputs — so
+  the order it keeps is asserted against the concatenation it was given,
+  over six inputs and six outputs, where a shuffle agrees once in 720. `Tx`
+  being a dataclass is a promise too, and `dataclasses.fields` is what
+  reads it: the constructor, the comparison and every conversion are
+  written out, so the decorator is left holding the field list and the
+  repr, and nothing asked for either
+- **a coinbase input in a non-coinbase transaction has a test of its own.**
+  That refusal was the one statement of `btclib/tx` that no test under
+  `tests/tx` reached: a script_engine vector did, which is a verdict on the
+  engine and none on the transaction, and it left the parser profile's
+  baseline one statement short of the scope it mutates
 - **the ten blocks Bitcoin Core carries in `blockfilters.json` are
   vendored and parsed** (issue #274). Core publishes no block-validity
   vector file — `src/test/data/` holds no block, and the two suites that
@@ -4451,6 +4487,52 @@ edit.
 
 ### Packaging, linting and CI
 
+- **mutation testing reaches the wire format**, a third configuration and a
+  second job (issue #327). `.github/mutation/parsers.toml` mutates
+  `btclib/tx/` with the `var_int` and `var_bytes` codecs under it: the
+  transaction encodings are where two of the five defects that opened the
+  issue lived — a fixed-width field that took a truncated read and
+  normalized it on serialization, and an octet parser that ignored what
+  followed the object (#322) — and both were inside a tree measuring 100%,
+  which is #219's question again on a different boundary. One
+  configuration and not three, `module-path` taking a list of paths as well
+  as a path, because one test command judges all six modules; and it names
+  `tests/parse_contract_test.py`, `tests/integer_policy_test.py` and
+  `tests/check_validity_test.py` beside the module suites, each for a class
+  of mutant the module suites cannot see. The last of those is the cheapest
+  fourteen kills in the profile: cosmic-ray turns the `*` of a keyword-only
+  marker into `/`, which moves `check_validity` into a positional slot, and
+  the ast walk in that file is the only thing that fails on it. Measured
+  before the budget was written, and the numbers are what the issue asked
+  for rather than an estimate: 1035 mutants, 88 skipped, the 947 that ran
+  taking 4 min 43 s of cpu, 54 surviving. So this profile *finishes*,
+  where the engine's five and a half hours are sampled — which is what
+  makes a survival rate comparable with the week before. Its own job, in
+  parallel with the consensus one and under a 60-minute ceiling, because
+  the two sessions there already spend 180 of the 200 minutes that job has:
+  the jobs are now a matrix over profiles, each cell naming its
+  configurations and their budgets, so a scope added next takes nothing
+  from the ones already measured. One artifact per profile, two uploads
+  under one name being an error, so `mutation-sessions` is now
+  `mutation-consensus-sessions` beside `mutation-parser-sessions`
+- **`cr-filter-operators` runs between `init` and `exec`** for every
+  configuration, and is a no-op for one that excludes no operator, so the
+  decision stays in the toml rather than in the workflow. What
+  `parsers.toml` excludes is the `|` of a type annotation: all four modules
+  open with `from __future__ import annotations`, so `Sequence[TxIn] | None`
+  is an unevaluated string, and cosmic-ray's eleven replacements for that
+  operator are 88 mutants nothing can reach. Measured rather than argued: an
+  unfiltered session over the same scope reports 142 survivors and every one
+  of those 88 is among them, so filtering leaves the 54 that are worth
+  reading and spends two minutes less, a survivor costing the whole test
+  command. Excluded by operator rather than with a
+  `# pragma: no mutate` on each of the 37 annotations, which is what
+  `sig_hash.toml` refused for six of them: a pragma is a line of library
+  source added for the benefit of a weekly report. The price is stated
+  where it is paid — a real `a | b` added to one of these modules would be
+  skipped in silence, and the grep that re-derives the claim is beside the
+  exclusion — as is what a skip does to the one number the workflow prints:
+  `cr-rate` counts a result that is not SURVIVED as a kill
 - **the bindings dependency states its policy where the pin is** (issue
   #325). `btclib_libsecp256k1>=0.7.1` has no upper bound, and the
   absence of a ceiling is now written down as the decision it is:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3989,8 +3989,10 @@ edit.
   satisfy every other attempt with two inputs — so `SystemRandom.shuffle` is
   monkeypatched to a known permutation, reversal, and each of the four flag
   combinations is one equality: the order a list comes back in says which
-  branch ran, where a real shuffle of six elements draws the order it was
-  given once in 720 and answers nothing the other 719 times. `Tx`
+  branch ran, where a real shuffle can preserve the order it was given —
+  once in 720 for six elements — and a run that draws it says nothing. The
+  ten-attempt randomized assertion beside it is gone for that reason, its
+  two inputs and four outputs making the odds 1 in 48 an attempt. `Tx`
   being a dataclass is a promise too, and `dataclasses.fields` is what
   reads it: the constructor, the comparison and every conversion are
   written out, so the decorator is left holding the field list and the
@@ -4528,19 +4530,22 @@ edit.
   `parsers.toml` excludes is the `|` of a type annotation: all four modules
   open with `from __future__ import annotations`, so `Sequence[TxIn] | None`
   is an unevaluated string, and cosmic-ray's eleven replacements for that
-  operator are 88 mutants nothing can reach. Measured rather than argued: an
-  unfiltered session over the same scope reports 144 survivors and every one
-  of those 88 is among them, so filtering leaves the 56 that are worth
-  reading and spends minutes less, a survivor costing the whole test command
-  where most kills cost a fraction of one. Excluded by operator rather than
-  with a
-  `# pragma: no mutate` on each of the 37 annotations, which is what
-  `sig_hash.toml` refused for six of them: a pragma is a line of library
-  source added for the benefit of a weekly report. The price is stated
-  where it is paid — a real `a | b` added to one of these modules would be
-  skipped in silence, and the grep that re-derives the claim is beside the
-  exclusion — as is what a skip does to the one number the workflow prints:
-  `cr-rate` counts a result that is not SURVIVED as a kill
+  operator are 88 mutants — eight such `|`, on seven lines — that nothing
+  can reach. Measured rather than argued: an unfiltered session over the same
+  scope reports 144 survivors and every one of those 88 is among them, so
+  filtering leaves the 56 that are worth reading and spends minutes less, a
+  survivor costing the whole test command where most kills cost a fraction of
+  one. Excluded by operator rather than with a `# pragma: no mutate`, and not
+  because seven lines of library source are many: `cr-filter-pragma` skips
+  whatever mutation *ends* on a marked line, and all seven are signatures, so
+  the pragma would take the `check_validity` default and the keyword-only `*`
+  on those lines with it — mutants this profile's survivor list is about. The
+  price of the operator is the other way round and stated where it is paid: a
+  real `a | b` added to one of these modules would be skipped in silence, and
+  the grep that re-derives the claim is beside the exclusion. So is what a
+  skip does to the one number the workflow prints: `cr-rate` counts a result
+  that is not SURVIVED as a kill, which a skip and a per-mutant timeout both
+  are
 - **the bindings dependency states its policy where the pin is** (issue
   #325). `btclib_libsecp256k1>=0.7.1` has no upper bound, and the
   absence of a ceiling is now written down as the decision it is:
@@ -4796,9 +4801,10 @@ edit.
   is what the issue asked for and refused to guess at: 727 mutants in
   `sig_hash.py` against 2768 in the engine, a survival rate measured on
   the first of those, and a `timeout` of 300 s rather than 60 because at
-  60 the *unmutated* baseline timed out on a machine under load — a
-  timeout is a verdict of its own, so slack is survivors not reported as
-  noise. It is not a gate and is not among master's required checks: a
+  60 the *unmutated* baseline timed out on a machine under load — and
+  cosmic-ray answers KILLED for a timeout, so a tight one turns a slow
+  mutant into a kill nobody earned. It is not a gate and is not among
+  master's required checks: a
   mutant survives because a test is missing, so a red merge would stop
   whoever next touched the file for a hole somebody else left
 - an `rpc-smoke` workflow asks live bitcoinds what the recorded replies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3986,10 +3986,11 @@ edit.
   is set, and what replaces it is the inequality of the two inputs, which is
   behaviour rather than the flag behind it; and a non-shuffled `join` was
   held to equalling *another* non-shuffled join, which two shuffled ones
-  satisfy every other attempt with two inputs — so the question asked is
-  whether anything shuffles at all when both flags are false, a monkeypatched
-  `SystemRandom.shuffle` failing the test if it is called, because six
-  elements drawn in the order they were given is still one run in 720. `Tx`
+  satisfy every other attempt with two inputs — so `SystemRandom.shuffle` is
+  monkeypatched to a known permutation, reversal, and each of the four flag
+  combinations is one equality: the order a list comes back in says which
+  branch ran, where a real shuffle of six elements draws the order it was
+  given once in 720 and answers nothing the other 719 times. `Tx`
   being a dataclass is a promise too, and `dataclasses.fields` is what
   reads it: the constructor, the comparison and every conversion are
   written out, so the decorator is left holding the field list and the
@@ -4509,7 +4510,7 @@ edit.
   the ast walk in that file is the only thing that fails on it. Measured
   before the budget was written, and the numbers are what the issue asked
   for rather than an estimate: 1035 mutants, 88 skipped, the 947 that ran
-  taking a little over five minutes of cpu, 56 surviving. So this profile
+  taking minutes rather than hours, 56 surviving. So this profile
   *finishes*,
   where the engine's five and a half hours are sampled — which is what
   makes a survival rate comparable with the week before. Its own job, in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4019,6 +4019,17 @@ edit.
   and on inputs that are all distinct are joined by the code and refused by
   the mutant. What is left of that shape in the profile is one mutant in
   `var_int._parse_number`, where the sizes compared are 2, 4 and 8
+- **validation asks even an empty witness to validate itself.** The base
+  `Witness` has nothing to reject when its stack is empty, so the old truth
+  guard changed none of its answers; a public subclass can still have an
+  invariant of its own, and `TxIn.assert_valid` now dispatches to it without
+  making non-emptiness stand in for validity. The test uses that falsey
+  subclass, which is the case that distinguishes the two implementations
+- **`join` flattens its inputs once**, then compares that list's length with
+  the serialized-input set and hands the same list to the transaction. The
+  duplicate check and the result therefore read one snapshot instead of
+  traversing every transaction's inputs separately for the count, the set
+  and the concatenation
 - **three assertions that could not fail say something now.** `assert
   tx_in.nSequence == tx_in.nSequence` compared the property with itself in
   three places, so the alias it is there to check was never read; `assert
@@ -4551,10 +4562,11 @@ edit.
   marker into `/`, which moves `check_validity` into a positional slot, and
   the ast walk in that file is the only thing that fails on it. Measured
   before the budget was written, and the numbers are what the issue asked
-  for rather than an estimate: 1035 mutants, 88 skipped, the 947 that ran
-  taking minutes rather than hours, and 31 surviving once the tests the runs
-  asked for were written — 127 before them. None of those 31 is a test anybody
-  can write: 28 are equivalent mutants, one turns `!=` into `is not` where the
+  for rather than an estimate: 1034 mutants, 88 skipped, the 946 that ran
+  taking minutes rather than hours, and 30 surviving once the tests the runs
+  asked for were written — 127 in the original run, before the tests and the
+  simplification above. Of those 30, 27 are classified as equivalent mutants,
+  one turns `!=` into `is not` where the
   sizes compared are 2, 4 and 8 and CPython interns all three, and two are the
   upper end of `assert_standard`'s version window, which issue #387 has to
   settle before a test may pin it. So this profile *finishes*,
@@ -4576,8 +4588,8 @@ edit.
   is an unevaluated string, and cosmic-ray's eleven replacements for that
   operator are 88 mutants — eight such `|`, on seven lines — that nothing
   can reach. Measured rather than argued: an unfiltered session over the same
-  scope reports 119 survivors and every one of those 88 is among them, so
-  filtering leaves the 31 that are worth reading and spends minutes less, a
+  scope reports 118 survivors and every one of those 88 is among them, so
+  filtering leaves the 30 that are worth reading and spends minutes less, a
   survivor costing the whole test command where most kills cost a fraction of
   one. Excluded by operator rather than with a `# pragma: no mutate`, and the
   collateral of a pragma is not the argument for it: grouped by the line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3968,24 +3968,28 @@ edit.
   `MAX_SIZE`'s value, every test around the cap holding for whatever the
   constant is; the non-canonical message naming the width the number was
   written in; the four-byte range of a version, a lock time and a sequence
-  at both ends rather than at one; the version window `assert_standard`
-  reads as signed, whose corners answer differently from `assert_valid`'s
-  range; the coinbase script_sig's 2 to 100 bytes, both included;
+  at both ends rather than at one; the versions `assert_standard` refuses
+  where `assert_valid` takes them, zero and every one whose top bit is set —
+  and not where it puts the upper end, which is issue #387's to answer and
+  no test's to pin; the coinbase script_sig's 2 to 100 bytes, both included;
   `assert_valid` asking every input and every output, which only a
   transaction whose sums are fine can reach; the legacy sigop count being
   the sum of both lists rather than a bitwise mix of them, one sigop on
-  each side being the case that tells those apart; and an output value read
-  as unsigned, the octets that tell the two readings apart being refused
-  before the conversion sees them
+  each side being the case that tells those apart; and an eight-byte output
+  value surviving an unchecked round trip byte for byte while validation
+  refuses it, which is the invariant either reading of the field satisfies
+  — issue #388 has the reading itself
 - **three assertions that could not fail say something now.** `assert
   tx_in.nSequence == tx_in.nSequence` compared the property with itself in
   three places, so the alias it is there to check was never read; `assert
   tx_in == tx_in2 or TX_IN_COMPARES_WITNESS` passes whichever way that flag
-  is set, and the two halves are now separate assertions; and a
-  non-shuffled `join` was held to equalling *another* non-shuffled join,
-  which two shuffled ones satisfy every other attempt with two inputs — so
-  the order it keeps is asserted against the concatenation it was given,
-  over six inputs and six outputs, where a shuffle agrees once in 720. `Tx`
+  is set, and what replaces it is the inequality of the two inputs, which is
+  behaviour rather than the flag behind it; and a non-shuffled `join` was
+  held to equalling *another* non-shuffled join, which two shuffled ones
+  satisfy every other attempt with two inputs — so the question asked is
+  whether anything shuffles at all when both flags are false, a monkeypatched
+  `SystemRandom.shuffle` failing the test if it is called, because six
+  elements drawn in the order they were given is still one run in 720. `Tx`
   being a dataclass is a promise too, and `dataclasses.fields` is what
   reads it: the constructor, the comparison and every conversion are
   written out, so the decorator is left holding the field list and the
@@ -4505,16 +4509,18 @@ edit.
   the ast walk in that file is the only thing that fails on it. Measured
   before the budget was written, and the numbers are what the issue asked
   for rather than an estimate: 1035 mutants, 88 skipped, the 947 that ran
-  taking 4 min 43 s of cpu, 54 surviving. So this profile *finishes*,
+  taking a little over five minutes of cpu, 56 surviving. So this profile
+  *finishes*,
   where the engine's five and a half hours are sampled — which is what
   makes a survival rate comparable with the week before. Its own job, in
-  parallel with the consensus one and under a 60-minute ceiling, because
-  the two sessions there already spend 180 of the 200 minutes that job has:
-  the jobs are now a matrix over profiles, each cell naming its
-  configurations and their budgets, so a scope added next takes nothing
-  from the ones already measured. One artifact per profile, two uploads
-  under one name being an error, so `mutation-sessions` is now
-  `mutation-consensus-sessions` beside `mutation-parser-sessions`
+  parallel with the consensus one, with a 30-minute budget under a
+  45-minute ceiling, because the two sessions there already spend 180 of
+  the 200 minutes that job has: the jobs are now a matrix over profiles,
+  each cell naming its configurations and their budgets, so a scope added
+  next takes nothing from the ones already measured. One artifact per
+  profile, two uploads under one name being an error, so
+  `mutation-sessions` is now `mutation-consensus-sessions` beside
+  `mutation-parsers-sessions`
 - **`cr-filter-operators` runs between `init` and `exec`** for every
   configuration, and is a no-op for one that excludes no operator, so the
   decision stays in the toml rather than in the workflow. What
@@ -4522,10 +4528,11 @@ edit.
   open with `from __future__ import annotations`, so `Sequence[TxIn] | None`
   is an unevaluated string, and cosmic-ray's eleven replacements for that
   operator are 88 mutants nothing can reach. Measured rather than argued: an
-  unfiltered session over the same scope reports 142 survivors and every one
-  of those 88 is among them, so filtering leaves the 54 that are worth
-  reading and spends two minutes less, a survivor costing the whole test
-  command. Excluded by operator rather than with a
+  unfiltered session over the same scope reports 144 survivors and every one
+  of those 88 is among them, so filtering leaves the 56 that are worth
+  reading and spends minutes less, a survivor costing the whole test command
+  where most kills cost a fraction of one. Excluded by operator rather than
+  with a
   `# pragma: no mutate` on each of the 37 annotations, which is what
   `sig_hash.toml` refused for six of them: a pragma is a line of library
   source added for the benefit of a weekly report. The price is stated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4568,9 +4568,9 @@ edit.
   `cr-filter-pragma` reads — the one a mutation *ends* on — six of the seven
   hold nothing but that annotation's eleven mutants, the multiline signatures
   putting the `*` and the `check_validity` default on lines of their own.
-  `out_point.py:97` is the exception and the only signature written on one
-  line, where a pragma would also skip the ten mutants of the keyword-only
-  `*` and the one of its default. What settles it is where the decision
+  `OutPoint.to_dict` is the exception, the only one of the seven written on a
+  single line, where a pragma would also skip the ten mutants of its
+  keyword-only `*` and the one of its default. What settles it is where the decision
   lives: one line in the file that already says what is mutated and what
   judges it, against a marker in each of seven library lines and again in
   every module a later `module-path` adds. The price is the same either way

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3985,12 +3985,19 @@ edit.
   check_validity:` negated, changed nothing any test asked about, so what
   every caller who says nothing gets was the one thing the flag's
   91 signatures did not promise. `tests/check_validity_test.py` carries the
-  table — an invalid instance of each class, built with the check off, and
-  invalid in a way its own conversions do not notice — and asks both
-  directions of both boundaries: `serialize` and `to_dict` refuse it by
-  default, `parse` and `from_dict` refuse the octets and the dict it writes,
-  and each of the four accepts with the flag off, which is the half that says
-  the flag still switches the check *off*. `TxOut` is out of the dict half
+  table, in two columns, because a fixture invalid only in a nested object
+  answers the *child's* guard: take `if check_validity:` out of
+  `TxIn.serialize` and the `prev_out.serialize` under it raises in its place,
+  a green suite about nothing. One column is therefore invalid at its own
+  class's boundary — a sequence of `True`, a transaction without inputs —
+  and holds `serialize`, `to_dict` and `from_dict`; the other is invalid in a
+  nested outpoint and holds `parse`, which the first cannot: a `True`
+  sequence reads back as the number one, and a transaction without inputs has
+  no octets to read at all, the input count being where the segwit marker
+  lives. Each accepts with the flag off, which is the half that says the flag
+  still switches the check *off*, and every guard was removed one at a time
+  to see the tests notice: eleven of the twelve go red, the twelfth being the
+  one below. `TxOut` is out of the dict half
   and by name: its only validity question is the amount, `to_dict` puts that
   through `btc_from_sats` and `from_dict` through `sats_from_btc`, and each of
   those is `valid_sats_amount` — so the conversion asks what `assert_valid`
@@ -4003,6 +4010,15 @@ edit.
   `tests/check_validity_test.py` states for the flag it is named after. The
   ast walk in that file only inspects signatures carrying `check_validity`,
   so these two were mutable from `*` to `/` with nothing red
+- **`join` compares numbers and not objects**, which is what let three of its
+  guards be mutated from `!=` to `is not` with nothing red: equal small
+  integers are the same object in CPython, so every case a test built from
+  literals passes either way. `int("1000")` builds a fresh object where the
+  literal would be the cached one, and 257 distinct inputs put a count past
+  the last cached integer, so transactions agreeing on version, on lock time
+  and on inputs that are all distinct are joined by the code and refused by
+  the mutant. What is left of that shape in the profile is one mutant in
+  `var_int._parse_number`, where the sizes compared are 2, 4 and 8
 - **three assertions that could not fail say something now.** `assert
   tx_in.nSequence == tx_in.nSequence` compared the property with itself in
   three places, so the alias it is there to check was never read; `assert
@@ -4536,12 +4552,12 @@ edit.
   the ast walk in that file is the only thing that fails on it. Measured
   before the budget was written, and the numbers are what the issue asked
   for rather than an estimate: 1035 mutants, 88 skipped, the 947 that ran
-  taking minutes rather than hours, and 34 surviving once the tests the first
-  run asked for were written — 127 before them. None of those 34 is a test
-  anybody can write: 28 are equivalent mutants, four turn `!=` into `is not`
-  on integers CPython interns, and two are the upper end of
-  `assert_standard`'s version window, which issue #387 has to settle before a
-  test may pin it. So this profile *finishes*,
+  taking minutes rather than hours, and 31 surviving once the tests the runs
+  asked for were written — 127 before them. None of those 31 is a test anybody
+  can write: 28 are equivalent mutants, one turns `!=` into `is not` where the
+  sizes compared are 2, 4 and 8 and CPython interns all three, and two are the
+  upper end of `assert_standard`'s version window, which issue #387 has to
+  settle before a test may pin it. So this profile *finishes*,
   where the engine's five and a half hours are sampled — which is what
   makes a survival rate comparable with the week before. Its own job, in
   parallel with the consensus one, with a 30-minute budget under a
@@ -4560,8 +4576,8 @@ edit.
   is an unevaluated string, and cosmic-ray's eleven replacements for that
   operator are 88 mutants — eight such `|`, on seven lines — that nothing
   can reach. Measured rather than argued: an unfiltered session over the same
-  scope reports 122 survivors and every one of those 88 is among them, so
-  filtering leaves the 34 that are worth reading and spends minutes less, a
+  scope reports 119 survivors and every one of those 88 is among them, so
+  filtering leaves the 31 that are worth reading and spends minutes less, a
   survivor costing the whole test command where most kills cost a fraction of
   one. Excluded by operator rather than with a `# pragma: no mutate`, and the
   collateral of a pragma is not the argument for it: grouped by the line
@@ -4569,10 +4585,12 @@ edit.
   hold nothing but that annotation's eleven mutants, the multiline signatures
   putting the `*` and the `check_validity` default on lines of their own.
   `OutPoint.to_dict` is the exception, the only one of the seven written on a
-  single line, where a pragma would also skip the ten mutants of its
-  keyword-only `*` and the one of its default. What settles it is where the decision
-  lives: one line in the file that already says what is mutated and what
-  judges it, against a marker in each of seven library lines and again in
+  single line: 23 mutations end there and a pragma would skip 12 the filter
+  does not — eleven replacements of its keyword-only `*`, `Mul_BitOr` among
+  them and so past the anchored pattern, and the one of its default. What
+  settles it is where the decision lives: one line in the file that already
+  says what is mutated and what judges it, against a marker in each of seven
+  library lines and again in
   every module a later `module-path` adds. The price is the same either way
   and is paid in the configuration instead of the library: a real `a | b`
   added to one of these modules would be skipped in silence, and the grep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3979,6 +3979,30 @@ edit.
   value surviving an unchecked round trip byte for byte while validation
   refuses it, which is the invariant either reading of the field satisfies
   — issue #388 has the reading itself
+- **`check_validity`'s default is held to checking**, class by class over the
+  wire format, and that is the shape 19 of the parser profile's survivors
+  had: a `check_validity: bool = True` mutated to `False`, or an `if
+  check_validity:` negated, changed nothing any test asked about, so what
+  every caller who says nothing gets was the one thing the flag's
+  91 signatures did not promise. `tests/check_validity_test.py` carries the
+  table — an invalid instance of each class, built with the check off, and
+  invalid in a way its own conversions do not notice — and asks both
+  directions of both boundaries: `serialize` and `to_dict` refuse it by
+  default, `parse` and `from_dict` refuse the octets and the dict it writes,
+  and each of the four accepts with the flag off, which is the half that says
+  the flag still switches the check *off*. `TxOut` is out of the dict half
+  and by name: its only validity question is the amount, `to_dict` puts that
+  through `btc_from_sats` and `from_dict` through `sats_from_btc`, and each of
+  those is `valid_sats_amount` — so the conversion asks what `assert_valid`
+  would, and the flag has nothing left to switch. A test of that exclusion
+  stands where the reason would otherwise be prose
+- **the two keyword-only flags of `btclib/tx/tx.py` that are not
+  `check_validity`** — `assert_valid`'s `unsigned_template` and
+  `_assert_valid_coinbase`'s `is_coinbase` — are held to refusing a
+  positional call, which is the hazard the star is there for and the one
+  `tests/check_validity_test.py` states for the flag it is named after. The
+  ast walk in that file only inspects signatures carrying `check_validity`,
+  so these two were mutable from `*` to `/` with nothing red
 - **three assertions that could not fail say something now.** `assert
   tx_in.nSequence == tx_in.nSequence` compared the property with itself in
   three places, so the alias it is there to check was never read; `assert
@@ -4512,8 +4536,12 @@ edit.
   the ast walk in that file is the only thing that fails on it. Measured
   before the budget was written, and the numbers are what the issue asked
   for rather than an estimate: 1035 mutants, 88 skipped, the 947 that ran
-  taking minutes rather than hours, 56 surviving. So this profile
-  *finishes*,
+  taking minutes rather than hours, and 34 surviving once the tests the first
+  run asked for were written — 127 before them. None of those 34 is a test
+  anybody can write: 28 are equivalent mutants, four turn `!=` into `is not`
+  on integers CPython interns, and two are the upper end of
+  `assert_standard`'s version window, which issue #387 has to settle before a
+  test may pin it. So this profile *finishes*,
   where the engine's five and a half hours are sampled — which is what
   makes a survival rate comparable with the week before. Its own job, in
   parallel with the consensus one, with a 30-minute budget under a
@@ -4532,8 +4560,8 @@ edit.
   is an unevaluated string, and cosmic-ray's eleven replacements for that
   operator are 88 mutants — eight such `|`, on seven lines — that nothing
   can reach. Measured rather than argued: an unfiltered session over the same
-  scope reports 144 survivors and every one of those 88 is among them, so
-  filtering leaves the 56 that are worth reading and spends minutes less, a
+  scope reports 122 survivors and every one of those 88 is among them, so
+  filtering leaves the 34 that are worth reading and spends minutes less, a
   survivor costing the whole test command where most kills cost a fraction of
   one. Excluded by operator rather than with a `# pragma: no mutate`, and not
   because seven lines of library source are many: `cr-filter-pragma` skips

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4030,6 +4030,24 @@ edit.
   duplicate check and the result therefore read one snapshot instead of
   traversing every transaction's inputs separately for the count, the set
   and the concatenation
+- **a subclass is where the invariant a base class cannot have lives**, and
+  eight mutants of `btclib/tx/` were reachable only through one: `Witness`,
+  `TxOut` and `TxIn` are public and not final, `parse` and `from_dict` build
+  `cls` on purpose, and the `check_validity=False` a parent hands a child is
+  observable the moment that child has something of its own to refuse. So
+  `tests/check_validity_test.py` holds the forwarded flag with a rejecting
+  `Witness` inside a `TxIn` and a rejecting `TxOut` on its own and inside a
+  `Tx`, and the amount-conversion exclusion beside it is narrowed to the base
+  class, which is all it ever showed. Four of those eight were the ones that
+  exclusion had covered
+- **`Tx.__eq__`'s witness fallback is exercised rather than masked.** The
+  branch runs only when `TX_IN_COMPARES_WITNESS` is false, and monkeypatching
+  that global cannot reach `field(compare=...)`, which the dataclass read at
+  class creation: the generated `TxIn` comparison went on reading the witness,
+  answered the same way as the branch, and hid whatever the branch did — a
+  deleted `not`, a doubled one, an `is` for `!=`, all three green. The input
+  is now a `TxIn` subclass whose equality leaves the witness out, as the false
+  setting makes the generated one, so the branch is the whole of the answer
 - **three assertions that could not fail say something now.** `assert
   tx_in.nSequence == tx_in.nSequence` compared the property with itself in
   three places, so the alias it is there to check was never read; `assert
@@ -4563,13 +4581,12 @@ edit.
   the ast walk in that file is the only thing that fails on it. Measured
   before the budget was written, and the numbers are what the issue asked
   for rather than an estimate: 1034 mutants, 88 skipped, the 946 that ran
-  taking minutes rather than hours, and 30 surviving once the tests the runs
+  taking minutes rather than hours, and 22 surviving once the tests the runs
   asked for were written — 127 in the original run, before the tests and the
-  simplification above. Of those 30, 27 are classified as equivalent mutants,
-  one turns `!=` into `is not` where the
-  sizes compared are 2, 4 and 8 and CPython interns all three, and two are the
-  upper end of `assert_standard`'s version window, which issue #387 has to
-  settle before a test may pin it. So this profile *finishes*,
+  simplification above. Of those 22, 19 are equivalent mutants, one turns `!=`
+  into `is not` where the sizes compared are 2, 4 and 8 and CPython interns
+  all three, and two are the upper end of `assert_standard`'s version window,
+  which issue #387 has to settle before a test may pin it. So this profile *finishes*,
   where the engine's five and a half hours are sampled — which is what
   makes a survival rate comparable with the week before. Its own job, in
   parallel with the consensus one, with a 30-minute budget under a
@@ -4588,8 +4605,8 @@ edit.
   is an unevaluated string, and cosmic-ray's eleven replacements for that
   operator are 88 mutants — eight such `|`, on seven lines — that nothing
   can reach. Measured rather than argued: an unfiltered session over the same
-  scope reports 118 survivors and every one of those 88 is among them, so
-  filtering leaves the 30 that are worth reading and spends minutes less, a
+  scope reports 110 survivors and every one of those 88 is among them, so
+  filtering leaves the 22 that are worth reading and spends minutes less, a
   survivor costing the whole test command where most kills cost a fraction of
   one. Excluded by operator rather than with a `# pragma: no mutate`, and the
   collateral of a pragma is not the argument for it: grouped by the line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4563,17 +4563,22 @@ edit.
   scope reports 122 survivors and every one of those 88 is among them, so
   filtering leaves the 34 that are worth reading and spends minutes less, a
   survivor costing the whole test command where most kills cost a fraction of
-  one. Excluded by operator rather than with a `# pragma: no mutate`, and not
-  because seven lines of library source are many: `cr-filter-pragma` skips
-  whatever mutation *ends* on a marked line, and all seven are signatures, so
-  the pragma would take the `check_validity` default and the keyword-only `*`
-  on those lines with it — mutants this profile's survivor list is about. The
-  price of the operator is the other way round and stated where it is paid: a
-  real `a | b` added to one of these modules would be skipped in silence, and
-  the grep that re-derives the claim is beside the exclusion. So is what a
-  skip does to the one number the workflow prints: `cr-rate` counts a result
-  that is not SURVIVED as a kill, which a skip and a per-mutant timeout both
-  are
+  one. Excluded by operator rather than with a `# pragma: no mutate`, and the
+  collateral of a pragma is not the argument for it: grouped by the line
+  `cr-filter-pragma` reads — the one a mutation *ends* on — six of the seven
+  hold nothing but that annotation's eleven mutants, the multiline signatures
+  putting the `*` and the `check_validity` default on lines of their own.
+  `out_point.py:97` is the exception and the only signature written on one
+  line, where a pragma would also skip the ten mutants of the keyword-only
+  `*` and the one of its default. What settles it is where the decision
+  lives: one line in the file that already says what is mutated and what
+  judges it, against a marker in each of seven library lines and again in
+  every module a later `module-path` adds. The price is the same either way
+  and is paid in the configuration instead of the library: a real `a | b`
+  added to one of these modules would be skipped in silence, and the grep
+  that re-derives the claim is beside the exclusion. So is what a skip does
+  to the one number the workflow prints: `cr-rate` counts a result that is
+  not SURVIVED as a kill, which a skip and a per-mutant timeout both are
 - **the bindings dependency states its policy where the pin is** (issue
   #325). `btclib_libsecp256k1>=0.7.1` has no upper bound, and the
   absence of a ceiling is now written down as the decision it is:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -337,7 +337,7 @@ same five commands run any of the three: `parsers.toml` is the one that
 excludes a family, and states which and why. `sig_hash.toml` or
 `engine.toml` in place of it is the other profile, at 727 mutants and half
 an hour of cpu against 2768 and five and a half hours; the parser profile
-is 1035 mutants and minutes, so it is the one that finishes. Each
+is 1034 mutants and minutes, so it is the one that finishes. Each
 configuration carries its own arithmetic. The report is `--surviving-only`,
 which is the whole of what anybody acts on: a killed mutant is the suite
 doing its job, and printing all 727 of them buries the dozen that are not.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,32 +307,40 @@ The `mutation` workflow, weekly and on demand, which gates nothing either
 and for a different reason: it asks whether the suite would *notice* a
 wrong line, where coverage only says the line ran, and a surviving mutant
 is a test nobody has written rather than a regression somebody just
-caused. Scoped to the consensus code — `btclib/script/engine/` and
-`btclib/script/sig_hash.py` — by the two configurations under
-`.github/mutation/`, which is also what a local run reads, so there is one
-statement of what is mutated and what judges it:
+caused. Two profiles, a parallel job with its own budget each: the
+consensus code — `btclib/script/engine/` and `btclib/script/sig_hash.py` —
+and the wire format, `btclib/tx/` with the `var_int` and `var_bytes`
+codecs under it. The three configurations under `.github/mutation/` are
+what says so, and are what a local run reads, so there is one statement of
+what is mutated and what judges it:
 
 ```shell
 uv run --locked --no-default-groups --group test --group mutation \
-    cosmic-ray baseline .github/mutation/sig_hash.toml
+    cosmic-ray baseline .github/mutation/parsers.toml
 uv run --locked --no-default-groups --group test --group mutation \
-    cosmic-ray init .github/mutation/sig_hash.toml sig_hash.sqlite
+    cosmic-ray init .github/mutation/parsers.toml parsers.sqlite
 uv run --locked --no-default-groups --group test --group mutation \
-    cosmic-ray exec .github/mutation/sig_hash.toml sig_hash.sqlite
+    cr-filter-operators parsers.sqlite .github/mutation/parsers.toml
 uv run --locked --no-default-groups --group test --group mutation \
-    cr-report --surviving-only --show-diff sig_hash.sqlite
+    cosmic-ray exec .github/mutation/parsers.toml parsers.sqlite
+uv run --locked --no-default-groups --group test --group mutation \
+    cr-report --surviving-only --show-diff parsers.sqlite
 ```
 
 `baseline` first, always: it runs the configured test command against the
 unmutated tree, and without it a stale path or a renamed test file fails
 every mutant identically and the session reports a perfect kill rate,
 which is the one failure mode of a mutation run that looks like good news.
-`engine.toml` in place of `sig_hash.toml` is the other scope, at 2768
-mutants against 727 and five and a half hours against half an hour of cpu;
-each configuration says what its own arithmetic is. The report is
-`--surviving-only`, which is the whole of what anybody acts on: a killed
-mutant is the suite doing its job, and printing all 727 of them buries the
-dozen that are not.
+`cr-filter-operators` marks as skipped the mutants a configuration
+excludes by operator, and is a no-op for one that excludes none, so the
+same five commands run any of the three: `parsers.toml` is the one that
+excludes a family, and states which and why. `sig_hash.toml` or
+`engine.toml` in place of it is the other profile, at 727 mutants and half
+an hour of cpu against 2768 and five and a half hours; the parser profile
+is 1035 mutants and minutes, so it is the one that finishes. Each
+configuration carries its own arithmetic. The report is `--surviving-only`,
+which is the whole of what anybody acts on: a killed mutant is the suite
+doing its job, and printing all 727 of them buries the dozen that are not.
 
 Three things to know before starting one. The session mutates the source
 file in place and restores it afterwards, so nothing else may read the

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -420,11 +420,9 @@ def join(
     if enforce_same_lock_time and any(tx.lock_time != lock_time for tx in txs):
         raise BTClibValueError("Lock times are not the same")
 
-    if sum(len(tx.vin) for tx in txs) != len(
-        {vin.serialize() for tx in txs for vin in tx.vin}
-    ):
-        raise BTClibValueError("common inputs")
     vin = [vin for tx in txs for vin in tx.vin]
+    if len(vin) != len({tx_in.serialize() for tx_in in vin}):
+        raise BTClibValueError("common inputs")
 
     vout = [vout for tx in txs for vout in tx.vout]
 

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -151,8 +151,7 @@ class TxIn:
         if not 0 <= self.sequence <= 0xFFFFFFFF:
             raise BTClibValueError(f"invalid sequence: {self.sequence}")
 
-        if self.script_witness:
-            self.script_witness.assert_valid()
+        self.script_witness.assert_valid()
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, Any]:
         """Return the input as a dict of json-friendly values.

--- a/tests/check_validity_test.py
+++ b/tests/check_validity_test.py
@@ -14,6 +14,13 @@ about signatures rather than about any one of them: it appears in 91 of
 them and is forwarded by hand from one to the next, so the guard has to be
 the rule itself. A new signature spelling it positionally is what this
 module fails on.
+
+What the flag *does* when nobody passes it is the other half, and the same
+kind of rule: every default is True, so a caller who says nothing gets the
+check. Nothing held any of those defaults to it -- the mutation profile of
+issue #327 reported one survivor per default and per `if check_validity:`
+in `btclib/tx/` -- and the tests at the end of this module are what does,
+over the wire-format classes that profile measures.
 """
 
 from __future__ import annotations
@@ -21,13 +28,16 @@ from __future__ import annotations
 import ast
 import dataclasses
 import pathlib
+from typing import Any
 
 import pytest
 
+from btclib.amount import _MAX_SATOSHI
 from btclib.curves import secp256k1
 from btclib.ecc import dsa
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.script.script_pub_key import ScriptPubKey
+from btclib.tx import TxIn, TxOut
 from btclib.tx.out_point import OutPoint
 from btclib.tx.tx import Tx
 
@@ -155,3 +165,115 @@ def test_a_parameter_before_the_flag_stays_positional() -> None:
     assert tx.serialize(False, check_validity=False) == tx.serialize(
         include_witness=False, check_validity=False
     )
+
+
+# an outpoint that is neither a coinbase marker nor an ordinary reference:
+# the all-zero tx_id with a real vout, which assert_valid refuses and
+# nothing else looks at
+_HALF_COINBASE = OutPoint(b"\x00" * 32, 0, check_validity=False)
+
+# one invalid object per wire-format class, built with the check off, and
+# invalid in a way its conversions do not notice: what is being asked is
+# whether the flag's default asks, so an object whose serialization fails
+# for some other reason would answer the wrong question
+_INVALID: list[tuple[str, Any]] = [
+    ("outpoint", _HALF_COINBASE),
+    ("tx_in", TxIn(_HALF_COINBASE, check_validity=False)),
+    ("tx_out", TxOut(_MAX_SATOSHI + 1, "", check_validity=False)),
+    (
+        "tx",
+        Tx(
+            1,
+            0,
+            [TxIn(_HALF_COINBASE, check_validity=False)],
+            [TxOut(1, "")],
+            check_validity=False,
+        ),
+    ),
+]
+
+# the dict half of the same table, tx_out excepted and by name: its only
+# validity question is the amount, and `to_dict` puts that amount through
+# `btc_from_sats`, which is `valid_sats_amount` -- the conversion asks what
+# assert_valid would ask, so there is no answer the flag could change. The
+# test after the two below is that exclusion, stated as a test rather than
+# as prose here
+_INVALID_FOR_A_DICT = [case for case in _INVALID if case[0] != "tx_out"]
+
+
+def _serialize(obj: Any, **flag: bool) -> bytes:
+    """Return the wire octets, `include_witness` being Tx's own parameter.
+
+    The flag is forwarded and never spelled: a default written here would
+    be a copy of the one under test, and the call with nothing to forward
+    is the case that matters.
+    """
+    if isinstance(obj, Tx):
+        return obj.serialize(include_witness=True, **flag)
+    octets: bytes = obj.serialize(**flag)
+    return octets
+
+
+@pytest.mark.parametrize(("name", "invalid"), _INVALID, ids=[c[0] for c in _INVALID])
+def test_the_default_checks_on_the_way_to_octets(name: str, invalid: Any) -> None:
+    """Serialize and parse validate unless the caller says not to.
+
+    Both directions of one boundary: the object that must not be written
+    is also the octets that must not be read back into an object, and each
+    is refused by a default nobody passed.
+    """
+    assert name  # the id of the case, so a failure names it
+
+    octets = _serialize(invalid, check_validity=False)
+    with pytest.raises((BTClibValueError, BTClibTypeError)):
+        _serialize(invalid)
+
+    assert type(invalid).parse(octets, check_validity=False)
+    with pytest.raises((BTClibValueError, BTClibTypeError)):
+        type(invalid).parse(octets)
+
+
+@pytest.mark.parametrize(
+    ("name", "invalid"),
+    _INVALID_FOR_A_DICT,
+    ids=[c[0] for c in _INVALID_FOR_A_DICT],
+)
+def test_the_default_checks_on_the_way_to_a_dict(name: str, invalid: Any) -> None:
+    """to_dict and from_dict validate unless the caller says not to.
+
+    The json boundary, where the default matters most: `from_dict` is what
+    reads a value somebody else wrote.
+    """
+    assert name
+
+    dict_ = invalid.to_dict(check_validity=False)
+    with pytest.raises((BTClibValueError, BTClibTypeError)):
+        invalid.to_dict()
+
+    assert type(invalid).from_dict(dict_, check_validity=False)
+    with pytest.raises((BTClibValueError, BTClibTypeError)):
+        type(invalid).from_dict(dict_)
+
+
+def test_a_tx_out_dict_refuses_the_amount_either_way() -> None:
+    """The exclusion above, and why it is one rather than an oversight.
+
+    A TxOut is valid when its amount is, and the dict form of an amount is
+    BTC: `to_dict` calls `btc_from_sats` and `from_dict` calls
+    `sats_from_btc`, each of which validates the amount on its own. So the
+    flag has nothing left to switch off here, and the refusal below is the
+    conversion's rather than assert_valid's.
+    """
+    invalid = TxOut(_MAX_SATOSHI + 1, "", check_validity=False)
+    for check_validity in (True, False):
+        with pytest.raises(BTClibValueError, match="invalid satoshi amount: "):
+            invalid.to_dict(check_validity=check_validity)
+
+    over = {"value": "21000000.00000001", "scriptPubKey": {"asm": "", "hex": ""}}
+    for check_validity in (True, False):
+        with pytest.raises(BTClibValueError, match="invalid BTC amount: "):
+            TxOut.from_dict(over, check_validity=check_validity)
+
+    # and what neither refusal takes with it: the octets, where the amount
+    # is eight bytes and `serialize` is the only reader of the flag
+    assert invalid.serialize(check_validity=False)

--- a/tests/check_validity_test.py
+++ b/tests/check_validity_test.py
@@ -171,17 +171,36 @@ def test_a_parameter_before_the_flag_stays_positional() -> None:
 # the all-zero tx_id with a real vout, which assert_valid refuses and
 # nothing else looks at
 _HALF_COINBASE = OutPoint(b"\x00" * 32, 0, check_validity=False)
+_GOOD_OUT_POINT = OutPoint(b"\x01" * 32, 0)
 
-# one invalid object per wire-format class, built with the check off, and
-# invalid in a way its conversions do not notice: what is being asked is
-# whether the flag's default asks, so an object whose serialization fails
-# for some other reason would answer the wrong question
+# invalid objects, built with the check off, and two shapes of invalid
+# rather than one because they answer different questions.
+#
+# `-itself` is invalid at that class's own boundary, which is what holds the
+# class's own guard: a parent forwards the flag to its children, so an object
+# invalid only in a child is refused by the child whatever the parent does --
+# take `if check_validity:` out of `TxIn.serialize` and the
+# `prev_out.serialize` below it raises in its place, a green suite about
+# nothing.
+#
+# `-nested` is invalid in a child, which is what holds the
+# `check_validity=False` a parent hands its children: turned True, that inner
+# call refuses an object the outer call was told not to look at. It is also
+# the only shape `parse` can be asked about, for the reason beside
+# _NO_OCTETS.
+#
+# Every one of them is invalid in a way the conversions do not notice: a
+# sequence of `True`, a transaction without inputs and an amount over
+# MoneyRange all serialize, so what refuses them is the flag and not the
+# arithmetic underneath
 _INVALID: list[tuple[str, Any]] = [
     ("outpoint", _HALF_COINBASE),
-    ("tx_in", TxIn(_HALF_COINBASE, check_validity=False)),
+    ("tx_in-itself", TxIn(_GOOD_OUT_POINT, b"", True, check_validity=False)),
+    ("tx_in-nested", TxIn(_HALF_COINBASE, check_validity=False)),
     ("tx_out", TxOut(_MAX_SATOSHI + 1, "", check_validity=False)),
+    ("tx-itself", Tx(1, 0, [], [TxOut(1, "")], check_validity=False)),
     (
-        "tx",
+        "tx-nested",
         Tx(
             1,
             0,
@@ -192,13 +211,22 @@ _INVALID: list[tuple[str, Any]] = [
     ),
 ]
 
-# the dict half of the same table, tx_out excepted and by name: its only
-# validity question is the amount, and `to_dict` puts that amount through
-# `btc_from_sats`, which is `valid_sats_amount` -- the conversion asks what
-# assert_valid would ask, so there is no answer the flag could change. The
-# test after the two below is that exclusion, stated as a test rather than
-# as prose here
-_INVALID_FOR_A_DICT = [case for case in _INVALID if case[0] != "tx_out"]
+# what a `parse` cannot be asked, and why: a sequence of `True` reads back as
+# the number one, which is a valid input, and a transaction without inputs
+# has no octets to read back at all -- the input count is where the segwit
+# marker lives, so its `\x00` opens a witness section rather than an empty
+# list
+_NO_OCTETS = {"tx_in-itself", "tx-itself"}
+
+# and what a dict cannot be asked. TxOut's only validity question is the
+# amount, and `to_dict` puts that amount through `btc_from_sats`, which is
+# `valid_sats_amount` -- the conversion asks what assert_valid would ask, so
+# there is no answer the flag could change. The last test below is that
+# exclusion, stated as a test rather than as prose here
+_NO_DICT = {"tx_out"}
+
+_OCTETS = [case for case in _INVALID if case[0] not in _NO_OCTETS]
+_DICTS = [case for case in _INVALID if case[0] not in _NO_DICT]
 
 
 def _serialize(obj: Any, **flag: bool) -> bytes:
@@ -215,30 +243,42 @@ def _serialize(obj: Any, **flag: bool) -> bytes:
 
 
 @pytest.mark.parametrize(("name", "invalid"), _INVALID, ids=[c[0] for c in _INVALID])
-def test_the_default_checks_on_the_way_to_octets(name: str, invalid: Any) -> None:
-    """Serialize and parse validate unless the caller says not to.
+def test_the_default_checks_the_object_it_is_asked_about(
+    name: str, invalid: Any
+) -> None:
+    """Serialize refuses an object its own class calls invalid.
 
-    Both directions of one boundary: the object that must not be written
-    is also the octets that must not be read back into an object, and each
-    is refused by a default nobody passed.
+    And writes it when the caller says so, which is the half that says the
+    flag still switches the check off rather than the half that says it is
+    there.
     """
     assert name  # the id of the case, so a failure names it
 
-    octets = _serialize(invalid, check_validity=False)
+    assert _serialize(invalid, check_validity=False)
     with pytest.raises((BTClibValueError, BTClibTypeError)):
         _serialize(invalid)
+
+
+@pytest.mark.parametrize(("name", "invalid"), _OCTETS, ids=[c[0] for c in _OCTETS])
+def test_the_default_checks_the_octets_it_reads(name: str, invalid: Any) -> None:
+    """Parse refuses octets that decode to an invalid object.
+
+    The other direction of the same boundary, and the one somebody else's
+    bytes arrive through.
+    """
+    assert name
+
+    octets = _serialize(invalid, check_validity=False)
 
     assert type(invalid).parse(octets, check_validity=False)
     with pytest.raises((BTClibValueError, BTClibTypeError)):
         type(invalid).parse(octets)
 
 
-@pytest.mark.parametrize(
-    ("name", "invalid"),
-    _INVALID_FOR_A_DICT,
-    ids=[c[0] for c in _INVALID_FOR_A_DICT],
-)
-def test_the_default_checks_on_the_way_to_a_dict(name: str, invalid: Any) -> None:
+@pytest.mark.parametrize(("name", "invalid"), _DICTS, ids=[c[0] for c in _DICTS])
+def test_the_default_checks_the_dict_it_writes_and_reads(
+    name: str, invalid: Any
+) -> None:
     """to_dict and from_dict validate unless the caller says not to.
 
     The json boundary, where the default matters most: `from_dict` is what

--- a/tests/check_validity_test.py
+++ b/tests/check_validity_test.py
@@ -36,6 +36,7 @@ from btclib.amount import _MAX_SATOSHI
 from btclib.curves import secp256k1
 from btclib.ecc import dsa
 from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.script import Witness
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.tx import TxIn, TxOut
 from btclib.tx.out_point import OutPoint
@@ -295,14 +296,68 @@ def test_the_default_checks_the_dict_it_writes_and_reads(
         type(invalid).from_dict(dict_)
 
 
-def test_a_tx_out_dict_refuses_the_amount_either_way() -> None:
+def test_a_nested_object_is_left_the_flag_it_was_given() -> None:
+    """The `check_validity=False` a parent hands its children is theirs.
+
+    Turned True, that inner call refuses an object the outer call was told
+    not to look at -- and a subclass is where the invariant that shows it
+    lives, `Witness`, `TxOut` and `TxIn` all being public and not final. The
+    base classes cannot say so: an empty witness has nothing to reject, and
+    a TxOut's only question is an amount its own conversion asks whatever
+    the flag says, which is the test below.
+
+    Held through the two constructors that build `cls` rather than a named
+    class, too, since a subclass is what they are `cls` for.
+    """
+
+    class RejectingWitness(Witness):
+        def assert_valid(self) -> None:
+            raise BTClibValueError("invalid witness")
+
+    class RejectingTxOut(TxOut):
+        def assert_valid(self) -> None:
+            raise BTClibValueError("invalid output")
+
+    tx_in = TxIn(
+        _GOOD_OUT_POINT,
+        b"",
+        0,
+        RejectingWitness(check_validity=False),
+        check_validity=False,
+    )
+    tx_out = RejectingTxOut(1, "", check_validity=False)
+    tx = Tx(1, 0, [TxIn(_GOOD_OUT_POINT)], [tx_out], check_validity=False)
+
+    for obj, err_msg in (
+        (tx_in, "invalid witness"),
+        (tx_out, "invalid output"),
+        (tx, "invalid output"),
+    ):
+        assert obj.to_dict(check_validity=False)
+        with pytest.raises(BTClibValueError, match=err_msg):
+            obj.to_dict()
+
+    dict_ = tx_out.to_dict(check_validity=False)
+    assert RejectingTxOut.from_dict(dict_, check_validity=False).value == 1
+    with pytest.raises(BTClibValueError, match="invalid output"):
+        RejectingTxOut.from_dict(dict_)
+
+    octets = tx_out.serialize(check_validity=False)
+    assert RejectingTxOut.parse(octets, check_validity=False).value == 1
+    with pytest.raises(BTClibValueError, match="invalid output"):
+        RejectingTxOut.parse(octets)
+
+
+def test_a_base_tx_out_dict_refuses_the_amount_either_way() -> None:
     """The exclusion above, and why it is one rather than an oversight.
 
-    A TxOut is valid when its amount is, and the dict form of an amount is
-    BTC: `to_dict` calls `btc_from_sats` and `from_dict` calls
-    `sats_from_btc`, each of which validates the amount on its own. So the
-    flag has nothing left to switch off here, and the refusal below is the
-    conversion's rather than assert_valid's.
+    A base TxOut is valid when its amount is, and the dict form of an amount
+    is BTC: `to_dict` calls `btc_from_sats` and `from_dict` calls
+    `sats_from_btc`, each of which validates the amount on its own. So for
+    this class the flag has nothing left to switch off, and the refusal below
+    is the conversion's rather than assert_valid's -- which is what the
+    subclass above answers for, an invariant of its own being the thing a
+    conversion cannot ask.
     """
     invalid = TxOut(_MAX_SATOSHI + 1, "", check_validity=False)
     for check_validity in (True, False):

--- a/tests/tx/out_point_test.py
+++ b/tests/tx/out_point_test.py
@@ -103,3 +103,37 @@ def test_invalid_outpoint() -> None:
     out_point = OutPoint(b"\x00" * 32, 0, check_validity=False)
     with pytest.raises(BTClibValueError, match="invalid OutPoint"):
         out_point.assert_valid()
+
+
+def test_a_tx_id_is_exactly_32_bytes() -> None:
+    """Too long is refused as well as too short, the field being fixed.
+
+    A length checked from below only is the shape issue 322 reported
+    elsewhere: 33 bytes serialize back to 37, so the octets an OutPoint
+    was built from and the octets it writes would differ, and the two
+    would name different outputs.
+    """
+    for size in (0, 31, 33, 64):
+        out_point = OutPoint(b"\x01" * size, 18, check_validity=False)
+        with pytest.raises(BTClibValueError, match="invalid OutPoint tx_id: "):
+            out_point.assert_valid()
+
+
+def test_a_coinbase_marker_is_both_fields_or_neither() -> None:
+    """is_coinbase answers for the pair, and half of it is not a coinbase.
+
+    assert_valid refuses the mix, so a valid OutPoint cannot tell the
+    conjunction from either half of it: the objects built with the check
+    off are the only place the question can be put, and the answer decides
+    whether a transaction with such an input is read as a coinbase.
+    """
+    assert OutPoint().is_coinbase()
+
+    for tx_id, vout in (
+        (b"\x00" * 32, 0),  # the null tx_id, a real vout
+        (b"\x01" * 32, 0xFFFFFFFF),  # a real tx_id, the null vout
+        (b"", 0xFFFFFFFF),  # no tx_id at all
+        (b"\x00" * 32, 0xFFFFFFFF + 1),  # a vout no four bytes hold
+        (b"\x01" * 32, 0),
+    ):
+        assert not OutPoint(tx_id, vout, check_validity=False).is_coinbase()

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -17,7 +17,6 @@ import pytest
 from btclib.exceptions import BTClibValueError
 from btclib.script import Witness
 from btclib.tx import OutPoint, Tx, TxIn
-from btclib.tx.tx_in import TX_IN_COMPARES_WITNESS
 from tests.conftest import JsonGolden
 
 
@@ -84,10 +83,10 @@ def test_tx_in() -> None:
     tx_in2 = TxIn.parse(tx_in.serialize())
     assert not tx_in2.is_segwit()
     # the witness is part of a TxIn comparison, so the input carrying one
-    # differs from the input that comes back off the wire without it. Both
-    # halves are stated: an `== ... or TX_IN_COMPARES_WITNESS` would pass
-    # whichever way the flag is set, which is no statement at all
-    assert TX_IN_COMPARES_WITNESS
+    # differs from the input that comes back off the wire without it. Said
+    # of the objects rather than of the flag behind them, and an
+    # `== ... or TX_IN_COMPARES_WITNESS` says neither: it passes whichever
+    # way that flag is set
     assert tx_in != tx_in2
     tx_in2 = TxIn.from_dict(tx_in.to_dict())
     assert tx_in2.is_segwit()

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -29,7 +29,7 @@ def test_tx_in() -> None:
     assert tx_in.sequence == 0
     assert tx_in.outpoint == tx_in.prev_out
     assert tx_in.scriptSig == tx_in.script_sig
-    assert tx_in.nSequence == tx_in.nSequence
+    assert tx_in.nSequence == tx_in.sequence
     assert tx_in.is_coinbase()
     assert not tx_in.is_segwit()
     tx_in2 = TxIn.parse(tx_in.serialize())
@@ -50,7 +50,7 @@ def test_tx_in() -> None:
     assert tx_in.sequence == sequence
     assert tx_in.outpoint == tx_in.prev_out
     assert tx_in.scriptSig == tx_in.script_sig
-    assert tx_in.nSequence == tx_in.nSequence
+    assert tx_in.nSequence == tx_in.sequence
     assert not tx_in.is_coinbase()
     assert not tx_in.is_segwit()
     tx_in2 = TxIn.parse(tx_in.serialize())
@@ -78,19 +78,27 @@ def test_tx_in() -> None:
     assert tx_in.sequence == sequence
     assert tx_in.outpoint == tx_in.prev_out
     assert tx_in.scriptSig == tx_in.script_sig
-    assert tx_in.nSequence == tx_in.nSequence
+    assert tx_in.nSequence == tx_in.sequence
     assert not tx_in.is_coinbase()
     assert tx_in.is_segwit()
     tx_in2 = TxIn.parse(tx_in.serialize())
     assert not tx_in2.is_segwit()
-    assert tx_in == tx_in2 or TX_IN_COMPARES_WITNESS
+    # the witness is part of a TxIn comparison, so the input carrying one
+    # differs from the input that comes back off the wire without it. Both
+    # halves are stated: an `== ... or TX_IN_COMPARES_WITNESS` would pass
+    # whichever way the flag is set, which is no statement at all
+    assert TX_IN_COMPARES_WITNESS
+    assert tx_in != tx_in2
     tx_in2 = TxIn.from_dict(tx_in.to_dict())
     assert tx_in2.is_segwit()
     assert tx_in == tx_in2
 
-    tx_in.sequence = 0xFFFFFFFF + 1
-    with pytest.raises(BTClibValueError, match="invalid sequence: "):
-        tx_in.assert_valid()
+    # the sequence is a 4-byte unsigned integer, so both ends of the range
+    # answer: 0 and 0xFFFFFFFF above are inputs this test built
+    for sequence in (-1, 0xFFFFFFFF + 1):
+        tx_in.sequence = sequence
+        with pytest.raises(BTClibValueError, match="invalid sequence: "):
+            tx_in.assert_valid()
 
 
 def test_default_arguments_are_not_shared() -> None:

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -122,6 +122,19 @@ def test_default_arguments_are_not_shared() -> None:
     assert not TxIn().script_witness.stack
 
 
+def test_an_empty_witness_is_still_validated() -> None:
+    """Validation dispatches to a witness even when its stack is empty."""
+
+    class RejectingWitness(Witness):
+        def assert_valid(self) -> None:
+            raise BTClibValueError("invalid witness")
+
+    witness = RejectingWitness(check_validity=False)
+    tx_in = TxIn(script_witness=witness, check_validity=False)
+    with pytest.raises(BTClibValueError, match="invalid witness"):
+        tx_in.assert_valid()
+
+
 def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
     """Compare a real input's to_dict with its golden json, and back."""
     fname = "d4f3c2c3c218be868c77ae31bedb497e2f908d6ee5bbbe91e4933e6da680c970.bin"

--- a/tests/tx/tx_out_test.py
+++ b/tests/tx/tx_out_test.py
@@ -82,6 +82,26 @@ def test_invalid_tx_out() -> None:
         TxOut(-1, script)
 
 
+def test_the_value_is_eight_unsigned_octets() -> None:
+    """The amount an output holds is unsigned, top bit set included.
+
+    Every amount a valid output carries is below MoneyRange, hence below
+    2^63, where the signed and unsigned readings agree -- so the octets
+    that tell them apart are refused by `assert_valid` and reach the
+    conversion only with the check off. Read as signed they are a negative
+    amount, which serializes back to something else or not at all: two
+    buffers for one object, the malleability issue 322 is about.
+    """
+    highest_bit_set = b"\xff" * 8 + b"\x00"  # the value, then an empty script
+
+    tx_out = TxOut.parse(highest_bit_set, check_validity=False)
+    assert tx_out.value == 0xFFFFFFFFFFFFFFFF
+    assert tx_out.serialize(check_validity=False) == highest_bit_set
+
+    with pytest.raises(BTClibValueError, match="invalid satoshi amount: "):
+        TxOut.parse(highest_bit_set)
+
+
 def test_tx_out_from_address() -> None:
     """Verify from_address keeps the address and infers the network."""
     address = "bc1qwqdg6squsna38e46795at95yu9atm8azzmyvckulcc7kytlcckxswvvzej"

--- a/tests/tx/tx_out_test.py
+++ b/tests/tx/tx_out_test.py
@@ -82,20 +82,21 @@ def test_invalid_tx_out() -> None:
         TxOut(-1, script)
 
 
-def test_the_value_is_eight_unsigned_octets() -> None:
-    """The amount an output holds is unsigned, top bit set included.
+def test_an_eight_byte_value_round_trips_and_is_refused() -> None:
+    """The octets survive an unchecked round trip, and validation refuses them.
 
     Every amount a valid output carries is below MoneyRange, hence below
-    2^63, where the signed and unsigned readings agree -- so the octets
-    that tell them apart are refused by `assert_valid` and reach the
-    conversion only with the check off. Read as signed they are a negative
-    amount, which serializes back to something else or not at all: two
-    buffers for one object, the malleability issue 322 is about.
+    2^63, where a signed and an unsigned reading of the field agree -- so
+    the octets that tell the two apart reach the conversion only with the
+    check off. What is asserted is what holds either way: the buffer comes
+    back byte for byte, so one buffer stays one object rather than two, and
+    the checked parse refuses the amount. Which integer btclib should show
+    for it -- Core's `CAmount` is signed, and reads these as -1 -- is issue
+    388's to answer, and no assertion here decides it.
     """
     highest_bit_set = b"\xff" * 8 + b"\x00"  # the value, then an empty script
 
     tx_out = TxOut.parse(highest_bit_set, check_validity=False)
-    assert tx_out.value == 0xFFFFFFFFFFFFFFFF
     assert tx_out.serialize(check_validity=False) == highest_bit_set
 
     with pytest.raises(BTClibValueError, match="invalid satoshi amount: "):

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -16,6 +16,7 @@ those bytes given a node with the transaction index.
 tests/_data/README.md has its size and wtxid.
 """
 
+import dataclasses
 import inspect
 from os import path
 
@@ -177,6 +178,131 @@ def test_exceptions() -> None:
         tx.assert_valid()
 
 
+def test_the_four_byte_fields_at_their_bounds() -> None:
+    """Zero and 0xFFFFFFFF are in the range, -1 and one more are out.
+
+    Both ends of both fields, and the accepted end is the half a refusal
+    test cannot state: a bound one too tight or one too loose refuses a
+    transaction that is in a block, which is the direction that cannot be
+    noticed from the outside.
+    """
+    tx_in = TxIn(OutPoint(b"\x01" * 32, 0))
+    tx_out = TxOut(1, "")
+
+    for value in (0, 1, 0xFFFFFFFE, 0xFFFFFFFF):
+        Tx(value, 0, [tx_in], [tx_out]).assert_valid()
+        Tx(1, value, [tx_in], [tx_out]).assert_valid()
+
+    for value in (-1, 0xFFFFFFFF + 1):
+        with pytest.raises(BTClibValueError, match="invalid version: "):
+            Tx(value, 0, [tx_in], [tx_out])
+        with pytest.raises(BTClibValueError, match="invalid lock time: "):
+            Tx(1, value, [tx_in], [tx_out])
+
+
+def test_the_top_of_the_four_byte_range_round_trips() -> None:
+    """Version and lock_time are unsigned on the wire, and above 2^31 too.
+
+    Read or written as signed, a version of 0xFFFFFFFF comes back as -1
+    and 0x80000000 does not serialize at all -- and assert_valid accepts
+    every one of them, only assert_standard reading the version as the
+    signed int Core relays on. A transaction below 0x80000000 cannot tell
+    the two spellings apart.
+    """
+    tx = Tx(
+        0xFFFFFFFF,
+        0xFFFFFFFF,
+        [TxIn(OutPoint(b"\x01" * 32, 0))],
+        [TxOut(1, "")],
+    )
+    tx_bytes = tx.serialize(include_witness=True)
+    assert tx_bytes.endswith(b"\xff" * 4)  # the lock time, little endian
+    assert tx_bytes.startswith(b"\xff" * 4)  # and the version before it
+
+    parsed = Tx.parse(tx_bytes)
+    assert parsed.version == 0xFFFFFFFF
+    assert parsed.lock_time == 0xFFFFFFFF
+    assert parsed == tx
+
+
+def test_a_standard_version_is_the_signed_range_without_zero() -> None:
+    """assert_standard wants 0 < version <= 0x7FFFFFFF, both ends of it.
+
+    The window is Core's IsStandardTx read as a signed int, and every one
+    of its four corners answers differently from the range assert_valid
+    checks: zero and 0x80000000 are valid versions that are not standard.
+    """
+    tx = Tx(1, 0, [TxIn(OutPoint(b"\x01" * 32, 0))], [TxOut(1, "")])
+
+    for version in (1, 2, 0x7FFFFFFE, 0x7FFFFFFF):
+        tx.version = version
+        tx.assert_standard()
+
+    for version in (0, 0x7FFFFFFF + 1, 0xFFFFFFFF):
+        tx.version = version
+        tx.assert_valid()
+        with pytest.raises(BTClibValueError, match="invalid version: "):
+            tx.assert_standard()
+
+
+def test_the_coinbase_script_size_window() -> None:
+    """A coinbase script_sig is 2 to 100 bytes, both included.
+
+    Consensus writes the rule as an inclusive range, so both ends are a
+    valid coinbase and one byte outside either is not: a bound one off
+    would reject a block that is in the chain, or accept one that is not.
+    """
+    tx_out = TxOut(1, "")
+
+    for size in (2, 3, 99, 100):
+        Tx(vin=[TxIn(OutPoint(), b"\x00" * size)], vout=[tx_out]).assert_valid()
+
+    for size in (0, 1, 101, 200):
+        with pytest.raises(BTClibValueError, match="Invalid coinbase script size"):
+            Tx(vin=[TxIn(OutPoint(), b"\x00" * size)], vout=[tx_out])
+
+
+def test_an_invalid_input_or_output_fails_the_transaction() -> None:
+    """assert_valid asks every input and every output, not only the sums.
+
+    A negative sequence and a negative amount are each invalid on their
+    own while leaving every transaction-level check happy -- the output
+    total is still inside MoneyRange -- so nothing but the delegation
+    catches them.
+    """
+    prev_out = OutPoint(b"\x01" * 32, 0)
+
+    tx_in = TxIn(prev_out, b"", -1, check_validity=False)
+    tx = Tx(1, 0, [tx_in], [TxOut(1, "")], check_validity=False)
+    with pytest.raises(BTClibValueError, match="invalid sequence: "):
+        tx.assert_valid()
+
+    tx_out = TxOut(-1, "", check_validity=False)
+    tx = Tx(1, 0, [TxIn(prev_out)], [tx_out], check_validity=False)
+    with pytest.raises(BTClibValueError, match="invalid satoshi amount: "):
+        tx.assert_valid()
+
+
+def test_sig_op_count_adds_the_two_sides() -> None:
+    """The count is the sum of both lists, which is not a mix of them.
+
+    One sigop in the inputs and one in the outputs is the case that says
+    so: a bitwise operator in place of the sum answers one or zero for it,
+    and answers correctly for a transaction whose inputs announce none.
+    """
+    check_sig = b"\xac"  # OP_CHECKSIG, one sigop wherever it is
+
+    tx = Tx(
+        1,
+        0,
+        [TxIn(OutPoint(b"\x01" * 32, 0), check_sig)],
+        [TxOut(1, check_sig)],
+    )
+    assert sig_op_count(tx.vin[0].script_sig) == 1
+    assert sig_op_count(tx.vout[0].script_pub_key.script) == 1
+    assert tx.sig_op_count == 2
+
+
 def test_output_total_is_bounded() -> None:
     """The outputs are bounded one by one and then as a sum.
 
@@ -267,6 +393,32 @@ def test_coinbase_block_1() -> None:
     assert tx.sig_op_count == 1
     assert sig_op_count(tx.vin[0].script_sig) == 0
     assert sig_op_count(tx.vout[0].script_pub_key.script) == 1
+
+
+def test_a_coinbase_input_belongs_to_a_coinbase_only() -> None:
+    """The null outpoint is refused where the transaction is not a coinbase.
+
+    Two inputs make `is_coinbase` false whatever they are, so the null
+    outpoint among them spends an output that does not exist and creates
+    the coinbase's money outside a coinbase. Core's CheckTransaction has
+    the rule; here it was the only statement of `btclib/tx` that the
+    directory's own tests never reached -- a script_engine vector did,
+    which is a verdict on the engine and no test of this one.
+    """
+    coinbase_in = TxIn(OutPoint())
+    tx_in = TxIn(OutPoint(b"\x01" * 32, 0))
+    tx_out = TxOut(1, "")
+
+    err_msg = "coinbase input in a non-coinbase transaction"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        Tx(vin=[tx_in, coinbase_in], vout=[tx_out])
+    with pytest.raises(BTClibValueError, match=err_msg):
+        Tx(vin=[coinbase_in, tx_in], vout=[tx_out])
+
+    # and what the refusal must not take with it: the coinbase itself,
+    # whose single input is that very outpoint, with a script_sig of the
+    # size consensus wants
+    Tx(vin=[TxIn(OutPoint(), b"\x00\x00")], vout=[tx_out]).assert_valid()
 
 
 # https://en.bitcoin.it/wiki/Protocol_documentation#tx
@@ -386,8 +538,16 @@ def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
     with open(filename, "rb") as binary_file_:
         tx = Tx.parse(binary_file_.read())
 
-    # Tx dataclass
+    # Tx dataclass, which is what `fields` reads and `isinstance` cannot
+    # say: __init__, __eq__ and every conversion here are written out, so
+    # the decorator is left holding the field list and the repr
     assert isinstance(tx, Tx)
+    assert [f.name for f in dataclasses.fields(tx)] == [
+        "version",
+        "lock_time",
+        "vin",
+        "vout",
+    ]
     assert tx.is_segwit()
     assert any(bool(w) for w in tx.vwitness)
     assert any(bool(tx_in.script_witness) for tx_in in tx.vin)
@@ -516,6 +676,36 @@ def test_join() -> None:
     params = inspect.signature(join).parameters
     assert "merge_out" not in params
     assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
+def test_join_keeps_the_order_it_was_given() -> None:
+    """Not shuffling is the concatenation, input for input and output too.
+
+    Two joins compared with each other agree whenever a shuffle draws the
+    order it was given, which with two inputs is every other attempt: the
+    count is what makes the answer deterministic, and at six the odds of a
+    shuffle passing for the concatenation are one in 720.
+    """
+    txs = [
+        Tx(
+            1,
+            0,
+            [TxIn(OutPoint(bytes([i]) * 32, 0)) for i in group],
+            [TxOut(i, "") for i in group],
+        )
+        for group in ((1, 2, 3), (4, 5, 6))
+    ]
+
+    joint_tx = join(
+        txs,
+        enforce_same_version=True,
+        enforce_same_lock_time=True,
+        shuffle_inp=False,
+        shuffle_out=False,
+    )
+
+    assert [tx_in.prev_out.tx_id[0] for tx_in in joint_tx.vin] == [1, 2, 3, 4, 5, 6]
+    assert [tx_out.value for tx_out in joint_tx.vout] == [1, 2, 3, 4, 5, 6]
 
 
 def test_eq() -> None:

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -27,6 +27,7 @@ import pytest
 from btclib.exceptions import BTClibValueError
 from btclib.script import ScriptPubKey, Witness, sig_op_count
 from btclib.tx import OutPoint, Tx, TxIn, TxOut, join
+from btclib.tx.tx import _assert_valid_coinbase
 from tests.conftest import JsonGolden
 
 
@@ -403,6 +404,28 @@ def test_coinbase_block_1() -> None:
     assert tx.sig_op_count == 1
     assert sig_op_count(tx.vin[0].script_sig) == 0
     assert sig_op_count(tx.vout[0].script_pub_key.script) == 1
+
+
+def test_the_other_two_flags_stay_keyword_only() -> None:
+    """`unsigned_template` and `is_coinbase` sit behind a star as well.
+
+    tests/check_validity_test.py states the rule for the flag it is named
+    after, and these are the two in this module that are not it: the hazard
+    is the same one, a parameter added in front of a positional flag taking
+    its slot in silence, and a keyword-only one makes that call a TypeError
+    instead. `_assert_valid_coinbase` is private and reached here directly,
+    a keyword call being all `Tx.assert_valid` can say about it.
+    """
+    tx = Tx(1, 0, [TxIn(OutPoint(b"\x01" * 32, 0))], [TxOut(1, "")])
+
+    with pytest.raises(TypeError, match="positional argument"):
+        tx.assert_valid(True)  # type: ignore[call-arg]
+    with pytest.raises(TypeError, match="positional argument"):
+        _assert_valid_coinbase(tx.vin, False)  # type: ignore[call-arg]
+
+    # and what the refusal must not take with it
+    tx.assert_valid(unsigned_template=True)
+    _assert_valid_coinbase(tx.vin, is_coinbase=False)
 
 
 def test_a_coinbase_input_belongs_to_a_coinbase_only() -> None:

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -206,10 +206,12 @@ def test_the_top_of_the_four_byte_range_round_trips() -> None:
     """Version and lock_time are unsigned on the wire, and above 2^31 too.
 
     Read or written as signed, a version of 0xFFFFFFFF comes back as -1
-    and 0x80000000 does not serialize at all -- and assert_valid accepts
-    every one of them, only assert_standard reading the version as the
-    signed int Core relays on. A transaction below 0x80000000 cannot tell
-    the two spellings apart.
+    and 0x80000000 does not serialize at all, so a transaction below
+    0x80000000 cannot tell the two spellings apart. Both are valid
+    versions, which is the other half of the boundary: `assert_valid`
+    takes the whole four-byte range and `assert_standard` refuses this end
+    of it -- what Core's own field is, signed in v27.2 and unsigned in
+    v31.1, is issue 387's, and no assertion here needs it.
     """
     tx = Tx(
         0xFFFFFFFF,
@@ -227,8 +229,8 @@ def test_the_top_of_the_four_byte_range_round_trips() -> None:
     assert parsed == tx
 
 
-def test_a_standard_version_is_neither_zero_nor_negative_as_signed() -> None:
-    """Versions 1 and 2 are standard; 0 and the negative-as-signed ones are not.
+def test_a_standard_version_excludes_zero_and_the_top_bit_set_ones() -> None:
+    """Versions 1 and 2 are standard; zero and a set top bit are not.
 
     Only the part of the window both Core policies agree on: 1 and 2 are
     standard for v27.2 and v31.1 alike, and every version whose top bit is
@@ -625,20 +627,12 @@ def test_join() -> None:
         shuffle_inp=False,
         shuffle_out=False,
     )
-    # testing shuffle
-    # 10 attempts should be enough to reduce to zero the probability
-    # of having (all) shuffled ones identical to the original one
-    assert any(
-        join(
-            [tx1, tx2],
-            enforce_same_version=True,
-            enforce_same_lock_time=True,
-            shuffle_inp=True,
-            shuffle_out=True,
-        )
-        != joint_tx
-        for _ in range(10)
-    )
+    # what each flag does is test_join_shuffles_only_when_it_is_told_to's,
+    # against a known permutation: these two transactions have two inputs
+    # and four outputs between them, so a real shuffle draws the order it
+    # was given once in 2! * 4! -- and an attempt that draws it says
+    # nothing either way, which is what makes ten of them an assertion
+    # about probability rather than about the join
 
     tx2.version = 2
     with pytest.raises(BTClibValueError, match="Version numbers are not the same"):

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -225,16 +225,22 @@ def test_the_top_of_the_four_byte_range_round_trips() -> None:
     assert parsed == tx
 
 
-def test_a_standard_version_is_the_signed_range_without_zero() -> None:
-    """assert_standard wants 0 < version <= 0x7FFFFFFF, both ends of it.
+def test_a_standard_version_is_neither_zero_nor_negative_as_signed() -> None:
+    """Versions 1 and 2 are standard; 0 and the negative-as-signed ones are not.
 
-    The window is Core's IsStandardTx read as a signed int, and every one
-    of its four corners answers differently from the range assert_valid
-    checks: zero and 0x80000000 are valid versions that are not standard.
+    Only the part of the window both Core policies agree on: 1 and 2 are
+    standard for v27.2 and v31.1 alike, and every version whose top bit is
+    set is standard for neither. Where `assert_standard` currently puts the
+    upper end -- 0x7FFFFFFF, which is standard for no Core -- is issue 387's
+    to answer, so it is deliberately not a test here.
+
+    What the low end is worth saying is that these are valid versions:
+    `assert_valid` takes zero and takes 0xFFFFFFFF, standardness being the
+    narrower question and the only one asked about relay.
     """
     tx = Tx(1, 0, [TxIn(OutPoint(b"\x01" * 32, 0))], [TxOut(1, "")])
 
-    for version in (1, 2, 0x7FFFFFFE, 0x7FFFFFFF):
+    for version in (1, 2):
         tx.version = version
         tx.assert_standard()
 
@@ -678,14 +684,22 @@ def test_join() -> None:
     assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
-def test_join_keeps_the_order_it_was_given() -> None:
+def test_join_keeps_the_order_it_was_given(monkeypatch: pytest.MonkeyPatch) -> None:
     """Not shuffling is the concatenation, input for input and output too.
 
-    Two joins compared with each other agree whenever a shuffle draws the
-    order it was given, which with two inputs is every other attempt: the
-    count is what makes the answer deterministic, and at six the odds of a
-    shuffle passing for the concatenation are one in 720.
+    The monkeypatch is what makes the answer deterministic rather than
+    likely: a shuffle of six elements draws the order it was given once in
+    720, and comparing two non-shuffled joins with each other is worse
+    still -- with two inputs they agree every other attempt. So the
+    question asked is whether anything shuffles at all when both flags are
+    false, and the order below is what that leaves.
     """
+
+    def refuse(_self: object, _sequence: object) -> None:
+        pytest.fail("join shuffled a list it was told to keep in order")
+
+    monkeypatch.setattr("btclib.tx.tx.secrets.SystemRandom.shuffle", refuse)
+
     txs = [
         Tx(
             1,

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -18,7 +18,9 @@ tests/_data/README.md has its size and wtxid.
 
 import dataclasses
 import inspect
+from collections.abc import MutableSequence
 from os import path
+from typing import Any
 
 import pytest
 
@@ -684,21 +686,25 @@ def test_join() -> None:
     assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values())
 
 
-def test_join_keeps_the_order_it_was_given(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Not shuffling is the concatenation, input for input and output too.
+def test_join_shuffles_only_when_it_is_told_to(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each flag decides one list, and off means the order it was given.
 
-    The monkeypatch is what makes the answer deterministic rather than
-    likely: a shuffle of six elements draws the order it was given once in
-    720, and comparing two non-shuffled joins with each other is worse
-    still -- with two inputs they agree every other attempt. So the
-    question asked is whether anything shuffles at all when both flags are
-    false, and the order below is what that leaves.
+    A known permutation in place of the system one, because the answer has
+    to be an equality rather than a likelihood: a real shuffle of six
+    elements draws the order it was given once in 720, and comparing two
+    non-shuffled joins with each other is worse still -- with two inputs
+    they agree every other attempt. Reversal is that permutation, so each
+    list says which of the two branches ran, and each flag is read on its
+    own: a join that shuffles what it was told to keep, or keeps what it was
+    told to shuffle, is one equality away either way.
     """
 
-    def refuse(_self: object, _sequence: object) -> None:
-        pytest.fail("join shuffled a list it was told to keep in order")
+    def reverse(_self: object, sequence: MutableSequence[Any]) -> None:
+        sequence.reverse()
 
-    monkeypatch.setattr("btclib.tx.tx.secrets.SystemRandom.shuffle", refuse)
+    monkeypatch.setattr("btclib.tx.tx.secrets.SystemRandom.shuffle", reverse)
 
     txs = [
         Tx(
@@ -710,16 +716,29 @@ def test_join_keeps_the_order_it_was_given(monkeypatch: pytest.MonkeyPatch) -> N
         for group in ((1, 2, 3), (4, 5, 6))
     ]
 
-    joint_tx = join(
-        txs,
-        enforce_same_version=True,
-        enforce_same_lock_time=True,
-        shuffle_inp=False,
-        shuffle_out=False,
-    )
+    def joined(*, shuffle_inp: bool, shuffle_out: bool) -> tuple[list[int], list[int]]:
+        joint_tx = join(
+            txs,
+            enforce_same_version=True,
+            enforce_same_lock_time=True,
+            shuffle_inp=shuffle_inp,
+            shuffle_out=shuffle_out,
+        )
+        return (
+            [tx_in.prev_out.tx_id[0] for tx_in in joint_tx.vin],
+            [tx_out.value for tx_out in joint_tx.vout],
+        )
 
-    assert [tx_in.prev_out.tx_id[0] for tx_in in joint_tx.vin] == [1, 2, 3, 4, 5, 6]
-    assert [tx_out.value for tx_out in joint_tx.vout] == [1, 2, 3, 4, 5, 6]
+    concatenated = [1, 2, 3, 4, 5, 6]
+    permuted = [6, 5, 4, 3, 2, 1]
+
+    assert joined(shuffle_inp=False, shuffle_out=False) == (
+        concatenated,
+        concatenated,
+    )
+    assert joined(shuffle_inp=True, shuffle_out=True) == (permuted, permuted)
+    assert joined(shuffle_inp=True, shuffle_out=False) == (permuted, concatenated)
+    assert joined(shuffle_inp=False, shuffle_out=True) == (concatenated, permuted)
 
 
 def test_eq() -> None:

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -758,6 +758,46 @@ def test_join_shuffles_only_when_it_is_told_to(
     assert joined(shuffle_inp=False, shuffle_out=True) == (concatenated, permuted)
 
 
+def test_join_compares_by_value_and_not_by_identity() -> None:
+    """The three guards of `join` read numbers, not objects.
+
+    `int("1000")` builds a fresh object where the literal 1000 would be one
+    CPython has already cached, and 257 inputs put a count past the last
+    cached integer. A guard spelled `is not` instead of `!=` accepts every
+    case a test with small numbers can build and refuses these three, so
+    what reads as one comparison is one only up to 256.
+    """
+    tx_out = TxOut(1, "")
+
+    def tx_with(offset: int, count: int, version: int, lock_time: int) -> Tx:
+        vin = [
+            TxIn(OutPoint((offset + i).to_bytes(32, "big"), 0))
+            for i in range(1, count + 1)
+        ]
+        return Tx(version, lock_time, vin, [tx_out])
+
+    def joined(txs: list[Tx]) -> Tx:
+        return join(
+            txs,
+            enforce_same_version=True,
+            enforce_same_lock_time=True,
+            shuffle_inp=False,
+            shuffle_out=False,
+        )
+
+    # equal versions that are not the same object, then equal lock times
+    same_version = [tx_with(i * 100, 1, int("1000"), 0) for i in range(2)]
+    assert joined(same_version).version == 1000
+
+    same_lock_time = [tx_with(i * 100, 1, 1, int("1000")) for i in range(2)]
+    assert joined(same_lock_time).lock_time == 1000
+
+    # and a count past 256: the inputs are all distinct, so the sum and the
+    # size of the set are the same number and not the same object
+    many = [tx_with(1000, 129, 1, 0), tx_with(2000, 128, 1, 0)]
+    assert len(joined(many).vin) == 257
+
+
 def test_eq() -> None:
     """Verify comparing a Tx with a non-Tx answers inequality."""
     tx = Tx(check_validity=False)

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -808,15 +808,44 @@ def test_eq() -> None:
 def test_eq_witness(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tx.__eq__ compares the witnesses only if TxIn.__eq__ does not.
 
-    With TX_IN_COMPARES_WITNESS the witness is part of the TxIn
-    comparison, baked into the dataclass at class creation: the
-    vwitness check in Tx.__eq__ only ever runs for the False setting,
-    which a monkeypatch is the only way to exercise.
+    Two halves, and the monkeypatch is only one of them.
+    TX_IN_COMPARES_WITNESS reaches `field(compare=...)` at class creation, so
+    patching the module global opens the `vwitness` branch of Tx.__eq__ and
+    leaves the generated TxIn comparison still reading the witness -- which
+    answers the same way, and so says nothing about the branch. The input
+    below is the other half: a TxIn whose equality leaves the witness out, as
+    the False setting makes the generated one, so what the branch decides is
+    the whole of the answer.
     """
-    segwit = Tx(vin=[TxIn(script_witness=Witness(["00"]))], check_validity=False)
-    stripped = Tx(vin=[TxIn()], check_validity=False)
+
+    class TxInIgnoringWitness(TxIn):
+        """A TxIn compared on everything but its witness."""
+
+        def __eq__(self, other: object) -> bool:
+            if not isinstance(other, TxIn):
+                return NotImplemented
+            return (self.prev_out, self.script_sig, self.sequence) == (
+                other.prev_out,
+                other.script_sig,
+                other.sequence,
+            )
+
+    def tx_with(*stack: str) -> Tx:
+        witness = Witness(list(stack))
+        return Tx(
+            vin=[TxInIgnoringWitness(script_witness=witness, check_validity=False)],
+            check_validity=False,
+        )
+
     monkeypatch.setattr("btclib.tx.tx.TX_IN_COMPARES_WITNESS", False)
-    assert segwit != stripped
-    assert segwit == Tx(
-        vin=[TxIn(script_witness=Witness(["00"]))], check_validity=False
-    )
+
+    # the inputs compare equal either way, so the branch is what answers
+    assert tx_with("00").vin == tx_with().vin
+    assert tx_with("00") != tx_with()
+    assert tx_with("00") == tx_with("00")
+
+    # and the input above answers a non-input the way TxIn does, which is
+    # what its NotImplemented is for. Annotated, so that what the comparison
+    # is about is the answer rather than the two types
+    not_an_input: object = "not an input"
+    assert tx_with().vin[0] != not_an_input

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -792,8 +792,8 @@ def test_join_compares_by_value_and_not_by_identity() -> None:
     same_lock_time = [tx_with(i * 100, 1, 1, int("1000")) for i in range(2)]
     assert joined(same_lock_time).lock_time == 1000
 
-    # and a count past 256: the inputs are all distinct, so the sum and the
-    # size of the set are the same number and not the same object
+    # and a count past 256: the inputs are all distinct, so the list length
+    # and the set size have the same value but are distinct integer objects
     many = [tx_with(1000, 129, 1, 0), tx_with(2000, 128, 1, 0)]
     assert len(joined(many).vin) == 257
 

--- a/tests/var_int_test.py
+++ b/tests/var_int_test.py
@@ -80,6 +80,17 @@ def test_var_int_conversion() -> None:
     assert var_int.parse("fe703a0f00") == 998000
 
 
+def test_max_size_is_bitcoin_cores() -> None:
+    """MAX_SIZE is serialize.h's number, and the number is the whole of it.
+
+    Every check around the cap -- that MAX_SIZE parses and one more does
+    not -- holds for whatever value the constant happens to have, so the
+    value is what has to be written down: it is a limit btclib shares with
+    Core rather than one it chooses.
+    """
+    assert var_int.MAX_SIZE == 0x02000000
+
+
 def test_var_int_max_size() -> None:
     """The MAX_SIZE range check of Bitcoin Core's ReadCompactSize."""
     assert var_int.parse(var_int.serialize(var_int.MAX_SIZE)) == var_int.MAX_SIZE
@@ -122,12 +133,30 @@ def test_a_bool_is_neither_a_count_nor_a_cap() -> None:
 
 def test_var_int_non_canonical() -> None:
     """Only the shortest encoding is valid, as in Bitcoin Core."""
-    # 1 fits in one byte, 0xfd in two, 0x10000 in four
-    for encoding in ("fd0100", "fd0000", "fe01000000", "fefdff0000", "fefeff0000"):
+    # 1 fits in one byte, 0xfd in two, 0x10000 in four. fdfc00 and
+    # feffff0000 are the boundary from below -- the largest number the
+    # shorter form holds, written in the longer one -- and each is the
+    # case a minimum one short of the right value would accept
+    for encoding in (
+        "fd0100",
+        "fd0000",
+        "fdfc00",
+        "fe01000000",
+        "fefdff0000",
+        "fefeff0000",
+        "feffff0000",
+    ):
         with pytest.raises(BTClibValueError, match="non-canonical var_int: "):
             var_int.parse(encoding)
     with pytest.raises(BTClibValueError, match="non-canonical var_int: "):
         var_int.parse(b"\xff" + (0xFFFFFFFF).to_bytes(8, "little"))
+
+    # the diagnosis names the number and the width it was written in,
+    # which is what tells a longer encoding from a number out of range:
+    # both refusals are about the same octets
+    err_msg = "non-canonical var_int: 252 encoded in 3 bytes"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        var_int.parse("fdfc00")
 
     # the boundary values are the shortest encoding of themselves
     assert var_int.parse("fcfd") == 0xFC  # 0xfc is a one byte integer


### PR DESCRIPTION
Closes #327.

The wire format gets the parser profile the issue asks for, in a job of its
own with its own budget: `.github/mutation/parsers.toml` mutates
`btclib/tx/` with the `var_int` and `var_bytes` codecs under it, and reports
rather than gates, as #219 decided. `module-path` takes a list as well as a
path, so the six modules are one configuration and one test command.

Two of the five defects that opened the issue lived in that scope — a
fixed-width field that took a truncated read and normalized it on
serialization, and an octet parser that ignored what followed the object
(#322) — and the first run says the boundaries around them were still
executed rather than checked.

## The first run, measured

| | |
|---|---|
| enumerated | 1034 mutants (tx.py 410, out_point.py 211, var_int.py 166, tx_in.py 128, tx_out.py 90, var_bytes.py 29) |
| skipped by the operator filter | 88 |
| completed | 946, nothing pending: the session finishes inside its budget |
| runtime | five to seven minutes of **wall clock**, depending on what else the machine is doing — elapsed and not cpu, which is what `timeout` and the job ceiling count; nothing pending |
| survivors | 22, `cr-rate` 2.13% over the session |
| survivors before the tests below | 127 |

A mutant killed by the first test costs about a quarter of a second and a
survivor the whole 1 s command, which is why 946 mutants take minutes: the
budget in `mutation.yml` is 30 of them, several times the measurement — about
4.3 to 6× a five-to-seven-minute run — and the ceiling 45.

## Triage of the 22, and nothing in it is a test

The 21 the first triage called missing tests are gone, and so are the three it
wrongly called identity-dependent: `join`'s guards on version, lock time and
input count read numbers, and `is not` agrees with `!=` only up to 256, so
`int("1000")` and a count of 257 distinct inputs are what tell them apart.

**19 are equivalent mutants**, each made so by a check above it, by the type
of what it compares, or by a conversion that asks the same question anyway:
`^` for `-` on two booleans; `vin[-1]` for `vin[0]` where one input has just
been established; `tx_id <= b"\x00" * 32` and `vout >= 0xFFFFFFFF` where the
length and range checks have already raised; the inner `check_validity=False` of `Witness.from_dict` and
`TxOut.from_dict` as the *classmethods* they are, which build a base object
whatever the surrounding class is, and of a `ScriptPubKey`, whose checks are
"the script is bytes" and a known network; `<` for `!=` against a maximum, and `>` for `!=`
against a set that cannot be larger than the count it is compared with;
`size | 1` and `size ^ 1` for `size + 1`, equal for every even size, and 2,
4 and 8 are the only sizes; `read(i)` compared with `< i` where it cannot
return more; and `if self.script_witness:` negated.

**1 is identity rather than value**: `is not` for `!=` in
`var_int._parse_number`, where the sizes compared are 2, 4 and 8 and CPython
interns all three. Unlike `join`'s three, no input can make those differ.

**2 are a policy question left open**, the upper end of
`Tx.assert_standard`'s version window: Core relays versions 1 to 3 in v31.1
and 1 to 2 in v27.2, so pinning `0x7FFFFFFF` as standard would state what no
Core does. #387 has the decision, and closing it kills these two.

## What the survivors bought

Every boundary the runs reported unchecked and this patch may pin is a test
now, and the survivor count went from 127 to 34:

- a tx_id length refused from below only — 33 bytes were an outpoint that
  serializes back to 37;
- `is_coinbase` on the pair rather than either half of it, which only
  unchecked objects can ask;
- the largest number a two- or four-byte `var_int` holds, `fdfc00` and
  `feffff0000`, which a canonical minimum one short of its value accepts;
- `MAX_SIZE`'s value, every test around the cap holding for whatever the
  constant is, and the non-canonical message naming the width;
- version, lock time and sequence at both ends of four bytes, `-1` and one
  past the top included;
- btclib's unsigned reading of those fields on the wire, above 2^31 where a
  signed one would differ — what Core's own field is, `int32_t` in v27.2 and
  `uint32_t` in v31.1, is #387's;
- the versions `assert_standard` refuses where `assert_valid` takes them,
  zero and every one whose top bit is set — and not where its upper end sits,
  which is #387's;
- the coinbase script_sig's 2 to 100 bytes, both ends in and one byte
  outside either out;
- `assert_valid` asking every input and every output, reachable only with a
  transaction whose sums are fine;
- the legacy sigop count as a sum rather than a bitwise mix, one sigop on
  each side telling them apart;
- an eight-byte output value surviving an unchecked round trip byte for byte
  while validation refuses it, which is the invariant either reading of the
  field satisfies — #388 has the reading itself.

Three assertions that could not fail say something now: `assert
tx_in.nSequence == tx_in.nSequence` in three places, `assert tx_in ==
tx_in2 or TX_IN_COMPARES_WITNESS`, replaced by the inequality of the two
inputs, and a non-shuffled `join` held to equalling another non-shuffled
join — which two shuffled ones satisfy every other attempt with two inputs,
so `SystemRandom.shuffle` is monkeypatched to a known permutation and each
of the four flag combinations is one equality — a real shuffle can preserve
the order it was given, once in 720 for six elements, and a run that draws it
says nothing. The ten-attempt randomized assertion beside it is gone for the
same reason, its two inputs and four outputs making one attempt inconclusive
with probability 1/48. `Tx` being a dataclass is read by `dataclasses.fields` rather
than assumed.

`check_validity`'s default is a promise now, class by class, and the table
holding it has two columns, with a third case beside it for what only a
subclass can say — `Witness`, `TxOut` and `TxIn` are public and not final, and
`parse` and `from_dict` build `cls` on purpose, so the flag a parent forwards
to a child is observable as soon as that child has an invariant of its own.
The two columns are: one invalid at its own class's boundary, which is
what holds that class's guard — a parent forwards the flag, so a fixture
invalid only in a child is refused by the child — and one invalid in a child,
which is what `parse` needs and what holds the `check_validity=False` a parent
hands its children. Every one of the twelve guards was removed on its own to
see the tests notice; eleven go red, the twelfth being `TxOut.to_dict`'s
documented exclusion. So are the two
keyword-only flags of `btclib/tx/tx.py` that are not `check_validity`,
`unsigned_template` and `is_coinbase`, which the ast walk in
`tests/check_validity_test.py` does not inspect.

And one statement of `btclib/tx` that no test under `tests/tx` reached now
has a test of its own: the refusal of a coinbase input in a non-coinbase
transaction. A script_engine vector reached it, which is a verdict on the
engine and none on the transaction, and it left the profile's baseline one
statement short of the scope it mutates.

## The operator filter

`cr-filter-operators` runs between `init` and `exec` for every
configuration, and is a no-op for one that excludes nothing, so the decision
stays in the toml. What `parsers.toml` excludes is the `|` of a type
annotation: all four modules open with `from __future__ import annotations`,
so `Sequence[TxIn] | None` is an unevaluated string, and cosmic-ray's eleven
replacements for that operator are mutants nothing can reach. Unfiltered the
same scope reports 110 survivors, 88 of them that `|`; filtered it reports
the other 22, which is the difference between a list somebody reads and one
nobody does — 88 against 22.

The 88 are eleven replacements of each of eight `|`, and those eight sit on
seven lines. Excluded by operator rather than with a `# pragma: no mutate`,
and the collateral of a pragma is not the argument: grouped by the line
`cr-filter-pragma` reads — the one a mutation *ends* on — six of the seven
hold nothing but that annotation's eleven mutants, the multiline signatures
putting the `*` and the `check_validity` default on lines of their own.
`OutPoint.to_dict` is the exception, the only one of the seven written on a
single line: 23 mutations end there and a pragma would skip 12 the filter does
not — eleven replacements of the keyword-only `*`, `Mul_BitOr` among them and
so past the anchored pattern, and the one of its default. What settles it is where the decision lives: one line in the
file that already states what is mutated and what judges it, against a marker
in each of seven library lines and again in every module a later
`module-path` adds. The price is the same either way and is paid in the
configuration instead of the library: a real `a | b` added to one of these
modules would be skipped in silence, with the grep that re-derives the claim
beside the exclusion. So is what a skip does to the one number the workflow
prints: `cr-rate` counts a result that is not SURVIVED as a kill — which a
skip and a per-mutant timeout both are, `run_tests` answering KILLED for
`TimeoutExpired`. Zero timeouts in every session measured here, and no
unbounded loop in this scope for the 300 s to guard: `Tx.parse`'s `range(n)`
stops at the first `read_exactly` and `var_bytes.parse` refuses a short
`stream.read(i)`, so the width is slack for a loaded runner and nothing
else.

## Acceptance criteria

- [x] a parser-focused configuration is checked in: `.github/mutation/parsers.toml`
- [x] its baseline runs in CI before mutation, and for every profile
- [x] the first run records mutant count, runtime, completed/pending and survival rate
- [x] the survivors are triaged into missing tests, equivalent mutants, identity-dependent ones and a policy question (#387) — and every one in the first of those categories is now a test, leaving 22 that no test can reach
- [x] the schedule has an explicit budget and displaces neither #219 session: parallel jobs, 30 minutes and 45 for this one, the consensus job's 180 and 200 untouched
- [x] the configuration and the local reproduction command are in CONTRIBUTING.md
- [ ] the follow-up expansion is decided from measured cost and yield — the measurements are in the issue: `btclib/ecc/ssa.py` at 977 mutants (319 of them that same annotation `|`) with a command that covers it in a second, and `btclib/utils.py` at 325, of which 10 are the exact-read helpers `read_exactly` and `assert_no_trailing`, three more the integer predicates beside them, and 176 the script number codec, whose judge is the engine

## Verification

```shell
uv run --locked pre-commit run --all-files                 # exit 0
uv run --locked --no-default-groups --group test pytest    # 17216 passed
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html
uv run --locked --no-default-groups --group test --group mutation \
    cosmic-ray baseline .github/mutation/parsers.toml
```

The reviews are answered commit by commit, each on its own comment;
`git log origin/dev..HEAD` is the current list, the shas having moved once when
the branch was rebased onto `origin/dev` after #384, #390 and 8b5cbbd4 landed.
`b939f35d` is yours — the unconditional witness dispatch and the single `join`
snapshot — and 5e54656c answers the review after it: eight survivors called
equivalent were reachable through a public subclass, `Witness`, `TxOut` and
`TxIn` all being non-final and `parse` and `from_dict` building `cls` on
purpose, and the witness fallback of `Tx.__eq__` was masked by the generated
`TxIn` comparison rather than exercised by the monkeypatch.

The session above is the re-measurement on that head: 1034 mutants, 88 skipped,
946 run, 924 killed, 22 survivors, `cr-rate` 2.13%, zero timeouts, 110
unfiltered.

`tests/release_notes_test.py` passes, so the new CHANGELOG bullets state no
entry count. Written in a worktree on `origin/dev`, the primary checkout
untouched.

The workflow itself is checked by `actionlint` and `zizmor` and by nothing
else, here or before this branch: `mutation.yml` is not on the default
branch, so it has no runs and `gh workflow run` answers `404 ... not found
on the default branch` for it — the file says as much about cron, and the
dispatch button turns out to want the same thing. So the sessions above are
local, as `sig_hash.toml`'s and `engine.toml`'s numbers were, and the first
CI run of any of the three is whatever follows `dev` reaching `master`.
