### PR TITLE
DeriveTarget's range checks, where assert_valid_pow made none of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -415,6 +415,33 @@ edit.
   the compact form cannot be nudged to meet a given hash either, its
   significand holding three bytes — which is precisely why the comparison
   has to be read off Core rather than tested against it
+- **a proof-of-work is checked against the network's limit**, and against
+  the three other range checks Core's `DeriveTarget` makes before it.
+  `BlockHeader.assert_valid_pow` was that hash comparison and nothing
+  else, where `CheckProofOfWork` refuses four targets without looking at
+  the hash at all: a negative `nBits`, a zero target, one 32 bytes cannot
+  hold, and one above `params.powLimit`. btclib made none of them at that
+  site — `target_from_bits` raises on the overflow, the zero target was
+  refused only by `block_work`, which this never called, and there was no
+  pow limit in a function that took no arguments — so a header claiming
+  regtest's `207fffff` on mainnet was a mainnet header for half a try's
+  worth of work. `assert_valid_pow(pow_limit_bits)` and
+  `Block.assert_valid(pow_limit_bits)` now take the network's easiest
+  target, `MAINNET_POW_LIMIT_BITS` by default as `next_bits` already took
+  it, and each refusal names which of the four it was where
+  `DeriveTarget` returns a bare `nullopt` for all of them. The sign bit is
+  `proof_of_work.is_negative_bits`, Core's `fNegative`, asked of the four
+  bytes because the target is unsigned and cannot carry it. It is a
+  parameter of `Block.assert_valid` and not of `__init__`, `parse` or
+  `serialize`: those three call it to ask whether the bytes are a block,
+  and a block of another network is built with `check_validity=False` and
+  then asked, which is the pair of steps a header being mined already
+  takes. What the four do not yet close is issue #402's: `SetCompact`
+  masks the significand before computing the value, so the two `nBits`
+  Core reads as zero, `03800000` and `1d800000`, are a target of 2^23 and
+  one of 2^215 here and reach the zero check as neither.
+  `tests/block/block_test.py` carries both as the `xfail` that turns red
+  the day the mask lands (issue #403)
 - **btclib can check a Merkle proof, not only compute a root.** It had
   the builder's side, `merkle_root_and_mutated_from_hashes`, and no
   entry point for the verifier's: from a txid, a branch of siblings and

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,6 +33,15 @@ against the `v2023.7.12` tag.
   This is the number consensus reads, `MAX_BLOCK_WEIGHT` bounding it; the
   sum is still available as `sum(t.weight for t in block.transactions)`,
   and `Block.stripped_size` is the other quantity a block is bounded by.
+- **a block is proved against a network's pow limit, mainnet's unless you
+  say which.** `BlockHeader.assert_valid_pow()` and `Block.assert_valid()`
+  compared the hash with the target and made none of `CheckProofOfWork`'s
+  four range checks on that target, so a regtest or signet block passed as
+  a mainnet one. Both now take a `pow_limit_bits`, and a block of another
+  network is answered `proof-of-work target above the limit` until it is
+  named: `assert_valid(REGTEST_POW_LIMIT_BITS)`. `Block.__init__`, `parse`
+  and `serialize` have no such parameter, so build with
+  `check_validity=False` and validate in a second step.
 - **a psbt carrying a PSBT v2 field is refused**, where every one of the
   twelve was filed under `unknown` and round-tripped. BIP370 forbids them
   in version 0, which is the only version btclib reads, so

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -17,7 +17,7 @@ from math import ceil
 from typing import Any
 
 from btclib import var_bytes, var_int
-from btclib.alias import BinaryData, Command
+from btclib.alias import BinaryData, Command, Octets
 from btclib.block.block_context import BlockContext
 from btclib.block.block_header import BlockHeader
 from btclib.block.limits import (
@@ -25,6 +25,7 @@ from btclib.block.limits import (
     MAX_BLOCK_WEIGHT,
     WITNESS_SCALE_FACTOR,
 )
+from btclib.block.proof_of_work import MAINNET_POW_LIMIT_BITS
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import (
     hash256,
@@ -461,13 +462,21 @@ class Block:
         if context.bip34_active:
             self.assert_valid_coinbase_height(context.height)
 
-    def assert_valid(self) -> None:
+    def assert_valid(self, pow_limit_bits: Octets = MAINNET_POW_LIMIT_BITS) -> None:
         """Refuse what Core's CheckBlock refuses, in Core's order.
 
         The header and its proof-of-work, the size bounds, exactly one
         coinbase and it first, every transaction on its own, the sigop
         bound, the merkle root, the witness commitment, the weight.
         Height and clock rules are assert_valid_contextual's.
+
+        `pow_limit_bits` is forwarded to assert_valid_pow, whose docstring
+        says why the network's easiest target is the caller's to state and
+        why mainnet's is the default. It is a parameter here and not of
+        __init__, parse or serialize: those three call this to answer
+        whether the bytes are a block, and a block of another network is
+        built with check_validity=False and then asked, which is the same
+        two steps a caller already takes to build a header being mined.
         """
         self.header.assert_valid()
         # the header alone does not assert this: a header being mined is
@@ -478,7 +487,7 @@ class Block:
         # CheckProofOfWork with fCheckPOW defaulted to true.
         # It is also what makes the vendored block_*.bin files verify
         # themselves: Block.parse recomputes the hash from the bytes
-        self.header.assert_valid_pow()
+        self.header.assert_valid_pow(pow_limit_bits)
 
         # Core's bad-blk-length is three questions in one condition -- an
         # empty transaction list, too many transactions, too many bytes --

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -18,7 +18,11 @@ from typing import Any
 
 from btclib.alias import BinaryData, Octets
 from btclib.block.limits import MAX_FUTURE_BLOCK_TIME
-from btclib.block.proof_of_work import target_from_bits
+from btclib.block.proof_of_work import (
+    MAINNET_POW_LIMIT_BITS,
+    is_negative_bits,
+    target_from_bits,
+)
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash256
 from btclib.utils import (
@@ -182,8 +186,24 @@ class BlockHeader:
             check_validity=check_validity,
         )
 
-    def assert_valid_pow(self) -> None:
+    def assert_valid_pow(self, pow_limit_bits: Octets = MAINNET_POW_LIMIT_BITS) -> None:
         """Assert whether the BlockHeader provides a valid proof-of-work.
+
+        Bitcoin Core's CheckProofOfWork: the target the bits denote must
+        be one the network allows, and the hash must not exceed it. The
+        range of the target is checked first and is four questions, which
+        are Core's DeriveTarget -- a negative bits value, a zero target,
+        a target 32 bytes cannot hold, a target above the network's
+        limit. Each is refused by name, where DeriveTarget returns a bare
+        nullopt for all four: a caller of this library is told which rule
+        it broke, and the four are as many different mistakes.
+
+        `pow_limit_bits` is the network's easiest target, mainnet's by
+        default as `next_bits` takes it, and it is the caller's to state:
+        a header carries no claim about which network it belongs to, so
+        nothing here can read one. Passing REGTEST_POW_LIMIT_BITS is what
+        makes a regtest header acceptable -- and what keeps a regtest one
+        from passing for mainnet, which is the hole this closes.
 
         Not called by assert_valid, which answers the other question:
         whether the eighty bytes are a well-formed header. A header being
@@ -195,6 +215,36 @@ class BlockHeader:
         calls CheckProofOfWork by default: a Block is a block, and the
         proof-of-work is what its transactions are committed by.
         """
+        # DeriveTarget's four range checks, in the order of the condition
+        # they are the disjuncts of. Only the last of them needs the
+        # network, and none of them looks at the hash: bits alone can be
+        # a target no chain would ever hand out.
+        #
+        # fNegative, which the target cannot report because it is
+        # unsigned -- 0x1d80ffff denotes a number below zero and its
+        # magnitude is a plausible mainnet target
+        if is_negative_bits(self.bits):
+            raise BTClibValueError(f"negative proof-of-work target: {self.bits.hex()}")
+
+        # fOverflow is raised by target_from_bits, which is where the
+        # 32 bytes are, so reading the target is the third check
+        target = self.target
+
+        # a target no hash can satisfy, since a hash is unsigned: Core
+        # refuses it here rather than letting the comparison below decide,
+        # and block_work refuses it for the same reason
+        if not int.from_bytes(target, byteorder="big", signed=False):
+            raise BTClibValueError(f"zero proof-of-work target: {self.bits.hex()}")
+
+        # both are 32 bytes big endian, so this is the comparison of the
+        # numbers they hold. The limit is the easiest target the network
+        # allows, so a target above it is work no network asked for
+        pow_limit = target_from_bits(pow_limit_bits)
+        if target > pow_limit:
+            err_msg = f"proof-of-work target above the limit: {target.hex()}"
+            err_msg += f" > {pow_limit.hex()}"
+            raise BTClibValueError(err_msg)
+
         # the target is a bound the hash may reach: CheckProofOfWork
         # rejects on "hash > bnTarget", so a hash equal to the target is
         # the last one that solves the block, and refusing it would be
@@ -202,9 +252,9 @@ class BlockHeader:
         # can show the difference -- equality asks a 256-bit hash for one
         # exact value -- so the comparison is right by matching Core's,
         # which is the only way it can be right here
-        if self.hash > self.target:
+        if self.hash > target:
             err_msg = f"invalid proof-of-work: {self.hash.hex()}"
-            err_msg += f" > {self.target.hex()}"
+            err_msg += f" > {target.hex()}"
             raise BTClibValueError(err_msg)
 
     def assert_valid_time(self, now: datetime) -> None:

--- a/btclib/block/mining.py
+++ b/btclib/block/mining.py
@@ -17,9 +17,11 @@ test, or watching the search work.
 
 What it is not a toy about is the header it produces. The merkle root
 comes from the same function `Block.assert_valid_merkle_root` checks
-against, and the solved header satisfies `assert_valid_pow`, so the
-result is a block every other implementation accepts -- at a difficulty
-nobody has to be convinced by.
+against, and the solved header satisfies `assert_valid_pow` for a network
+whose pow limit the bits are within -- `REGTEST_POW_LIMIT_BITS` for a
+target of that grade, since mainnet's is the default there and refuses
+one. So the result is a block every other implementation accepts, at a
+difficulty nobody has to be convinced by.
 """
 
 from __future__ import annotations
@@ -114,9 +116,13 @@ def mine(header: BlockHeader, max_tries: int = 1 << 20) -> BlockHeader | None:
     stop = min(candidate.nonce + max_tries, NONCE_SPACE)
     for nonce in range(candidate.nonce, stop):
         candidate.nonce = nonce
-        # the comparison assert_valid_pow makes, so that what is returned
-        # from here is what a Block will accept: the target is a bound the
-        # hash may reach, Core rejecting on "hash > bnTarget"
+        # the last comparison assert_valid_pow makes, so that what is
+        # returned from here is what a Block will accept: the target is a
+        # bound the hash may reach, Core rejecting on "hash > bnTarget".
+        # The range checks it makes before it are about the bits and not
+        # the nonce, so they are the same for every candidate and none of
+        # this loop's business: a target no network allows is one this
+        # search solves and assert_valid_pow still refuses
         if candidate.hash <= target:
             return candidate
 

--- a/btclib/block/proof_of_work.py
+++ b/btclib/block/proof_of_work.py
@@ -44,6 +44,7 @@ __all__ = [
     "block_work",
     "chain_work",
     "hash_rate",
+    "is_negative_bits",
     "next_bits",
     "retarget_first_height",
     "target_from_bits",
@@ -107,6 +108,28 @@ def target_from_bits(bits: Octets) -> bytes:
     return value.to_bytes(TARGET_SIZE, "big", signed=False)
 
 
+def is_negative_bits(bits: Octets) -> bool:
+    """Return whether the compact `bits` denote a negative number.
+
+    Bitcoin Core's `fNegative`, the flag `SetCompact` reports beside the
+    value: 0x00800000 of the significand is a sign and not magnitude, so
+    `bits` carrying it denote a number below zero, which no target is and
+    no header may claim. `CheckProofOfWork` refuses such a header, and
+    `BlockHeader.assert_valid_pow` is where btclib does.
+
+    A significand of zero has no sign, which is Core's `nWord != 0 &&`:
+    0x03800000 denotes zero rather than negative zero, the sign bit being
+    all there is of it. This asks the sign of the number the four bytes
+    denote and not the sign of the target, which is unsigned and cannot
+    carry the answer -- hence a predicate, where Core has an
+    out-parameter.
+    """
+    bits = bytes_from_octets(bits, 4)
+
+    significand = int.from_bytes(bits[1:], byteorder="big", signed=False)
+    return bool(significand & 0x007FFFFF) and bool(significand & 0x00800000)
+
+
 def bits_from_target(target: Octets) -> bytes:
     """Return the compact `bits` denoting a target, rounded down.
 
@@ -119,8 +142,9 @@ def bits_from_target(target: Octets) -> bytes:
     change of base. The compact form reads 0x00800000 as "negative", so
     a significand whose high bit is set is divided by 256 and the
     exponent raised -- 0x800000 is written 0x04008000, four bytes rather
-    than three, and never 0x03800000, which denotes a negative number no
-    header may carry.
+    than three, and never 0x03800000, where that bit is the sign and
+    `SetCompact` masks it off, leaving four bytes that denote zero.
+    is_negative_bits is the flag itself, for the other direction.
     """
     target = bytes_from_octets(target)
     if len(target) > TARGET_SIZE:

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -30,6 +30,7 @@ from btclib.block.limits import (
     MAX_BLOCK_WEIGHT,
     WITNESS_SCALE_FACTOR,
 )
+from btclib.block.proof_of_work import REGTEST_POW_LIMIT_BITS
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.network import NETWORKS
 from btclib.script import ScriptPubKey
@@ -880,3 +881,92 @@ def test_a_block_still_requires_the_work() -> None:
     forged[76] ^= 0x01
     with pytest.raises(BTClibValueError, match="invalid proof-of-work: "):
         Block.parse(bytes(forged))
+
+
+def test_assert_valid_pow_makes_derive_targets_range_checks() -> None:
+    """Four targets are refused before the hash is looked at.
+
+    `fNegative`, a zero target, `fOverflow` and a target above the
+    network's pow limit: the four disjuncts of the one condition in
+    Core's `DeriveTarget`, which `CheckProofOfWorkImpl` answers with a
+    bare false for all four. btclib says which of the four it was, and
+    the order is Core's -- 0x1d80ffff is above mainnet's limit as well as
+    negative, and it is refused as negative (issue #403).
+    """
+    fname = "block_1.bin"
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        header_bytes = file_.read()[:80]
+
+    header = BlockHeader.parse(header_bytes)
+    # the regression guard for the whole change: the first mainnet block
+    # after genesis carries mainnet's limit as its bits, so it sits on
+    # the boundary all four checks are drawn around
+    header.assert_valid_pow()
+
+    # 0x22ffffff is not among them: it overflows *and* is negative, and
+    # Core reads fNegative first, so it is the row that would not tell
+    # the two apart. 0xff000001 overflows with the sign bit clear
+    for bits_hex, err_msg in (
+        ("1d80ffff", "negative proof-of-work target: "),
+        ("0000ffff", "zero proof-of-work target: "),
+        ("ff000001", "invalid proof-of-work target: "),
+        ("207fffff", "proof-of-work target above the limit: "),
+    ):
+        header.bits = bytes.fromhex(bits_hex)
+        with pytest.raises(BTClibValueError, match=err_msg):
+            header.assert_valid_pow()
+
+
+@pytest.mark.xfail(reason="issue #402: the nBits sign bit is read as magnitude")
+@pytest.mark.parametrize("bits_hex", ["03800000", "1d800000"])
+def test_the_zero_target_check_is_only_as_good_as_the_target(bits_hex: str) -> None:
+    """Two nBits Core reads as zero, and btclib does not.
+
+    `SetCompact` masks the significand with 0x007fffff before computing
+    the value, so `nWord` is zero for both of these and `DeriveTarget`
+    refuses the header on `bnTarget == 0`. btclib reads the sign bit as
+    magnitude, so 0x03800000 is a target of 2^23 and 0x1d800000 one of
+    2^215, and the zero check below fires for neither.
+
+    That is issue #402 and not the range checks of #403: every other row
+    of `DeriveTarget`'s condition already agrees with Core, and this one
+    will the day the significand is masked, which is what turns this
+    marker red.
+    """
+    fname = "block_1.bin"
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        header_bytes = file_.read()[:80]
+
+    header = BlockHeader.parse(header_bytes)
+    header.bits = bytes.fromhex(bits_hex)
+    with pytest.raises(BTClibValueError, match="zero proof-of-work target: "):
+        header.assert_valid_pow()
+
+
+def test_the_pow_limit_is_the_callers_to_state() -> None:
+    """A header carries no network, so nothing but the caller knows one.
+
+    Block 1's hash is far below regtest's target, so a header claiming
+    regtest's bits on mainnet is the block Core rejects and btclib used
+    to accept (issue #403). What tells the two apart is the limit passed
+    in, and Block.assert_valid forwards it so a block is answered for the
+    same network its header is.
+    """
+    fname = "block_1.bin"
+    filename = path.join(path.dirname(__file__), "_data", fname)
+    with open(filename, "rb") as file_:
+        block_bytes = file_.read()
+
+    block = Block.parse(block_bytes)
+    block.header.bits = REGTEST_POW_LIMIT_BITS
+
+    # the work satisfies the target it claims, and the target is one no
+    # mainnet block may claim
+    assert block.header.hash <= block.header.target
+    with pytest.raises(BTClibValueError, match="target above the limit: "):
+        block.assert_valid()
+
+    # and the same block is a block on the network those bits belong to
+    block.assert_valid(REGTEST_POW_LIMIT_BITS)

--- a/tests/block/mining_test.py
+++ b/tests/block/mining_test.py
@@ -9,9 +9,9 @@
 # or distributed except according to the terms contained in the LICENSE file.
 """Tests for the `btclib.block.mining` module.
 
-The target mined against is `2000ffff`, easier than anything a network
-allows and harder than regtest's own limit: it is satisfied by one hash
-in 256, so the search takes a few hundred evaluations and under a
+The target mined against is `2000ffff`, harder than regtest's own limit
+and easier than anything else a network allows: it is satisfied by one
+hash in 256, so the search takes a few hundred evaluations and under a
 millisecond, and is still a search rather than a lucky first nonce. The
 nonces asserted below are therefore fixed by the candidate they solve --
 change a byte of one and its nonce moves. Every assertion goes through the
@@ -19,6 +19,12 @@ ordinary validation -- `Block.assert_valid`, which asserts the
 proof-of-work, the merkle root and the coinbase -- so what is being
 checked is that a block built here is a block, not that two copies of
 the same arithmetic agree.
+
+Regtest is therefore the network every block here belongs to, and it is
+said out loud: `assert_valid` and `assert_valid_pow` default to mainnet's
+limit, which these targets are far above, so each call names
+`REGTEST_POW_LIMIT_BITS`. A validation that passed without naming it
+would be one that let a regtest block pass for a mainnet one.
 """
 
 from datetime import datetime, timezone
@@ -72,13 +78,18 @@ def test_a_mined_block_is_a_block() -> None:
     assert candidate.version == VERSION
     assert len(candidate.serialize()) == 80
     with pytest.raises(BTClibValueError, match="invalid proof-of-work: "):
-        candidate.assert_valid_pow()
+        candidate.assert_valid_pow(REGTEST_POW_LIMIT_BITS)
 
     header = mine(candidate)
     assert header is not None
     assert header.nonce == 373
     assert header.hash <= header.target
-    header.assert_valid_pow()
+    header.assert_valid_pow(REGTEST_POW_LIMIT_BITS)
+
+    # and the same work is no proof-of-work on mainnet, whose limit these
+    # bits are 2^24 above: what the header solved is the network it says
+    with pytest.raises(BTClibValueError, match="target above the limit: "):
+        header.assert_valid_pow()
 
     # everything except the nonce is what the candidate carried
     assert header.merkle_root == candidate.merkle_root
@@ -87,11 +98,14 @@ def test_a_mined_block_is_a_block() -> None:
     assert header.bits == candidate.bits
 
     # and the block it heads validates in full: work, merkle root,
-    # coinbase, witness commitment
-    block = Block(header, transactions)
-    block.assert_valid()
+    # coinbase, witness commitment. Built unchecked and then checked,
+    # because __init__ has no network to be told about and defaults to
+    # mainnet's limit -- the two steps Block.assert_valid documents
+    block = Block(header, transactions, check_validity=False)
+    block.assert_valid(REGTEST_POW_LIMIT_BITS)
     assert block.height == 700_000
-    assert block == Block.parse(block.serialize())
+    round_tripped = block.serialize(check_validity=False)
+    assert block == Block.parse(round_tripped, check_validity=False)
 
     # the caller's candidate was not touched
     assert candidate.nonce == 0
@@ -126,7 +140,16 @@ def test_regtest_target_is_solved_by_the_first_nonce() -> None:
     header = mine(candidate, 2)
     assert header is not None
     assert header.nonce == 0
-    Block(header, transactions).assert_valid()
+    Block(header, transactions, check_validity=False).assert_valid(
+        REGTEST_POW_LIMIT_BITS
+    )
+
+    # issue #403 measured from here: a header solved against regtest's
+    # limit and offered to mainnet, which Core's DeriveTarget refuses on
+    # "bnTarget > powLimit" and btclib used to accept. Half a try's worth
+    # of work, and it was a mainnet block
+    with pytest.raises(BTClibValueError, match="target above the limit: "):
+        Block(header, transactions, check_validity=False).assert_valid()
 
 
 def test_a_bounded_search_can_find_nothing() -> None:

--- a/tests/block/proof_of_work_test.py
+++ b/tests/block/proof_of_work_test.py
@@ -36,6 +36,7 @@ from btclib.block.proof_of_work import (
     block_work,
     chain_work,
     hash_rate,
+    is_negative_bits,
     next_bits,
     retarget_first_height,
     target_from_bits,
@@ -152,6 +153,37 @@ def test_bits_from_target_edges() -> None:
     # a target is 256 bits
     with pytest.raises(BTClibValueError, match="invalid target: 33 bytes"):
         bits_from_target(b"\xff" * 33)
+
+
+def test_is_negative_bits() -> None:
+    """Core's fNegative, the flag SetCompact reports beside the value.
+
+    `nWord = nCompact & 0x007fffff` and `*pfNegative = nWord != 0 &&
+    (nCompact & 0x00800000) != 0`, so the answers below are read off
+    `arith_uint256.cpp` and not off btclib: 0x03800000 is the row that
+    tells the two apart, its significand masking to zero, which is a
+    number with no sign rather than a negative zero.
+
+    The flag is asked of the four bytes and not of the target, which is
+    unsigned and cannot carry it. `assert_valid_pow` is what refuses a
+    header for it, as `CheckProofOfWork` does.
+    """
+    # every bits value this file and the vendored blocks already use
+    for bits_hex in ("1d00ffff", "207fffff", "1a05db8b", "18013ce9", "2000ffff"):
+        assert not is_negative_bits(bits_hex)
+
+    # the sign bit set, over a significand that is not zero
+    assert is_negative_bits("03ffffff")
+    assert is_negative_bits("1d80ffff")
+    assert is_negative_bits("03800001")
+
+    # and set over one that is: no sign on zero
+    assert not is_negative_bits("03800000")
+    assert not is_negative_bits("1d800000")
+
+    # bits are four bytes, whatever else is handed over
+    with pytest.raises(BTClibValueError, match="invalid size: 3 bytes instead of 4"):
+        is_negative_bits("00ffff")
 
 
 def test_retarget_first_height() -> None:


### PR DESCRIPTION
Closes #403.

## What changed

`BlockHeader.assert_valid_pow` was one comparison, `hash > target`, and
Core's `CheckProofOfWork` makes four range checks on the target before
that comparison — [`DeriveTarget`](https://github.com/bitcoin/bitcoin/blob/v31.1/src/pow.cpp#L146-L159):

```cpp
if (fNegative || bnTarget == 0 || fOverflow || bnTarget > UintToArith256(pow_limit))
    return {};
```

btclib made none of them at that site. It makes all four now, in that
order, and each names itself where `DeriveTarget` returns a bare
`nullopt` for all of them:

- `negative proof-of-work target: 1d80ffff` — the new
  `proof_of_work.is_negative_bits`, Core's `fNegative`. A predicate and
  not a second return value from `target_from_bits`: the target is
  unsigned and cannot carry the answer, and the eight call sites of
  `target_from_bits` stay as they are.
- `zero proof-of-work target: 0000ffff` — no hash can satisfy it.
- `invalid proof-of-work target: … overflows 32 bytes` — `fOverflow`,
  which `target_from_bits` already raised and which stays there.
- `proof-of-work target above the limit: … > …` — the check that was
  missing entirely, the function having taken no arguments.

`assert_valid_pow(pow_limit_bits)` and `Block.assert_valid(pow_limit_bits)`
default to `MAINNET_POW_LIMIT_BITS`, as `next_bits` already did. It is
not a parameter of `Block.__init__`, `parse` or `serialize`: those three
call `assert_valid` to ask whether the bytes are a block, so a block of
another network is built with `check_validity=False` and asked in a
second step — the pair of steps a header being mined already takes.

## The hole it closes

A header solved against regtest's `207fffff` and offered to mainnet, half
a try's worth of work, measured before and after:

```
nBits 207fffff
  btclib target       7fffff000000…0000
  Core DeriveTarget   REJECTS (bnTarget > powLimit)
  before              ACCEPTS
  after               proof-of-work target above the limit: 7fffff…0000 > 00000000ffff…0000
```

`tests/block/mining_test.py::test_regtest_target_is_solved_by_the_first_nonce`
mines it and asserts both answers.

## What #402 still owns

`SetCompact` masks the significand with `0x007fffff` before computing the
value and `target_from_bits` does not, so the two `nBits` Core reads as
**zero** are a target of 2^23 and one of 2^215 here:

| nBits | Core | btclib, after this PR |
|---|---|---|
| `03800000` | zero | ok — accepted |
| `1d800000` | zero | above the limit — refused, wrong reason |

Every other row agrees with Core; these two are #402's masking and not
these range checks. Both are in `tests/block/block_test.py` as an
`xfail`, which `xfail_strict` turns red the day the mask lands.

## Verified

```
uv run pre-commit run --all-files                                    # 0
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html # 0
uv run --locked --no-default-groups --group test \
    pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests
    # 17306 passed, 2 xfailed; coverage 100.00%
```

Every `nBits` in the new tests was cross-checked against a
line-for-line reimplementation of `arith_uint256::SetCompact` and
`DeriveTarget`, not against btclib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align proof-of-work validation with Bitcoin Core by enforcing full target range checks and making the network’s pow limit an explicit parameter of block validation.

New Features:
- Introduce is_negative_bits helper to expose Bitcoin Core’s fNegative compact bits flag semantics.

Bug Fixes:
- Reject headers whose compact bits encode negative, zero, overflowing, or above-limit proof-of-work targets, preventing regtest or other easy-network blocks from being accepted as mainnet.
- Ensure block and header validation use the correct network-specific pow limit by requiring callers to pass pow_limit_bits instead of implicitly treating all blocks as mainnet.

Enhancements:
- Extend BlockHeader.assert_valid_pow and Block.assert_valid to accept a configurable pow_limit_bits with sensible defaults, improving multi-network support.
- Clarify mining and proof-of-work documentation and comments to describe the role of network pow limits and range checks.
- Add targeted tests around proof-of-work target edge cases, negative bits detection, and regtest vs mainnet pow-limit behavior, including xfail markers for known SetCompact masking discrepancies.

Documentation:
- Document the strengthened proof-of-work range checks and network pow-limit handling in CHANGELOG and HISTORY.