### PR TITLE
hash_type is Core's int32_t in both pre-taproot preimages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1157,6 +1157,27 @@ edit.
   exception contract. What each commits to is unchanged, `-1` and
   `0xffffffffffffffff` being the same eight octets. Found while
   reviewing #386
+- **the hash type the two pre-taproot preimages write is `int32_t
+  nHashType`, Core's own parameter type, not an unsigned integer** (issue
+  #405). `sig_hash.legacy` and `sig_hash.segwit_v0` are public and take it
+  as a plain `int`, and wrote it `signed=False`: `-1` — `ffffffff`, the
+  four octets Core's `ss << nHashType` puts there — was an
+  `OverflowError` out of `int.to_bytes` rather than a preimage, and so was
+  anything from 2^32 up, both from underneath the library rather than
+  through its exception contract. Either spelling of a 32-bit word is
+  hashed now, the two differing nowhere else either, `-1 & 0x1F` and
+  `0xffffffff & 0x1F` being the same 31 that chooses the commitment; what
+  the field cannot carry is a `BTClibValueError` naming it, refused before
+  the transaction is copied so that the SIGHASH_SINGLE bug cannot answer
+  with the constant 1 first. Core's sighash.json carries negative hash
+  types among its vectors, `InsecureRand32()` filling the whole word, and
+  they go in as Core wrote them where the test had been adding 2^32 to
+  each by hand. The seven defined values commit to what they did, and
+  `assert_valid_hash_type` stays out of both preimages: without STRICTENC
+  the script engine hashes whatever byte a signature carries, so refusing
+  an undefined hash type there would refuse preimages consensus asks for
+  — that vector file is nothing but undefined ones. Found while auditing
+  btclib's consensus types against Core v31.1
 
 ### Immutability and shared state
 

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -97,6 +97,32 @@ def assert_valid_hash_type(hash_type: int) -> None:
         raise BTClibValueError(f"invalid sig_hash type: {hex(hash_type)}")
 
 
+def _serialized_hash_type(hash_type: int) -> bytes:
+    """Return the four bytes the two pre-taproot preimages end with.
+
+    Core's `SignatureHash` takes `int32_t nHashType` and writes it as one,
+    so the field is a 32-bit word and -1 is `ffffffff` on the wire. Either
+    spelling of that word is taken -- Core's signed -1 and the
+    `0xffffffff` of a caller who read the field off a preimage -- because
+    the two differ nowhere else either: `-1 & 0x1F` and `0xffffffff & 0x1F`
+    are the same 31, Python's `&` reading a negative in the same two's
+    complement the wire carries. What does not fit the field is a
+    BTClibValueError, where `int.to_bytes` answers with an `OverflowError`
+    from underneath the library (issue #405).
+
+    Not assert_valid_hash_type: the seven defined types are what a signer
+    chooses, not what a preimage may be computed over. Without STRICTENC
+    the script engine hashes whatever byte a signature carries, which is
+    consensus and not taste, and Core's sighash.json is nothing but
+    undefined hash types with the hash each of them must produce.
+    """
+    if not -(2**31) <= hash_type < 2**32:
+        raise BTClibValueError(
+            f"sig_hash type too wide for its four bytes: {hash_type}"
+        )
+    return (hash_type & 0xFFFFFFFF).to_bytes(4, byteorder="little")
+
+
 # the op code a script code is measured from, read out of the table so
 # that a name that stops existing fails at import rather than leaving a
 # rule that quietly stops matching
@@ -273,7 +299,17 @@ def legacy(script_code: Octets, tx: Tx, vin_i: int, hash_type: int) -> bytes:
     serialization and the four hash-type bytes is the answer. The
     SINGLE bug is kept, being consensus: an input with no matching
     output signs the constant 1, not an error.
