### PR TITLE
The psbt's transaction version is unsigned, as Tx's is (#404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1178,6 +1178,26 @@ edit.
   an undefined hash type there would refuse preimages consensus asks for
   — that vector file is nothing but undefined ones. Found while auditing
   btclib's consensus types against Core v31.1
+- **A version 2 psbt now holds every transaction version `Tx` accepts**
+  (issue #404). BIP370 calls `PSBT_GLOBAL_TX_VERSION` a "32-bit little
+  endian signed integer" and btclib read it that way, while `Tx.version`
+  is unsigned, for the two mainnet transactions `Tx.parse`'s comment
+  names; the two readings met in `to_v2`, where a version above
+  `0x7fffffff` had no four-byte signed encoding and left through
+  `int.to_bytes` as a bare `OverflowError`, from underneath the library
+  rather than through its exception contract. The field is unsigned now,
+  at the parse and at the serialization both, so `Tx`'s own
+  `0 <= version <= 0xffffffff` is the only bound the version has and the
+  same four octets mean one thing whichever version of the psbt carries
+  them: `ffffffff` reads as `4294967295` where it used to read as `-1`
+  and then be refused as `invalid version: -1`. A comment at both sites
+  says why the BIP's word is not followed — Core declares
+  `CTransaction::version` a `uint32_t` and implements no PSBTv2, so it
+  has no counterpart for this field to be aligned with, and a psbt
+  version `Tx` cannot hold is of no use whatever the BIP says.
+  `PSBT_OUT_AMOUNT` is untouched, the BIP and Core agreeing on `int64_t`
+  there. Found while auditing btclib's consensus types against Core
+  v31.1, after #388
 
 ### Immutability and shared state
 

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -276,10 +276,18 @@ def _sequence(psbt_in: PsbtIn) -> int:
 # things and in nothing else -- and it is what keeps the parse of the
 # global map one dispatch rather than one branch per field
 _V2_GLOBAL_PARSERS: dict[bytes, tuple[str, str, Callable[[bytes, bytes, str], int]]] = {
+    # unsigned, where BIP370 calls this field a "32-bit little endian
+    # signed integer": what it holds is Tx.version one layer down, and
+    # there it is unsigned, for the two mainnet transactions Tx.parse
+    # names. Core arbitrates neither way -- it implements no PSBTv2, so
+    # it has no counterpart to this field at all -- and the type it does
+    # declare, CTransaction::version, is uint32_t. Read as signed, the
+    # versions above 0x7fffffff come back negative and Tx refuses them,
+    # so the BIP's word would buy a psbt this library cannot hold
     PSBT_GLOBAL_TX_VERSION: (
         "tx_version",
         "tx version",
-        lambda k, v, what: deserialize_sized_int(k, v, what, 4, signed=True),
+        lambda k, v, what: deserialize_sized_int(k, v, what, 4),
     ),
     PSBT_GLOBAL_FALLBACK_LOCKTIME: (
         "fallback_lock_time",
@@ -894,10 +902,12 @@ class Psbt:
             # ascending by type byte, which is the order BIP370's own
             # psbts are written in and so the order a byte-for-byte
             # comparison with them requires
+
+            # the version is written unsigned, where BIP370 says signed;
+            # _V2_GLOBAL_PARSERS says why, and every version Tx accepts
+            # has to be writable here
             psbt_bin.append(
-                serialize_sized_int(
-                    PSBT_GLOBAL_TX_VERSION, self.tx_version, 4, signed=True
-                )
+                serialize_sized_int(PSBT_GLOBAL_TX_VERSION, self.tx_version, 4)
             )
             if self.fallback_lock_time is not None:
                 psbt_bin.append(

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -186,8 +186,10 @@ def deserialize_sized_int(
     value of any length is a field boundary left to whoever writes the
     bytes.
 
-    signed=True for the two values the BIPs define as signed, the
-    transaction version and an output's amount.
+    signed=True for an output's amount, the one field btclib reads as
+    the signed integer the BIPs define. BIP370 defines the transaction
+    version as signed too, and `btclib.psbt.psbt` reads it unsigned,
+    with the reason at the two sites that do.
     """
     if len(k) != 1:
         err_msg = f"invalid {type_} key length: {len(k)}"

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -1300,6 +1300,34 @@ def test_explicit_version() -> None:
         Psbt.b64decode(ten, check_validity=False)
 
 
+@pytest.mark.parametrize("version", [0x80000000, 0xFFFFFFFF])
+def test_tx_version_over_the_signed_bound(version: int) -> None:
+    """A version 2 psbt holds every transaction version `Tx` does.
+
+    BIP370 calls PSBT_GLOBAL_TX_VERSION a signed integer and btclib
+    reads it unsigned, which is `Tx`'s own reading of the same four
+    octets; the parser table says why. Read as signed, these two
+    versions have no four-byte encoding to be written into and the
+    field's `ffffffff` comes back as -1, which `Tx` then refuses.
+    """
+    tx_in = TxIn(OutPoint(bytes(range(32)), 1), b"", 0xFFFFFFFF)
+    tx_out = TxOut(2500000, "a914f987c321394968be164053d352fc49763b2be55c87")
+    psbt = Psbt.from_tx(Tx(version, 0, [tx_in], [tx_out]))
+
+    psbt_v2 = psbt.to_v2()
+    psbt_bin = psbt_v2.serialize()
+    # 0x01 0x02, the key length and the global type, then the four
+    # little-endian octets of the version, which is what a signed field
+    # could not have written
+    assert bytes.fromhex("0102") + b"\x04" + version.to_bytes(4, "little") in psbt_bin
+
+    parsed = Psbt.parse(psbt_bin)
+    assert parsed.tx_version == version
+    assert parsed == psbt_v2
+    assert psbt_v2.to_v0() == psbt
+    assert psbt_v2.tx == psbt.tx
+
+
 def test_global_unknown() -> None:
     """Round-trip a psbt carrying an unknown global key."""
     psbt_str = "cHNidP8BAJoCAAAAAljoeiG1ba8MI76OcHBFbDNvfLqlyHV5JPVFiHuyq911AAAAAAD/////g40EJ9DsZQpoqka7CwmK6kQiwHGyyng1Kgd5WdB86h0BAAAAAP////8CcKrwCAAAAAAWABTYXCtx0AYLCcmIauuBXlCZHdoSTQDh9QUAAAAAFgAUAK6pouXw+HaliN9VRuh0LR2HAI8AAAAAAAEAuwIAAAABqtc5MQGL0l+ErkALaISL4J23BurCrBgpi6vucatlb4sAAAAASEcwRAIgWPb8fGoz4bMVSNSByCbAFb0wE1qtQs1neQ2rZtKtJDsCIEoc7SYExnNbY5PltBaR3XiwDwxZQvufdRhW+qk4FX26Af7///8CgPD6AgAAAAAXqRQPuUY0IWlrgsgzryQceMF9295JNIfQ8gonAQAAABepFCnKdPigj4GZlCgYXJe12FLkBj9hh2UAAAAiAgKVg785rgpgl0etGZrd1jT6YQhVnWxc05tMIYPxq5bgf0cwRAIgdAGK1BgAl7hzMjwAFXILNoTMgSOJEEjn282bVa1nnJkCIHPTabdA4+tT3O+jOCPIBwUUylWn3ZVE8VfBZ5EyYRGMASICAtq2H/SaFNtqfQKwzR+7ePxLGDErW05U2uTbovv+9TbXSDBFAiEA9hA4swjcHahlo0hSdG8BV3KTQgjG0kRUOTzZm98iF3cCIAVuZ1pnWm0KArhbFOXikHTYolqbV2C+ooFvZhkQoAbqAQEDBAEAAAABBEdSIQKVg785rgpgl0etGZrd1jT6YQhVnWxc05tMIYPxq5bgfyEC2rYf9JoU22p9ArDNH7t4/EsYMStbTlTa5Nui+/71NtdSriIGApWDvzmuCmCXR60Zmt3WNPphCFWdbFzTm0whg/GrluB/ENkMak8AAACAAAAAgAAAAIAiBgLath/0mhTban0CsM0fu3j8SxgxK1tOVNrk26L7/vU21xDZDGpPAAAAgAAAAIABAACAAAEBIADC6wsAAAAAF6kUt/X69A49QKWkWbHbNTXyty+pIeiHIgIDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtxHMEQCIGLrelVhB6fHP0WsSrWh3d9vcHX7EnWWmn84Pv/3hLyyAiAMBdu3Rw2/LwhVfdNWxzJcHtMJE+mWzThAlF2xIijaXwEiAgI63ZBPPW3PWd25BrDe4jUpt/+57VDl6GFRkmhgIh8Oc0cwRAIgZfRbpZmLWaJ//hp77QFq8fH5DVSzqo90UKpfVqJRA70CIH9yRwOtHtuWaAsoS1bU/8uI9/t1nqu+CKow8puFE4PSAQEDBAEAAAABBCIAIIwjUxc3Q7WV37Sge3K6jkLjeX2nTof+fZ10l+OyAokDAQVHUiEDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtwhAjrdkE89bc9Z3bkGsN7iNSm3/7ntUOXoYVGSaGAiHw5zUq4iBgI63ZBPPW3PWd25BrDe4jUpt/+57VDl6GFRkmhgIh8OcxDZDGpPAAAAgAAAAIADAACAIgYDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtwQ2QxqTwAAAIAAAACAAgAAgAAiAgOppMN/WZbTqiXbrGtXCvBlA5RJKUJGCzVHU+2e7KWHcRDZDGpPAAAAgAAAAIAEAACAACICAn9jmXV9Lv9VoTatAsaEsYOLZVbl8bazQoKpS2tQBRCWENkMak8AAACAAAAAgAUAAIAA"


### PR DESCRIPTION
Closes #404.

BIP370 calls `PSBT_GLOBAL_TX_VERSION` a «32-bit little endian signed
integer»; `Tx.version` reads the same four octets unsigned, for the two
mainnet transactions `Tx.parse`'s comment names. The two readings met in
`to_v2`:

- a version above `0x7fffffff` had no signed four-byte encoding, so
  `to_v2().serialize()` left through `int.to_bytes` as a bare
  `OverflowError` — from underneath the library, not through its
  exception contract;
- the other way round, a `PSBT_GLOBAL_TX_VERSION` of `ffffffff` parsed
  to `-1` and was then refused as `invalid version: -1`, so the same
  octets passed through version 0 and failed through version 2.

The field is unsigned now at the parse and at the serialization both,
which leaves `Tx`'s own `0 <= version <= 0xffffffff` the only bound the
version has. A comment at each site says why the BIP's word is not
followed: Core declares `CTransaction::version` a `uint32_t` and
implements no PSBTv2 — v31.1 has `PSBT_HIGHEST_VERSION = 0` and no
`PSBT_GLOBAL_TX_VERSION` at all — so there is no Core counterpart for
this field to be aligned with, and a psbt version `Tx` cannot hold is of
no use whatever the BIP says. `PSBT_OUT_AMOUNT` is untouched: BIP370 and
Core's `CAmount` agree on `int64_t` there (#388).

The suite passed unchanged — nothing pinned the signed reading — and a
new parametrized test round-trips `0x80000000` and `0xffffffff` through
`from_tx -> to_v2 -> serialize -> parse`, asserting the octets on the
wire and the `4294967295` they parse back to.

Gates run locally, all green: `pre-commit run --all-files`,
`pytest --cov=btclib --cov=tests` (100.00%, 17305 passed) and the `-W`
sphinx build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Treat PSBTv2 transaction versions as unsigned 32-bit values to match Tx.version, and add tests and documentation to ensure high-bound versions round-trip correctly.

Bug Fixes:
- Align PSBTv2 transaction version handling with Tx by treating PSBT_GLOBAL_TX_VERSION as an unsigned 32-bit value, avoiding overflow errors and invalid negative versions.

Enhancements:
- Document the unsigned interpretation of PSBT_GLOBAL_TX_VERSION in the parser table, serializer, and changelog for consistency with Core and Tx.version.

Tests:
- Add a parametrized PSBT round-trip test to cover transaction versions above the signed 32-bit bound, including 0x80000000 and 0xFFFFFFFF.