### PR TITLE
Core's chain names where Core is spoken, and the check they enable

### DIFF
--- a/.github/scripts/rpc_smoke.py
+++ b/.github/scripts/rpc_smoke.py
@@ -73,8 +73,13 @@ from btclib.fetch.transport import http_request
 
 # regtest, and the node is started with no -rpcport so that the port is
 # Core's own default for the chain rather than one this script chose:
-# `from_network` builds that number from Core's table, and a live node is
+# `from_chain` builds that number from Core's table, and a live node is
 # what says the two still agree
+#
+# One constant for two vocabularies, which regtest is the name that allows:
+# it is Core's chain name -- what `-regtest` and `from_chain` take -- and
+# btclib's network name, spelled alike, where mainnet and testnet are not.
+# So this is also passed to `b32.p2wpkh` and to `BitcoinCoreFetcher` below
 NETWORK = "regtest"
 RPC_PORT = 18443
 
@@ -160,7 +165,7 @@ def node(bitcoind: Path, datadir: Path) -> Iterator[BitcoinCoreRpcClient]:
     """Run a regtest bitcoind on Core's own rpc port, and stop it after.
 
     No `-rpcport` and no `-rpcuser`: the port, the datadir layout and the
-    cookie are the node's defaults, which is what makes `from_network` and
+    cookie are the node's defaults, which is what makes `from_chain` and
     `cookie_auth` checkable at all. `-txindex` so `getrawtransaction`
     answers for a transaction no wallet of this node knows, and `-listen=0`
     because a smoke test has no peers.
@@ -185,7 +190,7 @@ def node(bitcoind: Path, datadir: Path) -> Iterator[BitcoinCoreRpcClient]:
     # the client before the node, so that the `finally` below always has
     # one to stop it with: the cookie is read at every call, so a client
     # built before the file exists is a client that works once it does
-    client = BitcoinCoreRpcClient.from_network(
+    client = BitcoinCoreRpcClient.from_chain(
         NETWORK, cookie_path=datadir / DATADIR_SUBDIR / ".cookie"
     )
     # S603: the executable is a path this script was handed, and every
@@ -342,7 +347,7 @@ def check_cookie(cookie_path: Path) -> None:
     """Check the credential in the file the node wrote.
 
     At Core's own path for the chain, which is the other half of what
-    `from_network` computes. The first field is documentation -- the node
+    `from_chain` computes. The first field is documentation -- the node
     compares the whole line -- so what is checked about it is that it is
     still what Core writes, a cookie whose first field is something else
     being a valid one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2351,6 +2351,45 @@ edit.
 
 ### The public API and the module layout
 
