### PR TITLE
Follow the client's rename, and drop the mypy override py.typed replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,11 @@ edit.
   `RpcError` as btclib's with the `status` and the `code` carried across,
   and `args[0]` rather than `str(e)` so a message composed in `__str__` is
   not composed twice. `EsploraFetcher.text` and
-  `BitcoinCoreFetcher._call` are the two lines that cross.
+  `BitcoinCoreFetcher._call` are the two lines that cross. The package
+  spells its own bases `BtcRpcValueError` and so on, where btclib spells
+  its `BTClibValueError`: two same-named classes is an `except` that reads
+  correct and catches the wrong one, which `assert_network` did until the
+  package renamed its three.
 - **`import btclib.exceptions` no longer loads `urllib.request`**, nor the
   `ssl` and `socket` under it. That cost was what the one bottom-upwards
   import in the package bought, and most of the library pays it: an

--- a/btclib/fetch/bitcoin_core.py
+++ b/btclib/fetch/bitcoin_core.py
@@ -205,12 +205,14 @@ class BitcoinCoreFetcher(Fetcher):
             return
         try:
             expected_chain = core_chain_from_network(self.network)
-        except rpc.BTClibValueError as e:
-            # the package's BTClibValueError and not btclib's, which is what
-            # the function above raises: it is `bitcoin_core_rpc`'s, and that
-            # package declares its own exceptions -- catching the wrong one
-            # here would let a name it does not know escape as something no
-            # caller of `assert_network` is told to expect.
+        except rpc.BtcRpcValueError as e:
+            # `BtcRpcValueError` and not btclib's `BTClibValueError`:
+            # `core_chain_from_network` is the package's function and raises
+            # the package's class, so catching btclib's here would let a
+            # name it does not know escape as something no caller of
+            # `assert_network` is told to expect. The two were spelled
+            # alike until the package renamed its own, and this line is
+            # why -- it read correct and was wrong.
             #
             # A Network the caller registered: its name is btclib's alone,
             # so there is nothing to compare a chain name with, and only a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -514,28 +514,6 @@ exclude = [
     "build",
 ]
 
-[[tool.mypy.overrides]]
-# bitcoin-core-rpc is annotated throughout and type checked in strict mode
-# in its own repository, but it cannot say so from here: PEP 561's marker
-# is a `py.typed` file inside a package directory, and that distribution is
-# a top-level module with no directory to put one in. Measured against the
-# installed wheel: without this, every name imported from it is `Any` --
-# which under `strict` is eight errors about the import and two more about
-# the `Any` leaking into a return type, and, worse, silence wherever it
-# should have been checking.
-#
-# So the annotations are read off the installed source instead. Scoped to
-# the one module rather than set globally: `follow_untyped_imports` at the
-# top of this table would extend the same trust to any dependency that
-# stops shipping a marker, and there is no other untyped import here to
-# want it. The alternatives are the other repository's to take -- a
-# `bitcoin_core_rpc-stubs` distribution, which is a hand-written second
-# copy of the interface, or a package directory, which costs the file the
-# single name that makes it copyable -- and its pyproject.toml records why
-# it took neither
-module = ["bitcoin_core_rpc"]
-follow_untyped_imports = true
-
 [tool.ruff]
 # target-version is inferred from project.requires-python
 

--- a/uv.lock
+++ b/uv.lock
@@ -279,7 +279,7 @@ wheels = [
 [[package]]
 name = "bitcoin-core-rpc"
 version = "2026.8"
-source = { git = "https://github.com/btclib-org/btclib-bitcoin-core-rpc?rev=dev#c9ac514be799eee6fcbc77063b61c37b351dabf5" }
+source = { git = "https://github.com/btclib-org/btclib-bitcoin-core-rpc?rev=dev#ca75283a4f4236f822f585454c48943ff600c263" }
 
 [[package]]
 name = "btclib"


### PR DESCRIPTION
`dev` is green and is one `uv lock --upgrade` away from red. This fixes it.

## The break, measured

bitcoin-core-rpc's `dev` renamed its three base exceptions
(`BTClibValueError` → `BtcRpcValueError` and so on) and started shipping
`py.typed`. btclib pins that dependency by **git rev**, and the committed
lock names the sha from before the rename:

```
source = { git = "...?rev=dev#c9ac514be799eee6fcbc77063b61c37b351dabf5" }
```

So CI is green on what it locked. Re-resolve and it is not:

```console
$ uv lock --upgrade-package bitcoin-core-rpc
Updated bitcoin-core-rpc v2026.8 (c9ac514b) -> v2026.8 (ca75283a)
$ uv run pytest tests/fetch
except rpc.BTClibValueError as e:
AttributeError: module 'bitcoin_core_rpc' has no attribute
'BTClibValueError'. Did you mean: 'BtcRpcValueError'?
```

`latest.yml` runs exactly that upgrade weekly, and Dependabot moves the
same pin, so this is a break already on the calendar rather than a
hypothetical one.

## The fix

**One line**, in the `except` around `core_chain_from_network` — the very
line whose two same-named classes the package renamed in order to make
visible. Its comment now says so.

**And 22 lines removed**: the `follow_untyped_imports` override for that
module, which the package's `py.typed` makes unnecessary. Verified by
deleting it and running the gate — mypy strict over 209 source files,
clean, and now genuinely reading the package's annotations rather than
being told to trust them.

## What does not change

`tool.uv.sources` stays: the package is still on no index (PyPI answers
404, no releases). Everything the merged PR's comment says about it still
holds, including that it makes `dist-py` green for the wrong reason.

## Verification

- `pytest`: 17155 passed
- `pytest --cov=btclib --cov=tests`: **100.00%**
- `pre-commit run --all-files`: every hook
- `sphinx-build -W --keep-going`: clean

## Summary by Sourcery

Align bitcoin-core integration with upstream exception renames and clean up now-redundant typing configuration.

Bug Fixes:
- Update bitcoin-core RPC exception handling to catch the renamed BtcRpcValueError instead of the similarly named btclib exception in assert_network.

Enhancements:
- Remove the mypy follow_untyped_imports override for bitcoin_core_rpc now that the dependency ships py.typed and is properly typed-checked.

Build:
- Refresh uv.lock to point bitcoin-core-rpc at a newer revision that includes the exception renames and typing marker.

Documentation:
- Document the bitcoin-core RPC base exception naming and its interaction with btclib exceptions in the changelog.