### PR TITLE
Check a taproot input's fields against the output key, and accept it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2153,6 +2153,30 @@ edit.
 
 ### Transactions, blocks and PSBT
 
+- **`Psbt.assert_signable` accepts a taproot input, and checks it**
+  (issue #435). It refused every one of them: `_signable_payload`
+  accepts only a witness kind beside a `witness_utxo`, and p2tr was not
+  in that list — BIP174 wrote the rule when witness v0 was the only
+  witness there was, so BIP371's own valid psbts failed the Signer's
+  pre-flight. An input carrying a `non_witness_utxo` took the other
+  branch and passed, which was worse: nothing about its taproot fields
+  was looked at, so an internal key tweaking to some other output key
+  and a leaf script no control block proves were both signable. What is
+  checked now is BIP341's version of the question the redeem and witness
+  script checks ask — that what the input says reaches the output being
+  spent — and a taproot output can be spent two ways, so it is two
+  answers: the internal key tweaked by `PSBT_IN_TAP_MERKLE_ROOT` must be
+  the output key, and each `PSBT_IN_TAP_LEAF_SCRIPT`'s control block
+  must prove its leaf against it. The leaf version is held to the
+  control block's, the two being read by different callers:
+  `check_output_pubkey` folds the hash from the version the control
+  block declares and `leaf_script` finds a leaf by the version the field
+  stores, so where they differ the proof is of a leaf nothing else looks
+  up. Absence is still absence, as for a p2sh input with no redeem
+  script. `taproot.output_pubkey_from_merkle_root` is the tweak with the
+  root already in hand, which is the form a psbt has it in —
+  `output_pubkey` takes the tree that produced the root, and a psbt
+  never carries one.
 - **`psbt.ecdsa_sig_hash` is the message a Signer signs** (issue #430),
   and with it `btclib.psbt` exports the pair: the ECDSA hash for the
   inputs whose signatures go in `PSBT_IN_PARTIAL_SIG` and

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -502,19 +502,26 @@ def _signable_payload(psbt_in: PsbtIn) -> bytes:
     """Return the hash the input's script_pub_key commits to.
 
     Which utxo the input carries is which kind of input it is. A
-    witness_utxo is the spent output itself, and it has to be a segwit
+    witness_utxo is the spent output itself, and it has to be a witness
     one: p2sh is accepted only as the wrapper, so what is typed then is
     the redeem script, while the payload stays the p2sh one -- the
     hash160 the caller checks that redeem script against. A
     non_witness_utxo is the whole previous transaction, and the output
     being spent is the one the input's own outpoint names.
+
+    p2tr is one of the three because it is a witness kind, which is the
+    whole of the rule: BIP174 wrote the rule when witness v0 was the
+    only witness there was. Only unwrapped, there being no p2sh-wrapped
+    taproot spend -- and a redeem script beside one is refused by the
+    hash160 the caller checks next, 20 bytes never equalling the 32 of
+    an output key.
     """
     if witness_utxo := psbt_in.witness_utxo:
         script_type, payload = type_and_payload(witness_utxo.script_pub_key.script)
         if script_type == "p2sh":
             script_type, _ = type_and_payload(psbt_in.redeem_script)
-        if script_type not in ("p2wpkh", "p2wsh"):
-            raise BTClibValueError("script type not in ('p2wpkh', 'p2wsh')")
+        if script_type not in ("p2wpkh", "p2wsh", "p2tr"):
+            raise BTClibValueError("script type not in ('p2wpkh', 'p2wsh', 'p2tr')")
         return payload
 
     if psbt_in.non_witness_utxo:
@@ -528,6 +535,60 @@ def _signable_payload(psbt_in: PsbtIn) -> bytes:
     raise BTClibValueError(err_msg)
 
 
+def _assert_taproot_signable(psbt_in: PsbtIn) -> None:
+    """Raise unless a taproot input's fields commit to the key being spent.
+
+    The same question the script checks below ask, in BIP341's terms:
+    what the input says about how it is spent has to reach the output
+    that is being spent. A taproot output commits to one key and can be
+    spent two ways, so there are two answers and an input may carry
+    either or both (issue #435):
+
+    - the key path: the output key is the internal key tweaked by the
+      merkle root, and `PSBT_IN_TAP_INTERNAL_KEY` with
+      `PSBT_IN_TAP_MERKLE_ROOT` has to produce the 32 bytes the
+      script_pub_key holds. No merkle root is key path only;
+    - the script path: each `PSBT_IN_TAP_LEAF_SCRIPT` is keyed by its
+      control block, which is BIP341's proof of that leaf against the
+      output key -- `check_output_pubkey`'s whole question.
+
+    Absence is not refused, as it is not for a p2sh input carrying no
+    redeem script: an input that says nothing about how it is spent has
+    told the signer nothing that can be wrong. What is there must be
+    true.
+
+    The leaf version is checked against the control block's because the
+    two are read by different callers: `check_output_pubkey` folds the
+    leaf hash from the version the *control block* declares, while
+    `leaf_script` finds a leaf by the hash of the version the *field*
+    stores. Where they disagree, the proof is of a leaf no other reader
+    will look up.
+    """
+    prev_out = _prev_out(psbt_in)
+    if prev_out is None or not is_p2tr(prev_out.script_pub_key.script):
+        return
+    output_key = type_and_payload(prev_out.script_pub_key.script)[1]
+
+    if psbt_in.taproot_internal_key:
+        tweaked = taproot.output_pubkey_from_merkle_root(
+            psbt_in.taproot_internal_key, psbt_in.taproot_merkle_root
+        )[0]
+        if tweaked != output_key:
+            err_msg = f"the tweaked internal key {tweaked.hex()} is not "
+            err_msg += f"the output key being spent, {output_key.hex()}"
+            raise BTClibValueError(err_msg)
+
+    for control_block, (script, leaf_version) in psbt_in.taproot_leaf_scripts.items():
+        if control_block[0] & 0xFE != leaf_version & 0xFE:
+            err_msg = f"leaf version {hex(leaf_version)} is not the control "
+            err_msg += f"block's {hex(control_block[0] & 0xFE)}"
+            raise BTClibValueError(err_msg)
+        if not taproot.check_output_pubkey(output_key, script, control_block):
+            err_msg = "the control block does not prove leaf script "
+            err_msg += f"{script.hex()} against output key {output_key.hex()}"
+            raise BTClibValueError(err_msg)
+
+
 def _assert_input_signable(psbt_in: PsbtIn) -> None:
     """Raise an exception unless the input carries what a Signer needs.
 
@@ -536,8 +597,14 @@ def _assert_input_signable(psbt_in: PsbtIn) -> None:
     names, and the witness script the sha256 in whichever of the two is
     the level above *it* -- the redeem script when the input is wrapped,
     the script_pub_key when it is native.
+
+    A taproot input has neither script and answers the same question
+    with its own fields, which `_assert_taproot_signable` asks. The two
+    are not exclusive: the checks below still run, and refuse the redeem
+    or witness script a taproot input has no use for.
     """
     payload = _signable_payload(psbt_in)
+    _assert_taproot_signable(psbt_in)
     redeem_script = psbt_in.redeem_script
 
     if redeem_script and payload != hash160(redeem_script):

--- a/btclib/script/__init__.py
+++ b/btclib/script/__init__.py
@@ -73,6 +73,7 @@ from btclib.script.taproot import (
     input_script_sig,
     output_prvkey,
     output_pubkey,
+    output_pubkey_from_merkle_root,
 )
 from btclib.script.witness import Witness
 
@@ -111,6 +112,7 @@ __all__ = [
     "op_int",
     "output_prvkey",
     "output_pubkey",
+    "output_pubkey_from_merkle_root",
     "p2ms_m_and_keys",
     "parse",
     "script_from_dict",

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -50,6 +50,7 @@ __all__ = [
     "leaf_hash",
     "output_prvkey",
     "output_pubkey",
+    "output_pubkey_from_merkle_root",
     "parse",
     "serialize",
     "tree_helper",
@@ -230,6 +231,15 @@ def output_pubkey(
         _, h = tree_helper(script_tree)
     else:
         h = b""
+    return _tweaked_pubkey(pub_key, h, ec)
+
+
+def _tweaked_pubkey(pub_key: bytes, h: bytes, ec: Curve) -> tuple[bytes, int]:
+    """Return the x-only key an internal key tweaked by h, and its parity.
+
+    The half of BIP341's output key that does not care where h came
+    from: a tree the caller built, or the merkle root a psbt carries.
+    """
     t = _tap_tweak(pub_key, h, ec)
 
     # secp256k1_xonly_pubkey_tweak_add is this very operation, parity
@@ -245,6 +255,27 @@ def output_pubkey(
     P_x = int.from_bytes(pub_key, "big")
     Q = ec.add((P_x, ec.y_even(P_x)), mult(t))
     return Q[0].to_bytes(32, "big"), Q[1] % 2
+
+
+def output_pubkey_from_merkle_root(
+    internal_pubkey: Octets, merkle_root: Octets = b"", ec: Curve = secp256k1
+) -> tuple[bytes, int]:
+    """Return a taproot output key from a merkle root, per BIP341.
+
+    `output_pubkey` with the root already in hand, which is the shape a
+    psbt has it in: BIP371's `PSBT_IN_TAP_MERKLE_ROOT` is the root and
+    not the tree that produced it, an input naming the branch it spends
+    by its leaf script and control block instead -- so a signer that
+    takes the key path is told the root and nothing else about the tree.
+    An empty root is key path only, as an empty tree is.
+
+    The internal key is x-only and 32 bytes, which is what BIP341 tweaks
+    and what the psbt field holds; `output_pubkey` takes the wider `Key`
+    because a caller building an output has the key in whatever form it
+    reached them in.
+    """
+    internal_pubkey = bytes_from_octets(internal_pubkey, 32)
+    return _tweaked_pubkey(internal_pubkey, bytes_from_octets(merkle_root), ec)
 
 
 def output_prvkey(

--- a/tests/psbt/_data/bip174_test_vectors.json
+++ b/tests/psbt/_data/bip174_test_vectors.json
@@ -146,7 +146,7 @@
     "signer check failures": [
         {
             "description": "A witness UTXO is provided for a non-witness input",
-            "error message": "script type not in ('p2wpkh', 'p2wsh')",
+            "error message": "script type not in ('p2wpkh', 'p2wsh', 'p2tr')",
             "encoded psbt": "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6W3vkAAAAAAD+////qwlJoIxa98SbghL0F+LxWrP1wz3PFTghqBOfh3pbe+QBAAAAAP7///8CYDvqCwAAAAAZdqkUdopAu9dAy+gdmI5x3ipNXHE5ax2IrI4kAAAAAAAAGXapFG9GILVT+glechue4O/p+gOcykWXiKwAAAAAAAEBItPf9QUAAAAAGXapFNSO0xELlAFMsRS9Mtb00GbcdCVriKwAAQEgAOH1BQAAAAAXqRQ1RebjO4MsRwUPJNPuuTycA5SLx4cBBBYAFIXRNTfy4mVAWjTbr6nj3aAfuCMIACICAurVlmh8qAYEPtw94RbN8p1eklfBls0FXPaYyNAr8k6ZELSmumcAAACAAAAAgAIAAIAAIgIDlPYr6d8ZlSxVh3aK63aYBhrSxKJciU9H2MFitNchPQUQtKa6ZwAAAIABAACAAgAAgAA="
         },
         {

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -2751,6 +2751,107 @@ def test_a_taproot_input_is_finalized_from_its_own_fields() -> None:
     )
 
 
+def _bip371_psbt(description: str) -> Psbt:
+    """Return the valid BIP371 psbt whose description contains this."""
+    return Psbt.b64decode(
+        next(
+            test_vector["encoded psbt"]
+            for test_vector in load("psbt", "_data", "bip371_test_vectors.json")[
+                "valid psbts"
+            ]
+            if description in test_vector["description"]
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "test_vector", psbt_vectors("bip371_test_vectors.json", "valid psbts")
+)
+def test_bip371s_own_psbts_are_signable(test_vector: dict[str, str]) -> None:
+    """Every valid BIP371 psbt passes the Signer's pre-flight (issue #435).
+
+    None of them did: a p2tr input carrying a witness_utxo was refused
+    as "script type not in ('p2wpkh', 'p2wsh')", the rule BIP174 wrote
+    for a witness utxo beside a legacy input, applied to a witness kind
+    that did not exist when it was written.
+
+    They are the positive case for what replaces it, and they cover both
+    ways a taproot output is spent: the key path ones carry an internal
+    key and no merkle root, the script path ones a root and three leaf
+    scripts with their control blocks.
+    """
+    Psbt.b64decode(test_vector["encoded psbt"]).assert_signable()
+
+
+def test_what_a_taproot_input_cannot_be_signed_from() -> None:
+    """Every way the taproot fields of an input fail to reach its output key.
+
+    What the redeem and witness script checks are for the other kinds:
+    the psbt is held to the output being spent, so a field that does not
+    reach it is a field a Signer must not act on.
+    """
+    key_path = "one P2TR key only input with internal key"
+    script_path = "one P2TR script path only input with dummy internal key"
+
+    # an internal key that tweaks to some other output key
+    psbt = _bip371_psbt(key_path)
+    psbt.inputs[0].taproot_internal_key = _PUB_KEY[1:]
+    with pytest.raises(BTClibValueError, match="is not the output key being spent"):
+        psbt.assert_signable()
+
+    # the right internal key and a merkle root the output does not
+    # commit to: a key path spend is the tweak by no root at all
+    psbt = _bip371_psbt(key_path)
+    psbt.inputs[0].taproot_merkle_root = b"\x01" * 32
+    with pytest.raises(BTClibValueError, match="is not the output key being spent"):
+        psbt.assert_signable()
+
+    # a leaf script the control block beside it does not prove
+    psbt = _bip371_psbt(script_path)
+    control_block, (script, leaf_version) = next(
+        iter(psbt.inputs[0].taproot_leaf_scripts.items())
+    )
+    psbt.inputs[0].taproot_leaf_scripts[control_block] = (
+        script + b"\x51",
+        leaf_version,
+    )
+    with pytest.raises(BTClibValueError, match="does not prove leaf script"):
+        psbt.assert_signable()
+
+    # a leaf version that is not the one the control block declares:
+    # the proof is then of a leaf `leaf_script` will not find
+    psbt = _bip371_psbt(script_path)
+    psbt.inputs[0].taproot_leaf_scripts[control_block] = (script, 0xC2)
+    with pytest.raises(BTClibValueError, match="is not the control block's"):
+        psbt.assert_signable()
+
+
+def test_a_taproot_input_is_checked_whichever_utxo_it_carries() -> None:
+    """The non_witness_utxo path used to be the one that checked nothing.
+
+    A taproot input carrying the whole previous transaction took the
+    branch that returns the payload without typing it, so the two checks
+    below never ran and every taproot field was signable. The output
+    being spent is the same output either way, which is what `_prev_out`
+    answers and what this asks it for.
+
+    The script_pub_key is built by `ScriptPubKey.p2tr`, which tweaks by
+    an empty *tree*, and the check tweaks by an empty *root*: that the
+    psbt is signable at all is the two spellings agreeing on this key.
+    """
+    internal_key = _PUB_KEY[1:]
+    prev_out = TxOut(100_000, ScriptPubKey.p2tr(_PUB_KEY))
+    tx, prev_tx = _spending_tx(prev_out)
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    psbt.inputs[0].taproot_internal_key = internal_key
+    psbt.assert_signable()
+
+    psbt.inputs[0].taproot_internal_key = _OTHER_PUB_KEY[1:]
+    with pytest.raises(BTClibValueError, match="is not the output key being spent"):
+        psbt.assert_signable()
+
+
 def test_what_a_taproot_input_cannot_be_finalized_from() -> None:
     """Every way the taproot fields of an input fail to be a spend of it."""
     # a signature of the wrong sig_hash type: the input asks for one and

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -19,7 +19,7 @@ import pytest
 
 from btclib import b32
 from btclib.alias import ScriptList
-from btclib.curves import mult
+from btclib.curves import bytes_from_point, mult
 from btclib.exceptions import BTClibValueError
 from btclib.script import (
     TaprootScriptTree,
@@ -29,10 +29,11 @@ from btclib.script import (
     is_p2tr,
     output_prvkey,
     output_pubkey,
+    output_pubkey_from_merkle_root,
     taproot,
     type_and_payload,
 )
-from btclib.script.taproot import parse, serialize
+from btclib.script.taproot import parse, serialize, tree_helper
 from btclib.tx import TxOut
 from tests import load, vector_id
 from tests.curves.curve_test import low_card_curves
@@ -224,6 +225,30 @@ def test_control_block() -> None:
     pub_key = output_pubkey(internal_pubkey, script_tree)[0]
     script, control = input_script_sig(internal_pubkey, script_tree, 0)
     assert check_output_pubkey(pub_key, serialize(script), control)
+
+
+def test_the_two_output_keys_are_one_tweak() -> None:
+    """A tree and its own merkle root reach the same output key.
+
+    Which is the whole claim of `output_pubkey_from_merkle_root`: it is
+    `output_pubkey` with the root already computed, the form a psbt
+    carries it in. Both halves of BIP341's tweak are checked -- the key
+    path, where the root is empty, and a tree, whose root comes from
+    `tree_helper`.
+
+    The unspendable internal key `output_pubkey` substitutes for a
+    missing one is not this function's business: the psbt field it
+    serves is either present or the input says nothing to check.
+    """
+    internal_pubkey = mult(123456)
+    x_only = bytes_from_point(internal_pubkey)[1:]
+    assert output_pubkey_from_merkle_root(x_only) == output_pubkey(internal_pubkey)
+
+    script_tree: TaprootScriptTree = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
+    merkle_root = tree_helper(script_tree)[1]
+    assert output_pubkey_from_merkle_root(x_only, merkle_root) == (
+        output_pubkey(internal_pubkey, script_tree)
+    )
 
 
 # the vector's scriptTree, not a tree: nested json lists of


### PR DESCRIPTION
Closes #435, and is the second step of #381 — the one that needed no
key-provider contract settled first.

## The defect

`Psbt.assert_signable` refused every taproot input. `_signable_payload`
takes a `witness_utxo` only beside a witness kind and p2tr was not in
that list, so BIP371's own six valid psbts failed the Signer's
pre-flight with "script type not in ('p2wpkh', 'p2wsh')" — BIP174's rule
for a witness utxo beside a legacy input, written when witness v0 was
the only witness there was.

An input carrying a `non_witness_utxo` took the other branch and passed,
which is worse: nothing about its taproot fields was read at all.

## The check

BIP341's version of the question the redeem and witness script checks
ask — what the input says about how it is spent has to reach the output
being spent. A taproot output is spent two ways, so it is two answers,
and an input may carry either or both:

- the internal key tweaked by `PSBT_IN_TAP_MERKLE_ROOT` must be the 32
  bytes in the script_pub_key. No merkle root is key path only;
- each `PSBT_IN_TAP_LEAF_SCRIPT` is keyed by its control block, which is
  BIP341's proof of that leaf against the output key —
  `taproot.check_output_pubkey`'s whole question.

Absence stays absence, as it does for a p2sh input with no redeem
script: an input that says nothing about how it is spent has told the
signer nothing that can be wrong. What is there must be true.

The leaf version is held to the control block's, because the two are
read by different callers. `check_output_pubkey` folds the leaf hash
from the version the *control block* declares; `psbt.leaf_script` finds
a leaf by the hash of the version the *field* stores. Where they differ,
the proof this check ran is of a leaf nothing else will look up.

The taproot assertion runs *beside* the existing checks rather than
instead of them, so a taproot input carrying a redeem or witness script
is still refused by the hash160 and sha256 it cannot match.

## `output_pubkey_from_merkle_root`

`taproot.output_pubkey` tweaks by a script *tree*, and a psbt carries
the merkle root rather than the tree that produced it: an input names
the branch it spends by its leaf script and control block, so a signer
taking the key path is told the root and nothing else. The new function
is that tweak with the root already in hand, x-only internal key in,
output key and parity out. It shares `_tap_tweak` and the
libsecp256k1/Python split with `output_pubkey` — the tail of that
function became `_tweaked_pubkey`, which both call.

## Verification

Nine new tests. All eight of the psbt ones were run against the unfixed
code first and fail there; the ninth is in `taproot_test.py` and says
the two output-key spellings agree, for an empty root and for a real
tree's.

The positive case is BIP371's own six valid psbts, key path and script
path both — parametrized, so a vector added to the file is a case added
here.

The signer-check vector's expected message moves with the message.
`tests/_data/README.md` records that field as btclib's own expectation
of btclib's own error, to be corrected there when the error is
corrected, which is what this does.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`
  — 17180 tests, 100.00%
- `pre-commit run --all-files` — every hook
- `sphinx-build -W --keep-going` — clean

Rebased on e01fdef6.

## Summary by Sourcery

Ensure taproot PSBT inputs are validated against their output key and treated as signable when correctly formed.

New Features:
- Add support in Psbt.assert_signable for taproot (p2tr) inputs, treating them as signable witness inputs.
- Introduce taproot.output_pubkey_from_merkle_root to derive a taproot output key directly from an internal key and merkle root.

Bug Fixes:
- Fix Psbt.assert_signable rejecting all taproot inputs that carry a witness_utxo and failing to validate taproot fields when only a non_witness_utxo is present.

Enhancements:
- Add taproot-specific validation that internal keys, merkle roots, and leaf scripts/control blocks commit to the output key being spent.
- Export output_pubkey_from_merkle_root via the script package for external use.

Documentation:
- Update CHANGELOG to document taproot PSBT signability checks and the new output_pubkey_from_merkle_root helper.

Tests:
- Extend PSBT tests to cover BIP371 valid taproot PSBTs and negative cases where taproot fields do not match the output key.
- Add taproot tests verifying that output_pubkey_from_merkle_root matches output_pubkey for both key-path and script-tree cases.