+
+    `hash_type` is Core's `int32_t nHashType`, and every 32-bit word has a
+    preimage: the seven defined types are what a signer picks, and an
+    undefined one is what a signature may carry and this must still hash.
     """
+    # the field is serialized here, before the transaction is copied, so
+    # that a hash type too wide for it is refused rather than met by the
+    # SINGLE bug's early return, which answers with the constant 1 and
+    # never reaches the serialization at the end
+    serialized_hash_type = _serialized_hash_type(hash_type)
+
     # the legacy preimage commits to the script code with its
     # OP_CODESEPARATORs elided, and Core does that here rather than to the
     # script code itself: SerializeScriptCode is part of the serializer,
@@ -306,7 +342,7 @@ def legacy(script_code: Octets, tx: Tx, vin_i: int, hash_type: int) -> bytes:
         new_tx.vin = [new_tx.vin[vin_i]]
 
     preimage = new_tx.serialize(include_witness=False, check_validity=False)
-    preimage += hash_type.to_bytes(4, byteorder="little", signed=False)
+    preimage += serialized_hash_type
 
     return hash256(preimage)
 
@@ -432,6 +468,9 @@ def segwit_v0(
     `precomputed`, when given, must describe this very transaction; a
     single call leaves it None and hashes only what its hash type
     commits to.
+
+    `hash_type` is Core's `int32_t nHashType`, as `legacy`'s is, and every
+    32-bit word has a preimage for the same reason.
     """
     script_code = bytes_from_octets(script_code)
 
@@ -486,7 +525,9 @@ def segwit_v0(
             tx.vin[vin_i].sequence.to_bytes(4, byteorder="little", signed=False),
             hash_outputs,
             tx.lock_time.to_bytes(4, byteorder="little", signed=False),
-            hash_type.to_bytes(4, byteorder="little", signed=False),
+            # an int32_t as Core's nHashType is, so that -1 is the
+            # `ffffffff` Core writes rather than an OverflowError (#405)
+            _serialized_hash_type(hash_type),
         ]
     )
     return hash256(preimage)

--- a/tests/script/sig_hash_legacy_test.py
+++ b/tests/script/sig_hash_legacy_test.py
@@ -19,7 +19,7 @@ import pytest
 
 from btclib.ecc import dsa
 from btclib.exceptions import BTClibValueError