+- **Core's chain names are spoken in the module that speaks to Core**, and
+  btclib's network names everywhere else (issue #379). The two vocabularies
+  name one chain and two of the names differ -- Core's `main` and `test`
+  against btclib's `mainnet` and `testnet` -- and nothing paired them, so a
+  caller who asked a node which chain it was on could not compare the answer
+  to the network they had asked btclib for. `btclib.bitcoin_core_rpc` now
+  holds the pairing, `core_chain_from_network` and `network_from_core_chain`,
+  each raising on a name it does not know rather than passing it through: a
+  chain Core adds later is a failure that names itself instead of a string
+  that reaches a node as a port lookup or a directory name. That module's
+  own tables are keyed on Core's names too, so
+  `BitcoinCoreRpcClient.from_network("mainnet")` is
+  `BitcoinCoreRpcClient.from_chain("main")` -- the string `-chain=` takes and
+  `getblockchaininfo` reports, which is what a project vendoring that one
+  file already has, where btclib's registry is what it does not. The
+  translation lives there and not in `btclib.network` because the two words
+  are not synonyms: btclib's `network` names the encoding table to encode
+  *with*, and answers `testnet` for a signet address on purpose, where
+  Core's `chain` is an identity; and because that module imports nothing of
+  btclib, `tests/key_io_test.py` reads the pairing for Core's own `key_io`
+  vectors without a key-encoding test acquiring `btclib.fetch`. A
+  translation of vocabulary and not a promise of availability: v31.1 warns
+  that testnet3 is deprecated and will be removed, so `test` is a name Core
+  still reads rather than a chain every node still serves.
+- **`BitcoinCoreFetcher.assert_network()`** asks the node whether it serves
+  the chain the fetcher labels outputs with, and raises when it does not.
+  Explicit, and not part of every fetch: it costs an rpc round trip that a
+  caller with one node and one chain has no use for, and the answer cannot
+  change under a client that goes on pointing at the same node. Worth the
+  one call because the failure it catches is silent -- a client built for a
+  testnet node, an explicit url with no port default in the way, under a
+  fetcher labelled `mainnet` renders a mainnet address for every output it
+  fetches, for coins that are not there. Signet is the case a name cannot
+  settle, Core reporting `signet` for the default one and for every custom
+  one alike: the p2p magic derived from the reply's `signet_challenge` is
+  compared with the network's own, which is also what makes a
+  caller-registered custom signet checkable (issue #207). A malformed reply
+  is a `FetchError` naming the method; a disagreement is a
+  `BTClibValueError`, the node being the authority on which chain it serves.
 - **`BitcoinCoreRpcClient` is one independently vendorable source file**
   (`btclib/bitcoin_core_rpc.py`), separate from the
   `BitcoinCoreFetcher` adapter that turns its answers into btclib `Tx`
@@ -2371,7 +2410,7 @@ edit.
   is that every import reaching `btclib.exceptions` -- most of the library,
   though not `import btclib` itself -- now loads `urllib.request`, and `ssl`
   and `socket` under it, where before only a caller who fetched did.
-  `from_network` therefore derives the cookie path from the home directory
+  `from_chain` therefore derives the cookie path from the home directory
   **at the call** rather than from a value computed at import: this module
   is what `btclib.exceptions` imports, so an import-time answer would be
   the `HOME` as it stood whenever anything first imported btclib, and an

--- a/btclib/bitcoin_core_rpc.py
+++ b/btclib/bitcoin_core_rpc.py
@@ -80,7 +80,7 @@ deliberately.
     # config file and printed in a traceback
     AuthServiceProxy(f"http://{user}:{password}@127.0.0.1:8332")
     BitcoinCoreRpcClient("http://127.0.0.1:8332", user=user, password=password)
-    BitcoinCoreRpcClient.from_network("mainnet")  # or the node's cookie file
+    BitcoinCoreRpcClient.from_chain("main")  # or the node's cookie file
 
     # one wallet of a multi-wallet node, percent-encoded
     client.for_wallet("hot").call("getbalance")
@@ -195,7 +195,9 @@ __all__ = [
     "HttpTransport",
     "RpcError",
     "cookie_auth",
+    "core_chain_from_network",
     "http_request",
+    "network_from_core_chain",
     "urlopen_transport",
 ]
 
@@ -687,26 +689,83 @@ def http_request(
     return status, body
 
 
-# the rpc port and the datadir subdirectory of each network, from Core's
-# `CreateBaseChainParams` in src/chainparamsbase.cpp. Mainnet's cookie is
-# in the datadir itself, which is the empty subdirectory below. Core's
-# chain names and not btclib's network registry, because what they index
-# here is a port and a directory: a chain btclib knows and Core has no
-# default port for is an explicit url, which is the constructor
+# the rpc port and the datadir subdirectory of each chain, from Core's
+# `CreateBaseChainParams` in src/chainparamsbase.cpp. Main's cookie is in
+# the datadir itself, which is the empty subdirectory below. Keyed by
+# Core's chain names -- `ChainTypeToString` in src/util/chaintype.cpp,
+# which is what `-chain=` reads and what `getblockchaininfo` reports --
+# because what they index here is a port and a directory: a chain btclib
+# knows and Core has no default port for is an explicit url, which is the
+# constructor.
+#
+# `test` indexes `testnet3`, which is the third vocabulary for that one
+# chain and the reason both columns are Core's: a directory name is no
+# more btclib's to choose than a port number is
 _RPC_PORT = {
-    "mainnet": 8332,
-    "testnet": 18332,
+    "main": 8332,
+    "test": 18332,
     "testnet4": 48332,
     "signet": 38332,
     "regtest": 18443,
 }
 _DATADIR_SUBDIR = {
-    "mainnet": "",
-    "testnet": "testnet3",
+    "main": "",
+    "test": "testnet3",
     "testnet4": "testnet4",
     "signet": "signet",
     "regtest": "regtest",
 }
+
+# btclib's network names against Core's chain names: `mainnet`/`main` and
+# `testnet`/`test` differ, the rest agree. btclib spells what BIP32 and
+# BIP173 spell, Core what `-chain=` takes, and neither vocabulary is going
+# to adopt the other -- btclib's `network` names the encoding table to
+# encode *with*, and answers `testnet` for a signet address, where Core's
+# `chain` is an identity. So the pair is written down once, here, this
+# being the file that speaks Core's protocol and therefore the boundary
+# between the two.
+#
+# A translation of vocabulary and not a promise of availability: v31.1
+# warns that support for testnet3 is deprecated and will be removed, so
+# `test` is a name Core still reads rather than a chain every node still
+# serves.
+_CORE_CHAIN_FROM_NETWORK = {
+    "mainnet": "main",
+    "testnet": "test",
+    "testnet4": "testnet4",
+    "signet": "signet",
+    "regtest": "regtest",
+}
+_NETWORK_FROM_CORE_CHAIN = {
+    chain: network for network, chain in _CORE_CHAIN_FROM_NETWORK.items()
+}
+
+
+def core_chain_from_network(network: str) -> str:
+    """Return Core's chain name for one of btclib's network names.
+
+    Raises rather than passing an unrecognized name through, in both
+    directions: a chain Core adds later is then a failure here, naming
+    what it knows, instead of a string that reaches a node as a port
+    lookup or a directory name.
+    """
+    if network not in _CORE_CHAIN_FROM_NETWORK:
+        known = ", ".join(_CORE_CHAIN_FROM_NETWORK)
+        raise BTClibValueError(f"unknown network: {network} not in ({known})")
+    return _CORE_CHAIN_FROM_NETWORK[network]
+
+
+def network_from_core_chain(chain: str) -> str:
+    """Return btclib's network name for one of Core's chain names.
+
+    The inverse of `core_chain_from_network`, and raising for the same
+    reason.
+    """
+    if chain not in _NETWORK_FROM_CORE_CHAIN:
+        known = ", ".join(_NETWORK_FROM_CORE_CHAIN)
+        raise BTClibValueError(f"unknown Core chain: {chain} not in ({known})")
+    return _NETWORK_FROM_CORE_CHAIN[chain]
+
 
 # the username bitcoind writes into the cookie file, COOKIEAUTH_USER in
 # src/rpc/request.cpp. The node ignores it -- cookie authentication
@@ -734,11 +793,11 @@ def _default_datadir() -> Path | None:
     read, so `~/.bitcoin/.cookie` would make a file a caller's cwd happens
     to contain the credential this client presents -- a wrong guess about
     the datadir is one thing, reading a credential from wherever the
-    process was started is another. `from_network` refuses instead, naming
+    process was started is another. `from_chain` refuses instead, naming
     `cookie_path` as what to pass; a caller on macOS or Windows already
     passes one.
 
-    Called by `from_network` when it derives a cookie path, and not once at
+    Called by `from_chain` when it derives a cookie path, and not once at
     import: `Path.home()` reads `HOME`, so a value computed at import is
     the environment as it stood whenever the first import reached this
     module -- which, this module holding the library's exceptions, is
@@ -761,7 +820,7 @@ def _default_datadir() -> Path | None:
 # looked for, which is what tells a caller on either platform to pass one
 #
 # This is the answer as it stood at import, kept for a caller who wants to
-# name the location or build a path under it. `from_network` does not read
+# name the location or build a path under it. `from_chain` does not read
 # it -- it asks `_default_datadir` at the call, so that a `HOME` set after
 # btclib was imported is the one that counts.
 #
@@ -1228,7 +1287,7 @@ class BitcoinCoreRpcClient:
     Credentials or a cookie path, and not both: each of the two says who
     is calling, so a client given both would have to rank them, and a
     caller who passed both has a mistaken idea of which one is in use.
-    `from_network` is the constructor that fills in a cookie path, along
+    `from_chain` is the constructor that fills in a cookie path, along
     with the port, from Core's own defaults.
 
     **Concurrent calls are supported while the configuration is not
@@ -1240,7 +1299,7 @@ class BitcoinCoreRpcClient:
     that one is the transport's own contract.
 
     **Basic authentication is cleartext over plain HTTP**, that being
-    what Core's rpc speaks. On loopback, which is what `from_network`
+    what Core's rpc speaks. On loopback, which is what `from_chain`
     builds, the cleartext is between one process and the node beside it.
     For a node anywhere else it is on the wire, and rpc credentials
     authorise every wallet command that node has: an `https` url, or a
@@ -1249,7 +1308,8 @@ class BitcoinCoreRpcClient:
     Nothing here asks the node which chain it is on. The url and the
     cookie path say where to ask; `BitcoinCoreFetcher`'s `network` says what
     the answers are labelled with, and holding the two together is the
-    caller's -- `getblockchaininfo` through `call` is how it is checked.
+    caller's -- `BitcoinCoreFetcher.assert_network` is what asks, and
+    `core_chain_from_network` is the vocabulary it compares through.
     """
 
     def __init__(
@@ -1319,9 +1379,9 @@ class BitcoinCoreRpcClient:
         self.transport = transport
 
     @classmethod
-    def from_network(
+    def from_chain(
         cls,
-        network: str = "mainnet",
+        chain: str = "main",
         *,
         user: str | None = None,
         password: str | None = None,
@@ -1329,18 +1389,21 @@ class BitcoinCoreRpcClient:
         timeout: float = DEFAULT_TIMEOUT,
         transport: HttpTransport = urlopen_transport,
     ) -> BitcoinCoreRpcClient:
-        """Return a client for the local node of one of Core's networks.
+        """Return a client for the local node of one of Core's chains.
 
         The convenience of not writing out a loopback url, a port and a
         datadir: all three come from Core's own tables, and everything
-        else is the constructor's. The five names are Core's chain names,
-        because what they index here is a port and a directory -- a chain
-        btclib knows and Core has no default port for is an explicit url
-        with a `cookie_path`, which is the constructor.
+        else is the constructor's. `chain` is spelled as Core spells it --
+        the string `-chain=` takes and `getblockchaininfo` reports, so
+        `main` where btclib says `mainnet` -- because what it indexes here
+        is a port and a directory, neither of which btclib names.
+        `core_chain_from_network` translates for a caller holding a btclib
+        name; a chain btclib knows and Core has no default port for is an
+        explicit url with a `cookie_path`, which is the constructor.
 
         Nor is this the chain the answers get labelled with. That is
-        `BitcoinCoreFetcher`'s `network`, and nothing here verifies that the
-        node agrees with either of them.
+        `BitcoinCoreFetcher`'s `network`, and `assert_network` there is
+        what asks the node whether it agrees.
 
         The datadir is asked for here rather than read off
         `DEFAULT_DATADIR`, so that the `HOME` of this call is the one that
@@ -1356,8 +1419,11 @@ class BitcoinCoreRpcClient:
         cookie derived before that check would report a missing home
         directory to a caller who passed a password and forgot the user.
         """
-        if network not in _RPC_PORT:
-            raise BTClibValueError(f"unknown network: {network}")
+        if chain not in _RPC_PORT:
+            known = ", ".join(_RPC_PORT)
+            err_msg = f"unknown chain: {chain} not in ({known})."
+            err_msg += " These are Core's names, not btclib's"
+            raise BTClibValueError(err_msg)
         if user is None and password is None and cookie_path is None:
             datadir = _default_datadir()
             if datadir is None:
@@ -1365,9 +1431,9 @@ class BitcoinCoreRpcClient:
                 err_msg += " the cookie file in: pass cookie_path, or user"
                 err_msg += " and password"
                 raise BTClibValueError(err_msg)
-            cookie_path = datadir / _DATADIR_SUBDIR[network] / ".cookie"
+            cookie_path = datadir / _DATADIR_SUBDIR[chain] / ".cookie"
         return cls(
-            f"http://127.0.0.1:{_RPC_PORT[network]}",
+            f"http://127.0.0.1:{_RPC_PORT[chain]}",
             user=user,
             password=password,
             cookie_path=cookie_path,

--- a/btclib/fetch/bitcoin_core.py
+++ b/btclib/fetch/bitcoin_core.py
@@ -15,14 +15,22 @@ keep the original `btclib.fetch.bitcoin_core` client path working while this
 module provides only the integration with btclib transactions and networks.
 """
 
+from collections.abc import Mapping
+from typing import Any
+
+from btclib import var_bytes
 from btclib.alias import Octets
 from btclib.bitcoin_core_rpc import (
     COOKIE_USER,
     DEFAULT_DATADIR,
     BitcoinCoreRpcClient,
     cookie_auth,
+    core_chain_from_network,
 )
+from btclib.exceptions import BTClibValueError
 from btclib.fetch.fetcher import Fetcher, fetch_errors, tx_from_raw, tx_id_hex
+from btclib.hashes import hash256
+from btclib.network import NETWORKS
 from btclib.tx import Tx
 from btclib.utils import bytes_from_octets
 
@@ -32,12 +40,26 @@ __all__ = [
     "BitcoinCoreFetcher",
     "BitcoinCoreRpcClient",
     "cookie_auth",
+    "core_chain_from_network",
 ]
 
 # What a reply that is a number or a hash may weigh: the JSON envelope and a
 # value of a few dozen octets. `getrawtransaction` is the one answer here that
 # is not small, and it keeps the client's default.
 _MAX_SMALL_REPLY = 1024
+
+
+def _signet_magic(challenge: str) -> bytes:
+    """Return the p2p magic a signet's block challenge determines.
+
+    Core: the message start is the first four bytes of the sha256d of the
+    block script, serialized with its CompactSize length, taken in the
+    order the digest produces them -- which is the reverse of how this
+    library writes `magic_bytes`, hence the slice reversed here.
+    `tests/network_test.py` checks the default signet's own magic against
+    this same computation, from the challenge in Core's chainparams.
+    """
+    return hash256(var_bytes.serialize(challenge))[:4][::-1]
 
 
 class BitcoinCoreFetcher(Fetcher):
@@ -50,8 +72,8 @@ class BitcoinCoreFetcher(Fetcher):
 
     `network` is btclib's chain label and belongs here, not to the connection:
     it is what the outputs of a fetched transaction are labelled with. The
-    client knows a URL and no chain, and nothing here asks the node which one
-    it serves; `getblockchaininfo` through `call` is how a caller checks.
+    client knows a URL and no chain, and no fetch asks the node which one it
+    serves; `assert_network` is that question, asked when a caller asks it.
     """
 
     def __init__(self, client: BitcoinCoreRpcClient, network: str = "mainnet") -> None:
@@ -82,3 +104,81 @@ class BitcoinCoreFetcher(Fetcher):
         with fetch_errors("getbestblockhash"):
             reply = self.client.call("getbestblockhash", max_body_size=_MAX_SMALL_REPLY)
             return bytes_from_octets(reply, 32)
+
+    def assert_network(self) -> None:
+        """Raise unless the node serves the chain this fetcher labels with.
+
+        Explicit, and asked by a caller rather than by every fetch: it
+        costs an rpc round trip that a caller with one node and one chain
+        has no use for, and the answer cannot change under a client that
+        goes on pointing at the same node.
+
+        Worth one call, though, because the failure it catches is silent.
+        A client built for a testnet node -- an explicit url, no port
+        default in the way -- under a fetcher labelled `mainnet` renders a
+        mainnet address for every output it fetches, for coins that are
+        not there. `getblockchaininfo` answers that in one round trip;
+        what it needs is a vocabulary to be compared through, which is
+        `core_chain_from_network`, Core naming the chain `main` where
+        btclib names it `mainnet`.
+
+        Signet is the case a name cannot settle: Core reports `signet` for
+        the default one and for every custom one alike, so two nodes
+        sharing nothing but the shape of a challenge answer the same
+        string. `signet_challenge` is what tells them apart, and the p2p
+        magic derived from it is compared with the network's own -- which
+        also checks a caller-registered custom signet, `NETWORKS` being a
+        dict a caller adds to, and issue #207 the reason they do.
+
+        A malformed reply is a `FetchError` naming the method. A
+        disagreement is a `BTClibValueError`: the node is the authority on
+        which chain it serves, so the fetcher's label is the thing to fix.
+        """
+        with fetch_errors("getblockchaininfo"):
+            info: Any = self.client.call("getblockchaininfo")
+            if not isinstance(info, Mapping):
+                err_msg = f"not a JSON object: {type(info).__name__}"
+                raise BTClibValueError(err_msg)
+            chain = info.get("chain")
+            if not isinstance(chain, str):
+                err_msg = f"no chain name in the reply: {chain!r}"
+                raise BTClibValueError(err_msg)
+            # None off signet, and the reason the comparison below is
+            # written against it rather than against the name a second
+            # time: what the node answered is read here, in one place,
+            # and what it is worth is decided there
+            node_magic: bytes | None = None
+            if chain == "signet":
+                challenge = info.get("signet_challenge")
+                if not isinstance(challenge, str):
+                    err_msg = f"no signet_challenge in the reply: {challenge!r}"
+                    raise BTClibValueError(err_msg)
+                node_magic = _signet_magic(challenge)
+
+        # outside the block above, so that a node that answered a
+        # well-formed disagreement is not reported as a failure to fetch
+        if node_magic is not None:
+            expected_magic = NETWORKS[self.network].magic_bytes
+            if node_magic != expected_magic:
+                # worded for both mismatches it catches: another signet,
+                # and a fetcher that is on no signet at all
+                err_msg = "the node is on a signet this fetcher is not:"
+                err_msg += f" its challenge derives magic {node_magic.hex()},"
+                err_msg += f" where {self.network} has {expected_magic.hex()}"
+                raise BTClibValueError(err_msg)
+            return
+        try:
+            expected_chain = core_chain_from_network(self.network)
+        except BTClibValueError as e:
+            # a Network the caller registered: its name is btclib's alone,
+            # so there is nothing to compare a chain name with, and only a
+            # signet carries an identity a node can be asked for
+            err_msg = f"the node is on {chain}, and {self.network} is no"
+            err_msg += " chain of Core's to compare that with: a custom"
+            err_msg += " network is identified by its challenge, so only a"
+            err_msg += " signet node can answer for one"
+            raise BTClibValueError(err_msg) from e
+        if chain != expected_chain:
+            err_msg = f"the node is on {chain}, this fetcher on"
+            err_msg += f" {self.network}, which is Core's {expected_chain}"
+            raise BTClibValueError(err_msg)

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -93,6 +93,7 @@ REEXPORTED = {
         "DEFAULT_DATADIR",
         "BitcoinCoreRpcClient",
         "cookie_auth",
+        "core_chain_from_network",
     ],
     "btclib.fetch.transport": [
         "DEFAULT_MAX_BODY_SIZE",

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -47,6 +47,8 @@ from btclib.bitcoin_core_rpc import (
     BitcoinCoreRpcClient,
     _default_datadir,
     cookie_auth,
+    core_chain_from_network,
+    network_from_core_chain,
 )
 from btclib.exceptions import (
     BTClibTypeError,
@@ -55,8 +57,9 @@ from btclib.exceptions import (
     HttpError,
     RpcError,
 )
-from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
+from btclib.fetch.bitcoin_core import BitcoinCoreFetcher, _signet_magic
 from btclib.fetch.transport import DEFAULT_MAX_BODY_SIZE, DEFAULT_TIMEOUT
+from btclib.network import NETWORKS, Network
 from btclib.tx import OutPoint
 from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
 
@@ -74,7 +77,7 @@ RPC_USER = "rpcuser"
 RPC_PASSWORD = "rpcpassword"  # noqa: S105  # pragma: allowlist secret
 
 # the endpoint the tests build against, written once. A url is required,
-# there being no network here to derive one from -- `from_network` is what
+# there being no chain here to derive one from -- `from_chain` is what
 # derives one, and has its own tests
 URL = "http://127.0.0.1:8332"
 
@@ -154,9 +157,9 @@ def sent(endpoint: BitcoinCoreRpcClient) -> dict[str, object]:
     return body
 
 
-def test_from_network_is_the_local_node_of_that_network() -> None:
+def test_from_chain_is_the_local_node_of_that_chain() -> None:
     """The rpc port and the datadir subdirectory of Core's chainparamsbase."""
-    # what `from_network` asks at the call. None where no absolute home is
+    # what `from_chain` asks at the call. None where no absolute home is
     # knowable, which is not a machine the suite runs on -- and asserting it
     # is what makes the paths below a Path
     datadir = _default_datadir()
@@ -165,19 +168,19 @@ def test_from_network_is_the_local_node_of_that_network() -> None:
     # caller to read, and not what the derivation goes through
     assert DEFAULT_DATADIR == datadir
 
-    from_network = BitcoinCoreRpcClient.from_network
-    assert from_network().url == "http://127.0.0.1:8332"
-    assert from_network("testnet").url == "http://127.0.0.1:18332"
-    assert from_network("testnet4").url == "http://127.0.0.1:48332"
-    assert from_network("signet").url == "http://127.0.0.1:38332"
-    assert from_network("regtest").url == "http://127.0.0.1:18443"
+    from_chain = BitcoinCoreRpcClient.from_chain
+    assert from_chain().url == "http://127.0.0.1:8332"
+    assert from_chain("test").url == "http://127.0.0.1:18332"
+    assert from_chain("testnet4").url == "http://127.0.0.1:48332"
+    assert from_chain("signet").url == "http://127.0.0.1:38332"
+    assert from_chain("regtest").url == "http://127.0.0.1:18443"
 
-    assert from_network().cookie_path == datadir / ".cookie"
-    assert from_network("testnet").cookie_path == datadir / "testnet3" / ".cookie"
-    assert from_network("regtest").cookie_path == datadir / "regtest" / ".cookie"
+    assert from_chain().cookie_path == datadir / ".cookie"
+    assert from_chain("test").cookie_path == datadir / "testnet3" / ".cookie"
+    assert from_chain("regtest").cookie_path == datadir / "regtest" / ".cookie"
 
 
-def test_from_network_reads_the_home_of_the_call_and_not_of_the_import(
+def test_from_chain_reads_the_home_of_the_call_and_not_of_the_import(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """A home set after btclib was imported is the one a cookie comes from.
@@ -186,7 +189,7 @@ def test_from_network_reads_the_home_of_the_call_and_not_of_the_import(
     all imports it: a datadir resolved once, at that moment, is the
     environment as it stood whenever some unrelated early import happened.
     Reproduced before this was fixed -- `HOME=/tmp/home-before`, `import
-    btclib.exceptions`, `HOME=/tmp/home-after`, and `from_network()` still
+    btclib.exceptions`, `HOME=/tmp/home-after`, and `from_chain()` still
     answered with `/tmp/home-before/.bitcoin/.cookie`.
 
     Which is what a test can only see by *not* patching `DEFAULT_DATADIR`:
@@ -197,11 +200,11 @@ def test_from_network_reads_the_home_of_the_call_and_not_of_the_import(
     monkeypatch.setattr(Path, "home", lambda: tmp_path / "home-after")
 
     expected = tmp_path / "home-after" / ".bitcoin" / "regtest" / ".cookie"
-    assert BitcoinCoreRpcClient.from_network("regtest").cookie_path == expected
+    assert BitcoinCoreRpcClient.from_chain("regtest").cookie_path == expected
     assert DEFAULT_DATADIR != _default_datadir()
 
 
-def test_from_network_derives_no_cookie_when_told_who_is_calling(
+def test_from_chain_derives_no_cookie_when_told_who_is_calling(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A user or a password is the answer to that, so nothing is derived.
@@ -219,7 +222,7 @@ def test_from_network_derives_no_cookie_when_told_who_is_calling(
     monkeypatch.setattr(Path, "home", lambda: pytest.fail("home consulted"))
     for kwargs in ({"password": RPC_PASSWORD}, {"user": RPC_USER}):
         with pytest.raises(BTClibValueError, match="go together"):
-            BitcoinCoreRpcClient.from_network(**kwargs)  # type: ignore[arg-type]
+            BitcoinCoreRpcClient.from_chain(**kwargs)  # type: ignore[arg-type]
 
 
 def test_no_absolute_home_is_no_default_datadir_and_no_exception(
@@ -253,14 +256,14 @@ def test_no_absolute_home_is_no_default_datadir_and_no_exception(
     assert _default_datadir() is None
 
 
-def test_from_network_refuses_a_datadir_it_cannot_name(
+def test_from_chain_refuses_a_datadir_it_cannot_name(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """No default datadir is a refusal, and never a path read against the cwd.
 
     The end of the same path as the test above, and the reason None is the
     answer there rather than an unexpanded `~/.bitcoin`: that is a relative
-    path, `pathlib` expands no tilde, and `from_network` handed it to the
+    path, `pathlib` expands no tilde, and `from_chain` handed it to the
     cookie reader unchanged -- so a `./~/.bitcoin/.cookie` that the working
     directory happened to contain became the credential this client presents
     to the node. Planted below, exactly as it was when that was reproduced.
@@ -283,12 +286,12 @@ def test_from_network_refuses_a_datadir_it_cannot_name(
     monkeypatch.setattr(Path, "home", no_home)
 
     with pytest.raises(BTClibValueError, match="pass cookie_path"):
-        BitcoinCoreRpcClient.from_network()
+        BitcoinCoreRpcClient.from_chain()
 
     # the file is there and readable, so the refusal above is what kept it
     # out and not an absent path: through an explicit `cookie_path` the very
     # same file is the credential
-    explicit = BitcoinCoreRpcClient.from_network("mainnet", cookie_path=planted)
+    explicit = BitcoinCoreRpcClient.from_chain("main", cookie_path=planted)
     assert (
         b64decode(explicit.auth_header().split()[1])
         == f"{COOKIE_USER}:planted".encode()
@@ -296,16 +299,16 @@ def test_from_network_refuses_a_datadir_it_cannot_name(
 
     # and credentials need no datadir at all
     assert (
-        BitcoinCoreRpcClient.from_network(
+        BitcoinCoreRpcClient.from_chain(
             "regtest", user=RPC_USER, password=RPC_PASSWORD
         ).cookie_path
         is None
     )
 
 
-def test_from_network_takes_credentials_instead_of_a_cookie() -> None:
+def test_from_chain_takes_credentials_instead_of_a_cookie() -> None:
     """Credentials given, no cookie path derived: the two are exclusive."""
-    endpoint = BitcoinCoreRpcClient.from_network(
+    endpoint = BitcoinCoreRpcClient.from_chain(
         "regtest", user=RPC_USER, password=RPC_PASSWORD
     )
     assert endpoint.cookie_path is None
@@ -318,9 +321,9 @@ def test_connection_controls_are_keyword_only() -> None:
     with pytest.raises(TypeError):
         constructor(URL, RPC_USER, RPC_PASSWORD)
 
-    from_network: Any = BitcoinCoreRpcClient.from_network
+    from_chain: Any = BitcoinCoreRpcClient.from_chain
     with pytest.raises(TypeError):
-        from_network("regtest", RPC_USER, RPC_PASSWORD)
+        from_chain("regtest", RPC_USER, RPC_PASSWORD)
 
 
 def test_a_colon_in_the_user_is_refused_and_one_in_the_password_is_not() -> None:
@@ -419,10 +422,18 @@ def test_a_method_that_is_not_a_string_is_refused(method: object) -> None:
         client().call(method)  # type: ignore[arg-type]
 
 
-def test_from_network_refuses_a_network_core_has_no_port_for() -> None:
-    """The five names are Core's chainparamsbase, not btclib's registry."""
-    with pytest.raises(BTClibValueError, match="unknown network: testnet5"):
-        BitcoinCoreRpcClient.from_network("testnet5")
+def test_from_chain_refuses_a_chain_core_has_no_port_for() -> None:
+    """The names are Core's chainparamsbase, not btclib's registry.
+
+    Which a btclib name is now the demonstration of: `mainnet` is a
+    network btclib has and a chain Core has not, so it is refused here
+    exactly as an invented name is. `core_chain_from_network` is what a
+    caller holding one goes through.
+    """
+    with pytest.raises(BTClibValueError, match="unknown chain: testnet5"):
+        BitcoinCoreRpcClient.from_chain("testnet5")
+    with pytest.raises(BTClibValueError, match="unknown chain: mainnet"):
+        BitcoinCoreRpcClient.from_chain("mainnet")
 
 
 def test_the_url_carries_no_network_and_no_registry() -> None:
@@ -1659,13 +1670,176 @@ def test_get_tx_labels_the_outputs_for_the_fetchers_network() -> None:
 def test_the_fetchers_network_is_btclibs_registry_not_cores() -> None:
     """Which is the point of the split: `Fetcher` validates against NETWORKS.
 
-    The client refuses no name at all, and `from_network` refuses one Core
+    The client refuses no name at all, and `from_chain` refuses one Core
     has no port for -- neither of which is the question this label answers.
     """
     with pytest.raises(BTClibValueError, match="unknown network"):
         BitcoinCoreFetcher(
             BitcoinCoreRpcClient(URL, user=RPC_USER, password=RPC_PASSWORD), "nowhere"
         )
+
+
+# a block challenge that is not Core's, which is the whole of what makes a
+# signet a different one. Any script serves: what the check reads from it
+# is a hash, and this is a p2wpkh of a public key hash nobody holds
+CUSTOM_CHALLENGE = "0014" + "ab" * 20
+OTHER_CHALLENGE = "0014" + "cd" * 20
+
+
+def blockchaininfo(**members: object) -> tuple[int, bytes]:
+    """Return a 200 answer whose result is a getblockchaininfo of these members.
+
+    Written here rather than recorded: the reply carries a dozen members
+    beyond the two this question reads, so a recording of it would be a
+    fixture to re-take whenever Core adds one, and every test below would
+    then be edited to change the one member it is about.
+    """
+    body = json.dumps({"jsonrpc": "2.0", "result": members, "id": "x"}).encode()
+    return 200, body
+
+
+def custom_signet(challenge: str) -> Network:
+    """Return a Network like the default signet, with this challenge's magic.
+
+    What a caller registers for a signet of their own -- issue #207 -- and
+    the magic is derived by the function the check itself uses. What that
+    derivation is worth is settled elsewhere, in
+    `tests/network_test.py`, against the magic Core publishes for its own
+    signet; here it is the pairing of a challenge with a Network that
+    matters.
+    """
+    return Network.from_dict(
+        {**NETWORKS["signet"].to_dict(), "magic_bytes": _signet_magic(challenge).hex()}
+    )
+
+
+def test_the_two_vocabularies_translate_both_ways() -> None:
+    """Core's chain names against btclib's network names, and back.
+
+    Two differ and the rest agree, which is what makes the pairing both
+    necessary and easy to leave out: `"main" != "mainnet"` is the mismatch
+    a correct comparison produces.
+    """
+    assert core_chain_from_network("mainnet") == "main"
+    assert core_chain_from_network("testnet") == "test"
+    for shared in ("testnet4", "signet", "regtest"):
+        assert core_chain_from_network(shared) == shared
+    for network in NETWORKS:
+        assert network_from_core_chain(core_chain_from_network(network)) == network
+
+
+def test_neither_direction_falls_back_on_a_name_it_does_not_know() -> None:
+    """A chain Core adds later fails here, rather than being passed through.
+
+    And the two vocabularies are not interchangeable in either direction:
+    Core's `main` is no network of btclib's, btclib's `mainnet` no chain
+    of Core's, and each is refused by the function that does not own it.
+    """
+    with pytest.raises(BTClibValueError, match="unknown network: main"):
+        core_chain_from_network("main")
+    with pytest.raises(BTClibValueError, match="unknown Core chain: mainnet"):
+        network_from_core_chain("mainnet")
+
+
+@pytest.mark.parametrize(
+    ("network", "chain"), [("mainnet", "main"), ("testnet", "test")]
+)
+def test_assert_network_accepts_the_chain_the_node_reports(
+    network: str, chain: str
+) -> None:
+    """The two names that differ, which are the two a mismatch hides behind."""
+    fetcher(blockchaininfo(chain=chain), network=network).assert_network()
+
+
+def test_assert_network_refuses_a_node_on_another_chain() -> None:
+    """The silent failure this exists for: a testnet node under a mainnet label.
+
+    A client with an explicit url reaches a testnet node with no port
+    default in the way, and every address rendered from what that fetcher
+    returns is then a mainnet address for coins that are not there.
+    Nothing else in the exchange says so.
+    """
+    with pytest.raises(
+        BTClibValueError, match="node is on test, this fetcher on mainnet"
+    ):
+        fetcher(blockchaininfo(chain="test"), network="mainnet").assert_network()
+
+
+def test_assert_network_tells_two_signets_apart() -> None:
+    """`signet` is the name of every signet, so the challenge is the identity.
+
+    Core reports `signet` for the default one and for a custom one alike,
+    so the name comparison passes here and the check has to go further:
+    the magic the challenge derives is what a fetcher for the default
+    signet does not share with a node on someone else's.
+    """
+    answer = blockchaininfo(chain="signet", signet_challenge=CUSTOM_CHALLENGE)
+    with pytest.raises(BTClibValueError, match="signet this fetcher is not"):
+        fetcher(answer, network="signet").assert_network()
+
+
+def test_assert_network_checks_a_caller_registered_signet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Network a caller built is checkable, which is what the magic buys.
+
+    Its name is btclib's alone and means nothing to a node, so the name is
+    not what is compared. `NETWORKS` is a dict a caller adds to, and
+    `monkeypatch.setitem` is how this one is taken back out.
+    """
+    monkeypatch.setitem(NETWORKS, "custom-signet", custom_signet(CUSTOM_CHALLENGE))
+
+    answer = blockchaininfo(chain="signet", signet_challenge=CUSTOM_CHALLENGE)
+    fetcher(answer, network="custom-signet").assert_network()
+
+    other = blockchaininfo(chain="signet", signet_challenge=OTHER_CHALLENGE)
+    with pytest.raises(BTClibValueError, match="signet this fetcher is not"):
+        fetcher(other, network="custom-signet").assert_network()
+
+
+def test_assert_network_has_nothing_to_compare_for_a_custom_name_off_signet(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller's own network against a node on main: a refusal, not a pass.
+
+    Only a signet answers with an identity, so a name Core never heard of
+    has nothing to be held against -- and passing silently is the failure
+    this method exists to catch.
+    """
+    monkeypatch.setitem(NETWORKS, "custom-signet", custom_signet(CUSTOM_CHALLENGE))
+    with pytest.raises(BTClibValueError, match="no chain of Core's"):
+        fetcher(blockchaininfo(chain="main"), network="custom-signet").assert_network()
+
+
+@pytest.mark.parametrize(
+    ("result", "message"),
+    [
+        pytest.param(3, "not a JSON object: int", id="not-an-object"),
+        pytest.param({}, "no chain name in the reply: None", id="no-chain"),
+        pytest.param(
+            {"chain": 5}, "no chain name in the reply: 5", id="chain-not-a-string"
+        ),
+        pytest.param(
+            {"chain": "signet"}, "no signet_challenge", id="signet-with-no-challenge"
+        ),
+        pytest.param(
+            {"chain": "signet", "signet_challenge": "not hex"},
+            "getblockchaininfo",
+            id="challenge-that-is-not-hex",
+        ),
+    ],
+)
+def test_assert_network_refuses_a_malformed_reply(result: object, message: str) -> None:
+    """A reply that is not an answer is a FetchError naming the method.
+
+    The same treatment every other answer here gets, and what tells it
+    apart from the case above: a node that said something unreadable is a
+    fetch that did not happen, where a node that named another chain
+    answered exactly what was asked.
+    """
+    body = json.dumps({"jsonrpc": "2.0", "result": result, "id": "x"}).encode()
+    with pytest.raises(FetchError, match=message):
+        fetcher((200, body), network="mainnet").assert_network()
 
 
 def test_get_tx_out_reads_one_output_of_the_previous_transaction() -> None:

--- a/tests/key_io_test.py
+++ b/tests/key_io_test.py
@@ -33,25 +33,30 @@ from __future__ import annotations
 import pytest
 
 from btclib import b32, b58
+from btclib.bitcoin_core_rpc import network_from_core_chain
 from btclib.exceptions import BTClibValueError
 from btclib.network import network_type_from_network
 from btclib.script import ScriptPubKey
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
 from tests import load, vector_id
 
-# Core names a chain as its `-chain=` argument does, and btclib spells
-# three of the four the same way: only "main" is "mainnet" here. So a
-# chain Core adds later needs no entry to be tried, and fails loudly --
-# "unknown network" -- rather than being read as one btclib knows
-_NETWORK_NAME = {"main": "mainnet"}
-
+# the `chain` of each vector is Core's name for it, as its `-chain=`
+# argument spells it, and btclib's name is what the encoders here take:
+# `network_from_core_chain` is the pair, which lives with the rest of
+# Core's vocabulary in the module that speaks Core's protocol -- and
+# imports nothing of btclib, so a key-encoding test reads it without
+# acquiring `btclib.fetch`.
+#
+# It raises on a name it does not know, which is the property wanted at
+# collection time: a chain Core adds to this file later stops the run
+# naming itself, rather than reaching an encoder as a network btclib has
 _VALID = load("_data", "key_io_valid.json")
 
 ADDRESS_VECTORS = [
     pytest.param(
         string,
         hexed,
-        _NETWORK_NAME.get(meta["chain"], meta["chain"]),
+        network_from_core_chain(meta["chain"]),
         id=vector_id(index, string),
     )
     for index, (string, hexed, meta) in enumerate(_VALID)
@@ -62,7 +67,7 @@ WIF_VECTORS = [
     pytest.param(
         string,
         hexed,
-        _NETWORK_NAME.get(meta["chain"], meta["chain"]),
+        network_from_core_chain(meta["chain"]),
         meta["isCompressed"],
         id=vector_id(index, string),
     )


### PR DESCRIPTION
Closes #379.

btclib names a network and Core names a chain, and two of the five names
differ. Nothing paired them, so a caller who asked a node which chain it was
on could not compare the answer to the network they had asked btclib for.

The decision, in full, is [in the issue][decision]. The short of it: the
pairing and Core's vocabulary go in `btclib.bitcoin_core_rpc`, and the
library keeps `network` and the BIPs' spellings.

[decision]: https://github.com/btclib-org/btclib/issues/379#issuecomment-5193237805

## What changed

- `_RPC_PORT` and `_DATADIR_SUBDIR` are keyed on Core's chain names, which
  is what the comment over them already claimed and the keys contradicted.
  `test` indexing `testnet3` is now visibly a translation between two of
  Core's own vocabularies rather than a mix of Core's and btclib's.
- `BitcoinCoreRpcClient.from_network("mainnet")` is
  `from_chain("main")` — the string `-chain=` takes and `getblockchaininfo`
  reports. A project vendoring that one file has Core's names and not
  btclib's registry, so this is the vocabulary its callers already hold.
- `core_chain_from_network` and `network_from_core_chain`: one table, both
  directions, each raising on a name it does not know. A chain Core adds
  later fails naming itself instead of reaching a node as a port lookup or
  a directory name. `tests/key_io_test.py` drops its one-entry
  `_NETWORK_NAME` dict for them — that module imports nothing of btclib, so
  a key-encoding test reads the pairing without acquiring `btclib.fetch`.
- `BitcoinCoreFetcher.assert_network()`, explicit rather than part of every
  fetch: it costs a round trip a caller with one node and one chain has no
  use for. Signet is the case a name cannot settle — Core reports `signet`
  for the default one and every custom one alike — so the p2p magic derived
  from `signet_challenge` is compared with the network's own, which is also
  what makes a caller-registered signet checkable (#207). Malformed reply →
  `FetchError` naming the method; disagreement → `BTClibValueError`.

## Why not rename the library

That was the other way to remove the mismatch, and it is the one thing this
does not do. `network` and `chain` are not two words for one idea here:
`network_from_key_value` answers `testnet` for a signet address on purpose,
and its docstring already says "It is not an answer to 'which chain is
this'", where Core's `chain` is exactly an identity. And `NetworkType` is
`Literal["main", "test"]`, SLIP44's family: renaming the values would leave
`chain="test"` and `chain_type="test"` as one string with two scopes, which
is the distinction `ScriptPubKey.__eq__` and BIP44's coin-type check exist
to draw.

No HISTORY.md bullet: `BitcoinCoreRpcClient` is new in the unreleased
v2026.8, so `from_chain` breaks no spelling a user has.

## Gates

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`,
  which is `coverage-py`'s command verbatim: 17294 passed, 100.00%, exit 0.
  (A bare `uv run pytest --cov` reports 99.97% here and on a pristine
  `origin/dev` alike — it measures every imported file, so it picks up
  `.github/scripts/mutation_counts.py`, whose `main()` is reached only by a
  test that runs the script as a subprocess. Out of CI's scope, and not
  something this branch touches.)
- `uv run pre-commit run --all-files`: exit 0, mypy strict included.
- `sphinx-build -W --keep-going`: build succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
