### PR TITLE
Follow btclib_libsecp256k1's rename to btclib-libsecp256k1 on GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
       value: >
         Not every bug reachable from btclib is a btclib bug: the elliptic
         curve operations are delegated to
-        [btclib_libsecp256k1](https://github.com/btclib-org/btclib_libsecp256k1/issues),
+        [btclib_libsecp256k1](https://github.com/btclib-org/btclib-libsecp256k1/issues),
         the Python bindings, and through them to
         [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1/issues).
         A traceback ending in either belongs there. If in doubt, report it

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -15,7 +15,7 @@ contact_links:
       maintainers alone; SECURITY.md gives an email address for anyone who
       would rather not use it.
   - name: Bug in the libsecp256k1 bindings
-    url: https://github.com/btclib-org/btclib_libsecp256k1/issues
+    url: https://github.com/btclib-org/btclib-libsecp256k1/issues
     about: Signing, verification and curve arithmetic are delegated there.
   - name: Chat with the developers
     url: https://bbt-training.slack.com/archives/C01CCJ85AES

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
         and prototyping as much as at production use: what belongs here is
         what a specification describes. Wrapping something libsecp256k1
         offers belongs in
-        [btclib_libsecp256k1](https://github.com/btclib-org/btclib_libsecp256k1/issues)
+        [btclib_libsecp256k1](https://github.com/btclib-org/btclib-libsecp256k1/issues)
         instead.
 
   - type: textarea

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ some of its algorithms could be broken using side-channel attacks.
 
 The library is not limited to the bitcoin elliptic curve secp256k1;
 for that curve, though, it always relies on
-[btclib_libsecp256k1](https://github.com/btclib-org/btclib_libsecp256k1),
+[btclib_libsecp256k1](https://github.com/btclib-org/btclib-libsecp256k1),
 FFI bindings to
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1)
 (the optimized C library used by Bitcoin Core):

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ equally welcome.
 
 Signing, verification and generator multiplication on secp256k1 are
 delegated to
-[btclib_libsecp256k1](https://github.com/btclib-org/btclib_libsecp256k1/security/advisories/new),
+[btclib_libsecp256k1](https://github.com/btclib-org/btclib-libsecp256k1/security/advisories/new),
 the Python bindings, and through them to
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1/security/advisories/new)
 itself, which has its own security policy and its own address. A flaw in


### PR DESCRIPTION
## What this changes, and why

`btclib_libsecp256k1` was renamed on GitHub to `btclib-org/btclib-libsecp256k1`
— a hyphen in the slug, matching every other repository in the org. The
package it ships stays `btclib_libsecp256k1`: the PyPI distribution name,
the import name, and the pin in `pyproject.toml` here are unrelated
identifiers a repository rename does not touch, and none of them change.

Five links here named the old repository by URL: both issue templates
that route a bug into the bindings' own tracker, the feature-request
template pointing a wrapper request there instead, README's mention of
the dependency, and SECURITY.md's link to file a security advisory on
it. Updated the URL alone in each — the visible link text stays
`btclib_libsecp256k1`, naming the package a reader installs rather than
the repository a browser opens.

Nothing else in this repository names `btclib_libsecp256k1` by URL:
`uv.lock`, the dependency pin in `pyproject.toml`, and every prose
mention across `CLAUDE.md`, `CONTRIBUTING.md`, `RELEASING.md` and the
workflow comments name the package, and stay as they are.
`CHANGELOG.md` and `HISTORY.md` are untouched on the same principle this
project already applies to its own release notes: they record what was
true when written.

GitHub redirects the old repository name for now, which is why nothing
here was actually broken before this pull request — worth fixing rather
than relying on, since the old name becomes claimable by someone else at
that point, and the redirect with it.

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [ ] new wrapped functionality is validated against vectors published
      elsewhere — not applicable, no functionality is wrapped here
- [x] comments that this change makes untrue have been updated
- [ ] `HISTORY.md` mentions it, if a user of the package would notice —
      not applicable: link maintenance, nothing the installed package
      exposes

## Summary by Sourcery

Update references to the btclib libsecp256k1 bindings repository to reflect its new GitHub slug while keeping the package name unchanged.

Documentation:
- Refresh README and SECURITY.md links to point to the renamed btclib-org/btclib-libsecp256k1 repository.
- Update issue and feature request templates to route users to the new btclib-libsecp256k1 GitHub URLs for bugs, features, and security advisories.