### PR TITLE
Name the release-process gaps, close two drift issues, and align ruff/mypy/pathlib config with the bindings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,11 +36,11 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      # friday, where the latest workflow runs thursday: the sentinel has
-      # just reported when the pull requests are opened. It buys the
+      # thursday, where the latest workflow runs wednesday: the sentinel
+      # has just reported when the pull requests are opened. It buys the
       # actions ecosystem nothing, which the sentinel does not cover, but
       # two schedules a day apart are one thing to remember instead of two
-      day: friday
+      day: thursday
     target-branch: dev
     groups:
       actions:
@@ -58,7 +58,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: friday
+      day: thursday
     target-branch: dev
     groups:
       dev-tooling:

--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -14,23 +14,26 @@ is an issue, never a commit.
 
 Scope is narrower than the README: only entries whose `behind` already
 reads 0 -- the ones a human last confirmed were exactly at upstream's
-tip. An entry already documented as behind (BIP32's mediawiki, 14
-revisions, none touching the vectors) is a decision already made, and
+tip. An entry documented as behind is a decision already made, and
 re-reporting the same gap every month would just be noise; if a *new*
 commit moves it further, `behind`'s own count in the README goes stale
 in a way this script cannot see either, which is the reason it never
 tries to judge relevance, only tip-vs-pinned identity.
 
-Three shapes in the README this script does not attempt: a path
-carrying a `<name>` placeholder (BIP327's eight files and BIP324's two
-share one pin across a directory, not a single path), an entry with no
+Two shapes in the README this script does not attempt: an entry with no
 `commit` at all (chain data self-identified by hash, files this project
-composed itself), and a `repo`/`path` pair naming prose rather than a
-single blob (transcribed BIPs, already excluded by the `behind != 0`
-rule above in every current case, but not guaranteed to always be).
-Every heading the README carries but this script did not check is
-listed in its own report, so nothing silently reads as "checked and
-clean" that was not checked at all.
+composed itself, a section heading with no pin of its own), and a path
+carrying a `<name>` placeholder -- one pin standing in for several real
+paths under a directory, which the "commits touching a path" call above
+cannot be asked about in one request. No current entry uses that shape:
+BIP327's eight files and BIP324's two were themselves written that way
+once, each pin citing one commit as the tip of every path it stood in
+for. Splitting them into one pin per real path is what brought them
+into this script's scope, and also corrected BIP327's, whose shared
+commit was the tip of only one of the eight. Every heading the README
+carries but this script did not check is listed in its own report, so
+nothing silently reads as "checked and clean" that was not checked at
+all.
 
     python .github/scripts/check_vendored_vectors.py tests/_data/README.md
 """

--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -110,6 +110,7 @@ def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
             fields.get("commit"),
         )
         if not (repo and path and commit):
+            skipped.append(f"{heading} (no commit to check against)")
             continue
         if "<" in path:
             skipped.append(f"{heading} (one pin serves several files)")

--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -1,0 +1,253 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Re-check every vendored-vector pin against upstream, monthly.
+
+tests/_data/README.md pins each vendored file to a commit and a git blob
+SHA-1, with a documented manual procedure to re-check one -- last done
+by hand on specific dates the file itself records. This automates that
+procedure and reports drift, rather than fixing it: refreshing a vector
+file is a decision this script does not get to make, so what it opens
+is an issue, never a commit.
+
+Scope is narrower than the README: only entries whose `behind` already
+reads 0 -- the ones a human last confirmed were exactly at upstream's
+tip. An entry already documented as behind (BIP32's mediawiki, 14
+revisions, none touching the vectors) is a decision already made, and
+re-reporting the same gap every month would just be noise; if a *new*
+commit moves it further, `behind`'s own count in the README goes stale
+in a way this script cannot see either, which is the reason it never
+tries to judge relevance, only tip-vs-pinned identity.
+
+Three shapes in the README this script does not attempt: a path
+carrying a `<name>` placeholder (BIP327's eight files and BIP324's two
+share one pin across a directory, not a single path), an entry with no
+`commit` at all (chain data self-identified by hash, files this project
+composed itself), and a `repo`/`path` pair naming prose rather than a
+single blob (transcribed BIPs, already excluded by the `behind != 0`
+rule above in every current case, but not guaranteed to always be).
+Every heading the README carries but this script did not check is
+listed in its own report, so nothing silently reads as "checked and
+clean" that was not checked at all.
+
+    python .github/scripts/check_vendored_vectors.py tests/_data/README.md
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_ISSUE_TITLE = "Vendored vectors behind upstream"
+
+# resolved once: S607 is what a bare "gh" in a subprocess list would be,
+# a partial executable path relying on PATH's own search order rather
+# than naming what actually runs
+_GH = shutil.which("gh") or "gh"
+
+# a vendored file's own ### heading, so a drift report -- and the
+# skipped-entry list -- can name the file rather than only its upstream
+# path
+_HEADING = re.compile(r"^### (.+)$", re.MULTILINE)
+
+# a fenced block's key/value lines; a value's own continuation onto a
+# further, unindented-marker line (BIP327's "behind" wraps) is not
+# captured, and is not needed -- every check below reads only the first
+# line of a field
+_FIELD = re.compile(r"^(repo|path|commit|blob|pulled|behind)\s+(.*)$", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class Entry:
+    """One pin this script can re-check: a single blob, a live commit."""
+
+    heading: str
+    repo: str
+    path: str
+    commit: str
+
+
+@dataclass(frozen=True)
+class Drift:
+    """A pin whose commit is no longer the tip of its own path."""
+
+    entry: Entry
+    latest_commit: str
+    latest_date: str
+
+
+def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
+    """Return the checkable entries, and the headings this skips.
+
+    A heading is skippable for any of three reasons: no repo/path/commit
+    triple at all, a path carrying a `<name>` placeholder, or a `behind`
+    already other than 0 -- a gap a human already decided not to close.
+    """
+    entries: list[Entry] = []
+    skipped: list[str] = []
+    heading = ""
+    pos = 0
+    for match in re.finditer(r"```text\n(.*?)\n```", readme, re.DOTALL):
+        headings_before = _HEADING.findall(readme[pos : match.start()])
+        if headings_before:
+            heading = headings_before[-1]
+        pos = match.end()
+
+        fields = dict(_FIELD.findall(match.group(1)))
+        repo, path, commit = (
+            fields.get("repo"),
+            fields.get("path"),
+            fields.get("commit"),
+        )
+        if not (repo and path and commit):
+            continue
+        if "<" in path:
+            skipped.append(f"{heading} (one pin serves several files)")
+            continue
+        if not fields.get("behind", "").startswith("0"):
+            skipped.append(f"{heading} (already documented as behind)")
+            continue
+        entries.append(Entry(heading, repo, path.strip(), commit.split()[0]))
+    return entries, skipped
+
+
+def _latest_commit(repo: str, path: str) -> tuple[str, str]:
+    """Return the sha and date of the most recent commit touching path."""
+    result = subprocess.run(  # noqa: S603
+        [
+            _GH,
+            "api",
+            "--method",
+            "GET",
+            f"repos/{repo}/commits",
+            "-f",
+            f"path={path}",
+            "-f",
+            "per_page=1",
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    (commit,) = json.loads(result.stdout)
+    date: str = commit["commit"]["committer"]["date"][:10]
+    sha: str = commit["sha"]
+    return sha, date
+
+
+def find_drift(readme_path: Path) -> tuple[list[Drift], list[str]]:
+    """Return every pin no longer at upstream's tip, and what was skipped."""
+    entries, skipped = _entries_at_tip(readme_path.read_text(encoding="utf-8"))
+    drifted = []
+    for entry in entries:
+        latest_sha, latest_date = _latest_commit(entry.repo, entry.path)
+        if latest_sha != entry.commit:
+            drifted.append(Drift(entry, latest_sha, latest_date))
+    return drifted, skipped
+
+
+def _issue_body(readme_path: Path, drifted: list[Drift], skipped: list[str]) -> str:
+    lines = [
+        f"`{readme_path}` pins below are no longer at upstream's tip.",
+        "Refreshing is a decision, not a chore -- this issue only reports it.",
+        "",
+    ]
+    for drift in drifted:
+        lines.append(
+            f"- **{drift.entry.heading}**: pinned to `{drift.entry.commit[:12]}`,"
+            f" upstream's tip of `{drift.entry.path}` is now"
+            f" `{drift.latest_commit[:12]}` ({drift.latest_date}),"
+            f" `{drift.entry.repo}`"
+        )
+    if skipped:
+        lines.append("")
+        lines.append("Not checked by this run, for the reason named:")
+        lines.extend(f"- {heading}" for heading in skipped)
+    return "\n".join(lines)
+
+
+def _open_issue_number() -> str | None:
+    result = subprocess.run(  # noqa: S603
+        [
+            _GH,
+            "issue",
+            "list",
+            "--state",
+            "open",
+            "--search",
+            f'"{_ISSUE_TITLE}" in:title',
+            "--json",
+            "number",
+        ],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    issues = json.loads(result.stdout)
+    return str(issues[0]["number"]) if issues else None
+
+
+def report(readme_path: Path, drifted: list[Drift], skipped: list[str]) -> None:
+    """Open, update, or close the tracking issue, whichever applies."""
+    number = _open_issue_number()
+    if not drifted:
+        if number is not None:
+            subprocess.run(  # noqa: S603
+                [
+                    _GH,
+                    "issue",
+                    "close",
+                    number,
+                    "--comment",
+                    "Re-checked: every pin with behind: 0 is still at upstream's tip.",
+                ],
+                check=True,
+            )
+        return
+    body = _issue_body(readme_path, drifted, skipped)
+    if number is None:
+        subprocess.run(  # noqa: S603
+            [_GH, "issue", "create", "--title", _ISSUE_TITLE, "--body", body],
+            check=True,
+        )
+    else:
+        subprocess.run(  # noqa: S603
+            [_GH, "issue", "edit", number, "--body", body], check=True
+        )
+
+
+def main() -> int:
+    """Check the README named on argv, report drift, and say so on stdout.
+
+    --dry-run skips opening, updating or closing the issue: what the
+    pull_request trigger of vendored-vectors.yml passes, so a change to
+    this script or to the README is exercised without the run editing
+    whatever tracking issue happens to be open at the time.
+    """
+    args = [a for a in sys.argv[1:] if a != "--dry-run"]
+    dry_run = len(args) != len(sys.argv) - 1
+    readme_path = Path(args[0])
+    drifted, skipped = find_drift(readme_path)
+    for drift in drifted:
+        print(
+            f"BEHIND: {drift.entry.heading} pinned to {drift.entry.commit[:12]},"
+            f" tip is {drift.latest_commit[:12]} ({drift.latest_date})"
+        )
+    for heading in skipped:
+        print(f"SKIPPED: {heading}")
+    if not drifted:
+        print("Every checked pin is still at upstream's tip.")
+    if not dry_run:
+        report(readme_path, drifted, skipped)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/mutation_counts.py
+++ b/.github/scripts/mutation_counts.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/.github/scripts/mutation_counts.py
+++ b/.github/scripts/mutation_counts.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Count a Cosmic Ray session by outcome, the skipped mutants left out.
 
 `cr-rate` answers the wrong question for a filtered session, and not by a

--- a/.github/scripts/rpc_smoke.py
+++ b/.github/scripts/rpc_smoke.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/.github/scripts/rpc_smoke.py
+++ b/.github/scripts/rpc_smoke.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The one claim recorded replies cannot make: a live node answers this way.
 
 `tests/fetch` exercises the whole of the request building, the status

--- a/.github/scripts/rpc_smoke.py
+++ b/.github/scripts/rpc_smoke.py
@@ -40,6 +40,14 @@ doing so has to fail this rather than be accommodated by it.
 Run it against a node of your own with `--bitcoind`; CONTRIBUTING.md
 carries the command, and `.github/workflows/rpc-smoke.yml` the download
 that verifies which binary it is.
+
+`tests/rpc_smoke_test.py` covers every function with no client behind it
+-- `check`, `port_is_free`, `check_legacy_reply`, `check_v2_reply`,
+`check_cookie` and `print_log_tail`, plus `main`'s own argument parsing.
+Everything else here is `# pragma: no cover`: it takes a real
+`BitcoinCoreRpcClient` talking to a real node, and mocking that node
+would be the recording this script exists to not trust. That half is
+`rpc-smoke.yml`'s to monitor, against Core itself.
 """
 
 from __future__ import annotations
@@ -157,7 +165,9 @@ def port_is_free(port: int) -> bool:
 
 
 @contextmanager
-def node(bitcoind: Path, datadir: Path) -> Iterator[BitcoinCoreRpcClient]:
+def node(
+    bitcoind: Path, datadir: Path
+) -> Iterator[BitcoinCoreRpcClient]:  # pragma: no cover
     """Run a regtest bitcoind on Core's own rpc port, and stop it after.
 
     No `-rpcport` and no `-rpcuser`: the port, the datadir layout and the
@@ -202,7 +212,7 @@ def node(bitcoind: Path, datadir: Path) -> Iterator[BitcoinCoreRpcClient]:
 
 def wait_for_rpc(
     client: BitcoinCoreRpcClient, process: subprocess.Popen[bytes]
-) -> None:
+) -> None:  # pragma: no cover
     """Wait until the node answers, or say what it did instead.
 
     Both failures on the way are the node not being up yet: no cookie file
@@ -224,7 +234,9 @@ def wait_for_rpc(
     raise SmokeError(f"no rpc answer in {STARTUP_TIMEOUT} s")
 
 
-def stop(client: BitcoinCoreRpcClient, process: subprocess.Popen[bytes]) -> None:
+def stop(
+    client: BitcoinCoreRpcClient, process: subprocess.Popen[bytes]
+) -> None:  # pragma: no cover
     """Ask the node to stop, and make sure it did.
 
     Through the rpc, which is how a node is stopped without losing what it
@@ -242,7 +254,7 @@ def stop(client: BitcoinCoreRpcClient, process: subprocess.Popen[bytes]) -> None
 
 def probe(
     client: BitcoinCoreRpcClient, method: str, params: Sequence[Any]
-) -> tuple[int, Mapping[str, Any]]:
+) -> tuple[int, Mapping[str, Any]]:  # pragma: no cover
     """Return the status and the json of a reply, before btclib reads it.
 
     The same request `call` builds, the 2.0 marker included, sent through
@@ -310,7 +322,7 @@ def check_v2_reply(status: int, reply: Mapping[str, Any], *, rpc_error: bool) ->
 
 def check_protocol(
     client: BitcoinCoreRpcClient, protocol: str, unknown_tx_id: str
-) -> None:
+) -> None:  # pragma: no cover
     """Read the two reply shapes off the wire, and then through `call`.
 
     A result and an error under the version the node speaks: the minimum,
@@ -355,7 +367,7 @@ def check_cookie(cookie_path: Path) -> None:
     check(bool(password), "the cookie carries a password after the colon")
 
 
-def check_credentials_refused(client: BitcoinCoreRpcClient) -> None:
+def check_credentials_refused(client: BitcoinCoreRpcClient) -> None:  # pragma: no cover
     """Check that a wrong credential is an HTTP failure with its status.
 
     Which is what `HttpError.status` is for: a 401 is the node refusing
@@ -379,7 +391,7 @@ def check_credentials_refused(client: BitcoinCoreRpcClient) -> None:
         raise SmokeError("the node accepted a credential that is not its cookie")
 
 
-def check_wallet_endpoint(client: BitcoinCoreRpcClient) -> None:
+def check_wallet_endpoint(client: BitcoinCoreRpcClient) -> None:  # pragma: no cover
     """Check `/wallet/<name>` against a node with two wallets loaded.
 
     Two, because that is the case where the endpoint is load-bearing: a
@@ -402,7 +414,7 @@ def check_wallet_endpoint(client: BitcoinCoreRpcClient) -> None:
         check(info["walletname"] == name, f"the endpoint of the wallet named {name!r}")
 
 
-def check_named_params(client: BitcoinCoreRpcClient) -> None:
+def check_named_params(client: BitcoinCoreRpcClient) -> None:  # pragma: no cover
     """Check both parameter structures Core accepts, against one method.
 
     An array read positionally and an object read by name, plus Core's
@@ -418,7 +430,7 @@ def check_named_params(client: BitcoinCoreRpcClient) -> None:
     )
 
 
-def check_amount_is_decimal(wallet: BitcoinCoreRpcClient) -> None:
+def check_amount_is_decimal(wallet: BitcoinCoreRpcClient) -> None:  # pragma: no cover
     """Check that an amount arrives as a Decimal and is exact.
 
     The reply is parsed with `parse_float=Decimal`, so a bitcoin amount
@@ -431,7 +443,9 @@ def check_amount_is_decimal(wallet: BitcoinCoreRpcClient) -> None:
     check(balance == SUBSIDY, f"the matured subsidy is exactly {SUBSIDY}")
 
 
-def generate_chain(client: BitcoinCoreRpcClient) -> tuple[int, str, str]:
+def generate_chain(
+    client: BitcoinCoreRpcClient,
+) -> tuple[int, str, str]:  # pragma: no cover
     """Generate the chain the fetcher answers are then checked against.
 
     Returns the height it left, the id of a wallet transaction and the id
@@ -467,7 +481,7 @@ def generate_chain(client: BitcoinCoreRpcClient) -> tuple[int, str, str]:
 
 def check_fetcher(
     client: BitcoinCoreRpcClient, height: int, tx_id: str, foreign_coinbase: str
-) -> None:
+) -> None:  # pragma: no cover
     """Check the three fetcher answers against the generated chain.
 
     The height is what was generated, so the expected value is arithmetic;
@@ -492,7 +506,9 @@ def check_fetcher(
     )
 
 
-def check_version(client: BitcoinCoreRpcClient, core_version: str) -> None:
+def check_version(
+    client: BitcoinCoreRpcClient, core_version: str
+) -> None:  # pragma: no cover
     """Check that the node is the version this run is about.
 
     What it catches is a download, an unpack or a `--bitcoind` naming
@@ -504,7 +520,9 @@ def check_version(client: BitcoinCoreRpcClient, core_version: str) -> None:
     check(subversion.startswith(expected), f"the node is Core {core_version}")
 
 
-def smoke(bitcoind: Path, datadir: Path, core_version: str, protocol: str) -> None:
+def smoke(
+    bitcoind: Path, datadir: Path, core_version: str, protocol: str
+) -> None:  # pragma: no cover
     """Ask a node of a stated version every question the client answers."""
     with node(bitcoind, datadir) as client:
         check_version(client, core_version)
@@ -548,18 +566,18 @@ def main() -> int:
         help="the json-rpc version that node answers",
     )
     args = parser.parse_args()
-    with TemporaryDirectory(prefix="btclib-rpc-smoke-") as tmp:
+    with TemporaryDirectory(prefix="btclib-rpc-smoke-") as tmp:  # pragma: no cover
         datadir = Path(tmp)
         try:
             smoke(args.bitcoind, datadir, args.core_version, args.protocol)
         except Exception:
             print_log_tail(datadir)
             raise
-    print(
+    print(  # pragma: no cover
         f"\nCore {args.core_version} answered every check,"
         f" over json-rpc {args.protocol}"
     )
-    return 0
+    return 0  # pragma: no cover
 
 
 if __name__ == "__main__":

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -14,7 +14,9 @@ name: latest
 # to be reviewed anyway, and its cause is one entry in a diff of many.
 # btclib_libsecp256k1 is the entry that matters most here: a release of
 # the bindings is a release in another repository, which nothing in this
-# one has to change for the pair to stop working.
+# one has to change for the pair to stop working. test-bindings-latest
+# below asks about that one entry alone, precisely, rather than folding
+# it into test-latest's broader upgrade -- see that job for why.
 #
 # The obvious alternative, dropping --locked from test.yml and resolving
 # afresh on every run, is what this workflow exists instead of: a pull
@@ -118,6 +120,48 @@ jobs:
       # wrote that lock, so this asserts nothing moved between the two and
       # keeps the convention that no uv command in these workflows
       # installs from a lock it has not checked
+      - name: Run pytest
+        run: uv run --locked --no-default-groups --group test pytest
+
+  # narrower than test-latest above, and for a different reason: that
+  # job upgrades every dependency, so a red run there buries a release
+  # of btclib_libsecp256k1 behind a dozen other candidates. This
+  # upgrades only that one, so a red run here names it without a
+  # bisect -- worth a job of its own because it is a sibling project
+  # under the same org, released by the same maintainer, which makes
+  # "did my own other release just break this one" a distinct and
+  # likely enough question to ask separately from "did some
+  # third-party wheel". Moved here from published.yml (issue #397): it
+  # is a question about drift against a tree not yet published, which
+  # belongs before publication rather than after
+  test-bindings-latest:
+    name: >-
+      Test ${{ matrix.python }} on ${{ matrix.os }}, bindings at latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.10", "3.14"]
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+      # upgrades one entry rather than every one of them, which is the
+      # whole difference from test-latest above: it prints "Update
+      # btclib_libsecp256k1 vA -> vB" when a release moved it and
+      # nothing when it did not, so the log names the suspect without a
+      # diff of uv.lock. Harmless on an ephemeral checkout; worth
+      # knowing before running the same command in a working tree
+      - name: Upgrade the bindings to their latest release
+        run: uv lock --upgrade-package btclib_libsecp256k1
       - name: Run pytest
         run: uv run --locked --no-default-groups --group test pytest
 

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -49,10 +49,13 @@ on:
   schedule:
     # weekly, on a minute that is not the hour: everything scheduled on
     # the hour is queued together, and a run that waits is a run whose
-    # failure is noticed later.
+    # failure is noticed later. Wednesday, the day after published.yml's
+    # Tuesday: a fixed, already-released artifact is checked first, this
+    # the more volatile question. Thursday is left for Dependabot,
+    # opening the day after this has already reported.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "43 4 * * 4"
+    - cron: "43 4 * * 3"
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,7 +20,12 @@ on:
   schedule:
     # Mondays, 04:17 UTC. Not on the hour: GitHub queues scheduled
     # workflows across every repository that asked for the same minute, and
-    # the run can be dropped outright when the queue is long
+    # the run can be dropped outright when the queue is long.
+    # First among the weekday sentinels: whether an external page still
+    # resolves is the least volatile of the four questions this week
+    # asks, published.yml (Tuesday), latest.yml (Wednesday) and
+    # Dependabot (Thursday) each asking something that changes more
+    # often than the last
     - cron: "17 4 * * 1"
   # the escape hatch, and the way to check a branch before merging a
   # documentation change that adds links

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -26,6 +26,11 @@ on:
     # to itself. Not on the hour: GitHub queues scheduled workflows across
     # every repository that asked for the same minute, and the run can be
     # dropped outright when the queue is long.
+    # The weekday sentinels run Monday through Thursday in the order the
+    # questions build on each other (links, published, latest, then
+    # Dependabot's pull request), and this one asks something on a
+    # different axis entirely -- the suite's own quality, not a
+    # dependency's -- which is what leaves it the weekend on its own.
     # Cron runs from the default branch only, so this file gates nothing
     # until it reaches master -- on dev it is reachable through the
     # dispatch button below and nowhere else

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -178,7 +178,17 @@ jobs:
       # is the numbers for the mutants that did run. 124 is what timeout
       # exits with when it cuts a session, and a session is resumable --
       # `cosmic-ray exec` runs the jobs still pending -- so a partial run
-      # is a partial answer rather than a lost one
+      # is a partial answer rather than a lost one.
+      #
+      # --signal=INT, not the default SIGTERM (issue #392): the local
+      # distributor applies a mutant and restores it from a `finally`
+      # block that only runs if the process can unwind. SIGTERM kills it
+      # outright, mid-mutant, before that block runs; SIGINT is what
+      # Python turns into a catchable KeyboardInterrupt, letting it
+      # unwind. Measured directly -- a process writing a marker, sleeping,
+      # and restoring the marker in `finally`, killed with each signal in
+      # turn -- SIGTERM leaves the marker at its mutated value, SIGINT at
+      # its restored one, timeout still exiting 124 either way
       - name: Run the mutation sessions
         env:
           SESSIONS: ${{ matrix.sessions }}
@@ -190,9 +200,22 @@ jobs:
               cosmic-ray init "$config" "$session"
             uv run --locked --no-default-groups --group test --group mutation \
               cr-filter-operators "$session" "$config"
-            timeout "$budget" \
+            timeout --signal=INT "$budget" \
               uv run --locked --no-default-groups --group test --group mutation \
               cosmic-ray exec "$config" "$session" || status=$?
+            # belt and braces beside the signal above: a session that
+            # restores every mutant it applies leaves the tracked source
+            # identical to HEAD, so anything git still sees changed here
+            # is exactly what issue #392 describes, whatever left it that
+            # way. Caught and restored before the next session in this
+            # loop can inherit it -- untracked files (the .sqlite session,
+            # the reports written below) are untouched, git diff not
+            # seeing them in the first place
+            if ! git diff --quiet; then
+              echo "::warning::$config left the tracked source changed after" \
+                "exec; restoring before the next session"
+              git checkout -- .
+            fi
             if [ "$status" -ne 0 ] && [ "$status" -ne 124 ]; then
               return "$status"
             fi

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -1,0 +1,153 @@
+---
+name: published
+
+# two questions, two jobs, and neither is asked by a pull request.
+#
+# test-bindings checks out this tree and upgrades only
+# btclib_libsecp256k1 to its newest release, so a red run names the
+# bindings among no other candidate: latest.yml already upgrades
+# everything and would bury this release behind a dozen others, and
+# dist-py's wheel smoke test pins every runtime dependency to uv.lock by
+# construction, so it cannot see a release published after that lock was
+# written. This is the sentinel issue #397 asked whether to keep, restored
+# with `uv lock --upgrade-package` in place of the `tool.uv.sources` table
+# #390 removed, --no-sources having been a no-op since.
+#
+# test-published checks out nothing: it installs btclib itself from PyPI,
+# which is the half of "does this work" that an import cannot answer.
+# `import btclib` runs __init__.py alone, and 25 files under
+# btclib/*/_data/ -- the twelve BIP39 wordlists among them -- are opened
+# by path at the first call that needs one, not imported, so a wheel
+# missing one of them installs cleanly, imports cleanly, and only fails
+# there. dist-py's smoke test and this job's check share that blind spot;
+# this job's second command is the one that does not have it.
+#
+# Both are version-independent on purpose, checking a BIP39 vector and a
+# BIP340 one whose values are fixed forever, so neither needs an edit
+# after a release the way a version-pinned assertion would
+
+on:
+  schedule:
+    # Wednesday, a minute that is not the hour: everything scheduled on
+    # the hour queues together, and a run that waits is a run whose
+    # failure is noticed later. links.yml has Monday, mutation.yml Sunday,
+    # latest.yml Thursday -- three sentinels in one inbox on one morning
+    # is one sentinel.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "31 4 * * 3"
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies) can read the token, so it must not be able to
+# write to the repository
+permissions:
+  contents: read
+
+# never cancel a sentinel: a scheduled run and a dispatched one are both
+# samples worth keeping, and neither supersedes the other. A concurrent
+# run queues instead
+concurrency:
+  group: published-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # narrower than test.yml's matrix, and for a different reason: there,
+  # every (os, interpreter) triple selects a distinct wheel of the
+  # bindings, which is the question this workflow is not asking. What
+  # varies here is only which release of one dependency the environment
+  # resolves to, which is what latest.yml's own narrower matrix answers
+  # for every dependency at once
+  test-bindings:
+    name: >-
+      Test ${{ matrix.python }} on ${{ matrix.os }}, bindings at latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.10", "3.14"]
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+      # upgrades one entry rather than every one of them, which is the
+      # whole difference from latest.yml: it prints "Update
+      # btclib_libsecp256k1 vA -> vB" when a release moved it and nothing
+      # when it did not, so the log names the suspect without a diff of
+      # uv.lock. Harmless on an ephemeral checkout; worth knowing before
+      # running the same command in a working tree
+      - name: Upgrade the bindings to their latest release
+        run: uv lock --upgrade-package btclib_libsecp256k1
+      - name: Run pytest
+        run: uv run --locked --no-default-groups --group test pytest
+
+  # no checkout, on purpose: nothing from this repository takes part,
+  # which is also what guarantees that the two checks below resolve to
+  # what pip installed and not to a source tree
+  test-published:
+    name: "Install btclib ${{ matrix.python }} on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          [
+            ubuntu-latest,
+            ubuntu-24.04-arm,
+            macos-26-intel,
+            macos-latest,
+            windows-latest,
+            windows-11-arm,
+          ]
+        # the two ends of the supported range, plus the free-threaded
+        # interpreter: btclib itself ships one universal wheel, so what
+        # varies across this matrix is entirely which wheel of
+        # btclib_libsecp256k1 each cell resolves to
+        python: ["3.10", "3.14", "3.14t"]
+    timeout-minutes: 20
+    steps:
+      - name: Set up Python ${{ matrix.python }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install btclib from PyPI
+        run: |
+          python -m pip install -U pip
+          python -m pip install --verbose btclib
+      # BIP340 vector 0 for the ecc surface, exactly what dist-py and
+      # release.yml already assert; a signature round trip is the one
+      # thing an import cannot get wrong by itself, and a bindings release
+      # that installs and answers incorrectly is what this catches
+      - name: Verify a signature, round tripped
+        shell: bash
+        run: |
+          python -c "import btclib; \
+            from btclib.ecc import dsa; \
+            from btclib.to_pub_key import pub_keyinfo_from_prv_key; \
+            print(btclib.__version__); \
+            assert btclib.__version__ != 'unknown'; \
+            assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
+              dsa.sign(b'btclib', 1))"
+      # the trezor test vector, whose seed is fixed forever: this is the
+      # check the header describes, the one that touches a _data/ file a
+      # bare import does not reach
+      - name: Verify a BIP39 seed, derived from shipped word lists
+        shell: bash
+        run: |
+          python -c "from btclib.mnemonic.bip39 import seed_from_mnemonic; \
+            m = 'abandon abandon abandon abandon abandon abandon abandon ' \
+                'abandon abandon abandon abandon about'; \
+            seed = seed_from_mnemonic(m, 'TREZOR').hex(); \
+            expected = ( \
+              'c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa370' \
+              '8e53495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c8' \
+              '1b2f001698e7463b04'); \
+            assert seed == expected, seed"

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -35,14 +35,15 @@ name: published
 
 on:
   schedule:
-    # Wednesday, a minute that is not the hour: everything scheduled on
-    # the hour queues together, and a run that waits is a run whose
-    # failure is noticed later. links.yml has Monday, mutation.yml Sunday,
-    # latest.yml Thursday -- three sentinels in one inbox on one morning
-    # is one sentinel.
+    # Tuesday, a minute that is not the hour: everything scheduled on the
+    # hour queues together, and a run that waits is a run whose failure
+    # is noticed later. The day after links.yml's Monday: a fixed,
+    # already-released artifact is checked here, before latest.yml asks
+    # the more volatile question of what the newest dependency does to a
+    # tree not yet released.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "31 4 * * 3"
+    - cron: "31 4 * * 2"
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -1,30 +1,30 @@
 ---
 name: published
 
-# two questions, two jobs, and neither is asked by a pull request.
+# checks whether what is already on PyPI actually works, not merely
+# installs -- which no pull request asks, checking out the tree it is
+# testing being the whole point of one. No checkout here either, on
+# purpose: nothing from this repository takes part, which is what
+# guarantees the checks below resolve to what pip installed and not to
+# a source tree.
 #
-# test-bindings checks out this tree and upgrades only
-# btclib_libsecp256k1 to its newest release, so a red run names the
-# bindings among no other candidate: latest.yml already upgrades
-# everything and would bury this release behind a dozen others, and
-# dist-py's wheel smoke test pins every runtime dependency to uv.lock by
-# construction, so it cannot see a release published after that lock was
-# written. This is the sentinel issue #397 asked whether to keep, restored
-# with `uv lock --upgrade-package` in place of the `tool.uv.sources` table
-# #390 removed, --no-sources having been a no-op since.
-#
-# test-published checks out nothing: it installs btclib itself from PyPI,
-# which is the half of "does this work" that an import cannot answer.
 # `import btclib` runs __init__.py alone, and 25 files under
 # btclib/*/_data/ -- the twelve BIP39 wordlists among them -- are opened
 # by path at the first call that needs one, not imported, so a wheel
 # missing one of them installs cleanly, imports cleanly, and only fails
-# there. dist-py's smoke test and this job's check share that blind spot;
-# this job's second command is the one that does not have it.
+# there. dist-py's smoke test and release.yml's share that blind spot;
+# this workflow's second check is the one that does not have it.
 #
-# Both are version-independent on purpose, checking a BIP39 vector and a
-# BIP340 one whose values are fixed forever, so neither needs an edit
-# after a release the way a version-pinned assertion would
+# Version-independent on purpose, checking a BIP39 vector and a BIP340
+# one whose values are fixed forever, so neither needs an edit after a
+# release the way a version-pinned assertion would.
+#
+# What this is not: a sentinel for whether the newest btclib_libsecp256k1
+# breaks this tree. That question -- issue #397 -- belongs to latest.yml's
+# test-bindings-latest job instead: it is about drift against a tree not
+# yet published, asked before publication rather than after, and asking
+# it here would be asking it one step too late to matter to what gets
+# published next
 
 on:
   schedule:
@@ -52,46 +52,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # narrower than test.yml's matrix, and for a different reason: there,
-  # every (os, interpreter) triple selects a distinct wheel of the
-  # bindings, which is the question this workflow is not asking. What
-  # varies here is only which release of one dependency the environment
-  # resolves to, which is what latest.yml's own narrower matrix answers
-  # for every dependency at once
-  test-bindings:
-    name: >-
-      Test ${{ matrix.python }} on ${{ matrix.os }}, bindings at latest
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.10", "3.14"]
-    timeout-minutes: 20
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          enable-cache: true
-          python-version: ${{ matrix.python }}
-      # upgrades one entry rather than every one of them, which is the
-      # whole difference from latest.yml: it prints "Update
-      # btclib_libsecp256k1 vA -> vB" when a release moved it and nothing
-      # when it did not, so the log names the suspect without a diff of
-      # uv.lock. Harmless on an ephemeral checkout; worth knowing before
-      # running the same command in a working tree
-      - name: Upgrade the bindings to their latest release
-        run: uv lock --upgrade-package btclib_libsecp256k1
-      - name: Run pytest
-        run: uv run --locked --no-default-groups --group test pytest
-
-  # no checkout, on purpose: nothing from this repository takes part,
-  # which is also what guarantees that the two checks below resolve to
-  # what pip installed and not to a source tree
   test-published:
     name: "Install btclib ${{ matrix.python }} on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -19,6 +19,13 @@ name: published
 # one whose values are fixed forever, so neither needs an edit after a
 # release the way a version-pinned assertion would.
 #
+# A schedule this quiet is also the one GitHub itself might stop
+# firing: it suspends a workflow's cron trigger after sixty days
+# without repository activity, and says so only by email. That is
+# exactly the interval this sentinel exists to cover, so a silence
+# from it is worth a look at the Actions tab before it is read as
+# green.
+#
 # What this is not: a sentinel for whether the newest btclib_libsecp256k1
 # breaks this tree. That question -- issue #397 -- belongs to latest.yml's
 # test-bindings-latest job instead: it is about drift against a tree not

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,18 @@ jobs:
             echo "::error::$version is not a final version; $msg"
             exit 1
           fi
+          # three components at least: the day is not optional on
+          # anything this pushes to PyPI, only on the placeholder "Open
+          # the next cycle" sets between releases -- which is never
+          # tagged, so this check never sees it. Without this, "v2026.8"
+          # passes every check above it and publishes a version with no
+          # day, indistinguishable from the placeholder that names the
+          # same month
+          if ! echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            msg="a release is YYYY.M.D, optionally YYYY.M.D.N for a patch"
+            echo "::error::$version has no day; $msg"
+            exit 1
+          fi
       # the release notes are HISTORY.md's section for the tag, lifted by
       # the github-release job below, and its fallback fires only on an
       # *empty* section: "## v2026.8 (work in progress, not released yet)"

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -1,0 +1,71 @@
+---
+name: vendored vectors
+
+# tests/_data/README.md pins every vendored test vector to a commit and a
+# git blob SHA-1, with a documented manual procedure to re-check one --
+# last done by hand on specific dates the file itself records. This runs
+# that procedure once a month instead, over every pin the script can
+# check, and opens or updates an issue on drift rather than fixing
+# anything: refreshing a vector file is a decision the script does not
+# get to make.
+#
+# issues: write is new to this repository -- links.yml's own comment
+# explains why every other scheduled workflow here stops at contents:
+# read, an automatic issue being the usual next step it deliberately
+# does not take. This one does take it, on purpose: a link is noticed
+# the next time somebody follows it, where a vendored vector is trusted
+# without anybody looking at it again, and that is exactly what a
+# monthly issue is for
+
+on:
+  schedule:
+    # the 1st of the month, 04:53 UTC. Not on the hour, for the reason
+    # links.yml's own cron comment gives -- GitHub queues same-minute
+    # scheduled workflows across every repository that asked for it, and
+    # a long queue can drop the run outright. Minute 53 is not shared
+    # with any other cron in this repository (17, 31, 41, 43)
+    - cron: "53 4 1 * *"
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/vendored-vectors.yml
+      - .github/scripts/check_vendored_vectors.py
+      - tests/_data/README.md
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: vendored-vectors-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check vendored vectors against upstream
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.14"
+
+      # no project dependency: the script imports only the standard
+      # library and shells out to gh, which every GitHub-hosted runner
+      # already has.
+      # --dry-run on the pull_request trigger only: a fork's read-only
+      # token could not write the issue anyway, and a same-repository
+      # pull request testing a change to this script or the README
+      # should not close or edit whatever tracking issue is open at the
+      # time as a side effect of that test
+      - name: Re-check every pin already at upstream's tip
+        run: >-
+          python .github/scripts/check_vendored_vectors.py
+          tests/_data/README.md
+          ${{ github.event_name == 'pull_request' && '--dry-run' || '' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,12 +62,10 @@ repos:
       # nothing. That is the whole reason the meta hooks are in this
       # file, and overruling one of them would be an odd way to keep them
       #
-      # its converse stays off too, and not by oversight: every module here
-      # opens with "#!/usr/bin/env python3", which is the house header
-      # above the copyright notice the hook below enforces and not a
-      # claim that the file is a script. 154 files have one and none is
-      # executable, so enabling this means either chmod +x on a library
-      # or deleting a convention -- measured, not guessed
+      # its converse stays off for the same reason now: no module here
+      # opens with "#!/usr/bin/env python3" any more -- a house header
+      # that was never a claim the file is a script, none of them being
+      # executable, and deleted rather than kept as a line nothing checks
       # - id: check-shebang-scripts-are-executable
       # no byte order mark anywhere today, and the same kind of guard as
       # check-executables-have-shebangs: what it costs is one line, what
@@ -76,38 +74,36 @@ repos:
       - id: fix-byte-order-marker
       # this one *adds* "# -*- coding: utf-8 -*-" to every Python file.
       # UTF-8 has been the default source encoding since Python 3 and the
-      # floor here is 3.10, so it is 155 dead lines
+      # floor here is 3.10, so every line it would add is dead on arrival
       # - id: fix-encoding-pragma
       - id: check-yaml
       - id: check-json
       # both of this hook's defaults are wrong for this tree: at
-      # --indent=2 it fails on 44 of the 45 json files, and with the key
-      # sort on, on 33. The golden-file
-      # fixture writes json.dumps(indent=4) (tests/conftest.py), so at
-      # indent 2 the two would rewrite each other on every run; and
-      # sorting the keys reorders a golden file against the insertion
-      # order to_dict() emits, which the next run of the suite reports as
-      # a mismatch -- the sort does not churn the diff, it breaks the
-      # tests. With both flags 39 of the 45 files already conform.
+      # --indent=2 nearly every json file here fails, the golden-file
+      # fixture writing json.dumps(indent=4) (tests/conftest.py) -- so at
+      # indent 2 the two would rewrite each other on every run. Sorting
+      # the keys reorders a golden file against the insertion order
+      # to_dict() emits, which the next run of the suite reports as a
+      # mismatch -- the sort does not churn the diff, it breaks the
+      # tests. With both flags most files already conform.
       # --autofix because every other fixing hook here corrects rather
       # than reports
       - id: pretty-format-json
         name: pretty-format-json (in place fixes)
         args: [--autofix, --indent=4, --no-sort-keys]
         # tests/**/_data/ is the vendored directory, as tests/_data/
-        # README.md declares it: five of the six files that do not
-        # conform are vectors that file gives a blob SHA and the verdict
-        # "identical" to, and a reformat voids the pin and the verdict
-        # together. Excluded by directory rather than by name so that the
-        # next file vendored into it is safe before anyone remembers this
-        # line; check-json above still answers the question worth asking
-        # of them, which is whether they parse. The lookahead is the five
-        # files in there that have no pinned blob for a reformat to void:
-        # four of btclib's own and one of chain data, whose provenance is
-        # a txid rather than a blob. By name because there are five, and
-        # because the default for anything else in that directory has to
-        # stay "not touched". (?x) is verbose mode, i.e. the newlines
-        # below are not part of the pattern
+        # README.md declares it: most files that do not conform are
+        # vectors that file gives a blob SHA and the verdict "identical"
+        # to, and a reformat voids the pin and the verdict together.
+        # Excluded by directory rather than by name so that the next file
+        # vendored into it is safe before anyone remembers this line;
+        # check-json above still answers the question worth asking of
+        # them, which is whether they parse. The lookahead names the
+        # files in there with no pinned blob for a reformat to void --
+        # btclib's own, and one of chain data whose provenance is a txid
+        # rather than a blob -- because the default for anything else in
+        # that directory has to stay "not touched". (?x) is verbose mode,
+        # i.e. the newlines below are not part of the pattern
         exclude: |
           (?x)^tests/([^/]+/)?_data/
           (?!btclib_test_vectors\.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4933,28 +4933,35 @@ edit.
   its own `# type: ignore[redundant-expr]` or `[unreachable]`, naming the
   code, rather than the three staying off for eight sites' sake
 - **The same audit, over ruff's own ignore list.** Every code still in
-  it was measured on its own rather than trusted on its comment: four
+  it was measured on its own rather than trusted on its comment: some
   found nothing at all and are gone -- `D406`, `D407`, `PLR0904`,
-  `PLR0914` -- and five found a short, nameable list of sites, now each
-  carrying a `# noqa` instead of the whole codebase going unchecked for
-  them: `RUF003` (2, a mathematical minus sign and a stray no-break
-  space -- the second one a typo, fixed rather than kept), `PLW1641` (4,
-  the mutable dataclasses and one test double whose `__eq__` was never
-  meant to survive hashing), `PLW2901` (4, not "throughout the code
-  base" as the old comment said), and `PLR0911` with `PLR0912` (3 and 2,
-  the same script-engine dispatch and classification functions the
-  mccabe `# noqa: C901` already named, now carrying it too). `D301` and
-  `D405`/`D413` found four sites each that needed fixing outright, not
-  ignoring: three were `r"""` withheld from a docstring on purpose, to
-  keep a doubled backslash rendering as one -- `bms.py`'s magic string,
-  two vector examples in tests -- and one, `utils.py`'s
-  `b'\xde\xad\xbe\xef'` example, was rendering as four decoded Latin-1
-  characters instead of the literal escapes, an actual bug the `r`
-  prefix now fixes; the section-heading and blank-line findings were
-  autofixed. `PLR2004`, `TRY003`, `SIM300`, `PLR0913` and `PLR0917`
-  stay: each was measured too, at 567, 516, 36, 64 and 45 findings, too
-  many and too spread out to be a short exception list rather than this
-  codebase's normal shape
+  `PLR0914` -- and others found a short, nameable list of sites, now
+  each carrying a `# noqa` instead of the whole codebase going unchecked
+  for them: `RUF003` (a mathematical minus sign and a stray no-break
+  space -- the second one a typo, fixed rather than kept), `PLW1641`
+  (the mutable dataclasses and one test double whose `__eq__` was never
+  meant to survive hashing), `PLW2901` (not "throughout the code base"
+  as the old comment said -- a handful of sites in a couple of files),
+  and `PLR0911` with `PLR0912` (the same script-engine dispatch and
+  classification functions the mccabe `# noqa: C901` already named, now
+  carrying it too). `D301` and `D405`/`D413` found a few sites each that
+  needed fixing outright, not ignoring: most were `r"""` withheld from a
+  docstring on purpose, to keep a doubled backslash rendering as one --
+  `bms.py`'s magic string, two code examples in tests -- and one,
+  `utils.py`'s `b'\xde\xad\xbe\xef'` example, was rendering as decoded
+  Latin-1 characters instead of the literal escapes, an actual bug the
+  `r` prefix now fixes; the section-heading and blank-line findings were
+  autofixed. `PLR2004`, `TRY003`, `PLR0913` and `PLR0917` stay: each was
+  measured too, and each is spread widely enough across the tree to be
+  this codebase's normal shape rather than a short exception list.
+  `SIM300` was the fifth measured that way and does not stay: see below
+- **`SIM300` is selected too, and every site it found was ruff's own
+  autofix.** Yoda-condition, chosen for the reason the old comment gave --
+  an uppercase math symbol such as `M`, `R` or `Q` reads to the rule as a
+  constant, and every finding on this tree was one of those read
+  backwards, `M >= (w2 // 2)` rewritten `(w2 // 2) <= M` -- rather than a
+  real Yoda condition anywhere. Equivalent either way, since flipping the
+  two sides of a comparison changes nothing it evaluates to
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4971,6 +4971,21 @@ edit.
   than an unenforceable one — `psbt.musig2._SessionParts` is a real
   `NamedTuple` subclass, not a construct this codebase lacks the way
   `DTZ` or `ASYNC` are
