### PR TITLE
ScriptPubKey hashes on the pair its __eq__ compares, and TxOut with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1351,6 +1351,24 @@ edit.
   twice: an instance holding the parse of that 16.5 kB script costs 55.4 kB
   against 0.2 kB without it, 277 times the script's own bytes, and nothing
   inside the library reads `.asm` at all (issue #165)
+- **`ScriptPubKey` is hashable, and the `TxOut` holding one with it.** The
+  class is frozen, which is what makes a hash safe, but it writes its
+  `__eq__` by hand — issue #207's comparison by network *type* — and
+  Python sets `__hash__` to `None` for any class defining one without the
+  other, so `hash(spk)` raised `TypeError: unhashable type`. It reached
+  `TxOut` too: frozen, so it *has* a generated `__hash__`, which raised on
+  the field it could not hash. An utxo set's key hashed and its value did
+  not. `__hash__` is written out beside `__eq__` now, over the same pair
+  that one compares — the script bytes and the network type, not the
+  network name — so a signet ScriptPubKey and the equal testnet one land
+  in the same bucket, and `Script`, which hashes its bytes alone, needs no
+  agreement with it: a Script never equals a ScriptPubKey, the generated
+  `__eq__` it inherits comparing by exact class. The comment that had
+  explained the asymmetry said `Script` defines `__eq__` without
+  `__hash__`, which the dataclass decorator makes false, and `tx_out.py`'s
+  said Script is unfrozen, which issue #165 made false; both state what
+  the code does. `# noqa: PLW1641` goes from the class, the rule finding
+  nothing there any more (issue #416)
 - **`assert_valid` no longer rewrites what it validates.**
   `BIP32KeyData.assert_valid` coerced six fields in place — `bytes()` over
   `version`, `parent_fingerprint`, `chain_code` and `key`, `int()` over
@@ -5480,14 +5498,15 @@ edit.
   dependency, the bindings included, to the newest release that satisfies
   pyproject.toml. `pip install -e .` works here now, and readthedocs
   drives uv for the lock rather than for the resolution.
-- **Each of the four `PLW1641` sites the audit above narrowed to now
-  states its own reason, not a bare `# noqa`.** `Tx` is mutable, which is
-  the dataclass default that sets `__hash__` to `None`; `EqualTransport`
-  and `TxInIgnoringWitness` are test doubles nothing hashes.
-  `ScriptPubKey`'s is different: its hand-written `__eq__` sets
-  `__hash__` to `None` the same way Python does for any class defining
-  one without the other, and whether that is the shape the class is
-  meant to have is issue #416, still open (issue #417)
+- **Each `PLW1641` site the audit above narrowed to states its own reason,
+  not a bare `# noqa`.** `Tx` is mutable, which is the dataclass default
+  that sets `__hash__` to `None`; `EqualTransport` and
+  `TxInIgnoringWitness` are test doubles nothing hashes. `ScriptPubKey`
+  was the odd one, its hand-written `__eq__` setting `__hash__` to `None`
+  the same way Python does for any class defining one without the other:
+  writing the reason down is what asked whether the class is meant to be
+  unhashable at all, answered by issue #416 above, and it carries a
+  `__hash__` rather than a `# noqa` now (issue #417)
 
 ### Documentation and the website
 

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -486,19 +486,24 @@ def type_and_payload(script_pub_key: Octets) -> tuple[ScriptType, bytes]:  # noq
 # reach through a frozen TxOut. So __init__ assigns through
 # object.__setattr__, as Network's and the three Sig classes' do
 #
-# the hand-written __eq__ below leaves __hash__ at Python's default for a
-# class defining __eq__ without __hash__, None; whether that is the shape
-# this class is meant to have is issue #416, open
+# __hash__ is written out below because __eq__ is: a class defining __eq__
+# without __hash__ gets __hash__ = None, and an unhashable ScriptPubKey
+# takes TxOut with it -- TxOut is frozen, so it has a generated __hash__,
+# which raises TypeError on the field that cannot hash. Frozen is what
+# makes hashing safe here, and every other frozen value class of the
+# library is hashable: OutPoint keys the dict an utxo set is, and TxOut
+# is the other half of it (issue #416)
 @dataclass(init=False, eq=False, frozen=True)
-class ScriptPubKey(Script):  # noqa: PLW1641
+class ScriptPubKey(Script):
     """A Script with the network its addresses render on.
 
     The script bytes and their validation are Script's; the network
-    enters `address`, `addresses` and the equality test, two
+    enters `address`, `addresses`, the equality test and the hash, two
     ScriptPubKey being equal when their scripts match and their
     networks are of one type -- mainnet against the rest -- rather
-    than of one name. The classmethods build the standard shapes, one
-    per type the classifier names.
+    than of one name. Frozen and hashable on that same pair, so a
+    ScriptPubKey can be a set member or a dict key. The classmethods
+    build the standard shapes, one per type the classifier names.
     """
 
     network: str
@@ -547,14 +552,22 @@ class ScriptPubKey(Script):  # noqa: PLW1641
         # carry: issue #207.
         #
         # Two ScriptPubKey are still not equal across types, so this is
-        # not a loosening of the funds-relevant check. ScriptPubKey is
-        # unhashable (Script defines __eq__ without __hash__), so there
-        # is no __hash__ to keep consistent with it
+        # not a loosening of the funds-relevant check. __hash__ below is
+        # over the same pair this compares, and moves with it
         if network_type_from_network(self.network) != network_type_from_network(
             other.network
         ):
             return False
         return super().__eq__(other)
+
+    def __hash__(self) -> int:
+        # the script and the network *type*, which is what __eq__ above
+        # compares: hashing the network *name* would put a signet
+        # ScriptPubKey and the equal testnet one in different buckets.
+        # Script hashes its bytes alone, and a Script never equals a
+        # ScriptPubKey -- the generated __eq__ it inherits compares by
+        # exact class -- so the two need not agree
+        return hash((self.script, network_type_from_network(self.network)))
 
     def __init__(
         self,

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -27,11 +27,13 @@ __all__ = [
 ]
 
 
-# frozen, but only shallowly: `value` is immutable, while
-# ScriptPubKey extends the plain dataclass Script, so `script_pub_key.script`
-# can still be rebound through a frozen TxOut. Freezing Script is a change
-# of its own. Its being unhashable also makes the generated TxOut.__hash__
-# raise TypeError, so a frozen TxOut is not a hashable one
+# frozen all the way down: `value` is immutable and ScriptPubKey is frozen
+# too (issue 165), so `tx_out.script_pub_key.script = b""` cannot reach
+# through a frozen TxOut and rebind the script of whatever else holds that
+# ScriptPubKey. Hashable all the way down for the same reason: the
+# generated __hash__ hashes the ScriptPubKey field, which is itself
+# hashable (issue 416), so a TxOut can be the value of the dict an
+# OutPoint keys, or a set member of its own
 @dataclass(frozen=True)
 class TxOut:
     """One output of a transaction: an amount and who can spend it.

--- a/tests/script/script_pub_key_test.py
+++ b/tests/script/script_pub_key_test.py
@@ -902,14 +902,41 @@ def test_script_is_frozen_and_asm_is_cached() -> None:
         spk.network = "mainnet"  # type: ignore[misc]
 
     # frozen and eq, so Script gets a generated __hash__ and can be a dict
-    # key or a set member. ScriptPubKey cannot: it defines __eq__, which
-    # leaves __hash__ None
+    # key or a set member
     assert len({Script(script.script), Script(script.script)}) == 1
-    with pytest.raises(TypeError, match="unhashable type"):
-        hash(spk)
 
     # and dataclasses.replace still works through the written-out __init__
     assert dataclasses.replace(spk).network == "testnet"
+
+
+def test_script_pub_key_hash_matches_eq() -> None:
+    """Verify the hash is over the pair __eq__ compares (issue 416).
+
+    A hand-written __eq__ leaves __hash__ None unless the class writes
+    one too, which had made a frozen ScriptPubKey -- and the frozen
+    TxOut holding it -- unhashable.
+    """
+    key = "03a1af804ac108a8a51782198c2d034b28bf90c8803f5a53f76276fa69a4eae77f"
+    testnet = ScriptPubKey.p2pkh(key, network="testnet")
+    signet = ScriptPubKey(testnet.script, "signet")
+    mainnet = ScriptPubKey(testnet.script, "mainnet")
+
+    # the network type, as __eq__ compares: equal ScriptPubKey hash equal,
+    # so a signet one finds the testnet key it is equal to
+    assert signet == testnet
+    assert hash(signet) == hash(testnet)
+    assert {testnet: "found"}[signet] == "found"
+
+    # and one set member for the two of them, two with the mainnet one
+    assert mainnet != testnet
+    assert len({testnet, signet}) == 1
+    assert len({testnet, signet, mainnet}) == 2
+
+    # a Script never equals a ScriptPubKey -- the generated __eq__ it
+    # inherits compares by exact class -- so both fit in one set
+    plain = Script(testnet.script)
+    assert plain != testnet
+    assert len({plain, testnet}) == 2
 
 
 def test_asm_parses_once_per_script() -> None:

--- a/tests/tx/tx_out_test.py
+++ b/tests/tx/tx_out_test.py
@@ -48,7 +48,7 @@ def test_tx_out() -> None:
 
 
 def test_frozen() -> None:
-    """Verify TxOut is frozen all the way down, and unhashable."""
+    """Verify TxOut is frozen all the way down, and hashable with it."""
     tx_out = TxOut(1, "0014751e76e8199196d454941c45d1b3a323f1433bd6")
 
     with pytest.raises(FrozenInstanceError):
@@ -65,10 +65,14 @@ def test_frozen() -> None:
         tx_out.script_pub_key.script = b""  # type: ignore[misc]
     assert tx_out.script_pub_key.script != b""
 
-    # a ScriptPubKey defines __eq__ and so is unhashable, which makes
-    # hashing the TxOut holding it a TypeError
-    with pytest.raises(TypeError, match="unhashable type"):
-        hash(tx_out)
+    # frozen buys the generated __hash__, and it reaches the ScriptPubKey
+    # field: an unhashable one made hashing the TxOut a TypeError, which
+    # is issue 416. Equal outputs hash equal, so a TxOut is the value of
+    # the dict an OutPoint keys
+    same = TxOut(1, "0014751e76e8199196d454941c45d1b3a323f1433bd6")
+    assert same == tx_out
+    assert hash(same) == hash(tx_out)
+    assert len({tx_out, same, TxOut(2, tx_out.script_pub_key)}) == 2
 
 
 def test_invalid_tx_out() -> None:


### PR DESCRIPTION
Closes #416.

`ScriptPubKey` is frozen, which is what makes a hash safe, but it writes
`__eq__` by hand — issue #207's comparison by network *type* — and Python
unsets `__hash__` for any class defining one without the other, so
`hash(spk)` raised `TypeError: unhashable type`. It reached `TxOut` too:
frozen, so it *has* a generated `__hash__`, which raised on the field it
could not hash. An utxo set's key hashed and its value did not, while
`out_point.py` says in as many words that hashing is what an OutPoint is
frozen for.

The asymmetry was not a decision: every other frozen value class of the
library is hashable — `Script`, `OutPoint`, `Witness`, nominally `TxOut` —
and the unhashable ones, `Tx` and `TxIn`, are unhashable because they are
mutable, which is Python's own rule.

`__hash__` is written out beside `__eq__` now, over the same pair that one
compares: the script bytes and the network *type*, not the name, so a
signet `ScriptPubKey` and the equal testnet one land in one bucket.
`Script` hashes its bytes alone and needs no agreement with it, a `Script`
never equalling a `ScriptPubKey` — the generated `__eq__` it inherits
compares by exact class.

Two comments went with it, both false rather than merely stale:

- `script_pub_key.py`'s said `Script` defines `__eq__` without `__hash__`,
  which the dataclass decorator makes false — the issue's own finding
- `tx_out.py`'s said `Script` is not frozen, which issue #165 made false,
  and `tests/tx/tx_out_test.py::test_frozen` has been asserting the
  opposite ever since

The class loses its `# noqa: PLW1641`; `ruff check --select PLW1641` finds
nothing there any more, and `RUF100` would fail the suppression if it
stayed. The three remaining sites — #417's — are unaffected.

Tests: `test_script_pub_key_hash_matches_eq` for the hash/eq contract, the
set and the dict lookup; `test_frozen` in both files flips from asserting
`TypeError` to asserting the hash.

Gates run in the worktree: `pytest --cov=btclib --cov=tests` (17404
passed, 100.00%), `pre-commit run --files <the five touched>`, and the
`-W` sphinx build. `pre-commit run --all-files` is red on
`tests/exceptions_test.py`, which this branch does not touch: that is
dev's own failure, and #425 is the fix.

## Summary by Sourcery

Make ScriptPubKey and TxOut hashable in line with their equality semantics so they can safely be used as keys in sets and dictionaries.

New Features:
- Support hashing ScriptPubKey instances based on their script bytes and network type.
- Ensure TxOut instances containing a ScriptPubKey are hashable and suitable as values keyed by OutPoint in UTXO maps.

Enhancements:
- Clarify and update comments around ScriptPubKey and TxOut freezing and hashing semantics, removing the PLW1641 noqa from ScriptPubKey.
- Document the new ScriptPubKey and TxOut hashing behavior in the changelog.

Tests:
- Add tests verifying ScriptPubKey __hash__ matches its __eq__ semantics and that set/dict lookups behave as expected.
- Update TxOut frozen tests to assert hashability and correct behavior in sets and dictionaries.