### PR TITLE
Drop bitcoin-core-rpc's git-source override now that it is on PyPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,21 @@ edit.
   `btclib.fetch.transport` and `btclib.fetch.bitcoin_core` re-export the
   package's names, so every import path a caller had still resolves except
   `btclib.bitcoin_core_rpc` itself.
+- **btclib develops against the released `bitcoin-core-rpc`**, once
+  v2026.8.6 published it. `pyproject.toml`'s `[tool.uv.sources]` is gone:
+  it pointed the package at a commit on its own `dev` branch because no
+  index had a release yet, and without a source `uv lock` could not
+  resolve it at all. The floor moves with it, from `>=2026.8`, which had
+  named intent with nothing to satisfy it, to `>=2026.8.6`, the release
+  itself. What that unlocks is `dist-py`'s wheel smoke test for the right
+  reason: it had already been green, but only because its constraints
+  file comes from `uv export --locked`, which carried the git source
+  through -- so the step named "with its dependencies from PyPI" installed
+  from git, and a plain `uv pip install` against the index answered
+  "bitcoin-core-rpc was not found in the package registry". Measured
+  after removing the override: the export names
+  `bitcoin-core-rpc==2026.8.6` from `pypi.org/simple` alone, and the
+  built wheel installs into an empty environment and imports clean.
 - **`btclib.exceptions` declares its own six classes again.** They were
   defined in the vendorable file and re-exported here, an exception
   wanting one identity; with the file gone the choice was to import

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,10 +68,12 @@ requires-python = ">=3.10"
 # It is one file with nothing but the standard library behind it, so
 # depending on it adds no transitive anything -- what it replaces is the
 # copy of that file btclib used to carry, and `btclib/fetch/` is the whole
-# of what reaches it
+# of what reaches it. Its lower bound went the same way the bindings' did:
+# >=2026.8 named intent while no index had anything at all, not even a
+# candidate, and >=2026.8.6 is that pin now that it is the first release.
 dependencies = [
     "btclib_libsecp256k1>=0.7.1",
-    "bitcoin-core-rpc>=2026.8",
+    "bitcoin-core-rpc>=2026.8.6",
 ]
 keywords = [
     "bitcoin",
@@ -170,30 +172,6 @@ dev = [
 # bare minimum specifier makes it install the latest uv, so the runners
 # are never behind the floor and there is nothing here to go stale
 required-version = ">=0.12.0"
-
-# TEMPORARY, and the one thing in this pull request to delete before it
-# merges: bitcoin-core-rpc is not on PyPI yet -- both indices answer 404 --
-# so without a source uv cannot resolve it and there is no lock to commit
-# at all. Pointing at the branch makes this reviewable.
-#
-# It also defeats the one job that would have caught the missing package,
-# which is the reason this cannot merge and not merely a note. `dist-py`
-# builds a constraints file with `uv export --locked`, and that export
-# carries the source:
-#
-#     bitcoin-core-rpc @ git+https://github.com/btclib-org/...@<sha>
-#
-# so the step named "with its dependencies from PyPI" installs from git
-# and passes. Measured: `dist-py` is green on this branch, and a plain
-# `uv pip install dist/*.whl` against the index is not --
-# "bitcoin-core-rpc was not found in the package registry". Do not read
-# that green as the wheel being installable.
-#
-# btclib carried a `tool.uv.sources` for the bindings once and removed it
-# when they were published: this goes the same way, and the dependency
-# above is already written as the ordinary requirement it becomes
-[tool.uv.sources]
-bitcoin-core-rpc = { git = "https://github.com/btclib-org/btclib-bitcoin-core-rpc", rev = "dev" }
 
 [tool.setuptools.packages.find]
 include = ["btclib*"]

--- a/uv.lock
+++ b/uv.lock
@@ -278,8 +278,12 @@ wheels = [
 
 [[package]]
 name = "bitcoin-core-rpc"
-version = "2026.8"
-source = { git = "https://github.com/btclib-org/btclib-bitcoin-core-rpc?rev=dev#ca75283a4f4236f822f585454c48943ff600c263" }
+version = "2026.8.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/f7/730c6799742191c9f4fd0767aaaf75f260a6c9ac6d31cd775d4f97422151/bitcoin_core_rpc-2026.8.6.tar.gz", hash = "sha256:255146afd79db13692349032c64f8607e729833b81eb3c576afbba0eea30f730", size = 283266, upload-time = "2026-08-06T11:52:12.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/41/d7e3ef7d96d2fe4485e810da5840bba6d15bc225236225411b9d9a8b8357/bitcoin_core_rpc-2026.8.6-py3-none-any.whl", hash = "sha256:7a282080f9f24ff0de86ba020eb1dcb1491c872a9ac08bd66d684a9c29735104", size = 32693, upload-time = "2026-08-06T11:52:11.013Z" },
+]
 
 [[package]]
 name = "btclib"
@@ -346,7 +350,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bitcoin-core-rpc", git = "https://github.com/btclib-org/btclib-bitcoin-core-rpc?rev=dev" },
+    { name = "bitcoin-core-rpc", specifier = ">=2026.8.6" },
     { name = "btclib-libsecp256k1", specifier = ">=0.7.1" },
 ]
 


### PR DESCRIPTION
#427's own body flagged this as the one thing left to do: `bitcoin-core-rpc`
was on no index yet, so `pyproject.toml` carried a temporary
`[tool.uv.sources]` pointing at a commit on the package's `dev` branch, and
`dist-py`'s wheel smoke test was green for the wrong reason — its
constraints file comes from `uv export --locked`, which carried the git
source through, so "with its dependencies from PyPI" installed from git
while a plain `uv pip install` against the index failed outright.

v2026.8.6 published the package a few minutes ago. This removes the
override, moves the floor from `>=2026.8` (which had named intent with
nothing to satisfy it) to `>=2026.8.6` (the release itself), and re-locks.

## Verification

- `uv lock`: resolves `bitcoin-core-rpc` from `pypi.org/simple`, no git
  source left anywhere
- `uv export --locked --no-dev --no-emit-project --no-hashes | grep bitcoin`:
  `bitcoin-core-rpc==2026.8.6`, registry source
- `pytest --cov=btclib --cov=tests`: 17155 passed, 100.00% coverage
- `pre-commit run --all-files`: every hook, mypy strict included
- `sphinx-build -W --keep-going`: clean
- `uv build` + install the built wheel into an empty venv from PyPI alone:
  succeeds, `import btclib`, `from btclib.fetch import BitcoinCoreRpcClient`
  and a `btclib.ecc.dsa` import all work

## Summary by Sourcery

Align bitcoin-core-rpc dependency with its first PyPI release and remove temporary git-source override so builds and smoke tests use the published package.

Enhancements:
- Update bitcoin-core-rpc dependency floor to version 2026.8.6 now that a release is available on PyPI.

Build:
- Remove uv git-source override for bitcoin-core-rpc and refresh uv.lock so packaging and wheel installs resolve exclusively from PyPI.

Documentation:
- Document the switch to the released bitcoin-core-rpc package and its impact on locking and wheel smoke tests in the changelog.