### PR TITLE
Name the sighash byte's seven values, and narrow only PsbtIn's field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3548,6 +3548,25 @@ edit.
   against the data instead: `network_test.py` against
   `dataclasses.fields(Network)` and `NETWORKS`, `mnemonic_test.py` against a
   fresh `WordLists`
+- **the sighash byte gets a `Literal` too, narrower than #216's four**
+  (issue #273). `alias.ValidSigHashType` names the seven values
+  `sig_hash.SIG_HASH_TYPES` already enforces — the low bits' four values
+  and each ORed with `ANYONECANPAY` — and types only `PsbtIn.sig_hash_type`,
+  the one place this vocabulary is closed. Not an `IntFlag` over the whole
+  byte: `SINGLE == ALL | NONE`, both 3, so a flag decomposition would make
+  `SINGLE` an alias of `ALL | NONE`, a bit structure the protocol does not
+  have. Not an `IntEnum` either, and on neither side of the boundary:
+  `legacy` and `segwit_v0` mask a hash type rather than validate it, so a
+  byte such as `0x05` must still hash, being a value a mined signature can
+  carry, which is why `assert_valid_hash_type` keeps `hash_type: int` and
+  is checked against all 256 possible bytes by
+  `sig_hash_taproot_test.py`'s own `test_valid_sighash_type` — a call a
+  `Literal`-typed parameter could not be given under mypy strict. The one
+  cost: `psbt_test.py`'s out-of-range `sig_hash_type` assignment now reads
+  `# type: ignore[assignment]`, the same way its neighbouring bad-value
+  assignments already do. `psbt_in_test.py` checks `ValidSigHashType`
+  against `SIG_HASH_TYPES`, the way `network_test.py` checks #216's two
+  data-derived aliases
 
 ### Performance
 

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -55,6 +55,7 @@ __all__ = [
     "TaprootLeaf",
     "TaprootLeafPaths",
     "TaprootScriptTree",
+    "ValidSigHashType",
 ]
 
 # Octets are a sequence of eight-bit bytes or a hex-string (not text string)
@@ -248,6 +249,22 @@ MnemonicLang = Literal[
     "zh_tw",
     "slip39",
 ]
+
+# The seven hash types script.sig_hash.SIG_HASH_TYPES allows: the low
+# five bits' four values -- DEFAULT, ALL, NONE, SINGLE -- alone and each
+# ORed with ANYONECANPAY. Not an IntFlag over the whole byte: SINGLE ==
+# ALL | NONE, both being 3, so a flag decomposition would make SINGLE an
+# alias of ALL | NONE, a bit structure the protocol does not have (issue
+# #273). Not an IntEnum either: the wire is wider than these seven --
+# `legacy` and `segwit_v0` mask rather than validate, and a byte such as
+# 0x05 must still hash, being a value a mined signature can carry -- so
+# assert_valid_hash_type keeps `hash_type: int` and checks a plain int
+# against all 256 possible bytes (sig_hash_taproot_test.py's
+# test_valid_sighash_type), which a Literal-typed parameter could not be
+# called with. Narrowed only where the wire is already closed:
+# PsbtIn.sig_hash_type, checked against this same set once truthy.
+# psbt_in_test.py checks the two stay equal
+ValidSigHashType = Literal[0, 1, 2, 3, 129, 130, 131]
 
 
 # The four address encodings a purpose level can name: 44 is p2pkh, 49

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -20,7 +20,7 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
-from btclib.alias import BinaryData, Octets
+from btclib.alias import BinaryData, Octets, ValidSigHashType
 from btclib.bip32.key_origin import (
     BIP32KeyOrigin,
     HdKeyPaths,
@@ -520,7 +520,7 @@ class PsbtIn:
     non_witness_utxo: Tx | None
     witness_utxo: TxOut | None
     partial_sigs: dict[bytes, bytes]
-    sig_hash_type: int | None
+    sig_hash_type: ValidSigHashType | None
     redeem_script: bytes
     witness_script: bytes
     hd_key_paths: HdKeyPaths
@@ -569,7 +569,7 @@ class PsbtIn:
         non_witness_utxo: Tx | None = None,
         witness_utxo: TxOut | None = None,
         partial_sigs: Mapping[Octets, Octets] | None = None,
-        sig_hash_type: int | None = None,
+        sig_hash_type: ValidSigHashType | None = None,
         redeem_script: Octets = b"",
         witness_script: Octets = b"",
         hd_key_paths: Mapping[Octets, BIP32KeyOrigin] | None = None,

--- a/tests/psbt/psbt_in_test.py
+++ b/tests/psbt/psbt_in_test.py
@@ -11,10 +11,11 @@
 
 from dataclasses import FrozenInstanceError, fields
 from io import BytesIO
-from typing import Any
+from typing import Any, get_args
 
 import pytest
 
+from btclib.alias import ValidSigHashType
 from btclib.bip32 import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
 from btclib.psbt import Psbt, PsbtIn
@@ -26,6 +27,7 @@ from btclib.psbt.psbt_in import (
 )
 from btclib.psbt.psbt_utils import PSBT_SEPARATOR
 from btclib.script import Witness
+from btclib.script.sig_hash import SIG_HASH_TYPES
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests.conftest import JsonGolden
 
@@ -76,6 +78,16 @@ def test_the_sig_hash_type_is_four_octets_and_no_other_number_of_them() -> None:
         for check_validity in (True, False):
             with pytest.raises(BTClibValueError, match=err_msg):
                 PsbtIn.parse(raw, check_validity=check_validity)
+
+
+def test_valid_sig_hash_type_matches_sig_hash_types() -> None:
+    """ValidSigHashType is a mypy fact about sig_hash_type, checked here.
+
+    Nothing of a Literal exists at run time (issue #273), so what mypy
+    cannot check against sig_hash.assert_valid_hash_type's own frozenset,
+    the suite does.
+    """
+    assert set(get_args(ValidSigHashType)) == SIG_HASH_TYPES
 
 
 def test_compatibility() -> None:

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -1498,7 +1498,7 @@ def test_exceptions() -> None:
         psbt.serialize()
 
     psbt = Psbt.b64decode(psbt_str)
-    psbt.inputs[0].sig_hash_type = 101
+    psbt.inputs[0].sig_hash_type = 101  # type: ignore[assignment]
     with pytest.raises(BTClibValueError, match="invalid sig_hash type: "):
         psbt.serialize()
 


### PR DESCRIPTION
Issue #216 deferred this vocabulary on purpose: "the enum would be an
IntFlag and the compatibility story is different -- a serialized byte,
not a name. Worth deciding after these, not with them." #273 is that
question, and this is the maintainer's own answer on it, implemented:
**`Literal`, one alias, narrowed only where the vocabulary is closed** --
the same discipline #226 already applied to the four `str` vocabularies.

## Why not IntFlag, why not IntEnum

Both are ruled out on the values themselves, not on taste, as #273
measured.

**`IntFlag` over the whole byte is wrong**: `SINGLE == ALL | NONE`, both
being 3. A flag decomposition would make `SINGLE` an alias of `ALL |
NONE`, a bit structure the protocol does not have. The low five bits are
an enumeration read with a mask, and only `ANYONECANPAY` is a flag.

**`IntEnum` is wrong on either side of the boundary, and not for a
formatting reason this time.** The four `str` vocabularies of #226 were
ruled out by a Python-version formatting split (`class Net(str, Enum)`
reads differently on 3.10 than on 3.11+); this one is ruled out because
the wire is wider than the seven values: `legacy` and `segwit_v0` mask a
hash type rather than validate it, so a byte such as `0x05` must still
hash -- it is a value a mined signature can carry. `assert_valid_hash_type`
keeps `hash_type: int` for exactly that reason, and it is not a stylistic
choice: `sig_hash_taproot_test.py`'s existing `test_valid_sighash_type`
calls it with all 256 possible bytes, a call a `Literal`-typed parameter
could not be given under mypy strict.

## What is narrowed

Only `PsbtIn.sig_hash_type`, the one place this vocabulary is actually
closed -- `assert_valid` already checks it against `SIG_HASH_TYPES` once
truthy. `alias.ValidSigHashType = Literal[0, 1, 2, 3, 129, 130, 131]`
names that same set.

## What it cost

One test needed a comment, not a rewrite: `psbt_test.py`'s existing test
of an out-of-range `sig_hash_type` assignment (`= 101`) now reads `#
type: ignore[assignment]`, the same way its neighbouring bad-value
assignments in that test already do -- it is still a runtime check
(`BTClibValueError`), which is the point being tested. `psbt_in_test.py`
gets a new test checking `ValidSigHashType` against `SIG_HASH_TYPES`,
the same alignment `network_test.py` already checks for #216's two
data-derived aliases.

`assert_valid_hash_type` itself keeps `hash_type: int`, unnarrowed, for
the reason above.

## Verification

Each gate run as documented, exit code checked:

- `uv run --locked --no-default-groups --group test pytest --cov=btclib --cov=tests`
  -- 17279 passed, 100.00% coverage, exit 0
- `uv run pre-commit run --all-files` -- every hook passed, exit 0 (mypy
  strict over `btclib` and `tests` among them)
- the docs gate, `sphinx-build -W --keep-going` -- build succeeded, exit 0

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a typed alias for valid sighash byte values and narrow PSBT input typing to this closed set while keeping broader validation unchanged.

New Features:
- Define ValidSigHashType Literal alias covering the seven supported sighash byte values and expose it via btclib.alias.
- Type PsbtIn.sig_hash_type as ValidSigHashType where the sighash vocabulary is known to be closed.

Enhancements:
- Add a regression test ensuring ValidSigHashType stays aligned with sig_hash.SIG_HASH_TYPES.
- Document the new sighash Literal typing and its rationale in the changelog, including why IntFlag/IntEnum are not used.

Tests:
- Extend PSBT input tests to verify ValidSigHashType matches the runtime sighash type set and adjust an existing negative test to account for the narrowed type.