### PR TITLE
The Combiner and the Constructor return a psbt of their own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1333,6 +1333,20 @@ edit.
 
 ### Immutability and shared state
 
+- **`psbt.combine` and `psbt.join` return a psbt that shares nothing
+  with the ones they were given.** `combine` returned `psbts[0]` itself,
+  merged into in place, so a coordinator that kept its own copy to check
+  the next signer's answer against held the copy the last answer had
+  gone into — and a check against it would pass whatever came back. The
+  copy is of the whole sequence and not only of the first, because
+  `_combine_field` assigns the objects it takes rather than copying
+  them: a `witness_utxo` or a leaf-script map that came from `psbts[1]`
+  was the very object `psbts[1]` still held, so mutating the combined
+  psbt reached back into an argument. `join` shared the same way, its
+  input and output maps being concatenated from every psbt joined, so an
+  Updater filling in a joined input filled in one somebody else held.
+  Both now copy, which is the rule `sign` and `finalize` already follow
+  and the one `extract_tx` states for itself.
 - a default-constructed `TxIn` no longer shares its `prev_out` and
   `script_witness` with every other one, nor a `PsbtIn` its
   `final_script_witness`: the defaults were `OutPoint()` and `Witness()`

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -1332,7 +1332,19 @@ def combine(psbts: Sequence[Psbt]) -> Psbt:
     which of the two the combined psbt is -- and, from v0 to v2, hand
     back a psbt whose lock time comes from the fallback rather than
     from the unsigned transaction the caller wrote it into.
+
+    The psbt handed back shares nothing with the ones handed in, which is
+    `finalize`'s rule and `extract_tx`'s stated one. It matters more here
+    than anywhere: without the copy this *is* `psbts[0]`, merged into in
+    place, so the copy a coordinator keeps to check the next signer's
+    answer against is the copy the last answer went into -- and a check
+    against it would then pass whatever came back. The whole sequence is
+    copied and not only the first, `_combine_field` assigning the objects
+    it takes rather than copying them: a witness_utxo or a leaf script
+    map that came from `psbts[1]` would otherwise be the very object
+    `psbts[1]` still holds.
     """
+    psbts = deepcopy(list(psbts))
     final_psbt = psbts[0]
     version = final_psbt.version
     for psbt in psbts[1:]:
@@ -2268,8 +2280,15 @@ def join(
     joined is asked for its two modifiable flags, and the joined psbt
     carries what all of them still allow. The versions must be the same,
     for the reason `combine` gives.
+
+    The joined psbt shares nothing with the ones joined, for the reason
+    `combine` copies: the input and output maps below are taken from
+    every psbt in the sequence, so without the copy the joined psbt's
+    inputs *are* theirs, and an Updater filling one in afterwards fills
+    in a psbt somebody else is still holding.
     """
     _ensure_consistency(psbts)
+    psbts = deepcopy(list(psbts))
 
     version = psbts[0].version
     for psbt in psbts[1:]:

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -2452,6 +2452,80 @@ def test_combining_refuses_two_participant_lists_for_one_aggregate_key() -> None
         combine([first, second])
 
 
