### PR TITLE
Say what latest.yml's sphinx gap actually is, not that CI skips docs

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -33,9 +33,12 @@ name: latest
 # pull request -- that pull request runs the whole matrix, so ruff and the
 # other pinned hooks already have their sentinel. mypy is the exception
 # and the reason the lint job below is here at all: its hook is local and
-# shells out to uv, so it is the lock that pins it. Not sphinx either:
-# nothing in CI builds the documentation, readthedocs does, and a build
-# there fails on its own.
+# shells out to uv, so it is the lock that pins it. Not sphinx: lint.yml's
+# second job already builds the docs, with --locked, on every pull
+# request, so a broken build surfaces there, not here. What it builds
+# against is the same lock this workflow exists to get ahead of, so a
+# sphinx break in the newest releases is the one gap this file leaves
+# open too, same as everywhere else in it.
 #
 # Nothing here gates anything, by construction: a separate workflow, with
 # no aggregate job, named by no branch protection rule. That is the point.


### PR DESCRIPTION
## Summary

Closes #419.

- `.github/workflows/latest.yml`'s comment claimed "nothing in CI
  builds the documentation, readthedocs does" -- false, since
  `lint.yml`'s second job, "Build the documentation", does exactly
  that, with `--locked`, as one of `master`'s four required checks.
  Reworded to say what this workflow is actually missing: a sphinx
  build against the *newest*, unlocked dependency releases, the same
  gap it leaves open for every other tool it upgrades.
- `REPOSITORY.md`'s `dev` branch-protection description was the
  issue's other stale spot, but it was already fixed on `dev` by
  606fe3dc ("Add required_conversation_resolution to dev, and record
  it here"), so nothing left to do there.

## Test plan

- [x] `uv run pre-commit run --files .github/workflows/latest.yml`
- [x] `uv run --locked --no-default-groups --group docs sphinx-build
      -W --keep-going -b html docs/source docs/build/html`

## Summary by Sourcery

Chores:
- Update latest.yml documentation comments to reflect current CI behavior and the specific Sphinx coverage gap.