-from btclib.hashes import hash160
+from btclib.hashes import hash160, hash256
 from btclib.script import serialize, sig_hash
 from btclib.script.engine import verify_transaction
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
@@ -241,9 +241,10 @@ def test_test_vectors(
     # not malformed, and every one of the 500 is valid. Passing
     # check_validity=False would say the opposite without ever checking
     # it, and would hide a vector that stops parsing
+    # the hash type as Core's file writes it, negative ones included: it is
+    # an int32_t there and in `legacy`, so half of these vectors are what
+    # says the four bytes are signed (issue #405)
     tx = Tx.parse(raw_tx)
-    if hash_type < 0:
-        hash_type += 0xFFFFFFFF + 1
     actual_hash = sig_hash.legacy(raw_script, tx, input_index, hash_type)
     assert actual_hash == bytes.fromhex(exp_hash)[::-1]
 
@@ -275,3 +276,76 @@ def test_test_vectors_are_all_undefined_hash_types() -> None:
     # and they are spread over every low-bit combination, the two the
     # legacy rules single out included
     assert {hash_type & 0x1F for hash_type in hash_types} == set(range(32))
+    # negative ones among them, which is what makes this file the authority
+    # for the int32_t Core's nHashType is (issue #405): the whole word is
+    # random, sign bit included, and the vectors go in as Core wrote them
+    assert any(hash_type < 0 for _, _, _, hash_type, _ in rows)
+
+
+# the script code every hash-type case below signs against: a p2pkh
+# script, and one with no OP_CODESEPARATOR, `legacy` eliding those itself
+_SCRIPT_CODE = serialize(
+    [
+        "OP_DUP",
+        "OP_HASH160",
+        "1018853670f9f3b0582c5b9ee8ce93764ac32b93",
+        "OP_EQUALVERIFY",
+        "OP_CHECKSIG",
+    ]
+)
+
+
+def _two_in_one_out() -> Tx:
+    """Return a transaction whose second input has no output of its own."""
+    tx_in_0 = TxIn(OutPoint(b"\x01" * 32, 0), b"", 0xFFFFFFFE)
+    tx_in_1 = TxIn(OutPoint(b"\x02" * 32, 1), serialize(["OP_1"]), 0xFFFFFFFF)
+    return Tx(1, 5, [tx_in_0, tx_in_1], [TxOut(1000, _SCRIPT_CODE)])
+
+
+def test_the_hash_type_is_a_signed_int32() -> None:
+    """Core's nHashType is an int32_t, so -1 has a preimage of its own.
+
+    `SignatureHash` takes an `int32_t` and serializes it as one, four `ff`
+    octets for -1, where an unsigned reading has no such hash type at all
+    and answers with an `OverflowError` from underneath the library
+    (issue #405). The bits of that word are what choose the commitment:
+    `-1 & 0x80` is ANYONECANPAY, so the copy keeps the signed input alone,
+    and `-1 & 0x1F` is 31, which is neither NONE nor SINGLE, so every
+    output stays and every other sequence with them.
+
+    The preimage is written out here, as the segwit v0 file's are, rather
+    than asked of the code under test.
+    """
+    tx = _two_in_one_out()
+    signed_input_only = Tx(
+        tx.version,
+        tx.lock_time,
+        [TxIn(tx.vin[0].prev_out, _SCRIPT_CODE, tx.vin[0].sequence)],
+        tx.vout,
+    )
+    preimage = signed_input_only.serialize(include_witness=False)
+    preimage += b"\xff\xff\xff\xff"
+    assert sig_hash.legacy(_SCRIPT_CODE, tx, 0, -1) == hash256(preimage)
+
+    # the unsigned spelling of the same 32-bit word: the same four octets
+    # go on the wire and the same bits choose the commitment, so it is the
+    # same preimage rather than a second hash type
+    assert sig_hash.legacy(_SCRIPT_CODE, tx, 0, 0xFFFFFFFF) == hash256(preimage)
+
+
+@pytest.mark.parametrize(
+    "hash_type", [-(2**31) - 1, 2**32, 2**32 + sig_hash.SINGLE, 2**64]
+)
+def test_hash_type_too_wide_for_its_four_bytes(hash_type: int) -> None:
+    """Refuse a hash type the field cannot carry, before anything else.
+
+    A `BTClibValueError` naming the field, where `int.to_bytes` answers
+    with an `OverflowError` from outside the library's exception contract
+    (issue #405). Input 1 has no output of its own, which is the SINGLE
+    bug: `2**32 + SINGLE` carries SINGLE's low five bits, and the bug
+    returns the constant 1 without ever reaching the serialization at the
+    end, so it is the case that says the check comes first.
+    """
+    tx = _two_in_one_out()
+    with pytest.raises(BTClibValueError, match="sig_hash type too wide"):
+        sig_hash.legacy(_SCRIPT_CODE, tx, 1, hash_type)

--- a/tests/script/sig_hash_segwitv0_test.py
+++ b/tests/script/sig_hash_segwitv0_test.py
@@ -13,7 +13,10 @@ test vector at
 https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
 """
 
+import pytest
+
 from btclib import var_bytes
+from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash256
 from btclib.script import Witness, sig_hash
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
@@ -322,3 +325,59 @@ def test_the_bip143_amount_is_a_signed_camount() -> None:
     assert sig_hash.segwit_v0(script_code, tx, 0, sig_hash.SINGLE, -1) == hash256(
         negative
     )
+
+
+def test_the_hash_type_is_a_signed_int32() -> None:
+    """Core's nHashType is an int32_t, so -1 has a preimage of its own.
+
+    `SignatureHash` takes an `int32_t` and BIP143's preimage ends with the
+    four bytes of one, `ffffffff` for -1, where an unsigned reading has no
+    such hash type at all and answers with an `OverflowError` from
+    underneath the library (issue #405). The bits of that word choose the
+    fields as they always do: `-1 & 0x80` is ANYONECANPAY, so hashPrevouts
+    and hashSequence are zero, and `-1 & 0x1F` is 31, neither NONE nor
+    SINGLE, so hashOutputs commits to every output.
+
+    The field list is written out here, as the file's other preimages are,
+    rather than asked of the code under test.
+    """
+    tx = Tx.parse(_BIP143_TX)
+    script_code = bytes.fromhex(_WITNESS_SCRIPT)
+    outputs = b"".join(vout.serialize() for vout in tx.vout)
+    preimage = b"".join(
+        [
+            tx.version.to_bytes(4, "little"),
+            b"\x00" * 32,  # hashPrevouts, ANYONECANPAY
+            b"\x00" * 32,  # hashSequence, ANYONECANPAY
+            tx.vin[0].prev_out.serialize(),
+            var_bytes.serialize(script_code),
+            _AMOUNT.to_bytes(8, "little", signed=True),  # a CAmount
+            tx.vin[0].sequence.to_bytes(4, "little"),
+            hash256(outputs),
+            tx.lock_time.to_bytes(4, "little"),
+            b"\xff\xff\xff\xff",
+        ]
+    )
+    assert sig_hash.segwit_v0(script_code, tx, 0, -1, _AMOUNT) == hash256(preimage)
+
+    # the unsigned spelling of the same 32-bit word: the same four octets
+    # go on the wire and the same bits choose the fields, so it is the same
+    # preimage rather than a second hash type
+    assert sig_hash.segwit_v0(script_code, tx, 0, 0xFFFFFFFF, _AMOUNT) == hash256(
+        preimage
+    )
+
+
+@pytest.mark.parametrize("hash_type", [-(2**31) - 1, 2**32, 2**64])
+def test_hash_type_too_wide_for_its_four_bytes(hash_type: int) -> None:
+    """Refuse a hash type the field cannot carry.
+
+    A `BTClibValueError` naming the field, where `int.to_bytes` answers
+    with an `OverflowError` from outside the library's exception contract
+    (issue #405). The same domain `legacy` has, both preimages writing the
+    same `nHashType`.
+    """
+    tx = Tx.parse(_BIP143_TX)
+    script_code = bytes.fromhex(_WITNESS_SCRIPT)
+    with pytest.raises(BTClibValueError, match="sig_hash type too wide"):
+        sig_hash.segwit_v0(script_code, tx, 0, hash_type, _AMOUNT)


### PR DESCRIPTION
Closes #405, with A rather than B — and B is not merely the wider answer,
it is one this tree cannot take.

## What changed

`sig_hash.legacy` and `sig_hash.segwit_v0` wrote the hash type with
`signed=False`, so `-1` — `ffffffff`, the four octets Core's `ss <<
nHashType` puts there — was an `OverflowError` out of `int.to_bytes`
rather than a preimage, and so was anything from 2^32 up: both from
underneath the library rather than through its exception contract.

`_serialized_hash_type` now writes the field for both, as the 32-bit word
Core's `int32_t nHashType` is. Either spelling of that word is taken, the
two differing nowhere else either — `-1 & 0x1F` and `0xffffffff & 0x1F`
are the same 31 that chooses the commitment — so nothing that used to
hash stops hashing. What does not fit the field is a `BTClibValueError`
naming it, and `legacy` serializes it before copying the transaction, so
that the SIGHASH_SINGLE bug's early return cannot answer an out-of-range
hash type with the constant 1.

## Why not B

B — `assert_valid_hash_type` in both preimages — would refuse preimages
consensus asks for. `fix_signature` checks the seven values only under
STRICTENC, which is not a consensus rule, so without it the engine hashes
whatever byte a signature carries. Measured on this tree, by probing both
functions for a hash type outside `SIG_HASH_TYPES` and running the suite:
1302 such calls, from `tests/script/sig_hash_legacy_test.py`,
`tests/script_engine/transactions_test.py`,
`tests/script_engine/python_path_test.py` and
`tests/script_engine/script_test.py`. `alias.py` already states the same
thing about the two — "`legacy` and `segwit_v0` mask rather than
validate, and a byte such as 0x05 must still hash".

So the part of B worth having is its exception contract, which is what
the `BTClibValueError` above is; the frozenset stays where the wire is
closed, in the engine's STRICTENC check and `PsbtIn.assert_valid`.

## Tests

Core's sighash.json is the authority for the signed field: its hash types
are full random 32-bit words, negative ones included, and they now go in
as Core wrote them where the test had been adding 2^32 to each by hand.
Beside that, a hand-written preimage per preimage for `-1` — `& 0x80` is
ANYONECANPAY and `& 0x1F` is 31, so the field list follows — with the
unsigned spelling asserted to give the same hash, and a parametrized
refusal for what the four bytes cannot carry, `2**32 + SINGLE` among them
for the early return.

## Gates

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`:
  17303 passed, 100.00%
- `pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align pre-taproot signature hash preimages with Bitcoin Core by treating the hash type as a signed 32-bit value and tightening its validation surface.

Bug Fixes:
- Fix sig_hash.legacy and sig_hash.segwit_v0 to serialize the hash type as a 32-bit int32_t-compatible field, preventing OverflowError from int.to_bytes and matching Core’s behavior for values like -1.

Enhancements:
- Introduce a shared helper for serializing the hash type with explicit bounds checking, returning consistent BTClibValueError errors when the value cannot be represented in four bytes.
- Document the new hash-type handling semantics in the changelog, clarifying compatibility with Bitcoin Core and consensus behavior.

Tests:
- Add regression tests covering negative and oversized hash types for both legacy and segwit_v0 sighash preimages, including explicit preimages for -1 and boundary conditions to ensure proper error reporting.