### PR TITLE
Give the Signer a KeyManager to ask, and sign() to run it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2153,6 +2153,32 @@ edit.
 
 ### Transactions, blocks and PSBT
 
+- **`psbt.sign` is the Signer role, played over a `KeyManager`'s
+  answers** (issue #439). BIP174 leaves the caller to find which keys
+  are its own and write a signature back; the guide's own **Signer**
+  paragraph asked the psbt for the hash and inserted the signature by
+  hand, keyed by public key. What a psbt offers to resolve a key by is
+  a public key, usually a `BIP32KeyOrigin` beside it, never an address,
+  so both travel together on every call to `KeyManager.sign_ecdsa` or
+  `.sign_schnorr` — a key match is a fact, an origin only a claim about
+  a four-byte fingerprint, and the second is what a watch-only-shaped
+  manager, one xprv over many unseen children, needs to answer from at
+  all. The manager signs and returns the bare signature; `sign` never
+  holds an xprv, appends the sig_hash type itself, and writes what came
+  back — the shape an external or hardware backend can implement
+  without a different contract. None is not an error: one signer of an
+  m-of-n answers for its own key and nothing else, and every input it
+  cannot answer for is left for another signer's turn rather than
+  raised on — so `sign` returns which inputs got a new signature beside
+  the copy, "there was nothing for me" and "done" being different
+  answers to a caller collecting a quorum. Taproot is limited to the
+  key path: MuSig2 is already `btclib.psbt.musig2`'s own Signer, and a
+  script path spend needs a leaf and a control block `sign` does not
+  choose between. `taproot.output_prvkey_from_merkle_root` is the
+  private counterpart of `output_pubkey_from_merkle_root` (issue #435,
+  below): the tweak with `PSBT_IN_TAP_MERKLE_ROOT` already in hand,
+  which is what a `KeyManager` signing a taproot key path spend needs
+  and never the script tree that produced the root.
 - **`Psbt.assert_signable` accepts a taproot input, and checks it**
   (issue #435). It refused every one of them: `_signable_payload`
   accepts only a witness kind beside a `witness_utxo`, and p2tr was not

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -7,14 +7,16 @@
 
 What this package exports is the format and the roles: the three maps a
 psbt is made of, the Combiner, the Finalizer, the Extractor, the outputs
-an unsigned psbt spends, the two messages a Signer signs, and the size
+an unsigned psbt spends, the two messages a Signer signs and `sign`
+which plays the role over a `KeyManager`'s answers, and the size
 estimation a fee rate is applied to. `musig2` is named as a module, being
 the BIP373 role rather than one function, the way btclib.ecc names dsa.
 
 `ecdsa_sig_hash` and `taproot_sig_hash` are here for the same reason
-`prevouts` is: the Signer role is the one BIP174 leaves to the caller,
-who has the keys, and the message is what it needs from the psbt to
-play it.
+`prevouts` is: `sign` needs the message before it needs anything else,
+and a caller playing the Signer by hand -- writing a signature into a
+psbt without going through `sign` -- needs it too, `KeyManager` not
+being the only way to hold a key.
 
 btclib.psbt.psbt_utils is not exported, and this is where that decision is
 recorded: serialize_bytes, deserialize_map, deserialize_tx,
@@ -31,6 +33,7 @@ half of that module from already.
 
 from btclib.psbt import musig2
 from btclib.psbt.psbt import (
+    KeyManager,
     Psbt,
     combine,
     ecdsa_sig_hash,
@@ -38,6 +41,7 @@ from btclib.psbt.psbt import (
     finalize,
     join,
     prevouts,
+    sign,
     taproot_sig_hash,
 )
 from btclib.psbt.psbt_in import PsbtIn
@@ -45,6 +49,7 @@ from btclib.psbt.psbt_out import PsbtOut
 from btclib.psbt.psbt_size import estimated_input_sizes
 
 __all__ = [
+    "KeyManager",
     "Psbt",
     "PsbtIn",
     "PsbtOut",
@@ -56,5 +61,6 @@ __all__ = [
     "join",
     "musig2",
     "prevouts",
+    "sign",
     "taproot_sig_hash",
 ]

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -32,7 +32,7 @@ from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
 from math import ceil
-from typing import Any, TypeVar, cast
+from typing import Any, Protocol, TypeVar, cast
 
 from btclib.alias import BinaryData, Octets, ScriptList, String
 from btclib.bip32 import (
@@ -103,6 +103,7 @@ __all__ = [
     "PSBT_MAGIC_BYTES",
     "PSBT_V0",
     "PSBT_V2",
+    "KeyManager",
     "Psbt",
     "combine",
     "ecdsa_sig_hash",
@@ -111,6 +112,7 @@ __all__ = [
     "join",
     "leaf_script",
     "prevouts",
+    "sign",
     "single_leaf_key",
     "taproot_sig_hash",
 ]
@@ -1881,6 +1883,149 @@ def ecdsa_sig_hash(psbt: Psbt, vin_i: int, *, hash_type: int | None = None) -> b
         err_msg += "no utxo, no redeem script, or no witness script"
         raise BTClibValueError(err_msg)
     return msg_hash
+
+
+class KeyManager(Protocol):
+    """A signature over a hash, by public key or origin: what `sign` asks.
+
+    `sign` has no key of its own; a KeyManager is where the keys are, and
+    each method answers what `sign` cannot -- is this key one you hold,
+    and if so, what does it sign msg_hash with. None answers "not mine"
+    rather than raising, which is what lets one signer of an m-of-n
+    answer for its own key alone: an input none of its keys can answer
+    for is somebody else's turn, not an error.
+
+    Both pub_key and origin travel on every call, in the order a psbt
+    itself gives them precedence: a key match is a fact, an origin only
+    a claim about a four-byte fingerprint, which collides. The claim is
+    what a watch-only-shaped manager -- one xprv, many children it has
+    never derived -- needs to answer at all, having no way to recognize
+    a child key it has not yet computed.
+
+    What comes back is the bare signature -- DER for ECDSA, 64 bytes
+    r||s for schnorr -- with no sig_hash type appended. `sign` appends
+    it, being the one that fixed the hash and therefore the type the
+    signature answers for; the secret stays inside the manager, which is
+    what lets a hardware backend implement this same contract without
+    `sign` ever holding what signs for it.
+    """
+
+    def sign_ecdsa(
+        self, pub_key: bytes, origin: BIP32KeyOrigin | None, msg_hash: bytes
+    ) -> bytes | None:
+        """Return the DER signature of msg_hash by pub_key, or None."""
+        ...
+
+    def sign_schnorr(
+        self,
+        pub_key: bytes,
+        origin: BIP32KeyOrigin | None,
+        msg_hash: bytes,
+        merkle_root: bytes,
+    ) -> bytes | None:
+        """Return the BIP340 signature of msg_hash by pub_key, or None.
+
+        pub_key is the taproot internal key, x-only and untweaked, and
+        the signature has to be the tweaked output key's: merkle_root is
+        `PSBT_IN_TAP_MERKLE_ROOT`, empty for a key-path-only output, and
+        tweaking by it is the manager's to do, `sign` never holding what
+        tweaking a private key needs.
+        """
+        ...
+
+
+def _sign_ecdsa_input(psbt: Psbt, vin_i: int, key_manager: KeyManager) -> bool:
+    """Write every partial signature key_manager gives for one input.
+
+    hd_key_paths is the candidate list: what a psbt names for an ECDSA
+    spend is a public key, never an address, and usually an origin
+    beside it. A key already in partial_sigs is left alone rather than
+    asked for again, and the message is computed at most once and only
+    once there is a candidate to ask for it -- an input key_manager
+    holds nothing for never reaches `ecdsa_sig_hash` to be refused for a
+    reason that is not key_manager's.
+    """
+    psbt_in = psbt.inputs[vin_i]
+    hash_type = ALL if psbt_in.sig_hash_type is None else psbt_in.sig_hash_type
+    msg_hash: bytes | None = None
+    signed = False
+    for pub_key, origin in psbt_in.hd_key_paths.items():
+        if pub_key in psbt_in.partial_sigs:
+            continue
+        if msg_hash is None:
+            msg_hash = ecdsa_sig_hash(psbt, vin_i, hash_type=hash_type)
+        sig = key_manager.sign_ecdsa(pub_key, origin, msg_hash)
+        if sig is None:
+            continue
+        psbt_in.partial_sigs[pub_key] = sig + hash_type.to_bytes(1, "big")
+        signed = True
+    return signed
+
+
+def _sign_taproot_key_path(psbt: Psbt, vin_i: int, key_manager: KeyManager) -> bool:
+    """Write the taproot key path signature key_manager gives, if any.
+
+    One candidate, the internal key, already signed or absent being the
+    two reasons there is nothing to ask for. Its origin is whichever
+    taproot_hd_key_paths entry is filed under it, and absent where the
+    Updater wrote none -- BIP371 does not require one, and key_manager
+    is left the pub_key alone to answer from.
+    """
+    psbt_in = psbt.inputs[vin_i]
+    if not psbt_in.taproot_internal_key or psbt_in.taproot_key_spend_signature:
+        return False
+    origin = psbt_in.taproot_hd_key_paths.get(psbt_in.taproot_internal_key)
+    msg_hash = taproot_sig_hash(psbt, vin_i)
+    sig = key_manager.sign_schnorr(
+        psbt_in.taproot_internal_key,
+        origin[1] if origin else None,
+        msg_hash,
+        psbt_in.taproot_merkle_root,
+    )
+    if sig is None:
+        return False
+    hash_type = psbt_in.sig_hash_type or DEFAULT
+    if hash_type:
+        sig += hash_type.to_bytes(1, "big")
+    psbt_in.taproot_key_spend_signature = sig
+    return True
+
+
+def sign(psbt: Psbt, key_manager: KeyManager) -> tuple[Psbt, list[int]]:
+    """Run the Signer role over every input key_manager answers for.
+
+    Per input the candidates are what the psbt itself names: hd_key_paths
+    for an ECDSA spend, the taproot internal key and its own
+    taproot_hd_key_paths entry for a taproot one. None from key_manager
+    skips the key rather than raising -- one signer of an m-of-n holds
+    one key, and an input it cannot answer for is not an error but
+    somebody else's turn. What comes back besides the copy is which
+    inputs got a new signature, since a caller collecting a quorum needs
+    to tell "there was nothing for me" from "done".
+
+    Taproot is limited to the key path: MuSig2's own Signer is
+    `btclib.psbt.musig2`, and a script path spend needs a leaf and a
+    control block `sign` does not choose between. Every other kind is
+    whatever `_finalized_input` can close over -- p2pk, p2pkh, p2wpkh,
+    p2sh-p2wpkh, p2wsh, bare and wrapped multisig.
+
+    Raises where the psbt cannot be signed at all -- `assert_signable`'s
+    question -- and where a candidate's own hash cannot be computed,
+    which is `ecdsa_sig_hash` refusing to guess at a caller's stop. A key
+    key_manager has nothing to say about is a different question and
+    does not raise.
+    """
+    psbt = deepcopy(psbt)
+    psbt.assert_signable()
+    signed_vins: list[int] = []
+    for vin_i, psbt_in in enumerate(psbt.inputs):
+        if is_p2tr(_spent_script(psbt_in)):
+            if _sign_taproot_key_path(psbt, vin_i, key_manager):
+                signed_vins.append(vin_i)
+            continue
+        if _sign_ecdsa_input(psbt, vin_i, key_manager):
+            signed_vins.append(vin_i)
+    return psbt, signed_vins
 
 
 def _assert_sig_hash_type(psbt_in: PsbtIn) -> None:

--- a/btclib/script/__init__.py
+++ b/btclib/script/__init__.py
@@ -72,6 +72,7 @@ from btclib.script.taproot import (
     check_output_pubkey,
     input_script_sig,
     output_prvkey,
+    output_prvkey_from_merkle_root,
     output_pubkey,
     output_pubkey_from_merkle_root,
 )
@@ -111,6 +112,7 @@ __all__ = [
     "is_segwit",
     "op_int",
     "output_prvkey",
+    "output_prvkey_from_merkle_root",
     "output_pubkey",
     "output_pubkey_from_merkle_root",
     "p2ms_m_and_keys",

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -49,6 +49,7 @@ __all__ = [
     "input_script_sig",
     "leaf_hash",
     "output_prvkey",
+    "output_prvkey_from_merkle_root",
     "output_pubkey",
     "output_pubkey_from_merkle_root",
     "parse",
@@ -290,12 +291,16 @@ def output_prvkey(
     script tree's root hash, so its public point is the output key
     exactly.
     """
-    internal_prvkey: int = int_from_prv_key(prv_key)
-    if script_tree:
-        _, h = tree_helper(script_tree)
-    else:
-        h = b""
+    h = tree_helper(script_tree)[1] if script_tree else b""
+    return _tweaked_prvkey(int_from_prv_key(prv_key), h, ec)
 
+
+def _tweaked_prvkey(internal_prvkey: int, h: bytes, ec: Curve) -> int:
+    """Return the private key an internal one tweaked by h.
+
+    The private half of `_tweaked_pubkey`, h coming from the same two
+    places: a tree the caller built, or the merkle root a psbt carries.
+    """
     # secp256k1_keypair_xonly_tweak_add is the whole of this function
     # below the tweak: it negates the key whose public point has an odd
     # y, as BIP341 requires, and adds the tweak to it -- in constant
@@ -316,6 +321,22 @@ def output_prvkey(
     internal_prvkey = internal_prvkey if has_even_y else ec.n - internal_prvkey
     t = _tap_tweak(P[0].to_bytes(32, "big"), h, ec)
     return (internal_prvkey + t) % ec.n
+
+
+def output_prvkey_from_merkle_root(
+    prv_key: PrvKey, merkle_root: Octets = b"", ec: Curve = secp256k1
+) -> int:
+    """Return the private key of a taproot output from a merkle root.
+
+    `output_prvkey` with the root already in hand, the shape
+    `PSBT_IN_TAP_MERKLE_ROOT` carries it in: a `KeyManager` signing a
+    taproot key path spend holds the internal private key and this
+    field, never the script tree that produced the root, a psbt naming
+    a script path by its leaf and control block instead.
+    """
+    return _tweaked_prvkey(
+        int_from_prv_key(prv_key), bytes_from_octets(merkle_root), ec
+    )
 
 
 def input_script_sig(

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -463,6 +463,7 @@ def test_psbt_exports_the_format_not_its_plumbing() -> None:
     of the format.
     """
     assert sorted(btclib.psbt.__all__) == [
+        "KeyManager",
         "Psbt",
         "PsbtIn",
         "PsbtOut",
@@ -474,6 +475,7 @@ def test_psbt_exports_the_format_not_its_plumbing() -> None:
         "join",
         "musig2",
         "prevouts",
+        "sign",
         "taproot_sig_hash",
     ]
 

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -16,7 +16,7 @@ import pytest
 from btclib import var_bytes
 from btclib.bip32 import BIP32KeyOrigin
 from btclib.curves import sec_point
-from btclib.ecc import dsa
+from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, hash256, ripemd160, sha256, tagged_hash
 from btclib.psbt import (
@@ -28,6 +28,7 @@ from btclib.psbt import (
     extract_tx,
     finalize,
     join,
+    sign,
 )
 from btclib.psbt import musig2 as psbt_musig2
 from btclib.psbt.psbt import (
@@ -45,8 +46,16 @@ from btclib.psbt.psbt_in import _V2_FIELDS as _V2_INPUT_FIELDS
 from btclib.psbt.psbt_in import LOCK_TIME_THRESHOLD
 from btclib.psbt.psbt_out import _V2_FIELDS as _V2_OUTPUT_FIELDS
 from btclib.psbt.psbt_utils import PSBT_SEPARATOR
-from btclib.script import ScriptPubKey, Witness, serialize, sig_hash
+from btclib.script import (
+    ScriptPubKey,
+    TaprootScriptTree,
+    Witness,
+    output_prvkey_from_merkle_root,
+    serialize,
+    sig_hash,
+)
 from btclib.script.engine import verify_transaction
+from btclib.script.taproot import tree_helper
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests import load, vector_id
@@ -1947,9 +1956,10 @@ def _spending_tx(prev_out: TxOut) -> tuple[Tx, Tx]:
 def _single_key_psbt(kind: str) -> tuple[Psbt, list[TxOut]]:
     """Build a one-input psbt of the given kind, signed and not finalized.
 
-    The Updater's job, done here because btclib has no Signer: the psbt
-    carries the utxo, the scripts the input needs, and one partial
-    signature filed under the public key that made it.
+    The Updater's job: the psbt carries the utxo, the scripts the input
+    needs, and one partial signature filed under the public key that
+    made it, built directly rather than through `sign` so these
+    finalizer-focused tests do not depend on it.
     """
     p2pk = serialize([_PUB_KEY, "OP_CHECKSIG"])
     witness_script = p2pk if "p2wsh" in kind else b""
@@ -2941,3 +2951,323 @@ def test_what_a_taproot_input_cannot_be_finalized_from() -> None:
     err_msg = "invalid taproot script path signature for key"
     with pytest.raises(BTClibValueError, match=err_msg):
         finalize(psbt)
+
+
+# issue 439: sign() over a KeyManager
+
+
+class _KeyManager:
+    """A `KeyManager` test double: keys known by pub_key, or by origin.
+
+    sign_calls counts every call that found a key, which is what the
+    idempotency test checks: a key `sign` already has a signature for
+    must never reach either method a second time.
+    """
+
+    def __init__(
+        self,
+        by_pub_key: dict[bytes, int] | None = None,
+        by_origin: dict[str, int] | None = None,
+    ) -> None:
+        self.by_pub_key = dict(by_pub_key or {})
+        self.by_origin = dict(by_origin or {})
+        self.sign_calls = 0
+
+    def _prv_key(self, pub_key: bytes, origin: BIP32KeyOrigin | None) -> int | None:
+        if pub_key in self.by_pub_key:
+            return self.by_pub_key[pub_key]
+        if origin is not None:
+            return self.by_origin.get(origin.description)
+        return None
+
+    def sign_ecdsa(
+        self, pub_key: bytes, origin: BIP32KeyOrigin | None, msg_hash: bytes
+    ) -> bytes | None:
+        prv_key = self._prv_key(pub_key, origin)
+        if prv_key is None:
+            return None
+        self.sign_calls += 1
+        return dsa.sign_(msg_hash, prv_key).serialize()
+
+    def sign_schnorr(
+        self,
+        pub_key: bytes,
+        origin: BIP32KeyOrigin | None,
+        msg_hash: bytes,
+        merkle_root: bytes,
+    ) -> bytes | None:
+        prv_key = self._prv_key(pub_key, origin)
+        if prv_key is None:
+            return None
+        self.sign_calls += 1
+        tweaked = output_prvkey_from_merkle_root(prv_key, merkle_root)
+        return ssa.sign_(msg_hash, tweaked).serialize()
+
+
+def _unsigned_multisig_psbt() -> Psbt:
+    """Build a one-input, unsigned native p2wsh 2-of-2 psbt.
+
+    Both cosigners' keys are in hd_key_paths, as BIP174 has the Updater
+    write them; the two origins only need to be distinct from each
+    other, their fingerprint and path not being what this test is about.
+    """
+    witness_script = serialize(
+        ["OP_2", _PUB_KEY, _OTHER_PUB_KEY, "OP_2", "OP_CHECKMULTISIG"]
+    )
+    script_pub_key = ScriptPubKey.p2wsh(witness_script)
+    prev_out = TxOut(100_000, script_pub_key)
+    tx, _ = _spending_tx(prev_out)
+
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].witness_utxo = prev_out
+    psbt.inputs[0].witness_script = witness_script
+    psbt.inputs[0].hd_key_paths = {
+        _PUB_KEY: BIP32KeyOrigin(b"\x00" * 4, "m/0"),
+        _OTHER_PUB_KEY: BIP32KeyOrigin(b"\x00" * 4, "m/1"),
+    }
+    return psbt
+
+
+_TAPROOT_PRV_KEY = _PRV_KEY + 2
+_TAPROOT_PUB_KEY = pub_keyinfo_from_prv_key(_TAPROOT_PRV_KEY)[0]
+# x-only, dropping the parity byte compressed carries and x-only never
+# does: PSBT_IN_TAP_INTERNAL_KEY is 32 bytes, and so is a KeyManager's
+# pub_key for a schnorr candidate
+_TAPROOT_INTERNAL_KEY = _TAPROOT_PUB_KEY[1:]
+
+
+def _taproot_key_path_psbt(
+    script_tree: TaprootScriptTree | None = None,
+) -> tuple[Psbt, list[TxOut]]:
+    """Build a one-input, unsigned p2tr psbt spendable by the key path.
+
+    script_tree only produces the merkle root the output key is tweaked
+    by: the psbt itself carries the root and not the tree, as BIP371
+    has it, and `sign` is never told the tree either.
+    """
+    script_pub_key = ScriptPubKey.p2tr(_TAPROOT_PUB_KEY, script_tree)
+    prev_out = TxOut(100_000, script_pub_key)
+    tx, _ = _spending_tx(prev_out)
+
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].witness_utxo = prev_out
+    psbt.inputs[0].taproot_internal_key = _TAPROOT_INTERNAL_KEY
+    psbt.inputs[0].taproot_merkle_root = (
+        tree_helper(script_tree)[1] if script_tree else b""
+    )
+    return psbt, [prev_out]
+
+
+@pytest.mark.parametrize(
+    "kind", ["p2pkh", "p2wpkh", "p2wsh", "p2sh-p2wpkh", "p2sh-p2wsh"]
+)
+def test_sign_writes_the_signature_a_key_manager_makes(kind: str) -> None:
+    """sign() reaches the same partial signature `_single_key_psbt` has.
+
+    hd_key_paths is the only difference between the two psbts: the one
+    built here carries no signature yet, and a BIP32KeyOrigin under
+    _PUB_KEY is what makes it the one candidate `sign` finds.
+    """
+    signed, prevouts = _single_key_psbt(kind)
+    expected_sig = signed.inputs[0].partial_sigs[_PUB_KEY]
+
+    psbt = deepcopy(signed)
+    psbt.inputs[0].partial_sigs = {}
+    psbt.inputs[0].hd_key_paths = {_PUB_KEY: BIP32KeyOrigin(b"\x00" * 4, "m/0")}
+
+    result, signed_vins = sign(psbt, _KeyManager(by_pub_key={_PUB_KEY: _PRV_KEY}))
+
+    assert signed_vins == [0]
+    assert result.inputs[0].partial_sigs == {_PUB_KEY: expected_sig}
+    verify_transaction(prevouts, extract_tx(finalize(result), check_validity=False))
+
+
+def test_sign_falls_back_to_the_origin_the_key_manager_recognizes() -> None:
+    """A manager that misses the exact key still answers by its origin.
+
+    Decision #1 of issue #439: both travel on every call, key first and
+    origin as the fallback a watch-only-shaped manager needs -- one that
+    knows a fingerprint and path rather than every child key derived
+    from it.
+    """
+    signed, _ = _single_key_psbt("p2wpkh")
+    expected_sig = signed.inputs[0].partial_sigs[_PUB_KEY]
+    origin = BIP32KeyOrigin(b"\x01\x02\x03\x04", "m/84h/0h/0h/0/0")
+
+    psbt = deepcopy(signed)
+    psbt.inputs[0].partial_sigs = {}
+    psbt.inputs[0].hd_key_paths = {_PUB_KEY: origin}
+
+    key_manager = _KeyManager(by_origin={origin.description: _PRV_KEY})
+    result, signed_vins = sign(psbt, key_manager)
+
+    assert signed_vins == [0]
+    assert result.inputs[0].partial_sigs == {_PUB_KEY: expected_sig}
+
+
+def test_sign_skips_a_key_the_key_manager_does_not_hold() -> None:
+    """One signer of a 2-of-2 answers for its own key, and stops there.
+
+    Decision #3 of issue #439: None is not an error, so the other
+    cosigner's key is left for its own turn rather than raised on.
+    """
+    result, signed_vins = sign(
+        _unsigned_multisig_psbt(), _KeyManager(by_pub_key={_PUB_KEY: _PRV_KEY})
+    )
+
+    assert signed_vins == [0]
+    assert list(result.inputs[0].partial_sigs) == [_PUB_KEY]
+
+
+def test_sign_never_asks_twice_for_a_key_already_signed() -> None:
+    """A second sign() over the first result asks key_manager nothing new."""
+    key_manager = _KeyManager(
+        by_pub_key={_PUB_KEY: _PRV_KEY, _OTHER_PUB_KEY: _OTHER_PRV_KEY}
+    )
+
+    once, signed_vins = sign(_unsigned_multisig_psbt(), key_manager)
+    assert signed_vins == [0]
+    assert key_manager.sign_calls == 2
+
+    twice, signed_vins_again = sign(once, key_manager)
+    assert signed_vins_again == []
+    assert key_manager.sign_calls == 2
+    assert twice.inputs[0].partial_sigs == once.inputs[0].partial_sigs
+
+
+def test_sign_returns_a_copy() -> None:
+    """The psbt handed to sign() is untouched, as finalize's own is."""
+    psbt = _unsigned_multisig_psbt()
+    sign(psbt, _KeyManager(by_pub_key={_PUB_KEY: _PRV_KEY}))
+    assert psbt.inputs[0].partial_sigs == {}
+
+
+def test_sign_writes_the_taproot_key_path_signature() -> None:
+    """A key-path-only p2tr input, signed and then finalized."""
+    psbt, prevouts = _taproot_key_path_psbt()
+    key_manager = _KeyManager(by_pub_key={_TAPROOT_INTERNAL_KEY: _TAPROOT_PRV_KEY})
+
+    result, signed_vins = sign(psbt, key_manager)
+
+    assert signed_vins == [0]
+    verify_transaction(prevouts, extract_tx(finalize(result), check_validity=False))
+
+
+def test_sign_tweaks_the_taproot_key_by_the_merkle_root() -> None:
+    """The key path signature of an output that also carries script leaves.
+
+    key_manager is handed only psbt_in.taproot_merkle_root, never the
+    tree that produced it -- BIP371's own shape -- and still has to
+    produce a signature of the tweaked output key the engine accepts.
+    """
+    script_tree: TaprootScriptTree = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
+    psbt, prevouts = _taproot_key_path_psbt(script_tree)
+    key_manager = _KeyManager(by_pub_key={_TAPROOT_INTERNAL_KEY: _TAPROOT_PRV_KEY})
+
+    result, signed_vins = sign(psbt, key_manager)
+
+    assert signed_vins == [0]
+    verify_transaction(prevouts, extract_tx(finalize(result), check_validity=False))
+
+
+def test_sign_skips_a_taproot_key_the_key_manager_does_not_hold() -> None:
+    """None from sign_schnorr leaves the input without a signature."""
+    psbt, _ = _taproot_key_path_psbt()
+    result, signed_vins = sign(psbt, _KeyManager())
+
+    assert signed_vins == []
+    assert not result.inputs[0].taproot_key_spend_signature
+
+
+def test_sign_leaves_a_taproot_input_already_signed_alone() -> None:
+    """A second sign() over the first result asks key_manager nothing new.
+
+    The taproot counterpart of
+    `test_sign_never_asks_twice_for_a_key_already_signed`: the one
+    candidate is the internal key, and taproot_key_spend_signature
+    already holding a signature is what says there is nothing to ask
+    for.
+    """
+    psbt, _ = _taproot_key_path_psbt()
+    key_manager = _KeyManager(by_pub_key={_TAPROOT_INTERNAL_KEY: _TAPROOT_PRV_KEY})
+
+    once, signed_vins = sign(psbt, key_manager)
+    assert signed_vins == [0]
+    assert key_manager.sign_calls == 1
+
+    twice, signed_vins_again = sign(once, key_manager)
+    assert signed_vins_again == []
+    assert key_manager.sign_calls == 1
+    assert (
+        twice.inputs[0].taproot_key_spend_signature
+        == once.inputs[0].taproot_key_spend_signature
+    )
+
+
+def test_sign_appends_the_sig_hash_type_a_taproot_input_asks_for() -> None:
+    """BIP341 appends the type where it is not the default, as `sign` does.
+
+    Every other taproot test here leaves sig_hash_type unset, which is
+    SIGHASH_DEFAULT and appends nothing; this is the other half.
+    """
+    psbt, prevouts = _taproot_key_path_psbt()
+    psbt.inputs[0].sig_hash_type = 1  # ALL
+    key_manager = _KeyManager(by_pub_key={_TAPROOT_INTERNAL_KEY: _TAPROOT_PRV_KEY})
+
+    result, signed_vins = sign(psbt, key_manager)
+
+    assert signed_vins == [0]
+    signature = result.inputs[0].taproot_key_spend_signature
+    assert len(signature) == 65
+    assert signature[-1] == sig_hash.ALL
+    verify_transaction(prevouts, extract_tx(finalize(result), check_validity=False))
+
+
+def test_sign_raises_on_a_psbt_that_cannot_be_signed() -> None:
+    """assert_signable's own pre-flight runs before any candidate does."""
+    psbt = Psbt.b64decode("cHNidP8BAAoAAAAAAAAAAAAAAA==")
+    with pytest.raises(BTClibValueError, match="nothing to sign: no inputs"):
+        sign(psbt, _KeyManager())
+
+
+def test_sign_raises_when_a_candidate_cannot_be_hashed() -> None:
+    """A candidate whose message cannot be built stops sign() outright.
+
+    A p2wsh input naming _PUB_KEY as a candidate but carrying no witness
+    script leaves ecdsa_sig_hash nothing to build the message from: the
+    same "no utxo, no redeem script, or no witness script" it refuses a
+    Signer with directly.
+    """
+    witness_script = serialize([_PUB_KEY, "OP_CHECKSIG"])
+    prev_out = TxOut(100_000, ScriptPubKey.p2wsh(witness_script))
+    tx, _ = _spending_tx(prev_out)
+
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].witness_utxo = prev_out
+    psbt.inputs[0].hd_key_paths = {_PUB_KEY: BIP32KeyOrigin(b"\x00" * 4, "m/0")}
+    # no witness_script: assert_signable does not require one, and
+    # ecdsa_sig_hash is what has nothing to compute a hash from
+
+    err_msg = "does not say what is being signed"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        sign(psbt, _KeyManager(by_pub_key={_PUB_KEY: _PRV_KEY}))
+
+
+def test_sign_leaves_alone_an_input_with_no_candidate() -> None:
+    """The same defect, with no candidate: sign() never asks and never raises.
+
+    hd_key_paths empty is "nothing here is mine to sign", which is not
+    the same claim as "this input is broken" -- an input none of
+    key_manager's keys are named for is not this Signer's business.
+    """
+    witness_script = serialize([_PUB_KEY, "OP_CHECKSIG"])
+    prev_out = TxOut(100_000, ScriptPubKey.p2wsh(witness_script))
+    tx, _ = _spending_tx(prev_out)
+
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].witness_utxo = prev_out
+
+    result, signed_vins = sign(psbt, _KeyManager(by_pub_key={_PUB_KEY: _PRV_KEY}))
+
+    assert signed_vins == []
+    assert result.inputs[0].partial_sigs == {}

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -28,6 +28,7 @@ from btclib.script import (
     input_script_sig,
     is_p2tr,
     output_prvkey,
+    output_prvkey_from_merkle_root,
     output_pubkey,
     output_pubkey_from_merkle_root,
     taproot,
@@ -248,6 +249,24 @@ def test_the_two_output_keys_are_one_tweak() -> None:
     merkle_root = tree_helper(script_tree)[1]
     assert output_pubkey_from_merkle_root(x_only, merkle_root) == (
         output_pubkey(internal_pubkey, script_tree)
+    )
+
+
+def test_the_two_output_prvkeys_are_one_tweak() -> None:
+    """A tree and its own merkle root tweak a private key the same way.
+
+    The private counterpart of `test_the_two_output_keys_are_one_tweak`:
+    a `KeyManager` signing a taproot key path spend has the merkle root
+    a psbt carries and not the tree that produced it, and this is what
+    tweaks a private key from the one it is given.
+    """
+    prv_key = 123456
+    assert output_prvkey_from_merkle_root(prv_key) == output_prvkey(prv_key)
+
+    script_tree: TaprootScriptTree = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
+    merkle_root = tree_helper(script_tree)[1]
+    assert output_prvkey_from_merkle_root(prv_key, merkle_root) == output_prvkey(
+        prv_key, script_tree
     )
 
 


### PR DESCRIPTION
## Summary

- `sign(psbt, key_manager)` plays the rest of the Signer role BIP174
  leaves to the caller: `KeyManager.sign_ecdsa`/`.sign_schnorr` are
  asked for a signature by public key, origin as the fallback a
  watch-only-shaped manager needs, and `None` skips the key rather than
  raising — one signer of an m-of-n answers for its own key and nothing
  else. The manager signs; `sign` never holds an xprv, and appends the
  sig_hash type itself. It returns a copy and which inputs got a new
  signature, so a caller collecting a quorum can tell "nothing for me"
  from "done".
- Taproot is limited to the key path (MuSig2 is already
  `btclib.psbt.musig2`'s own Signer, and a script path spend needs a
  leaf `sign` does not choose between).
  `taproot.output_prvkey_from_merkle_root` is `output_prvkey`'s
  counterpart to `output_pubkey_from_merkle_root` (issue #435): the
  tweak with `PSBT_IN_TAP_MERKLE_ROOT` already in hand, which is what a
  `KeyManager` signing a taproot key path spend needs and never the
  script tree that produced the root.
- Named `KeyManager` rather than the issue's first-pass "key-provider":
  it never hands out a key, only a signature over one it holds.

Part of #381. Closes #439.

## Test plan

- [x] `uv run pytest --cov`: 17198 passed, `btclib/psbt/psbt.py` and
  `btclib/script/taproot.py` at 100% coverage (the one remaining gap,
  `.github/scripts/mutation_counts.py`, is pre-existing on `dev` and
  untouched by this branch — verified against a clean `origin/dev`
  checkout).
- [x] `uv run pre-commit run --all-files`: all hooks pass.
- [x] `sphinx-build -W --keep-going`: builds clean.
- [x] New tests cover: every ECDSA input kind the Finalizer already
  builds, key-then-origin resolution, skipping a key `key_manager`
  doesn't hold, idempotency on an already-signed key/input, the taproot
  key path with and without a non-empty merkle root, the sig_hash type
  append rule for both schemes, and the two raise/no-raise boundaries
  (`assert_signable`'s pre-flight vs. a candidate with no computable
  hash vs. an input with no candidate at all).

## Summary by Sourcery

Introduce a psbt.sign API that delegates signing to an abstract KeyManager, and add taproot private-key tweaking support from a merkle root.

New Features:
- Add psbt.sign to perform the PSBT Signer role using a provided KeyManager, covering ECDSA and taproot key-path spends.
- Define a KeyManager protocol to abstract over backends that hold private keys and produce signatures without exposing secrets.
- Provide output_prvkey_from_merkle_root to derive taproot output private keys directly from an internal key and merkle root.

Enhancements:
- Export KeyManager and sign from the btclib.psbt package and integrate them into the public PSBT interface and documentation.
- Refactor taproot private-key tweaking logic into a reusable helper shared by tree-based and merkle-root-based derivations.

Tests:
- Add comprehensive tests for psbt.sign across legacy, segwit, multisig, and taproot key-path inputs, including idempotency and error boundaries.
- Add tests ensuring taproot output private keys derived from a merkle root match those derived from the full script tree.
- Update export-coverage tests to include the new KeyManager and sign symbols in btclib.psbt and output_prvkey_from_merkle_root in btclib.script.