### PR TITLE
Match Tx.assert_standard version bounds to Core v31.1's relay policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -781,6 +781,17 @@ edit.
   proof-of-work target" of `block_work` instead of dividing by zero.
   A test walks every exponent against a transcription of `SetCompact`,
   value and both flags, rather than pinning a handful of numbers
+- **`Tx.assert_standard` refuses a version outside Core v31.1's relay
+  window, not outside the positive half of the four-byte range**
+  (issue #387). It read the version as though standardness were "not
+  the top bit", so 4 and every value up to 0x7FFFFFFF passed as
+  standard where Core's `policy.h` relays 1 through 3 only —
+  `TX_MIN_STANDARD_VERSION` and `TX_MAX_STANDARD_VERSION`, the second
+  being v31.1's own addition over v27.2's 2, BIP431's TRUC. The window
+  is closed on both sides now, `_TX_MIN_STANDARD_VERSION` and
+  `_TX_MAX_STANDARD_VERSION` in `btclib/tx/tx.py`, and a test pins both
+  accepted endpoints and the first refused value on either side; found
+  while reviewing #386
 
 ### Malformed input and the exception contract
 

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -41,6 +41,12 @@ __all__ = [
 
 _SEGWIT_MARKER = b"\x00\x01"
 
+# Core v31.1's policy.h, TX_MIN_STANDARD_VERSION through
+# TX_MAX_STANDARD_VERSION: 1 and 2 are what v27.2 and v31.1 agree on, 3
+# is v31.1's own addition, BIP431's TRUC (issue #387)
+_TX_MIN_STANDARD_VERSION = 1
+_TX_MAX_STANDARD_VERSION = 3
+
 
 def _assert_valid_coinbase(vin: Sequence[TxIn], *, is_coinbase: bool) -> None:
     """Raise an exception if the inputs disagree with the coinbase rule.
@@ -242,14 +248,15 @@ class Tx:
     def assert_standard(self) -> None:
         """Refuse what assert_valid refuses, plus a non-standard version.
 
-        Standardness reads the version as the signed int Core relays
-        on, so zero and anything above 0x7FFFFFFF fail here and not in
-        assert_valid, negative-as-signed versions being in blocks.
+        Core v31.1's relay policy, `TX_MIN_STANDARD_VERSION` through
+        `TX_MAX_STANDARD_VERSION`: 1 and 2 both v27.2 and v31.1 relay,
+        3 is v31.1's own addition, BIP431's TRUC, and every version
+        outside that window fails here and not in assert_valid, whose
+        four-byte range takes it.
         """
         self.assert_valid()
 
-        # should be a 4-bytes __signed__ integer
-        if not 0 < self.version <= 0x7FFFFFFF:
+        if not _TX_MIN_STANDARD_VERSION <= self.version <= _TX_MAX_STANDARD_VERSION:
             raise BTClibValueError(f"invalid version: {self.version}")
 
     def assert_valid(self, *, unsigned_template: bool = False) -> None:

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -210,9 +210,9 @@ def test_the_top_of_the_four_byte_range_round_trips() -> None:
     and 0x80000000 does not serialize at all, so a transaction below
     0x80000000 cannot tell the two spellings apart. Both are valid
     versions, which is the other half of the boundary: `assert_valid`
-    takes the whole four-byte range and `assert_standard` refuses this end
-    of it -- what Core's own field is, signed in v27.2 and unsigned in
-    v31.1, is issue 387's, and no assertion here needs it.
+    takes the whole four-byte range and `assert_standard` refuses this
+    end of it -- what Core's own field is, signed in v27.2 and unsigned
+    in v31.1, is a different question, and no assertion here needs it.
     """
     tx = Tx(
         0xFFFFFFFF,
@@ -230,14 +230,13 @@ def test_the_top_of_the_four_byte_range_round_trips() -> None:
     assert parsed == tx
 
 
-def test_a_standard_version_excludes_zero_and_the_top_bit_set_ones() -> None:
-    """Versions 1 and 2 are standard; zero and a set top bit are not.
+def test_a_standard_version_is_core_v31_1s_window() -> None:
+    """Versions 1 through 3 are standard; 0, 4 and a set top bit are not.
 
-    Only the part of the window both Core policies agree on: 1 and 2 are
-    standard for v27.2 and v31.1 alike, and every version whose top bit is
-    set is standard for neither. Where `assert_standard` currently puts the
-    upper end -- 0x7FFFFFFF, which is standard for no Core -- is issue 387's
-    to answer, so it is deliberately not a test here.
+    Core v31.1's policy.h: 1 and 2 are standard for v27.2 and v31.1
+    alike, 3 is v31.1's own addition, BIP431's TRUC, and everything
+    outside 1..3 is refused, immediately below and above it as well as
+    every version whose top bit is set (issue #387).
 
     What the low end is worth saying is that these are valid versions:
     `assert_valid` takes zero and takes 0xFFFFFFFF, standardness being the
@@ -245,11 +244,11 @@ def test_a_standard_version_excludes_zero_and_the_top_bit_set_ones() -> None:
     """
     tx = Tx(1, 0, [TxIn(OutPoint(b"\x01" * 32, 0))], [TxOut(1, "")])
 
-    for version in (1, 2):
+    for version in (1, 2, 3):
         tx.version = version
         tx.assert_standard()
 
-    for version in (0, 0x7FFFFFFF + 1, 0xFFFFFFFF):
+    for version in (0, 4, 0x80000000, 0xFFFFFFFF):
         tx.version = version
         tx.assert_valid()
         with pytest.raises(BTClibValueError, match="invalid version: "):


### PR DESCRIPTION
Closes #387.

`Tx.assert_standard` checked `0 < version <= 0x7FFFFFFF`, a range that
comes from treating the version as a signed 4-byte int rather than
from any Core policy. Core v31.1's `policy.h` relays
`TX_MIN_STANDARD_VERSION` through `TX_MAX_STANDARD_VERSION`, 1 through
3 — 1 and 2 are what v27.2 and v31.1 agree on, 3 is v31.1's own
addition, BIP431's TRUC. So versions 4 through 0x7FFFFFFF passed as
standard where a v31.1 node would refuse them.

## Change

- `btclib/tx/tx.py`: `_TX_MIN_STANDARD_VERSION` and
  `_TX_MAX_STANDARD_VERSION`, named constants read off `policy.h`,
  replace the ad hoc `0x7FFFFFFF` bound; `assert_standard`'s docstring
  states which Core policy it follows.
- `tests/tx/tx_test.py`: the test that deliberately deferred the upper
  bound to this issue now pins the whole window — 1 through 3 accepted,
  0 and 4 the immediate misses on either side, 0x80000000 and
  0xFFFFFFFF still refused. A stray "is issue 387's" note in a
  neighboring docstring, about a different question (the field's
  signedness, already settled by #404/#412), is corrected to stop
  pointing at this issue once it closes.
- CHANGELOG.md entry under "Consensus rules".

## Test plan

- [x] `uv run pytest --cov` — 17320 passed, coverage gap is
      pre-existing and unrelated (`.github/scripts/mutation_counts.py`)
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `sphinx-build -W --keep-going -b html docs/source docs/build/html`
      — build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align transaction standardness checks with Bitcoin Core v31.1’s relay policy for version fields.

Bug Fixes:
- Correct Tx.assert_standard to reject transaction versions outside Core v31.1’s standard relay window instead of relying on a generic positive signed 4-byte range.

Enhancements:
- Introduce named constants for the minimum and maximum standard transaction versions based on Core v31.1 policy and reference them in documentation and tests.

Documentation:
- Document the corrected standardness window and behavior in the changelog under consensus rules.

Tests:
- Tighten transaction version standardness tests to pin Core v31.1’s accepted window (1–3) and explicitly cover boundary and out-of-range versions.