### PR TITLE
Skip the ?-filename case of mutation_counts_test.py on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4644,6 +4644,15 @@ edit.
 
 ### Packaging, linting and CI
 
+- **`tests/mutation_counts_test.py` skips its `?` filename case on
+  Windows**, now that `test.yml`'s matrix runs `windows-latest` and
+  `windows-11-arm` again. The case exists to show that `_read_only`'s URI
+  construction treats `?` as an ordinary filename character rather than
+  `file:{path}?mode=ro`'s query-string delimiter, and NTFS refuses that
+  character in a filename outright, so there is no such file for the
+  fixture to write there. `#`, the other delimiter the same parametrize
+  covers, is ordinary on NTFS and keeps running everywhere, so the
+  escaping stays covered on every platform the matrix tests.
 - **mutation testing reaches the wire format**, a third configuration and a
   second job (issue #327). `.github/mutation/parsers.toml` mutates
   `btclib/tx/` with the `var_int` and `var_bytes` codecs under it: the

--- a/tests/mutation_counts_test.py
+++ b/tests/mutation_counts_test.py
@@ -152,7 +152,19 @@ def test_an_outcome_that_is_no_verdict_is_named_and_is_not_sound(
     assert "no-test 1" in line
 
 
-@pytest.mark.parametrize("name", ["session?copy.sqlite", "session#copy.sqlite"])
+@pytest.mark.parametrize(
+    "name",
+    [
+        pytest.param(
+            "session?copy.sqlite",
+            marks=pytest.mark.skipif(
+                sys.platform == "win32",
+                reason="NTFS refuses `?` in a filename, so there is none to write",
+            ),
+        ),
+        "session#copy.sqlite",
+    ],
+)
 def test_a_session_whose_name_is_not_a_uri(
     counter: ModuleType, tmp_path: Path, name: str
 ) -> None:
@@ -163,6 +175,10 @@ def test_a_session_whose_name_is_not_a_uri(
     `no such table`, and a `session` created beside it -- the `mode=ro` that
     would have forbidden the creation having been parsed as part of the name.
     A downloaded session artifact is exactly where a `?` in a name comes from.
+
+    Skipped for `?` on Windows: NTFS refuses that character in a filename, so
+    the fixture has no file to write there, and `#` alone still exercises the
+    same escaping on that platform.
     """
     line, sound = counter.report(
         counter.counts(session(tmp_path / name, [("KILLED", "NORMAL")] * 2)), 2


### PR DESCRIPTION
## What is red

`bd730b36` restored `macos-26-intel`, `macos-latest`, `windows-latest` and
`windows-11-arm` in `test.yml`'s matrix, commented out until then. macOS
passes. Every Windows cell (seven interpreters on `windows-latest`, seven on
`windows-11-arm`) fails on the same test:

```
FAILED tests/mutation_counts_test.py::test_a_session_whose_name_is_not_a_uri[session?copy.sqlite]
sqlite3.OperationalError: unable to open database file
```

This blocks #126 (`dev` → `master`), currently `BLOCKED` with fifteen red
checks, all this same test on different interpreters.

## Why

`?` is one of the characters NTFS refuses in a filename outright, so
`tmp_path / "session?copy.sqlite"` cannot be created on Windows at all —
the fixture's own `sqlite3.connect(path)` fails before the module under
test, `.github/scripts/mutation_counts.py`, ever sees the file. This is a
limit of the filesystem the test runs on, not a defect in `_read_only`'s
URI construction, which is what the test exists to check.

The parametrize's other case, `session#copy.sqlite`, uses the *other*
character `file:{path}?mode=ro` would otherwise misparse as a query-string
delimiter, and `#` is ordinary on NTFS — it passes on every platform
already, and keeps exercising the same escaping on Windows once the `?`
case is skipped there.

## What changes

`tests/mutation_counts_test.py`: the `?` parameter gets
`pytest.mark.skipif(sys.platform == "win32", ...)` via `pytest.param(...,
marks=...)`, with the docstring saying why. Nothing in
`.github/scripts/mutation_counts.py` changes.

## Verified

- `uv run pytest --cov-report term-missing:skip-covered --cov=btclib
  --cov=tests` — 17278 passed, 100.00% coverage (the CI `coverage-py`
  command from `tests/README.md`).
- `uv run pre-commit run --files CHANGELOG.md tests/mutation_counts_test.py`
  — every hook passed, including mypy strict.
- The skip mechanics themselves, isolated from this suite (this interpreter
  cannot fake `sys.platform == "win32"` without breaking stdlib imports that
  branch on it): a throwaway `pytest.param(..., marks=pytest.mark.skipif(True,
  ...))` skips exactly the marked case and runs the other, confirming the
  marks are wired the way this fix relies on.

## Note

CHANGELOG.md gets an entry under "Packaging, linting and CI"; this is a test
portability fix with no change to library behavior.

## Summary by Sourcery

Skip a Windows-incompatible test case that uses a `?` in a filename while preserving URI-escaping coverage via the remaining case.

Documentation:
- Document the Windows-specific test skip and its rationale in the changelog under packaging, linting, and CI.

Tests:
- Skip the `session?copy.sqlite` parameterized case on Windows due to NTFS filename restrictions, keeping the `session#copy.sqlite` case active across all platforms.