+def test_combining_leaves_every_psbt_it_was_given_alone() -> None:
+    """The Combiner returns a copy, and merged into none of its arguments.
+
+    Without it the returned psbt *is* `psbts[0]`: a coordinator that
+    keeps its own copy to check the next signer's answer against holds
+    the copy the last answer was merged into, so the check would pass
+    whatever came back.
+    """
+    first = Psbt.b64decode(TO_BE_FINALIZED)
+    second = deepcopy(first)
+    first.inputs[0].sha256_preimages = {sha256(b"one"): b"one"}
+    second.inputs[0].sha256_preimages = {sha256(b"two"): b"two"}
+    first_before, second_before = deepcopy(first), deepcopy(second)
+
+    combined = combine([first, second])
+
+    assert combined is not first
+    assert first == first_before
+    assert second == second_before
+
+
+def test_the_combined_psbt_shares_no_object_with_what_was_combined() -> None:
+    """Not only psbts[0]: `_combine_field` assigns what it takes.
+
+    A field taken from a later psbt is that psbt's own object -- a
+    witness_utxo, a preimage map -- so mutating the combined psbt would
+    reach into an argument the caller still holds. Mutation is the test
+    because identity is what is being asserted, and `==` cannot see it.
+    """
+    first = Psbt.b64decode(TO_BE_FINALIZED)
+    second = deepcopy(first)
+    # a map only `second` carries, so the combined psbt takes second's
+    second.inputs[0].sha256_preimages = {sha256(b"two"): b"two"}
+    first.inputs[0].sha256_preimages = {}
+
+    combined = combine([first, second])
+    assert combined.inputs[0].sha256_preimages == {sha256(b"two"): b"two"}
+
+    combined.inputs[0].sha256_preimages.clear()
+    combined.inputs[0].partial_sigs.clear()
+    assert second.inputs[0].sha256_preimages == {sha256(b"two"): b"two"}
+    assert first.inputs[0].partial_sigs
+
+
+def test_joining_leaves_every_psbt_it_was_given_alone() -> None:
+    """The joined psbt shares no input or output with what was joined.
+
+    `join` concatenates the input and output maps of every psbt, so
+    without a copy the joined psbt's inputs *are* theirs, and an Updater
+    filling one in afterwards fills in a psbt somebody else holds.
+
+    Two psbts of different kinds, which is what `join` needs: they spend
+    different outputs, so they have different outpoints, and one
+    transaction cannot spend one output twice -- two copies of one psbt
+    are refused as "common inputs".
+    """
+    first, _ = _single_key_psbt("p2wpkh")
+    second, _ = _single_key_psbt("p2wsh")
+    first_before, second_before = deepcopy(first), deepcopy(second)
+
+    joined = join([first, second], False, False, False, False)
+
+    assert first == first_before
+    assert second == second_before
+    given = [*first.inputs, *second.inputs]
+    assert all(inp is not joined_inp for inp in given for joined_inp in joined.inputs)
+
+    joined.inputs[0].witness_script = b"\x51"
+    joined.outputs[0].redeem_script = b"\x51"
+    joined.inputs[0].partial_sigs.clear()
+    assert first == first_before
+    assert second == second_before
+
+
 def test_finalize_refuses_a_signature_of_another_sig_hash_type() -> None:
     """BIP174 charges the Finalizer with the check, and it is per input.
 


### PR DESCRIPTION
## Summary

`combine` returned `psbts[0]` **itself**, merged into in place. That is
the sharp edge for the returned-psbt validator #381 needs next: a
coordinator keeps its own copy to check the next signer's answer
against, and without a copy that is the copy the last answer went into
— so the check would pass whatever came back.

The copy is of the whole sequence, not only the first: `_combine_field`
assigns the objects it takes rather than copying them, so a
`witness_utxo` or a leaf-script map taken from `psbts[1]` was the very
object `psbts[1]` still held.

`join` shared the same way — its input and output maps are concatenated
from every psbt joined — so an Updater filling in a joined input filled
in one somebody else was holding.

Both now copy, which is the rule `sign` and `finalize` already follow
and the one `extract_tx` states for itself.

Part of #381.

## Test plan

Measured, not asserted — with the two `deepcopy` lines disabled all
three new tests fail; with them, all pass:

- [x] `test_combining_leaves_every_psbt_it_was_given_alone`
- [x] `test_the_combined_psbt_shares_no_object_with_what_was_combined` —
  mutates the result and checks the arguments, identity being what is
  asserted and `==` not able to see it
- [x] `test_joining_leaves_every_psbt_it_was_given_alone`
- [x] `uv run pytest --cov`: 17201 passed; the one coverage gap
  (`.github/scripts/mutation_counts.py`) is pre-existing on `dev`
- [x] `uv run pre-commit run --all-files`: exit 0
- [x] `sphinx-build -W --keep-going`: exit 0

CI is not waited on: GitHub Actions is degraded today, failing at
"Set up job" with "Failed to resolve action download info" before any
test runs. The gates above are local.

## Summary by Sourcery

Ensure PSBT combiner and joiner return independent PSBT instances that do not share mutable state with their inputs.

Bug Fixes:
- Prevent psbt.combine from returning and mutating the original first PSBT and from sharing internal objects with later PSBTs.
- Prevent psbt.join from sharing input/output objects with source PSBTs so that updates to the joined PSBT do not affect originals.

Enhancements:
- Document the immutability guarantees for psbt.combine and psbt.join in the changelog to align them with sign, finalize, and extract_tx semantics.

Tests:
- Add tests verifying combine leaves all input PSBTs unchanged and the combined PSBT shares no internal objects with its inputs.
- Add tests verifying join leaves all input PSBTs unchanged and the joined PSBT shares no inputs or outputs with the originals.