### PR TITLE
Hold a returned psbt to the one that was sent, before combining it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1505,6 +1505,12 @@ edit.
 
 ### What an error says
 
+- an invalid partial-signature public key is named rather than described
+  as `{pub_key!r}`: the message was a format string missing its `f`, so
+  `PsbtIn.assert_valid` printed the placeholder instead of the key. Found
+  by a test asserting on that message. `ruff --select RUF027` catches the
+  shape and reports the tree otherwise clean, but the rule is in preview,
+  which this project does not enable.
 - a script verification failure says what went wrong, and where. The 76
   bare `BTClibValueError()` raises — 70 of them under `script/engine/` —
   carried an empty message, so a wrong public key encoding, an unbalanced
@@ -2167,6 +2173,37 @@ edit.
 
 ### Transactions, blocks and PSBT
 
+- **`psbt.assert_signatures_only` is the check that belongs before
+  `combine` when the psbt came from somebody else** (issue #381).
+  BIP174 gives the Combiner no such role: it takes the union of what it
+  is given and may resolve a conflict by picking either side, so it
+  compares the psbt's identifier and merges the rest. That left three
+  ways for an answer to change what was sent — adding a field the
+  request left empty, overwriting *one entry* of a field that is a map
+  (`_combine_field` merges those pair by pair, so a single
+  `hd_key_paths` origin or leaf script can be replaced), and, in a
+  version 2 psbt, changing a sequence, which the identifier cannot see
+  because BIP370 zeroes every sequence in it. The rule is one sentence:
+  everything that is not a signature comes back as it was sent, the
+  signature fields may only gain entries, and every signature that
+  arrived is verified before anything is merged. `_SIGNATURE_FIELDS` is
+  the list of what may grow — `partial_sigs`, the two taproot signature
+  fields and BIP373's two round maps — and every other field of `PsbtIn`
+  and `PsbtOut` is walked with `dataclasses.fields`, so a field added
+  later must come back unchanged by default. Two consequences worth
+  naming: an answer that *finalizes* an input is refused, a finalized
+  script being no signature and its correctness a question for the
+  script engine rather than for a field comparison; and an answer that
+  adds an `unknown` vendor field is refused too. Where the Finalizer
+  leaves a signature it has no message for alone, this refuses it — a
+  signature that cannot be checked is the one thing that must not be
+  merged. `tx_modifiable` is the single field an answer may change, and
+  only by tightening, which is `_combined_tx_modifiable`'s own rule. The
+  two musig2 maps are permitted additions and are not verified here: a
+  BIP327 partial signature is checked against an aggregate nonce that
+  needs every participant's, which a psbt mid-session need not carry
+  yet, and `musig2.partial_sigs_agg` refuses an aggregate that does not
+  verify.
 - **the Finalizer clears one list of fields, whichever kind the input
   is, and finalizing twice is finalizing once.** BIP174: "All other data
   except the UTXO and unknown fields in the input key-value map should

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -12,6 +12,12 @@ which plays the role over a `KeyManager`'s answers, and the size
 estimation a fee rate is applied to. `musig2` is named as a module, being
 the BIP373 role rather than one function, the way btclib.ecc names dsa.
 
+`assert_signatures_only` is the check that belongs before `combine` when
+the psbt being merged came from somebody else. BIP174 gives the Combiner
+no such role -- it takes the union of what it is given and may resolve a
+conflict by picking either side -- so a caller merging an external
+signer's answer has to hold it to the request first.
+
 `ecdsa_sig_hash` and `taproot_sig_hash` are here for the same reason
 `prevouts` is: `sign` needs the message before it needs anything else,
 and a caller playing the Signer by hand -- writing a signature into a
@@ -35,6 +41,7 @@ from btclib.psbt import musig2
 from btclib.psbt.psbt import (
     KeyManager,
     Psbt,
+    assert_signatures_only,
     combine,
     ecdsa_sig_hash,
     extract_tx,
@@ -53,6 +60,7 @@ __all__ = [
     "Psbt",
     "PsbtIn",
     "PsbtOut",
+    "assert_signatures_only",
     "combine",
     "ecdsa_sig_hash",
     "estimated_input_sizes",

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -105,6 +105,7 @@ __all__ = [
     "PSBT_V2",
     "KeyManager",
     "Psbt",
+    "assert_signatures_only",
     "combine",
     "ecdsa_sig_hash",
     "extract_tx",
@@ -2038,6 +2039,236 @@ def sign(psbt: Psbt, key_manager: KeyManager) -> tuple[Psbt, list[int]]:
         if _sign_ecdsa_input(psbt, vin_i, key_manager):
             signed_vins.append(vin_i)
     return psbt, signed_vins
+
+
+# the input fields a signer's answer may add to, and the only ones:
+# everything else it carries has to be what was sent. That is what makes
+# `assert_signatures_only` a check on an answer rather than a merge of
+# two opinions -- `combine` is the merge, and BIP174 lets it resolve a
+# conflict by picking either side, which is the wrong instinct entirely
+# when one side came from somebody else.
+#
+# The two musig2 maps are here because BIP373 puts a session's rounds in
+# them: a public nonce in round 1 and a partial signature in round 2 are
+# what that signer's answer *is*.
+_SIGNATURE_FIELDS = frozenset(
+    {
+        "partial_sigs",
+        "taproot_key_spend_signature",
+        "taproot_script_spend_signatures",
+        "musig2_pub_nonces",
+        "musig2_partial_sigs",
+    }
+)
+
+
+def _assert_unchanged(
+    request_map: PsbtIn | PsbtOut, returned_map: PsbtIn | PsbtOut, what: str
+) -> None:
+    """Raise unless every field that is not a signature came back as sent.
+
+    Walked with `dataclasses.fields` and not from a list of its own, so
+    that a field added to `PsbtIn` or `PsbtOut` has to come back
+    unchanged by default: the safe answer for a field nobody has thought
+    about yet is that an external signer may not touch it.
+
+    Equality and not "was not overwritten", which is what `combine`
+    settles for: a signer that adds a `witness_utxo` the request did not
+    carry, or a `redeem_script`, is playing Updater as well, and a caller
+    who wants that has `combine` and no illusion that it was checked.
+    That is also how the two decisions about `unknown` and the finalized
+    scripts are kept -- neither is a signature, so both must be equal,
+    and an answer that finalizes an input or adds a vendor field is
+    refused here rather than merged.
+    """
+    for field in fields(request_map):
+        if field.name in _SIGNATURE_FIELDS:
+            continue
+        if getattr(returned_map, field.name) != getattr(request_map, field.name):
+            raise BTClibValueError(f"{what}: {field.name} was changed")
+
+
+def _assert_signatures_added_only(
+    request_in: PsbtIn, returned_in: PsbtIn, vin_i: int
+) -> None:
+    """Raise unless the signature fields only gained entries.
+
+    A signature the request already carried must come back as it was, and
+    dropping one is refused too: the answer is meant to be the request
+    plus what this signer had to add, and `combine` would put a dropped
+    signature back without anybody noticing that it had been taken out.
+    """
+    for name in sorted(_SIGNATURE_FIELDS):
+        was, now = getattr(request_in, name), getattr(returned_in, name)
+        if isinstance(was, dict):
+            for key, value in was.items():
+                if key not in now:
+                    err_msg = f"input {vin_i}: {name} of {key.hex()} was dropped"
+                    raise BTClibValueError(err_msg)
+                if now[key] != value:
+                    err_msg = f"input {vin_i}: {name} of {key.hex()} was changed"
+                    raise BTClibValueError(err_msg)
+        elif was and now != was:
+            raise BTClibValueError(f"input {vin_i}: {name} was changed")
+
+
+def _assert_new_ecdsa_sigs_verify(
+    request_in: PsbtIn, returned_in: PsbtIn, tx: Tx, vin_i: int
+) -> None:
+    """Raise unless each partial signature that arrived verifies.
+
+    Where `_assert_partial_sigs_verify` leaves an unverifiable signature
+    alone, this refuses it, and the difference is who is asking: the
+    Finalizer learns nothing about a signature from a psbt that does not
+    say what was signed, while here a signature that cannot be checked is
+    the one thing that must not be merged.
+
+    lower_s=False for the Finalizer's reason: the question is whether that
+    key made that signature, the low-s rule being policy the script engine
+    applies under its flags.
+    """
+    for pub_key, sig in returned_in.partial_sigs.items():
+        if pub_key in request_in.partial_sigs:
+            continue
+        msg_hash = _sig_hash_from_psbt_in(returned_in, tx, vin_i, sig[-1])
+        if msg_hash is None:
+            err_msg = f"input {vin_i}: cannot verify the signature of "
+            err_msg += f"{pub_key.hex()}, the psbt does not say what was signed"
+            raise BTClibValueError(err_msg)
+        if not dsa.verify_(msg_hash, pub_key, sig[:-1], lower_s=False):
+            err_msg = f"input {vin_i}: invalid signature for pub_key {pub_key.hex()}"
+            raise BTClibValueError(err_msg)
+
+
+def _assert_new_taproot_sigs_verify(request: Psbt, returned: Psbt, vin_i: int) -> None:
+    """Raise unless each taproot signature that arrived verifies.
+
+    The Finalizer's own checks, asked one role earlier: a key path
+    signature against the output key being spent, a script path one
+    against the key its tapleaf hash names. The sig_hash type each
+    commits to has to be the type the input asks for, which is what
+    `_assert_taproot_sig_hash_type` answers and what decides the message.
+
+    A taproot signature beside an input that does not spend a taproot
+    output is refused rather than verified: there is no output key to
+    check it against, and an answer carrying one is describing some other
+    input.
+    """
+    request_in, returned_in = request.inputs[vin_i], returned.inputs[vin_i]
+    new_key_sig = returned_in.taproot_key_spend_signature and (
+        not request_in.taproot_key_spend_signature
+    )
+    new_script_sigs = {
+        key_data: sig
+        for key_data, sig in returned_in.taproot_script_spend_signatures.items()
+        if key_data not in request_in.taproot_script_spend_signatures
+    }
+    if not new_key_sig and not new_script_sigs:
+        return
+
+    script = _spent_script(returned_in)
+    if not is_p2tr(script):
+        err_msg = f"input {vin_i}: a taproot signature for an input spending "
+        err_msg += "no taproot output"
+        raise BTClibValueError(err_msg)
+
+    if new_key_sig:
+        sig = returned_in.taproot_key_spend_signature
+        hash_type = _assert_taproot_sig_hash_type(
+            sig, returned_in, "taproot key path signature"
+        )
+        msg = taproot_sig_hash(returned, vin_i, hash_type=hash_type)
+        output_key = type_and_payload(script)[1]
+        if not ssa.verify_(msg, output_key, sig[:64]):
+            err_msg = f"input {vin_i}: invalid taproot key path signature for "
+            err_msg += f"output key {output_key.hex()}"
+            raise BTClibValueError(err_msg)
+
+    for key_data, sig in new_script_sigs.items():
+        pub_key, leaf_hash = key_data[:LEAF_HASH_SIZE], key_data[LEAF_HASH_SIZE:]
+        hash_type = _assert_taproot_sig_hash_type(
+            sig, returned_in, "taproot script path signature"
+        )
+        msg = taproot_sig_hash(
+            returned, vin_i, leaf_hash=leaf_hash, hash_type=hash_type
+        )
+        if not ssa.verify_(msg, pub_key, sig[:64]):
+            err_msg = f"input {vin_i}: invalid taproot script path signature for "
+            err_msg += f"key {pub_key.hex()}"
+            raise BTClibValueError(err_msg)
+
+
+def assert_signatures_only(request: Psbt, returned: Psbt) -> None:
+    """Raise unless `returned` is `request` with signatures added, and no more.
+
+    What a caller has to know before merging an answer from somebody
+    else -- an external signer, a hardware device, a cosigner -- because
+    `combine` will not tell them: BIP174's Combiner takes the union of
+    what it is given and may resolve a conflict by picking either side,
+    so it compares only the psbt's identifier and merges the rest. Which
+    leaves three ways for an answer to change what was sent: adding a
+    field the request left empty, overwriting one entry of a field that
+    is a map, and -- in a version 2 psbt, whose identifier zeroes every
+    sequence -- changing a sequence.
+
+    The rule here is one sentence. Everything that is not a signature
+    comes back as it was sent; the signature fields may only gain
+    entries; every signature that arrived is verified before anything is
+    merged. `_SIGNATURE_FIELDS` is the second clause, `_assert_unchanged`
+    the first, and both walk the fields a map declares rather than a list
+    kept beside them.
+
+    The transaction being signed is compared whole, `Psbt.tx` being
+    computed from the fields of either version: that is what catches the
+    changed sequence of a version 2 psbt, which `unique_id` cannot see,
+    and it makes the input and output counts equal without a check of
+    their own.
+
+    `tx_modifiable` is the one field an answer may legitimately change,
+    a Signer clearing a bit when it adds a signature that a change would
+    break. What it may not do is loosen one, and the rule for that is
+    `_combined_tx_modifiable`'s already: an answer no more permissive
+    than the request is one the two combine into unchanged.
+
+    The two musig2 maps are permitted additions and are not verified
+    here. A BIP327 partial signature is checked against the session's
+    aggregate nonce, which needs every participant's nonce, and a psbt
+    mid-session need not carry them yet; `musig2.partial_sigs_agg`
+    refuses an aggregate that does not verify, which is the check that
+    can be made once the session is complete.
+    """
+    returned.assert_valid()
+
+    if returned.version != request.version:
+        err_msg = f"mismatched psbt version: {returned.version} vs {request.version}"
+        raise BTClibValueError(err_msg)
+    if returned.tx != request.tx:
+        raise BTClibValueError("the transaction being signed was changed")
+    if returned.fallback_lock_time != request.fallback_lock_time:
+        raise BTClibValueError("fallback_lock_time was changed")
+    if returned.hd_key_paths != request.hd_key_paths:
+        raise BTClibValueError("the global hd_key_paths were changed")
+    if returned.unknown != request.unknown:
+        raise BTClibValueError("the global unknown fields were changed")
+    if _combined_tx_modifiable([request, returned]) != returned.tx_modifiable:
+        raise BTClibValueError("tx_modifiable is more permissive than the request's")
+
+    # read once, as `finalize` reads it once: every signature of every
+    # input is against the same transaction
+    tx = returned.tx
+    for vin_i, (request_in, returned_in) in enumerate(
+        zip(request.inputs, returned.inputs, strict=True)
+    ):
+        _assert_unchanged(request_in, returned_in, f"input {vin_i}")
+        _assert_signatures_added_only(request_in, returned_in, vin_i)
+        _assert_sig_hash_type(returned_in)
+        _assert_new_ecdsa_sigs_verify(request_in, returned_in, tx, vin_i)
+        _assert_new_taproot_sigs_verify(request, returned, vin_i)
+
+    for vout_i, (request_out, returned_out) in enumerate(
+        zip(request.outputs, returned.outputs, strict=True)
+    ):
+        _assert_unchanged(request_out, returned_out, f"output {vout_i}")
 
 
 def _assert_sig_hash_type(psbt_in: PsbtIn) -> None:

--- a/btclib/psbt/psbt_in.py
+++ b/btclib/psbt/psbt_in.py
@@ -174,7 +174,7 @@ def _assert_valid_partial_sigs(partial_sigs: Mapping[bytes, bytes]) -> None:
             # pub_key must be a valid secp256k1 Point in SEC representation
             sec_point.point_from_octets(pub_key)
         except BTClibValueError as e:
-            err_msg = "invalid partial signature pub_key: {pub_key!r}"
+            err_msg = f"invalid partial signature pub_key: {pub_key!r}"
             raise BTClibValueError(err_msg) from e
         try:
             # the DER signature alone: a partial signature is that plus a

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -467,6 +467,7 @@ def test_psbt_exports_the_format_not_its_plumbing() -> None:
         "Psbt",
         "PsbtIn",
         "PsbtOut",
+        "assert_signatures_only",
         "combine",
         "ecdsa_sig_hash",
         "estimated_input_sizes",

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -24,6 +24,7 @@ from btclib.psbt import (
     Psbt,
     PsbtIn,
     PsbtOut,
+    assert_signatures_only,
     combine,
     ecdsa_sig_hash,
     extract_tx,
@@ -3455,3 +3456,344 @@ def test_finalizing_twice_is_finalizing_once(kind: str) -> None:
     signed, _ = sign(psbt, key_manager)
     once = finalize(signed)
     assert finalize(once) == once
+
+
+# the check that belongs before combine when the answer came from
+# somebody else
+
+
+def _request_and_answer() -> tuple[Psbt, Psbt]:
+    """Return a 2-of-2 request the first signer signed, and the answer.
+
+    The shape the validator exists for: the coordinator holds `request`
+    and gets `returned` back, and everything in it but the second
+    signature has to be what was sent.
+    """
+    request, signed_vins = sign(
+        _unsigned_multisig_psbt(), _KeyManager(by_pub_key={_PUB_KEY: _PRV_KEY})
+    )
+    assert signed_vins == [0]
+    returned, signed_vins = sign(
+        deepcopy(request), _KeyManager(by_pub_key={_OTHER_PUB_KEY: _OTHER_PRV_KEY})
+    )
+    assert signed_vins == [0]
+    return request, returned
+
+
+def test_an_answer_carrying_only_a_new_signature_is_accepted() -> None:
+    """The honest case, and the one that has to keep working.
+
+    Both signatures are there afterwards, so the psbt finalizes: the
+    validator refusing a good answer would be the expensive kind of
+    wrong.
+    """
+    request, returned = _request_and_answer()
+
+    assert_signatures_only(request, returned)
+
+    combined = combine([request, returned])
+    assert set(combined.inputs[0].partial_sigs) == {_PUB_KEY, _OTHER_PUB_KEY}
+
+
+def test_an_answer_that_changes_the_transaction_is_refused() -> None:
+    """Whichever field of it, and a sequence included (issue #381).
+
+    `combine` compares the psbt's identifier, and for a version 2 psbt
+    that identifier zeroes every sequence -- BIP370 making the sequence a
+    field an Updater may set. So a changed sequence is exactly what it
+    cannot see, and comparing the transaction whole is what does.
+    """
+    request, returned = _request_and_answer()
+    returned.outputs[0].amount = 1
+    with pytest.raises(BTClibValueError, match="the transaction being signed"):
+        assert_signatures_only(request, returned)
+
+    request, returned = _request_and_answer()
+    returned.inputs[0].sequence = 0xFFFFFFFD
+    with pytest.raises(BTClibValueError, match="the transaction being signed"):
+        assert_signatures_only(request, returned)
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("witness_script", b"\x51"),
+        ("redeem_script", b"\x51"),
+        ("sig_hash_type", 3),
+        ("final_script_sig", b"\x51"),
+        ("taproot_internal_key", b"\x02" * 32),
+    ],
+)
+def test_an_answer_that_changes_a_context_field_is_refused(
+    field: str, value: object
+) -> None:
+    """A signer's answer may add a signature and nothing else.
+
+    Equality and not `combine`'s "was not overwritten": a signer that
+    fills in a script the request left empty is playing Updater too, and
+    a caller who wants that has `combine` and no illusion it was checked.
+    `final_script_sig` is here because that is the decision about a
+    finalized answer -- it is not a signature, so it must be equal, and
+    an answer that finalizes an input is refused rather than merged.
+    """
+    request, returned = _request_and_answer()
+    setattr(returned.inputs[0], field, value)
+    with pytest.raises(BTClibValueError, match=f"input 0: {field} was changed"):
+        assert_signatures_only(request, returned)
+
+
+def test_an_answer_that_overwrites_one_entry_of_a_map_is_refused() -> None:
+    """The sharp edge `combine` has: `_combine_field` does dict.update.
+
+    A field that is several key-value pairs is merged pair by pair, so an
+    answer cannot add a whole `hd_key_paths` where the request had one --
+    but it can replace the origin filed under a single public key, and
+    the merge takes it.
+    """
+    request, returned = _request_and_answer()
+    returned.inputs[0].hd_key_paths[_PUB_KEY] = BIP32KeyOrigin(b"\xff" * 4, "m/9")
+    with pytest.raises(BTClibValueError, match="input 0: hd_key_paths was changed"):
+        assert_signatures_only(request, returned)
+
+
+def test_an_answer_that_adds_a_preimage_or_a_vendor_field_is_refused() -> None:
+    """Neither is a signature, so neither may appear (issue #381).
+
+    An `unknown` entry is the decision about vendor fields: they are data
+    a caller re-serializes and hands on, and an answer is not the place
+    they arrive from.
+    """
+    request, returned = _request_and_answer()
+    returned.inputs[0].sha256_preimages = {sha256(b"x"): b"x"}
+    with pytest.raises(BTClibValueError, match="input 0: sha256_preimages"):
+        assert_signatures_only(request, returned)
+
+    request, returned = _request_and_answer()
+    returned.inputs[0].unknown = {b"\xfc\x01": b"vendor"}
+    with pytest.raises(BTClibValueError, match="input 0: unknown was changed"):
+        assert_signatures_only(request, returned)
+
+
+def test_an_answer_that_touches_the_first_signature_is_refused() -> None:
+    """Dropped or replaced, both refused.
+
+    `combine` would put a dropped signature back with nobody the wiser
+    that it had been taken out, and a replaced one is a signature this
+    coordinator never saw made.
+    """
+    request, returned = _request_and_answer()
+    del returned.inputs[0].partial_sigs[_PUB_KEY]
+    with pytest.raises(BTClibValueError, match="partial_sigs of .* was dropped"):
+        assert_signatures_only(request, returned)
+
+    request, returned = _request_and_answer()
+    returned.inputs[0].partial_sigs[_PUB_KEY] = returned.inputs[0].partial_sigs[
+        _OTHER_PUB_KEY
+    ]
+    with pytest.raises(BTClibValueError, match="partial_sigs of .* was changed"):
+        assert_signatures_only(request, returned)
+
+
+def test_an_answer_carrying_a_signature_that_does_not_verify_is_refused() -> None:
+    """Every signature that arrived is checked before anything is merged."""
+    request, returned = _request_and_answer()
+    good = returned.inputs[0].partial_sigs[_OTHER_PUB_KEY]
+    # the same key, a signature of some other message: the DER of the
+    # first signer's signature under the second signer's key
+    returned.inputs[0].partial_sigs[_OTHER_PUB_KEY] = (
+        request.inputs[0].partial_sigs[_PUB_KEY][:-1] + good[-1:]
+    )
+    err_msg = "input 0: invalid signature for pub_key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_signatures_only(request, returned)
+
+
+def test_a_signature_whose_message_cannot_be_computed_is_refused() -> None:
+    """Where the Finalizer leaves it alone, the validator refuses it.
+
+    `_assert_partial_sigs_verify` skips a signature the psbt gives it no
+    message for -- a Finalizer learns nothing about a signature from a
+    psbt that does not say what was signed. Here it is the one thing that
+    must not be merged, so the same silence is a refusal.
+
+    Both psbts lose the witness script, so it is not a changed field: the
+    request is one that never said what the signature covers.
+    """
+    request, returned = _request_and_answer()
+    request.inputs[0].witness_script = b""
+    returned.inputs[0].witness_script = b""
+    del request.inputs[0].partial_sigs[_PUB_KEY]
+
+    err_msg = "cannot verify the signature of .*does not say what was signed"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_signatures_only(request, returned)
+
+
+def test_an_answer_that_loosens_tx_modifiable_is_refused() -> None:
+    """The one field an answer may change, and only in one direction.
+
+    A Signer clears a modifiable bit when it adds a signature a change
+    would break, so tightening is the legitimate answer; setting a bit
+    the request had clear says the psbt may still be modified in a way
+    the request said it may not. `_combined_tx_modifiable` is the rule,
+    and an answer no more permissive than the request is one the two
+    combine into unchanged.
+
+    Version 2, `PSBT_GLOBAL_TX_MODIFIABLE` being a field BIP370 does not
+    allow a version 0 psbt to carry.
+    """
+    request, returned = _request_and_answer()
+    request, returned = request.to_v2(), returned.to_v2()
+    request.tx_modifiable = 0
+    returned.tx_modifiable = INPUTS_MODIFIABLE
+    with pytest.raises(BTClibValueError, match="tx_modifiable is more permissive"):
+        assert_signatures_only(request, returned)
+
+    # the other way round is a Signer doing its job
+    request.tx_modifiable = INPUTS_MODIFIABLE | OUTPUTS_MODIFIABLE
+    returned.tx_modifiable = OUTPUTS_MODIFIABLE
+    assert_signatures_only(request, returned)
+
+
+def test_an_answer_that_changes_the_fallback_lock_time_is_refused() -> None:
+    """Inert for this psbt, and a field that travels all the same.
+
+    The transaction comparison catches a changed fallback wherever the
+    lock time is computed from it, which is every psbt whose inputs
+    require none. This is the other case: an input requiring a height
+    lock time makes the fallback unused, so the two psbts agree on the
+    transaction and differ on a field that becomes live again the moment
+    that requirement is dropped. Not a signature, so it must be equal.
+    """
+    request, returned = _request_and_answer()
+    request, returned = request.to_v2(), returned.to_v2()
+    for psbt in (request, returned):
+        psbt.inputs[0].required_height_lock_time = 700_000
+    request.fallback_lock_time = 500_000
+    returned.fallback_lock_time = 600_000
+    assert request.lock_time == returned.lock_time == 700_000
+
+    with pytest.raises(BTClibValueError, match="fallback_lock_time was changed"):
+        assert_signatures_only(request, returned)
+
+
+def test_an_answer_that_changes_a_global_field_or_an_output_is_refused() -> None:
+    """The global maps and every output field, none of them signatures."""
+    request, returned = _request_and_answer()
+    returned.version = 2
+    with pytest.raises(BTClibValueError, match="mismatched psbt version"):
+        assert_signatures_only(request, returned)
+
+    request, returned = _request_and_answer()
+    returned.hd_key_paths = {_PUB_KEY: BIP32KeyOrigin(b"\xff" * 4, "m/9")}
+    with pytest.raises(BTClibValueError, match="global hd_key_paths were changed"):
+        assert_signatures_only(request, returned)
+
+    request, returned = _request_and_answer()
+    returned.unknown = {b"\xfc\x02": b"vendor"}
+    with pytest.raises(BTClibValueError, match="global unknown fields were changed"):
+        assert_signatures_only(request, returned)
+
+    request, returned = _request_and_answer()
+    returned.outputs[0].redeem_script = b"\x51"
+    with pytest.raises(BTClibValueError, match="output 0: redeem_script was changed"):
+        assert_signatures_only(request, returned)
+
+
+def _taproot_request_and_answer() -> tuple[Psbt, Psbt, list[TxOut]]:
+    """Return an unsigned p2tr key path request, and the answer to it."""
+    request, prevouts_ = _taproot_key_path_psbt()
+    returned, signed_vins = sign(
+        deepcopy(request),
+        _KeyManager(by_pub_key={_TAPROOT_INTERNAL_KEY: _TAPROOT_PRV_KEY}),
+    )
+    assert signed_vins == [0]
+    return request, returned, prevouts_
+
+
+def test_a_taproot_answer_is_checked_against_the_output_key() -> None:
+    """The Finalizer's own check, asked one role earlier."""
+    request, returned, prevouts_ = _taproot_request_and_answer()
+    assert_signatures_only(request, returned)
+    verify_transaction(prevouts_, extract_tx(finalize(returned), check_validity=False))
+
+    request, returned, _ = _taproot_request_and_answer()
+    returned.inputs[0].taproot_key_spend_signature = b"\x01" * 64
+    err_msg = "invalid taproot key path signature for output key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_signatures_only(request, returned)
+
+
+def test_a_taproot_answer_that_changes_the_signature_it_was_sent_is_refused() -> None:
+    """The scalar field's own rule: set once, it must come back as it was."""
+    # the answer of the first round is the request of the second, which is
+    # what makes the signature a field that is already set
+    signed_request = _taproot_request_and_answer()[1]
+    tampered = deepcopy(signed_request)
+    tampered.inputs[0].taproot_key_spend_signature = b"\x02" * 64
+
+    err_msg = "taproot_key_spend_signature was changed"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_signatures_only(signed_request, tampered)
+
+
+def test_a_taproot_signature_beside_a_non_taproot_input_is_refused() -> None:
+    """There is no output key to check it against.
+
+    An answer that files a schnorr signature on an input spending a
+    witness v0 output is describing some other input, and the Finalizer
+    would not read the field either -- it dispatches on the spent script.
+    """
+    request, returned = _request_and_answer()
+    returned.inputs[0].taproot_key_spend_signature = b"\x01" * 64
+    err_msg = "a taproot signature for an input spending no taproot output"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_signatures_only(request, returned)
+
+
+def test_an_answer_whose_signature_commits_to_another_sig_hash_type() -> None:
+    """The type the input asks for is the type the answer must sign.
+
+    `_assert_sig_hash_type` is BIP174's rule for the Finalizer, asked
+    here as well: a signature committing to something other than the
+    input asked for is one the other participants did not agree to, and
+    refusing it before the merge is cheaper than refusing it after.
+    """
+    request, returned = _request_and_answer()
+    request.inputs[0].sig_hash_type = 1
+    returned.inputs[0].sig_hash_type = 1
+    sig = returned.inputs[0].partial_sigs[_OTHER_PUB_KEY]
+    returned.inputs[0].partial_sigs[_OTHER_PUB_KEY] = sig[:-1] + b"\x03"
+    with pytest.raises(BTClibValueError, match="mismatched sig_hash type"):
+        assert_signatures_only(request, returned)
+
+
+def test_a_taproot_script_path_answer_is_checked_against_the_leaf_key() -> None:
+    """The script path half, against the key its tapleaf hash names.
+
+    BIP373's own vector is the signature, aggregated from the session the
+    psbt carries; the request is that psbt with the signature taken back
+    out, so every other field agrees by construction and the signature is
+    the only difference.
+    """
+    description = "a key in a script is a MuSig2 Aggregate Pubkey, with all partial"
+    returned = _taproot_signed(description)
+    request = deepcopy(returned)
+    request.inputs[0].taproot_script_spend_signatures = {}
+
+    assert_signatures_only(request, returned)
+
+    key_data = next(iter(returned.inputs[0].taproot_script_spend_signatures))
+    returned.inputs[0].taproot_script_spend_signatures[key_data] = b"\x01" * 64
+    err_msg = "invalid taproot script path signature for key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_signatures_only(request, returned)
+
+
+def test_an_answer_that_is_not_a_valid_psbt_is_refused() -> None:
+    """It came from outside, so it is validated before it is compared."""
+    request, returned = _request_and_answer()
+    returned.inputs[0].partial_sigs[b"\x02" * 10] = b"\x30\x06"
+    err_msg = "invalid partial signature pub_key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_signatures_only(request, returned)


### PR DESCRIPTION
## Summary

BIP174 gives the Combiner no validating role: it takes the union of what
it is given and may resolve a conflict by picking either side, so it
compares the psbt's *identifier* and merges the rest. Measured, that
leaves three ways for an answer from an external signer to change what
was sent:

- adding a field the request left empty (a `witness_utxo`, a
  `redeem_script`, a taproot internal key);
- **overwriting one entry of a field that is a map** — `_combine_field`
  merges those pair by pair, so a single `hd_key_paths` origin or leaf
  script can be replaced and the merge takes it;
- in a **version 2** psbt, changing a **sequence**: `unique_id` zeroes
  every sequence, BIP370 making it a field an Updater may set, so the
  identifier comparison cannot see it.

`assert_signatures_only(request, returned)` is one sentence: everything
that is not a signature comes back as it was sent, the signature fields
may only gain entries, and every signature that arrived is verified
before anything is merged.

`_SIGNATURE_FIELDS` is what may grow — `partial_sigs`, the two taproot
signature fields, and BIP373's two round maps. Every other field of
`PsbtIn` and `PsbtOut` is walked with `dataclasses.fields`, so a field
added later has to come back unchanged **by default**.

Two consequences worth naming, both of them the decisions this was
scoped with:

- an answer that **finalizes** an input is refused — a finalized script
  is no signature, and its correctness is a question for the script
  engine rather than for a field comparison;
- an answer that adds an **`unknown`** vendor field is refused, that
  being data a caller re-serializes and hands on.

Where the Finalizer leaves a signature it has no message for alone, this
refuses it: a signature that cannot be checked is the one thing that
must not be merged.

`tx_modifiable` is the single field an answer may change, and only by
tightening — which is `_combined_tx_modifiable`'s own rule, reused rather
than restated.

The two musig2 maps are permitted additions and are **not** verified
here: a BIP327 partial signature is checked against an aggregate nonce
that needs every participant's, which a psbt mid-session need not carry
yet, and `musig2.partial_sigs_agg` refuses an aggregate that does not
verify. Stated in the docstring so the gap is not mistaken for an
oversight.

Builds on #442 (the Combiner returning a copy is what makes
"validate, then merge" safe) and #443 (one clearing rule, so a finalized
input has one shape rather than two). Part of #381.

## Drive-by fix, disclosed

`PsbtIn.assert_valid` printed the literal `{pub_key!r}` — a format string
missing its `f`. Found by a test asserting on that message; one
occurrence in the whole tree. `ruff --select RUF027` catches the shape
and reports the tree otherwise clean, but the rule is in **preview**,
which this project does not enable — that call is yours, so this PR only
fixes the instance.

## Test plan

21 new tests, one per way an answer can differ:

- [x] the honest answer is accepted and still finalizes with both
  signatures
- [x] transaction changed (an output amount; **a sequence**)
- [x] context fields changed, parametrized: `witness_script`,
  `redeem_script`, `sig_hash_type`, `final_script_sig`,
  `taproot_internal_key`
- [x] one map entry overwritten (`hd_key_paths` under a single key)
- [x] a preimage added; an `unknown` vendor field added
- [x] the first signer's signature dropped, and replaced
- [x] a signature that does not verify; a signature whose message cannot
  be computed
- [x] a signature committing to another sighash type
- [x] `tx_modifiable` loosened (refused) and tightened (accepted)
- [x] global `hd_key_paths`, global `unknown`, `version`,
  `fallback_lock_time`, and an output field
- [x] taproot key path against the output key; taproot script path
  against the leaf key (BIP373's own vector); a taproot signature beside
  a non-taproot input
- [x] an answer that is not a valid psbt

Gates:

- [x] `uv run pytest --cov`: 17226 passed, `btclib/psbt/psbt.py` back to
  100% — the one remaining gap
  (`.github/scripts/mutation_counts.py`, 9 statements) is pre-existing on
  `dev`
- [x] `uv run pre-commit run --all-files`: exit 0
- [x] `sphinx-build -W --keep-going`: exit 0

CI is not waited on: GitHub Actions is degraded today, failing at
"Set up job" before any test runs. The gates above are local.

## Summary by Sourcery

Introduce a validator to ensure externally returned PSBTs only add valid signatures before combining them.

New Features:
- Add public psbt.assert_signatures_only API to validate that an external signer’s PSBT reply only adds signatures and does not alter other transaction or PSBT fields.

Bug Fixes:
- Fix PsbtIn.assert_valid error message to correctly interpolate the offending partial-signature public key instead of printing the format placeholder.

Enhancements:
- Enforce strict equality of non-signature PSBT fields between a signing request and response, including tx_modifiable tightening, fallback lock time, and global maps, and verify any newly added ECDSA and taproot signatures.
- Allow Musig2 round maps to be extended in PSBTs without verification at this stage, deferring validation to aggregate signature checks.

Documentation:
- Document the new assert_signatures_only behavior and guarantees in the changelog and psbt package documentation, clarifying its role before combine when handling external signers.

Tests:
- Add comprehensive PSBT tests covering accepted and rejected signer responses, including transaction changes, context field mutations, map overwrites, vendor fields, malformed signatures, sig-hash mismatches, taproot cases, tx_modifiable changes, and invalid PSBTs.
- Extend export tests to ensure assert_signatures_only is exposed from the psbt package API.