### PR TITLE
Fix tests/exceptions_test.py's copyright header and parametrize style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1546,6 +1546,12 @@ edit.
   second `(rpc error code -5)` every time. `str(e)` is unchanged; `e.args`
   is the tuple of arguments now rather than a one-tuple of the composed
   message, and `repr(e)` names the fields with it (issue #391)
+- `tests/exceptions_test.py`, added for the entry above, carried a
+  shebang line and the pre-uv copyright header instead of the one every
+  other file states, and its four `parametrize` calls passed the names
+  as a tuple where `pyproject.toml` sets `parametrize-names-type = "csv"`
+  for a reason: neither had been caught before merging, so `dev`'s lint
+  job has been red since.
 
 ### Curves, signatures and keys
 

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -1,12 +1,8 @@
-#!/usr/bin/env python3
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
 
-# Copyright (C) The btclib developers
-#
-# This file is part of btclib. It is subject to the license terms in the
-# LICENSE file found in the top-level directory of this distribution.
-#
-# No part of btclib including this file, may be copied, modified, propagated,
-# or distributed except according to the terms contained in the LICENSE file.
 """Tests for `btclib.exceptions`, and for what an exception carries.
 
 The classes with nothing added to their base need no test of their own:
@@ -97,7 +93,7 @@ def _assert_same(back: BaseException, error: BaseException, fields: Any) -> None
         assert getattr(back, name) == value
 
 
-@pytest.mark.parametrize(("error", "args", "message", "fields"), CASES)
+@pytest.mark.parametrize("error, args, message, fields", CASES)
 def test_a_field_carrying_exception_says_what_it_carries(
     error: BaseException, args: tuple[Any, ...], message: str, fields: Any
 ) -> None:
@@ -112,7 +108,7 @@ def test_a_field_carrying_exception_says_what_it_carries(
     assert repr(error) == f"{type(error).__name__}{args!r}"
 
 
-@pytest.mark.parametrize(("error", "args", "message", "fields"), CASES)
+@pytest.mark.parametrize("error, args, message, fields", CASES)
 def test_a_field_carrying_exception_survives_pickle(
     error: BaseException, args: tuple[Any, ...], message: str, fields: Any
 ) -> None:
@@ -123,7 +119,7 @@ def test_a_field_carrying_exception_survives_pickle(
     assert str(back) == message
 
 
-@pytest.mark.parametrize(("error", "args", "message", "fields"), CASES)
+@pytest.mark.parametrize("error, args, message, fields", CASES)
 def test_a_field_carrying_exception_survives_copy(
     error: BaseException, args: tuple[Any, ...], message: str, fields: Any
 ) -> None:
@@ -134,7 +130,7 @@ def test_a_field_carrying_exception_survives_copy(
         assert str(back) == message
 
 
-@pytest.mark.parametrize(("error", "args", "message", "fields"), CASES)
+@pytest.mark.parametrize("error, args, message, fields", CASES)
 def test_the_message_is_composed_once(
     error: BaseException, args: tuple[Any, ...], message: str, fields: Any
 ) -> None:


### PR DESCRIPTION
## Summary
- `tests/exceptions_test.py` (added by #415) carried a shebang line and
  the pre-uv copyright header instead of the one COPYRIGHT and every
  other file states — the `copyright-notice` hook has been failing on
  it since.
- Its four `@pytest.mark.parametrize` calls passed the names as a tuple;
  `pyproject.toml` sets `parametrize-names-type = "csv"`, so `ruff check`
  flagged all four as PT006.
- Both are why `dev`'s lint job, and the release PR (#126) that tracks
  `dev`, have been red.

## Test plan
- [x] `uv run pre-commit run --all-files` — clean
- [x] `uv run pytest` — 17403 passed
- [x] `sphinx-build -W --keep-going` — clean

## Summary by Sourcery

Align tests/exceptions_test.py with project standards and fix lint issues in parametrized tests, documenting the corrections in the changelog.

Bug Fixes:
- Replace the non-standard header and shebang in tests/exceptions_test.py with the project-wide MIT license notice.
- Update pytest parametrize declarations in tests/exceptions_test.py to use CSV-style argument names to satisfy linting configuration.

Documentation:
- Add a changelog entry describing the corrections to tests/exceptions_test.py and the resulting fix to the failing lint job.