### PR TITLE
A script number is the int64_t Core holds it in (#406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1225,6 +1225,25 @@ edit.
   `PSBT_OUT_AMOUNT` is untouched, the BIP and Core agreeing on `int64_t`
   there. Found while auditing btclib's consensus types against Core
   v31.1, after #388
+- **a script number is bounded by the `int64_t` it is**, so
+  `utils.encode_num` and `script.serialize` refuse one outside
+  `[-2^63, 2^63-1]` with `script number out of range` (issue #406).
+  Core stores a `CScriptNum` in an `int64_t` and takes a number into a
+  script through `CScript::operator<<(int64_t)`, which has no wider
+  parameter; btclib's serializer took an unbounded Python int, so
+  `serialize([2**100])` wrote a 13-octet push and `serialize([2**200])`
+  a 26-octet one -- pushes no node can have built, and pushes the engine
+  refuses on execution anyway, capping every operand at four bytes and
+  five for CLTV and CSV. Both extremes still serialize, the most
+  negative int64 taking the nine octets Core's `CScriptNum::serialize`
+  gives it too, sign-magnitude having no room for its magnitude in
+  eight. `utils.decode_num` is deliberately not bounded to match: it is
+  the reader, the engine caps an operand before reaching it, and
+  `Block.height` decodes whatever a coinbase pushed -- BIP34 in btclib
+  being the byte comparison of `assert_valid_coinbase_height`, as it is
+  in Core -- so a bound there would refuse a coinbase the network
+  accepts. Found while auditing the consensus types against Core v31.1,
+  after #388
 
 ### Immutability and shared state
 

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -390,11 +390,12 @@ def serialize(script: Sequence[Command]) -> bytes:
     """Serialize a script from its commands.
 
     An integer is encoded as the number it pushes -- with a warning
-    where a one-byte op code means the same -- a string is an op code
-    name, an UNKNOWN_OP_CODE_n byte, or hex data, and bytes are data;
-    data is always the minimal push, per BIP62. What parse returns
-    round-trips, ERROR_COMMAND excepted, that marker being a place in
-    the bytes rather than an instruction.
+    where a one-byte op code means the same, and a refusal outside the
+    int64 a script number is -- a string is an op code name, an
+    UNKNOWN_OP_CODE_n byte, or hex data, and bytes are data; data is
+    always the minimal push, per BIP62. What parse returns round-trips,
+    ERROR_COMMAND excepted, that marker being a place in the bytes
+    rather than an instruction.
     """
     r: list[bytes] = []
     for command in script:

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -292,6 +292,13 @@ def decode_num(data: bytes) -> int:
 
     Positive zero is also represented by a null-length byte vector,
     which is considered the canonical one.
+
+    Not bounded the way `encode_num` is: this is the reader, and its two
+    callers ask different things of it. The engine's `_to_num` caps an
+    operand at four bytes -- five for CLTV and CSV -- before it gets
+    here, and `Block.height` decodes whatever a coinbase pushed, BIP34
+    being a byte comparison rather than a number, so an int64 bound here
+    would refuse a coinbase the network accepts.
     """
     length = len(data)
     if length == 0:
@@ -303,6 +310,15 @@ def decode_num(data: bytes) -> int:
         i &= mask
         i *= -1
     return i
+
+
+# the int64_t of Core's CScriptNum, which is the type of the only
+# parameter `CScript::operator<<` takes a number through: no script Core
+# can build carries one outside this range, so no serializer of btclib's
+# writes one either (issue #406). Here and not in script.serialize
+# because every caller reaches the octets through encode_num
+_MIN_SCRIPT_NUM = -(2**63)
+_MAX_SCRIPT_NUM = 2**63 - 1
 
 
 def encode_num(i: int) -> bytes:
@@ -321,7 +337,23 @@ def encode_num(i: int) -> bytes:
 
     Positive zero is also represented by a null-length byte vector,
     which is considered the canonical one.
+
+    The number is a CScriptNum, i.e. an int64, and a Python int outside
+    that range is refused rather than encoded: what it would write is a
+    push no node can have built, and one the interpreter -- capping every
+    operand at four bytes, five for CLTV and CSV -- cannot read back
+    either.
+
+    The bound is on the value and not on the width: the most negative
+    int64 is in range and takes nine octets, sign-magnitude having no
+    room for its magnitude in eight, which is what Core's
+    `CScriptNum::serialize` writes for it as well.
     """
+    if not _MIN_SCRIPT_NUM <= i <= _MAX_SCRIPT_NUM:
+        err_msg = f"script number out of range: {i}"
+        err_msg += f", not in [{_MIN_SCRIPT_NUM}, {_MAX_SCRIPT_NUM}]"
+        raise BTClibValueError(err_msg)
+
     # i.bit_length() bits, plus a sign bit
     n_bits = i.bit_length() + 1
     # The number of bytes necessary to accommodate n_bits

--- a/tests/script/script_test.py
+++ b/tests/script/script_test.py
@@ -327,6 +327,26 @@ def test_integer_serialization() -> None:
         serialized_int = serialize([i])
 
 
+def test_serialize_refuses_a_number_wider_than_an_int64() -> None:
+    """Serialize writes only the script numbers Core's int64_t can hold.
+
+    A number reaches a script through `CScript::operator<<(int64_t)`,
+    which has no wider parameter, so an unbounded Python int writes a
+    push no node can have built -- 13 octets for 2**100, 26 for 2**200
+    -- and one the interpreter cannot read back either, capping every
+    operand at four bytes (issue #406).
+
+    Both extremes serialize: the eight-octet largest, and the nine-octet
+    most negative.
+    """
+    assert serialize([2**63 - 1]) == bytes.fromhex("08ffffffffffffff7f")
+    assert serialize([-(2**63)]) == bytes.fromhex("09000000000000008080")
+
+    for i in (2**63, -(2**63) - 1, 2**100, 2**200, -(2**100)):
+        with pytest.raises(BTClibValueError, match="script number out of range: "):
+            serialize([i])
+
+
 def test_single_byte_serialization() -> None:
     """Round-trip every single-byte hex string as a two-byte push."""
     for i in range(256):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -169,3 +169,29 @@ def test_encode_num() -> None:
     # 16 bits + sign bit = 17 bits = 3 byte (plus 1 byte for length)
     i = 0b1111111111111111
     assert len(encode_num(i)) == 3
+
+
+def test_encode_num_is_bounded_by_the_int64_of_a_script_number() -> None:
+    """A script number is an int64, so both ends of int64 are the bound.
+
+    Core takes a number into a script through
+    `CScript::operator<<(int64_t)` and has no wider parameter, so an
+    integer past either end is one no script can carry (issue #406).
+    Both extremes are in range, and the most negative one takes nine
+    octets rather than eight, its magnitude not fitting beside a sign
+    bit -- which is what Core's `CScriptNum::serialize` writes for it
+    too.
+    """
+    assert encode_num(2**63 - 1) == bytes.fromhex("ffffffffffffff7f")
+    assert encode_num(-(2**63)) == bytes.fromhex("000000000000008080")
+
+    with pytest.raises(BTClibValueError, match="script number out of range: "):
+        encode_num(2**63)
+    with pytest.raises(BTClibValueError, match="script number out of range: "):
+        encode_num(-(2**63) - 1)
+
+    # the reader is not bounded to match: it answers for a coinbase push
+    # of any width, which is what Block.height reads
+    assert decode_num(encode_num(2**63 - 1)) == 2**63 - 1
+    assert decode_num(encode_num(-(2**63))) == -(2**63)
+    assert decode_num(bytes.fromhex("00000000000000000010")) == 2**76


### PR DESCRIPTION
Closes #406.

`encode_num` took an unbounded Python int, so `script.serialize` wrote a
13-octet push for `2**100` and a 26-octet one for `2**200`: numbers Core
cannot put in a script at all, `CScriptNum` being an `int64_t` and
`CScript::operator<<(int64_t)` having no wider parameter. Not a consensus
divergence — the engine caps every operand at four bytes, five for
CLTV/CSV, so such a push is refused on execution — but the public API
writing what no consensus path will read, the same shape as #388.

The bound goes on `encode_num`, which every caller reaches the octets
through, so `_serialize_int_command` inherits it; the message names both
ends. Both extremes still serialize, the most negative int64 taking the
nine octets Core's `CScriptNum::serialize` gives it too, sign-magnitude
having no room for its magnitude in eight.

`decode_num` stays unbounded, and its docstring says why: it is the
reader, the engine caps an operand before reaching it, and `Block.height`
decodes whatever a coinbase pushed — BIP34 in btclib being the byte
comparison of `assert_valid_coinbase_height`, as it is in Core — so a
bound there would refuse coinbases the network accepts.

Tests pin both bounds and both refusals, in `tests/utils_test.py` for the
codec and `tests/script/script_test.py` for `serialize`; the vendored
`script_tests.json` results are unchanged.

Gates, run locally on the pushed commit:

- `uv run pre-commit run --all-files`: exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html`: exit 0
- `uv run --locked --no-default-groups --group test pytest --cov=btclib
  --cov=tests`: 17296 passed, 100.00% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Constrain script number encoding and serialization to the int64 range used by Bitcoin Core while keeping numeric decoding unbounded for coinbase height handling.

Bug Fixes:
- Prevent script serialization from encoding Python integers outside the int64 CScriptNum range, which could previously produce script pushes no Bitcoin node can create or execute.

Enhancements:
- Document the rationale for leaving numeric decoding unbounded to preserve compatibility with coinbase height semantics and script engine limits.

Documentation:
- Update the changelog to describe the new int64 bounds for script numbers and the distinction between bounded encoding/serialization and unbounded decoding.

Tests:
- Add tests that pin the int64 bounds for script number encoding and serialization and assert that out-of-range values are rejected while valid boundary values still round-trip correctly.