### PR TITLE
Hand a Signer the psbt's message, and fix the Combiner and the Finalizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2153,6 +2153,55 @@ edit.
 
 ### Transactions, blocks and PSBT
 
+- **`psbt.ecdsa_sig_hash` is the message a Signer signs** (issue #430),
+  and with it `btclib.psbt` exports the pair: the ECDSA hash for the
+  inputs whose signatures go in `PSBT_IN_PARTIAL_SIG` and
+  `taproot_sig_hash` for the schnorr ones, which is the split `finalize`
+  dispatches on. The dispatch existed and was private, reached only by
+  the Finalizer verifying signatures it had been handed, so a Signer
+  computed the hash itself — as the guide's own **Signer** paragraph did,
+  reaching past the psbt for `sig_hash.from_tx`. That function cannot
+  serve here: it reads the redeem script out of an input's script_sig and
+  the witness script off its witness stack, and in a psbt they are
+  fields. The hash type defaults to the one the input asks for and to
+  SIGHASH_ALL where it asks for none; SIGHASH_DEFAULT is refused, 0 being
+  a taproot type no ECDSA signature carries. Where the private helper
+  answers None — no utxo, no redeem script, no witness script — this
+  raises: a Finalizer checking a signature learns nothing from a psbt
+  that does not say what was signed, and a Signer about to make one has
+  to stop.
+- **the Finalizer orders a multisig input's signatures, and pushes the
+  threshold many** (issue #431). OP_CHECKMULTISIG walks the keys forward
+  and never goes back, so the signatures have to arrive in the order the
+  script lists the keys they belong to — and `partial_sigs` is a dict,
+  whose order is the order it was written in, which for a coordinator is
+  the order the copies came back from `combine`. Nothing related the two,
+  so a 2-of-3 whose signers answered out of order finalized into a spend
+  no node accepts. The count was wrong the same way: every signature the
+  input carried was pushed, so a 1-of-2 that both participants signed put
+  a signature where BIP147's empty element belongs. Both are now read off
+  the script — `script_pub_key.p2ms_m_and_keys`, which is `addresses`
+  and `assert_p2ms`'s own parser with the answer kept — and an input
+  short of the threshold is refused rather than built into a script_sig
+  one element shy. A signature whose key the script does not list is
+  dropped, not refused: the Finalizer builds the spend that script asks
+  for.
+- **`combine` merges every field a psbt map holds** (issue #432). It
+  walked BIP174's list, so the preimage maps, every BIP371 taproot field
+  and every BIP373 musig2 field were dropped, silently and both ways
+  round. The cost was not only that a Combiner could not merge what an
+  external signer returns: **a MuSig2 session did not survive its own
+  Combiner** — round 1 puts one nonce in one psbt per signer, and keeping
+  the first psbt's alone leaves `session_context` deriving a session no
+  partial signature was made against. Two fields do not take the union:
+  `taproot_tree` is positional and is taken whole, the way a witness
+  stack is, and two different participant lists under one aggregate key
+  are refused rather than picked from — the key is computed from the
+  list, so one of the two says it aggregates something it does not, and
+  nothing in either psbt says which. `amount`, `script_pub_key`,
+  `previous_tx_id` and `output_index` stay out: they are part of what
+  identifies the psbt, and two psbts disagreeing on one of them are two
+  transactions.
 - **a MuSig2 session is carried out over a psbt** (issue #266, the second
   half): `btclib.psbt.musig2` is BIP373's three roles over
   `btclib.ecc.musig2` — `add_participant_pub_keys` for an Updater,

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -7,9 +7,14 @@
 
 What this package exports is the format and the roles: the three maps a
 psbt is made of, the Combiner, the Finalizer, the Extractor, the outputs
-an unsigned psbt spends, and the size estimation a fee rate is applied to.
-`musig2` is named as a module, being the BIP373 role rather than one
-function, the way btclib.ecc names dsa.
+an unsigned psbt spends, the two messages a Signer signs, and the size
+estimation a fee rate is applied to. `musig2` is named as a module, being
+the BIP373 role rather than one function, the way btclib.ecc names dsa.
+
+`ecdsa_sig_hash` and `taproot_sig_hash` are here for the same reason
+`prevouts` is: the Signer role is the one BIP174 leaves to the caller,
+who has the keys, and the message is what it needs from the psbt to
+play it.
 
 btclib.psbt.psbt_utils is not exported, and this is where that decision is
 recorded: serialize_bytes, deserialize_map, deserialize_tx,
@@ -28,10 +33,12 @@ from btclib.psbt import musig2
 from btclib.psbt.psbt import (
     Psbt,
     combine,
+    ecdsa_sig_hash,
     extract_tx,
     finalize,
     join,
     prevouts,
+    taproot_sig_hash,
 )
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
@@ -42,10 +49,12 @@ __all__ = [
     "PsbtIn",
     "PsbtOut",
     "combine",
+    "ecdsa_sig_hash",
     "estimated_input_sizes",
     "extract_tx",
     "finalize",
     "join",
     "musig2",
     "prevouts",
+    "taproot_sig_hash",
 ]

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -74,12 +74,13 @@ from btclib.script import (
     is_p2tr,
     is_p2wpkh,
     is_p2wsh,
+    p2ms_m_and_keys,
     serialize,
     sig_hash,
     taproot,
     type_and_payload,
 )
-from btclib.script.sig_hash import DEFAULT
+from btclib.script.sig_hash import ALL, DEFAULT, assert_valid_hash_type
 from btclib.tx import Tx, TxIn, TxOut
 from btclib.utils import (
     assert_no_trailing,
@@ -104,6 +105,7 @@ __all__ = [
     "PSBT_V2",
     "Psbt",
     "combine",
+    "ecdsa_sig_hash",
     "extract_tx",
     "finalize",
     "join",
@@ -1215,11 +1217,37 @@ def _combined_tx_modifiable(psbts: Sequence[Psbt]) -> int | None:
     return (and_bits & modifiable) | (or_bits & ~modifiable & 0xFF)
 
 
+def _combine_musig2_participants(
+    psbt_map: PsbtIn | PsbtOut, out: PsbtIn | PsbtOut
+) -> None:
+    """Merge the participant lists, refusing two of them under one key.
+
+    Not `_combine_field`'s union, which for a map takes each side's pairs
+    and lets the second write over the first: an aggregate key is
+    computed from its participants, so two different lists filed under
+    one key are not a conflict to resolve by picking. One of the two says
+    that key aggregates something it does not, and nothing in either psbt
+    says which.
+    """
+    for key, participants in psbt_map.musig2_participant_pub_keys.items():
+        other = out.musig2_participant_pub_keys.get(key)
+        if other is not None and other != participants:
+            err_msg = f"mismatched musig2 participants for aggregate key {key.hex()}"
+            raise BTClibValueError(err_msg)
+        out.musig2_participant_pub_keys[key] = participants
+
+
 def combine(psbts: Sequence[Psbt]) -> Psbt:
     """Merge the data of several psbts of one transaction: the Combiner.
 
     BIP174's Combiner role, whose ordinary use is merging the partial
     signatures different signers added to copies of one psbt.
+
+    Every field a psbt map holds is merged, and the four left out are
+    left out for one reason: `amount`, `script_pub_key`, `previous_tx_id`
+    and `output_index` are part of what identifies the psbt, so the psbt
+    being merged into carries them already and two psbts disagreeing
+    about one of them are two transactions, refused above.
 
     Which psbts are of one transaction is a question the two versions
     answer differently, and each is asked its own: a version 0 psbt is
@@ -1262,6 +1290,29 @@ def combine(psbts: Sequence[Psbt]) -> Psbt:
             _combine_field(psbt.inputs[i], inp, "final_script_sig")
             _combine_field(psbt.inputs[i], inp, "final_script_witness")
             _combine_field(psbt.inputs[i], inp, "unknown")
+            _combine_field(psbt.inputs[i], inp, "ripemd160_preimages")
+            _combine_field(psbt.inputs[i], inp, "sha256_preimages")
+            _combine_field(psbt.inputs[i], inp, "hash160_preimages")
+            _combine_field(psbt.inputs[i], inp, "hash256_preimages")
+            # the key path signature is one key-value pair, so the rule
+            # for it is the arbitrary pick, and here that pick is between
+            # two spends rather than between two descriptions of one.
+            # Taking the first is defensible only because either one
+            # finalizes the input on its own -- unlike the merged maps
+            # below, where the halves are of one spend
+            _combine_field(psbt.inputs[i], inp, "taproot_key_spend_signature")
+            _combine_field(psbt.inputs[i], inp, "taproot_script_spend_signatures")
+            _combine_field(psbt.inputs[i], inp, "taproot_leaf_scripts")
+            _combine_field(psbt.inputs[i], inp, "taproot_hd_key_paths")
+            _combine_field(psbt.inputs[i], inp, "taproot_internal_key")
+            _combine_field(psbt.inputs[i], inp, "taproot_merkle_root")
+            # merging the musig2 maps is what makes a session survive a
+            # Combiner: BIP373 puts round 1 in one psbt per signer, and
+            # a nonce that does not reach the aggregate is a session the
+            # partial signatures of the others are not against
+            _combine_musig2_participants(psbt.inputs[i], inp)
+            _combine_field(psbt.inputs[i], inp, "musig2_pub_nonces")
+            _combine_field(psbt.inputs[i], inp, "musig2_partial_sigs")
             # the two lock times an input may require are not part of
             # what identifies the psbt -- the identifier holds the lock
             # time they compute, not which input asked for it -- so a
@@ -1278,6 +1329,13 @@ def combine(psbts: Sequence[Psbt]) -> Psbt:
             _combine_field(psbt.outputs[i], out, "witness_script")
             _combine_field(psbt.outputs[i], out, "hd_key_paths")
             _combine_field(psbt.outputs[i], out, "unknown")
+            _combine_field(psbt.outputs[i], out, "taproot_internal_key")
+            # a taproot tree is positional -- depth, leaf version and
+            # script, in the order that rebuilds the merkle root -- so it
+            # is taken whole or not at all, the way a witness stack is
+            _combine_field(psbt.outputs[i], out, "taproot_tree")
+            _combine_field(psbt.outputs[i], out, "taproot_hd_key_paths")
+            _combine_musig2_participants(psbt.outputs[i], out)
 
         _combine_field(psbt, final_psbt, "hd_key_paths")
         _combine_field(psbt, final_psbt, "unknown")
@@ -1348,6 +1406,21 @@ def _single_key(psbt_in: PsbtIn) -> bytes:
     return next(iter(psbt_in.partial_sigs))
 
 
+def _satisfied_script(psbt_in: PsbtIn) -> bytes:
+    """Return the script the input's signatures are pushed for, or b"".
+
+    The witness script where the multisig is wrapped in a p2wsh,
+    `_spent_script` naming the p2wsh there rather than what it commits
+    to; and `_spent_script` itself for a bare multisig and for a legacy
+    p2sh, whose redeem script that already is.
+
+    Two questions read it -- how many elements the spend pushes, and in
+    which order -- and both are the script's to answer, so it is found
+    in one place.
+    """
+    return psbt_in.witness_script or _spent_script(psbt_in)
+
+
 def _bip147_dummy(psbt_in: PsbtIn) -> list[bytes]:
     """Return the empty push OP_CHECKMULTISIG pops, or nothing.
 
@@ -1363,10 +1436,8 @@ def _bip147_dummy(psbt_in: PsbtIn) -> list[bytes]:
     all the same, and on a p2pk carrying two signatures, which is caller
     error and gets a dummy on top of it (issue #305).
 
-    The script to read is the witness script where the multisig is
-    wrapped in a p2wsh, `_spent_script` naming the p2wsh there rather
-    than what it commits to; and it is `_spent_script` itself for a bare
-    multisig and for a legacy p2sh, whose redeem script that already is.
+    `_satisfied_script` is the script to read, and says why it is that
+    one.
 
     The count survives as the fallback for an input that says nothing.
     A bare multisig needs no script of its own to be finalized, so it
@@ -1376,10 +1447,52 @@ def _bip147_dummy(psbt_in: PsbtIn) -> list[bytes]:
     an element short, unknowably: one signature, no script, and nothing
     to tell it from a p2pk.
     """
-    script = psbt_in.witness_script or _spent_script(psbt_in)
+    script = _satisfied_script(psbt_in)
     if script:
         return [b""] if is_p2ms(script) else []
     return [b""] if len(psbt_in.partial_sigs) > 1 else []
+
+
+def _pushed_sigs(psbt_in: PsbtIn) -> list[bytes]:
+    """Return the signatures the spend pushes, in the order it needs them.
+
+    A multisig input pushes the signatures of the keys its script lists,
+    in the order the script lists them, and as many as the script asks
+    for. Both halves matter to OP_CHECKMULTISIG: it walks the keys
+    forward and never goes back, so a signature out of that order is one
+    it cannot match; and it pops one element beyond the threshold, which
+    BIP147 requires to be empty, so an extra signature is one that lands
+    where the dummy belongs (issue #431).
+
+    Nothing about `partial_sigs` gives that order. A dict holds what it
+    was given in the order it was given, and `combine` merges with an
+    update, so for a coordinator it is the order the copies came back
+    in.
+
+    A signature whose key the script does not list is dropped rather
+    than refused: the Finalizer builds the spend this script asks for,
+    and a key that is not in it is not evidence of anything wrong.
+    Fewer than the threshold is refused, being an input that cannot be
+    finalized at all.
+
+    Every other kind pushes what the input carries, which for the
+    single-key ones is the one signature `_single_key` pairs with its
+    key, and for a p2pk the one the script already names.
+    """
+    script = _satisfied_script(psbt_in)
+    if not is_p2ms(script):
+        return list(psbt_in.partial_sigs.values())
+
+    m, pub_keys = p2ms_m_and_keys(script)
+    sigs = [
+        psbt_in.partial_sigs[pub_key]
+        for pub_key in pub_keys
+        if pub_key in psbt_in.partial_sigs
+    ]
+    if len(sigs) < m:
+        err_msg = f"{len(sigs)} signatures for a {m}-of-{len(pub_keys)} multisig"
+        raise BTClibValueError(err_msg)
+    return sigs[:m]
 
 
 def _finalized_input(psbt_in: PsbtIn) -> tuple[bytes, Witness]:
@@ -1402,7 +1515,7 @@ def _finalized_input(psbt_in: PsbtIn) -> tuple[bytes, Witness]:
     own engine refuses as "non-empty script_sig for a native segwit
     input" (issue #249).
     """
-    sigs: list[bytes] = list(psbt_in.partial_sigs.values())
+    sigs: list[bytes] = _pushed_sigs(psbt_in)
     cmds: list[bytes] = _bip147_dummy(psbt_in) + sigs
     redeem_script: list[bytes] = (
         [psbt_in.redeem_script] if psbt_in.redeem_script else []
@@ -1660,6 +1773,47 @@ def _sig_hash_from_psbt_in(
     if not script or is_p2tr(script):
         return None
     return sig_hash.legacy(script, tx, vin_i, hash_type)
+
+
+def ecdsa_sig_hash(psbt: Psbt, vin_i: int, *, hash_type: int | None = None) -> bytes:
+    """Return the hash an ECDSA spend of one input signs.
+
+    What a Signer puts in `PSBT_IN_PARTIAL_SIG` is a signature of this,
+    with the hash type appended; `taproot_sig_hash` is the same question
+    for the schnorr signatures of a taproot input, and the two are the
+    split `finalize` dispatches on.
+
+    hash_type defaults to the type the input asks for, and to
+    SIGHASH_ALL when it asks for none. An input asking for
+    SIGHASH_DEFAULT is refused: 0 is a taproot type, no ECDSA signature
+    carries it, and a psbt asking for it is one no partial signature can
+    finalize -- which is what `_assert_sig_hash_type` says from the
+    Finalizer's end.
+
+    Every kind a partial signature can belong to is covered, the wrapped
+    ones included: `_sig_hash_from_psbt_in` is the dispatch and says how.
+    Where it answers None this raises, and the difference is the caller:
+    a Finalizer checking a signature it was handed learns nothing from a
+    psbt that does not say what was signed, while a Signer about to make
+    one has to stop.
+    """
+    psbt_in = psbt.inputs[vin_i]
+    if hash_type is None:
+        hash_type = ALL if psbt_in.sig_hash_type is None else psbt_in.sig_hash_type
+    assert_valid_hash_type(hash_type)
+    if hash_type == DEFAULT:
+        raise BTClibValueError("SIGHASH_DEFAULT is not an ECDSA sig_hash type")
+
+    if is_p2tr(_spent_script(psbt_in)):
+        err_msg = f"input {vin_i} is taproot: its message is taproot_sig_hash's"
+        raise BTClibValueError(err_msg)
+
+    msg_hash = _sig_hash_from_psbt_in(psbt_in, psbt.tx, vin_i, hash_type)
+    if msg_hash is None:
+        err_msg = f"input {vin_i} does not say what is being signed: "
+        err_msg += "no utxo, no redeem script, or no witness script"
+        raise BTClibValueError(err_msg)
+    return msg_hash
 
 
 def _assert_sig_hash_type(psbt_in: PsbtIn) -> None:

--- a/btclib/script/__init__.py
+++ b/btclib/script/__init__.py
@@ -64,6 +64,7 @@ from btclib.script.script_pub_key import (
     is_p2wpkh,
     is_p2wsh,
     is_segwit,
+    p2ms_m_and_keys,
     type_and_payload,
 )
 from btclib.script.sig_ops import sig_op_count
@@ -110,6 +111,7 @@ __all__ = [
     "op_int",
     "output_prvkey",
     "output_pubkey",
+    "p2ms_m_and_keys",
     "parse",
     "script_from_dict",
     "script_to_dict",

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -53,6 +53,7 @@ __all__ = [
     "is_p2wpkh",
     "is_p2wsh",
     "is_segwit",
+    "p2ms_m_and_keys",
     "type_and_payload",
 ]
 
@@ -89,8 +90,25 @@ def address(script_pub_key: Octets, network: str = "mainnet") -> str:
     return ""
 
 
-def addresses(script_pub_key: Octets, network: str = "mainnet") -> list[str]:
-    """Return the p2pkh addresses of the pub_keys in a p2ms script_pub_key."""
+def p2ms_m_and_keys(script_pub_key: Octets) -> tuple[int, list[bytes]]:
+    """Return the threshold and the pub keys of a p2ms script_pub_key.
+
+    The bounds are checked -- 0 < m <= n < 17 -- and each key is read as
+    a push of the declared length and then parsed as a public key: a
+    push that is not one is what makes the bytes not a p2ms, which is the
+    answer `is_p2ms` gives.
+
+    The keys come back as the script holds them, uncompressed ones
+    included, and not as the parse normalized them: BIP174 keys a partial
+    signature by the key "as it appears in the scriptPubKey or
+    redeemScript", so the Finalizer below matches these bytes.
+
+    Three callers ask this one question, which is why it is asked in one
+    place: `addresses` wants a p2pkh address per key, `assert_p2ms` the
+    exception alone, and the psbt Finalizer both halves of the answer --
+    OP_CHECKMULTISIG takes m signatures, in the order the script lists
+    the keys they belong to.
+    """
     script_pub_key = bytes_from_octets(script_pub_key)
     # p2ms: m pub_keys n OP_CHECKMULTISIG
     length = len(script_pub_key)
@@ -111,6 +129,15 @@ def addresses(script_pub_key: Octets, network: str = "mainnet") -> list[str]:
     if stream.read(1):
         raise BTClibValueError("invalid p2ms script_pub_key size")
 
+    for pub_key in pub_keys:
+        pub_keyinfo_from_key(pub_key)
+
+    return m, pub_keys
+
+
+def addresses(script_pub_key: Octets, network: str = "mainnet") -> list[str]:
+    """Return the p2pkh addresses of the pub_keys in a p2ms script_pub_key."""
+    _, pub_keys = p2ms_m_and_keys(script_pub_key)
     return [b58.p2pkh(pub_key, network) for pub_key in pub_keys]
 
 
@@ -217,11 +244,9 @@ def is_p2sh(script_pub_key: Octets) -> bool:
 def assert_p2ms(script_pub_key: Octets) -> None:
     """Refuse bytes that are not p2ms: m, the pushed keys, n, OP_CHECKMULTISIG.
 
-    The bounds are checked -- 0 < m <= n < 17 -- and each key is read
-    as a push of the declared length; the keys are not checked to be
-    curve points.
+    `p2ms_m_and_keys` is the whole of the check, and says what it is.
     """
-    addresses(script_pub_key)
+    p2ms_m_and_keys(script_pub_key)
 
 
 def is_p2ms(script_pub_key: Octets) -> bool:

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -680,14 +680,26 @@ puts it in:
 600000000
 
 **Signer.** btclib does not sign a PSBT for you — it has no idea which
-keys are yours. You compute the sighash and put the signature in the
-slot BIP174 defines for it, keyed by public key, with the hash type
+keys are yours. What it hands you is the message: ``ecdsa_sig_hash``
+reads the utxo and the scripts off the psbt, which is where a psbt keeps
+them, and returns the hash the input signs. The signature then goes in
+the slot BIP174 defines for it, keyed by public key, with the hash type
 appended:
 
->>> msg_hash = sig_hash.from_tx([prevout], psbt.tx, 0, 0x01)
+>>> from btclib.psbt import ecdsa_sig_hash
+>>> msg_hash = ecdsa_sig_hash(psbt, 0)
 >>> der = dsa.sign_(msg_hash, prv_key).serialize()
 >>> psbt.inputs[0].partial_sigs = {pub_key: der + b"\x01"}
 >>> psbt.assert_signable()
+
+The hash type is the one the input asks for, ``SIGHASH_ALL`` when it
+asks for none, and a keyword argument when the signer chooses.
+``sig_hash.from_tx`` above cannot serve here: it reads the redeem script
+out of an input's script_sig and the witness script off its witness
+stack, and an unsigned transaction has neither — in a psbt they are
+fields. A taproot input signs ``taproot_sig_hash`` instead, its
+signature being schnorr and travelling in the taproot fields rather than
+in ``partial_sigs``.
 
 A PSBT survives base64 round-tripping, which is how it moves between
 programs:

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -467,12 +467,14 @@ def test_psbt_exports_the_format_not_its_plumbing() -> None:
         "PsbtIn",
         "PsbtOut",
         "combine",
+        "ecdsa_sig_hash",
         "estimated_input_sizes",
         "extract_tx",
         "finalize",
         "join",
         "musig2",
         "prevouts",
+        "taproot_sig_hash",
     ]
 
     # BIP373 is a role, so the module is the name, as btclib.ecc.dsa is

--- a/tests/psbt/musig2_test.py
+++ b/tests/psbt/musig2_test.py
@@ -5,6 +5,7 @@
 
 """Tests for the `btclib.psbt.musig2` module."""
 
+from copy import deepcopy
 from typing import Any
 
 import pytest
@@ -12,7 +13,7 @@ import pytest
 from btclib.curves import secp256k1
 from btclib.ecc import ssa
 from btclib.exceptions import BTClibValueError
-from btclib.psbt import Psbt, extract_tx, finalize, musig2
+from btclib.psbt import Psbt, combine, extract_tx, finalize, musig2
 from btclib.psbt.psbt import prevouts, taproot_sig_hash
 from btclib.script import type_and_payload
 from btclib.script.engine import verify_transaction
@@ -128,6 +129,27 @@ def test_aggregating_bip373s_partial_signatures_spends_the_output(
     verify_transaction(spent, tx)
 
 
+def _participants_only_psbt() -> Psbt:
+    """Return BIP373's first vector: the participants of the output key.
+
+    The one psbt in the file that carries a session's participants and
+    nothing else, so that what a Signer and a Finalizer add to it is
+    everything the two rounds write.
+    """
+    return Psbt.b64decode(
+        next(
+            test_vector["encoded psbt"]
+            for test_vector in load("psbt", "_data", "bip373_test_vectors.json")[
+                "valid psbts"
+            ]
+            if test_vector["description"].startswith(
+                "Spend of a Taproot output where the output key"
+            )
+            and "participant pubkeys only" in test_vector["description"]
+        )
+    )
+
+
 def test_a_whole_session_is_run_over_the_psbt() -> None:
     """Both rounds and every role, with btclib as all three signers.
 
@@ -140,17 +162,7 @@ def test_a_whole_session_is_run_over_the_psbt() -> None:
     `nonce_gen` returning them -- and each is spent exactly once, `sign`
     zeroing the bytearray it consumes.
     """
-    encoded = next(
-        test_vector["encoded psbt"]
-        for test_vector in load("psbt", "_data", "bip373_test_vectors.json")[
-            "valid psbts"
-        ]
-        if test_vector["description"].startswith(
-            "Spend of a Taproot output where the output key"
-        )
-        and "participant pubkeys only" in test_vector["description"]
-    )
-    psbt = Psbt.b64decode(encoded)
+    psbt = _participants_only_psbt()
     aggregate_pub_key = bytes.fromhex(AGGREGATE_PUB_KEY)
     spent = prevouts(psbt)
 
@@ -180,6 +192,49 @@ def test_a_whole_session_is_run_over_the_psbt() -> None:
 
     tx = extract_tx(finalize(psbt))
     verify_transaction(spent, tx)
+
+
+def test_a_session_survives_the_combiner() -> None:
+    """The same two rounds, each signer on its own copy (issue #432).
+
+    Which is how BIP373 is actually run: the coordinator hands out the
+    psbt, every signer writes its own nonce into its own copy, and what
+    comes back is merged. A Combiner that drops the musig2 fields keeps
+    one signer's nonce out of three, and the session `session_context`
+    then derives is one no partial signature was made against -- so the
+    round that follows fails on a psbt in which nothing is wrong.
+
+    The secret nonces are the signers' and never travel: only the psbts
+    are combined.
+    """
+    psbt = _participants_only_psbt()
+    aggregate_pub_key = bytes.fromhex(AGGREGATE_PUB_KEY)
+    spent = prevouts(psbt)
+
+    round_1 = [deepcopy(psbt) for _ in PARTICIPANT_PRV_KEYS]
+    sec_nonces = [
+        musig2.nonce_gen(copy, 0, prv_key, aggregate_pub_key)
+        for copy, prv_key in zip(round_1, PARTICIPANT_PRV_KEYS, strict=True)
+    ]
+    for copy in round_1:
+        assert len(copy.inputs[0].musig2_pub_nonces) == 1
+    nonces_in = combine(round_1)
+    assert len(nonces_in.inputs[0].musig2_pub_nonces) == 3
+
+    round_2 = [deepcopy(nonces_in) for _ in PARTICIPANT_PRV_KEYS]
+    for copy, prv_key, sec_nonce in zip(
+        round_2, PARTICIPANT_PRV_KEYS, sec_nonces, strict=True
+    ):
+        musig2.partial_sign(copy, 0, sec_nonce, prv_key, aggregate_pub_key)
+    signed = combine(round_2)
+    assert len(signed.inputs[0].musig2_partial_sigs) == 3
+
+    for participant_pub_key in PARTICIPANT_PUB_KEYS:
+        assert musig2.partial_sig_verify(
+            signed, 0, participant_pub_key, aggregate_pub_key
+        )
+    musig2.partial_sigs_agg(signed, 0, aggregate_pub_key)
+    verify_transaction(spent, extract_tx(finalize(signed)))
 
 
 def test_the_updater_files_a_list_under_the_key_it_aggregates_to() -> None:

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -24,6 +24,7 @@ from btclib.psbt import (
     PsbtIn,
     PsbtOut,
     combine,
+    ecdsa_sig_hash,
     extract_tx,
     finalize,
     join,
@@ -2075,7 +2076,9 @@ def test_a_single_key_input_takes_one_signature() -> None:
 # signatures'
 
 
-def _multisig_psbt(threshold: int, kind: str) -> tuple[Psbt, list[TxOut]]:
+def _multisig_psbt(
+    threshold: int, kind: str, signers: int | None = None
+) -> tuple[Psbt, list[TxOut]]:
     """Build a one-input threshold-of-2 psbt, signed and not finalized.
 
     `_single_key_psbt` one key further, and the four kinds are the four
@@ -2088,6 +2091,12 @@ def _multisig_psbt(threshold: int, kind: str) -> tuple[Psbt, list[TxOut]]:
     `lexicographic_sorting=False` makes the order given here:
     OP_CHECKMULTISIG never goes back, so a witness ordered otherwise is
     one the engine refuses whatever the dummy.
+
+    `signers` is how many of the two sign, and defaults to the threshold,
+    which is the psbt a coordinator stops collecting at. The other two
+    counts are what a Finalizer has to answer for: everyone signing a
+    1-of-2, which is more signatures than the script pops, and one
+    signer of a 2-of-2, which is fewer.
     """
     keys = [_PUB_KEY, _OTHER_PUB_KEY]
     multisig = ScriptPubKey.p2ms(threshold, keys, lexicographic_sorting=False).script
@@ -2121,7 +2130,7 @@ def _multisig_psbt(threshold: int, kind: str) -> tuple[Psbt, list[TxOut]]:
         # script and for a bare multisig the script_pub_key: the same
         # bytes either way here
         msg_hash = sig_hash.legacy(multisig, tx, 0, 1)
-    prv_keys = [_PRV_KEY, _OTHER_PRV_KEY][:threshold]
+    prv_keys = [_PRV_KEY, _OTHER_PRV_KEY][: threshold if signers is None else signers]
     psbt.inputs[0].partial_sigs = {
         pub_keyinfo_from_prv_key(prv_key)[0]: dsa.sign_(msg_hash, prv_key).serialize()
         + b"\x01"
@@ -2213,6 +2222,116 @@ def test_an_input_that_says_no_script_is_left_with_the_count() -> None:
     assert final.final_script_sig == serialize([b"", *sigs])
 
 
+def _spent_with(
+    psbt_in: PsbtIn, sigs: tuple[bytes, ...]
+) -> tuple[bytes, tuple[bytes, ...]]:
+    """Return the script_sig and witness stack a multisig input spends with.
+
+    The shape the test above asserts, as the expectation of the tests
+    below, which vary the signatures rather than the kind: BIP147's empty
+    element, the signatures, and the script the spend names -- the
+    witness script in the witness of a p2wsh, the redeem script last in
+    the script_sig of everything else.
+
+    The input has to be the one before `finalize`, which clears both
+    scripts.
+    """
+    redeem_script = [psbt_in.redeem_script] if psbt_in.redeem_script else []
+    if psbt_in.witness_script:
+        return serialize(redeem_script), (b"", *sigs, psbt_in.witness_script)
+    return serialize([b"", *sigs, *redeem_script]), ()
+
+
+@pytest.mark.parametrize("kind", ["multi", "sh-multi", "wsh-multi", "sh-wsh-multi"])
+def test_a_multisig_input_is_spent_in_the_order_the_script_lists_its_keys(
+    kind: str,
+) -> None:
+    """The Finalizer orders the signatures, and the dict does not (issue #431).
+
+    OP_CHECKMULTISIG walks the keys forward and never goes back, so the
+    signatures have to arrive in the order the script lists the keys they
+    belong to. `partial_sigs` cannot supply it: a dict holds what it was
+    given in the order it was given, and `combine` merges with an update,
+    so for a coordinator it is the order the copies came back in.
+
+    Reversing the map is that coordinator, and the engine is the
+    authority on the result.
+    """
+    psbt, prev_outs = _multisig_psbt(2, kind)
+    in_script_order = tuple(psbt.inputs[0].partial_sigs.values())
+    expected = _spent_with(psbt.inputs[0], in_script_order)
+    psbt.inputs[0].partial_sigs = dict(
+        reversed(list(psbt.inputs[0].partial_sigs.items()))
+    )
+
+    finalized = finalize(psbt)
+    verify_transaction(prev_outs, extract_tx(finalized, check_validity=False))
+    final = finalized.inputs[0]
+    assert (final.final_script_sig, final.final_script_witness.stack) == expected
+
+
+@pytest.mark.parametrize("kind", ["multi", "sh-multi", "wsh-multi", "sh-wsh-multi"])
+def test_a_multisig_input_pushes_the_threshold_and_not_every_signature(
+    kind: str,
+) -> None:
+    """A 1-of-2 both participants signed spends with one (issue #431).
+
+    OP_CHECKMULTISIG pops as many signatures as the script says and then
+    one element more, which BIP147 requires to be empty. Pushing both
+    signatures therefore puts the first of them where the dummy belongs,
+    and the spend fails on the dummy rule with the real dummy left over.
+
+    Which of the two is kept is the script's answer and not the map's:
+    the first key it lists that has signed.
+    """
+    psbt, prev_outs = _multisig_psbt(1, kind, signers=2)
+    first_in_script_order = next(iter(psbt.inputs[0].partial_sigs.values()))
+    expected = _spent_with(psbt.inputs[0], (first_in_script_order,))
+
+    finalized = finalize(psbt)
+    verify_transaction(prev_outs, extract_tx(finalized, check_validity=False))
+    final = finalized.inputs[0]
+    assert (final.final_script_sig, final.final_script_witness.stack) == expected
+
+
+def test_a_multisig_input_short_of_the_threshold_is_not_finalized() -> None:
+    """One signature does not satisfy a 2-of-2 (issue #431).
+
+    The Finalizer's own question -- whether the input has enough data to
+    pass validation -- and for a multisig the script answers it. What
+    used to be built instead was a script_sig one element short, which
+    only the engine then refused.
+    """
+    psbt, _ = _multisig_psbt(2, "multi", signers=1)
+    with pytest.raises(BTClibValueError, match="1 signatures for a 2-of-2 multisig"):
+        finalize(psbt)
+
+
+def test_a_signature_of_a_key_the_multisig_script_omits_is_dropped() -> None:
+    """A signature is not evidence that its key belongs to this script.
+
+    The Finalizer builds the spend the script asks for, and a key the
+    script does not list has no place in it -- so the signature is left
+    out rather than refused, an input being free to carry what some other
+    branch would need. It is a real signature over this input's own
+    sig_hash, which is what the Finalizer verifies every one of them
+    against.
+    """
+    psbt, prev_outs = _multisig_psbt(1, "multi")
+    signed = tuple(psbt.inputs[0].partial_sigs.values())
+    expected = _spent_with(psbt.inputs[0], signed)
+    msg_hash = sig_hash.legacy(prev_outs[0].script_pub_key.script, psbt.tx, 0, 1)
+    stranger = _PRV_KEY + 2
+    psbt.inputs[0].partial_sigs[pub_keyinfo_from_prv_key(stranger)[0]] = (
+        dsa.sign_(msg_hash, stranger).serialize() + b"\x01"
+    )
+
+    finalized = finalize(psbt)
+    verify_transaction(prev_outs, extract_tx(finalized, check_validity=False))
+    final = finalized.inputs[0]
+    assert (final.final_script_sig, final.final_script_witness.stack) == expected
+
+
 def _one_input_finalized_each() -> tuple[Psbt, Psbt]:
     """Return the two psbts of two participants, one input finalized each."""
     finalized = finalize(Psbt.b64decode(TO_BE_FINALIZED))
@@ -2253,6 +2372,74 @@ def test_combining_takes_the_union_of_the_final_witnesses() -> None:
     first.inputs[1].final_script_witness = Witness([b"\x01"])
     combined = combine([first, second])
     assert combined.inputs[1].final_script_witness == Witness([b"\x01"])
+
+
+def test_combining_merges_every_field_a_map_holds() -> None:
+    """The preimages, the taproot fields and the musig2 maps too (issue #432).
+
+    "The resulting PSBT must contain all of the key-value pairs from each
+    of the PSBTs", and the list of fields the Combiner walked was the
+    BIP174 one: everything BIP371 and BIP373 added to an input or an
+    output was dropped, silently and both ways round.
+
+    One field of each kind here -- a map, a single value, and the
+    positional list a taproot tree is -- with the two psbts carrying
+    disjoint halves so that the union is the whole.
+    """
+    first = Psbt.b64decode(TO_BE_FINALIZED)
+    second = deepcopy(first)
+    internal_key = bytes.fromhex("aa" * 32)
+    leaf_hash = bytes.fromhex("bb" * 32)
+
+    first.inputs[0].sha256_preimages = {sha256(b"one"): b"one"}
+    second.inputs[0].sha256_preimages = {sha256(b"two"): b"two"}
+    first.inputs[0].taproot_internal_key = internal_key
+    second.inputs[0].taproot_script_spend_signatures = {
+        internal_key + leaf_hash: bytes.fromhex("cc" * 64)
+    }
+    second.outputs[0].taproot_tree = [(0, 192, b"\x51")]
+
+    combined = combine([first, second])
+    assert combined.inputs[0].sha256_preimages == {
+        sha256(b"one"): b"one",
+        sha256(b"two"): b"two",
+    }
+    assert combined.inputs[0].taproot_internal_key == internal_key
+    assert combined.inputs[0].taproot_script_spend_signatures
+    assert combined.outputs[0].taproot_tree == [(0, 192, b"\x51")]
+
+
+def test_combining_refuses_two_participant_lists_for_one_aggregate_key() -> None:
+    """A merge that would write a key's participants into something else.
+
+    An aggregate key is computed from its list, so two different lists
+    under one key are not the conflict BIP174 lets a Combiner pick from:
+    one of them says that key aggregates something it does not, and no
+    reader could tell which. The same list twice is no conflict at all.
+    """
+    first = Psbt.b64decode(TO_BE_FINALIZED)
+    second = deepcopy(first)
+    aggregate_pub_key = bytes.fromhex(f"02{'aa' * 32}")
+    participants = [bytes.fromhex(f"02{'bb' * 32}"), bytes.fromhex(f"02{'cc' * 32}")]
+
+    first.inputs[0].musig2_participant_pub_keys = {aggregate_pub_key: participants}
+    second.inputs[0].musig2_participant_pub_keys = {
+        aggregate_pub_key: list(participants)
+    }
+    combined = combine([first, second])
+    assert combined.inputs[0].musig2_participant_pub_keys[aggregate_pub_key] == (
+        participants
+    )
+
+    first = Psbt.b64decode(TO_BE_FINALIZED)
+    second = deepcopy(first)
+    first.outputs[0].musig2_participant_pub_keys = {aggregate_pub_key: participants}
+    second.outputs[0].musig2_participant_pub_keys = {
+        aggregate_pub_key: list(reversed(participants))
+    }
+    err_msg = "mismatched musig2 participants for aggregate key "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        combine([first, second])
 
 
 def test_finalize_refuses_a_signature_of_another_sig_hash_type() -> None:
@@ -2402,6 +2589,93 @@ def test_the_sig_hash_of_every_input_kind_a_partial_signature_signs() -> None:
     # a count, so that a loop that stops finding signatures is a failure
     # and not a green run over nothing
     assert checked == 3
+
+
+def test_the_signer_signs_the_hash_the_finalizer_checks() -> None:
+    """`ecdsa_sig_hash` is the public half of the Finalizer's own dispatch.
+
+    Both halves of BIP174's valid psbts are covered by asking the two
+    for the same input: whatever the private helper answers a Finalizer,
+    the Signer is told, and a signature made over one verifies under the
+    other. The vectors' own signatures are what
+    `test_the_sig_hash_of_every_input_kind_a_partial_signature_signs`
+    checks that hash against.
+    """
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    for vin_i, psbt_in in enumerate(psbt.inputs):
+        for sig in psbt_in.partial_sigs.values():
+            assert ecdsa_sig_hash(psbt, vin_i, hash_type=sig[-1]) == (
+                _sig_hash_from_psbt_in(psbt_in, psbt.tx, vin_i, sig[-1])
+            )
+
+
+def test_the_signer_is_told_the_hash_type_the_input_asks_for() -> None:
+    """The default is the input's field, and SIGHASH_ALL where it has none.
+
+    An input that asks for a type is an input whose signatures must
+    commit to it, which is what the Finalizer refuses them for; a Signer
+    reading the psbt therefore needs no argument in the ordinary case.
+    SIGHASH_ALL is the fallback because it is what a signature with
+    nothing said about it means.
+    """
+    psbt, _ = _single_key_psbt("p2wpkh")
+    assert psbt.inputs[0].sig_hash_type is None
+    assert ecdsa_sig_hash(psbt, 0) == ecdsa_sig_hash(psbt, 0, hash_type=1)
+
+    psbt.inputs[0].sig_hash_type = 3
+    assert ecdsa_sig_hash(psbt, 0) == ecdsa_sig_hash(psbt, 0, hash_type=3)
+    assert ecdsa_sig_hash(psbt, 0) != ecdsa_sig_hash(psbt, 0, hash_type=1)
+
+
+def test_what_a_signer_cannot_be_given_a_hash_for() -> None:
+    """Four inputs a Signer is stopped on, where the Finalizer is not.
+
+    None out of the private helper is "the psbt does not say what is
+    being signed", and a Finalizer checking a signature it was handed
+    learns nothing from that. A Signer about to make one has to stop, so
+    the same three cases raise here -- and a taproot input is named for
+    what it is rather than reported as silence, its message being
+    `taproot_sig_hash`'s.
+
+    SIGHASH_DEFAULT is the fourth, and it is not about the input: 0 is a
+    taproot type that no ECDSA signature carries, so a psbt asking for it
+    is one the Finalizer could not accept a partial signature for either.
+    """
+    psbt = Psbt.b64decode(TO_BE_FINALIZED)
+    err_msg = "input 0 does not say what is being signed"
+
+    no_utxo = deepcopy(psbt)
+    no_utxo.inputs[0].non_witness_utxo = None
+    with pytest.raises(BTClibValueError, match=err_msg):
+        ecdsa_sig_hash(no_utxo, 0)
+
+    no_redeem_script = deepcopy(psbt)
+    no_redeem_script.inputs[0].redeem_script = b""
+    with pytest.raises(BTClibValueError, match=err_msg):
+        ecdsa_sig_hash(no_redeem_script, 0)
+
+    no_witness_script = deepcopy(psbt)
+    no_witness_script.inputs[1].witness_script = b""
+    with pytest.raises(BTClibValueError, match="input 1 does not say"):
+        ecdsa_sig_hash(no_witness_script, 1)
+
+    taproot_input = deepcopy(psbt)
+    taproot_input.inputs[0].non_witness_utxo = None
+    taproot_input.inputs[0].witness_utxo = TxOut(
+        100000, ScriptPubKey("5120" + "aa" * 32)
+    )
+    with pytest.raises(BTClibValueError, match="input 0 is taproot"):
+        ecdsa_sig_hash(taproot_input, 0)
+
+    with pytest.raises(BTClibValueError, match="SIGHASH_DEFAULT is not an ECDSA"):
+        ecdsa_sig_hash(psbt, 0, hash_type=0)
+    asking_for_default = deepcopy(psbt)
+    asking_for_default.inputs[0].sig_hash_type = 0
+    with pytest.raises(BTClibValueError, match="SIGHASH_DEFAULT is not an ECDSA"):
+        ecdsa_sig_hash(asking_for_default, 0)
+
+    with pytest.raises(BTClibValueError, match="invalid sig_hash type: 0x4"):
+        ecdsa_sig_hash(psbt, 0, hash_type=4)
 
 
 def test_the_outpoint_names_an_output_of_the_non_witness_utxo() -> None:


### PR DESCRIPTION
Three pieces of #381, in one pull request because #431 and #432 both
land in `combine`/`finalize` and #430 rewrites the guide paragraph whose
failure the other two describe. Each is useful on its own, and none of
them needs the key-provider contract of #381's first step settled first.

## #430 — the message a Signer signs

`taproot_sig_hash` was public and its ECDSA counterpart was not, so a
Signer computed the hash itself; the guide's own **Signer** paragraph did
exactly that, reaching past the psbt for `sig_hash.from_tx` — which
cannot serve, reading the redeem script out of an input's script_sig and
the witness script off its witness stack, neither of which an unsigned
transaction has.

`psbt.ecdsa_sig_hash(psbt, vin_i, *, hash_type=None)` wraps the private
dispatch and differs from it in three ways: the `(psbt, vin_i)` shape of
its taproot counterpart; a hash type defaulting to what the input asks
for, `SIGHASH_ALL` where it asks for none, and refusing
`SIGHASH_DEFAULT`, which no ECDSA signature carries; and it raises where
the helper answers `None`. The helper is unchanged — the Finalizer's
per-hash-type caching wants that `None`, and a psbt that does not say
what was signed is not evidence against a signature the Finalizer was
handed, while for a Signer about to make one it is a stop.

Both names are now in `btclib.psbt`'s `__all__`, where neither was.

## #431 — the Finalizer and a multisig input

`_finalized_input` pushed `list(partial_sigs.values())`: every signature
the input carried, in dict order.

- **Order.** OP_CHECKMULTISIG walks the keys forward and never goes back.
  `combine` merges with `dict.update`, so for a coordinator the order is
  the order the copies came back in, related to the script by nothing.
- **Count.** It pops one element beyond the threshold, which BIP147
  requires to be empty, so a 1-of-2 that both participants signed put a
  signature where the dummy belongs.

Both are read off the script now — the witness script of a p2wsh, the
redeem script or script_pub_key otherwise, which `_bip147_dummy` beside
it already read. `script_pub_key.p2ms_m_and_keys` is `addresses`'s own
parser with the answer kept instead of turned into p2pkh addresses and
dropped; `assert_p2ms` calls it too, and its docstring stops claiming
the keys go unchecked, which the parse by way of `b58.p2pkh` never did.

Fewer signatures than the threshold is refused. A signature whose key the
script does not list is dropped, not refused: the Finalizer builds the
spend that script asks for.

## #432 — the Combiner

`combine` walked BIP174's list of fields, so the four preimage maps,
every BIP371 taproot field and every BIP373 musig2 field were dropped,
silently and both ways round.

The consequence is not only that it cannot merge what an external signer
returns: **a MuSig2 session did not survive its own Combiner.** Round 1
puts one nonce in one psbt per signer, and keeping the first psbt's alone
leaves `session_context` deriving a session no partial signature was made
against — the BIP373 this library ships, unreachable through the Combiner
it ships. `test_a_session_survives_the_combiner` is that round trip:
three signers, three copies, combined between the rounds, aggregated and
run through the script engine.

Two fields do not take the union. `taproot_tree` is positional and is
taken whole, the way a witness stack is. Two different participant lists
under one aggregate key are refused rather than picked from: the key is
computed from the list, so one of them says it aggregates something it
does not and nothing in either psbt says which.

`amount`, `script_pub_key`, `previous_tx_id` and `output_index` stay out,
and the docstring now says why: they are part of what identifies the
psbt, so two psbts disagreeing on one of them are two transactions,
refused above.

## Verification

Sixteen new tests. The eleven behavioural ones were run against the
unfixed code first and fail there — four orderings, four counts, the
short threshold, the stranger's signature, and the MuSig2 round trip.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`
  — 17171 tests, 100.00%
- `pre-commit run --all-files` — every hook
- `sphinx-build -W --keep-going` — clean, the guide's doctest included

Rebased on d767daf1.

## Summary by Sourcery

Expose signer-facing ECDSA PSBT message computation, and fix multisig finalization and PSBT combination for taproot and MuSig2 data.

New Features:
- Add public `ecdsa_sig_hash` API and export both ECDSA and taproot signing hashes from the PSBT package.

Bug Fixes:
- Ensure multisig inputs are finalized with signatures ordered by script key order and limited to the threshold, refusing under-signed inputs and ignoring signatures for keys not in the script.
- Fix PSBT combiner to merge all relevant preimage, taproot, and MuSig2 fields, and to reject conflicting participant lists for a single aggregate key.

Enhancements:
- Factor shared p2ms parsing into `p2ms_m_and_keys` for reuse by address derivation, validation, and PSBT finalization logic.

Tests:
- Add comprehensive tests covering multisig signature ordering and threshold handling, combiner behavior with taproot and MuSig2 fields, signer hash-type defaults and error cases, and survival of a full MuSig2 session through combination.