### PR TITLE
Test that bitcoin_core_rpc's three chain tables stay in step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4843,6 +4843,15 @@ edit.
   signature enumerates to the empty list where the singular raises "not a
   low s" — every candidate fails the rule and a failing candidate is
   dropped rather than reported
+- **`bitcoin_core_rpc`'s three chain tables are held in step.** `_RPC_PORT`,
+  `_DATADIR_SUBDIR` and `_CORE_CHAIN_FROM_NETWORK` agreed by construction and
+  nothing checked it: a chain added to `_RPC_PORT` alone passed `from_chain`'s
+  membership guard and then raised a bare `KeyError` at the
+  `_DATADIR_SUBDIR` lookup, not the `BTClibValueError` this module raises
+  everywhere else; added to both and not to `_CORE_CHAIN_FROM_NETWORK`, it
+  stayed reachable through `from_chain` while `core_chain_from_network`
+  refused to name it. One test now asserts all three keyed sets equal
+  (issue #418)
 
 ### Supported interpreters and dependencies
 

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -38,6 +38,9 @@ from urllib.request import Request
 import pytest
 
 from btclib.bitcoin_core_rpc import (
+    _CORE_CHAIN_FROM_NETWORK,
+    _DATADIR_SUBDIR,
+    _RPC_PORT,
     COOKIE_USER,
     DEFAULT_DATADIR,
     BitcoinCoreRpcClient,
@@ -1707,6 +1710,20 @@ def custom_signet(challenge: str) -> Network:
     return Network.from_dict(
         {**NETWORKS["signet"].to_dict(), "magic_bytes": _signet_magic(challenge).hex()}
     )
+
+
+def test_every_chain_with_a_port_has_a_datadir_and_a_name() -> None:
+    """The three tables are keyed by Core's chain names and must agree.
+
+    `from_chain` walks `_RPC_PORT` and then `_DATADIR_SUBDIR` with no
+    guard between them, so a chain in one and not the other is a bare
+    `KeyError` where every other failure in this module is a
+    `BTClibValueError`. A chain in neither `_CORE_CHAIN_FROM_NETWORK` is
+    reachable through `from_chain` and unreachable through the vocabulary
+    function meant to feed it -- silently, in both directions.
+    """
+    assert _RPC_PORT.keys() == _DATADIR_SUBDIR.keys()
+    assert _RPC_PORT.keys() == set(_CORE_CHAIN_FROM_NETWORK.values())
 
 
 def test_the_two_vocabularies_translate_both_ways() -> None:


### PR DESCRIPTION
## Summary
- `_RPC_PORT`, `_DATADIR_SUBDIR` and `_CORE_CHAIN_FROM_NETWORK` agree today but nothing checked it
- adds a four-line test asserting the three keyed sets are equal, so a future mismatch fails loudly instead of surfacing as a bare `KeyError` from `from_chain` or a silently unreachable chain in `core_chain_from_network`

## Test plan
- [x] `uv run pytest tests/fetch/bitcoin_core_test.py` (193 passed)
- [x] `uv run pre-commit run --files tests/fetch/bitcoin_core_test.py CHANGELOG.md`
- [x] `uv run pytest --cov` (full suite green; the one coverage gap is pre-existing in `.github/scripts/mutation_counts.py`, untouched by this change)

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a regression test to ensure bitcoin_core_rpc's internal chain-mapping tables remain consistent and document the behavioral guarantee in the changelog.

Documentation:
- Document that bitcoin_core_rpc now enforces consistency between its internal chain tables and clarifies the previously silent failure modes.

Tests:
- Add a test asserting that the RPC port, datadir subdir, and core-chain-name mappings stay in sync so mismatches fail explicitly.