### PR TITLE
Fix RELEASING.md against what the sibling repositories already got right

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -193,7 +193,9 @@ against a pin about to be a version behind.
    that reaches `master`'s history: the pull request is where it stays,
    and where a reader of any commit in it arrives. A template left
    unfilled, or a bot's summary of the diff, is not a substitute — the
-   summary can stay, but what the diff cannot say has to be written.
+   summary can stay, but what the diff cannot say has to be written, and
+   what a reader should not have to discover at the button belongs there
+   too.
 
    And merge it with **"Rebase and merge"**, never *"Squash and merge"*.
    All three methods are enabled here and GitHub preselects whichever was

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -239,6 +239,17 @@ pyroma), build, wheel smoke test — and publishes to
    `attestation_bundles[].publisher` should name this repository and
    `release.yml`.
 
+1. Dispatch the `published` workflow (Actions → published → Run workflow)
+   and expect it green: no checkout, so it resolves to what PyPI actually
+   serves rather than to a source tree. It checks a BIP39 vector against
+   the twenty-five `_data/` files a wheel missing one would still install
+   and import cleanly, and a BIP340 vector besides -- both fixed forever,
+   so neither needs an edit after a release the way a version-pinned
+   assertion would. From then on it runs weekly on its own, and a failure
+   means the outside world moved, not this repository — a new interpreter
+   release, PyPI serving a file that does not match its own hash — which
+   is why it is a workflow of its own rather than a job of this one.
+
 1. Realign `dev` onto `master`, before anything else is committed to it.
    **Rebase and merge** replays `dev`'s commits with new SHAs, so the
    moment a release lands the two branches hold the same tree through

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -111,6 +111,19 @@ pyroma), build, wheel smoke test — and publishes to
 
 ## Release to PyPI
 
+`latest` is worth dispatching before the tag rather than waiting for its
+Wednesday cron, because what it answers is cheaper to know before a version
+is consumed than after. It gates nothing, so it will not stop you:
+reading it is the point. A release ships what `uv.lock` pins, so a red
+run here does not make the release wrong — it says the next dependency
+bump is going to be work. Its `test-bindings-latest` job is the one worth
+reading closely: it asks about the newest btclib_libsecp256k1 release
+alone, precisely, rather than folding it into the broader upgrade the
+rest of the workflow makes — a release of the bindings is a release in
+another repository, which nothing here has to change for the pair to
+stop working, and this release is the moment to find out before shipping
+against a pin about to be a version behind.
+
 1. Make sure the released btclib_libsecp256k1 satisfies the pin in
    pyproject.toml: if the pin is only satisfied by an unreleased version,
    release the bindings first. The wheel smoke test of the `dist-py` job


### PR DESCRIPTION
## What this changes, and why

Three fixes to RELEASING.md found by comparing it against the same file
in btclib_libsecp256k1 and btclib-bitcoin-core-rpc, which follow the
same conventions by design.

- **Dispatch `published` after a release.** The workflow exists and does
  exactly the check a release checklist should ask for — no checkout, so
  it resolves to what PyPI actually serves rather than to a source tree
  — but nothing here ever dispatched or read it. Both sibling
  repositories already have this step.
- **Say that `latest` is worth dispatching before the tag.**
  btclib_libsecp256k1's own file already makes this point: a release
  freezes `uv.lock`, so checking `latest` right then is cheaper than
  finding out during the next dependency bump. Left unmentioned here
  despite `latest.yml` doing exactly that — and worth reading closely
  here specifically for `test-bindings-latest`, the job that checks the
  newest btclib_libsecp256k1 release alone, the one runtime dependency
  whose own release is a release in another repository. Not propagated:
  the equivalent line about `mutation`, deliberately — it asks a
  different kind of question, one release timing does not answer, and
  it already runs on its own schedule regardless.
- **Complete the pull-request-body clause.** btclib_libsecp256k1's copy
  of "give it its title and its body" has one clause this file was
  missing: what a reader should not have to discover at the merge button
  belongs in the body, not sprung on them there.

## Checklist

- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run pytest` passes (17180 passed)
- [ ] new wrapped functionality is validated against vectors published
      elsewhere — not applicable, documentation only
- [x] comments that this change makes untrue have been updated
- [ ] `HISTORY.md` mentions it — not applicable, nothing a user of the
      package would notice

## Summary by Sourcery

Update release documentation to align with sibling repositories’ workflows and clarify required checks and PR expectations.

Documentation:
- Document running the `latest` workflow before tagging a release to surface dependency issues earlier.
- Clarify that pull request bodies must include context that cannot be inferred from the diff, including anything a reviewer should not discover only at merge time.
- Document dispatching and monitoring the `published` workflow after a release to verify what PyPI actually serves.