### PR TITLE
The Finalizer clears one list of fields, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2167,6 +2167,28 @@ edit.
 
 ### Transactions, blocks and PSBT
 
+- **the Finalizer clears one list of fields, whichever kind the input
+  is, and finalizing twice is finalizing once.** BIP174: "All other data
+  except the UTXO and unknown fields in the input key-value map should
+  be cleared from the PSBT". The taproot branch cleared *nothing*, so a
+  finalized psbt went on publishing that input's key origins — master
+  fingerprint and derivation path, per key — where an ECDSA input
+  published none; and the ECDSA branch left the four preimage maps,
+  which by then are in the witness anyway. Neither was a wrong spend,
+  the witness being built already, but no reader could state what the
+  rule was. `_FINALIZED_KEEPS` is now that rule, once: the utxo and
+  `unknown`, which the sentence above exempts by name, the two finalized
+  scripts, and BIP370's transaction fields — which are not data *about*
+  the input but the input itself, a v2 psbt with `previous_tx_id`
+  cleared naming no outpoint. It is a keep list rather than a clear
+  list, so a field added to `PsbtIn` is dropped by default. An input
+  that already carries its final scripts is now skipped rather than
+  refused: "the Input Finalizer determines if the input has enough
+  data", one already finalized has more than enough, and refusing it
+  meant a psbt whose signer had finalized one input could not be
+  finalized at all. btclib is stricter than Bitcoin Core here, whose
+  `PSBTInput::FromSignatureData` clears four fields and leaves the
+  taproot ones, the sighash type and the preimages in place.
 - **`psbt.sign` is the Signer role, played over a `KeyManager`'s
   answers** (issue #439). BIP174 leaves the caller to find which keys
   are its own and write a signature back; the guide's own **Signer**

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -30,7 +30,7 @@ import base64
 import secrets
 from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from math import ceil
 from typing import Any, Protocol, TypeVar, cast
 
@@ -2104,6 +2104,69 @@ def _assert_partial_sigs_verify(psbt_in: PsbtIn, tx: Tx, vin_i: int) -> None:
             raise BTClibValueError(err_msg)
 
 
+# what a finalized input keeps, BIP174's rule being that everything else
+# goes: "All other data except the UTXO and unknown fields in the input
+# key-value map should be cleared from the PSBT". Three groups, and the
+# BIP names only the first two --
+#
+# - the utxo and `unknown`, exempted by that sentence: the utxo so that
+#   "Transaction Extractors [can] verify the final network serialized
+#   transaction", and the unknown fields because no reader here knows
+#   what dropping one would cost;
+# - the two finalized scripts, which are what finalizing produced;
+# - BIP370's transaction fields, which are not "data" about how the input
+#   is spent but the input *itself*: clearing `previous_tx_id` and
+#   `output_index` would leave a version 2 psbt naming no outpoint, and
+#   the sequence and the two required lock times are what its unsigned
+#   transaction is computed from.
+#
+# A keep list and not a clear list, so that a field added to PsbtIn is
+# cleared by default: BIP174's sentence is about everything, and a new
+# field that has to survive finalization is the exception worth writing
+# down here.
+_FINALIZED_KEEPS = frozenset(
+    {
+        "non_witness_utxo",
+        "witness_utxo",
+        "unknown",
+        "final_script_sig",
+        "final_script_witness",
+        "previous_tx_id",
+        "output_index",
+        "sequence",
+        "required_time_lock_time",
+        "required_height_lock_time",
+    }
+)
+
+
+def _clear_finalized(psbt_in: PsbtIn) -> None:
+    """Drop everything finalizing the input made redundant.
+
+    One rule for both kinds of input, which is the point of it being one
+    function: a taproot input cleared nothing at all, so a finalized psbt
+    went on publishing that input's key origins -- master fingerprint and
+    derivation path, per key -- where an ECDSA input published none. The
+    asymmetry was not a wrong spend, the witness being built already, but
+    no reader could state what the rule was.
+
+    Each field is set to what a fresh `PsbtIn` has, rather than to a
+    literal per field: the empty value of a field is the constructor's
+    business, and spelling it twice is how the two drift.
+
+    btclib is stricter than Bitcoin Core here, whose
+    `PSBTInput::FromSignatureData` clears `partial_sigs`, `hd_keypaths`,
+    `redeem_script` and `witness_script` and leaves the taproot fields,
+    the sighash type and the preimages in place. BIP174's sentence covers
+    those too, and what they buy after finalization is nothing: the
+    preimage a hash-locked script needs is in the witness by then.
+    """
+    empty = PsbtIn(check_validity=False)
+    for field in fields(psbt_in):
+        if field.name not in _FINALIZED_KEEPS:
+            setattr(psbt_in, field.name, getattr(empty, field.name))
+
+
 def finalize(psbt: Psbt) -> Psbt:
     """Finalize the Psbt.
 
@@ -2117,7 +2180,8 @@ def finalize(psbt: Psbt) -> Psbt:
     All other data except the UTXO and unknown fields in the input key-
     value map should be cleared from the PSBT. The UTXO should be kept
     to allow Transaction Extractors to verify the final network
-    serialized transaction.
+    serialized transaction. `_FINALIZED_KEEPS` is that list, and one list
+    for both kinds of input is what keeps the two from drifting apart.
 
     Deciding that an input has enough data is two checks beyond the
     presence of a signature, and both are per input: the sighash type
@@ -2127,6 +2191,14 @@ def finalize(psbt: Psbt) -> Psbt:
     What is then built is the spend the input's own kind asks for, which
     is what _finalized_input dispatches on: a witness script alone does
     not say, being absent from every single-key segwit input.
+
+    An input that is already finalized is left alone rather than refused,
+    so finalizing twice is finalizing once. "The Input Finalizer
+    determines if the input has enough data" and one carrying its final
+    scripts has more than enough; Bitcoin Core's `SignPSBTInput` skips it
+    too. Refusing it would mean a psbt whose signer finalized one input
+    could not be finalized at all -- the rest of it would raise "missing
+    signatures" for the input that is already done.
     """
     psbt = deepcopy(psbt)
     psbt.assert_valid()
@@ -2135,6 +2207,9 @@ def finalize(psbt: Psbt) -> Psbt:
     # every signature is against the same one
     tx = psbt.tx
     for vin_i, psbt_in in enumerate(psbt.inputs):
+        if psbt_in.final_script_sig or psbt_in.final_script_witness:
+            continue
+
         # a taproot input is finalized from its own fields and not from
         # partial_sigs, which is keyed by compressed key and holds ECDSA
         # signatures: a schnorr signature travels in PSBT_IN_TAP_KEY_SIG
@@ -2142,22 +2217,16 @@ def finalize(psbt: Psbt) -> Psbt:
         # aggregate signature of a MuSig2 session into them
         if is_p2tr(_spent_script(psbt_in)):
             script_sig, witness = _finalized_taproot_input(psbt, vin_i)
-            psbt_in.final_script_sig = script_sig
-            psbt_in.final_script_witness = witness
-            continue
+        else:
+            if not psbt_in.partial_sigs:
+                raise BTClibValueError("missing signatures")
+            _assert_sig_hash_type(psbt_in)
+            _assert_partial_sigs_verify(psbt_in, tx, vin_i)
+            script_sig, witness = _finalized_input(psbt_in)
 
-        if not psbt_in.partial_sigs:
-            raise BTClibValueError("missing signatures")
-        _assert_sig_hash_type(psbt_in)
-        _assert_partial_sigs_verify(psbt_in, tx, vin_i)
-        script_sig, witness = _finalized_input(psbt_in)
+        _clear_finalized(psbt_in)
         psbt_in.final_script_sig = script_sig
         psbt_in.final_script_witness = witness
-        psbt_in.partial_sigs = {}
-        psbt_in.sig_hash_type = None
-        psbt_in.redeem_script = b""
-        psbt_in.witness_script = b""
-        psbt_in.hd_key_paths = {}
     return psbt
 
 

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -6,6 +6,7 @@
 """Tests for the `btclib.psbt.psbt` module."""
 
 import base64
+import dataclasses
 import inspect
 from copy import deepcopy
 from io import BytesIO
@@ -3345,3 +3346,112 @@ def test_sign_leaves_alone_an_input_with_no_candidate() -> None:
 
     assert signed_vins == []
     assert result.inputs[0].partial_sigs == {}
+
+
+# the Finalizer's clearing rule, one list for both kinds of input
+
+
+def _fully_populated(psbt: Psbt) -> Psbt:
+    """Fill in every field a Finalizer is meant to drop, and some it keeps.
+
+    The preimage maps are keyed by the hash of their own preimage, which
+    `PsbtIn.assert_valid` checks, so they cannot be filled with
+    arbitrary bytes.
+    """
+    psbt_in = psbt.inputs[0]
+    psbt_in.ripemd160_preimages = {ripemd160(b"one"): b"one"}
+    psbt_in.sha256_preimages = {sha256(b"two"): b"two"}
+    psbt_in.hash160_preimages = {hash160(b"three"): b"three"}
+    psbt_in.hash256_preimages = {hash256(b"four"): b"four"}
+    psbt_in.unknown = {b"\xfc\x01": b"vendor"}
+    return psbt
+
+
+@pytest.mark.parametrize("kind", ["p2wsh", "p2tr"])
+def test_a_finalized_input_keeps_the_utxo_and_the_unknown_fields_only(
+    kind: str,
+) -> None:
+    """BIP174's rule, and the same one whichever kind the input is.
+
+    "All other data except the UTXO and unknown fields in the input
+    key-value map should be cleared from the PSBT." The taproot branch
+    cleared nothing at all, so a finalized psbt went on publishing that
+    input's key origins -- master fingerprint and derivation path, per
+    key -- where an ECDSA input published none; and the ECDSA branch left
+    the four preimage maps, which after finalization are in the witness
+    anyway.
+
+    btclib is stricter than Bitcoin Core here, whose
+    `PSBTInput::FromSignatureData` clears four fields and leaves the
+    taproot ones, the sighash type and the preimages.
+    """
+    if kind == "p2tr":
+        psbt, prevouts = _taproot_key_path_psbt()
+        psbt.inputs[0].hd_key_paths = {_PUB_KEY: BIP32KeyOrigin(b"\x00" * 4, "m/0")}
+        key_manager = _KeyManager(by_pub_key={_TAPROOT_INTERNAL_KEY: _TAPROOT_PRV_KEY})
+    else:
+        signed, prevouts = _single_key_psbt(kind)
+        psbt = deepcopy(signed)
+        psbt.inputs[0].partial_sigs = {}
+        psbt.inputs[0].hd_key_paths = {_PUB_KEY: BIP32KeyOrigin(b"\x00" * 4, "m/0")}
+        key_manager = _KeyManager(by_pub_key={_PUB_KEY: _PRV_KEY})
+
+    signed, signed_vins = sign(_fully_populated(psbt), key_manager)
+    assert signed_vins == [0]
+    psbt_in = finalize(signed).inputs[0]
+
+    # spelled out rather than imported from psbt.py: `_FINALIZED_KEEPS`
+    # is what the code believes, and a test that imported it would agree
+    # with a wrong list as readily as with a right one. Every other field
+    # of PsbtIn is walked, so a field added there and left out of both
+    # lists fails here
+    kept = {
+        "non_witness_utxo",
+        "witness_utxo",
+        "unknown",
+        "previous_tx_id",
+        "output_index",
+        "sequence",
+        "required_time_lock_time",
+        "required_height_lock_time",
+        "final_script_sig",
+        "final_script_witness",
+    }
+    empty = PsbtIn(check_validity=False)
+    for field in dataclasses.fields(psbt_in):
+        if field.name not in kept:
+            assert getattr(psbt_in, field.name) == getattr(empty, field.name), (
+                f"{field.name} survived finalization"
+            )
+
+    # the two BIP174 exempts by name, and the spend it built
+    assert psbt_in.unknown == {b"\xfc\x01": b"vendor"}
+    assert psbt_in.witness_utxo or psbt_in.non_witness_utxo
+    assert psbt_in.final_script_sig or psbt_in.final_script_witness
+    verify_transaction(prevouts, extract_tx(finalize(signed), check_validity=False))
+
+
+@pytest.mark.parametrize("kind", ["p2wsh", "p2tr"])
+def test_finalizing_twice_is_finalizing_once(kind: str) -> None:
+    """An input already finalized is left alone, not refused.
+
+    "The Input Finalizer determines if the input has enough data" and one
+    carrying its final scripts has more than enough; Core's
+    `SignPSBTInput` skips it too. Refusing it meant a psbt whose signer
+    had finalized one input could not be finalized at all: the second
+    pass raised "missing signatures" for the input already done, the
+    first pass having cleared the signatures it used.
+    """
+    if kind == "p2tr":
+        psbt, _ = _taproot_key_path_psbt()
+        key_manager = _KeyManager(by_pub_key={_TAPROOT_INTERNAL_KEY: _TAPROOT_PRV_KEY})
+    else:
+        signed, _ = _single_key_psbt(kind)
+        psbt = deepcopy(signed)
+        psbt.inputs[0].partial_sigs = {}
+        psbt.inputs[0].hd_key_paths = {_PUB_KEY: BIP32KeyOrigin(b"\x00" * 4, "m/0")}
+        key_manager = _KeyManager(by_pub_key={_PUB_KEY: _PRV_KEY})
+
+    signed, _ = sign(psbt, key_manager)
+    once = finalize(signed)
+    assert finalize(once) == once


### PR DESCRIPTION
## Summary

BIP174: *"All other data except the UTXO and unknown fields in the input
key-value map should be cleared from the PSBT"*. Measured before/after
on a fully-populated input, the two branches disagreed:

| branch | cleared | left in place |
| --- | --- | --- |
| ECDSA | `partial_sigs`, `sig_hash_type`, `redeem_script`, `witness_script`, `hd_key_paths` | the 4 preimage maps |
| taproot | **nothing** | signature, internal key, merkle root, `taproot_hd_key_paths`, `hd_key_paths`, `sig_hash_type`, … |

So a finalized taproot input went on publishing its **key origins** —
master fingerprint and derivation path, per key — where an ECDSA input
published none. Neither is a wrong spend, the witness being built
already, but no reader could state what the rule was.

`_FINALIZED_KEEPS` is now that rule, once, for both kinds. A *keep* list
rather than a clear list, so a field added to `PsbtIn` is dropped by
default; it keeps the utxo and `unknown` (exempted by the sentence
above), the two finalized scripts, and BIP370's transaction fields —
which are not data *about* the input but the input itself, a v2 psbt
with `previous_tx_id` cleared naming no outpoint.

**Finalizing twice is now finalizing once.** An input already carrying
its final scripts is skipped, not refused: refusing it meant a psbt
whose signer had finalized one input could not be finalized at all, the
second pass raising `missing signatures` for the input already done.
Core's `SignPSBTInput` skips it too.

Stricter than Bitcoin Core, whose `PSBTInput::FromSignatureData` (v29.0)
clears four fields and leaves the taproot ones, the sighash type and the
preimages in place. What those buy after finalization is nothing — the
preimage a hash-locked script needs is in the witness by then.

This is the asymmetry #381 said the returned-psbt validator would have
to take a position on; with one rule the position is trivial, a
finalized input having one shape rather than two.

Part of #381.

## Test plan

- [x] `test_a_finalized_input_keeps_the_utxo_and_the_unknown_fields_only[p2wsh, p2tr]`
  walks **every** `PsbtIn` field via `dataclasses.fields`, so a field
  added and left out of both lists fails the test. The keep set is
  spelled out rather than imported: a test that imported
  `_FINALIZED_KEEPS` would agree with a wrong list as readily as a right
  one.
- [x] `test_finalizing_twice_is_finalizing_once[p2wsh, p2tr]`
- [x] the extracted transaction still verifies against the script engine
  for both kinds
- [x] measured on the old code: 3 of the 4 new tests fail. The fourth,
  `finalizing_twice[p2tr]`, passed *because of* the defect — the taproot
  branch left the signature in place, so re-finalizing found it again.
- [x] `uv run pytest --cov`: 17205 passed; the one gap
  (`.github/scripts/mutation_counts.py`) is pre-existing on `dev`
- [x] `uv run pre-commit run --all-files`: exit 0
- [x] `sphinx-build -W --keep-going`: exit 0

CI is not waited on: GitHub Actions is degraded today, failing at
"Set up job" before any test runs. The gates above are local.

## Summary by Sourcery

Unify PSBT input finalization so all input types apply a single field-clearing rule based on BIP174, while allowing already-finalized inputs to be re-finalized without error.

Bug Fixes:
- Ensure taproot PSBT inputs no longer retain key origin and other ancillary data after finalization, matching BIP174 and ECDSA behavior.
- Prevent finalization from failing when processing inputs that are already finalized, making repeated finalization idempotent.

Enhancements:
- Introduce a centralized `_FINALIZED_KEEPS` definition that specifies which PSBT input fields are preserved across finalization for all input types.
- Use the PSBT input dataclass definition to drive clearing of non-kept fields, reducing drift risk when new fields are added.

Documentation:
- Update the changelog to document the unified finalization rule, the kept field set, and the new idempotent behavior of PSBT finalization.

Tests:
- Add tests that assert finalized inputs only retain UTXO and unknown fields plus final scripts and transaction fields, for both p2wsh and taproot.
- Add tests that verify finalizing an already-finalized PSBT is a no-op for both p2wsh and taproot inputs.