+- **A monthly workflow re-checks every vendored-vector pin against
+  upstream**, and opens, updates or closes a tracking issue on what it
+  finds. `tests/_data/README.md`'s own "Re-checking a pin" section was a
+  manual procedure, last run by hand on the dates it records;
+  `.github/scripts/check_vendored_vectors.py` automates exactly that
+  procedure and nothing past it -- refreshing a stale vector stays a
+  decision nobody but a maintainer makes. Scope is narrower than the
+  README: only entries whose `behind` already reads 0, an entry already
+  documented as behind being a gap someone already decided not to close,
+  which re-reporting monthly would only turn into noise. Every heading
+  the script does not check for that reason, or because one pin serves
+  several files (BIP327's eight, BIP324's two), is named in its own
+  report, so nothing reads as checked that was not. `issues: write` is
+  new to this repository -- every other scheduled workflow stops at
+  `contents: read`, on purpose, and this one does not, also on purpose
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4932,6 +4932,29 @@ edit.
   protocol can guarantee. Each keeps the check on everywhere else with
   its own `# type: ignore[redundant-expr]` or `[unreachable]`, naming the
   code, rather than the three staying off for eight sites' sake
+- **The same audit, over ruff's own ignore list.** Every code still in
+  it was measured on its own rather than trusted on its comment: four
+  found nothing at all and are gone -- `D406`, `D407`, `PLR0904`,
+  `PLR0914` -- and five found a short, nameable list of sites, now each
+  carrying a `# noqa` instead of the whole codebase going unchecked for
+  them: `RUF003` (2, a mathematical minus sign and a stray no-break
+  space -- the second one a typo, fixed rather than kept), `PLW1641` (4,
+  the mutable dataclasses and one test double whose `__eq__` was never
+  meant to survive hashing), `PLW2901` (4, not "throughout the code
+  base" as the old comment said), and `PLR0911` with `PLR0912` (3 and 2,
+  the same script-engine dispatch and classification functions the
+  mccabe `# noqa: C901` already named, now carrying it too). `D301` and
+  `D405`/`D413` found four sites each that needed fixing outright, not
+  ignoring: three were `r"""` withheld from a docstring on purpose, to
+  keep a doubled backslash rendering as one -- `bms.py`'s magic string,
+  two vector examples in tests -- and one, `utils.py`'s
+  `b'\xde\xad\xbe\xef'` example, was rendering as four decoded Latin-1
+  characters instead of the literal escapes, an actual bug the `r`
+  prefix now fixes; the section-heading and blank-line findings were
+  autofixed. `PLR2004`, `TRY003`, `SIM300`, `PLR0913` and `PLR0917`
+  stay: each was measured too, at 567, 516, 36, 64 and 45 findings, too
+  many and too spread out to be a short exception list rather than this
+  codebase's normal shape
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4986,6 +4986,17 @@ edit.
   report, so nothing reads as checked that was not. `issues: write` is
   new to this repository -- every other scheduled workflow stops at
   `contents: read`, on purpose, and this one does not, also on purpose
+- **Four pins move from "behind, already reviewed" to the tip, into the
+  monthly check above**: `bip32_test_vectors.json`,
+  `bip32_invalid_keys.json`, `bip371_test_vectors.json` and
+  `bip67_test_vectors.json` were each re-checked against the current tip
+  of their path and re-pinned to it, a `behind` of anything but 0 being
+  exactly what the check above skips. BIP32's two and BIP67's carried no
+  change at all. BIP371's 17 cases didn't either, but two of their
+  `description` labels did: "PSBT_KEY_PATH_SIG" is upstream's own older
+  name for the field renamed `PSBT_IN_TAP_KEY_SIG` between the original
+  pin and the tip, and both labels now read the field's current name --
+  the `encoded psbt` of every case is unchanged throughout
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4962,6 +4962,15 @@ edit.
   backwards, `M >= (w2 // 2)` rewritten `(w2 // 2) <= M` -- rather than a
   real Yoda condition anywhere. Equivalent either way, since flipping the
   two sides of a comparison changes nothing it evaluates to
+- **Five more rule sets never surveyed before, all clean today: `FA`,
+  `FIX`, `FLY`, `SLOT`, `T10`.** `TD` was the other zero-finding set the
+  same survey turned up, and is not selected: it and `FIX` both watch
+  TODO-style comments, one disciplining the format and the other
+  refusing them outright, and only one of the two belongs in a codebase
+  that finishes what it starts. `SLOT` reads as a fresh ratchet rather
+  than an unenforceable one — `psbt.musig2._SessionParts` is a real
+  `NamedTuple` subclass, not a construct this codebase lacks the way
+  `DTZ` or `ASYNC` are
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5090,8 +5090,8 @@ edit.
   README: only entries whose `behind` already reads 0, an entry already
   documented as behind being a gap someone already decided not to close,
   which re-reporting monthly would only turn into noise. Every heading
-  the script does not check for that reason, or because one pin serves
-  several files (BIP327's eight, BIP324's two), is named in its own
+  the script does not check for that reason, or because its path is a
+  placeholder standing in for several real ones, is named in its own
   report, so nothing reads as checked that was not. `issues: write` is
   new to this repository -- every other scheduled workflow stops at
   `contents: read`, on purpose, and this one does not, also on purpose
@@ -5106,6 +5106,19 @@ edit.
   name for the field renamed `PSBT_IN_TAP_KEY_SIG` between the original
   pin and the tip, and both labels now read the field's current name --
   the `encoded psbt` of every case is unchanged throughout
+- **BIP327's eight files and BIP324's two are pinned one real path at a
+  time now, not one placeholder path standing in for a whole
+  directory**, which is what brings all ten into the monthly check
+  above: a placeholder is not a path GitHub's own "commits touching a
+  path" call can be asked about. Splitting BIP324's pair changed
+  nothing else, both genuinely tipped by one commit throughout. BIP327's
+  eight were not: the placeholder cited one commit as the tip of all
+  eight paths, but that commit touches only `sig_agg_vectors.json`; six
+  of the other seven have been untouched since the commit that added
+  all eight in 2023, and `sign_verify_vectors.json` was fixed once more
+  in between. Each of the eight is now pinned to its own real tip, and
+  every one is still the blob already vendored -- nothing to refresh,
+  the fix is only in which commit each cites
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5119,6 +5119,16 @@ edit.
   in between. Each of the eight is now pinned to its own real tip, and
   every one is still the blob already vendored -- nothing to refresh,
   the fix is only in which commit each cites
+- **BIP324's two files are "identical but for line endings", not
+  byte-identical as the README had it.** A blob-SHA match against
+  upstream's tip only proves upstream has not moved since the pin, not
+  that upstream and the vendored copy agree, and fetching the actual
+  bytes found both `ellswift_decode_test_vectors.csv` and
+  `xswiftec_inv_test_vectors.csv` are CRLF upstream -- `mixed-line-ending`
+  normalizes our copy to LF, the same exception `bip340_test_vectors.csv`
+  already documented. Nothing in either file's vectors changed; the fix
+  is the Verdict describing them, and the Summary list moving the pair
+  from "identical byte for byte" to "identical but for CRLF against LF"
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5129,6 +5129,24 @@ edit.
   already documented. Nothing in either file's vectors changed; the fix
   is the Verdict describing them, and the Summary list moving the pair
   from "identical byte for byte" to "identical but for CRLF against LF"
+- **`check_vendored_vectors.py` and `rpc_smoke.py` now have test files,
+  matching `mutation_counts.py`'s own** -- both are loaded by path and
+  their `gh`/socket/file boundaries replaced with fakes, the same
+  pattern `tests/mutation_counts_test.py` already uses and for the same
+  reason. Writing `check_vendored_vectors.py`'s found a real bug on the
+  way: an entry with no `commit` at all -- chain data, a file this
+  project composed itself, a section heading with no pin of its own --
+  was silently skipped, in contradiction of the script's own docstring,
+  which already claimed every such heading would be named. It is now,
+  and the README's seven chain-data and composed-locally headings appear
+  in a `--dry-run` report for the first time. `check_vendored_vectors.py`
+  reaches 100% this way. `rpc_smoke.py` cannot: most of it is a real
+  `BitcoinCoreRpcClient` talking to a real bitcoind, which is the one
+  thing the script exists to have rather than mock, so that half is
+  `# pragma: no cover`, monitored instead by `rpc-smoke.yml` against
+  Core itself -- what is covered is every function with no client behind
+  it, `check_legacy_reply`, `check_v2_reply`, `check_cookie` and
+  `print_log_tail` among them, plus `main`'s own argument parsing
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4918,6 +4918,20 @@ edit.
   decision this file made, unlike everything around it. The comma is how
   pytest's own documentation writes a parametrize signature, and it is
   also what the bindings had already chosen, with that reason stated
+- **`redundant-expr`, `possibly-undefined` and `warn_unreachable` are on**,
+  closing the last three codes the mypy survey had left off as a block.
+  Re-measured one at a time: `possibly-undefined`'s one finding was a
+  `while True: break` retry loop mypy's flow analysis cannot follow,
+  unrelated to the other two and gone now that
+  `test_low_cardinality` counts the retry with a sentinel `while` instead.
+  The other eight, in `network.py`, `bip21.py`, `script.py`,
+  `bitcoin_core_rpc.py` (twice), `utils.py`, `block_context.py` and
+  `fetch/fetcher.py`, are the deliberate idiom the old comment named:
+  a runtime guard against a value whose static type promises more than
+  json, a caller ignoring an annotation, or an operator's own dispatch
+  protocol can guarantee. Each keeps the check on everywhere else with
+  its own `# type: ignore[redundant-expr]` or `[unreachable]`, naming the
+  code, rather than the three staying off for eight sites' sake
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3626,6 +3626,12 @@ edit.
   assignments already do. `psbt_in_test.py` checks `ValidSigHashType`
   against `SIG_HASH_TYPES`, the way `network_test.py` checks #216's two
   data-derived aliases
+- **`network.datadir` and `curves.curve.datadir` are `Path`, not `str`.**
+  Both mark where each package keeps its own json catalogue, and each
+  docstring already promised "the path" to a caller who asks — a promise
+  `pathlib.Path` keeps more precisely than the string ruff's new `PTH`
+  rule set found underneath it. `str(btclib.network.datadir)` is the
+  `v2023.7.12` value back; string concatenation and `.startswith` are not
 
 ### Performance
 
@@ -4893,6 +4899,18 @@ edit.
   never fire reads as an enforced invariant while enforcing nothing.
   `check-readthedocs` joins `check-dependabot` on the same argument,
   `.readthedocs.yaml` being 2.7 KB that nothing read as a build definition
+- **`PTH` is selected too, the seventh of that survey's rejects to move.**
+  130 `os.path` calls and bare `open()`s, 23 of them in the library, are
+  now `pathlib.Path`: `curves.curve`'s four catalogue loaders and
+  `network`'s five, `bip44`'s purposes table, `mnemonic.electrum`'s old
+  wordlist, and every fixture loader in `tests/block`, `tests/tx`,
+  `tests/mnemonic`, `tests/fuzz_test.py`, `tests/parse_contract_test.py`
+  and the package's own `tests/__init__.py` loaders. `mnemonic.data_file`
+  and `WordLists.load_lang` keep their `str`: a caller passes a filename
+  of their own to register a language there, and narrowing what it hands
+  back was not this rule's question to answer. `network.datadir` and
+  `curves.curve.datadir` are the two names whose type this did change —
+  see Types below
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4911,6 +4911,13 @@ edit.
   back was not this rule's question to answer. `network.datadir` and
   `curves.curve.datadir` are the two names whose type this did change —
   see Types below
