### PR TITLE
Field-carrying exceptions rebuild from their arguments, so they pickle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1523,6 +1523,24 @@ edit.
   and a size are not secret. Both classes are `BTClibValueError`s, so code
   catching that is unaffected. `to_pub_key` still guesses the same way and
   is untouched
+- **an exception carrying a field can be pickled and copied**, where
+  `HttpError`, `RpcError`, `ScriptError` and `InvalidContributionError`
+  answered a TypeError about their own constructor. Each composed its
+  message in `__init__` and handed that one string to
+  `BaseException.__init__`, so `args` held the message alone, and
+  `BaseException.__reduce__` returns `(cls, self.args)`: a class taking
+  two or three arguments is not rebuilt from one. `pickle`, `copy.copy`
+  and `copy.deepcopy` failed on it alike, and so did a
+  `ProcessPoolExecutor` — a fetch fanned out across processes, which is
+  the reason `HttpError.status` exists, got a `BrokenProcessPool` and no
+  status wherever the node answered 503 and a working pool wherever it
+  answered. The four now hand every constructor argument to
+  `BaseException.__init__` and compose their message in `__str__`, which
+  is what `subprocess.CalledProcessError` and `UnicodeDecodeError` do;
+  composing there is the half that keeps a round trip from adding a
+  second `(rpc error code -5)` every time. `str(e)` is unchanged; `e.args`
+  is the tuple of arguments now rather than a one-tuple of the composed
+  message, and `repr(e)` names the fields with it (issue #391)
 
 ### Curves, signatures and keys
 

--- a/btclib/bitcoin_core_rpc.py
+++ b/btclib/bitcoin_core_rpc.py
@@ -216,6 +216,23 @@ __all__ = [
 #
 # The three BTClib bases come with them so the established TypeError,
 # ValueError, and RuntimeError hierarchies remain exact.
+#
+# The two carrying a field hand every constructor argument to
+# `BaseException.__init__` and compose their message in `__str__`, which is
+# what `subprocess.CalledProcessError` and `UnicodeDecodeError` do, and what
+# makes them picklable: `BaseException.__reduce__` returns `(cls, self.args)`,
+# so a class whose `args` is the composed message alone is rebuilt by calling
+# it with one argument, and one argument is not what it takes. That is a
+# TypeError out of `pickle`, out of `copy.copy` and out of `copy.deepcopy` --
+# and out of a `ProcessPoolExecutor`, which cannot send the exception back and
+# reports a broken pool instead of the status the worker died of. Composing in
+# `__str__` is the half that keeps the round trip faithful rather than merely
+# possible: a message composed in `__init__` from an argument that is itself a
+# composed message gains a second `(rpc error code -5)` every time.
+#
+# The visible price is `args`, which is a tuple of the arguments now and not a
+# one-tuple of the message, and `repr`, which names the fields with it. `str`
+# is the message it always was.
 
 
 class BTClibValueError(ValueError):
@@ -273,7 +290,12 @@ class HttpError(FetchError):
 
     def __init__(self, message: str, status: int) -> None:
         self.status = status
-        super().__init__(message)
+        super().__init__(message, status)
+
+    def __str__(self) -> str:
+        # the message alone, which is what BaseException returns for a
+        # single argument and not for the two this now carries
+        return str(self.args[0])
 
 
 class RpcError(FetchError):
@@ -299,7 +321,10 @@ class RpcError(FetchError):
     def __init__(self, message: str, code: int, data: Any = None) -> None:
         self.code = code
         self.data = data
-        super().__init__(f"{message} (rpc error code {code})")
+        super().__init__(message, code, data)
+
+    def __str__(self) -> str:
+        return f"{self.args[0]} (rpc error code {self.code})"
 
 
 # Inside btclib these have always been public from `btclib.exceptions`, and a

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -20,6 +20,24 @@ The exceptions to that are the few classes below carrying a field: what
 a peer got wrong, the node's rpc error code, an HTTP status. Those are
 values a caller acts on, and reading them back out of a message is what
 the field spares them.
+
+Each of those hands every constructor argument to
+`BaseException.__init__` and composes its message in `__str__`, which is
+what `subprocess.CalledProcessError` and `UnicodeDecodeError` do, and
+what makes it picklable: `BaseException.__reduce__` returns `(cls,
+self.args)`, so a class whose `args` is the composed message alone is
+rebuilt by calling it with one argument, and one argument is not what it
+takes. That is a TypeError out of `pickle`, out of `copy.copy` and out
+of `copy.deepcopy` -- and out of a `ProcessPoolExecutor`, which cannot
+send the exception back and reports a broken pool instead of the failure
+the worker died of. Composing in `__str__` is the half that keeps the
+round trip faithful rather than merely possible: a message composed in
+`__init__` from an argument that is itself a composed message gains a
+second `(command 3, stack depth 2)` every time.
+
+The visible price is `args`, which is a tuple of the arguments now and
+not a one-tuple of the message, and `repr`, which names the fields with
+it. `str` is the message it always was.
 """
 
 from __future__ import annotations
@@ -85,7 +103,11 @@ class ScriptError(BTClibValueError):
     def __init__(self, message: str, index: int, stack_depth: int) -> None:
         self.index = index
         self.stack_depth = stack_depth
-        super().__init__(f"{message} (command {index}, stack depth {stack_depth})")
+        super().__init__(message, index, stack_depth)
+
+    def __str__(self) -> str:
+        where = f"command {self.index}, stack depth {self.stack_depth}"
+        return f"{self.args[0]} ({where})"
 
 
 class NotAPrvKeyError(BTClibValueError):
@@ -137,8 +159,11 @@ class InvalidContributionError(BTClibRuntimeError):
     def __init__(self, signer: int | None, contrib: str) -> None:
         self.signer = signer
         self.contrib = contrib
-        who = "the aggregator" if signer is None else f"signer {signer}"
-        super().__init__(f"invalid {contrib} from {who}")
+        super().__init__(signer, contrib)
+
+    def __str__(self) -> str:
+        who = "the aggregator" if self.signer is None else f"signer {self.signer}"
+        return f"invalid {self.contrib} from {who}"
 
 
 class BTClibUserWarning(UserWarning):

--- a/tests/bitcoin_core_rpc_standalone_test.py
+++ b/tests/bitcoin_core_rpc_standalone_test.py
@@ -73,8 +73,10 @@ def test_the_single_copied_file_imports_and_calls_without_btclib(
     vendored = tmp_path / "bitcoin_core_rpc.py"
     shutil.copy2(_source_path(), vendored)
     smoke = """
+import copy
 import importlib.util
 import json
+import pickle
 import sys
 from decimal import Decimal
 
@@ -84,6 +86,18 @@ for module_name in ("a_vendored_bitcoin_core_rpc", "z_vendored_bitcoin_core_rpc"
     rpc = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(rpc)
     assert rpc.FetchError.__module__ == module_name
+    # a copy's exceptions cross a process boundary the way the package's
+    # do, and pickle looks a class up by the module it names: registering
+    # what importlib loaded is what makes that name resolve, here and in
+    # any application loading the copy the same way
+    sys.modules[module_name] = rpc
+    error = rpc.RpcError("getrawtransaction: not found", -5, {"tx": 1})
+    said = "getrawtransaction: not found (rpc error code -5)"
+    assert str(error) == said
+    for back in (pickle.loads(pickle.dumps(error)), copy.deepcopy(error)):
+        assert type(back) is rpc.RpcError
+        assert str(back) == said
+        assert back.code == -5 and back.data == {"tx": 1}
 
 # what -I -S bought, asserted rather than assumed: no site packages, no
 # PYTHONPATH and no script directory on sys.path, so there is no btclib

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+
+# Copyright (C) The btclib developers
+#
+# This file is part of btclib. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution.
+#
+# No part of btclib including this file, may be copied, modified, propagated,
+# or distributed except according to the terms contained in the LICENSE file.
+"""Tests for `btclib.exceptions`, and for what an exception carries.
+
+The classes with nothing added to their base need no test of their own:
+what they are is the base, and every module raising one asserts the
+message it raised. What is tested here is the four carrying a field --
+`HttpError`, `RpcError`, `ScriptError` and `InvalidContributionError` --
+and specifically that a field survives leaving the process it was raised
+in, which is the case the field exists for and the one nothing else in
+the suite exercises: pytest-xdist sends a report as text, so no exception
+object crosses between workers (issue #391).
+"""
+
+from __future__ import annotations
+
+import copy
+import pickle
+from concurrent.futures import ProcessPoolExecutor
+from typing import Any
+
+import pytest
+
+from btclib.exceptions import (
+    BTClibValueError,
+    FetchError,
+    HttpError,
+    InvalidContributionError,
+    RpcError,
+    ScriptError,
+)
+
+HTTP_MESSAGE = "getblockcount at http://127.0.0.1:8332: HTTP 503"
+
+# the exception, the `args` it is expected to carry, its message, and the
+# fields a caller reads. Constructed here and shared by every test below:
+# none of them mutates one, and an exception that a test could mutate is
+# an exception this module would have to say more about
+CASES = [
+    pytest.param(
+        HttpError(HTTP_MESSAGE, 503),
+        (HTTP_MESSAGE, 503),
+        HTTP_MESSAGE,
+        {"status": 503},
+        id="HttpError",
+    ),
+    pytest.param(
+        RpcError("getrawtransaction: not found", -5, {"txid": "00"}),
+        ("getrawtransaction: not found", -5, {"txid": "00"}),
+        "getrawtransaction: not found (rpc error code -5)",
+        {"code": -5, "data": {"txid": "00"}},
+        id="RpcError",
+    ),
+    pytest.param(
+        RpcError("getblock: block not found", -5),
+        ("getblock: block not found", -5, None),
+        "getblock: block not found (rpc error code -5)",
+        {"code": -5, "data": None},
+        id="RpcError-without-data",
+    ),
+    pytest.param(
+        ScriptError("unbalanced conditional", 3, 2),
+        ("unbalanced conditional", 3, 2),
+        "unbalanced conditional (command 3, stack depth 2)",
+        {"index": 3, "stack_depth": 2},
+        id="ScriptError",
+    ),
+    pytest.param(
+        InvalidContributionError(2, "psig"),
+        (2, "psig"),
+        "invalid psig from signer 2",
+        {"signer": 2, "contrib": "psig"},
+        id="InvalidContributionError",
+    ),
+    pytest.param(
+        InvalidContributionError(None, "aggnonce"),
+        (None, "aggnonce"),
+        "invalid aggnonce from the aggregator",
+        {"signer": None, "contrib": "aggnonce"},
+        id="InvalidContributionError-aggregator",
+    ),
+]
+
+
+def _assert_same(back: BaseException, error: BaseException, fields: Any) -> None:
+    assert type(back) is type(error)
+    assert str(back) == str(error)
+    assert back.args == error.args
+    for name, value in fields.items():
+        assert getattr(back, name) == value
+
+
+@pytest.mark.parametrize(("error", "args", "message", "fields"), CASES)
+def test_a_field_carrying_exception_says_what_it_carries(
+    error: BaseException, args: tuple[Any, ...], message: str, fields: Any
+) -> None:
+    """`args` is the constructor's arguments and `str` is the message."""
+    assert error.args == args
+    assert str(error) == message
+    for name, value in fields.items():
+        assert getattr(error, name) == value
+    # `repr` names the fields with the message, which is the visible half
+    # of `args` holding them: rebuilding the class from what it prints is
+    # what a one-tuple of the composed message could not offer
+    assert repr(error) == f"{type(error).__name__}{args!r}"
+
+
+@pytest.mark.parametrize(("error", "args", "message", "fields"), CASES)
+def test_a_field_carrying_exception_survives_pickle(
+    error: BaseException, args: tuple[Any, ...], message: str, fields: Any
+) -> None:
+    """The class, the message and every field come back from `pickle`."""
+    back = pickle.loads(pickle.dumps(error))  # noqa: S301
+    _assert_same(back, error, fields)
+    assert back.args == args
+    assert str(back) == message
+
+
+@pytest.mark.parametrize(("error", "args", "message", "fields"), CASES)
+def test_a_field_carrying_exception_survives_copy(
+    error: BaseException, args: tuple[Any, ...], message: str, fields: Any
+) -> None:
+    """`copy` and `deepcopy` need no process, and used to fail the same way."""
+    for back in (copy.copy(error), copy.deepcopy(error)):
+        _assert_same(back, error, fields)
+        assert back.args == args
+        assert str(back) == message
+
+
+@pytest.mark.parametrize(("error", "args", "message", "fields"), CASES)
+def test_the_message_is_composed_once(
+    error: BaseException, args: tuple[Any, ...], message: str, fields: Any
+) -> None:
+    """A round trip of a round trip still says what one raise said.
+
+    The trap this pins is composing in `__init__` from an argument that is
+    itself a composed message: the message grows a second `(rpc error code
+    -5)` per round trip, so a single one shows it and a second makes what
+    is accumulating unmistakable.
+    """
+    back: BaseException = error
+    for _ in range(2):
+        back = pickle.loads(pickle.dumps(back))  # noqa: S301
+        assert str(back) == message
+    assert back.args == args
+    _assert_same(back, error, fields)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [FetchError("no answer from http://127.0.0.1:8332"), BTClibValueError("bad")],
+    ids=["FetchError", "BTClibValueError"],
+)
+def test_an_exception_adding_nothing_round_trips_too(error: BaseException) -> None:
+    """The control: a class taking a message alone was never affected."""
+    for back in (pickle.loads(pickle.dumps(error)), copy.copy(error)):  # noqa: S301
+        assert type(back) is type(error)
+        assert str(back) == str(error)
+        assert back.args == error.args
+
+
+def _raise_http_error() -> None:
+    raise HttpError(HTTP_MESSAGE, 503)
+
+
+def test_a_field_carrying_exception_crosses_a_process_boundary() -> None:
+    """What the field is for: a fetch fanned out across processes.
+
+    A worker that cannot send its exception back does not merely lose the
+    diagnosis -- `ProcessPoolExecutor` reports a `BrokenProcessPool`, so
+    the pool dies wherever the node answers 503 and works wherever it does
+    not. The same raise in this process is the control: the two have to
+    agree on the class, the message and the status.
+    """
+    with pytest.raises(HttpError) as local:
+        _raise_http_error()
+
+    with ProcessPoolExecutor(max_workers=1) as pool, pytest.raises(HttpError) as remote:
+        pool.submit(_raise_http_error).result()
+
+    assert type(remote.value) is type(local.value)
+    assert str(remote.value) == str(local.value)
+    assert remote.value.status == local.value.status == 503


### PR DESCRIPTION
Closes #391.

`HttpError`, `RpcError`, `ScriptError` and `InvalidContributionError`
composed their message in `__init__` and handed that one string to
`BaseException.__init__`, so `args` held the message alone.
Reconstruction goes through `BaseException.__reduce__`, which returns
`(cls, self.args)`: a class taking two or three arguments was called
with one, and `pickle`, `copy.copy` and `copy.deepcopy` each answered a
TypeError about the constructor rather than about what was asked for. A
`ProcessPoolExecutor` answered `BrokenProcessPool` — a worker raising
`HttpError` could not send it back, so a fetch fanned out across
processes, which is the reason `HttpError.status` exists, died wherever
the node answered 503 and worked wherever it answered.

## The shape chosen, of the two the issue measured

`args` holds the constructor arguments and `__str__` composes the
message, which is what `subprocess.CalledProcessError` and
`UnicodeDecodeError` do; not a `__reduce__` per class, `json`'s shape,
which would need the two composing classes to keep the raw message in a
private attribute beside the composed one. It needs no such attribute,
it leaves `args` honest, and it reads as ordinary Python rather than as
machinery — which is what the vendored copy of `bitcoin_core_rpc.py`
asks for.

Composing in `__str__` is the half that keeps the round trip faithful
rather than merely possible: rebuilding from `args[0]` with the
composition left in `__init__` gives `not found (rpc error code -5) (rpc
error code -5)`, once per round trip.

What is visible: `str(e)` is unchanged, `e.args` is the tuple of
arguments rather than a one-tuple of the composed message, and `repr(e)`
names the fields with it. Stated in the module docstring of
`exceptions.py` and in the comment above the classes in
`bitcoin_core_rpc.py`, which carries its own copy because a vendored file
has no other. No HISTORY.md entry: none of the four existed at
`v2023.7.12`, so nothing a user of the last release has to act on.

## Tests

`tests/exceptions_test.py` pins `args`, `str`, `repr` and the fields for
each of the four — including `RpcError` without `data` and
`InvalidContributionError` for the aggregator — then round-trips each
through `pickle`, `copy.copy` and `copy.deepcopy`, twice over for the
doubling. It raises one in a `ProcessPoolExecutor` worker against the
same raise in-process, the two having to agree on the class, the message
and the status; and it keeps the issue's control, that a class adding
nothing to its base was never affected.

The vendored copy is covered where it is already exercised, in the `-I
-S` smoke of `bitcoin_core_rpc_standalone_test.py`: it registers the
module it loaded through importlib, which is what lets `pickle` resolve
the name the class carries — without it the copy pickles nothing, and
that is a fact about loading a module by path rather than about this
change.

## Gates

- `uv run pytest --cov=btclib --cov=tests` — 17347 passed, 100.00%
- `UV_PROJECT_ENVIRONMENT=.venv-3.10 uv run --locked --no-default-groups
  --group test --python 3.10 pytest` — 17347 passed
- `uv run pre-commit run --all-files` — exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` — exit 0

## Summary by Sourcery

Ensure field-carrying exceptions can be reliably pickled, copied, and transmitted across processes by reconstructing them from their original constructor arguments instead of a pre-composed message.

Bug Fixes:
- Fix HttpError, RpcError, ScriptError and InvalidContributionError failing to round-trip through pickle, copy, deepcopy and ProcessPoolExecutor due to mismatched constructor arguments on reconstruction.

Enhancements:
- Align exception argument and message handling with standard library patterns so args reflect constructor parameters, str remains the user-facing message, and repr exposes the underlying fields.

Documentation:
- Document the behaviour of field-carrying exceptions and their pickling semantics in exceptions.py, the vendored bitcoin_core_rpc.py copy, and the changelog.

Tests:
- Add dedicated tests for field-carrying exceptions to validate args, str, repr, field access, round-tripping via pickle/copy/deepcopy, and crossing process boundaries, including coverage for the vendored bitcoin_core_rpc.py copy.