### PR TITLE
Drop RELEASING.md's and CONTRIBUTING.md's rpc-smoke step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -406,45 +406,6 @@ exits non-zero for one, which is the only thing the workflow is red about.
 Its docstring says why it reads the session file rather than `cosmic-ray
 dump`, which cannot read one of these sessions at all.
 
-The `rpc-smoke` workflow, on demand and before a release, and the one job
-here that needs something uv cannot fetch: a bitcoind. It is what stands
-behind the recorded replies under `tests/fetch/_data` — the reply shapes of
-both protocol versions read off the wire, the cookie the node wrote, the
-`/wallet/<name>` endpoint, and the three fetcher answers against a regtest
-chain it generates. Two versions, and `rpc-smoke.yml` states the rule for
-moving the pins: the last v27 release for the JSON-RPC 1.1 path, whatever
-is current for 2.0.
-
-The node comes from the release directory of its version, verified against
-the digest that workflow carries — never a `latest` url, and verified
-before the archive is unpacked. `sha256sum` is coreutils, so on macOS the
-command is `shasum -a 256`:
-
-```shell
-core=27.2
-archive="bitcoin-$core-x86_64-linux-gnu.tar.gz"
-curl --fail --proto '=https' --tlsv1.2 --output "$archive" \
-    "https://bitcoincore.org/bin/bitcoin-core-$core/$archive"
-printf '%s  %s\n' "<the digest in rpc-smoke.yml>" "$archive" \
-    | sha256sum --check --strict -
-tar --extract --gzip --file "$archive" "bitcoin-$core/bin/bitcoind"
-```
-
-Then the command the workflow runs, verbatim, for that half of the matrix:
-
-```shell
-uv run --locked --no-default-groups python .github/scripts/rpc_smoke.py \
-    --bitcoind bitcoin-27.2/bin/bitcoind --core-version 27.2 --protocol 1.1
-```
-
-A bitcoind already on the machine does as well, `--core-version` being
-what says which one it has to be. The script starts it itself, in a
-temporary datadir, with no `-rpcport`: the port, the datadir layout and the
-cookie are then the node's own defaults, which is what makes them
-something to check rather than something to configure — and why it refuses
-to run while anything else is listening on regtest's rpc port. Both cells
-of the matrix are two runs of that command, with `31.1` and `2.0`.
-
 The documentation, which the `Build the documentation` job of `lint.yml`
 runs with this same command, as read the docs does. `-W` is what makes an
 `automodule` whose module does not import a failure rather than an empty

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -191,18 +191,6 @@ pyroma), build, wheel smoke test — and publishes to
    commit and the attestations bound to it outliving any attempt to
    rewrite the history back.
 
-1. Dispatch the `rpc-smoke` workflow (Actions → rpc-smoke → Run workflow)
-   and see both cells green. It is the one job here that talks to a live
-   bitcoind: everything about the rpc client of `btclib.fetch` is otherwise
-   tested against recorded replies, which cannot say that Core still sends
-   them — so this asks the legacy compatibility boundary and current Core,
-   the last v27 release for the JSON-RPC 1.1 path and v31.1 for 2.0. That
-   first one is end of life upstream, which is what makes it the boundary:
-   it is the last major that does not know the 2.0 marker. Red here is a
-   release that must not describe that client as production ready.
-   CONTRIBUTING.md has the same command for a node of your own, and
-   `.github/workflows/rpc-smoke.yml` the rule for moving the two pins.
-
 1. Rehearse on TestPyPI (see above) from master.
 
 1. Tag the release commit and push the tag:


### PR DESCRIPTION
#427 moved `BitcoinCoreRpcClient`, its live-node smoke script and the
`rpc-smoke` workflow out of this repository and into
[bitcoin-core-rpc](https://github.com/btclib-org/btclib-bitcoin-core-rpc),
which has its own `rpc-smoke.yml` now. Two files here never caught up:

- RELEASING.md's release checklist still said to dispatch the `rpc-smoke`
  workflow "Actions → rpc-smoke → Run workflow" before tagging. That
  workflow no longer exists in this repository — the step would find
  nothing to run.
- CONTRIBUTING.md still documented `.github/scripts/rpc_smoke.py`, the
  bitcoind download/verify recipe and the exact command the workflow ran,
  none of which exist here either.

Both are deleted rather than repointed at the sibling repository: the
live-node compatibility boundary they tested is `bitcoin-core-rpc`'s own
release gate now, not something a btclib release re-verifies.

## Verification

- `pre-commit run --all-files`: every hook
- `pytest`: 17171 passed
- `sphinx-build -W --keep-going`: clean
- grep for `rpc-smoke`/`rpc_smoke` across both files: no hits left

## Summary by Sourcery

Documentation:
- Delete CONTRIBUTING and RELEASING sections that reference the legacy rpc-smoke workflow, scripts, and release checklist step now owned by the bitcoin-core-rpc repository.