+- **`pytest.mark.parametrize`'s names are a comma-separated string, not a
+  tuple.** `("hexed", "encoded")` is `"hexed, encoded"` now, at 89 call
+  sites over 37 files; `flake8-pytest-style`'s `parametrize-names-type`
+  had never been set, so `tuple` was ruff's own default rather than a
+  decision this file made, unlike everything around it. The comma is how
+  pytest's own documentation writes a parametrize signature, and it is
+  also what the bindings had already chosen, with that reason stated
 - **80 columns on the prose, and the yaml measured for the first time.**
   `ruff-format` reflows code to its 88 columns and never touches a
   comment or a docstring, which is why `E501` is ignored and stays so:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,24 +296,24 @@ worth repeating:
 uv lock --upgrade
 ```
 
-The `published` workflow, weekly and on demand, two jobs asking two
-different questions. The first upgrades only the bindings and re-runs the
-suite — narrower than `latest`, which moves every dependency, so a red
-run here names the one responsible instead of burying it behind a dozen
-others:
+That workflow has a second job, `test-bindings-latest`, upgrading only
+the bindings and re-running the suite — narrower than the upgrade above,
+which moves every dependency, so a red run here names the one responsible
+instead of burying it behind a dozen others:
 
 ```shell
 uv lock --upgrade-package btclib_libsecp256k1
 uv run --locked --no-default-groups --group test pytest
 ```
 
-The second installs btclib itself from PyPI, nothing checked out, and
-asks whether it works rather than whether it installs: `import btclib`
-runs `__init__.py` alone, and the files under `btclib/*/_data/` — the
-wordlists among them — are opened by path at the first call that needs
-one, not imported, so a wheel missing one would pass the import and fail
-only here. Both checks are version-independent, a BIP340 vector and a
-BIP39 one whose values are fixed forever:
+The `published` workflow, weekly and on demand, installs btclib itself
+from PyPI, nothing checked out, and asks whether it works rather than
+whether it installs: `import btclib` runs `__init__.py` alone, and the
+files under `btclib/*/_data/` — the wordlists among them — are opened by
+path at the first call that needs one, not imported, so a wheel missing
+one would pass the import and fail only here. Both checks are
+version-independent, a BIP340 vector and a BIP39 one whose values are
+fixed forever:
 
 ```shell
 python -m pip install btclib

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -296,6 +296,41 @@ worth repeating:
 uv lock --upgrade
 ```
 
+The `published` workflow, weekly and on demand, two jobs asking two
+different questions. The first upgrades only the bindings and re-runs the
+suite — narrower than `latest`, which moves every dependency, so a red
+run here names the one responsible instead of burying it behind a dozen
+others:
+
+```shell
+uv lock --upgrade-package btclib_libsecp256k1
+uv run --locked --no-default-groups --group test pytest
+```
+
+The second installs btclib itself from PyPI, nothing checked out, and
+asks whether it works rather than whether it installs: `import btclib`
+runs `__init__.py` alone, and the files under `btclib/*/_data/` — the
+wordlists among them — are opened by path at the first call that needs
+one, not imported, so a wheel missing one would pass the import and fail
+only here. Both checks are version-independent, a BIP340 vector and a
+BIP39 one whose values are fixed forever:
+
+```shell
+python -m pip install btclib
+python -c "import btclib; \
+    from btclib.ecc import dsa; \
+    from btclib.to_pub_key import pub_keyinfo_from_prv_key; \
+    assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
+      dsa.sign(b'btclib', 1))"
+python -c "from btclib.mnemonic.bip39 import seed_from_mnemonic; \
+    m = 'abandon abandon abandon abandon abandon abandon abandon ' \
+        'abandon abandon abandon abandon about'; \
+    assert seed_from_mnemonic(m, 'TREZOR').hex() == ( \
+      'c55257c360c07c72029aebc1b53c05ed0362ada38ead3e3e9efa3708e53' \
+      '495531f09a6987599d18264c1e1c92f2cf141630c7a3c4ab7c81b2f0016' \
+      '98e7463b04')"
+```
+
 The `links` workflow, weekly and on demand, which is the one that needs a
 tool uv does not provide: lychee is a rust binary, and the workflow uses
 the action. It gates nothing — a link rots without anybody touching the

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,7 +1,4 @@
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -369,6 +369,10 @@ against the `v2023.7.12` tag.
   `__getattr__`, so `import btclib` still costs the metadata lookup alone
   and `btclib.b58` answers without an import of its own. `btclib.name` is
   where it was, and is no longer star-imported.
+- **`network.datadir` and `curves.curve.datadir` are `Path`, not `str`.**
+  `str(btclib.network.datadir)` recovers the `v2023.7.12` value; code
+  that concatenated it, sliced it, or called a string method on it does
+  not.
 
 Two changes are deliberately *not* on that list, because what they change
 stays compatible. The new `BTClibTypeError`, `NotAPrvKeyError` and

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -24,12 +24,13 @@ Telling these apart is most of what can go wrong when cutting a release.
   value `btclib.__version__` reads back from installed metadata; and
   `2026.8.4.1`, a fourth number added only if `2026.8.4` shipped broken
   and cannot be reuploaded (see "If something goes wrong"). All three
-  are typed by hand, and nothing in `version-check` tells them apart
-  from each other — only from a tag that disagrees with whichever one
-  is declared. Three components is always the release day; four is
-  always a patch on it. The day is never dropped in favor of a fourth
-  digit standing in for it, which is what would make the two
-  indistinguishable
+  are typed by hand. Three components is always the release day; four
+  is always a patch on it. The day is never dropped in favor of a
+  fourth digit standing in for it, which is what would make the two
+  indistinguishable — and `version-check` refuses a tag on the
+  placeholder shape for exactly that reason: two components reach the
+  check and nothing past it, whichever one is declared. It does not
+  tell three apart from four, both being a release it accepts
 - **`v2026.8.4`**, the tag, carries no version of its own: it picks the
   index, PyPI rather than TestPyPI, and `version-check` exists to
   confirm it says what `pyproject.toml` says

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,7 +53,10 @@ Telling these apart is most of what can go wrong when cutting a release.
   resolve
 
 PEP 440 sorts `2026.8.4.dev7` before `2026.8.4`, so a rehearsal never
-shadows the release it rehearses.
+shadows the release it rehearses. `git tag` on its own does not read
+the numbers the same way: measured, `v2026.10` lists before `v2026.7`,
+alphabetically rather than chronologically. `git tag --sort=v:refname`
+reads them as PEP 440 does.
 
 ## One-time setup
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,6 +11,46 @@ configured to trust the workflow itself
 The same workflow, started by hand instead of by a tag, is a full
 rehearsal against TestPyPI. A rehearsal is never tagged.
 
+## Which version string is which
+
+Telling these apart is most of what can go wrong when cutting a release.
+
+- **`pyproject.toml`'s own `version`** takes three shapes over one
+  cycle, never two at once: `2026.8`, month only, between releases —
+  the placeholder "Open the next cycle" sets, so a checkout of `dev`
+  reports itself as work in progress rather than as a release it is
+  not; `2026.8.4`, with the day added on release day — calendar
+  versioning, `YYYY.M.D` — which is what gets published and the only
+  value `btclib.__version__` reads back from installed metadata; and
+  `2026.8.4.1`, a fourth number added only if `2026.8.4` shipped broken
+  and cannot be reuploaded (see "If something goes wrong"). All three
+  are typed by hand, and nothing in `version-check` tells them apart
+  from each other — only from a tag that disagrees with whichever one
+  is declared
+- **`v2026.8.4`**, the tag, carries no version of its own: it picks the
+  index, PyPI rather than TestPyPI, and `version-check` exists to
+  confirm it says what `pyproject.toml` says
+- **`.dev<run number>`** is not a version but the template the `build`
+  job patches into `pyproject.toml` before a rehearsal, `github.
+  run_number` counted for `release.yml` alone. Only `workflow_dispatch`
+  adds it, and nothing commits the result: `uv lock` runs straight
+  after, so the lockfile the sdist ships agrees with the version it is
+  named for
+- **`2026.8.4.dev7`** is what that template produces rehearsing
+  `2026.8.4` the seventh time `release.yml` has run. That count is
+  what makes a rehearsal's version unique, and what makes re-running a
+  finished one collide with itself rather than mint a new one
+- **`2026.8.4rc1`**, and a `v2026.8.4rc1` tag, have no place in this
+  scheme: there is no pre-release here, only a version not yet tagged.
+  `version-check` refuses anything that is not digits and dots, which
+  is what stops `2026.8.4rc1` at `pyproject.toml` before a tag is even
+  pushed — and what a `v2026.8.4rc1` tag would otherwise pass, the
+  comparison against it burning a version `--pre` installs would then
+  resolve
+
+PEP 440 sorts `2026.8.4.dev7` before `2026.8.4`, so a rehearsal never
+shadows the release it rehearses.
+
 ## One-time setup
 
 Already done for btclib-org/btclib; kept here for the record.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,7 +26,10 @@ Telling these apart is most of what can go wrong when cutting a release.
   and cannot be reuploaded (see "If something goes wrong"). All three
   are typed by hand, and nothing in `version-check` tells them apart
   from each other — only from a tag that disagrees with whichever one
-  is declared
+  is declared. Three components is always the release day; four is
+  always a patch on it. The day is never dropped in favor of a fourth
+  digit standing in for it, which is what would make the two
+  indistinguishable
 - **`v2026.8.4`**, the tag, carries no version of its own: it picks the
   index, PyPI rather than TestPyPI, and `version-check` exists to
   confirm it says what `pyproject.toml` says
@@ -181,14 +184,48 @@ pyroma), build, wheel smoke test — and publishes to
 1. Tag the release commit and push the tag:
 
    ```shell
-   git tag -a v2026.8 -m "release v2026.8"
-   git push origin v2026.8
+   git tag -a v2026.8.4 -m "release v2026.8.4"
+   git push origin v2026.8.4
    ```
 
-1. The workflow does the rest: full matrix, build and checks, PyPI
-   upload, and the GitHub release with the distribution files attached
-   and the HISTORY.md section as its body. Give the release notes a
-   read once it lands.
+1. The workflow builds the full matrix and the distribution files, then
+   pauses at the `pypi` environment for the review "One-time setup"
+   describes. Approve it. That approval is not the point of no return:
+   the OIDC token exchange happens after it, so a trusted publisher
+   whose claims do not match fails there having uploaded nothing, and
+   the version survives — delete the tag, fix the registration, tag
+   again. The same holds for a rehearsal failing the same way on
+   TestPyPI: its `.dev<run number>` is not consumed either, and `gh run
+   rerun --failed` re-runs the publish job alone, against the artifacts
+   already built, rather than the whole matrix again. The upload itself
+   is the point of no return, PyPI accepting no file name twice even
+   after deletion; the GitHub release follows it, with the distribution
+   files attached and the HISTORY.md section as its body. Give the
+   release notes a read once it lands.
+
+1. Install what was just published into an environment of its own,
+   then exercise something that touches the shipped data rather than
+   only importing it. `import btclib` runs `__init__.py` alone, and the
+   25 files under `_data/` — the twelve BIP39 wordlists among them —
+   are opened by path at the first call that needs one, not imported,
+   so a wheel missing `wordlist.txt` would install and import cleanly
+   and only fail there:
+
+   ```shell
+   uv run --isolated --no-project --with btclib \
+     python -c "from btclib.mnemonic.bip39 import seed_from_mnemonic; \
+       m = 'abandon abandon abandon abandon abandon abandon abandon ' \
+           'abandon abandon abandon abandon about'; \
+       print(seed_from_mnemonic(m, 'TREZOR').hex())"
+   ```
+
+1. Check the PEP 740 attestations SECURITY.md says every release
+   carries. The JSON API is not where: its `provenance` field answers
+   `null` even on a release that has them. The project page shows them,
+   and machine-readably they are under
+   `/integrity/<project>/<version>/<filename>/provenance`, whose
+   `attestation_bundles[].publisher` should name this repository and
+   `release.yml`.
 
 1. Open the next cycle: set a generic next version without the day
    (e.g. after 2026.8.4, use 2026.9) in pyproject.toml, and start a new
@@ -200,13 +237,13 @@ pyroma), build, wheel smoke test — and publishes to
   uploaded. Delete the tag, fix, and tag again:
 
   ```shell
-  git tag -d v2026.8
-  git push origin :refs/tags/v2026.8
+  git tag -d v2026.8.4
+  git push origin :refs/tags/v2026.8.4
   ```
 
 - The upload succeeded but the release is broken: PyPI never accepts a
   file name twice, even after deletion. Yank the bad release on PyPI
-  and publish a new patch version (`2026.8` → `2026.8.1`).
+  and publish a new patch version (`2026.8.4` → `2026.8.4.1`).
 
 - Only the `github-release` job failed: the PyPI upload is already
   done; re-run the failed job, or create the release by hand from the

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -55,9 +55,10 @@ Both branches are protected, and differently on purpose.
 pushes, no deletions, `required_conversation_resolution`, and
 `enforce_admins` *off* — an administrator can bypass all of it.
 
-`dev`: no force pushes, no deletions, linear history, and nothing else —
-no required check, no review, no signature, so a direct push still works,
-which is what `uv run` and both bots rely on.
+`dev`: no force pushes, no deletions, linear history, resolved
+conversations, and nothing beyond that — no required check, no review, no
+signature, so a direct push still works, which is what `uv run` and both
+bots rely on.
 
 That asymmetry is the answer to issue #158, and it is a choice rather
 than a copy for two measured reasons. Commits on `dev` are **unsigned**

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The btclib package: what it publishes, and the version metadata.
 
 `__all__` here is the root of the library's public tree: the packages and

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
@@ -72,7 +72,7 @@ __author_email__ = "devs@btclib.org"
 # which the copyright-notice hook enforces, so it never needs editing.
 # docs/source/conf.py reads this line rather than importing it, read the
 # docs not installing this package into the environment it builds in
-__copyright__ = "Copyright (C) 2017-2026 The btclib developers"
+__copyright__ = "Copyright (c) 2017-2026 The btclib developers"
 __license__ = "MIT License"
 
 __all__ = [

--- a/btclib/_ripemd160.py
+++ b/btclib/_ripemd160.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/_ripemd160.py
+++ b/btclib/_ripemd160.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Pure Python RIPEMD-160, for an interpreter whose hashlib has none.
 
 Vendored from bitcoin/bitcoin at 08a4a56c, where the file is

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The type aliases of the public API, and the input conventions they name.
 
 Octets and String below are both `bytes | str`, so mypy cannot tell

--- a/btclib/amount.py
+++ b/btclib/amount.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/amount.py
+++ b/btclib/amount.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Monetary amounts: satoshi ints and BTC Decimals, never floats.
 
 A BTC amount is an int number of satoshi (1 BTC is 100_000_000) or a

--- a/btclib/b32.py
+++ b/btclib/b32.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/b32.py
+++ b/btclib/b32.py
@@ -1,12 +1,7 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
 
 # Copyright (c) 2017 Pieter Wuille
 #

--- a/btclib/b58.py
+++ b/btclib/b58.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/b58.py
+++ b/btclib/b58.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Base58 address and WIF functions.
 
 **The bitcoin semantics.** Base58 encoding of public keys and scripts as

--- a/btclib/base58.py
+++ b/btclib/base58.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/base58.py
+++ b/btclib/base58.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Base58 encoding and decoding functions.
 
 **The codec.** This module is base58 itself, with no bitcoin in it: bytes in,

--- a/btclib/bech32.py
+++ b/btclib/bech32.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/bech32.py
+++ b/btclib/bech32.py
@@ -1,12 +1,7 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
 
 # Copyright (c) 2017 Pieter Wuille
 #

--- a/btclib/bip21.py
+++ b/btclib/bip21.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/bip21.py
+++ b/btclib/bip21.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """BIP21 payment URI: bitcoin:<address>[?amount=&label=&message=].
 
 https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki

--- a/btclib/bip21.py
+++ b/btclib/bip21.py
@@ -157,7 +157,7 @@ class Bip21:
 
     def assert_valid(self) -> None:
         """Refuse a URI without a decodable address, or a bad amount."""
-        if not isinstance(self.address, str) or not self.address:
+        if not isinstance(self.address, str) or not self.address:  # type: ignore[redundant-expr]
             raise BTClibValueError("missing address in the bip21 URI")
         # the decoders *are* the validation, and each says what is wrong
         # with the string it refused, which is more than this module

--- a/btclib/bip32/__init__.py
+++ b/btclib/bip32/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/bip32/__init__.py
+++ b/btclib/bip32/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """BIP32 extended keys, derivation, and key origins."""
 
 from btclib.bip32.bip32 import (

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """BIP32 hierarchical deterministic wallet functions.
 
 https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """BIP32 derivation path and key origin.
 
 A BIP32 derivation path can be represented as:

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The BIP32KeyOrigin dataclass and the bip32_derivs codecs."""
 
 from __future__ import annotations

--- a/btclib/bip44.py
+++ b/btclib/bip44.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/bip44.py
+++ b/btclib/bip44.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Callable
-from os import path
+from pathlib import Path
 
 from btclib import b32, b58
 from btclib.alias import BIP44ScriptType, NetworkType
@@ -60,8 +60,8 @@ _LEVELS = 5
 # recovery helper wants next -- per-wallet rows, with the xpub version
 # each writes -- is more of this file and no more of this module, and
 # that list tracks the wallet ecosystem rather than the library
-_PURPOSES_FILE = path.join(path.dirname(__file__), "_data", "bip44_purposes.json")
-with open(_PURPOSES_FILE, encoding="ascii") as _purposes:
+_PURPOSES_FILE = Path(__file__).parent / "_data" / "bip44_purposes.json"
+with _PURPOSES_FILE.open(encoding="ascii") as _purposes:
     # json object keys are strings; a purpose is an int, as it is in a
     # derivation path. The values are annotated and not validated here:
     # BIP44ScriptType is a mypy fact and json.load answers Any, so what

--- a/btclib/bip44.py
+++ b/btclib/bip44.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """BIP44 address: an extended key and m/purpose/coin/account/change/index.
 
 https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki

--- a/btclib/bitcoin_core_rpc.py
+++ b/btclib/bitcoin_core_rpc.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/bitcoin_core_rpc.py
+++ b/btclib/bitcoin_core_rpc.py
@@ -1,12 +1,7 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
 
 # Those terms are the ones below, embedded rather than referenced: this file
 # is meant to be copied out of the distribution, and a copy has no LICENSE

--- a/btclib/bitcoin_core_rpc.py
+++ b/btclib/bitcoin_core_rpc.py
@@ -967,7 +967,7 @@ def _params_member(params: Sequence[Any] | Mapping[str, Any] | None) -> Any:
         raise BTClibTypeError(err_msg)
     if isinstance(params, Sequence):
         return list(params)
-    err_msg = "rpc params is neither a sequence nor a mapping, but a"
+    err_msg = "rpc params is neither a sequence nor a mapping, but a"  # type: ignore[unreachable]
     err_msg += f" {type(params).__name__}"
     raise BTClibTypeError(err_msg)
 
@@ -1343,7 +1343,7 @@ class BitcoinCoreRpcClient:
                 # every traceback and log that renders one. The type is what a
                 # caller needs to see, and `bytes` is the mistake this catches
                 # most often
-                err_msg = f"non-string rpc {name}: {type(value).__name__}"
+                err_msg = f"non-string rpc {name}: {type(value).__name__}"  # type: ignore[unreachable]
                 raise BTClibTypeError(err_msg)
         if user is not None and ":" in user:
             # the Basic credential is `user:password`, and Core splits it at

--- a/btclib/block/__init__.py
+++ b/btclib/block/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/block/__init__.py
+++ b/btclib/block/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Blocks: header and block, their rules, proof of work, merkle proofs."""
 
 from btclib.block import merkle_proof, mining, proof_of_work

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The Block dataclass and its rules; the class docstring has the contract."""
 
 from __future__ import annotations

--- a/btclib/block/block_context.py
+++ b/btclib/block/block_context.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/block/block_context.py
+++ b/btclib/block/block_context.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """BlockContext dataclass.
 
 What a block cannot be validated against from its own bytes: the height it

--- a/btclib/block/block_context.py
+++ b/btclib/block/block_context.py
@@ -119,7 +119,7 @@ class BlockContext:
                 raise BTClibValueError(f"invalid {key}: {value}")
 
         if not isinstance(self.now, datetime):
-            err_msg = f"invalid now type: {type(self.now).__name__}"
+            err_msg = f"invalid now type: {type(self.now).__name__}"  # type: ignore[unreachable]
             raise BTClibTypeError(err_msg)
 
         # a naive datetime has no instant attached to it: timestamp() would

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The BlockHeader dataclass; the class docstring has the contract."""
 
 from __future__ import annotations

--- a/btclib/block/limits.py
+++ b/btclib/block/limits.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/block/limits.py
+++ b/btclib/block/limits.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The consensus limits on a block, with Bitcoin Core's names.
 
 Core declares the first three in `consensus/consensus.h` and

--- a/btclib/block/merkle_proof.py
+++ b/btclib/block/merkle_proof.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/block/merkle_proof.py
+++ b/btclib/block/merkle_proof.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Verification of a merkle branch against a block header's merkle root.
 
 The verifier's side of the tree `btclib.block.Block` builds: given a

--- a/btclib/block/mining.py
+++ b/btclib/block/mining.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/block/mining.py
+++ b/btclib/block/mining.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Candidate block headers, and a toy search for the nonce that solves one.
 
 A toy, and the word is meant: `mine` hashes one nonce at a time in

--- a/btclib/block/proof_of_work.py
+++ b/btclib/block/proof_of_work.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/block/proof_of_work.py
+++ b/btclib/block/proof_of_work.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Proof-of-work arithmetic: compact targets, retargeting, work, hash rate.
 
 Pure functions over the four `bits` bytes a header carries and the times

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Module btclib.curves.
 
 **The arithmetic.** btclib.curves holds the elliptic curve itself: the field

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -30,7 +30,7 @@ import json
 from collections.abc import Sequence
 from hashlib import sha256
 from math import sqrt
-from os import path
+from pathlib import Path
 from typing import Any
 
 from btclib_libsecp256k1.keys import parse as libsecp256k1_pubkey_parse
@@ -282,7 +282,7 @@ class Curve(CurveGroup):
         return (*super()._eq_key(), *self.G, self.n, self.cofactor)
 
 
-datadir = path.join(path.dirname(__file__), "_data")
+datadir = Path(__file__).parent / "_data"
 
 
 def _catalogued_curve(params: list[Any], name: str) -> Curve:
@@ -307,8 +307,8 @@ def _catalogued_curve(params: list[Any], name: str) -> Curve:
 # Elliptic Curve Cryptography (ECC)
 # Brainpool Standard Curves and Curve Generation
 # https://www.rfc-editor.org/rfc/rfc5639.html
-_filename = path.join(datadir, "ec_Brainpool.json")
-with open(_filename, encoding="ascii") as _file:
+_filename = datadir / "ec_Brainpool.json"
+with _filename.open(encoding="ascii") as _file:
     Brainpool_params2 = json.load(_file)
 Brainpool: dict[str, Curve] = {
     _ec_name: _catalogued_curve(Brainpool_params2[_ec_name], _ec_name)
@@ -318,8 +318,8 @@ Brainpool: dict[str, Curve] = {
 # FEDERAL INFORMATION PROCESSING STANDARDS PUBLICATION
 # Digital Signature Standard (DSS)
 # https://oag.ca.gov/sites/all/files/agweb/pdfs/erds1/fips_pub_07_2013.pdf
-_filename = path.join(datadir, "ec_NIST.json")
-with open(_filename, encoding="ascii") as _file:
+_filename = datadir / "ec_NIST.json"
+with _filename.open(encoding="ascii") as _file:
     NIST_params2 = json.load(_file)
 NIST: dict[str, Curve] = {
     _ec_name: _catalogued_curve(NIST_params2[_ec_name], _ec_name)
@@ -327,8 +327,8 @@ NIST: dict[str, Curve] = {
 }
 # SEC 2 v.1 curves, removed from SEC 2 v.2 as insecure ones
 # http://www.secg.org/SEC2-Ver-1.0.pdf
-_filename = path.join(datadir, "ec_SEC2v1_insecure.json")
-with open(_filename, encoding="ascii") as _file:
+_filename = datadir / "ec_SEC2v1_insecure.json"
+with _filename.open(encoding="ascii") as _file:
     SEC2v1_params2 = json.load(_file)
 SEC2v1: dict[str, Curve] = {
     _ec_name: _catalogued_curve(SEC2v1_params2[_ec_name], _ec_name)
@@ -336,8 +336,8 @@ SEC2v1: dict[str, Curve] = {
 }
 # curves included in both SEC 2 v.1 and SEC 2 v.2
 # http://www.secg.org/sec2-v2.pdf
-_filename = path.join(datadir, "ec_SEC2v2.json")
-with open(_filename, encoding="ascii") as _file:
+_filename = datadir / "ec_SEC2v2.json"
+with _filename.open(encoding="ascii") as _file:
     SEC2v2_params2 = json.load(_file)
 SEC2v2: dict[str, Curve] = {}
 for _ec_name in SEC2v2_params2:

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The prime-order Curve and the multiplications built on it.
 
 mult, double_mult and multi_mult dispatch secp256k1 to the

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Elliptic CurveGroup class and functions.
 
 CurveGroup is every point of the curve, a group that needs be neither

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -748,7 +748,7 @@ def mods(m: int, w: int) -> int:
     """Signed modulo function."""
     w2: int = pow(2, w)
     M = m % w2
-    return M - w2 if M >= (w2 // 2) else M
+    return M - w2 if (w2 // 2) <= M else M
 
 
 def wNAF_of_m(m: int, w: int) -> list[int]:

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -135,7 +135,7 @@ class CurveGroup:
         # multiplied all the same, in the digits it needs
         self.scalar_len = plen + 1
 
-        # 2. check that a and b are integers in the interval [0, p−1]
+        # 2. check that a and b are integers in [0, p−1]  # noqa: RUF003
         if a < 0:
             raise BTClibValueError(f"negative a: {a}")
         if p <= a:

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -57,6 +57,7 @@ follow-ups; what is here is the rest:
       one joint recoding of both scalars instead of one NAF each, fewer
       total additions in exchange for digit pairs that do not index a
       per-point table of odd multiples
+
 """
 
 from __future__ import annotations

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Elliptic curve point multiplication functions.
 
 The implemented algorithms are:

--- a/btclib/curves/curve_group_f.py
+++ b/btclib/curves/curve_group_f.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/curves/curve_group_f.py
+++ b/btclib/curves/curve_group_f.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """CurveGroup explorer functions, for low-cardinality didactic curves.
 
 Enumerating the points of a group is feasible only when the group is

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """SEC compressed/uncompressed point representation."""
 
 import contextlib

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Output descriptors: the checksum, the parser, the scripts, the spend.
 
 A descriptor says which scripts a wallet owns, in one line of text. This

--- a/btclib/ecc/__init__.py
+++ b/btclib/ecc/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/__init__.py
+++ b/btclib/ecc/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Module btclib.ecc.
 
 **The schemes.** btclib.ecc holds what is built *on* an elliptic curve:

--- a/btclib/ecc/bip340_nonce.py
+++ b/btclib/ecc/bip340_nonce.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/bip340_nonce.py
+++ b/btclib/ecc/bip340_nonce.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Generation of the ephemeral key (nonce) following BIP340.
 
 https://github.com/bitcoin/bips/blob/master/bip-0340.mediawiki

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -104,7 +104,10 @@ matching Core and btclib).
 https://github.com/bitcoin/bitcoin/pull/524
 
 https://github.com/bitcoin/bips/blob/master/bip-0137.mediawiki
-"""
+"""  # noqa: D301
+# the "\n" a few paragraphs up is two characters, backslash and n, naming
+# the magic string's own escape notation rather than embedding a newline
+# in this one: an r prefix would double that backslash instead
 
 from __future__ import annotations
 

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Bitcoin message signing (BMS): address-based signatures over text.
 
 A BMS signature proves control of the private key behind an address.

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Borromean ring signature functions.
 
 References:

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -11,6 +11,7 @@ References:
 
 Both are also cited inside `sign`, which is not where a reader looks
 first; they are here because the module is what one arrives at.
+
 """
 
 from __future__ import annotations

--- a/btclib/ecc/commit_nonce.py
+++ b/btclib/ecc/commit_nonce.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/commit_nonce.py
+++ b/btclib/ecc/commit_nonce.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Commitment-tweaked ephemeral key (nonce): sign-to-contract.
 
 A signature commits to a value by tweaking its nonce with it, at no cost

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Diffie-Hellman elliptic curve key agreement, per SEC 1 v.2.
 
 Two parties, each holding the other's public key, compute the same

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -1009,8 +1009,9 @@ def recover_pub_keys_(
 ) -> list[Point]:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
 
-    See also:
+    See Also:
     - https://crypto.stackexchange.com/questions/18105/how-does-recovering-the-public-key-from-an-ecdsa-signature-work/18106#18106
+
     """
     if isinstance(sig, Sig):
         sig.assert_valid()
@@ -1054,8 +1055,9 @@ def recover_pub_keys(
 ) -> list[Point]:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
 
-    See also:
+    See Also:
     - https://crypto.stackexchange.com/questions/18105/how-does-recovering-the-public-key-from-an-ecdsa-signature-work/18106#18106
+
     """
     msg_hash = reduce_to_hlen(msg, hf)
     return recover_pub_keys_(msg_hash, sig, lower_s, hf)
@@ -1194,8 +1196,9 @@ def recover_pub_key_(
 ) -> Point:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
 
-    See also:
+    See Also:
     - https://crypto.stackexchange.com/questions/18105/how-does-recovering-the-public-key-from-an-ecdsa-signature-work/18106#18106
+
     """
     if isinstance(sig, Sig):
         sig.assert_valid()
@@ -1232,8 +1235,9 @@ def recover_pub_key(
 ) -> Point:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
 
-    See also:
+    See Also:
     - https://crypto.stackexchange.com/questions/18105/how-does-recovering-the-public-key-from-an-ecdsa-signature-work/18106#18106
+
     """
     msg_hash = reduce_to_hlen(msg, hf)
     return recover_pub_key_(key_id, msg_hash, sig, lower_s, hf)

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Elliptic Curve Digital Signature Algorithm (ECDSA).
 
 Implementation according to SEC 1 v.2:

--- a/btclib/ecc/ecies.py
+++ b/btclib/ecc/ecies.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/ecies.py
+++ b/btclib/ecc/ecies.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """ECIES in the BIE1 layout, with the block cipher supplied by the caller.
 
 BIE1 is the ECIES variant the bitcoin world converged on: Electrum's

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -152,7 +152,7 @@ def _xswiftec(u: int, t: int, ec: Curve) -> int:
     raise BTClibRuntimeError(err_msg)  # pragma: no cover
 
 
-def _xswiftec_inv(x: int, u: int, case: int, ec: Curve) -> int | None:
+def _xswiftec_inv(x: int, u: int, case: int, ec: Curve) -> int | None:  # noqa: PLR0911
     """Return a t with _xswiftec(u, t) == x, or None if this case has none.
 
     `xswiftec_inv` of BIP324's reference implementation. Up to eight t

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """ElligatorSwift encoding of a public key, and the x-only ECDH on it.
 
 An ElligatorSwift encoding is 64 bytes that are indistinguishable from

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """MuSig2 key and signature aggregation, according to BIP327.
 
 https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Pedersen commitment functions.
 
 In a commitment scheme the committer:

--- a/btclib/ecc/rfc6979_nonce.py
+++ b/btclib/ecc/rfc6979_nonce.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/rfc6979_nonce.py
+++ b/btclib/ecc/rfc6979_nonce.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Deterministic generation of the ephemeral key following RFC6979.
 
 https://www.rfc-editor.org/rfc/rfc6979.html

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Elliptic Curve Schnorr Signature Algorithm (ECSSA).
 
 This implementation is according to BIP340-Schnorr:

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -719,7 +719,7 @@ def assert_batch_as_valid_(
     points: list[Point] = []
     for i, (msg, Q, sig) in enumerate(zip(msgs, Qs, sigs, strict=True)):
         # any size, as in sign_ and assert_as_valid_
-        msg = bytes_from_octets(msg)
+        msg = bytes_from_octets(msg)  # noqa: PLW2901
 
         K = sig.r, _y_even(sig.r, ec)
 

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Exception classes.
 
 These exist only to tell an exception raised by btclib from one raised by

--- a/btclib/fee.py
+++ b/btclib/fee.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/fee.py
+++ b/btclib/fee.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Fee rates, the fee a virtual size owes, and the dust threshold.
 
 Three answers, each a function of its arguments alone: what a fee rate

--- a/btclib/fetch/__init__.py
+++ b/btclib/fetch/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/fetch/__init__.py
+++ b/btclib/fetch/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Module btclib.fetch.
 
 **Where the chain is.** Everything else in btclib works on bytes it was

--- a/btclib/fetch/bitcoin_core.py
+++ b/btclib/fetch/bitcoin_core.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/fetch/bitcoin_core.py
+++ b/btclib/fetch/bitcoin_core.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The btclib fetcher backed by a `BitcoinCoreRpcClient`.
 
 The client itself lives in `btclib.bitcoin_core_rpc`: that file has no btclib

--- a/btclib/fetch/esplora.py
+++ b/btclib/fetch/esplora.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/fetch/esplora.py
+++ b/btclib/fetch/esplora.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The block-explorer fallback, for a caller with no node.
 
 Esplora's HTTP api, because it is an api and not a product: Blockstream

--- a/btclib/fetch/fetcher.py
+++ b/btclib/fetch/fetcher.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/fetch/fetcher.py
+++ b/btclib/fetch/fetcher.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The interface a chain backend answers, whichever backend it is.
 
 Three questions btclib cannot answer from bytes it was handed: what

--- a/btclib/fetch/fetcher.py
+++ b/btclib/fetch/fetcher.py
@@ -181,7 +181,7 @@ def tx_from_raw(raw: Octets, tx_id: str, network: str) -> Tx:
         # through untouched, so a json number where the hex belongs
         # surfaces as AttributeError on `.read` -- a traceback into the
         # parser for what is the backend answering the wrong shape
-        err_msg = f"transaction {tx_id}: not a serialization,"
+        err_msg = f"transaction {tx_id}: not a serialization,"  # type: ignore[unreachable]
         err_msg += f" but a {type(raw).__name__}"
         raise FetchError(err_msg)
     with fetch_errors(f"transaction {tx_id}"):

--- a/btclib/fetch/transport.py
+++ b/btclib/fetch/transport.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/fetch/transport.py
+++ b/btclib/fetch/transport.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Compatibility exports for the standard-library HTTP transport.
 
 The implementation lives beside `BitcoinCoreRpcClient` in the standalone

--- a/btclib/hashes.py
+++ b/btclib/hashes.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/hashes.py
+++ b/btclib/hashes.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The hash functions of bitcoin.
 
 ripemd160 and sha1 through sha256, the hash160 and hash256 pairs,

--- a/btclib/keystore.py
+++ b/btclib/keystore.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/keystore.py
+++ b/btclib/keystore.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Keystore: the addresses handed out, and the key that signs for each.
 
 `btclib.ecc.bms` says it in its own docstring -- "at signing time, a

--- a/btclib/mnemonic/__init__.py
+++ b/btclib/mnemonic/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/mnemonic/__init__.py
+++ b/btclib/mnemonic/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Module btclib.mnemonic.
 
 bip39, electrum and slip39 are the three mnemonic schemes this package

--- a/btclib/mnemonic/bip39.py
+++ b/btclib/mnemonic/bip39.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/mnemonic/bip39.py
+++ b/btclib/mnemonic/bip39.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """BIP39 entropy / mnemonic / seed functions.
 
 https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki.

--- a/btclib/mnemonic/dispatch.py
+++ b/btclib/mnemonic/dispatch.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/mnemonic/dispatch.py
+++ b/btclib/mnemonic/dispatch.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Which mnemonic scheme claims a sentence, and in what order.
 
 btclib holds a validator for each scheme and had no entry point that

--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Electrum entropy / mnemonic / seed functions.
 
 Electrum mnemonic is versioned, conveying BIP32 derivation rule too.

--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -61,7 +61,7 @@ import string
 import unicodedata
 from functools import cache
 from hashlib import pbkdf2_hmac, sha256, sha512
-from os import path
+from pathlib import Path
 
 from btclib.bip32 import derive, rootxprv_from_seed
 from btclib.bip32.der_path import _HARDENED_OFFSET
@@ -158,9 +158,7 @@ _CJK_INTERVALS = (
 # contemporary poetry -- so a re-sorted copy decodes every seed to
 # something else. There is no upstream file to compare bytes against,
 # the words living inside a python module rather than in a .txt
-_OLD_WORDLIST_FILE = path.join(
-    path.dirname(__file__), "_data", "electrum_old_english.txt"
-)
+_OLD_WORDLIST_FILE = Path(__file__).parent / "_data" / "electrum_old_english.txt"
 
 # the rounds of Old_KeyStore.stretch_key, which is what a pre-2.0 seed
 # has instead of the versioned scheme's 2048 PBKDF2 iterations
@@ -226,7 +224,7 @@ def _old_wordlist() -> tuple[str, ...]:
     into this list is not a digit, and none of the entropy machinery a
     registered language reaches applies to it.
     """
-    with open(_OLD_WORDLIST_FILE, encoding="ascii") as file_:
+    with _OLD_WORDLIST_FILE.open(encoding="ascii") as file_:
         return tuple(line.rstrip("\n") for line in file_)
 
 

--- a/btclib/mnemonic/entropy.py
+++ b/btclib/mnemonic/entropy.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/mnemonic/entropy.py
+++ b/btclib/mnemonic/entropy.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Entropy conversion functions.
 
 Depending on the function, input entropy can be expressed as raw (i.e.

--- a/btclib/mnemonic/mnemonic.py
+++ b/btclib/mnemonic/mnemonic.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/mnemonic/mnemonic.py
+++ b/btclib/mnemonic/mnemonic.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Mnemonic sentence conversion from/to sequence of integer indexes."""
 
 from __future__ import annotations

--- a/btclib/mnemonic/mnemonic.py
+++ b/btclib/mnemonic/mnemonic.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import threading
 import unicodedata
 from collections.abc import Sequence
-from os import path
+from pathlib import Path
 
 from btclib.exceptions import BTClibValueError
 
@@ -32,7 +32,7 @@ WordList = Sequence[str]
 
 def data_file(filename: str) -> str:
     """Return the path of a word-list shipped with btclib."""
-    return path.join(path.dirname(__file__), "_data", filename)
+    return str(Path(__file__).parent / "_data" / filename)
 
 
 # The twelve word-lists of BIP39's reference implementation, keyed by
@@ -182,7 +182,7 @@ class WordLists:
         # ascii, japanese and korean not even close, and the BIP
         # publishes them NFKD-encoded. A '#' starts a comment, which is
         # what carries the licence header of electrum's Portuguese list
-        with open(filename, encoding="utf-8") as file_:
+        with Path(filename).open(encoding="utf-8") as file_:
             lines = file_.readlines()
         stripped = (line.split("#")[0].strip() for line in lines)
         words = [unicodedata.normalize("NFKD", word) for word in stripped if word]

--- a/btclib/mnemonic/slip39.py
+++ b/btclib/mnemonic/slip39.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/mnemonic/slip39.py
+++ b/btclib/mnemonic/slip39.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """SLIP-0039 share / master secret / seed functions.
 
 https://github.com/satoshilabs/slips/blob/master/slip-0039.md.

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -261,7 +261,7 @@ class Network:
         # bytes fields, TypeError being what they raise for a field
         # rebound to something else
         if not isinstance(self.hrp, str):
-            err_msg = f"invalid hrp type: {type(self.hrp).__name__}"
+            err_msg = f"invalid hrp type: {type(self.hrp).__name__}"  # type: ignore[unreachable]
             raise BTClibTypeError(err_msg)
 
         # NetworkType is a Literal, which is a mypy fact and not a runtime

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The Network dataclass, NETWORKS, and the lookups over them.
 
 What this module exports is the dataclass, the catalogue, the three

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass
-from os import path
+from pathlib import Path
 from typing import Any
 
 from btclib.alias import NetworkField, NetworkName, NetworkType, Octets
@@ -281,7 +281,7 @@ class Network:
 
 
 NETWORKS: dict[str, Network] = {}
-datadir = path.join(path.dirname(__file__), "_data")
+datadir = Path(__file__).parent / "_data"
 # order matters, and it is the order of the reverse lookups below: the
 # first network holding a version prefix is the one they answer with, so
 # testnet, the oldest, answers for the four networks that share its
@@ -306,8 +306,8 @@ _network_names: tuple[NetworkName, ...] = (
 # module globals like any other, so `net`, `filename` and the open file
 # would be three names of this module that no caller has any use for
 for _net in _network_names:
-    _filename = path.join(datadir, f"{_net}.json")
-    with open(_filename, encoding="ascii") as _network_file:
+    _filename = datadir / f"{_net}.json"
+    with _filename.open(encoding="ascii") as _network_file:
         NETWORKS[_net] = Network.from_dict(json.load(_network_file))
 
 

--- a/btclib/number_theory.py
+++ b/btclib/number_theory.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/number_theory.py
+++ b/btclib/number_theory.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Number theory and modular arithmetic functions.
 
 Implementations originally from

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Partially signed bitcoin transactions and the BIP174/BIP370 roles.
 
 What this package exports is the format and the roles: the three maps a

--- a/btclib/psbt/musig2.py
+++ b/btclib/psbt/musig2.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/psbt/musig2.py
+++ b/btclib/psbt/musig2.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The three roles BIP373 defines, over `btclib.ecc.musig2`.
 
 https://github.com/bitcoin/bips/blob/master/bip-0373.mediawiki

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Partially Signed Bitcoin Transaction (Psbt) dataclass and functions.
 
 https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Partially Signed Bitcoin Transaction Input (PsbtIn) dataclass and functions.
 
 https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki

--- a/btclib/psbt/psbt_out.py
+++ b/btclib/psbt/psbt_out.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/psbt/psbt_out.py
+++ b/btclib/psbt/psbt_out.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Partially Signed Bitcoin Transaction Output (PsbtOut).
 
 Dataclass and functions.

--- a/btclib/psbt/psbt_size.py
+++ b/btclib/psbt/psbt_size.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/psbt/psbt_size.py
+++ b/btclib/psbt/psbt_size.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """How large the inputs of a Psbt will be once they are signed.
 
 `Tx.size`, `Tx.vsize` and `Tx.weight` are read off a serialization, so

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Partially Signed Bitcoin Transaction (Psbt) helper functions.
 
 https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki

--- a/btclib/script/__init__.py
+++ b/btclib/script/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/__init__.py
+++ b/btclib/script/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Scripts: types, classification, sig hashes, taproot, the engine.
 
 The flat surface is the script itself: the codec, the `ScriptPubKey`

--- a/btclib/script/engine/__init__.py
+++ b/btclib/script/engine/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/engine/__init__.py
+++ b/btclib/script/engine/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The script engine: transaction verification against the consensus rules."""
 
 from __future__ import annotations

--- a/btclib/script/engine/flags.py
+++ b/btclib/script/engine/flags.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/engine/flags.py
+++ b/btclib/script/engine/flags.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Bitcoin Script verification flags.
 
 A bitmask, not a list of plain strings asked `"P2SH" in flags`: that

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The legacy and segwit v0 interpreter loop of the script engine."""
 
 from __future__ import annotations

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -465,7 +465,7 @@ OPERATIONS: Mapping[str, ScriptOp] = {
 # what the OPERATIONS table cannot hold, read against Core's EvalScript:
 # the op codes needing the engine's own state, and the pushes matched by
 # shape rather than by name
-def verify_script(  # noqa: C901
+def verify_script(  # noqa: C901, PLR0912
     script_bytes: bytes,
     stack: list[bytes],
     prevout_value: int,

--- a/btclib/script/engine/script_op_codes.py
+++ b/btclib/script/engine/script_op_codes.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/engine/script_op_codes.py
+++ b/btclib/script/engine/script_op_codes.py
@@ -1,10 +1,8 @@
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Bitcoin Script legacy op codes.
 
 One function per op code, each the matching case of Core's EvalScript;

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -232,7 +232,7 @@ OPERATIONS: Mapping[str, ScriptOp] = {
 # what the OPERATIONS table cannot hold, read against Core's tapscript
 # rules: the op codes needing the engine's own state, the sigops budget
 # among it
-def verify_script_path_vc0(  # noqa: C901
+def verify_script_path_vc0(  # noqa: C901, PLR0912
     script_bytes: bytes,
     stack: list[bytes],
     prevouts: list[TxOut],

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The tapscript interpreter loop of the script engine, per BIP342."""
 
 from __future__ import annotations

--- a/btclib/script/limits.py
+++ b/btclib/script/limits.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/limits.py
+++ b/btclib/script/limits.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The consensus limits on a script, with Bitcoin Core's names.
 
 The five caps at the top of Core's `script/script.h`, in one place because

--- a/btclib/script/op_codes_tapscript.py
+++ b/btclib/script/op_codes_tapscript.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/op_codes_tapscript.py
+++ b/btclib/script/op_codes_tapscript.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The tapscript op code tables, per BIP342.
 
 OP_VERIF (0x65) and OP_VERNOTIF (0x66) are named here although no script

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -637,7 +637,7 @@ class Script:
     def __add__(self, other: Script) -> Script:
         return (
             Script(self.script + other.script)
-            if isinstance(other, Script)
+            if isinstance(other, Script)  # type: ignore[redundant-expr]
             else NotImplemented
         )
 

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -565,7 +565,7 @@ def read_op_code(script: bytes, start: int) -> tuple[int, int] | None:
     stop = start + 1
     if 0 < op_code <= 78:  # a push, of its own length or of a declared one
         data_length = op_code
-        if 75 < op_code:  # OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4
+        if op_code > 75:  # OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4
             size = 2 ** (op_code - 76)  # 1, 2 or 4 bytes of little-endian length
             if stop + size > len(script):
                 return None

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Bitcoin Script.
 
 https://en.bitcoin.it/wiki/Script

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """ScriptPubKey and the classification of the standard script shapes.
 
 Every standard shape has an assert_* function, raising

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -425,7 +425,7 @@ def _witness_type_and_payload(
     return None
 
 
-def type_and_payload(script_pub_key: Octets) -> tuple[ScriptType, bytes]:
+def type_and_payload(script_pub_key: Octets) -> tuple[ScriptType, bytes]:  # noqa: PLR0911
     """Return (script_pub_key type, payload) from the input script_pub_key.
 
     The returns here and in _witness_type_and_payload are the whole of
@@ -486,7 +486,7 @@ def type_and_payload(script_pub_key: Octets) -> tuple[ScriptType, bytes]:
 # reach through a frozen TxOut. So __init__ assigns through
 # object.__setattr__, as Network's and the three Sig classes' do
 @dataclass(init=False, eq=False, frozen=True)
-class ScriptPubKey(Script):
+class ScriptPubKey(Script):  # noqa: PLW1641
     """A Script with the network its addresses render on.
 
     The script bytes and their validation are Script's; the network

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The hashes a transaction signature commits to, one per era.
 
 Three preimages for one question -- what does this input's signature

--- a/btclib/script/sig_ops.py
+++ b/btclib/script/sig_ops.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/sig_ops.py
+++ b/btclib/script/sig_ops.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The legacy signature check operation count of a script.
 
 Bitcoin Core's `CScript::GetSigOpCount(false)`, which `GetLegacySigOpCount`

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Taproot keys, script trees and control blocks, per BIP341.
 
 The output side and the spend side of taproot, tapscript execution

--- a/btclib/script/witness.py
+++ b/btclib/script/witness.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/script/witness.py
+++ b/btclib/script/witness.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The Witness dataclass; the class docstring has the contract."""
 
 from __future__ import annotations

--- a/btclib/slip132.py
+++ b/btclib/slip132.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/slip132.py
+++ b/btclib/slip132.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """SLIP132 address.
 
 https://github.com/satoshilabs/slips/blob/master/slip-0132.md

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Functions for conversions between different private key formats."""
 
 from __future__ import annotations

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Functions for conversions between different public key formats."""
 
 from __future__ import annotations

--- a/btclib/tx/__init__.py
+++ b/btclib/tx/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/tx/__init__.py
+++ b/btclib/tx/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Transactions: OutPoint, TxIn, TxOut, Tx, and join."""
 
 from btclib.tx.out_point import OutPoint

--- a/btclib/tx/out_point.py
+++ b/btclib/tx/out_point.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/tx/out_point.py
+++ b/btclib/tx/out_point.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The OutPoint dataclass; the class docstring has the contract."""
 
 from __future__ import annotations

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -62,7 +62,7 @@ def _assert_valid_coinbase(vin: Sequence[TxIn], *, is_coinbase: bool) -> None:
 
 
 @dataclass
-class Tx:
+class Tx:  # noqa: PLW1641
     """A Bitcoin transaction: version, lock time, inputs, outputs.
 
     Mutable, being what a builder and a signer edit in place; `id` and

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The Tx dataclass and join; the class docstring has the contract."""
 
 from __future__ import annotations

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The TxIn dataclass; the class docstring has the contract."""
 
 from __future__ import annotations

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The TxOut dataclass; the class docstring has the contract."""
 
 from __future__ import annotations

--- a/btclib/tx_or_psbt.py
+++ b/btclib/tx_or_psbt.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/tx_or_psbt.py
+++ b/btclib/tx_or_psbt.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """One entry point for a transaction or a psbt, in whatever it arrives as.
 
 A transaction copied from a block explorer is hex, a

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Assorted conversion utilities.
 
 Most conversions from SEC 1 v.2 2.3 are included.

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -78,7 +78,7 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
     elif isinstance(out_size, Iterable):
         sizes = tuple(out_size)
     else:
-        err_msg = f"invalid output size type: {type(out_size).__name__}"
+        err_msg = f"invalid output size type: {type(out_size).__name__}"  # type: ignore[unreachable]
         raise BTClibTypeError(err_msg)
 
     for size in sizes:

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -217,7 +217,7 @@ def int_from_bits(octets: Octets, nlen: int) -> int:
 
 
 def int_from_integer(i: Integer) -> int:
-    """Return an int from many possible integer representations.
+    r"""Return an int from many possible integer representations.
 
     Allowed integer representations are:
 

--- a/btclib/var_bytes.py
+++ b/btclib/var_bytes.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/var_bytes.py
+++ b/btclib/var_bytes.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Varbytes encoding and decoding: a var_int length, then the bytes."""
 
 from btclib import var_int

--- a/btclib/var_int.py
+++ b/btclib/var_int.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/btclib/var_int.py
+++ b/btclib/var_int.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Varint encoding and decoding functions.
 
 Bitcoin's variable-length integer, Core's CompactSize: what the wire

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
@@ -33,10 +33,10 @@ PYPROJECT = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 
 project = "btclib"
 # from btclib/__init__.py, where the years are declared once, minus the
-# "Copyright (C) " that sphinx prepends itself. Read from the file rather
+# "Copyright (c) " that sphinx prepends itself. Read from the file rather
 # than imported, for the same reason as the version below
 project_copyright = re.search(
-    r'^__copyright__ = "Copyright \(C\) (.+)"$',
+    r'^__copyright__ = "Copyright \(c\) (.+)"$',
     (ROOT / "btclib" / "__init__.py").read_text(encoding="utf-8"),
     re.MULTILINE,
 ).group(1)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Configuration file for the Sphinx documentation builder.
 
 For the full list of built-in configuration values, see the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,12 @@ readme = "README.md"
 #
 # AUTHORS.md is named beside LICENSE rather than dropped: setuptools'
 # default globs match both, so both are in `dist-info/licenses/` today, and
-# the MIT notice this repository carries names "Ferdinando M. Ametrano and
-# btclib contributors" -- AUTHORS.md being where that list is kept.
-# `["LICENSE"]` alone would take the attribution out of every wheel
+# the MIT notice this repository carries names "The btclib developers" --
+# the same holder `authors` below declares -- rather than a list of
+# people. AUTHORS.md answers where that list would be instead: by
+# pointing at the revision history, the record that keeps itself, not by
+# keeping one of its own. `["LICENSE"]` alone would take that pointer out
+# of every wheel
 license = "MIT"
 license-files = ["LICENSE", "AUTHORS.md"]
 authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -609,6 +609,10 @@ ignore = [
 # and the same for the mutation counter, whose one line of output is what
 # the workflow step exists to put in the log
 ".github/scripts/mutation_counts.py" = ["T201"]
+# and the vendored-vector checker: BEHIND, SKIPPED and the all-clear line
+# are what a monthly run's log says happened, the issue it opens or
+# closes being the same report a second way
+".github/scripts/check_vendored_vectors.py" = ["T201"]
 # the D rules are not here: a public test function, fixture or method
 # states what it verifies -- the property, the vector, the failure
 # mode -- under the same docstring gate as the library's public

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -645,3 +645,11 @@ max-doc-length = 80
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"
+
+[tool.ruff.lint.flake8-pytest-style]
+# matching the bindings' own choice, and its reason: the names of a
+# parametrize are a signature, and the comma-separated string is how
+# pytest's own documentation writes one. Ruff's default, tuple, was never
+# a decision this file made -- every other setting in it carries the
+# measurement or the reason that chose it, and this one had neither
+parametrize-names-type = "csv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,19 @@ dev = [
     { include-group = "mutation" },
 ]
 
+[tool.uv]
+# the oldest uv allowed to touch uv.lock, matching the rev the uv-lock
+# hook of .pre-commit-config.yaml pins: that hook is what regenerates the
+# file, and its rev is something pre-commit.ci moves on its own schedule.
+# Declared here the floor holds for every uv command rather than for the
+# hook alone, so an older uv on a developer's machine says so instead of
+# rewriting the lock in a format the runners then fail to read -- uv is
+# pre-1.0 and has changed that format before. It also reaches CI without
+# a second pin: setup-uv, given no version input, reads this key, and a
+# bare minimum specifier makes it install the latest uv, so the runners
+# are never behind the floor and there is nothing here to go stale
+required-version = ">=0.12.0"
+
 [tool.setuptools.packages.find]
 include = ["btclib*"]
 namespaces = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -431,7 +431,7 @@ show_error_codes = true
 # whose static type promises more than an untrusted source -- unvalidated
 # json in network.py's from_dict, a caller ignoring an annotation in
 # bitcoin_core_rpc.py and bip21.py, an operator's own dispatch protocol in
-# script.py's __add__ -- can guarantee. Eight sites, each carrying its own
+# script.py's __add__ -- can guarantee. Each of those sites carries its own
 # `# type: ignore[...]` naming the code rather than a second global
 # exemption: the check is worth having everywhere else, and a blanket
 # ignore-list entry would have silenced it there too
@@ -487,9 +487,9 @@ exclude = [
 # unselected rule set was run over btclib and tests, and these are the
 # ones that either find nothing today
 # -- a ratchet, costing no cleanup -- or find something worth removing.
-# PTH is the same case with a wider cleanup: 130 os.path and bare open()
-# calls, 23 of them in the library, all replaced by pathlib. Two of the
-# 23 are the module-level `datadir` of btclib.curves.curve and
+# PTH is the same case with a wider cleanup: every os.path and bare open()
+# call in the library and its tests, replaced by pathlib. Two of the
+# library sites are the module-level `datadir` of btclib.curves.curve and
 # btclib.network, each a path a caller can read directly, so its type
 # changes from str to Path there too -- a breaking change, recorded in
 # HISTORY.md, and not one this rule set finds on its own: ruff has no
@@ -559,21 +559,28 @@ ignore = [
     # an extended key or a base64 signature on one line. The prose the
     # formatter never touches is measured instead by max-doc-length below
     "E501", # line-too-long
-    # uppercase math symbols (M, R, Q, ...) are variables, not constants:
-    # ruff mistakes comparisons against them for Yoda conditions
-    "SIM300", # yoda-condition
     # complexity metrics this codebase does not bound globally: measured
-    # one at a time, PLR0913 and PLR0917 find 64 and 45 functions with
-    # several parameters and PLR0915 finds 16 long functions, none of it
-    # a short, nameable list of exceptions the way PLR0904, PLR0911,
+    # one at a time, PLR0913 and PLR0917 find many functions with several
+    # parameters and PLR0915 finds several long ones too, none of it a
+    # short, nameable list of exceptions the way PLR0904, PLR0911,
     # PLR0912 and PLR0914 were -- those four are gone from this list now,
     # the first and last for finding nothing, the middle two carrying a
-    # `# noqa` at each of their five sites instead
+    # `# noqa` at each of their sites instead
     "PLR0913", # too-many-arguments
     "PLR0915", # too-many-statements
     "PLR0917", # too-many-positional-arguments
+    # not a complexity metric, and measured widely on its own: what is
+    # compared is almost always the size of a cryptographic object -- 32
+    # or 33 for a key, 64 or 65 for a signature, 20 for a hash160 -- or an
+    # index into a standardized algorithm's own constants, as
+    # _ripemd160.py's 2, 3 and 4 are. The size *is* the domain, not a
+    # value this code chose and could have named instead
     "PLR2004", # magic-value-comparison
-    # exception messages are built inline, on purpose
+    # measured widely too, and every one on purpose: the message is built
+    # where the exception is raised because that is the only place holding
+    # what went wrong -- the value refused, the length found instead of the
+    # one expected -- and a shared exception class could not say that
+    # without every raise site passing it back in anyway
     "TRY003", # raise-vanilla-args
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -483,9 +483,9 @@ exclude = [
 # target-version is inferred from project.requires-python
 
 [tool.ruff.lint]
-# A, BLE, C90, RSE, T20 and TID are here by measurement: every
-# unselected rule set was run over btclib and tests, and these are the
-# ones that either find nothing today
+# A, BLE, C90, FA, FIX, FLY, RSE, SLOT, T10, T20 and TID are here by
+# measurement: every unselected rule set was run over btclib and tests,
+# and these are the ones that either find nothing today
 # -- a ratchet, costing no cleanup -- or find something worth removing.
 # PTH is the same case with a wider cleanup: every os.path and bare open()
 # call in the library and its tests, replaced by pathlib. Two of the
@@ -513,7 +513,11 @@ exclude = [
 # The zero-finding sets not taken are the ones for constructs this code
 # base does not contain -- DTZ without datetime, G and LOG without
 # logging, ASYNC, NPY -- because a rule that can never fire reads as an
-# enforced invariant while enforcing nothing
+# enforced invariant while enforcing nothing. TD is the other zero-finding
+# set left out on purpose rather than for want of a construct: it and FIX
+# both watch TODO-style comments, TD disciplining their format and FIX
+# refusing them outright, and a codebase that finishes what it starts
+# wants the second
 select = [
     "A",    # flake8-builtins: a name that shadows a builtin
     "B",    # flake8-bugbear
@@ -524,6 +528,9 @@ select = [
     "E",    # pycodestyle errors
     "ERA",  # eradicate: code that was commented out instead of deleted
     "F",    # pyflakes
+    "FA",   # flake8-future-annotations
+    "FIX",  # flake8-fixme: a TODO left behind is a thing not finished
+    "FLY",  # flynt: string concatenation ruff can turn into an f-string
     "FURB", # refurb
     "I",    # isort
     "ISC",  # flake8-implicit-str-concat
@@ -537,6 +544,8 @@ select = [
     "RUF",  # ruff-specific rules
     "S",    # flake8-bandit
     "SIM",  # flake8-simplify
+    "SLOT", # flake8-slots: a tuple/NamedTuple subclass without __slots__
+    "T10",  # flake8-debugger: a breakpoint() left in
     "T20",  # flake8-print: a library writes to no stream of its own
     "TID",  # flake8-tidy-imports: absolute, so the layering is readable
     "TRY",  # tryceratops

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -553,11 +553,6 @@ ignore = [
     "D107", # undocumented-public-init
     "D203", # incorrect-blank-line-before-class (conflicts with D211)
     "D213", # multi-line-summary-second-line (conflicts with D212)
-    "D301", # escape-sequence-in-docstring
-    "D405", # capitalize-section-name, and the other section rules
-    "D406", # new-line-after-section-name
-    "D407", # dashed-underline-after-section
-    "D413", # blank-line-after-last-section
     # code length is enforced by the formatter, which reflows to its 88
     # columns everything it is allowed to rewrite. What is left for E501
     # to find is what no width can break, almost all of it a test vector,
@@ -567,18 +562,14 @@ ignore = [
     # uppercase math symbols (M, R, Q, ...) are variables, not constants:
     # ruff mistakes comparisons against them for Yoda conditions
     "SIM300", # yoda-condition
-    # ambiguous unicode (−, non-breaking space) in comments is intentional
-    "RUF003",
-    # rebinding the loop variable is used throughout the code base
-    "PLW2901", # redefined-loop-name
-    # dataclasses define __eq__ without __hash__ on purpose
-    "PLW1641", # eq-without-hash
-    # complexity metrics: not enforced on this codebase
-    "PLR0904", # too-many-public-methods
-    "PLR0911", # too-many-return-statements
-    "PLR0912", # too-many-branches
+    # complexity metrics this codebase does not bound globally: measured
+    # one at a time, PLR0913 and PLR0917 find 64 and 45 functions with
+    # several parameters and PLR0915 finds 16 long functions, none of it
+    # a short, nameable list of exceptions the way PLR0904, PLR0911,
+    # PLR0912 and PLR0914 were -- those four are gone from this list now,
+    # the first and last for finding nothing, the middle two carrying a
+    # `# noqa` at each of their five sites instead
     "PLR0913", # too-many-arguments
-    "PLR0914", # too-many-locals
     "PLR0915", # too-many-statements
     "PLR0917", # too-many-positional-arguments
     "PLR2004", # magic-value-comparison

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -482,6 +482,13 @@ exclude = [
 # unselected rule set was run over btclib and tests, and these are the
 # ones that either find nothing today
 # -- a ratchet, costing no cleanup -- or find something worth removing.
+# PTH is the same case with a wider cleanup: 130 os.path and bare open()
+# calls, 23 of them in the library, all replaced by pathlib. Two of the
+# 23 are the module-level `datadir` of btclib.curves.curve and
+# btclib.network, each a path a caller can read directly, so its type
+# changes from str to Path there too -- a breaking change, recorded in
+# HISTORY.md, and not one this rule set finds on its own: ruff has no
+# opinion on what a module chooses to expose.
 #
 # What the same survey rejected, with the reason it was rejected rather
 # than the count it reached -- `uv run ruff check --select N --no-cache
@@ -491,7 +498,7 @@ exclude = [
 # which ruff's own documentation recommends against alongside the
 # formatter), EM, FBT, EXE (all EXE001, i.e. the shebang-not-executable
 # finding that .pre-commit-config.yaml records the same decision about),
-# TC, PTH, ARG, ANN (all ANN401, the explicit Any of the vector loaders),
+# TC, ARG, ANN (all ANN401, the explicit Any of the vector loaders),
 # SLF (all SLF001, tests reaching into private members on purpose), PERF
 # (all PERF203, try/except in a retry loop).
 # ERA is selected despite what it found on that survey: about half was
@@ -519,6 +526,7 @@ select = [
     "PIE",  # flake8-pie
     "PL",   # pylint
     "PT",   # flake8-pytest-style
+    "PTH",  # flake8-use-pathlib
     "RET",  # flake8-return
     "RSE",  # flake8-raise
     "RUF",  # ruff-specific rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -418,32 +418,37 @@ strict = true
 show_column_numbers = true
 show_error_codes = true
 # the optional error codes strict does not turn on, surveyed one by one
-# over btclib and tests: each of them finds nothing today, so each is a
-# ratchet and none is a cleanup. Two carry their own weight beyond that --
-# ignore-without-code makes every "type: ignore" name the rule it
-# silences, so a blanket one cannot creep in, and deprecated reports a
-# stdlib API on its way out, which on a 3.10 to 3.14 spread is the same
-# early warning filterwarnings = ["error"] buys at runtime.
+# over btclib and tests. ignore-without-code makes every "type: ignore"
+# name the rule it silences, so a blanket one cannot creep in, and
+# deprecated reports a stdlib API on its way out, which on a 3.10 to 3.14
+# spread is the same early warning filterwarnings = ["error"] buys at
+# runtime.
 #
-# Three codes are deliberately absent, and the survey is why:
-# redundant-expr and possibly-undefined, which --enable-error-code adds,
-# and warn_unreachable, which is a flag of its own -- all point at the same
-# deliberate idiom, a runtime isinstance guard on a field mypy already
-# believes is typed. btclib/network.py says it in a
-# comment: a Literal is a mypy fact and not a runtime one, and from_dict
-# takes whatever the json says. Turning them on would ask this code base
-# to stop checking what it decided to check
+# redundant-expr and possibly-undefined are the two more --enable-error-code
+# adds beyond what a first pass found clean, and warn_unreachable below is
+# the flag mypy exposes the third one through rather than through this
+# list. All three found something: a runtime isinstance guard on a value
+# whose static type promises more than an untrusted source -- unvalidated
+# json in network.py's from_dict, a caller ignoring an annotation in
+# bitcoin_core_rpc.py and bip21.py, an operator's own dispatch protocol in
+# script.py's __add__ -- can guarantee. Eight sites, each carrying its own
+# `# type: ignore[...]` naming the code rather than a second global
+# exemption: the check is worth having everywhere else, and a blanket
+# ignore-list entry would have silenced it there too
 enable_error_code = [
     "deprecated",
     "exhaustive-match",
     "ignore-without-code",
     "mutable-override",
     "narrowed-type-not-subtype",
+    "possibly-undefined",
+    "redundant-expr",
     "redundant-self",
     "truthy-bool",
     "truthy-iterable",
     "unimported-reveal",
 ]
+warn_unreachable = true
 # the oldest interpreter this package supports, and also the oldest mypy
 # can be aimed at -- "Python 3.9 is not supported (must be 3.10 or
 # higher)" is its answer to anything lower. The two agree, so this key

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Non-regression tests for btclib, and the vendored vectors they read.
 
 The vector files are Bitcoin Core's, the BIPs' and a few other projects':

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,10 +32,10 @@ beside the helpers of `tests/script/__init__.py` and
 import csv
 import json
 import re
-from os import path
+from pathlib import Path
 from typing import Any
 
-_TESTS_DIR = path.dirname(__file__)
+_TESTS_DIR = Path(__file__).parent
 
 
 def load(*relative_path: str, encoding: str = "ascii") -> Any:
@@ -46,14 +46,14 @@ def load(*relative_path: str, encoding: str = "ascii") -> Any:
     share one file without the `dirname(dirname(__file__))` walk that
     breaks the moment a test module moves.
     """
-    with open(path.join(_TESTS_DIR, *relative_path), encoding=encoding) as file_:
+    with _TESTS_DIR.joinpath(*relative_path).open(encoding=encoding) as file_:
         return json.load(file_)
 
 
 def load_csv(*relative_path: str, encoding: str = "ascii") -> list[list[str]]:
     """Read a vendored csv vector file, header row dropped."""
-    with open(
-        path.join(_TESTS_DIR, *relative_path), newline="", encoding=encoding
+    with _TESTS_DIR.joinpath(*relative_path).open(
+        newline="", encoding=encoding
     ) as file_:
         return list(csv.reader(file_))[1:]
 
@@ -66,7 +66,7 @@ def load_bin(*relative_path: str) -> bytes:
     transactions of a block are the fixtures of more than one question
     about them.
     """
-    with open(path.join(_TESTS_DIR, *relative_path), "rb") as file_:
+    with _TESTS_DIR.joinpath(*relative_path).open("rb") as file_:
         return file_.read()
 
 

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -336,8 +336,10 @@ pulled  2026-08-03, split into its own pin 2026-08-06
 behind  0 revisions; that commit is the tip of the path
 ```
 
-Verdict: **identical**, line endings included — LF upstream, where
-`bip340_test_vectors.csv` above is CRLF.
+Verdict: **identical but for line endings** — upstream is CRLF and this
+repository is LF throughout, which `mixed-line-ending` enforces with
+`--fix=lf`, so our blob is `bcc5b319` rather than the one above, the
+same exception `bip340_test_vectors.csv` above documents.
 
 ### `tests/ecc/_data/xswiftec_inv_test_vectors.csv`
 
@@ -350,7 +352,8 @@ pulled  2026-08-03, split into its own pin 2026-08-06
 behind  0 revisions; that commit is the tip of the path
 ```
 
-Verdict: **identical**, line endings included too.
+Verdict: **identical but for line endings**, the same exception, our
+blob `135958f6` rather than the one above.
 
 The two files test the two halves of the map, and both halves are
 btclib's own Python: `tests/ecc/ellswift_test.py` runs the decode file
@@ -1351,11 +1354,12 @@ Against a pinned upstream blob:
   `script_tests.json`, `tx_valid.json`, `tx_invalid.json`,
   `key_io_valid.json`, `key_io_invalid.json`,
   `base58_encode_decode.json`, `blockfilters.json`,
-  `checkblock_valid.json`, `checkblock_invalid.json`, the eight
-  BIP327 vector files, and the two BIP324 ones.
+  `checkblock_valid.json`, `checkblock_invalid.json`, and the eight
+  BIP327 vector files.
 - identical but for a trailing newline:
   `script_assets_test.json`, `vectors.json`.
-- identical but for CRLF against LF: `bip340_test_vectors.csv`.
+- identical but for CRLF against LF: `bip340_test_vectors.csv` and the
+  two BIP324 vector files.
 - JSON-equal, reformatted: `pubkey.json`, `ecdsa_sig.json`,
   `ecdsa_custom_nonce_sig.json`, `signmessage.json`,
   `test_JP_BIP39.json`.

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -179,31 +179,20 @@ and under upstream's own names: `key_sort_vectors.json`,
 `key_agg_vectors.json`, `nonce_gen_vectors.json`,
 `nonce_agg_vectors.json`, `sign_verify_vectors.json`,
 `tweak_vectors.json`, `det_sign_vectors.json` and
-`sig_agg_vectors.json`.
-
-One pin serves all eight, the entries below differing only in the blob:
-
-```text
-repo    bitcoin/bips
-path    bip-0327/vectors/<name>.json
-commit  1c6ac0c4cf1f39ea806b8594d6060b6d52fd1439  2024-07-19
-pulled  2026-08-02
-behind  0 revisions; that commit is the tip of the path, which has
-        three revisions in all
-```
-
-Verdict for every one of them: **identical**. The eight blobs are
-
-```text
-de088a746e27953614b9f5394553911fb2c86d59  key_sort_vectors.json
-b2e623de60f302c4004a6d656581bdba1f4e1e05  key_agg_vectors.json
-ced946f3efd9f80cb1a3819939f2b39de2061e42  nonce_gen_vectors.json
-1c04b8818f340a5fe2e10eaf73c17a2c9e020f46  nonce_agg_vectors.json
-f71c8dd9d935c8c5f398e6a3888943e1e68b729d  sign_verify_vectors.json
-d0a7cfe832bfe22375af0d64cd5d0dbb350592e0  tweak_vectors.json
-261669ccd01cd4098fa97045f3d32654f64a48af  det_sign_vectors.json
-519562c343b6e4bf686ba6e3eda8cee5c8e8b55d  sig_agg_vectors.json
-```
+`sig_agg_vectors.json`. Each is pinned below in its own entry, one real
+path per pin, rather than to one placeholder path shared by all eight:
+a placeholder is not a path GitHub's own "commits touching a path" API
+can be asked about, which is what kept every one of the eight out of
+the monthly check. It also papered over a real difference between
+them: six were untouched since the commit that added all eight,
+`87394eaeb436d02e0a68b38a1e94bc526d50056e` (2023-03-27, "Add BIP327:
+MuSig2 for BIP340-compatible Multi-Signatures"); `sign_verify_vectors.json`
+was fixed once since, at `508e3a6a40a6e73c73cbfa8a33aa18a2bc7b9d91`
+(2024-05-14, "Fix the four test vectors"); and `sig_agg_vectors.json`
+once more again, at `1c6ac0c4cf1f39ea806b8594d6060b6d52fd1439`
+(2024-07-19, "bip327: minor fixes") -- the one commit the shared
+placeholder cited as the tip of all eight paths, when it is the tip of
+only that one.
 
 56 cases between them, and `tests/ecc/musig2_test.py` runs every one:
 1 sorting, 4 + 5 aggregations valid and failing, 4 nonce derivations,
@@ -222,27 +211,146 @@ because the `error.message` field of a case is compared byte for byte.
 That file is not vendored — it is an implementation, not data, and
 btclib's is the one under test.
 
-### BIP324 (ElligatorSwift): two files under `tests/ecc/_data/`
-
-`ellswift_decode_test_vectors.csv` and `xswiftec_inv_test_vectors.csv`,
-under upstream's own names. One commit is the tip of both paths, so one
-pin serves the pair:
+### `tests/ecc/_data/key_sort_vectors.json`
 
 ```text
 repo    bitcoin/bips
-path    bip-0324/<name>.csv
-commit  cc177ab7bc5abcdcdf9c956ee88afd1052053328  2023-01-11
-pulled  2026-08-03
-behind  0 revisions; that commit is the tip of both paths
+path    bip-0327/vectors/key_sort_vectors.json
+commit  87394eaeb436d02e0a68b38a1e94bc526d50056e  2023-03-27
+blob    de088a746e27953614b9f5394553911fb2c86d59
+pulled  2026-08-02, split into its own pin 2026-08-06
+behind  0 revisions; that commit is the tip of the path
 ```
 
-Verdict for both: **identical**, line endings included — these two are
-LF upstream, where `bip340_test_vectors.csv` above is CRLF. The blobs:
+Verdict: **identical**.
+
+### `tests/ecc/_data/key_agg_vectors.json`
 
 ```text
-1bab96b721e2f3ab90142c318523551eb520f753  ellswift_decode_test_vectors.csv
-138c4cf85c040785a45c6552c0169c8c12fd3cfc  xswiftec_inv_test_vectors.csv
+repo    bitcoin/bips
+path    bip-0327/vectors/key_agg_vectors.json
+commit  87394eaeb436d02e0a68b38a1e94bc526d50056e  2023-03-27
+blob    b2e623de60f302c4004a6d656581bdba1f4e1e05
+pulled  2026-08-02, split into its own pin 2026-08-06
+behind  0 revisions; that commit is the tip of the path
 ```
+
+Verdict: **identical**.
+
+### `tests/ecc/_data/nonce_gen_vectors.json`
+
+```text
+repo    bitcoin/bips
+path    bip-0327/vectors/nonce_gen_vectors.json
+commit  87394eaeb436d02e0a68b38a1e94bc526d50056e  2023-03-27
+blob    ced946f3efd9f80cb1a3819939f2b39de2061e42
+pulled  2026-08-02, split into its own pin 2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**.
+
+### `tests/ecc/_data/nonce_agg_vectors.json`
+
+```text
+repo    bitcoin/bips
+path    bip-0327/vectors/nonce_agg_vectors.json
+commit  87394eaeb436d02e0a68b38a1e94bc526d50056e  2023-03-27
+blob    1c04b8818f340a5fe2e10eaf73c17a2c9e020f46
+pulled  2026-08-02, split into its own pin 2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**.
+
+### `tests/ecc/_data/sign_verify_vectors.json`
+
+```text
+repo    bitcoin/bips
+path    bip-0327/vectors/sign_verify_vectors.json
+commit  508e3a6a40a6e73c73cbfa8a33aa18a2bc7b9d91  2024-05-14
+blob    f71c8dd9d935c8c5f398e6a3888943e1e68b729d
+pulled  2026-08-02, split into its own pin 2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**.
+
+### `tests/ecc/_data/tweak_vectors.json`
+
+```text
+repo    bitcoin/bips
+path    bip-0327/vectors/tweak_vectors.json
+commit  87394eaeb436d02e0a68b38a1e94bc526d50056e  2023-03-27
+blob    d0a7cfe832bfe22375af0d64cd5d0dbb350592e0
+pulled  2026-08-02, split into its own pin 2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**.
+
+### `tests/ecc/_data/det_sign_vectors.json`
+
+```text
+repo    bitcoin/bips
+path    bip-0327/vectors/det_sign_vectors.json
+commit  87394eaeb436d02e0a68b38a1e94bc526d50056e  2023-03-27
+blob    261669ccd01cd4098fa97045f3d32654f64a48af
+pulled  2026-08-02, split into its own pin 2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**.
+
+### `tests/ecc/_data/sig_agg_vectors.json`
+
+```text
+repo    bitcoin/bips
+path    bip-0327/vectors/sig_agg_vectors.json
+commit  1c6ac0c4cf1f39ea806b8594d6060b6d52fd1439  2024-07-19
+blob    519562c343b6e4bf686ba6e3eda8cee5c8e8b55d
+pulled  2026-08-02, split into its own pin 2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**.
+
+### BIP324 (ElligatorSwift): two files under `tests/ecc/_data/`
+
+`ellswift_decode_test_vectors.csv` and `xswiftec_inv_test_vectors.csv`,
+under upstream's own names, both genuinely tipped by the same commit --
+unlike BIP327 above, there is no exception a shared pin would have
+papered over here. Each is pinned below in its own entry, one real path
+per pin, rather than to one placeholder path standing in for both: a
+placeholder is not a path GitHub's own "commits touching a path" API can
+be asked about, which is what kept the pair out of the monthly check.
+
+### `tests/ecc/_data/ellswift_decode_test_vectors.csv`
+
+```text
+repo    bitcoin/bips
+path    bip-0324/ellswift_decode_test_vectors.csv
+commit  cc177ab7bc5abcdcdf9c956ee88afd1052053328  2023-01-11
+blob    1bab96b721e2f3ab90142c318523551eb520f753
+pulled  2026-08-03, split into its own pin 2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**, line endings included — LF upstream, where
+`bip340_test_vectors.csv` above is CRLF.
+
+### `tests/ecc/_data/xswiftec_inv_test_vectors.csv`
+
+```text
+repo    bitcoin/bips
+path    bip-0324/xswiftec_inv_test_vectors.csv
+commit  cc177ab7bc5abcdcdf9c956ee88afd1052053328  2023-01-11
+blob    138c4cf85c040785a45c6552c0169c8c12fd3cfc
+pulled  2026-08-03, split into its own pin 2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**, line endings included too.
 
 The two files test the two halves of the map, and both halves are
 btclib's own Python: `tests/ecc/ellswift_test.py` runs the decode file

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -281,9 +281,9 @@ Verdict: **identical**.
 ```text
 repo    bitcoin/bips
 path    bip-0032.mediawiki
-commit  b0521f076c0b40208e82208f5476c48071aab785  2020-11-04
-pulled  2020-05-08, vector 4 added 2021-08-25
-behind  14 revisions, none of which touches the vectors
+commit  c0644a054fd1568ecbfc9c2b656ad5200b16ff74  2026-03-05
+pulled  2020-05-08, vector 4 added 2021-08-25, re-pinned to the tip 2026-08-06
+behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **transcribed**. BIP32 ships its vectors as prose, so there is
@@ -291,26 +291,25 @@ no upstream file and no byte comparison to make. All four seeds and all
 34 extended keys of test vectors 1 to 4 appear verbatim in the pinned
 text, and the derivation counts match: 6, 6, 2, 3.
 
-The pin is the commit that *added* test vector 4 rather than the one
-current when btclib transcribed it: it is the earliest revision holding
-all 34 keys, and the parent holds 28, which makes the pin checkable
-rather than merely plausible.
-
-Re-checked on 2026-07-30 against the tip of the path,
-`c0644a054fd1568ecbfc9c2b656ad5200b16ff74` (2026-03-05): the BIP still
-carries test vectors 1 to 5 and no sixth, and every extended key in it is
-one of ours — 48 match the key pattern, our 34 valid plus 14 of the 16
-invalid, the other 2 being the zero-prefix keys of test vector 5, which
-serialize outside it. Nothing to refresh.
+The original pin was the commit that *added* test vector 4 rather than
+the one current when btclib transcribed it: the earliest revision
+holding all 34 keys, the parent holding 28, which made that pin checkable
+rather than merely plausible. Re-checked against the tip on 2026-07-30
+and again on 2026-08-06 — both times still test vectors 1 to 5 and no
+sixth, every extended key in it one of ours, 48 matching the key
+pattern: our 34 valid plus 14 of the 16 invalid, the other 2 being the
+zero-prefix keys of test vector 5, which serialize outside it — the pin
+above is now that tip, so the monthly automated check can carry it.
 
 ### `tests/bip32/_data/bip32_invalid_keys.json`
 
 ```text
 repo    bitcoin/bips
 path    bip-0032.mediawiki
-commit  ee2e0598206b8b8a16555a14b8f0c0a70105f93e  2020-05-16
-pulled  2020-05-16, error strings last changed 2026-07-30
-behind  13 revisions; the 16 keys are unchanged on master
+commit  c0644a054fd1568ecbfc9c2b656ad5200b16ff74  2026-03-05
+pulled  2020-05-16, error strings last changed 2026-07-30, re-pinned to
+        the tip 2026-08-06
+behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **transcribed**. All 16 invalid extended keys are exactly the 16
@@ -318,10 +317,13 @@ of BIP32 test vector 5 — no omissions, no local additions — both at the
 pinned commit and on master today.
 
 btclib is the upstream here, not the consumer: commit ee2e0598, "added
-invalid extended keys vectors", is Ferdinando Ametrano's. The second
-column is btclib's own: it holds btclib error messages, which the BIP
-does not and should not carry, and which change when the messages change.
-Refreshing from upstream means refreshing the keys, never the messages.
+invalid extended keys vectors", is Ferdinando Ametrano's, and is what
+first put these 16 keys into the BIP. The pin above is the tip of the
+same path rather than that commit, so the monthly automated check can
+carry it too; the second column of the file is btclib's own regardless —
+it holds btclib error messages, which the BIP does not and should not
+carry, and which change when the messages change. Refreshing from
+upstream means refreshing the keys, never the messages.
 
 ### `tests/psbt/_data/bip174_test_vectors.json`
 
@@ -354,16 +356,18 @@ correcting it here too.
 ```text
 repo    bitcoin/bips
 path    bip-0371.mediawiki
-commit  4ab7faad749856bfc8178f9a12f4c1a8d40f632f  2023-02-15
-pulled  2023-07-07
-behind  8 revisions, none of which touches the cases
+commit  24e96e870fffaa257b465ce1f0370c14aac588e8  2026-01-12
+pulled  2023-07-07, re-pinned to the tip 2026-08-06
+behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **transcribed**, complete. All 17 psbts in the pinned text are
-in our file and all 17 of ours are in the text — 11 invalid, 6 valid.
-Re-checked on 2026-07-30 against the tip of the path,
-`24e96e870fffaa257b465ce1f0370c14aac588e8` (2026-01-12): still 17 cases,
-still the same 17. Nothing to refresh.
+in our file and all 17 of ours are in the text — 11 invalid, 6 valid, the
+same 17 on 2026-07-30 and again on 2026-08-06 when re-checked against the
+tip. The two "PSBT_KEY_PATH_SIG" cases were renamed
+"PSBT_IN_TAP_KEY_SIG" between the original pin and the tip, matching the
+field's own name; the `description` of both is updated to match, the
+`encoded psbt` of every case unchanged throughout.
 
 ### `tests/psbt/_data/bip370_test_vectors.json`
 
@@ -444,14 +448,14 @@ one is.
 ```text
 repo    bitcoin/bips
 path    bip-0067.mediawiki
-commit  b7090922b5e364409e4ddcd1558d85f2dd434c16  2020-04-28
-pulled  2020-05-31
-behind  10 revisions, none of which touches the vectors
+commit  24e96e870fffaa257b465ce1f0370c14aac588e8  2026-01-12
+pulled  2020-05-31, re-pinned to the tip 2026-08-06
+behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **transcribed**, complete. All five groups — their 15 public keys
 and their five p2sh addresses — appear verbatim in the pinned text, and
-re-checking against the tip `24e96e87` (2026-01-12) on 2026-07-30 found no
+re-checking against the tip on 2026-07-30 and again on 2026-08-06 found no
 sixth group. Nothing to refresh.
 
 ## bitcoin/bitcoin

--- a/tests/alias_test.py
+++ b/tests/alias_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/alias_test.py
+++ b/tests/alias_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the type aliases of btclib.alias.
 
 Two of them are about hash functions: HashF, the constructor that every

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for what the library exports.
 
 `__all__` is a decision about the public surface, and it had drifted: it

--- a/tests/amount_test.py
+++ b/tests/amount_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/amount_test.py
+++ b/tests/amount_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.amount` module."""
 
 from __future__ import annotations

--- a/tests/b32_test.py
+++ b/tests/b32_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/b32_test.py
+++ b/tests/b32_test.py
@@ -1,12 +1,7 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
 
 # Copyright (c) 2017 Pieter Wuille
 #

--- a/tests/b58_test.py
+++ b/tests/b58_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/b58_test.py
+++ b/tests/b58_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.b58` module."""
 
 from __future__ import annotations

--- a/tests/base58_test.py
+++ b/tests/base58_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/base58_test.py
+++ b/tests/base58_test.py
@@ -60,7 +60,7 @@ def test_trailing_zeros() -> None:
     assert decode(encode(b"\x00\x00hello world"), 13) == b"\x00\x00hello world"
 
 
-@pytest.mark.parametrize(("hexed", "encoded"), CODEC_VECTORS)
+@pytest.mark.parametrize("hexed, encoded", CODEC_VECTORS)
 def test_core_codec_vectors(hexed: str, encoded: str) -> None:
     """Both directions of Core's codec vectors, over the raw functions.
 

--- a/tests/base58_test.py
+++ b/tests/base58_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.base58` module."""
 
 import pytest

--- a/tests/bech32_test.py
+++ b/tests/bech32_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/bech32_test.py
+++ b/tests/bech32_test.py
@@ -68,7 +68,7 @@ def test_bech32() -> None:
         assert decoded == decode(test.encode("ascii"), _BECH32_1_CONST)
         assert encode(*decoded, _BECH32_1_CONST).decode() == test.lower()
         pos = test.rfind("1")
-        test = test[: pos + 1] + chr(ord(test[pos + 1]) ^ 1) + test[pos + 2 :]
+        test = test[: pos + 1] + chr(ord(test[pos + 1]) ^ 1) + test[pos + 2 :]  # noqa: PLW2901
         with pytest.raises(BTClibValueError):  # assorted error messages
             decode(test, _BECH32_1_CONST)
 
@@ -126,7 +126,7 @@ def test_bech32m() -> None:
         assert decoded == decode(test.encode("ascii"), _BECH32_M_CONST)
         assert encode(*decoded, _BECH32_M_CONST).decode() == test.lower()
         pos = test.rfind("1")
-        test = test[: pos + 1] + chr(ord(test[pos + 1]) ^ 1) + test[pos + 2 :]
+        test = test[: pos + 1] + chr(ord(test[pos + 1]) ^ 1) + test[pos + 2 :]  # noqa: PLW2901
         with pytest.raises(BTClibValueError):
             decode(test, _BECH32_M_CONST)
 

--- a/tests/bech32_test.py
+++ b/tests/bech32_test.py
@@ -1,12 +1,7 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
 
 # Copyright (c) 2017 Pieter Wuille
 #

--- a/tests/bip21_test.py
+++ b/tests/bip21_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/bip21_test.py
+++ b/tests/bip21_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.bip21` module.
 
 The URIs of the "Examples" section of BIP21 are the vectors, transcribed

--- a/tests/bip32/__init__.py
+++ b/tests/bip32/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/bip32/__init__.py
+++ b/tests/bip32/__init__.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Non-regression tests for btclib.bip32."""

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.bip32` module."""
 
 import hmac

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -185,7 +185,7 @@ def bip32_vectors() -> list[Any]:
     ]
 
 
-@pytest.mark.parametrize(("seed", "der_path", "xpub", "xprv"), bip32_vectors())
+@pytest.mark.parametrize("seed, der_path, xpub, xprv", bip32_vectors())
 def test_bip32_vectors(seed: str, der_path: str, xpub: str, xprv: str) -> None:
     """BIP32 test vectors #1, #2, #3, and #4.
 
@@ -197,7 +197,7 @@ def test_bip32_vectors(seed: str, der_path: str, xpub: str, xprv: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("xkey", "err_msg"),
+    "xkey, err_msg",
     [
         pytest.param(xkey, err_msg, id=vector_id(index, err_msg))
         for index, (xkey, err_msg) in enumerate(

--- a/tests/bip32/der_path_test.py
+++ b/tests/bip32/der_path_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/bip32/der_path_test.py
+++ b/tests/bip32/der_path_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.bip32.der_path` module."""
 
 import pytest

--- a/tests/bip32/key_origin_test.py
+++ b/tests/bip32/key_origin_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/bip32/key_origin_test.py
+++ b/tests/bip32/key_origin_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.bip32.key_origin` module."""
 
 import pytest

--- a/tests/bip44_test.py
+++ b/tests/bip44_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/bip44_test.py
+++ b/tests/bip44_test.py
@@ -103,7 +103,7 @@ _VECTORS = [
 ]
 
 
-@pytest.mark.parametrize(("mxkey", "xpub", "der_path", "address"), _VECTORS)
+@pytest.mark.parametrize("mxkey, xpub, der_path, address", _VECTORS)
 def test_bip44_vectors(mxkey: str, xpub: str, der_path: str, address: str) -> None:
     """Reproduce SLIP132, BIP49, BIP84 and BIP86 addresses, any level."""
     # from the master key, walking the whole path
@@ -184,7 +184,7 @@ def test_coin_type() -> None:
 
 
 @pytest.mark.parametrize(
-    ("der_path", "err_msg"),
+    "der_path, err_msg",
     [
         ("m/84h/0h/0h/0", "invalid BIP44 path: 4 levels instead of 5"),
         ("m/84h/0h/0h/0/0/0", "invalid BIP44 path: 6 levels instead of 5"),

--- a/tests/bip44_test.py
+++ b/tests/bip44_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.bip44` module."""
 
 from __future__ import annotations

--- a/tests/bitcoin_core_rpc_standalone_test.py
+++ b/tests/bitcoin_core_rpc_standalone_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/bitcoin_core_rpc_standalone_test.py
+++ b/tests/bitcoin_core_rpc_standalone_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The Bitcoin Core RPC source is standalone and canonically re-exported."""
 
 from __future__ import annotations

--- a/tests/block/__init__.py
+++ b/tests/block/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/block/__init__.py
+++ b/tests/block/__init__.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Non-regression tests for btclib.block."""

--- a/tests/block/block_context_test.py
+++ b/tests/block/block_context_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/block/block_context_test.py
+++ b/tests/block/block_context_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The two block rules that need something the block does not carry.
 
 `Block.assert_valid` is Bitcoin Core's `CheckBlock`, and these are the

--- a/tests/block/block_context_test.py
+++ b/tests/block/block_context_test.py
@@ -19,7 +19,7 @@ height, so its coinbase commitment is one the whole network agreed on.
 """
 
 from datetime import datetime, timedelta, timezone
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -35,8 +35,8 @@ _MAINNET_BIP34_HEIGHT = 227_931
 
 def block_of(fname: str) -> Block:
     """Parse a vendored block from this directory's `_data`."""
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         return Block.parse(file_.read())
 
 

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -16,7 +16,7 @@ and sizes.
 """
 
 from datetime import datetime, timedelta, timezone
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -37,8 +37,8 @@ from tests.conftest import JsonGolden
 def test_block_1() -> None:
     """Test first block after genesis."""
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     block = Block.parse(block_bytes)
@@ -74,8 +74,8 @@ def test_block_1() -> None:
 def test_exceptions() -> None:
     """Verify the error each truncation or malformed header field raises."""
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     # a truncated header is reported as truncated, whichever field the
@@ -169,8 +169,8 @@ def test_exceptions() -> None:
 def test_block_header_keywords() -> None:
     """Test that every BlockHeader field is a valid keyword argument."""
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         header_bytes = file_.read()[:80]
 
     header = BlockHeader.parse(header_bytes)
@@ -193,8 +193,8 @@ def test_block_header_keywords() -> None:
 def test_block_170() -> None:
     """Test first block with a transaction."""
     fname = "block_170.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     block = Block.parse(block_bytes)
@@ -230,8 +230,8 @@ def test_block_170() -> None:
 def test_block_200000() -> None:
     """Verify block 200,000: 388 transactions and a BIP34 height."""
     fname = "block_200000.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     block = Block.parse(block_bytes)
@@ -283,8 +283,8 @@ def test_block_merkle_mutation() -> None:
     commits to this one. Core rejects it as bad-txns-duplicate.
     """
     fname = "block_200000.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     block = Block.parse(block_bytes)
@@ -302,8 +302,8 @@ def test_block_481824() -> None:
     merkle_root = "6438250cad442b982801ae6994edb8a9ec63c0a0ba117779fbe7ef7f07cad140"
     hash_ = "0000000000000000001c8018d9cb3b742ef25114f27563e3fc4a1902167f9893"
     for i, fname in enumerate(["block_481824.bin", "block_481824_complete.bin"]):
-        filename = path.join(path.dirname(__file__), "_data", fname)
-        with open(filename, "rb") as file_:
+        filename = Path(__file__).parent / "_data" / fname
+        with filename.open("rb") as file_:
             block_bytes = file_.read()
 
         block = Block.parse(block_bytes)
@@ -355,8 +355,8 @@ def test_block_witness_commitment() -> None:
     bad-witness-merkle-match.
     """
     fname = "block_481824_complete.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     block = Block.parse(block_bytes)
@@ -401,8 +401,8 @@ def test_block_witness_nonce() -> None:
     them as bad-witness-nonce-size.
     """
     fname = "block_481824_complete.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     for stack in ([], [b"\x00" * 31], [b"\x00" * 32] * 2):
@@ -421,8 +421,8 @@ def test_block_unexpected_witness() -> None:
     rejects the block as unexpected-witness.
     """
     fname = "block_170.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     block = Block.parse(block_bytes)
@@ -436,8 +436,8 @@ def test_block_unexpected_witness() -> None:
 def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
     """Round-trip Block and BlockHeader through their dict and golden json."""
     fname = "block_481824.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as binfile_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as binfile_:
         block = binfile_.read()
 
     # dataclass
@@ -541,8 +541,8 @@ def test_block_without_transactions() -> None:
     surface as an IndexError.
     """
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     # the count follows the 80 bytes of the header
@@ -571,8 +571,8 @@ def test_a_block_carries_one_coinbase() -> None:
     which is where Core checks it too (issue #250).
     """
     fname = "block_200000.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     block = Block.parse(block_bytes)
@@ -590,8 +590,8 @@ def test_assert_valid_checks_the_coinbase_transaction() -> None:
     skipped.
     """
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block = Block.parse(file_.read())
 
     block.transactions[0].vin[0].script_sig = b""
@@ -608,8 +608,8 @@ def test_assert_valid_does_not_rewrite_the_header() -> None:
     json -- the reason it exists -- goes through it.
     """
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         header_bytes = file_.read()[:80]
 
     header = BlockHeader.parse(header_bytes)
@@ -658,8 +658,8 @@ def test_a_candidate_header_can_be_built() -> None:
     serialized, or hashed through the ordinary API. Hashing it is mining.
     """
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         header_bytes = file_.read()[:80]
 
     mined = BlockHeader.parse(header_bytes)
@@ -719,8 +719,8 @@ def test_the_weight_is_the_block_and_not_its_transactions(
     four times the stripped size plus the witness bytes, and three times
     the stripped size plus the size.
     """
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     block = Block.parse(block_bytes)
@@ -746,8 +746,8 @@ def test_a_block_cannot_announce_too_many_sigops() -> None:
     transaction has been checked on its own.
     """
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     limit = MAX_BLOCK_SIGOPS_COST // WITNESS_SCALE_FACTOR
@@ -790,8 +790,8 @@ def test_a_block_cannot_hold_too_many_transactions_or_too_many_bytes() -> None:
     million-byte output script.
     """
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     limit = MAX_BLOCK_WEIGHT // WITNESS_SCALE_FACTOR
@@ -835,8 +835,8 @@ def test_a_block_cannot_weigh_more_than_the_cap() -> None:
     this is where that claim is measured.
     """
     fname = "block_481824_complete.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     stuffing = Witness([b"\x00" * 46_000])
@@ -864,8 +864,8 @@ def test_a_block_still_requires_the_work() -> None:
     Block.parse recomputes the hash from the bytes on every run.
     """
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     block = Block.parse(block_bytes)

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.block` module.
 
 The `_data/block_*.bin` files are consensus bytes, so there is no upstream

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -917,8 +917,8 @@ def test_assert_valid_pow_makes_derive_targets_range_checks() -> None:
     negative, and it is refused as negative (issue #403).
     """
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         header_bytes = file_.read()[:80]
 
     header = BlockHeader.parse(header_bytes)
@@ -953,8 +953,8 @@ def test_the_zero_target_check_is_only_as_good_as_the_target(bits_hex: str) -> N
     check was only as good as the number it was handed (issue #402).
     """
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         header_bytes = file_.read()[:80]
 
     header = BlockHeader.parse(header_bytes)
@@ -973,8 +973,8 @@ def test_the_pow_limit_is_the_callers_to_state() -> None:
     same network its header is.
     """
     fname = "block_1.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
 
     block = Block.parse(block_bytes)

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -501,7 +501,7 @@ def test_target_from_compact_bits() -> None:
 
 
 @pytest.mark.parametrize(
-    ("height", "nbits", "difficulty"),
+    "height, nbits, difficulty",
     [
         (0, 486604799, 1.000),
         (33_333, 486594666, 1.183),
@@ -695,7 +695,7 @@ def test_a_candidate_header_can_be_built() -> None:
 
 
 @pytest.mark.parametrize(
-    ("fname", "delta"),
+    "fname, delta",
     [
         ("block_1.bin", 324),
         ("block_170.bin", 324),

--- a/tests/block/blockfilters_test.py
+++ b/tests/block/blockfilters_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/block/blockfilters_test.py
+++ b/tests/block/blockfilters_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The ten testnet blocks Bitcoin Core carries in `blockfilters.json`.
 
 `src/test/data/blockfilters.json` is Core's BIP158 vector file, and each

--- a/tests/block/blockfilters_test.py
+++ b/tests/block/blockfilters_test.py
@@ -84,7 +84,7 @@ def block_at(height: int) -> Block:
     return next(Block.parse(row[2]) for row in _rows() if row[0] == height)
 
 
-@pytest.mark.parametrize(("height", "block_hash", "serialization"), params())
+@pytest.mark.parametrize("height, block_hash, serialization", params())
 def test_blockfilters_block(height: int, block_hash: str, serialization: str) -> None:
     """Parse each row's block, round-trip it, and check its two claims.
 
@@ -106,7 +106,7 @@ def test_blockfilters_block(height: int, block_hash: str, serialization: str) ->
     assert block.sig_op_count == _SIG_OP_COUNT[height]
 
 
-@pytest.mark.parametrize(("height", "block_hash", "serialization"), params())
+@pytest.mark.parametrize("height, block_hash, serialization", params())
 def test_blockfilters_coinbase_height(
     height: int, block_hash: str, serialization: str
 ) -> None:

--- a/tests/block/checkblock_test.py
+++ b/tests/block/checkblock_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/block/checkblock_test.py
+++ b/tests/block/checkblock_test.py
@@ -114,7 +114,7 @@ def context_at(cur_time: int) -> BlockContext:
 
 
 @pytest.mark.parametrize(
-    ("comment", "check_pow", "cur_time", "serialization"),
+    "comment, check_pow, cur_time, serialization",
     params("checkblock_valid.json"),
 )
 def test_checkblock_valid(
@@ -140,7 +140,7 @@ def test_checkblock_valid(
 
 
 @pytest.mark.parametrize(
-    ("comment", "check_pow", "cur_time", "serialization"),
+    "comment, check_pow, cur_time, serialization",
     params("checkblock_invalid.json"),
 )
 def test_checkblock_invalid(

--- a/tests/block/checkblock_test.py
+++ b/tests/block/checkblock_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Block validity vectors from python-bitcoinlib, byte for byte.
 
 `bitcoin/tests/data/checkblock_valid.json` and `checkblock_invalid.json`

--- a/tests/block/merkle_proof_test.py
+++ b/tests/block/merkle_proof_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/block/merkle_proof_test.py
+++ b/tests/block/merkle_proof_test.py
@@ -14,7 +14,7 @@ the authority on the answer, but neither is needed to have the vectors:
 the block carries the transactions and the root that commits to them.
 """
 
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -26,8 +26,8 @@ from btclib.tx import OutPoint, Tx, TxIn, TxOut
 
 def _load(fname: str) -> Block:
     """Return a vendored block, parsed from tests/block/_data."""
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         return Block.parse(file_.read())
 
 

--- a/tests/block/merkle_proof_test.py
+++ b/tests/block/merkle_proof_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.block.merkle_proof` module.
 
 The vectors are the `_data/block_*.bin` blocks the rest of tests/block

--- a/tests/block/mining_test.py
+++ b/tests/block/mining_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/block/mining_test.py
+++ b/tests/block/mining_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.block.mining` module.
 
 The target mined against is `2000ffff`, easier than anything a network

--- a/tests/block/proof_of_work_test.py
+++ b/tests/block/proof_of_work_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/block/proof_of_work_test.py
+++ b/tests/block/proof_of_work_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.block.proof_of_work` module.
 
 Every retarget vector below is mainnet history, and every number in it

--- a/tests/block/proof_of_work_test.py
+++ b/tests/block/proof_of_work_test.py
@@ -17,7 +17,7 @@ comes from one of two places, named per test:
 """
 
 from datetime import datetime, timedelta, timezone
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -46,8 +46,8 @@ def _time(timestamp: int) -> datetime:
 
 def _bits_of(fname: str) -> bytes:
     """Return the bits of a vendored block, which verifies itself."""
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
         block_bytes = file_.read()
     return Block.parse(block_bytes).header.bits
 

--- a/tests/block/proof_of_work_test.py
+++ b/tests/block/proof_of_work_test.py
@@ -93,7 +93,7 @@ def test_target_from_bits() -> None:
 
 
 @pytest.mark.parametrize(
-    ("bits_hex", "target_hex", "negative"),
+    "bits_hex, target_hex, negative",
     [
         # the genesis bits, where the sign bit is not set and nothing
         # about them changes

--- a/tests/check_validity_test.py
+++ b/tests/check_validity_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/check_validity_test.py
+++ b/tests/check_validity_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `check_validity` convention.
 
 `check_validity` is keyword-only throughout the package, which is a rule

--- a/tests/check_validity_test.py
+++ b/tests/check_validity_test.py
@@ -239,7 +239,7 @@ def _serialize(obj: Any, **flag: bool) -> bytes:
     return octets
 
 
-@pytest.mark.parametrize(("name", "invalid"), _INVALID, ids=[c[0] for c in _INVALID])
+@pytest.mark.parametrize("name, invalid", _INVALID, ids=[c[0] for c in _INVALID])
 def test_the_default_checks_the_object_it_is_asked_about(
     name: str, invalid: Any
 ) -> None:
@@ -256,7 +256,7 @@ def test_the_default_checks_the_object_it_is_asked_about(
         _serialize(invalid)
 
 
-@pytest.mark.parametrize(("name", "invalid"), _OCTETS, ids=[c[0] for c in _OCTETS])
+@pytest.mark.parametrize("name, invalid", _OCTETS, ids=[c[0] for c in _OCTETS])
 def test_the_default_checks_the_octets_it_reads(name: str, invalid: Any) -> None:
     """Parse refuses octets that decode to an invalid object.
 
@@ -272,7 +272,7 @@ def test_the_default_checks_the_octets_it_reads(name: str, invalid: Any) -> None
         type(invalid).parse(octets)
 
 
-@pytest.mark.parametrize(("name", "invalid"), _DICTS, ids=[c[0] for c in _DICTS])
+@pytest.mark.parametrize("name, invalid", _DICTS, ids=[c[0] for c in _DICTS])
 def test_the_default_checks_the_dict_it_writes_and_reads(
     name: str, invalid: Any
 ) -> None:

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -1,0 +1,456 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the vendored-vector re-checker of `.github/scripts`.
+
+Its only external dependency is `gh`, called five different ways across
+`_latest_commit`, `_open_issue_number` and `report`. Every test here
+replaces `subprocess.run` with `FakeGh`, which answers each call the way
+a real `gh api`/`gh issue` would rather than reaching GitHub: a real call
+would need a token, would not be deterministic across a re-run, and is
+the one thing the parsing and reporting logic below does not need to
+have working to be tested.
+
+The script is loaded by path, `.github/scripts` being no package: the
+mutation-counter test does the same for the same reason. Its dataclasses
+need one thing that one does not -- `Entry` and `Drift` are decorated
+with `from __future__ import annotations` in scope, so `@dataclass`
+resolves their field types through `sys.modules[cls.__module__]`, which
+has to name the module before `exec_module` runs it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import runpy
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).parents[1] / ".github" / "scripts" / "check_vendored_vectors.py"
+)
+
+
+@pytest.fixture
+def checker(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Return the script, imported by path, registered before it runs."""
+    spec = importlib.util.spec_from_file_location("check_vendored_vectors", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, "check_vendored_vectors", module)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeGh:
+    """A `subprocess.run` stand-in, answering by which `gh` call this is.
+
+    `commits` maps a (repo, path) pair to the sha and date `_latest_commit`
+    should read back; `open_issue` is the number `_open_issue_number`
+    should report open, or None for no issue open. Every call is recorded
+    in `calls`, argv and all, so a test can assert what was asked for
+    rather than only what came back.
+    """
+
+    def __init__(self) -> None:
+        self.commits: dict[tuple[str, str], tuple[str, str]] = {}
+        self.open_issue: int | None = None
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self, argv: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        """Record the call, and answer as the `gh` sub-command it names."""
+        self.calls.append(list(argv))
+        if argv[1] == "api":
+            repo = argv[4].removeprefix("repos/").removesuffix("/commits")
+            path = argv[6].removeprefix("path=")
+            sha, date = self.commits[(repo, path)]
+            commit = {
+                "sha": sha,
+                "commit": {"committer": {"date": f"{date}T00:00:00Z"}},
+            }
+            return subprocess.CompletedProcess(argv, 0, stdout=json.dumps([commit]))
+        if argv[2] == "list":
+            issues = (
+                [{"number": self.open_issue}] if self.open_issue is not None else []
+            )
+            return subprocess.CompletedProcess(argv, 0, stdout=json.dumps(issues))
+        return subprocess.CompletedProcess(argv, 0, stdout="")
+
+
+@pytest.fixture
+def fake_gh(checker: ModuleType, monkeypatch: pytest.MonkeyPatch) -> FakeGh:
+    """Install a `FakeGh` in place of the script's own `subprocess.run`."""
+    fake = FakeGh()
+    monkeypatch.setattr(checker.subprocess, "run", fake)
+    return fake
+
+
+def readme(*blocks: str) -> str:
+    """Join fenced ```text blocks under one ### heading each, README-shaped."""
+    return "\n\n".join(blocks)
+
+
+def entry(heading: str, **fields: str) -> str:
+    """Return one `### heading` and its fenced field block, README-shaped."""
+    body = "\n".join(f"{key}  {value}" for key, value in fields.items())
+    return f"### {heading}\n\n```text\n{body}\n```"
+
+
+def test_a_checkable_entry_is_returned(checker: ModuleType) -> None:
+    """A pin with repo, path, commit and `behind: 0` is a checkable Entry."""
+    text = readme(
+        entry(
+            "`f.json`",
+            repo="btclib-org/btclib",
+            path="tests/f.json",
+            commit="deadbeef  2026-01-01",
+            behind="0 revisions; that commit is the tip of the path",
+        )
+    )
+    entries, skipped = checker._entries_at_tip(text)
+    assert skipped == []
+    assert entries == [
+        checker.Entry("`f.json`", "btclib-org/btclib", "tests/f.json", "deadbeef")
+    ]
+
+
+def test_a_placeholder_path_is_skipped(checker: ModuleType) -> None:
+    """A `<name>` path is a group pin, not a checkable single path."""
+    text = readme(
+        entry(
+            "group",
+            repo="bitcoin/bips",
+            path="bip-0327/vectors/<name>.json",
+            commit="deadbeef  2026-01-01",
+            behind="0 revisions",
+        )
+    )
+    entries, skipped = checker._entries_at_tip(text)
+    assert entries == []
+    assert skipped == ["group (one pin serves several files)"]
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        {"behind": "3 revisions, none touching the vectors"},
+        {},  # no `behind` field at all
+    ],
+)
+def test_a_behind_pin_is_skipped(checker: ModuleType, fields: dict[str, str]) -> None:
+    """A `behind` reading anything but 0, explicit or absent, is a skip."""
+    text = readme(
+        entry(
+            "stale",
+            repo="btclib-org/btclib",
+            path="tests/f.json",
+            commit="deadbeef  2026-01-01",
+            **fields,
+        )
+    )
+    entries, skipped = checker._entries_at_tip(text)
+    assert entries == []
+    assert skipped == ["stale (already documented as behind)"]
+
+
+@pytest.mark.parametrize(
+    "fields",
+    [
+        {"repo": "btclib-org/btclib", "path": "tests/f.json"},  # no commit
+        {"repo": "btclib-org/btclib", "commit": "deadbeef"},  # no path
+        {"path": "tests/f.json", "commit": "deadbeef"},  # no repo
+        {"pulled": "2020-01-01"},  # chain data: no pin at all
+    ],
+)
+def test_an_entry_with_no_commit_is_skipped(
+    checker: ModuleType, fields: dict[str, str]
+) -> None:
+    """Missing repo, path or commit skips too -- named, not silently."""
+    text = readme(entry("no pin", **fields))
+    entries, skipped = checker._entries_at_tip(text)
+    assert entries == []
+    assert skipped == ["no pin (no commit to check against)"]
+
+
+def test_the_heading_is_the_nearest_one_before_the_block(checker: ModuleType) -> None:
+    """An intro heading with no block of its own never names an entry."""
+    text = (
+        "### intro heading, no block of its own\n\n"
+        "some prose about a whole group\n\n"
+        + entry(
+            "`f.json`",
+            repo="btclib-org/btclib",
+            path="tests/f.json",
+            commit="deadbeef  2026-01-01",
+            behind="0 revisions",
+        )
+    )
+    entries, _ = checker._entries_at_tip(text)
+    assert [e.heading for e in entries] == ["`f.json`"]
+
+
+def test_a_block_with_no_heading_before_it_has_an_empty_one(
+    checker: ModuleType,
+) -> None:
+    """A fenced block before any `### ` heading names an empty heading."""
+    text = "```text\nrepo btclib-org/btclib\n```"
+    entries, skipped = checker._entries_at_tip(text)
+    assert entries == []
+    assert skipped == [" (no commit to check against)"]
+
+
+def test_commit_and_path_whitespace_is_stripped(checker: ModuleType) -> None:
+    """Only the commit's own sha is kept, and the path is trimmed."""
+    text = readme(
+        entry(
+            "`f.json`",
+            repo="btclib-org/btclib",
+            path=" tests/f.json ",
+            commit="deadbeef  2026-01-01, refreshed 2026-08-06",
+            behind="0 revisions",
+        )
+    )
+    (found,) = checker._entries_at_tip(text)[0]
+    assert found.path == "tests/f.json"
+    assert found.commit == "deadbeef"
+
+
+def test_latest_commit_asks_for_one_commit_touching_the_path(
+    checker: ModuleType, fake_gh: FakeGh
+) -> None:
+    """The one `gh api` call, and the sha and date it reads back."""
+    fake_gh.commits[("btclib-org/btclib", "tests/f.json")] = ("cafe1234", "2026-08-01")
+    sha, date = checker._latest_commit("btclib-org/btclib", "tests/f.json")
+    assert (sha, date) == ("cafe1234", "2026-08-01")
+    (call,) = fake_gh.calls
+    assert call[1:5] == ["api", "--method", "GET", "repos/btclib-org/btclib/commits"]
+    assert "path=tests/f.json" in call
+    assert "per_page=1" in call
+
+
+def test_find_drift_tells_moved_pins_from_still_current_ones(
+    checker: ModuleType, fake_gh: FakeGh, tmp_path: Path
+) -> None:
+    """One pin drifted, one did not, and a `behind` pin is skipped too."""
+    path = tmp_path / "README.md"
+    path.write_text(
+        readme(
+            entry(
+                "`moved.json`",
+                repo="r",
+                path="moved.json",
+                commit="old0000  2020-01-01",
+                behind="0",
+            ),
+            entry(
+                "`still.json`",
+                repo="r",
+                path="still.json",
+                commit="cur0000  2020-01-01",
+                behind="0",
+            ),
+            entry("stale", repo="r", path="stale.json", commit="x", behind="1"),
+        ),
+        encoding="utf-8",
+    )
+    fake_gh.commits[("r", "moved.json")] = ("new0000", "2026-01-01")
+    fake_gh.commits[("r", "still.json")] = ("cur0000", "2020-01-01")
+
+    drifted, skipped = checker.find_drift(path)
+
+    assert skipped == ["stale (already documented as behind)"]
+    (drift,) = drifted
+    assert drift.entry.heading == "`moved.json`"
+    assert (drift.latest_commit, drift.latest_date) == ("new0000", "2026-01-01")
+
+
+def _entry(checker: ModuleType, heading: str, commit: str = "old0000") -> object:
+    return checker.Entry(heading, "r", "p.json", commit)
+
+
+def test_the_issue_body_names_every_drift_and_every_skip(checker: ModuleType) -> None:
+    """The body names the pinned and the new commit, and every skip."""
+    drift = checker.Drift(_entry(checker, "`p.json`"), "new0000", "2026-01-01")
+    body = checker._issue_body(Path("tests/_data/README.md"), [drift], ["skipped one"])
+    assert "`p.json`" in body
+    assert "`old0000" in body
+    assert "`new0000` (2026-01-01)" in body
+    assert "Not checked by this run" in body
+    assert "- skipped one" in body
+
+
+def test_the_issue_body_omits_the_skip_section_when_nothing_was_skipped(
+    checker: ModuleType,
+) -> None:
+    """No skip list at all, rather than an empty one, when nothing skipped."""
+    drift = checker.Drift(_entry(checker, "`p.json`"), "new0000", "2026-01-01")
+    body = checker._issue_body(Path("README.md"), [drift], [])
+    assert "Not checked by this run" not in body
+
+
+def test_open_issue_number_reads_the_first_match(
+    checker: ModuleType, fake_gh: FakeGh
+) -> None:
+    """The number of the first issue `gh issue list` names, as a string."""
+    fake_gh.open_issue = 42
+    assert checker._open_issue_number() == "42"
+
+
+def test_open_issue_number_is_none_when_none_is_open(
+    checker: ModuleType, fake_gh: FakeGh
+) -> None:
+    """An empty `gh issue list` is None, not an empty string."""
+    assert checker._open_issue_number() is None
+
+
+def test_report_closes_an_open_issue_when_nothing_drifted(
+    checker: ModuleType, fake_gh: FakeGh, tmp_path: Path
+) -> None:
+    """Nothing drifted, an issue was open: it gets closed."""
+    fake_gh.open_issue = 7
+    checker.report(tmp_path / "README.md", [], [])
+    verbs = [call[2] for call in fake_gh.calls if call[1] == "issue"]
+    assert verbs == ["list", "close"]
+
+
+def test_report_does_nothing_when_clean_and_no_issue_is_open(
+    checker: ModuleType, fake_gh: FakeGh, tmp_path: Path
+) -> None:
+    """Nothing drifted, no issue was open: nothing is written."""
+    checker.report(tmp_path / "README.md", [], [])
+    assert [call[2] for call in fake_gh.calls] == ["list"]
+
+
+def test_report_creates_an_issue_when_none_is_open(
+    checker: ModuleType, fake_gh: FakeGh, tmp_path: Path
+) -> None:
+    """Something drifted, no issue was open: a new one is created."""
+    drift = checker.Drift(_entry(checker, "`p.json`"), "new0000", "2026-01-01")
+    checker.report(tmp_path / "README.md", [drift], [])
+    verbs = [call[2] for call in fake_gh.calls if call[1] == "issue"]
+    assert verbs == ["list", "create"]
+
+
+def test_report_edits_the_open_issue(
+    checker: ModuleType, fake_gh: FakeGh, tmp_path: Path
+) -> None:
+    """Something drifted, an issue was already open: it is edited, by number."""
+    fake_gh.open_issue = 9
+    drift = checker.Drift(_entry(checker, "`p.json`"), "new0000", "2026-01-01")
+    checker.report(tmp_path / "README.md", [drift], [])
+    verbs = [call[2] for call in fake_gh.calls if call[1] == "issue"]
+    assert verbs == ["list", "edit"]
+    (edit_call,) = (call for call in fake_gh.calls if call[2] == "edit")
+    assert edit_call[3] == "9"
+
+
+def _write_readme(tmp_path: Path, *blocks: str) -> Path:
+    path = tmp_path / "README.md"
+    path.write_text(readme(*blocks), encoding="utf-8")
+    return path
+
+
+def test_main_dry_run_prints_but_never_calls_issue(
+    checker: ModuleType,
+    fake_gh: FakeGh,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Prints drift and skips, and never touches an issue, on --dry-run."""
+    path = _write_readme(
+        tmp_path,
+        entry(
+            "`p.json`",
+            repo="r",
+            path="p.json",
+            commit="old0000  2020-01-01",
+            behind="0",
+        ),
+        entry("stale", repo="r", path="s.json", commit="x", behind="1"),
+    )
+    fake_gh.commits[("r", "p.json")] = ("new0000", "2026-01-01")
+    monkeypatch.setattr(sys, "argv", ["prog", str(path), "--dry-run"])
+
+    assert checker.main() == 0
+
+    out = capsys.readouterr().out
+    assert "BEHIND: `p.json` pinned to old0000, tip is new0000 (2026-01-01)" in out
+    assert "SKIPPED: stale (already documented as behind)" in out
+    assert not any(call[1] == "issue" for call in fake_gh.calls)
+
+
+def test_main_reports_and_says_nothing_drifted_when_clean(
+    checker: ModuleType,
+    fake_gh: FakeGh,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Clean and not a dry run: prints the all-clear and closes the issue."""
+    path = _write_readme(
+        tmp_path,
+        entry(
+            "`p.json`",
+            repo="r",
+            path="p.json",
+            commit="old0000  2020-01-01",
+            behind="0",
+        ),
+    )
+    fake_gh.commits[("r", "p.json")] = ("old0000", "2020-01-01")
+    fake_gh.open_issue = 3
+    monkeypatch.setattr(sys, "argv", ["prog", str(path)])
+
+    assert checker.main() == 0
+
+    out = capsys.readouterr().out
+    assert "Every checked pin is still at upstream's tip." in out
+    assert [call[2] for call in fake_gh.calls if call[1] == "issue"] == [
+        "list",
+        "close",
+    ]
+
+
+def test_the_main_guard_runs_the_script_as___main__(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Cover `if __name__ == "__main__":` without a subprocess.
+
+    A real subprocess -- what the mutation-counter test uses for its own
+    end-to-end check -- runs in its own interpreter, and this project
+    collects no coverage from one: `mutation_counts.py`'s own guard is
+    exactly as uncovered today. `runpy.run_path` executes the file fresh
+    with `__name__` set to `"__main__"` in this interpreter instead, so
+    the guard itself is under test, not only the function it calls.
+    """
+    path = _write_readme(
+        tmp_path,
+        entry(
+            "`p.json`",
+            repo="r",
+            path="p.json",
+            commit="old0000  2020-01-01",
+            behind="0",
+        ),
+    )
+    fake = FakeGh()
+    fake.commits[("r", "p.json")] = ("old0000", "2020-01-01")
+    monkeypatch.setattr(subprocess, "run", fake)
+    monkeypatch.setattr(sys, "argv", ["prog", str(path), "--dry-run"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(_SCRIPT), run_name="__main__")
+
+    assert excinfo.value.code == 0
+    assert "Every checked pin is still at upstream's tip." in capsys.readouterr().out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """What the whole suite shares: hypothesis profiles, and one fixture.
 
 Registered once here rather than passed to each `@given`: a settings

--- a/tests/conftest_test.py
+++ b/tests/conftest_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/conftest_test.py
+++ b/tests/conftest_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the golden-file check the suite's own fixture runs.
 
 Eleven modules compare a `to_dict()` against a committed json through

--- a/tests/copyright_test.py
+++ b/tests/copyright_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/copyright_test.py
+++ b/tests/copyright_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """LICENSE, __copyright__ and pyproject.toml's author, checked together.
 
 Issue #389: LICENSE named "Ferdinando M. Ametrano and btclib contributors"

--- a/tests/copyright_test.py
+++ b/tests/copyright_test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""LICENSE, __copyright__ and pyproject.toml's author, checked together.
+
+Issue #389: LICENSE named "Ferdinando M. Ametrano and btclib contributors"
+while __copyright__ had already moved to "The btclib developers", each
+edited on its own with nothing to notice the other had not moved too.
+docs/source/conf.py reads __copyright__ back by regex instead of
+declaring a value of its own, which is why that one file never drifted;
+LICENSE and pyproject.toml's `authors` are both static text with nothing
+deriving either from the other, so a change to one is silent everywhere
+else until something reads the same sources this reads.
+
+Regex rather than `tomllib` for the one line wanted out of
+pyproject.toml: the floor here is 3.10, and `tomllib` is 3.11 -- the same
+reason `release.yml` gives for reaching for it only from a `python -` a
+workflow can pin to a newer interpreter, which a module in this package
+cannot. Once 3.10 is dropped, `_pyproject_author` can read the file the
+way `release.yml` already does.
+"""
+
+import re
+from pathlib import Path
+
+import btclib
+
+_ROOT = Path(__file__).parents[1]
+_HOLDER_RE = r"Copyright \([Cc]\) (\d{4})-(\d{4}) (.+)"
+_AUTHOR_RE = r'authors\s*=\s*\[\{\s*name\s*=\s*"([^"]+)"'
+
+
+def _license_holder() -> tuple[str, str, str]:
+    text = (_ROOT / "LICENSE").read_text(encoding="utf-8")
+    match = re.search(_HOLDER_RE, text)
+    assert match, f"LICENSE has no 'Copyright (c) YYYY-YYYY holder' line: {text[:80]!r}"
+    return match.group(1), match.group(2), match.group(3)
+
+
+def _copyright_holder() -> tuple[str, str, str]:
+    match = re.search(_HOLDER_RE, btclib.__copyright__)
+    assert match, (
+        f"btclib.__copyright__ does not match the expected shape: {btclib.__copyright__!r}"
+    )
+    return match.group(1), match.group(2), match.group(3)
+
+
+def _pyproject_author() -> str:
+    text = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(_AUTHOR_RE, text)
+    assert match, "pyproject.toml has no 'authors = [{ name = ... }]' line"
+    return match.group(1)
+
+
+def test_license_and_copyright_name_the_same_holder_and_years() -> None:
+    """The two places a human edits a year range must edit it together."""
+    license_start, license_end, license_holder = _license_holder()
+    copyright_start, copyright_end, copyright_holder = _copyright_holder()
+    assert (license_start, license_end, license_holder) == (
+        copyright_start,
+        copyright_end,
+        copyright_holder,
+    ), (
+        f"LICENSE says {license_start}-{license_end} {license_holder!r}, "
+        f"btclib.__copyright__ says {copyright_start}-{copyright_end} "
+        f"{copyright_holder!r}. Edit both together, or make one read the "
+        "other -- docs/source/conf.py already does, for its own copyright "
+        "line"
+    )
+
+
+def test_license_holder_matches_the_declared_author() -> None:
+    """The wheel's `Author` metadata is the same holder LICENSE names."""
+    _, _, license_holder = _license_holder()
+    author = _pyproject_author()
+    assert license_holder == author, (
+        f"LICENSE names {license_holder!r}, pyproject.toml's author "
+        f"{author!r}. A wheel built from one and read from the other "
+        "would disagree about who holds the copyright"
+    )

--- a/tests/curves/__init__.py
+++ b/tests/curves/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/curves/__init__.py
+++ b/tests/curves/__init__.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Non-regression tests for btclib.curves."""

--- a/tests/curves/curve_group_2_test.py
+++ b/tests/curves/curve_group_2_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/curves/curve_group_2_test.py
+++ b/tests/curves/curve_group_2_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.curve_group_2` module."""
 
 import secrets

--- a/tests/curves/curve_group_f_test.py
+++ b/tests/curves/curve_group_f_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/curves/curve_group_f_test.py
+++ b/tests/curves/curve_group_f_test.py
@@ -20,7 +20,7 @@ def test_ecf() -> None:
     P = (8045, 6936)
     S = ec.negate(P)
     S_exp = (8045, 2803)
-    assert S == S_exp
+    assert S_exp == S
 
     # Point Addition
     X = (5274, 2841)
@@ -33,7 +33,7 @@ def test_ecf() -> None:
     S = ec.add(ec.add(ec.add(P, P), Q), R)
     ec.require_on_curve(S)
     S_exp = (4215, 2162)
-    assert S == S_exp
+    assert S_exp == S
 
     # Scalar Multiplication
     X = (5323, 5438)
@@ -42,7 +42,7 @@ def test_ecf() -> None:
     S = mult_aff(7863, P, ec)
     ec.require_on_curve(S)
     S_exp = (9467, 2742)
-    assert S == S_exp
+    assert S_exp == S
 
     # Curves and Logs
     all_points = find_all_points(ec)

--- a/tests/curves/curve_group_f_test.py
+++ b/tests/curves/curve_group_f_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.curve_group_f` module."""
 
 import pytest

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.curve_group` module."""
 
 import random

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -55,7 +55,7 @@ def test_mult_recursive_aff() -> None:
         assert mult_aff(1, ec.G, ec) == ec.G
 
         Q = ec.add_aff(ec.G, ec.G)
-        assert Q == mult_recursive_aff(2, ec.G, ec)
+        assert mult_recursive_aff(2, ec.G, ec) == Q
 
         Q = mult_recursive_aff(ec.n - 1, ec.G, ec)
         assert ec.negate(ec.G) == Q
@@ -74,8 +74,8 @@ def test_mult_recursive_aff() -> None:
             assert ec.is_on_curve(Q), f"{q}, {ec}"
             QJ = _mult(q, ec.GJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(QJ)), f"{q}, {ec}"
-            assert Q == ec.aff_from_jac(QJ), f"{q}, {ec}"
-            assert INF == mult_recursive_aff(q, INF, ec), f"{q}, {ec}"
+            assert ec.aff_from_jac(QJ) == Q, f"{q}, {ec}"
+            assert mult_recursive_aff(q, INF, ec) == INF, f"{q}, {ec}"
             assert ec.jac_equality(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
 
 
@@ -118,7 +118,7 @@ def test_mult_aff() -> None:
         assert mult_aff(1, ec.G, ec) == ec.G
 
         Q = ec.add_aff(ec.G, ec.G)
-        assert Q == mult_aff(2, ec.G, ec)
+        assert mult_aff(2, ec.G, ec) == Q
 
         Q = mult_aff(ec.n - 1, ec.G, ec)
         assert ec.negate(ec.G) == Q
@@ -137,8 +137,8 @@ def test_mult_aff() -> None:
             assert ec.is_on_curve(Q), f"{q}, {ec}"
             QJ = _mult(q, ec.GJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(QJ)), f"{q}, {ec}"
-            assert Q == ec.aff_from_jac(QJ), f"{q}, {ec}"
-            assert INF == mult_aff(q, INF, ec), f"{q}, {ec}"
+            assert ec.aff_from_jac(QJ) == Q, f"{q}, {ec}"
+            assert mult_aff(q, INF, ec) == INF, f"{q}, {ec}"
             assert ec.jac_equality(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
 
 

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.curve` module."""
 
 import copy

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -267,13 +267,13 @@ def test_aff_jac_conversions() -> None:
         # just a point, not INF
         Q = ec.G
         QJ = jac_from_aff(Q)
-        assert Q == ec.aff_from_jac(QJ)
+        assert ec.aff_from_jac(QJ) == Q
         x_Q = ec.x_aff_from_jac(QJ)
         assert Q[0] == x_Q
         y_Q = ec.y_aff_from_jac(QJ)
         assert Q[1] == y_Q
 
-        assert INF == ec.aff_from_jac(jac_from_aff(INF))
+        assert ec.aff_from_jac(jac_from_aff(INF)) == INF
 
         with pytest.raises(BTClibValueError, match="INF has no x-coordinate"):
             ec.x_aff_from_jac(INFJ)
@@ -291,7 +291,7 @@ def test_add_double_aff() -> None:
 
         # double G
         G2 = ec.add_aff(ec.G, ec.G)
-        assert G2 == ec.double_aff(ec.G)
+        assert ec.double_aff(ec.G) == G2
 
         # double INF
         assert ec.add_aff(INF, INF) == INF
@@ -336,13 +336,13 @@ def test_add_double_aff_jac() -> None:
         # add Q and G
         R = ec.add_aff(Q, ec.G)
         RJ = ec.add_jac(QJ, ec.GJ)
-        assert R == ec.aff_from_jac(RJ)
+        assert ec.aff_from_jac(RJ) == R
 
         # double Q
         R = ec.double_aff(Q)
         RJ = ec.double_jac(QJ)
-        assert R == ec.aff_from_jac(RJ)
-        assert R == ec.add_aff(Q, Q)
+        assert ec.aff_from_jac(RJ) == R
+        assert ec.add_aff(Q, Q) == R
         assert ec.jac_equality(RJ, ec.add_jac(QJ, QJ))
 
 
@@ -416,7 +416,7 @@ def test_point_addition_exhaustive() -> None:
                         got = None if RJ[2] == 0 else ec.aff_from_jac(RJ)
                         assert got == expected, f"{name}: {PJ} + {QJ}"
                 R = ec.add_aff(INF if P is None else P, INF if Q is None else Q)
-                assert R == (INF if expected is None else expected), (
+                assert (INF if expected is None else expected) == R, (
                     f"{name}: {P} + {Q}"
                 )
 
@@ -850,7 +850,7 @@ def test_assorted_mult() -> None:
             shamir = double_mult(k1, ec.G, k2, H, ec)
             assert ec.is_on_curve(shamir)
             K1K2 = ec.add(K1, K2)
-            assert K1K2 == shamir
+            assert shamir == K1K2
 
             k3 = ec.n // 3  # just a random point, not INF
             K3 = mult(k3, ec.G, ec)
@@ -858,7 +858,7 @@ def test_assorted_mult() -> None:
             assert ec.is_on_curve(K1K2K3)
             boscoster = multi_mult([k1, k2, k3], [ec.G, H, ec.G], ec)
             assert ec.is_on_curve(boscoster)
-            assert K1K2K3 == boscoster, k3
+            assert boscoster == K1K2K3, k3
 
             k4 = ec.n // 4  # just a random point, not INF
             K4 = mult(k4, H, ec)
@@ -867,11 +867,11 @@ def test_assorted_mult() -> None:
             points = [ec.G, H, ec.G, H]
             boscoster = multi_mult([k1, k2, k3, k4], points, ec)
             assert ec.is_on_curve(boscoster)
-            assert K1K2K3K4 == boscoster, k4
-            assert K1K2K3 == multi_mult([k1, k2, k3, 0], points, ec)
-            assert K1K2 == multi_mult([k1, k2, 0, 0], points, ec)
-            assert K1 == multi_mult([k1, 0, 0, 0], points, ec)
-            assert INF == multi_mult([0, 0, 0, 0], points, ec)
+            assert boscoster == K1K2K3K4, k4
+            assert multi_mult([k1, k2, k3, 0], points, ec) == K1K2K3
+            assert multi_mult([k1, k2, 0, 0], points, ec) == K1K2
+            assert multi_mult([k1, 0, 0, 0], points, ec) == K1
+            assert multi_mult([0, 0, 0, 0], points, ec) == INF
 
             err_msg = "mismatch between number of scalars and points: "
             with pytest.raises(BTClibValueError, match=err_msg):

--- a/tests/curves/sec_point_test.py
+++ b/tests/curves/sec_point_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/curves/sec_point_test.py
+++ b/tests/curves/sec_point_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.sec_point` module."""
 
 import pytest

--- a/tests/curves/sec_point_test.py
+++ b/tests/curves/sec_point_test.py
@@ -48,11 +48,11 @@ def test_octets2point() -> None:
     for ec in all_curves.values():
         G_bytes = bytes_from_point(ec.G, ec)
         G_point = point_from_octets(G_bytes, ec)
-        assert ec.G == G_point
+        assert G_point == ec.G
 
         G_bytes = bytes_from_point(ec.G, ec, False)
         G_point = point_from_octets(G_bytes, ec)
-        assert ec.G == G_point
+        assert G_point == ec.G
 
         # just a point, not INF
         Q = ec.G

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -89,7 +89,7 @@ CHECKSUM_VECTORS = [
 
 # descriptors taken from https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md
 # checksum calculated using https://docs.rs/bdk/latest/bdk/descriptor/checksum/fn.get_checksum.html
-@pytest.mark.parametrize(("descriptor", "expected_checksum"), CHECKSUM_VECTORS)
+@pytest.mark.parametrize("descriptor, expected_checksum", CHECKSUM_VECTORS)
 def test_checksum(descriptor: str, expected_checksum: str) -> None:
     """Reproduce the checksum of each descriptor of Core's descriptors.md."""
     assert checksum(descriptor) == expected_checksum
@@ -445,7 +445,7 @@ DERIVATION_VECTORS = [
 ]
 
 
-@pytest.mark.parametrize(("private", "public", "scripts"), DERIVATION_VECTORS)
+@pytest.mark.parametrize("private, public, scripts", DERIVATION_VECTORS)
 def test_core_derivation_vector(
     private: str, public: str | None, scripts: list[list[str]]
 ) -> None:
@@ -832,7 +832,7 @@ UNPARSABLE = [
 
 
 @pytest.mark.parametrize(
-    ("descriptor", "message"),
+    "descriptor, message",
     [
         pytest.param(descriptor, message, id=vector_id(index, descriptor))
         for index, (descriptor, message) in enumerate(UNPARSABLE)
@@ -862,7 +862,7 @@ UNIMPLEMENTED = [
 
 
 @pytest.mark.parametrize(
-    ("descriptor", "message"),
+    "descriptor, message",
     [
         pytest.param(descriptor, message, id=vector_id(index, descriptor))
         for index, (descriptor, message) in enumerate(UNIMPLEMENTED)
@@ -937,9 +937,7 @@ FINALIZER_VECTORS = [
 ]
 
 
-@pytest.mark.parametrize(
-    ("descriptor", "signing_keys", "redeem", "witness"), FINALIZER_VECTORS
-)
+@pytest.mark.parametrize("descriptor, signing_keys, redeem, witness", FINALIZER_VECTORS)
 def test_satisfy_matches_the_psbt_finalizer(
     descriptor: str, signing_keys: list[str], redeem: str, witness: str
 ) -> None:
@@ -1080,7 +1078,7 @@ UNSATISFIABLE: list[tuple[str, dict[Octets, Octets], str]] = [
 
 
 @pytest.mark.parametrize(
-    ("descriptor", "signatures", "message"),
+    "descriptor, signatures, message",
     [
         pytest.param(descriptor, signatures, message, id=vector_id(index, descriptor))
         for index, (descriptor, signatures, message) in enumerate(UNSATISFIABLE)
@@ -1132,9 +1130,7 @@ def psbt_spending(descriptor: Descriptor, index: int = 0) -> Psbt:
     return psbt
 
 
-@pytest.mark.parametrize(
-    ("descriptor", "signing_keys", "redeem", "witness"), FINALIZER_VECTORS
-)
+@pytest.mark.parametrize("descriptor, signing_keys, redeem, witness", FINALIZER_VECTORS)
 def test_the_updater_fills_what_the_finalizer_dispatches_on(
     descriptor: str, signing_keys: list[str], redeem: str, witness: str
 ) -> None:
@@ -1367,7 +1363,7 @@ UNUPDATABLE = [
 
 
 @pytest.mark.parametrize(
-    ("descriptor", "message"),
+    "descriptor, message",
     [
         pytest.param(descriptor, message, id=vector_id(index, descriptor))
         for index, (descriptor, message) in enumerate(UNUPDATABLE)

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.descriptors` module.
 
 The derivation vectors are Bitcoin Core's own, transcribed from the

--- a/tests/docs_examples_test.py
+++ b/tests/docs_examples_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/docs_examples_test.py
+++ b/tests/docs_examples_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Every example in the documentation is what the library answers.
 
 A page of worked examples is a promise, and prose cannot keep it: an

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Every module btclib ships is documented.
 
 The pages under `docs/source/` are hand written, which invites drift, and

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -130,7 +130,7 @@ def test_shipped_module_is_a_dotted_btclib_name(name: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("parts", "public"),
+    "parts, public",
     [
         (("curve",), True),
         (("curves", "curve"), True),

--- a/tests/ecc/__init__.py
+++ b/tests/ecc/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/__init__.py
+++ b/tests/ecc/__init__.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Non-regression tests for btclib.ecc."""

--- a/tests/ecc/anti_exfil_test.py
+++ b/tests/ecc/anti_exfil_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/anti_exfil_test.py
+++ b/tests/ecc/anti_exfil_test.py
@@ -69,7 +69,7 @@ _RHO = sha256(b"the host's randomness").digest()
 _OTHER_RHO = sha256(b"a second draw").digest()
 
 
-@pytest.mark.parametrize(("rho", "opening", "exfil_opening"), _ZKP_VECTORS)
+@pytest.mark.parametrize("rho, opening, exfil_opening", _ZKP_VECTORS)
 def test_signer_commit_vectors(rho: str, opening: str, exfil_opening: str) -> None:
     """R is the opening test_ecdsa_anti_exfil_signer_commit expects.
 
@@ -87,7 +87,7 @@ def test_signer_commit_vectors(rho: str, opening: str, exfil_opening: str) -> No
     assert exfil_opening != opening
 
 
-@pytest.mark.parametrize(("rho", "opening", "exfil_opening"), _ZKP_VECTORS)
+@pytest.mark.parametrize("rho, opening, exfil_opening", _ZKP_VECTORS)
 def test_step_2_and_step_4_reach_one_nonce(
     rho: str, opening: str, exfil_opening: str
 ) -> None:

--- a/tests/ecc/anti_exfil_test.py
+++ b/tests/ecc/anti_exfil_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the ECDSA Anti-Exfil Protocol of `btclib.ecc.dsa`.
 
 The protocol is libsecp256k1-zkp's, and its `ecdsa_s2c` module carries

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.bms` module."""
 
 # `Point | None` below is evaluated at def time without this, and py3.9 --

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.borromean` module."""
 
 import hashlib

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -195,7 +195,7 @@ _ZKP_VECTORS = [
 ]
 
 
-@pytest.mark.parametrize(("commit_hash", "opening"), _ZKP_VECTORS)
+@pytest.mark.parametrize("commit_hash, opening", _ZKP_VECTORS)
 def test_libsecp256k1_zkp_fixed_vectors(commit_hash: str, opening: str) -> None:
     """The receipt is the opening libsecp256k1-zkp's own fixture expects."""
     sig, receipt = dsa.sign_(_ZKP_MSG_HASH, _ZKP_PRV_KEY, commit_hash=commit_hash)
@@ -261,7 +261,7 @@ def _sha256_midstate(block: bytes) -> tuple[int, ...]:
     )
 
 
-@pytest.mark.parametrize(("tag", "midstate"), _ZKP_MIDSTATES)
+@pytest.mark.parametrize("tag, midstate", _ZKP_MIDSTATES)
 def test_the_tags_are_libsecp256k1s(tag: bytes, midstate: tuple[int, ...]) -> None:
     """Each tag string reproduces the midstate the C source publishes."""
     assert _sha256_midstate(sha256(tag).digest() * 2) == midstate

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.ecc.commit_nonce` module.
 
 The commitment is a parameter of `dsa.sign` and `ssa.sign`, so what is

--- a/tests/ecc/der_test.py
+++ b/tests/ecc/der_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/der_test.py
+++ b/tests/ecc/der_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.der` module."""
 
 import pytest

--- a/tests/ecc/dh_test.py
+++ b/tests/ecc/dh_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/dh_test.py
+++ b/tests/ecc/dh_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.dh` module."""
 
 from hashlib import sha1, sha224, sha256, sha384, sha512

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -71,7 +71,9 @@ def test_parse_stops_at_the_end_of_the_sequence() -> None:
     IsValidSignatureEncoding, and only under the flags asking for
     canonical DER: hence strict here, and hence the lenient parse the
     engine uses when DERSIG is off still takes it.
-    """
+    """  # noqa: D301
+    # `b"\x01"` above is the literal text of the code quoted, backslash
+    # and all: an r prefix would double that backslash instead
     q, _ = dsa.gen_keys(0x1)
     der = dsa.sign(b"Satoshi Nakamoto", q).serialize()
     assert dsa.Sig.parse(der).serialize() == der
@@ -358,7 +360,7 @@ def test_crack_prv_key() -> None:
 
     q_cracked, k_cracked = dsa.crack_prv_key(msg1, sig1.serialize(), msg2, sig2)
 
-    #  if the lower_s convention has changed only one of s1 and s2
+    #  if the lower_s convention has changed only one of s1 and s2
     sig2 = dsa.Sig(sig2.r, ec.n - sig2.s)
     qc2, kc2 = dsa.crack_prv_key(msg1, sig1, msg2, sig2.serialize())
 

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.dsa` module."""
 
 import secrets

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -662,7 +662,7 @@ def test_recovery_multiplies_in_libsecp256k1(
 
 
 @pytest.mark.parametrize(
-    ("r", "expected_key_ids"),
+    "r, expected_key_ids",
     [(2, [0, 1, 2, 3]), (7, [2, 3])],
     ids=["four-candidates", "the-j-one-pair-alone"],
 )

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -492,7 +492,7 @@ def test_the_two_secret_multiplications_answer_the_python_point(
             assert dsa.gen_keys(q)[1] == Q
             assert dsa._sign_(0x1234, q, nonce, True, ec) == sig
 
-        assert Q == ec.aff_from_jac(_mult(q, ec.GJ, ec))
+        assert ec.aff_from_jac(_mult(q, ec.GJ, ec)) == Q
         assert sig.r == ec.x_aff_from_jac(_mult(nonce, ec.GJ, ec)) % ec.n
 
 

--- a/tests/ecc/ecies_test.py
+++ b/tests/ecc/ecies_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/ecies_test.py
+++ b/tests/ecc/ecies_test.py
@@ -281,7 +281,7 @@ _ELECTRUM_VECTORS = [
 ]
 
 
-@pytest.mark.parametrize(("plaintext", "armor"), _ELECTRUM_VECTORS)
+@pytest.mark.parametrize("plaintext, armor", _ELECTRUM_VECTORS)
 def test_decrypt_electrum_ciphertext(plaintext: bytes, armor: str) -> None:
     """Verify btclib reads what Electrum wrote.
 
@@ -292,7 +292,7 @@ def test_decrypt_electrum_ciphertext(plaintext: bytes, armor: str) -> None:
     assert ecies.decrypt(armor, prv_key, aes_128_cbc_decrypt) == plaintext
 
 
-@pytest.mark.parametrize(("plaintext", "armor"), _ELECTRUM_VECTORS)
+@pytest.mark.parametrize("plaintext, armor", _ELECTRUM_VECTORS)
 def test_rebuild_electrum_ciphertext(plaintext: bytes, armor: str) -> None:
     """Verify btclib writes what Electrum wrote, byte for byte.
 
@@ -494,7 +494,7 @@ def _valid_parts() -> tuple[bytes, bytes, bytes, bytes]:
 
 
 @pytest.mark.parametrize(
-    ("field", "value", "err_msg"),
+    "field, value, err_msg",
     [
         (0, b"BIE", "invalid magic size"),
         (1, bytes(32), "invalid ephemeral public key size"),
@@ -535,7 +535,7 @@ def test_parse_rejects_the_wrong_magic() -> None:
 
 
 @pytest.mark.parametrize(
-    ("armor", "err_msg"),
+    "armor, err_msg",
     [
         ("not base64 at all!", "invalid base64 encoding"),
         ("QklFMQ", "invalid base64 encoding"),

--- a/tests/ecc/ecies_test.py
+++ b/tests/ecc/ecies_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.ecc.ecies` module.
 
 **There is an AES-128 in this file, and it is here because tests are not

--- a/tests/ecc/ellswift_test.py
+++ b/tests/ecc/ellswift_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/ellswift_test.py
+++ b/tests/ecc/ellswift_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.ecc.ellswift` module.
 
 The two BIP324 vector files pin the map itself, which is deterministic.

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.ecc.musig2` module.
 
 The vectors are BIP327's own, all eight files of

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -81,7 +81,7 @@ def key_agg_valid_vectors() -> list[Any]:
     ]
 
 
-@pytest.mark.parametrize(("pub_keys", "expected"), key_agg_valid_vectors())
+@pytest.mark.parametrize("pub_keys, expected", key_agg_valid_vectors())
 def test_key_agg_vectors(pub_keys: list[bytes], expected: bytes) -> None:
     """Reproduce the valid cases of BIP327's key_agg_vectors.json."""
     assert musig2.key_agg(pub_keys).x_only_pub_key == expected
@@ -103,9 +103,7 @@ def key_agg_error_vectors() -> list[Any]:
     ]
 
 
-@pytest.mark.parametrize(
-    ("pub_keys", "tweaks", "is_xonly", "error"), key_agg_error_vectors()
-)
+@pytest.mark.parametrize("pub_keys, tweaks, is_xonly, error", key_agg_error_vectors())
 def test_key_agg_error_vectors(
     pub_keys: list[bytes], tweaks: list[bytes], is_xonly: list[bool], error: Any
 ) -> None:
@@ -155,7 +153,7 @@ def nonce_agg_valid_vectors() -> list[Any]:
     ]
 
 
-@pytest.mark.parametrize(("pub_nonces", "expected"), nonce_agg_valid_vectors())
+@pytest.mark.parametrize("pub_nonces, expected", nonce_agg_valid_vectors())
 def test_nonce_agg_vectors(pub_nonces: list[bytes], expected: bytes) -> None:
     """Reproduce the valid cases of BIP327's nonce_agg_vectors.json."""
     assert musig2.nonce_agg(pub_nonces) == expected
@@ -174,7 +172,7 @@ def nonce_agg_error_vectors() -> list[Any]:
     ]
 
 
-@pytest.mark.parametrize(("pub_nonces", "error"), nonce_agg_error_vectors())
+@pytest.mark.parametrize("pub_nonces, error", nonce_agg_error_vectors())
 def test_nonce_agg_error_vectors(pub_nonces: list[bytes], error: Any) -> None:
     """Reproduce the error cases of BIP327's nonce_agg_vectors.json."""
     with pytest.raises(_ERRORS) as excinfo:
@@ -501,7 +499,7 @@ _MSG = b"a message the two signers agree on, and not of 32 bytes"
 
 
 @pytest.mark.parametrize(
-    ("tweaks", "is_xonly"),
+    "tweaks, is_xonly",
     [
         pytest.param([], [], id="no-tweak"),
         pytest.param([bytes(31) + b"\x07"], [True], id="x-only-tweak"),

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -304,7 +304,7 @@ def test_tweak_vectors_consistency() -> None:
     """The file's own cross-references, as the reference checks them."""
     assert _TW_PUB_KEYS[0] == musig2.individual_pub_key(_TW_SK)
     assert _TW_PUB_NONCES[0] == _pub_nonce_of(_TW_SEC_NONCE)
-    assert _TW_AGG_NONCE == musig2.nonce_agg(_TW_PUB_NONCES[:3])
+    assert musig2.nonce_agg(_TW_PUB_NONCES[:3]) == _TW_AGG_NONCE
 
 
 def tweak_valid_vectors() -> list[Any]:

--- a/tests/ecc/pedersen_test.py
+++ b/tests/ecc/pedersen_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/pedersen_test.py
+++ b/tests/ecc/pedersen_test.py
@@ -28,7 +28,7 @@ def test_second_generator() -> None:
         0x50929B74C1A04954B78B4B6035E97A5E078A5A0F28EC96D547BFEE9ACE803AC0,
         0x31D3C6863973926E049E637CB1B5F40A36DAC28AF1766968C30C2313F3A38904,
     )
-    assert H == pedersen.second_generator(secp256k1, sha256)
+    assert pedersen.second_generator(secp256k1, sha256) == H
 
     _ = pedersen.second_generator(secp256r1, sha256)
     _ = pedersen.second_generator(secp384r1, sha384)

--- a/tests/ecc/pedersen_test.py
+++ b/tests/ecc/pedersen_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.pedersen` module."""
 
 from hashlib import sha256, sha384

--- a/tests/ecc/rfc6979_test.py
+++ b/tests/ecc/rfc6979_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/rfc6979_test.py
+++ b/tests/ecc/rfc6979_test.py
@@ -94,7 +94,7 @@ SECP256K1_VECTORS: tuple[tuple[int, str, int, str, str], ...] = (
 
 
 @pytest.mark.parametrize(
-    ("prv_key", "msg", "k", "r", "s"),
+    "prv_key, msg, k, r, s",
     [
         pytest.param(*vector, id=vector_id(index, vector[1]))
         for index, vector in enumerate(SECP256K1_VECTORS)
@@ -171,9 +171,7 @@ def rfc6979_vectors() -> list[Any]:
     ]
 
 
-@pytest.mark.parametrize(
-    ("ec", "x", "x_U", "y_U", "hf", "msg", "k", "r", "s"), rfc6979_vectors()
-)
+@pytest.mark.parametrize("ec, x, x_U, y_U, hf, msg, k, r, s", rfc6979_vectors())
 def test_rfc6979_nonce_tv(
     ec: Curve, x: str, x_U: str, y_U: str, hf: str, msg: str, k: str, r: str, s: str
 ) -> None:

--- a/tests/ecc/rfc6979_test.py
+++ b/tests/ecc/rfc6979_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.rfc6979` module.
 
 The last four compare it against `btclib.ecc.bip340_nonce`, the other

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.ssa` module."""
 
 from __future__ import annotations

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -256,13 +256,12 @@ def test_low_cardinality() -> None:
         for q in range(1, ec.n // 2):  # all possible private keys
             q_fixed, x_Q = ssa.gen_keys(q, ec)
             QJ = jac_from_aff((x_Q, ec.y_even(x_Q)))
-            while True:
+            sig: ssa.Sig | None = None
+            while sig is None:
                 try:
                     sig = ssa.sign(msg, q, aux, ec)
-                    break
                 except BTClibRuntimeError:  # invalid zero challenge
                     msg += b"\x01"
-                    continue
             ssa.assert_as_valid(msg, x_Q, sig)
             for k in range(1, ec.n // 2):  # all possible ephemeral keys
                 k_fixed, r = ssa.gen_keys(k, ec)

--- a/tests/fee_test.py
+++ b/tests/fee_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/fee_test.py
+++ b/tests/fee_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.fee` module.
 
 The dust tests are the interesting half. `dust_threshold` computes what

--- a/tests/fee_test.py
+++ b/tests/fee_test.py
@@ -48,7 +48,7 @@ def test_the_unit_is_in_the_name() -> None:
 
 
 @pytest.mark.parametrize(
-    ("sats_per_vbyte", "sats_per_kvbyte"),
+    "sats_per_vbyte, sats_per_kvbyte",
     [
         (0, 0),
         (1, 1000),
@@ -137,7 +137,7 @@ def test_rates_compare_and_hash() -> None:
 
 
 @pytest.mark.parametrize(
-    ("sats_per_kvbyte", "vsize", "fee"),
+    "sats_per_kvbyte, vsize, fee",
     [
         # the rate is per thousand virtual bytes, so a thousand of them
         # owe exactly the rate: no rounding to hide a factor of 1000 in
@@ -218,7 +218,7 @@ def _script_pub_keys() -> dict[str, bytes]:
 
 
 @pytest.mark.parametrize(
-    ("script_type", "threshold"),
+    "script_type, threshold",
     [
         # electrum/bitcoin.py's DUST_LIMIT_* table, every entry of it
         ("p2pkh", 546),

--- a/tests/fee_test.py
+++ b/tests/fee_test.py
@@ -251,7 +251,7 @@ def test_dust_threshold_takes_a_hex_string_too() -> None:
 def test_the_dust_relay_rate_is_a_parameter() -> None:
     """-dustrelayfee is Core's option, and this is the same knob."""
     script_pub_key = _script_pub_keys()["p2pkh"]
-    assert DUST_RELAY_FEE_RATE == FeeRate(sats_per_kvbyte=3000)
+    assert FeeRate(sats_per_kvbyte=3000) == DUST_RELAY_FEE_RATE
     assert dust_threshold(script_pub_key, DUST_RELAY_FEE_RATE) == 546
     # the 182 virtual bytes Core's comment names, at three other rates
     assert dust_threshold(script_pub_key, FeeRate(sats_per_kvbyte=1000)) == 182

--- a/tests/fetch/__init__.py
+++ b/tests/fetch/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/fetch/__init__.py
+++ b/tests/fetch/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """What the btclib.fetch tests share: a transport that opens no socket.
 
 Not one test in this directory reaches the network, and none can: every

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -162,7 +162,7 @@ def test_from_chain_is_the_local_node_of_that_chain() -> None:
     assert datadir is not None
     # the constant is the same answer, taken at import: a snapshot for a
     # caller to read, and not what the derivation goes through
-    assert DEFAULT_DATADIR == datadir
+    assert datadir == DEFAULT_DATADIR
 
     from_chain = BitcoinCoreRpcClient.from_chain
     assert from_chain().url == "http://127.0.0.1:8332"
@@ -197,7 +197,7 @@ def test_from_chain_reads_the_home_of_the_call_and_not_of_the_import(
 
     expected = tmp_path / "home-after" / ".bitcoin" / "regtest" / ".cookie"
     assert BitcoinCoreRpcClient.from_chain("regtest").cookie_path == expected
-    assert DEFAULT_DATADIR != _default_datadir()
+    assert _default_datadir() != DEFAULT_DATADIR
 
 
 def test_from_chain_derives_no_cookie_when_told_who_is_calling(

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -347,7 +347,7 @@ def test_a_colon_in_the_user_is_refused_and_one_in_the_password_is_not() -> None
 
 
 @pytest.mark.parametrize(
-    ("kwargs", "match"),
+    "kwargs, match",
     [
         ({"user": 7, "password": RPC_PASSWORD}, "non-string rpc user: int"),
         ({"user": b"alice", "password": RPC_PASSWORD}, "non-string rpc user: bytes"),
@@ -448,7 +448,7 @@ def test_the_url_carries_no_network_and_no_registry() -> None:
 
 
 @pytest.mark.parametrize(
-    ("url", "match"),
+    "url, match",
     [
         ("ftp://127.0.0.1:8332", "invalid rpc url scheme"),
         ("file:///etc/passwd", "invalid rpc url scheme"),
@@ -489,7 +489,7 @@ def test_credentials_in_the_url_are_refused(url: str) -> None:
         BitcoinCoreRpcClient(url, cookie_path="/nowhere/.cookie")
 
 
-@pytest.mark.parametrize(("user", "password"), [(RPC_USER, None), (None, RPC_PASSWORD)])
+@pytest.mark.parametrize("user, password", [(RPC_USER, None), (None, RPC_PASSWORD)])
 def test_a_user_without_a_password_is_refused(
     user: str | None, password: str | None
 ) -> None:
@@ -1481,7 +1481,7 @@ def test_a_number_the_exact_decimal_parser_will_not_build() -> None:
     _decimal_represents(_HUGE_EXPONENT_NUMBER),
     reason="this interpreter's decimal has a finite value for that exponent",
 )
-@pytest.mark.parametrize(("status", "raised"), [(200, FetchError), (503, HttpError)])
+@pytest.mark.parametrize("status, raised", [(200, FetchError), (503, HttpError)])
 def test_a_non_finite_decimal_is_refused_whatever_the_caller_traps(
     status: int, raised: type[FetchError]
 ) -> None:
@@ -1605,7 +1605,7 @@ def test_a_wallet_endpoint_is_the_path_core_documents() -> None:
 
 
 @pytest.mark.parametrize(
-    ("name", "path"),
+    "name, path",
     [
         ("my wallet", "my%20wallet"),
         ("a/b", "a%2Fb"),
@@ -1737,9 +1737,7 @@ def test_neither_direction_falls_back_on_a_name_it_does_not_know() -> None:
         network_from_core_chain("mainnet")
 
 
-@pytest.mark.parametrize(
-    ("network", "chain"), [("mainnet", "main"), ("testnet", "test")]
-)
+@pytest.mark.parametrize("network, chain", [("mainnet", "main"), ("testnet", "test")])
 def test_assert_network_accepts_the_chain_the_node_reports(
     network: str, chain: str
 ) -> None:
@@ -1808,7 +1806,7 @@ def test_assert_network_has_nothing_to_compare_for_a_custom_name_off_signet(
 
 
 @pytest.mark.parametrize(
-    ("result", "message"),
+    "result, message",
     [
         pytest.param(3, "not a JSON object: int", id="not-an-object"),
         pytest.param({}, "no chain name in the reply: None", id="no-chain"),

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for btclib.bitcoin_core_rpc, against recorded replies.
 
 Under `tests/fetch/` although its subject moved out of `btclib.fetch`, and

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for btclib.fetch.esplora, against recorded bodies.
 
 `BLOCKSTREAM_INFO` appears here as a value, never as a host reached: the

--- a/tests/fetch/fetcher_test.py
+++ b/tests/fetch/fetcher_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/fetch/fetcher_test.py
+++ b/tests/fetch/fetcher_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for btclib.fetch.fetcher, the half no backend re-implements."""
 
 from __future__ import annotations

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for btclib.fetch.transport."""
 
 from __future__ import annotations

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -491,7 +491,7 @@ def test_a_transport_equal_to_the_default_is_still_the_callers_transport(
         ),
     )
 
-    class EqualTransport:
+    class EqualTransport:  # noqa: PLW1641
         def __init__(self) -> None:
             self.requests: list[Request] = []
 

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -509,7 +509,7 @@ def test_a_transport_equal_to_the_default_is_still_the_callers_transport(
 
 
 @pytest.mark.parametrize(
-    ("status", "is_error"),
+    "status, is_error",
     [(int("399"), False), (int("400"), True), (int("401"), True)],
 )
 def test_a_caller_transport_uses_400_as_the_error_boundary(

--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -209,7 +209,7 @@ MUTATED_PARSERS: dict[str, tuple[Callable[[bytes], Any], bytes]] = {
 
 
 @pytest.mark.parametrize(
-    ("parse", "sample"),
+    "parse, sample",
     MUTATED_PARSERS.values(),
     ids=list(MUTATED_PARSERS.keys()),
 )

--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Every parser, on input nobody wrote down.
 
 The rest of the suite is fixed vectors: exactly what conformance needs,

--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -22,7 +22,7 @@ green rather than for having written it once.
 import contextlib
 import json
 from collections.abc import Callable
-from os import path
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -142,14 +142,14 @@ def test_text_parser_honors_the_exception_contract(
 
 def _load(*parts: str) -> bytes:
     """Return the bytes of a file vendored under tests/."""
-    with open(path.join(path.dirname(__file__), *parts), "rb") as file_:
+    with Path(__file__).parent.joinpath(*parts).open("rb") as file_:
         return file_.read()
 
 
 def _first_valid_psbt() -> bytes:
     """Return BIP174's first valid psbt, re-serialized to bytes."""
-    filename = path.join("psbt", "_data", "bip174_test_vectors.json")
-    with open(path.join(path.dirname(__file__), filename), encoding="ascii") as file_:
+    filename = Path("psbt") / "_data" / "bip174_test_vectors.json"
+    with (Path(__file__).parent / filename).open(encoding="ascii") as file_:
         vectors = json.load(file_)
     return Psbt.b64decode(vectors["valid psbts"][0]["encoded psbt"]).serialize()
 

--- a/tests/hashes_test.py
+++ b/tests/hashes_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/hashes_test.py
+++ b/tests/hashes_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.hashes` module."""
 
 import hashlib

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the import graph of the `btclib` package.
 
 Every module must be importable *first*, with no other btclib module in

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/init_test.py
+++ b/tests/init_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib` package metadata."""
 
 import importlib

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the one policy on integer fields: a bool is not a number.
 
 One file rather than a case per module, because the decision is one and

--- a/tests/key_io_test.py
+++ b/tests/key_io_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/key_io_test.py
+++ b/tests/key_io_test.py
@@ -85,7 +85,7 @@ REFUSED_VECTORS = [
 ]
 
 
-@pytest.mark.parametrize(("address", "script_pub_key", "network"), ADDRESS_VECTORS)
+@pytest.mark.parametrize("address, script_pub_key, network", ADDRESS_VECTORS)
 def test_address_script(address: str, script_pub_key: str, network: str) -> None:
     """The address decodes to the scriptPubKey Core encodes it from."""
     spk = ScriptPubKey.from_address(address)
@@ -94,7 +94,7 @@ def test_address_script(address: str, script_pub_key: str, network: str) -> None
     assert network_type_from_network(spk.network) == network_type_from_network(network)
 
 
-@pytest.mark.parametrize(("address", "script_pub_key", "network"), ADDRESS_VECTORS)
+@pytest.mark.parametrize("address, script_pub_key, network", ADDRESS_VECTORS)
 def test_address_network(address: str, script_pub_key: str, network: str) -> None:
     """Which chain the address itself can name, which is fewer than four.
 
@@ -116,7 +116,7 @@ def test_address_network(address: str, script_pub_key: str, network: str) -> Non
     assert ScriptPubKey.from_address(address).network == expected
 
 
-@pytest.mark.parametrize(("address", "script_pub_key", "network"), ADDRESS_VECTORS)
+@pytest.mark.parametrize("address, script_pub_key, network", ADDRESS_VECTORS)
 def test_address_payload(address: str, script_pub_key: str, network: str) -> None:
     """The codec layer reads a payload and writes the address back.
 
@@ -133,7 +133,7 @@ def test_address_payload(address: str, script_pub_key: str, network: str) -> Non
         assert b58.address_from_h160(script_type, h160, network) == address
 
 
-@pytest.mark.parametrize(("address", "script_pub_key", "network"), ADDRESS_VECTORS)
+@pytest.mark.parametrize("address, script_pub_key, network", ADDRESS_VECTORS)
 def test_address_from_script(address: str, script_pub_key: str, network: str) -> None:
     """Core's scriptPubKey renders back to Core's address, every row of it.
 
@@ -146,13 +146,13 @@ def test_address_from_script(address: str, script_pub_key: str, network: str) ->
     assert ScriptPubKey(script_pub_key, network).address == address
 
 
-@pytest.mark.parametrize(("address", "script_pub_key"), CASE_FLIP_VECTORS)
+@pytest.mark.parametrize("address, script_pub_key", CASE_FLIP_VECTORS)
 def test_address_case_flip(address: str, script_pub_key: str) -> None:
     """`tryCaseFlip`: bech32 in upper case is the same address."""
     assert ScriptPubKey.from_address(address.upper()).script.hex() == script_pub_key
 
 
-@pytest.mark.parametrize(("wif", "prv_key", "network", "compressed"), WIF_VECTORS)
+@pytest.mark.parametrize("wif, prv_key, network, compressed", WIF_VECTORS)
 def test_wif(wif: str, prv_key: str, network: str, compressed: bool) -> None:
     """The key Core encoded, its compression flag, and the WIF written back."""
     q, net, compr = prv_keyinfo_from_prv_key(wif, network)
@@ -162,7 +162,7 @@ def test_wif(wif: str, prv_key: str, network: str, compressed: bool) -> None:
     assert b58.wif_from_prv_key(q, network, compressed) == wif
 
 
-@pytest.mark.parametrize(("wif", "prv_key", "network", "compressed"), WIF_VECTORS)
+@pytest.mark.parametrize("wif, prv_key, network, compressed", WIF_VECTORS)
 def test_wif_without_a_network(
     wif: str, prv_key: str, network: str, compressed: bool
 ) -> None:

--- a/tests/key_io_test.py
+++ b/tests/key_io_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Bitcoin Core's key_io vectors, over addresses and WIFs.
 
 The vectors are Core's `src/test/data/key_io_valid.json` and

--- a/tests/keystore_test.py
+++ b/tests/keystore_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/keystore_test.py
+++ b/tests/keystore_test.py
@@ -41,7 +41,7 @@ _PUB_KEY = "0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c"
 
 
 @pytest.mark.parametrize(
-    ("purpose", "script_type", "addresses"),
+    "purpose, script_type, addresses",
     [
         pytest.param(
             44,
@@ -170,7 +170,7 @@ def test_the_key_index_must_be_the_path_element_at_its_depth() -> None:
 
 
 @pytest.mark.parametrize(
-    ("der_path", "err_msg"),
+    "der_path, err_msg",
     [
         ("m/84h/0h", "invalid account path: 2 levels instead of 3"),
         ("m/84h/0h/0h/0", "invalid account path: 4 levels instead of 3"),
@@ -320,7 +320,7 @@ def test_the_derivation_bounds_are_bip32s_own() -> None:
 
 
 @pytest.mark.parametrize(
-    ("script_type", "address"),
+    "script_type, address",
     [
         ("p2pkh", "14dD6ygPi5WXdwwBTt1FBZK3aD8uDem1FY"),
         ("p2wpkh-p2sh", "3G6hxdgC91ETUpsGCrVywYRDZBp8LHarPF"),

--- a/tests/keystore_test.py
+++ b/tests/keystore_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.keystore` module."""
 
 from __future__ import annotations

--- a/tests/mnemonic/__init__.py
+++ b/tests/mnemonic/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/mnemonic/__init__.py
+++ b/tests/mnemonic/__init__.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Non-regression tests for btclib.mnemonic."""

--- a/tests/mnemonic/bip39_test.py
+++ b/tests/mnemonic/bip39_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/mnemonic/bip39_test.py
+++ b/tests/mnemonic/bip39_test.py
@@ -80,7 +80,7 @@ BIP39_VECTORS = [
 ]
 
 
-@pytest.mark.parametrize(("lang", "entr", "mnemonic", "seed", "xprv"), BIP39_VECTORS)
+@pytest.mark.parametrize("lang, entr, mnemonic, seed, xprv", BIP39_VECTORS)
 def test_vectors(lang: str, entr: str, mnemonic: str, seed: str, xprv: str) -> None:
     """BIP39 test vectors, all twelve languages of them.
 
@@ -310,7 +310,7 @@ JAPANESE_VECTORS = [
 ]
 
 
-@pytest.mark.parametrize(("words", "seed", "xprv"), JAPANESE_VECTORS)
+@pytest.mark.parametrize("words, seed, xprv", JAPANESE_VECTORS)
 def test_nfkd_japanese_vectors(words: list[str], seed: str, xprv: str) -> None:
     """BIP39 stretches the NFKD of the sentence and of the passphrase.
 

--- a/tests/mnemonic/bip39_test.py
+++ b/tests/mnemonic/bip39_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.bip39` module."""
 
 import secrets

--- a/tests/mnemonic/dispatch_test.py
+++ b/tests/mnemonic/dispatch_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/mnemonic/dispatch_test.py
+++ b/tests/mnemonic/dispatch_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.mnemonic.dispatch` module.
 
 The Electrum half of the table is electrum's own, from the Test_seeds

--- a/tests/mnemonic/dispatch_test.py
+++ b/tests/mnemonic/dispatch_test.py
@@ -131,7 +131,7 @@ DISPATCH_VECTORS = [
 ]
 
 
-@pytest.mark.parametrize(("mnemonic", "seed_type", "seed_types"), DISPATCH_VECTORS)
+@pytest.mark.parametrize("mnemonic, seed_type, seed_types", DISPATCH_VECTORS)
 def test_dispatch_vectors(mnemonic: str, seed_type: str, seed_types: list[str]) -> None:
     """Verify each sentence's seed type and its full candidate list."""
     assert dispatch.seed_type_from_mnemonic(mnemonic) == seed_type
@@ -344,7 +344,7 @@ def test_slip39_bad_set_of_good_sentences(mnemonics: list[str]) -> None:
 
 
 @pytest.mark.parametrize(
-    ("share", "electrum_type"),
+    "share, electrum_type",
     [
         pytest.param(SLIP39_ELECTRUM_STANDARD, "electrum_standard", id="standard"),
         pytest.param(SLIP39_ELECTRUM_2FA, "electrum_2fa", id="2fa"),

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.electrum` module.
 
 Most of the vectors here are electrum's own, from `spesmilo/electrum`'s

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -394,7 +394,7 @@ def test_word_order() -> None:
     assert int(reversed_entr, 2) == 0xFB0A779F83FEDDB0E39AA0DDE898CC384
 
 
-@pytest.mark.parametrize(("mnemonic", "passphrase", "version", "seed"), SEED_VECTORS)
+@pytest.mark.parametrize("mnemonic, passphrase, version, seed", SEED_VECTORS)
 def test_seed_vectors(mnemonic: str, passphrase: str, version: str, seed: str) -> None:
     """Reproduce electrum's SEED_TEST_CASES, version and seed alike."""
     assert electrum._seed_from_mnemonic(mnemonic, passphrase) == (
@@ -403,7 +403,7 @@ def test_seed_vectors(mnemonic: str, passphrase: str, version: str, seed: str) -
     )
 
 
-@pytest.mark.parametrize(("mnemonic", "version"), VERSION_VECTORS)
+@pytest.mark.parametrize("mnemonic, version", VERSION_VECTORS)
 def test_version_vectors(mnemonic: str, version: str) -> None:
     """Reproduce electrum's Test_seeds table, refusals included."""
     if not version:
@@ -495,7 +495,7 @@ OLD_HEX_SEEDS = [
 ]
 
 
-@pytest.mark.parametrize(("hex_seed", "mnemonic", "master_pub_key"), OLD_HEX_SEEDS)
+@pytest.mark.parametrize("hex_seed, mnemonic, master_pub_key", OLD_HEX_SEEDS)
 def test_old_vectors(hex_seed: str, mnemonic: str, master_pub_key: str | None) -> None:
     """The pre-2.0 scheme, both directions and the stretch, against electrum.
 
@@ -766,7 +766,7 @@ def test_2fa_words() -> None:
         electrum.version_from_mnemonic(thirteen_words)
 
 
-@pytest.mark.parametrize(("mnemonic", "lang", "entropy"), DECODE_VECTORS)
+@pytest.mark.parametrize("mnemonic, lang, entropy", DECODE_VECTORS)
 def test_decode_vectors(mnemonic: str, lang: str, entropy: int) -> None:
     """The entropy electrum's mnemonic_decode reads off each sentence.
 
@@ -780,7 +780,7 @@ def test_decode_vectors(mnemonic: str, lang: str, entropy: int) -> None:
 
 
 @pytest.mark.parametrize(
-    ("lang", "mnemonic_type", "entropy", "mnemonic", "seed"), GENERATED_VECTORS
+    "lang, mnemonic_type, entropy, mnemonic, seed", GENERATED_VECTORS
 )
 def test_generated_vectors(
     lang: str, mnemonic_type: str, entropy: int, mnemonic: str, seed: str
@@ -969,7 +969,7 @@ ELECTRUM_VECTORS = [
 
 
 @pytest.mark.parametrize(
-    ("mnemonic", "passphrase", "rmxprv", "rmxpub", "address"), ELECTRUM_VECTORS
+    "mnemonic, passphrase, rmxprv, rmxpub, address", ELECTRUM_VECTORS
 )
 def test_vectors(
     mnemonic: str, passphrase: str, rmxprv: str, rmxpub: str, address: str

--- a/tests/mnemonic/entropy_test.py
+++ b/tests/mnemonic/entropy_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/mnemonic/entropy_test.py
+++ b/tests/mnemonic/entropy_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.entropy` module."""
 
 import math

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -114,7 +114,7 @@ def respace(mnemonic: str, prefix: str, separator: str, suffix: str) -> str:
     return prefix + separator.join(mnemonic.split()) + suffix
 
 
-@pytest.mark.parametrize(("prefix", "separator", "suffix"), WHITESPACE_SHAPES)
+@pytest.mark.parametrize("prefix, separator, suffix", WHITESPACE_SHAPES)
 def test_bip39_whitespace(prefix: str, separator: str, suffix: str) -> None:
     """Verify BIP39's answers are unchanged by the whitespace shape."""
     mnemonic = respace(BIP39_MNEMONIC, prefix, separator, suffix)
@@ -130,7 +130,7 @@ def test_bip39_whitespace(prefix: str, separator: str, suffix: str) -> None:
     )
 
 
-@pytest.mark.parametrize(("prefix", "separator", "suffix"), WHITESPACE_SHAPES)
+@pytest.mark.parametrize("prefix, separator, suffix", WHITESPACE_SHAPES)
 def test_electrum_whitespace(prefix: str, separator: str, suffix: str) -> None:
     """Verify electrum's answers are unchanged by the whitespace shape."""
     mnemonic = respace(ELECTRUM_MNEMONIC, prefix, separator, suffix)
@@ -145,7 +145,7 @@ def test_electrum_whitespace(prefix: str, separator: str, suffix: str) -> None:
     )
 
 
-@pytest.mark.parametrize(("prefix", "separator", "suffix"), WHITESPACE_SHAPES)
+@pytest.mark.parametrize("prefix, separator, suffix", WHITESPACE_SHAPES)
 def test_indexes_from_mnemonic_whitespace(
     prefix: str, separator: str, suffix: str
 ) -> None:

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.mnemonic` module."""
 
 import builtins

--- a/tests/mnemonic/mnemonic_test.py
+++ b/tests/mnemonic/mnemonic_test.py
@@ -5,9 +5,8 @@
 
 """Tests for the `btclib.mnemonic` module."""
 
-import builtins
 import threading
-from os import path
+from pathlib import Path
 from typing import Any, get_args
 from unicodedata import normalize
 
@@ -189,7 +188,7 @@ def test_wordlist_2() -> None:
     # english.txt if that ever changes, which it has not since 2014;
     # tests/_data/README.md records both
     fname = "fakeenglish.txt"
-    filename = path.join(path.dirname(__file__), "_data", fname)
+    filename = str(Path(__file__).parent / "_data" / fname)
     err_msg = "invalid wordlist length: "
     with pytest.raises(BTClibValueError, match=err_msg):
         word_lists.load_lang(lang, filename)
@@ -203,7 +202,7 @@ def test_wordlist_2() -> None:
     # dynamically add a new language
     lang = "en2"
     fname = "english.txt"
-    filename = path.join(path.dirname(__file__), "_data", fname)
+    filename = str(Path(__file__).parent / "_data" / fname)
     word_lists.load_lang(lang, filename)
     length = word_lists.language_length(lang)
     assert length == 2048
@@ -279,7 +278,7 @@ def test_power_of_two() -> None:
     rather than of the loader.
     """
     fname = "fakeenglish.txt"
-    filename = path.join(path.dirname(__file__), "_data", fname)
+    filename = str(Path(__file__).parent / "_data" / fname)
 
     with pytest.raises(BTClibValueError, match="invalid wordlist length: 2047"):
         WordLists().load_lang("fakeen", filename)
@@ -358,19 +357,19 @@ def test_load_lang_is_idempotent_and_reads_once() -> None:
     """Loaded lazily, and read from disk only once."""
     word_lists = WordLists()
     reads = []
-    real_open = builtins.open
+    real_open = Path.open
 
-    def counting_open(*args: Any, **kwargs: Any) -> Any:
-        reads.append(args[0])
-        return real_open(*args, **kwargs)
+    def counting_open(self: Path, *args: Any, **kwargs: Any) -> Any:
+        reads.append(self)
+        return real_open(self, *args, **kwargs)
 
-    builtins.open = counting_open
+    Path.open = counting_open  # type: ignore[method-assign]
     try:
         assert word_lists.language_length("en") == 2048
         assert len(word_lists.wordlist("en")) == 2048
         assert word_lists.language_length("en") == 2048
     finally:
-        builtins.open = real_open
+        Path.open = real_open  # type: ignore[method-assign]
 
     assert len(reads) == 1
 

--- a/tests/mnemonic/slip39_test.py
+++ b/tests/mnemonic/slip39_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/mnemonic/slip39_test.py
+++ b/tests/mnemonic/slip39_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.mnemonic.slip39` module."""
 
 from collections.abc import Callable

--- a/tests/mnemonic/slip39_test.py
+++ b/tests/mnemonic/slip39_test.py
@@ -79,7 +79,7 @@ def test_wordlist() -> None:
     assert set(wordlist) != set(WORDLISTS.wordlist("en"))
 
 
-@pytest.mark.parametrize(("mnemonics", "master_secret", "xprv"), VECTORS)
+@pytest.mark.parametrize("mnemonics, master_secret, xprv", VECTORS)
 def test_vectors(mnemonics: list[str], master_secret: str, xprv: str) -> None:
     """SLIP-0039 test vectors.
 
@@ -107,7 +107,7 @@ def test_vectors(mnemonics: list[str], master_secret: str, xprv: str) -> None:
         assert slip39.mnemonic_from_share(share) == mnemonic
 
 
-@pytest.mark.parametrize(("mnemonic", "master_secret"), SINGLE_SHARE_VECTORS)
+@pytest.mark.parametrize("mnemonic, master_secret", SINGLE_SHARE_VECTORS)
 def test_generation_vectors(mnemonic: str, master_secret: str) -> None:
     """Regenerate the 1-of-1 vectors, mnemonic for mnemonic.
 
@@ -239,7 +239,7 @@ def test_invalid_passphrase(passphrase: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("field", "value"),
+    "field, value",
     [
         ("identifier", -1),
         ("identifier", 1 << 15),
@@ -305,7 +305,7 @@ def test_one_of_many_group() -> None:
 
 
 @pytest.mark.parametrize(
-    ("groups", "group_threshold"),
+    "groups, group_threshold",
     [
         ([(2, 3)], 0),  # a threshold of no group
         ([(2, 3)], 2),  # more groups needed than there are

--- a/tests/mutation_counts_test.py
+++ b/tests/mutation_counts_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/mutation_counts_test.py
+++ b/tests/mutation_counts_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the mutation session counter of `.github/scripts`.
 
 The script is what the `mutation` workflow prints, and what it prints is the

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.network` module."""
 
 from dataclasses import fields

--- a/tests/number_theory_test.py
+++ b/tests/number_theory_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/number_theory_test.py
+++ b/tests/number_theory_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.number_theory` module."""
 
 import math

--- a/tests/parse_contract_test.py
+++ b/tests/parse_contract_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/parse_contract_test.py
+++ b/tests/parse_contract_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the parse contract every `parse` in btclib owes its caller.
 
 One file rather than a case per module, because the rule is one and

--- a/tests/parse_contract_test.py
+++ b/tests/parse_contract_test.py
@@ -25,7 +25,7 @@ import importlib
 import pkgutil
 from collections.abc import Callable
 from io import BytesIO
-from os import path
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -53,8 +53,8 @@ _XPRV = (
 
 def _block_1() -> bytes:
     """Return the consensus bytes of the block after genesis."""
-    filename = path.join(path.dirname(__file__), "block", "_data", "block_1.bin")
-    with open(filename, "rb") as file_:
+    filename = Path(__file__).parent / "block" / "_data" / "block_1.bin"
+    with filename.open("rb") as file_:
         return file_.read()
 
 

--- a/tests/parse_contract_test.py
+++ b/tests/parse_contract_test.py
@@ -96,7 +96,7 @@ _IDS = [case[0] for case in _CASES]
 _PARSE_AND_BYTES = [(case[1].parse, case[2]) for case in _CASES]
 
 
-@pytest.mark.parametrize(("parse", "serialization"), _PARSE_AND_BYTES, ids=_IDS)
+@pytest.mark.parametrize("parse, serialization", _PARSE_AND_BYTES, ids=_IDS)
 @pytest.mark.parametrize("check_validity", [True, False], ids=["checked", "unchecked"])
 def test_no_prefix_of_an_encoding_is_an_object(
     parse: Callable[..., Any], serialization: bytes, *, check_validity: bool
@@ -114,7 +114,7 @@ def test_no_prefix_of_an_encoding_is_an_object(
             parse(serialization[:size], check_validity=check_validity)
 
 
-@pytest.mark.parametrize(("parse", "serialization"), _PARSE_AND_BYTES, ids=_IDS)
+@pytest.mark.parametrize("parse, serialization", _PARSE_AND_BYTES, ids=_IDS)
 @pytest.mark.parametrize("check_validity", [True, False], ids=["checked", "unchecked"])
 def test_octets_are_one_whole_object(
     parse: Callable[..., Any], serialization: bytes, *, check_validity: bool
@@ -129,7 +129,7 @@ def test_octets_are_one_whole_object(
             parse((serialization + trailing).hex(), check_validity=check_validity)
 
 
-@pytest.mark.parametrize(("parse", "serialization"), _PARSE_AND_BYTES, ids=_IDS)
+@pytest.mark.parametrize("parse, serialization", _PARSE_AND_BYTES, ids=_IDS)
 def test_a_stream_is_the_callers(
     parse: Callable[..., Any], serialization: bytes
 ) -> None:

--- a/tests/psbt/__init__.py
+++ b/tests/psbt/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/psbt/__init__.py
+++ b/tests/psbt/__init__.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Non-regression tests for btclib.psbt."""

--- a/tests/psbt/_data/bip371_test_vectors.json
+++ b/tests/psbt/_data/bip371_test_vectors.json
@@ -6,12 +6,12 @@
             "encoded psbt": "cHNidP8BAHECAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////Anh8AQAAAAAAFgAUg6fjS9mf8DpJYu+KGhAbspVGHs5gawQqAQAAABYAFHrDad8bIOAz1hFmI5V7CsSfPFLoAAAAAAABASsA8gUqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXARchAv40kGTJjW4qhT+jybEr2LMEoZwZXGDvp+4jkwRtP6IyAAAA"
         },
         {
-            "description": "PSBT With PSBT_KEY_PATH_SIG signature that is too short",
+            "description": "PSBT With PSBT_IN_TAP_KEY_SIG signature that is too short",
             "error message": "invalid taproot key path signature length",
             "encoded psbt": "cHNidP8BAHECAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////Anh8AQAAAAAAFgAUg6fjS9mf8DpJYu+KGhAbspVGHs5gawQqAQAAABYAFHrDad8bIOAz1hFmI5V7CsSfPFLoAAAAAAABASsA8gUqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXARM/Fzuz02wHSvtxb+xjB6BpouRQuZXzyCeFlFq43w4kJg3NcDsMvzTeOZGEqUgawrNYbbZgHwJqd/fkk4SBvDR1AAAA"
         },
         {
-            "description": "PSBT With PSBT_KEY_PATH_SIG signature that is too long",
+            "description": "PSBT With PSBT_IN_TAP_KEY_SIG signature that is too long",
             "error message": "invalid taproot key path signature length",
             "encoded psbt": "cHNidP8BAHECAAAAASd0Srq/MCf+DWzyOpbu4u+xiO9SMBlUWFiD5ptmJLJCAAAAAAD/////Anh8AQAAAAAAFgAUg6fjS9mf8DpJYu+KGhAbspVGHs5gawQqAQAAABYAFHrDad8bIOAz1hFmI5V7CsSfPFLoAAAAAAABASsA8gUqAQAAACJRIFosLPW1LPMfg60ujaY/8DGD7Nj2CcdRCuikjgORCgdXARNCFzuz02wHSvtxb+xjB6BpouRQuZXzyCeFlFq43w4kJg3NcDsMvzTeOZGEqUgawrNYbbZgHwJqd/fkk4SBvDR1FwGqAAAA"
         },

--- a/tests/psbt/musig2_test.py
+++ b/tests/psbt/musig2_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/psbt/musig2_test.py
+++ b/tests/psbt/musig2_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.psbt.musig2` module."""
 
 from typing import Any

--- a/tests/psbt/psbt_in_test.py
+++ b/tests/psbt/psbt_in_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/psbt/psbt_in_test.py
+++ b/tests/psbt/psbt_in_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.psbt.psbt_in` module."""
 
 from dataclasses import FrozenInstanceError, fields

--- a/tests/psbt/psbt_in_test.py
+++ b/tests/psbt/psbt_in_test.py
@@ -122,7 +122,7 @@ def test_key_type_tables_name_every_field() -> None:
     # a name here that is not a field is silent too: the drop would simply
     # not happen, and a finalized input would carry what BIP174 says it
     # must not
-    assert _DROPPED_ONCE_FINALIZED < field_names
+    assert field_names > _DROPPED_ONCE_FINALIZED
 
     parsed = {name for name, _, _ in _WHOLE_VALUE_FIELDS.values()}
     parsed |= {name for name, _ in _KEY_DATA_FIELDS.values()}

--- a/tests/psbt/psbt_out_test.py
+++ b/tests/psbt/psbt_out_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/psbt/psbt_out_test.py
+++ b/tests/psbt/psbt_out_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.psbt.psbt_out` module."""
 
 from __future__ import annotations

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.psbt.psbt_size` module.
 
 What an estimate has to be checked against is transactions that were

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -105,7 +105,7 @@ def is_sig(element: bytes) -> bool:
     return True
 
 
-def psbt_input_from_spend(tx_in: TxIn) -> tuple[PsbtIn, bytes] | None:
+def psbt_input_from_spend(tx_in: TxIn) -> tuple[PsbtIn, bytes] | None:  # noqa: PLR0911
     """Rebuild the PsbtIn an Updater would have, read off the signed input.
 
     A spend says what it spent: the pub key of a p2pkh script_sig

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -322,7 +322,7 @@ def test_the_bip174_spend_is_read_back_off_the_wire() -> None:
 
 
 @pytest.mark.parametrize(
-    ("block_name", "first", "kinds"),
+    "block_name, first, kinds",
     [
         # the first 600 transactions of the first segwit block, which is
         # where its seven segwit spends are -- p2wpkh and p2sh-p2wpkh,

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.psbt.psbt` module."""
 
 import base64

--- a/tests/psbt/psbt_utils_test.py
+++ b/tests/psbt/psbt_utils_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/psbt/psbt_utils_test.py
+++ b/tests/psbt/psbt_utils_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.psbt.psbt_utils` module."""
 
 from io import BytesIO

--- a/tests/release_notes_test.py
+++ b/tests/release_notes_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/release_notes_test.py
+++ b/tests/release_notes_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """What CHANGELOG.md and HISTORY.md must not say about themselves.
 
 A count is the one fact in either file nothing derives: prose can be

--- a/tests/ripemd160_test.py
+++ b/tests/ripemd160_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/ripemd160_test.py
+++ b/tests/ripemd160_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib._ripemd160` module.
 
 The vectors are the ones the authors of RIPEMD-160 publish at

--- a/tests/ripemd160_test.py
+++ b/tests/ripemd160_test.py
@@ -45,7 +45,7 @@ TEST_VECTORS = (
 )
 
 
-@pytest.mark.parametrize(("msg", "digest"), TEST_VECTORS)
+@pytest.mark.parametrize("msg, digest", TEST_VECTORS)
 def test_ripemd160(msg: bytes, digest: str) -> None:
     """Reproduce the designers' published RIPEMD-160 vectors."""
     assert ripemd160(msg).hex() == digest

--- a/tests/rpc_smoke_test.py
+++ b/tests/rpc_smoke_test.py
@@ -1,0 +1,319 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the pure half of the rpc smoke script of `.github/scripts`.
+
+Most of `rpc_smoke.py` is not testable here at all, and is not supposed to
+be: `node`, `probe`, `check_protocol`, `check_cookie`'s wallet-bearing
+siblings, `generate_chain` and everything `smoke` calls in turn all talk
+to a real `BitcoinCoreRpcClient` backed by a real bitcoind, which is the
+one thing this script exists to have -- a mock of it would be testing
+that the mock agrees with itself. `.github/workflows/rpc-smoke.yml` is
+where that half is exercised, against Core itself, on a schedule and
+before a release; it is not duplicated here.
+
+What is covered is the half with no node behind it: `check`, the plain
+predicate every other function calls; `port_is_free`, a socket check;
+`check_legacy_reply` and `check_v2_reply`, which read a status and a
+plain `dict` -- exactly the shape `probe` hands them, but built here by
+hand rather than read off a wire; `check_cookie`, which is file
+parsing (`cookie_auth` reads a path, no client passed to it at all); and
+`print_log_tail`. `main`'s argument parsing is covered by its own
+failure modes, which is what does not need `--bitcoind` to be real.
+
+The script is loaded by path, `.github/scripts` being no package: the
+mutation-counter test does the same for the same reason.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import runpy
+import sys
+from contextlib import closing
+from pathlib import Path
+from socket import socket
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "rpc_smoke.py"
+
+
+@pytest.fixture(scope="module")
+def smoke() -> ModuleType:
+    """Return the script, imported by path."""
+    spec = importlib.util.spec_from_file_location("rpc_smoke", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_check_prints_ok_on_a_true_claim(
+    smoke: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A true claim prints `ok` and the claim, and raises nothing."""
+    smoke.check(True, "the node answers")
+    assert capsys.readouterr().out == "ok   the node answers\n"
+
+
+def test_check_raises_on_a_false_claim(smoke: ModuleType) -> None:
+    """A false claim is a SmokeError naming the claim that failed."""
+    with pytest.raises(smoke.SmokeError, match="the node answers"):
+        smoke.check(False, "the node answers")
+
+
+def test_port_is_free_when_nothing_listens(smoke: ModuleType) -> None:
+    """A port nothing binds to any more reads as free."""
+    with closing(socket()) as probe:
+        probe.bind(("127.0.0.1", 0))
+        free_port = probe.getsockname()[1]
+    assert smoke.port_is_free(free_port)
+
+
+def test_port_is_free_is_false_once_something_listens(smoke: ModuleType) -> None:
+    """A port a listening socket holds reads as not free."""
+    with closing(socket()) as listener:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        assert not smoke.port_is_free(listener.getsockname()[1])
+
+
+@pytest.mark.parametrize("rpc_error", [False, True])
+def test_check_legacy_reply_accepts_a_wellformed_reply(
+    smoke: ModuleType, rpc_error: bool
+) -> None:
+    """A 1.1 result and a 1.1 error, each shaped as Core shapes them."""
+    reply: dict[str, Any] = {
+        "result": None if rpc_error else 1,
+        "error": {} if rpc_error else None,
+    }
+    smoke.check_legacy_reply(500 if rpc_error else 200, reply, rpc_error=rpc_error)
+
+
+def test_check_legacy_reply_rejects_a_jsonrpc_member(smoke: ModuleType) -> None:
+    """A 1.1 reply carries no `jsonrpc` member at all."""
+    reply = {"jsonrpc": "2.0", "result": 1, "error": None}
+    with pytest.raises(smoke.SmokeError, match="no jsonrpc member"):
+        smoke.check_legacy_reply(200, reply, rpc_error=False)
+
+
+def test_check_legacy_reply_rejects_a_missing_member(smoke: ModuleType) -> None:
+    """A 1.1 reply carries both `result` and `error`, one of them null."""
+    with pytest.raises(smoke.SmokeError, match="both result and error"):
+        smoke.check_legacy_reply(200, {"result": 1}, rpc_error=False)
+
+
+def test_check_legacy_reply_rejects_the_wrong_status_for_an_error(
+    smoke: ModuleType,
+) -> None:
+    """A 1.1 rpc error arrives under an HTTP 500, not a 200."""
+    reply: dict[str, Any] = {"result": None, "error": {}}
+    with pytest.raises(smoke.SmokeError, match="HTTP 500"):
+        smoke.check_legacy_reply(200, reply, rpc_error=True)
+
+
+def test_check_legacy_reply_rejects_a_populated_result_on_an_error(
+    smoke: ModuleType,
+) -> None:
+    """A 1.1 error reply's `result` is null, never a value."""
+    reply = {"result": 1, "error": {}}
+    with pytest.raises(smoke.SmokeError, match="null result"):
+        smoke.check_legacy_reply(500, reply, rpc_error=True)
+
+
+def test_check_legacy_reply_rejects_a_missing_error_object(smoke: ModuleType) -> None:
+    """A 1.1 error reply's `error` is populated, never null."""
+    reply = {"result": None, "error": None}
+    with pytest.raises(smoke.SmokeError, match="has the error object"):
+        smoke.check_legacy_reply(500, reply, rpc_error=True)
+
+
+def test_check_legacy_reply_rejects_a_populated_error_on_a_result(
+    smoke: ModuleType,
+) -> None:
+    """A 1.1 result reply's `error` is null, never populated."""
+    reply = {"result": 1, "error": {}}
+    with pytest.raises(smoke.SmokeError, match="null error"):
+        smoke.check_legacy_reply(200, reply, rpc_error=False)
+
+
+@pytest.mark.parametrize("rpc_error", [False, True])
+def test_check_v2_reply_accepts_a_wellformed_reply(
+    smoke: ModuleType, rpc_error: bool
+) -> None:
+    """A 2.0 result and a 2.0 error, each with exactly one member set."""
+    reply: dict[str, Any] = {"jsonrpc": "2.0"}
+    reply["error" if rpc_error else "result"] = {} if rpc_error else 1
+    smoke.check_v2_reply(200, reply, rpc_error=rpc_error)
+
+
+def test_check_v2_reply_rejects_a_missing_marker(smoke: ModuleType) -> None:
+    """A 2.0 reply echoes the `jsonrpc: "2.0"` marker."""
+    with pytest.raises(smoke.SmokeError, match="echoes the 2.0 marker"):
+        smoke.check_v2_reply(200, {"result": 1}, rpc_error=False)
+
+
+def test_check_v2_reply_rejects_a_non_200_status(smoke: ModuleType) -> None:
+    """A 2.0 reply arrives under an HTTP 200, error or not."""
+    reply = {"jsonrpc": "2.0", "result": 1}
+    with pytest.raises(smoke.SmokeError, match="HTTP 200"):
+        smoke.check_v2_reply(500, reply, rpc_error=False)
+
+
+def test_check_v2_reply_rejects_a_result_with_no_result_member(
+    smoke: ModuleType,
+) -> None:
+    """A 2.0 result reply carries a `result` member."""
+    with pytest.raises(smoke.SmokeError, match="has a result member"):
+        smoke.check_v2_reply(200, {"jsonrpc": "2.0"}, rpc_error=False)
+
+
+def test_check_v2_reply_rejects_a_result_carrying_both_members(
+    smoke: ModuleType,
+) -> None:
+    """A 2.0 result reply carries no `error` member alongside it."""
+    reply = {"jsonrpc": "2.0", "result": 1, "error": {}}
+    with pytest.raises(smoke.SmokeError, match="no error member"):
+        smoke.check_v2_reply(200, reply, rpc_error=False)
+
+
+def test_check_v2_reply_rejects_an_error_with_no_error_member(
+    smoke: ModuleType,
+) -> None:
+    """A 2.0 error reply carries an `error` member."""
+    with pytest.raises(smoke.SmokeError, match="has an error member"):
+        smoke.check_v2_reply(200, {"jsonrpc": "2.0"}, rpc_error=True)
+
+
+def test_check_v2_reply_rejects_an_error_carrying_both_members(
+    smoke: ModuleType,
+) -> None:
+    """A 2.0 error reply carries no `result` member alongside it."""
+    reply = {"jsonrpc": "2.0", "result": 1, "error": {}}
+    with pytest.raises(smoke.SmokeError, match="no result member"):
+        smoke.check_v2_reply(200, reply, rpc_error=True)
+
+
+def test_check_cookie_reads_the_credential(smoke: ModuleType, tmp_path: Path) -> None:
+    """A cookie naming the node's own user and a non-empty password passes."""
+    cookie = tmp_path / ".cookie"
+    cookie.write_text(f"{smoke.COOKIE_USER}:s3cr3t", encoding="utf-8")
+    smoke.check_cookie(cookie)
+
+
+def test_check_cookie_rejects_a_missing_file(smoke: ModuleType, tmp_path: Path) -> None:
+    """No file at the cookie path is a SmokeError, not a crash."""
+    with pytest.raises(smoke.SmokeError, match="wrote its cookie"):
+        smoke.check_cookie(tmp_path / "no-such-cookie")
+
+
+def test_check_cookie_rejects_the_wrong_user(smoke: ModuleType, tmp_path: Path) -> None:
+    """The cookie's user field has to be `COOKIE_USER`."""
+    cookie = tmp_path / ".cookie"
+    cookie.write_text("someoneelse:s3cr3t", encoding="utf-8")
+    with pytest.raises(smoke.SmokeError, match=f"names {smoke.COOKIE_USER}"):
+        smoke.check_cookie(cookie)
+
+
+def test_check_cookie_rejects_an_empty_password(
+    smoke: ModuleType, tmp_path: Path
+) -> None:
+    """A cookie with nothing after the colon has no password to check."""
+    cookie = tmp_path / ".cookie"
+    cookie.write_text(f"{smoke.COOKIE_USER}:", encoding="utf-8")
+    with pytest.raises(smoke.SmokeError, match="carries a password"):
+        smoke.check_cookie(cookie)
+
+
+def test_print_log_tail_prints_only_the_last_lines(
+    smoke: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Only the last `LOG_TAIL_LINES` lines of the log reach stderr."""
+    datadir = tmp_path
+    log = datadir / smoke.DATADIR_SUBDIR / "debug.log"
+    log.parent.mkdir(parents=True)
+    lines = [f"line {n}" for n in range(smoke.LOG_TAIL_LINES + 5)]
+    log.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    smoke.print_log_tail(datadir)
+
+    err = capsys.readouterr().err
+    assert "line 4\n" not in err
+    assert "line 5" in err
+    assert f"line {smoke.LOG_TAIL_LINES + 4}" in err
+
+
+def test_print_log_tail_is_silent_when_there_is_no_log(
+    smoke: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No debug.log at all prints nothing, rather than failing to read one."""
+    smoke.print_log_tail(tmp_path)
+    assert capsys.readouterr().err == ""
+
+
+def test_main_requires_every_argument(
+    smoke: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Argparse's own failure, which needs no bitcoind to reach.
+
+    Called in-process rather than through a subprocess: a subprocess runs
+    in its own interpreter, and this project collects no coverage from
+    one, which would leave `main`'s own argument parsing looking untested
+    when it is exactly what this covers.
+    """
+    monkeypatch.setattr(sys, "argv", ["rpc_smoke.py"])
+    with pytest.raises(SystemExit) as excinfo:
+        smoke.main()
+    assert excinfo.value.code == 2
+    assert "--bitcoind" in capsys.readouterr().err
+
+
+def test_main_rejects_an_unknown_protocol(
+    smoke: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`--protocol` only accepts the two json-rpc versions Core speaks."""
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "rpc_smoke.py",
+            "--bitcoind",
+            "/does/not/matter",
+            "--core-version",
+            "27.2",
+            "--protocol",
+            "1.0",
+        ],
+    )
+    with pytest.raises(SystemExit) as excinfo:
+        smoke.main()
+    assert excinfo.value.code == 2
+    assert "--protocol" in capsys.readouterr().err
+
+
+def test_the_main_guard_runs_the_script_as___main__(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Cover `if __name__ == "__main__":` without a subprocess or a node.
+
+    `runpy.run_path` executes the file fresh with `__name__` set to
+    `"__main__"` in this interpreter, so the guard is under test; an
+    argument argparse itself refuses is what lets that happen with no
+    `--bitcoind` needed -- the failure is raised evaluating `main()`,
+    before anything past argument parsing runs.
+    """
+    monkeypatch.setattr(sys, "argv", ["rpc_smoke.py"])
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(_SCRIPT), run_name="__main__")
+    assert excinfo.value.code == 2
+    assert "--bitcoind" in capsys.readouterr().err

--- a/tests/script/__init__.py
+++ b/tests/script/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/__init__.py
+++ b/tests/script/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Non-regression tests for btclib.script."""
 
 from collections.abc import Callable

--- a/tests/script/op_codes_taproot_test.py
+++ b/tests/script/op_codes_taproot_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/op_codes_taproot_test.py
+++ b/tests/script/op_codes_taproot_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.script.op_codes_tapscript` module."""
 
 import pytest

--- a/tests/script/script_pub_key_test.py
+++ b/tests/script/script_pub_key_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/script_pub_key_test.py
+++ b/tests/script/script_pub_key_test.py
@@ -865,7 +865,9 @@ def test_the_two_index_errors_the_broad_catch_was_hiding() -> None:
     exception contract -- and _is_funct turned both into a plain False by
     catching Exception. Narrowing the catch to ValueError needed them fixed
     first, or is_nulldata(b"\\x6a") would have started raising.
-    """
+    """  # noqa: D301
+    # `b"\x6a"` above is the literal text of the code quoted, backslash
+    # and all: an r prefix would double that backslash instead
     # a lone OP_RETURN: no data length marker to read
     with pytest.raises(BTClibValueError, match="missing data length marker"):
         assert_nulldata(b"\x6a")

--- a/tests/script/script_pub_key_test.py
+++ b/tests/script/script_pub_key_test.py
@@ -643,7 +643,7 @@ BIP67_VECTORS = load("script", "_data", "bip67_test_vectors.json")
 
 
 @pytest.mark.parametrize(
-    ("keys", "addr"),
+    "keys, addr",
     [
         pytest.param(keys, addr, id=vector_id(int(i), addr))
         for i, (keys, addr) in BIP67_VECTORS.items()

--- a/tests/script/script_pub_key_test.py
+++ b/tests/script/script_pub_key_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.script.script_pub_key` module."""
 
 from __future__ import annotations

--- a/tests/script/script_test.py
+++ b/tests/script/script_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/script_test.py
+++ b/tests/script/script_test.py
@@ -306,7 +306,7 @@ def test_op_int_serialization() -> None:
 
 def test_integer_serialization() -> None:
     """Verify integers parse back as data, warned only in [0, 16]."""
-    assert ["OP_0"] == parse(b"\x00")
+    assert parse(b"\x00") == ["OP_0"]
 
     # [0, 16] is exactly the range with a shorter op code form, so every
     # serialize() below warns; from 17 on, none does

--- a/tests/script/script_test.py
+++ b/tests/script/script_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.script.script` module."""
 
 from __future__ import annotations

--- a/tests/script/sig_hash_legacy_test.py
+++ b/tests/script/sig_hash_legacy_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/sig_hash_legacy_test.py
+++ b/tests/script/sig_hash_legacy_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.sig_hash` module.
 
 - https://github.com/bitcoin/bitcoin/blob/master/src/test/data/sighash.json

--- a/tests/script/sig_hash_legacy_test.py
+++ b/tests/script/sig_hash_legacy_test.py
@@ -223,7 +223,7 @@ SIG_HASH_VECTORS = [
 
 
 @pytest.mark.parametrize(
-    ("raw_tx", "raw_script", "input_index", "hash_type", "exp_hash"), SIG_HASH_VECTORS
+    "raw_tx, raw_script, input_index, hash_type, exp_hash", SIG_HASH_VECTORS
 )
 def test_test_vectors(
     raw_tx: str, raw_script: str, input_index: int, hash_type: int, exp_hash: str

--- a/tests/script/sig_hash_precomputed_test.py
+++ b/tests/script/sig_hash_precomputed_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/sig_hash_precomputed_test.py
+++ b/tests/script/sig_hash_precomputed_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for `sig_hash.PrecomputedTxData`.
 
 No vector file here: what is asserted is that computing the

--- a/tests/script/sig_hash_script_code_test.py
+++ b/tests/script/sig_hash_script_code_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/sig_hash_script_code_test.py
+++ b/tests/script/sig_hash_script_code_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the script code a sig_hash commits to (issue #176).
 
 The script code is a *slice of the script's own bytes*, and every test

--- a/tests/script/sig_hash_segwitv0_test.py
+++ b/tests/script/sig_hash_segwitv0_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/sig_hash_segwitv0_test.py
+++ b/tests/script/sig_hash_segwitv0_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.sig_hash` module.
 
 test vector at

--- a/tests/script/sig_hash_taproot_test.py
+++ b/tests/script/sig_hash_taproot_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/sig_hash_taproot_test.py
+++ b/tests/script/sig_hash_taproot_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.sig_hash` module.
 
 Two vendored files, from two upstreams:

--- a/tests/script/sig_ops_test.py
+++ b/tests/script/sig_ops_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/sig_ops_test.py
+++ b/tests/script/sig_ops_test.py
@@ -26,7 +26,7 @@ _MAX = MAX_PUBKEYS_PER_MULTISIG
 
 
 @pytest.mark.parametrize(
-    ("count", "script"),
+    "count, script",
     [
         pytest.param(0, b"", id="an-empty-script-announces-nothing"),
         pytest.param(1, serialize([_KEY, "OP_CHECKSIG"]), id="p2pk"),

--- a/tests/script/sig_ops_test.py
+++ b/tests/script/sig_ops_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.script.sig_ops` module.
 
 Bitcoin Core's `CScript::GetSigOpCount(false)`, the count the block rule

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.script.taproot` module.
 
 The same two vendored files as `sig_hash_taproot_test.py`, and the same

--- a/tests/script/witness_test.py
+++ b/tests/script/witness_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script/witness_test.py
+++ b/tests/script/witness_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.script.witness` module."""
 
 from dataclasses import FrozenInstanceError

--- a/tests/script_engine/__init__.py
+++ b/tests/script_engine/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script_engine/__init__.py
+++ b/tests/script_engine/__init__.py
@@ -32,7 +32,7 @@ def parse_script(bitcoin_core_script: str) -> str:
             script_pub_key += serialize([bytes(y[1:-1], "ascii")]).hex()
         else:
             if y[:3] != "OP_":
-                y = f"OP_{y}"
+                y = f"OP_{y}"  # noqa: PLW2901
             script_pub_key += BYTE_FROM_OP_CODE_NAME[y].hex()
     return script_pub_key
 

--- a/tests/script_engine/__init__.py
+++ b/tests/script_engine/__init__.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Btclib.script.engine non-regression tests."""
 
 import warnings

--- a/tests/script_engine/flags_test.py
+++ b/tests/script_engine/flags_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script_engine/flags_test.py
+++ b/tests/script_engine/flags_test.py
@@ -75,7 +75,7 @@ def test_all_flags_is_the_consensus_set() -> None:
 
 
 @pytest.mark.parametrize(
-    ("flags", "expected"),
+    "flags, expected",
     [
         (None, ALL_FLAGS),
         (ALL_FLAGS, ALL_FLAGS),

--- a/tests/script_engine/flags_test.py
+++ b/tests/script_engine/flags_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.script.engine.flags` module."""
 
 import re

--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """The vendored consensus vectors, judged by the Python implementation.
 
 The engine imports its signature verification from the bindings, which

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.script.engine` module.
 
 The vectors are Bitcoin Core's `src/test/data/script_tests.json`, entire

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -300,7 +300,7 @@ def test_ifdup_casts_to_bool() -> None:
 
 
 @pytest.mark.parametrize(
-    ("script", "message"),
+    "script, message",
     [
         (
             ["OP_0", "OP_1NEGATE", "OP_1NEGATE", "OP_CHECKMULTISIG"],

--- a/tests/script_engine/transactions_test.py
+++ b/tests/script_engine/transactions_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/script_engine/transactions_test.py
+++ b/tests/script_engine/transactions_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.script.engine` module.
 
 Three vendored files, none of them from a BIP, and all three under the

--- a/tests/slip132_test.py
+++ b/tests/slip132_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/slip132_test.py
+++ b/tests/slip132_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.slip132` module."""
 
 from __future__ import annotations

--- a/tests/to_key_test.py
+++ b/tests/to_key_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/to_key_test.py
+++ b/tests/to_key_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Test vectors of valid and invalid keys.
 
 Used by `btclib.tests.to_pub_key` and `btclib.tests.to_pub_key` modules.

--- a/tests/to_prv_key_test.py
+++ b/tests/to_prv_key_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/to_prv_key_test.py
+++ b/tests/to_prv_key_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.to_prv_key` module."""
 
 # Third party imports

--- a/tests/to_pub_key_test.py
+++ b/tests/to_pub_key_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/to_pub_key_test.py
+++ b/tests/to_pub_key_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.to_pub_key` module."""
 
 from collections.abc import Callable, Sequence

--- a/tests/to_pub_key_test.py
+++ b/tests/to_pub_key_test.py
@@ -80,7 +80,7 @@ def _check_point(point_from: Callable[..., Point], key: Key) -> None:
     has that scalar: secp256r1 answers with the r1 point rather than
     raising, which is why the int forms skip the check.
     """
-    assert Q == point_from(key)
+    assert point_from(key) == Q
     if not isinstance(key, int):
         with pytest.raises(BTClibValueError):
             point_from(key, secp256r1)

--- a/tests/tx/__init__.py
+++ b/tests/tx/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/tx/__init__.py
+++ b/tests/tx/__init__.py
@@ -1,10 +1,6 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Non-regression tests for btclib.tx."""

--- a/tests/tx/out_point_test.py
+++ b/tests/tx/out_point_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/tx/out_point_test.py
+++ b/tests/tx/out_point_test.py
@@ -6,7 +6,7 @@
 """Tests for the `btclib.tx_in` module."""
 
 from dataclasses import FrozenInstanceError
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -60,8 +60,8 @@ def test_frozen() -> None:
 def test_dataclasses_json_dict_out_point(json_golden: JsonGolden) -> None:
     """Round-trip an OutPoint through dict, against the golden json."""
     fname = "d4f3c2c3c218be868c77ae31bedb497e2f908d6ee5bbbe91e4933e6da680c970.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as binary_file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as binary_file_:
         temp = Tx.parse(binary_file_.read())
 
     out_point_data = temp.vin[0].prev_out

--- a/tests/tx/out_point_test.py
+++ b/tests/tx/out_point_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.tx_in` module."""
 
 from dataclasses import FrozenInstanceError

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.tx_in` module."""
 
 from dataclasses import FrozenInstanceError

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -6,7 +6,7 @@
 """Tests for the `btclib.tx_in` module."""
 
 from dataclasses import FrozenInstanceError
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -134,8 +134,8 @@ def test_an_empty_witness_is_still_validated() -> None:
 def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
     """Compare a real input's to_dict with its golden json, and back."""
     fname = "d4f3c2c3c218be868c77ae31bedb497e2f908d6ee5bbbe91e4933e6da680c970.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as binary_file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as binary_file_:
         temp = Tx.parse(binary_file_.read())
 
     tx_in = temp.vin[0]

--- a/tests/tx/tx_out_test.py
+++ b/tests/tx/tx_out_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/tx/tx_out_test.py
+++ b/tests/tx/tx_out_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.tx_out` module."""
 
 from dataclasses import FrozenInstanceError

--- a/tests/tx/tx_out_test.py
+++ b/tests/tx/tx_out_test.py
@@ -6,7 +6,7 @@
 """Tests for the `btclib.tx_out` module."""
 
 from dataclasses import FrozenInstanceError
-from os import path
+from pathlib import Path
 
 import pytest
 
@@ -113,8 +113,8 @@ def test_tx_out_from_address() -> None:
 def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
     """Round-trip a parsed output's dict, held to the committed json."""
     fname = "d4f3c2c3c218be868c77ae31bedb497e2f908d6ee5bbbe91e4933e6da680c970.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as binary_file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as binary_file_:
         temp = Tx.parse(binary_file_.read())
 
     tx_out_data = temp.vout[0]

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -814,7 +814,7 @@ def test_eq_witness(monkeypatch: pytest.MonkeyPatch) -> None:
     the whole of the answer.
     """
 
-    class TxInIgnoringWitness(TxIn):
+    class TxInIgnoringWitness(TxIn):  # noqa: PLW1641
         """A TxIn compared on everything but its witness."""
 
         def __eq__(self, other: object) -> bool:

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.tx` module.
 
 `_data/<txid>.bin` is consensus bytes rather than a vendored vector: the

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -15,7 +15,7 @@ tests/_data/README.md has its size and wtxid.
 import dataclasses
 import inspect
 from collections.abc import MutableSequence
-from os import path
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -563,8 +563,8 @@ def test_double_witness() -> None:
 def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
     """Round-trip a segwit Tx through its dict and golden json."""
     fname = "d4f3c2c3c218be868c77ae31bedb497e2f908d6ee5bbbe91e4933e6da680c970.bin"
-    filename = path.join(path.dirname(__file__), "_data", fname)
-    with open(filename, "rb") as binary_file_:
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as binary_file_:
         tx = Tx.parse(binary_file_.read())
 
     # Tx dataclass, which is what `fields` reads and `isinstance` cannot

--- a/tests/tx_or_psbt_test.py
+++ b/tests/tx_or_psbt_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/tx_or_psbt_test.py
+++ b/tests/tx_or_psbt_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.tx_or_psbt` module."""
 
 from __future__ import annotations

--- a/tests/tx_or_psbt_test.py
+++ b/tests/tx_or_psbt_test.py
@@ -95,7 +95,7 @@ def test_check_validity_reaches_the_parser() -> None:
 
 
 @pytest.mark.parametrize(
-    ("data", "err_msg"),
+    "data, err_msg",
     [
         pytest.param("", "no data", id="an empty string"),
         pytest.param(b"", "no data", id="empty bytes"),

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.utils` module."""
 
 import random

--- a/tests/var_bytes_test.py
+++ b/tests/var_bytes_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/var_bytes_test.py
+++ b/tests/var_bytes_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.var_bytes` module."""
 
 from io import BytesIO

--- a/tests/var_int_test.py
+++ b/tests/var_int_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/var_int_test.py
+++ b/tests/var_int_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """Tests for the `btclib.var_int` module."""
 
 import pytest

--- a/tests/vendored_data_test.py
+++ b/tests/vendored_data_test.py
@@ -1,4 +1,4 @@
-# Copyright (C) The btclib developers
+# Copyright (c) The btclib developers
 #
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.

--- a/tests/vendored_data_test.py
+++ b/tests/vendored_data_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
-
 # Copyright (C) The btclib developers
 #
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
 """What `tests/_data/README.md` must not say about itself.
 
 The same claim `release_notes_test.py` forbids CHANGELOG.md, for the same


### PR DESCRIPTION
## Summary

Three groups of work landed on this branch across several sessions. The
description below covered only the first; the others are what answering
#397 turned up along the way, plus two independently tracked fixes.

**RELEASING.md and the `published` workflow — closes #394, #393, #397**

- **#394** — adds "Which version string is which" to RELEASING.md,
  disambiguating the five strings a release cycle produces that look
  like a version, and states explicitly that a three-component version
  is always the release day and a four-component one always a patch on
  it. Also adds the missing detail on the approval gate: the OIDC token
  exchange happens *after* it, so a mismatched publisher fails having
  uploaded nothing and the version survives.
- **#393** — adds a post-publish verification step to RELEASING.md
  (install from PyPI, exercise a BIP39 seed rather than only import,
  since 25 files under `btclib/*/_data/` are opened by path and not
  imported) and a step to check the PEP 740 attestations. Restores a
  `published` workflow with a job that installs btclib from PyPI on
  every platform and asserts the same two things, on a schedule.
- **#397** — the same workflow's other job answers the question that
  issue asked: whether a sentinel aimed at `btclib_libsecp256k1` alone
  is worth keeping now that `--no-sources` is a no-op. Restored, with
  `uv lock --upgrade-package btclib_libsecp256k1` in place of the
  `tool.uv.sources` table #390 removed, and moved to `latest.yml`
  (`test-bindings-latest`) rather than kept in `published.yml`, since
  the question is about a tree not yet released.

**Two independently tracked fixes — closes #392, #389**

- **#392** — `timeout`'s default SIGTERM kills a mutation session
  mid-mutant, before the `finally` that restores the tracked file can
  run. `--signal=INT` turns it into a catchable `KeyboardInterrupt`
  instead; belt and braces, `git diff --quiet` after every session
  restores the file regardless of what left it mutated.
- **#389** — `LICENSE`, `btclib.__copyright__` and `pyproject.toml`'s
  `license-files` comment had drifted: different holders, and a comment
  describing an `AUTHORS.md` role that no longer matches what the file
  is for. The holder is now `The btclib developers` everywhere this
  project writes its own notice (a third party's own quoted notice —
  Core's, Wuille's, Electrum's — keeps whatever case they wrote). A new
  test reads LICENSE, `__copyright__` and the declared author back and
  compares them, so the drift fails the suite instead of sitting
  unnoticed. The MIT template's lowercase `Copyright (c)` replaces this
  project's own `Copyright (C)`, matching the license text rather than
  a second, unexplained casing beside it.

**A ruff/mypy/pathlib sweep, seeded by comparing config with the
bindings while answering #397**

- **PTH**: 130 `os.path`/bare `open()` call sites (23 in the library)
  converted to `pathlib.Path`. `network.datadir` and
  `curves.curve.datadir` become `Path` themselves — a breaking change,
  recorded in HISTORY.md; `mnemonic.data_file` and
  `WordLists.load_lang` keep `str` and cast at the pathlib boundary,
  since each takes a caller's own filename rather than promising a
  path.
- **`parametrize`'s name argument**: csv string, not tuple — 89 call
  sites over 37 files, ruff's own (unsafe) autofix, reviewed.
- the last three mypy codes this project had never enabled
  (`redundant-expr`, `possibly-undefined`, `warn_unreachable`): eight
  real findings get a local `# type: ignore[code]` rather than the
  check staying off everywhere; the ninth (`ssa_test.py`'s retry loop)
  restructured so the ambiguity mypy saw is gone rather than
  suppressed.
- every remaining ruff ignore in `.pre-commit-config.yaml` re-measured
  against its own `--select`: four (D406, D407, PLR0904, PLR0914) found
  nothing and are dropped entirely; five move from a blanket ignore to
  a `# noqa` at the handful of sites that actually fire; D301/D405/D413
  fixed rather than ignored — one, `utils.py`'s `b'\xde\xad\xbe\xef'`
  docstring, was a real rendering bug; SIM300 enabled (every site
  ruff's own autofix); five previously-unsurveyed rule sets (FA, FIX,
  FLY, SLOT, T10) added at zero findings.
- a floor pinned on `uv` itself, matching the bindings' own guard, so
  an older `uv` cannot silently rewrite `uv.lock` into a format the
  pinned `uv-lock` hook then fails to read.
- file headers: the shebang dropped from 210 non-executable files, the
  restrictive-reading opening line replaced with one naming the MIT
  license up front, a blank line after the header added to match the
  bindings' own files.
- `tests/_data/README.md`'s vendored-vector pins get a monthly
  automated re-check against upstream, reporting drift by opening or
  updating a tracking issue rather than fixing it silently; four pins
  already reviewed by hand and left alone by that check are
  re-verified against the current tip and re-pinned.

**Repository configuration**

- `required_conversation_resolution` added to `dev`'s branch
  protection, matching `master` and the bindings' own `dev`.
- the four weekday sentinel workflows (`links`, `published`, `latest`,
  `mutation`) ordered by how volatile the question each asks is;
  `latest.yml` gets a comment noting GitHub suspends a cron trigger
  after 60 days without repository activity.

**The merge fix**

`origin/dev` landed three tests and a `parametrize` call in the
`os.path`/tuple idiom while this branch was converting the whole tree
away from both, so the automatic merge was textually clean but broke
at four sites this branch's own conventions cover (three `NameError`
on `path`, one `PT006`). Merged `dev` into this branch directly rather
than rebasing it, and fixed the four sites in the idiom the rest of
each file already uses.

## Test plan

- [x] `uv run --locked pre-commit run --all-files --show-diff-on-failure`
  exits 0 — every hook, ruff, mypy and sphinx's linked-check siblings
  included
- [x] `uv run --locked --no-default-groups --group test pytest
  --cov-report term-missing:skip-covered --cov=btclib --cov=tests` —
  17322 passed, coverage 100.00%
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` exits 0
- [x] both new RELEASING.md shell snippets (the BIP39 seed, the dsa
  round trip) run verbatim against the current tree and match the
  values documented
- [x] `uv lock --upgrade-package btclib_libsecp256k1` runs cleanly (a
  no-op today, the lock already at 0.7.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
