### PR TITLE
TxOut's value is CAmount, Core's signed int64_t, not unsigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1137,6 +1137,16 @@ edit.
   own exception contract; it is a `BTClibTypeError` now, `bool` included,
   through the `is_integer` of #326. The bound above is unchanged and its
   message with it
+- **`TxOut`'s eight-byte value is read and written as `CAmount`, Core's
+  signed `int64_t`, not as an unsigned integer** (issue #388). Every valid
+  amount is below MAX_MONEY, hence below 2^63, where the two readings
+  agree; `check_validity=False` is what makes the difference observable,
+  and it now matches Core rather than a `signed=False` nobody had chosen
+  on purpose: eight `ff` octets parse to `-1`, Core's own null-value
+  sentinel for the field, instead of a satoshi count twice MAX_MONEY. The
+  checked parse still refuses either reading, negative or merely too
+  large, and a valid amount serializes exactly as before, the two
+  readings not differing below 2^63. Found while reviewing #386
 
 ### Immutability and shared state
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1146,7 +1146,17 @@ edit.
   sentinel for the field, instead of a satoshi count twice MAX_MONEY. The
   checked parse still refuses either reading, negative or merely too
   large, and a valid amount serializes exactly as before, the two
-  readings not differing below 2^63. Found while reviewing #386
+  readings not differing below 2^63. The three other places the same
+  field goes on the wire move with it, so that one field has one
+  reading: BIP143's `amount`, BIP341's `sha_amounts`, and the amount
+  ANYONECANPAY writes inline. Each wrote the octets a caller had
+  already been handed as a negative integer, so they answered a
+  prevout of `TxOut.parse`'s own making with a bare `OverflowError`
+  from `int.to_bytes` -- reachable through `sig_hash.taproot`,
+  `sig_hash.segwit_v0` and `PrecomputedTxData`, and from outside the
+  exception contract. What each commits to is unchanged, `-1` and
+  `0xffffffffffffffff` being the same eight octets. Found while
+  reviewing #386
 
 ### Immutability and shared state
 

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -332,9 +332,12 @@ def _serialized_outputs(tx: Tx) -> bytes:
 
 
 def _serialized_amounts(prevouts: list[TxOut]) -> bytes:
+    # signed, as TxOut.serialize is and for the same reason: this is the
+    # same CAmount field, Core's `ss << txout.nValue`, so the two must
+    # agree on which integers the eight bytes stand for (issue #388)
     return b"".join(
         [
-            prevout.value.to_bytes(8, byteorder="little", signed=False)
+            prevout.value.to_bytes(8, byteorder="little", signed=True)
             for prevout in prevouts
         ]
     )
@@ -476,7 +479,10 @@ def segwit_v0(
             hash_seqs,
             tx.vin[vin_i].prev_out.serialize(check_validity=False),
             var_bytes.serialize(script_code),
-            amount.to_bytes(8, byteorder="little", signed=False),  # value
+            # a CAmount, signed as TxOut's is: BIP143's `amount` is the
+            # spent output's value, and Core writes it with the same
+            # serializer (issue #388)
+            amount.to_bytes(8, byteorder="little", signed=True),  # value
             tx.vin[vin_i].sequence.to_bytes(4, byteorder="little", signed=False),
             hash_outputs,
             tx.lock_time.to_bytes(4, byteorder="little", signed=False),
@@ -549,7 +555,7 @@ def taproot(
         prevout = prevouts[input_index]
         parts += [
             transaction.vin[input_index].prev_out.serialize(check_validity=False),
-            prevout.value.to_bytes(8, "little"),
+            prevout.value.to_bytes(8, "little", signed=True),  # a CAmount
             var_bytes.serialize(prevout.script_pub_key.script),
             transaction.vin[input_index].nSequence.to_bytes(4, "little"),
         ]

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -291,14 +291,14 @@ def legacy(script_code: Octets, tx: Tx, vin_i: int, hash_type: int) -> bytes:
         # sig_hash single bug
         if vin_i >= len(new_tx.vout):
             return (256**31).to_bytes(32, byteorder="big", signed=False)
-        # every output before the signed one is blanked: value -1 as an
-        # unsigned 8-bytes int, and an empty script_pub_key. Rebuilt one by
-        # one rather than assigned into, TxOut being frozen — and one
-        # instance each, a single blanked TxOut repeated being the aliasing
-        # that issue #139 was about
+        # every output before the signed one is blanked: value -1, Core's
+        # own `nValue = -1` on the CAmount it is (issue #388), and an
+        # empty script_pub_key. Rebuilt one by one rather than assigned
+        # into, TxOut being frozen — and one instance each, a single
+        # blanked TxOut repeated being the aliasing that issue #139 was
+        # about
         new_tx.vout = [
-            TxOut(0xFFFFFFFFFFFFFFFF, ScriptPubKey(b""), check_validity=False)
-            for _ in range(vin_i)
+            TxOut(-1, ScriptPubKey(b""), check_validity=False) for _ in range(vin_i)
         ] + [new_tx.vout[vin_i]]
         _zero_other_sequences(new_tx, vin_i)
 

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -46,7 +46,9 @@ class TxOut:
     having to parse.
     """
 
-    # 8 bytes, unsigned little endian
+    # 8 bytes, little endian, signed -- Core's CAmount is int64_t, and
+    # check_validity=False exposes that: the highest bit set parses as
+    # negative rather than as a satoshi count twice MAX_MONEY (issue 388)
     value: int  # denominated in satoshi
     script_pub_key: ScriptPubKey
 
@@ -125,11 +127,16 @@ class TxOut:
         )
 
     def serialize(self, *, check_validity: bool = True) -> bytes:
-        """Return the wire serialization: the value, then the script."""
+        """Return the wire serialization: the value, then the script.
+
+        The value is written as CAmount, Core's signed int64_t: a valid
+        amount is never negative, but check_validity=False lets one
+        through and it must still fit in the eight bytes it came from.
+        """
         if check_validity:
             self.assert_valid()
 
-        out = self.value.to_bytes(8, byteorder="little", signed=False)
+        out = self.value.to_bytes(8, byteorder="little", signed=True)
         out += var_bytes.serialize(self.script_pub_key.script)
         return out
 
@@ -143,11 +150,14 @@ class TxOut:
         """Build a TxOut by parsing its wire serialization.
 
         The network is mainnet, the wire not carrying one; the script
-        is taken as it comes, scripts on chain not having to parse.
+        is taken as it comes, scripts on chain not having to parse. The
+        value is read as CAmount, Core's signed int64_t: with
+        check_validity=False, a high bit set parses negative -- as it
+        does for Core -- rather than as an amount above MAX_MONEY.
         """
         stream = bytesio_from_binarydata(data)
         value = int.from_bytes(
-            read_exactly(stream, 8, "output value"), byteorder="little", signed=False
+            read_exactly(stream, 8, "output value"), byteorder="little", signed=True
         )
         script = var_bytes.parse(stream)
         assert_no_trailing(data, stream, "transaction output")

--- a/tests/script/sig_hash_segwitv0_test.py
+++ b/tests/script/sig_hash_segwitv0_test.py
@@ -223,7 +223,7 @@ def _bip143_preimage(
             b"\x00" * 32,
             tx.vin[vin_i].prev_out.serialize(),
             var_bytes.serialize(script_code),
-            amount.to_bytes(8, "little"),
+            amount.to_bytes(8, "little", signed=True),  # a CAmount
             tx.vin[vin_i].sequence.to_bytes(4, "little"),
             hash_outputs,
             tx.lock_time.to_bytes(4, "little"),
@@ -291,4 +291,34 @@ def test_sighash_single_past_the_last_output() -> None:
     preimage = _bip143_preimage(tx, 0, script_code, _AMOUNT, hash_outputs)
     assert sig_hash.segwit_v0(script_code, tx, 0, sig_hash.SINGLE, _AMOUNT) == hash256(
         preimage
+    )
+
+
+def test_the_bip143_amount_is_a_signed_camount() -> None:
+    """BIP143's amount is Core's CAmount, so the eight bytes are signed.
+
+    The amount reaches the preimage from a spent output's value, which
+    is a signed int64 (issue #388), so the two must agree on which
+    integers the field stands for: -1 is what eight `ff` octets mean,
+    and writing them is what Core's `ss << amount` does. Asserted as
+    the bytes rather than as a number, the preimage being what is
+    signed -- and hand-written here, as the file's other preimage is.
+    """
+    tx = Tx.parse(_BIP143_TX)
+    script_code = bytes.fromhex(_WITNESS_SCRIPT)
+    hash_outputs = hash256(tx.vout[0].serialize())
+
+    preimage = _bip143_preimage(tx, 0, script_code, _AMOUNT, hash_outputs)
+    assert sig_hash.segwit_v0(script_code, tx, 0, sig_hash.SINGLE, _AMOUNT) == hash256(
+        preimage
+    )
+
+    # the octets a signed and an unsigned reading disagree about: what
+    # goes into the preimage is `ffffffffffffffff` either way, so the
+    # hash is unchanged and only the integer naming those octets moves
+    assert (-1).to_bytes(8, "little", signed=True) == b"\xff" * 8
+    negative = _bip143_preimage(tx, 0, script_code, -1, hash_outputs)
+    assert b"\xff" * 8 in negative
+    assert sig_hash.segwit_v0(script_code, tx, 0, sig_hash.SINGLE, -1) == hash256(
+        negative
     )

--- a/tests/script/sig_hash_taproot_test.py
+++ b/tests/script/sig_hash_taproot_test.py
@@ -29,7 +29,7 @@ import pytest
 from btclib.alias import ScriptList, TaprootScriptTree
 from btclib.ecc import ssa
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
-from btclib.hashes import hash160
+from btclib.hashes import hash160, sha256
 from btclib.script import (
     ScriptPubKey,
     Witness,
@@ -595,3 +595,36 @@ def test_script_path_spend_round_trip(annex: bytes) -> None:
     # the signature on the stack is not part of what is signed: the same
     # message comes back out of the completed spend
     assert sig_hash.from_tx(prevouts, tx, 0, sig_hash.DEFAULT) == msg_hash
+
+
+def test_the_spent_amounts_are_signed_camounts() -> None:
+    """BIP341's sha_amounts holds CAmounts, so its eight-byte words are signed.
+
+    Every amount is a spent output's value, a signed int64 (issue #388),
+    and Core hashes them with `ss << txout.nValue` -- so what
+    `TxOut.parse` reads with the check off must be what this commits to.
+    Eight `ff` octets are -1, and the field carries those octets: the
+    hash is the one an unsigned reading of the same buffer produced,
+    which is the point, only the integer naming them having moved.
+    """
+    high_bit_set = b"\xff" * 8 + b"\x00"  # the value, then an empty script
+    prevout = TxOut.parse(high_bit_set, check_validity=False)
+    assert prevout.value == -1
+
+    tx = Tx(
+        1,
+        0,
+        [TxIn(OutPoint(b"\x11" * 32, 0), b"", 0xFFFFFFFF, Witness([b"\x00" * 64]))],
+        [TxOut(1000, "00141d0f172a0ecb48aee1be1f2687d2963ae33f71a1")],
+    )
+
+    # the octets, and the two entry points that write them: neither
+    # raises the OverflowError an unsigned field answers -1 with
+    precomputed = sig_hash.PrecomputedTxData(tx, [prevout])
+    assert precomputed.sha_amounts == sha256(b"\xff" * 8)
+    assert sig_hash.taproot(tx, 0, [prevout], sig_hash.DEFAULT, 0, b"", b"")
+
+    # and ANYONECANPAY, which writes the one amount inline instead
+    assert sig_hash.taproot(
+        tx, 0, [prevout], sig_hash.ANYONECANPAY | sig_hash.ALL, 0, b"", b""
+    )

--- a/tests/tx/tx_out_test.py
+++ b/tests/tx/tx_out_test.py
@@ -88,15 +88,16 @@ def test_an_eight_byte_value_round_trips_and_is_refused() -> None:
     Every amount a valid output carries is below MoneyRange, hence below
     2^63, where a signed and an unsigned reading of the field agree -- so
     the octets that tell the two apart reach the conversion only with the
-    check off. What is asserted is what holds either way: the buffer comes
-    back byte for byte, so one buffer stays one object rather than two, and
-    the checked parse refuses the amount. Which integer btclib should show
-    for it -- Core's `CAmount` is signed, and reads these as -1 -- is issue
-    388's to answer, and no assertion here decides it.
+    check off. btclib reads the field as Core's `CAmount` does, signed,
+    settling issue 388: the highest bit set parses as -1, not as a
+    satoshi count twice MAX_MONEY, and the buffer comes back byte for
+    byte, so one buffer stays one object rather than two. The checked
+    parse refuses the amount either way, negative or merely too large.
     """
     highest_bit_set = b"\xff" * 8 + b"\x00"  # the value, then an empty script
 
     tx_out = TxOut.parse(highest_bit_set, check_validity=False)
+    assert tx_out.value == -1
     assert tx_out.serialize(check_validity=False) == highest_bit_set
 
     with pytest.raises(BTClibValueError, match="invalid satoshi amount: "):


### PR DESCRIPTION
Closes #388.

`TxOut.parse` read the eight-byte output value with `signed=False`, and
`TxOut.serialize` wrote it the same way. For every valid output the
distinction is invisible: an amount is non-negative and far below
2^63. It becomes observable through the public `check_validity=False`
path, which is where #386's mutation profile found it.

Bitcoin Core defines `CAmount` as `int64_t`, and `CTxOut.nValue` is a
`CAmount` — the same eight `ff` octets are `-1` there, which Core also
uses as `CTxOut`'s null sentinel. This is not a consensus rule (any
transaction carrying either representation is rejected by validation)
but it is the definition of the field, so it is what "align with Core"
means here — not an implementation-style detail of Core's C++.

## Change

- `TxOut.parse` and `TxOut.serialize` both use `signed=True` now.
- `btclib.script.sig_hash.legacy`'s SIGHASH_SINGLE blanking constructed
  the same sentinel as the unsigned bit pattern `0xFFFFFFFFFFFFFFFF`,
  which no longer fits an 8-byte signed round trip; it is `-1`, the
  literal Core itself assigns to `nValue`, and produces the identical
  wire bytes.
- `tests/tx/tx_out_test.py::test_an_eight_byte_value_round_trips_and_is_refused`,
  which explicitly deferred to this issue, now asserts `value == -1`.
- CHANGELOG.md entry under "Malformed input and the exception contract";
  no HISTORY.md entry, matching how the section's other unchecked-path
  fixes (e.g. the empty-witness-element one) are not listed there either
  — narrow edge cases on wire data the checked path already refuses.

Every amount a valid output carries round-trips identically to before;
only the `check_validity=False` reading of an already-invalid amount
changes.

## Test plan

- [x] `uv run pytest --cov` — 17279 passed, coverage gap is pre-existing
      and unrelated (`.github/scripts/mutation_counts.py`, untouched by
      this branch)
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `sphinx-build -W --keep-going -b html docs/source docs/build/html`
      — build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align TxOut value parsing and serialization with Bitcoin Core’s signed CAmount definition while preserving existing behavior for valid outputs.

Bug Fixes:
- Interpret and serialize TxOut’s eight-byte value as a signed int64_t CAmount so that invalid values exposed via check_validity=False match Core’s semantics.
- Use -1 as the SIGHASH_SINGLE blanking sentinel value to match Core’s CTxOut null output behavior and still round-trip to the same wire bytes.

Documentation:
- Document the TxOut CAmount signedness fix and its impact on malformed input handling in the changelog.

Tests:
- Update TxOut round-trip tests to assert the high-bit sentinel parses as -1 while remaining rejected by the validated path.