### PR TITLE
The nBits sign bit is a sign, not the target's high bit (#402)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -436,12 +436,11 @@ edit.
   `serialize`: those three call it to ask whether the bytes are a block,
   and a block of another network is built with `check_validity=False` and
   then asked, which is the pair of steps a header being mined already
-  takes. What the four do not yet close is issue #402's: `SetCompact`
-  masks the significand before computing the value, so the two `nBits`
-  Core reads as zero, `03800000` and `1d800000`, are a target of 2^23 and
-  one of 2^215 here and reach the zero check as neither.
-  `tests/block/block_test.py` carries both as the `xfail` that turns red
-  the day the mask lands (issue #403)
+  takes. The zero check is only as good as the target handed to it, which
+  is what issue #402 was about: the two `nBits` Core reads as zero,
+  `03800000` and `1d800000`, reach it as zero because the significand is
+  masked before the value is computed, and
+  `tests/block/block_test.py` carries both rows (issue #403)
 - **btclib can check a Merkle proof, not only compute a root.** It had
   the builder's side, `merkle_root_and_mutated_from_hashes`, and no
   entry point for the verifier's: from a txid, a branch of siblings and
@@ -759,6 +758,29 @@ edit.
   TAPROOT off; the shapes they miss are a test. No consensus verdict
   moves: every flag named here is outside ALL_FLAGS, save WITNESS and
   TAPROOT, which move nothing when both are on
+- **the sign bit of `nBits` is a sign, and `target_from_bits` no longer
+  reads it as magnitude** (issue #402). The compact form is a float with
+  a sign bit: Core's `SetCompact` takes the number out of `nCompact &
+  0x007fffff` and reports the bit separately, through the `fNegative`
+  out-parameter `DeriveTarget` refuses the header on. btclib read all
+  three significand bytes, so every `nBits` with `0x00800000` set
+  answered a number no node computes — `0x1d80ffff` put the sign bit
+  *inside* the target's own bytes and made it 2^7 easier than the
+  genesis one, and `0x03800000`, which Core reads as zero, came back as
+  `0x800000`. The mask is Core's now, so `target_from_bits` still answers
+  one target and every call site of it is left alone; the sign it hides
+  is `is_negative_bits`, which `assert_valid_pow` refuses the header on.
+  That predicate reads the magnitude after the exponent, as Core reads it
+  for `nWord != 0 &&`, so a sign bit over a significand the exponent
+  shifts away is not negative either: `0x018000ff` is zero, as
+  `0x03800000` is. `BlockHeader.difficulty` stops redoing
+  the compact arithmetic by hand and takes the ratio of two targets, so
+  one header can no longer have a `target` and a `difficulty` that
+  disagree about which number its `bits` denote; the difficulty of every
+  real header is unchanged, and a zero target now answers the "zero
+  proof-of-work target" of `block_work` instead of dividing by zero.
+  A test walks every exponent against a transcription of `SetCompact`,
+  value and both flags, rather than pinning a handful of numbers
 
 ### Malformed input and the exception contract
 

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -103,16 +103,25 @@ class BlockHeader:
         The difficulty of the genesis block is 2^32 (4*2^30), i.e. 4
         GigaHash function evaluations.
         """
-        # genesis block target
-        genesis_significand = 0x00FFFF
-        genesis_exponent = 0x1D
-        # significand ratio
-        significand = genesis_significand / int.from_bytes(
-            self.bits[1:], byteorder="big", signed=False
-        )
-        # power term ratio
-        power_term = pow(256, genesis_exponent - self.bits[0])
-        return float(significand * power_term)
+        # the ratio of the two targets, and never the compact form
+        # decoded a second time here: the sign bit of `bits` is masked
+        # off in one place, `target_from_bits`, so that this and `target`
+        # cannot disagree about which number the header carries. Core's
+        # GetDifficulty divides by the unmasked significand, which it can
+        # afford to: the header reaching it has passed CheckProofOfWork,
+        # so the bit is not set. This property answers for any header.
+        # MAINNET_POW_LIMIT_BITS is the genesis target, which is what
+        # makes the genesis difficulty 1
+        genesis_target = int.from_bytes(target_from_bits(MAINNET_POW_LIMIT_BITS), "big")
+        target = int.from_bytes(self.target, "big")
+        if not target:
+            # no hash can satisfy a zero target, so no block carries one.
+            # Raised as the exception contract requires, rather than left
+            # to the ZeroDivisionError of the division below, which names
+            # neither the field nor the header
+            raise BTClibValueError(f"zero proof-of-work target: {self.bits.hex()}")
+
+        return genesis_target / target
 
     @property
     def hash(self) -> bytes:

--- a/btclib/block/proof_of_work.py
+++ b/btclib/block/proof_of_work.py
@@ -22,6 +22,12 @@ rather than after Core's spelling -- `bits_from_target` is `GetCompact`,
 `target_from_bits` is `SetCompact`, `next_bits` is
 `CalculateNextWorkRequired`, `block_work` is `GetBlockProof` -- and each
 docstring names its counterpart.
+
+`SetCompact` answers three things at once, the number and two
+out-parameters, so it is two functions here: `target_from_bits` is the
+number and raises where `fOverflow` is set, `is_negative_bits` is
+`fNegative`. Refusing a header on either takes both, which is what
+`BlockHeader.assert_valid_pow` asks.
 """
 
 from __future__ import annotations
@@ -53,6 +59,13 @@ __all__ = [
 # a target is a 256-bit number, i.e. the hash it is compared against
 TARGET_SIZE = 32
 
+# the high bit of the three-byte significand is a sign and not a
+# magnitude: Core's SetCompact reads the number out of
+# `nCompact & 0x007fffff` and reports the bit through fNegative. Not
+# exported, the two functions below being what a caller asks instead
+_SIGNIFICAND_MASK = 0x007FFFFF
+_SIGNIFICAND_SIGN_BIT = 0x00800000
+
 # two weeks, the timespan a difficulty period aims at
 POW_TARGET_TIMESPAN = 14 * 24 * 60 * 60
 # ten minutes, the block interval it aims at
@@ -76,25 +89,41 @@ MAINNET_POW_LIMIT_BITS = b"\x1d\x00\xff\xff"
 REGTEST_POW_LIMIT_BITS = b"\x20\x7f\xff\xff"
 
 
-def target_from_bits(bits: Octets) -> bytes:
-    """Return the 32-byte target the compact `bits` denote.
+def _value_from_bits(bits: bytes) -> int:
+    """Return the magnitude the compact `bits` denote, unbounded.
 
-    The target yyzzww * 256^(xx-3) is represented by the 4 bytes
-    'bits' xxyyzzww. Bitcoin Core spells this `SetCompact`.
+    The body of Core's `SetCompact` and neither of its flags: nothing
+    here objects to what 32 bytes cannot hold, which is the caller's
+    business, and the sign is masked off rather than reported.
     """
-    bits = bytes_from_octets(bits, 4)
-
-    # significand (also known as mantissa or coefficient)
-    significand = int.from_bytes(bits[1:], byteorder="big", signed=False)
+    # significand (also known as mantissa or coefficient), the sign bit
+    # masked off as Core's `nCompact & 0x007fffff` does
+    significand = (
+        int.from_bytes(bits[1:], byteorder="big", signed=False) & _SIGNIFICAND_MASK
+    )
     # power term, also called characteristics. Core's SetCompact shifts
     # rather than multiplying by a power of 256, and so does this:
     # pow(256, -1) is a float in Python, so an exponent below 3 would send
     # a 256-bit number through float arithmetic
     exponent = bits[0]
     if exponent < 3:
-        value = significand >> (8 * (3 - exponent))
-    else:
-        value = significand << (8 * (exponent - 3))
+        return significand >> (8 * (3 - exponent))
+    return significand << (8 * (exponent - 3))
+
+
+def target_from_bits(bits: Octets) -> bytes:
+    """Return the 32-byte target the compact `bits` denote.
+
+    The target yyzzww * 256^(xx-3) is represented by the 4 bytes
+    'bits' xxyyzzww. Bitcoin Core spells this `SetCompact`.
+
+    The high bit of yy is the sign of that number and not part of it, so
+    it is masked off here and answered by `is_negative_bits`: a target
+    is what a hash is compared against, and 0x1d80ffff denotes the
+    genesis target with a sign, not one 2^7 easier.
+    """
+    bits = bytes_from_octets(bits, 4)
+    value = _value_from_bits(bits)
 
     # the compact form can denote what 32 bytes cannot hold, which
     # to_bytes would answer with an OverflowError. Core raises the same
@@ -115,19 +144,23 @@ def is_negative_bits(bits: Octets) -> bool:
     value: 0x00800000 of the significand is a sign and not magnitude, so
     `bits` carrying it denote a number below zero, which no target is and
     no header may claim. `CheckProofOfWork` refuses such a header, and
-    `BlockHeader.assert_valid_pow` is where btclib does.
+    `BlockHeader.assert_valid_pow` is where btclib does. `target_from_bits`
+    masks the bit off and answers the magnitude alone, which is what makes
+    the flag a question of its own.
 
     A significand of zero has no sign, which is Core's `nWord != 0 &&`:
     0x03800000 denotes zero rather than negative zero, the sign bit being
-    all there is of it. This asks the sign of the number the four bytes
-    denote and not the sign of the target, which is unsigned and cannot
+    all there is of it. The magnitude asked about is the one the exponent
+    has already been applied to, as it is in Core, so 0x018000ff is zero
+    as well -- the only byte its masked significand holds is shifted out
+    by an exponent of 1. And it is the sign of the number the four bytes
+    denote, not the sign of the target, which is unsigned and cannot
     carry the answer -- hence a predicate, where Core has an
     out-parameter.
     """
     bits = bytes_from_octets(bits, 4)
-
     significand = int.from_bytes(bits[1:], byteorder="big", signed=False)
-    return bool(significand & 0x007FFFFF) and bool(significand & 0x00800000)
+    return bool(significand & _SIGNIFICAND_SIGN_BIT) and _value_from_bits(bits) != 0
 
 
 def bits_from_target(target: Octets) -> bytes:
@@ -162,7 +195,7 @@ def bits_from_target(target: Octets) -> bytes:
     else:
         significand = value >> (8 * (exponent - 3))
 
-    if significand & 0x00800000:
+    if significand & _SIGNIFICAND_SIGN_BIT:
         significand >>= 8
         exponent += 1
 

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -538,6 +538,33 @@ def test_difficulty_from_compact_bits(
     assert round(header.difficulty, 3) == difficulty
 
 
+def test_difficulty_decodes_bits_once() -> None:
+    """The difficulty and the target decode `bits` once (issue #402).
+
+    `difficulty` used to redo the compact arithmetic itself, so masking
+    the sign bit in `target_from_bits` alone would leave one header with
+    two answers: a target with the bit taken off and a difficulty
+    computed with it in. The genesis bits signed are the case that shows
+    it -- difficulty 1, which is what the unsigned spelling gives, and
+    not the 0.00775 of a target 2^7 easier.
+    """
+    genesis = BlockHeader(bits="1d00ffff", check_validity=False)
+    signed = BlockHeader(bits="1d80ffff", check_validity=False)
+
+    assert signed.target == genesis.target
+    assert signed.difficulty == genesis.difficulty == 1
+
+    # a zero target is no ratio to take, and the answer is the refusal
+    # assert_valid_pow and block_work give it rather than a
+    # ZeroDivisionError out of the library. Both spellings: an exponent
+    # that shifts the significand away, and a significand that is only
+    # the sign bit
+    for bits in ("00000000", "0000ffff", "03800000"):
+        header = BlockHeader(bits=bits, check_validity=False)
+        with pytest.raises(BTClibValueError, match="zero proof-of-work target: "):
+            _ = header.difficulty
+
+
 def test_block_without_transactions() -> None:
     """A block with no coinbase is not a block with nothing in it.
 
@@ -918,21 +945,16 @@ def test_assert_valid_pow_makes_derive_targets_range_checks() -> None:
             header.assert_valid_pow()
 
 
-@pytest.mark.xfail(reason="issue #402: the nBits sign bit is read as magnitude")
 @pytest.mark.parametrize("bits_hex", ["03800000", "1d800000"])
 def test_the_zero_target_check_is_only_as_good_as_the_target(bits_hex: str) -> None:
-    """Two nBits Core reads as zero, and btclib does not.
+    """Two nBits Core reads as zero, and so does btclib.
 
     `SetCompact` masks the significand with 0x007fffff before computing
     the value, so `nWord` is zero for both of these and `DeriveTarget`
-    refuses the header on `bnTarget == 0`. btclib reads the sign bit as
-    magnitude, so 0x03800000 is a target of 2^23 and 0x1d800000 one of
-    2^215, and the zero check below fires for neither.
-
-    That is issue #402 and not the range checks of #403: every other row
-    of `DeriveTarget`'s condition already agrees with Core, and this one
-    will the day the significand is masked, which is what turns this
-    marker red.
+    refuses the header on `bnTarget == 0`. btclib used to read the sign
+    bit as magnitude, which made 0x03800000 a target of 2^23 and
+    0x1d800000 one of 2^215, and the zero check fired for neither: the
+    check was only as good as the number it was handed (issue #402).
     """
     fname = "block_1.bin"
     filename = path.join(path.dirname(__file__), "_data", fname)

--- a/tests/block/proof_of_work_test.py
+++ b/tests/block/proof_of_work_test.py
@@ -96,6 +96,107 @@ def test_target_from_bits() -> None:
         target_from_bits("00ffff")
 
 
+@pytest.mark.parametrize(
+    ("bits_hex", "target_hex", "negative"),
+    [
+        # the genesis bits, where the sign bit is not set and nothing
+        # about them changes
+        ("1d00ffff", f"{'00' * 4}{'ff' * 2}{'00' * 26}", False),
+        # the sign bit alone, in the significand's own byte: masked off,
+        # so the number is 0x7fffff and not 0xffffff
+        ("03ffffff", f"{'00' * 29}7fffff", True),
+        # a significand that is nothing but the sign bit is zero, which
+        # is why Core's fNegative asks nWord != 0 as well
+        ("03800000", "00" * 32, False),
+        # the genesis bits signed: the same target, not one 2^7 easier
+        ("1d80ffff", f"{'00' * 4}{'ff' * 2}{'00' * 26}", True),
+        # the magnitude is read after the exponent, as Core reads it: the
+        # one byte left of the masked significand is shifted out
+        ("018000ff", "00" * 32, False),
+        # regtest's limit signed, and the target above it unchanged
+        ("20ffffff", f"7fffff{'00' * 29}", True),
+    ],
+)
+def test_target_from_bits_sign_bit(
+    bits_hex: str, target_hex: str, negative: bool
+) -> None:
+    """The sign bit of nBits is a sign, and not the target's high bit.
+
+    Core's `SetCompact` masks the significand with 0x007fffff and reports
+    0x00800000 through its `fNegative` out-parameter; the rows are its
+    values for the same input, `target_from_bits` answering the number
+    and `is_negative_bits` the flag (issue #402).
+    """
+    assert target_from_bits(bits_hex).hex() == target_hex
+    assert is_negative_bits(bits_hex) is negative
+
+    # the sign does not survive the round trip, and cannot: bits_from_target
+    # never emits a negative encoding, which is what its docstring is about
+    assert not is_negative_bits(bits_from_target(target_from_bits(bits_hex)))
+
+
+def _set_compact(n_compact: int) -> tuple[int, bool, bool]:
+    """Return what Core's `arith_uint256::SetCompact` computes.
+
+    A transcription of the reference, value and both out-parameters,
+    kept here rather than folded into vectors: the claim being checked is
+    that btclib agrees with it over the whole four-byte space, and a
+    handful of hard-coded numbers cannot say that. The value wraps, as
+    the arith_uint256 it is assigned to does.
+    """
+    n_size = n_compact >> 24
+    n_word = n_compact & 0x007FFFFF
+    if n_size <= 3:
+        n_word >>= 8 * (3 - n_size)
+        value = n_word
+    else:
+        value = n_word << (8 * (n_size - 3))
+    negative = n_word != 0 and (n_compact & 0x00800000) != 0
+    overflow = n_word != 0 and (
+        n_size > 34
+        or (n_word > 0xFF and n_size > 33)
+        or (n_word > 0xFFFF and n_size > 32)
+    )
+    return value % 2**256, negative, overflow
+
+
+def test_target_from_bits_agrees_with_set_compact() -> None:
+    """Every exponent against Core's SetCompact, sign bit included.
+
+    The significands are the edges: zero, the smallest, the byte and
+    two-byte boundaries the overflow rule reads, and each of them with
+    the sign bit set. Where Core flags an overflow btclib raises instead,
+    which is the same refusal and is asserted as such -- and where it
+    does not, the two numbers and the two flags must agree.
+    """
+    significands = (
+        0x000000,
+        0x000001,
+        0x0000FF,
+        0x000100,
+        0x00FFFF,
+        0x010000,
+        0x123456,
+        0x7FFFFF,
+    )
+    for exponent in range(0x100):
+        for significand in significands:
+            for sign in (0, 0x800000):
+                n_compact = (exponent << 24) | sign | significand
+                bits = n_compact.to_bytes(4, "big")
+                value, negative, overflow = _set_compact(n_compact)
+
+                assert is_negative_bits(bits) is negative, bits.hex()
+                if overflow:
+                    err_msg = "invalid proof-of-work target: "
+                    with pytest.raises(BTClibValueError, match=err_msg):
+                        target_from_bits(bits)
+                else:
+                    assert int.from_bytes(target_from_bits(bits), "big") == value, (
+                        bits.hex()
+                    )
+
+
 def test_bits_from_target_round_trip() -> None:
     """Bits taken from real headers survive the round trip."""
     # every vendored block, i.e. every bits value this directory already


### PR DESCRIPTION
Fixes #402. Rebased on #413, which landed `DeriveTarget`'s range checks
in the meantime.

Core's `SetCompact` takes the number out of `nCompact & 0x007fffff` and
reports `0x00800000` separately, through the `fNegative` out-parameter
`DeriveTarget` refuses the header on. btclib read all three significand
bytes, so every `nBits` with the bit set answered a number no node
computes: `0x1d80ffff` put the sign *inside* the target's own bytes and
made it 2^7 easier than the genesis one, and `0x03800000`, which Core
reads as zero, came back as `0x800000`.

## What changed

- `target_from_bits` masks the significand as Core does. It still answers
  one target, so every call site of it is left alone, and the overflow it
  already raised on is unchanged in kind.
- `is_negative_bits`, which #413 added, reads the magnitude *after* the
  exponent, as Core does for `nWord != 0 &&`. A sign bit over a
  significand the exponent shifts away is not negative either:
  `0x018000ff` is zero, as `0x03800000` is.
- `BlockHeader.difficulty` stops redoing the compact arithmetic by hand
  and takes the ratio of two targets, so one header can no longer have a
  `target` and a `difficulty` that disagree about which number its `bits`
  denote. Nothing decodes `nBits` outside `proof_of_work` now. Every real
  header's difficulty is unchanged, bit for bit; a zero target answers
  the "zero proof-of-work target" the other two sites give instead of
  dividing by zero.

## Tests

The issue's rows, plus the two edges where the sign bit is set and the
value is still zero, and a walk of every exponent against a transcription
of `SetCompact` — value, `fNegative` and `fOverflow`, the last as the
exception raised in its place. #413's `xfail` on the two `nBits` Core
reads as zero is a passing test now, which is what it was written to
become.

## Gates

`uv run --locked --no-default-groups --group test pytest --cov=btclib
--cov=tests` — 17316 passed, coverage 100.00%; `uv run pre-commit run
--all-files` and the `-W` sphinx build both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)