### PR TITLE
Give each PLW1641 noqa its own reason, not a bare suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5469,6 +5469,14 @@ edit.
   dependency, the bindings included, to the newest release that satisfies
   pyproject.toml. `pip install -e .` works here now, and readthedocs
   drives uv for the lock rather than for the resolution.
+- **Each of the four `PLW1641` sites the audit above narrowed to now
+  states its own reason, not a bare `# noqa`.** `Tx` is mutable, which is
+  the dataclass default that sets `__hash__` to `None`; `EqualTransport`
+  and `TxInIgnoringWitness` are test doubles nothing hashes.
+  `ScriptPubKey`'s is different: its hand-written `__eq__` sets
+  `__hash__` to `None` the same way Python does for any class defining
+  one without the other, and whether that is the shape the class is
+  meant to have is issue #416, still open (issue #417)
 
 ### Documentation and the website
 

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -485,6 +485,10 @@ def type_and_payload(script_pub_key: Octets) -> tuple[ScriptType, bytes]:  # noq
 # and Script is frozen so that `tx_out.script_pub_key.script = b""` cannot
 # reach through a frozen TxOut. So __init__ assigns through
 # object.__setattr__, as Network's and the three Sig classes' do
+#
+# the hand-written __eq__ below leaves __hash__ at Python's default for a
+# class defining __eq__ without __hash__, None; whether that is the shape
+# this class is meant to have is issue #416, open
 @dataclass(init=False, eq=False, frozen=True)
 class ScriptPubKey(Script):  # noqa: PLW1641
     """A Script with the network its addresses render on.

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -67,6 +67,8 @@ def _assert_valid_coinbase(vin: Sequence[TxIn], *, is_coinbase: bool) -> None:
             raise BTClibValueError("coinbase input in a non-coinbase transaction")
 
 
+# mutable (a builder and a signer edit it in place), so unhashable is the
+# dataclass default: eq=True and frozen=False set __hash__ to None
 @dataclass
 class Tx:  # noqa: PLW1641
     """A Bitcoin transaction: version, lock time, inputs, outputs.

--- a/tests/fetch/transport_test.py
+++ b/tests/fetch/transport_test.py
@@ -491,6 +491,7 @@ def test_a_transport_equal_to_the_default_is_still_the_callers_transport(
         ),
     )
 
+    # a test helper answering equal to one sentinel object, never hashed
     class EqualTransport:  # noqa: PLW1641
         def __init__(self) -> None:
             self.requests: list[Request] = []

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -813,6 +813,7 @@ def test_eq_witness(monkeypatch: pytest.MonkeyPatch) -> None:
     the whole of the answer.
     """
 
+    # narrows equality by dropping a field, a test helper never hashed
     class TxInIgnoringWitness(TxIn):  # noqa: PLW1641
         """A TxIn compared on everything but its witness."""
 


### PR DESCRIPTION
## Summary

The blanket `PLW1641` (eq-without-hash) ruff ignore was already
narrowed to four local `# noqa: PLW1641` lines in a prior audit, but
none of them said why -- the gap #417 is about.

- `btclib/tx/tx.py`: `Tx` is mutable, which is the dataclass default
  that leaves `__hash__` unset.
- `btclib/script/script_pub_key.py`: `ScriptPubKey`'s hand-written
  `__eq__` unsets `__hash__` the same way Python does for any class
  defining one without the other; whether that is deliberate is #416,
  still open, so the comment points there rather than asserting an
  answer.
- `tests/fetch/transport_test.py` and `tests/tx/tx_test.py`: both are
  test doubles nothing ever hashes.

Closes #417

## Test plan

- [x] `uv run pytest tests/tx/tx_test.py tests/fetch/transport_test.py
      tests/script/script_pub_key_test.py tests/release_notes_test.py`
- [x] `uv run pre-commit run --files <the five changed files>`

## Summary by Sourcery

Document the rationale for each remaining PLW1641 noqa suppression and record the change in the changelog.

Documentation:
- Add changelog entry describing the clarified PLW1641 noqa sites and their rationale.
- Expand inline documentation explaining why ScriptPubKey, Tx, EqualTransport, and TxInIgnoringWitness intentionally trigger PLW1641 and are unhashable or only used as non-hashed test helpers.