### PR TITLE
Read three hardening symbols and write the two BIP380 allows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -848,6 +848,29 @@ edit.
 
 ### Malformed input and the exception contract
 
+- **a derivation path step that is not one raises btclib's own error**,
+  where `int_from_index_str` let `int` raise: `derive(xprv, ";/0")` died
+  with `invalid literal for int() with base 10: ';'` and now raises
+  `BTClibValueError: invalid derivation index: ;`. `BTClibValueError` is
+  a `ValueError`, so a caller catching that still catches; only the
+  message changes. What the same function was *meant* to do it did not:
+  it opened with `s.strip().lower()` and dropped the result on the
+  floor, a statement with no effect, so it read two hardening symbols
+  where its docstring promised three and `_indexes_from_der_path_str`
+  -- which lowercases each step itself -- delivered three. BIP32 spells
+  its own test vectors `m/0H/1/2H`, so `int_from_index_str("0H")` now
+  answers as the path reader around it always has. No linter available
+  here reports the discarded call: ruff's B018 finds the discarded
+  attribute and the discarded constant beside it, and skips calls
+  because a call may have side effects, and mypy `--strict` with every
+  optional error code is silent.
+- **a descriptor's derivation path is held to BIP380's grammar**, by
+  `indexes_from_der_path(..., bip380_enforced=True)` rather than by a
+  regular expression of its own. The rule is unchanged and now stated
+  once: `h` and `'` are the two hardened indicators, the uppercase `H`
+  of BIP32 is not one, and a step's number is decimal digits -- not the
+  `+1`, `1_0` and `m / 0 h / 0` that `int` and the BIP32 reader take.
+  BIP380's four invalid-hardened-indicator vectors are in the suite.
 - **a psbt claiming a version that does not exist is refused as one.**
   `invalid non-zero version: 1` is `invalid psbt version: 1`, and the
   rule behind it is no longer "anything but 0": version 2 is read now,
@@ -2738,6 +2761,20 @@ edit.
 
 ### The public API and the module layout
 
+- **`hardenings_from_der_path` reports the symbol each step was spelled
+  with**, one entry per index and `""` where the step is unhardened or
+  the path is not text. `0h` and `0'` are one index and two strings, and
+  a descriptor *is* the string: the two spellings have different
+  checksums, so a serializer that cannot tell them apart hands back a
+  descriptor that is not the one it read. `indexes_from_der_path` and
+  `int_from_index_str` take the `bip380_enforced` keyword beside it, for
+  the stricter reading a descriptor needs. **`str_from_index_int` no
+  longer accepts `"H"`**: three symbols are read and two are written,
+  because the uppercase one is a hardened indicator BIP380 lists as
+  invalid and neither of Bitcoin Core's two parsers accepts -- the
+  descriptor one taking `'` and `h`, `ParseHDKeypath` the apostrophe
+  alone. `str_from_index_int(0x80000000, "H")` returned `"0H"` and now
+  raises `invalid hardening symbol: H`.
 - **Core's chain names are spoken in the module that speaks to Core**, and
   btclib's network names everywhere else (issue #379). The two vocabularies
   name one chain and two of the names differ -- Core's `main` and `test`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -23,6 +23,10 @@ The changes below break code that worked on v2023.7.12. Each is described in
 full in [CHANGELOG.md](./CHANGELOG.md). Every "before" spelling was checked
 against the `v2023.7.12` tag.
 
+- **`str_from_index_int(i, "H")` raises.** A derivation path is written
+  with `h` or `'`, the two hardened indicators BIP380 allows; the
+  uppercase `H` that BIP32 writes its own vectors with is still read and
+  is no longer written. Pass `"h"` or `"'"`, or take the default.
 - **`btclib.bitcoin_core_rpc` is the `bitcoin-core-rpc` package.** The
   Bitcoin Core rpc client is no longer a module of btclib: it is
   [a distribution of its own](https://pypi.org/project/bitcoin-core-rpc/),

--- a/btclib/bip32/__init__.py
+++ b/btclib/bip32/__init__.py
@@ -17,6 +17,7 @@ from btclib.bip32.bip32 import (
 )
 from btclib.bip32.der_path import (
     bytes_from_der_path,
+    hardenings_from_der_path,
     indexes_from_der_path,
     int_from_index_str,
     str_from_der_path,
@@ -44,6 +45,7 @@ __all__ = [
     "derive",
     "derive_from_account",
     "encode_to_bip32_derivs",
+    "hardenings_from_der_path",
     "indexes_from_der_path",
     "int_from_index_str",
     "pub_key_derivation_tweaks",

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -10,10 +10,18 @@ A BIP32 derivation path can be represented as:
 - "m/44h/0'/1H/0/10" or "44h/0'/1H/0/10" string
 - sequence of integer indexes (even a single int)
 - bytes (multiples of 4-bytes index)
+
+Three hardening symbols are read and two are written, which is not an
+oversight: BIP32 spells its own test vectors "m/0H/1/2H", while BIP380
+lists "[deadbeef/0H/0H/0H]" among its invalid hardened indicators, beside
+"0f" and "-0". So a path is read leniently, and `bip380_enforced` is the
+stricter reading a descriptor needs -- the two symbols it allows, and the
+number spelled the one way it spells it.
 """
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 
 from btclib.alias import Octets
@@ -23,14 +31,29 @@ from btclib.utils import is_integer
 __all__ = [
     "DerPath",
     "bytes_from_der_path",
+    "hardenings_from_der_path",
     "indexes_from_der_path",
     "int_from_index_str",
     "str_from_der_path",
     "str_from_index_int",
 ]
 
-# default hardening symbol among the possible ones: "h", "H", "'"
+# the symbols a hardened step is read with, and the two of them BIP380
+# allows. Writing takes the second list: an uppercase H is a path Bitcoin
+# Core's own parsers refuse, both the descriptor one -- `last == '\'' ||
+# last == 'h'` -- and `ParseHDKeypath`, which takes the apostrophe alone
+_HARDENINGS = ("'", "h", "H")
+_BIP380_HARDENINGS = ("'", "h")
+
+# the symbol written where the caller names none, and the one Core's
+# FormatHDKeypath writes when it is not echoing an apostrophe it read
 _HARDENING = "h"
+
+# BIP380's spelling of a step's number: decimal digits, and nothing else.
+# `int` is what the lenient reading uses instead, and it takes "+1", "1_0"
+# and the spaces of "m / 0 h / 0" -- none of them a step a descriptor may
+# carry, and all of them a path this module has always accepted
+_BIP380_INDEX = re.compile("[0-9]+")
 
 # the offset a hardened index carries: BIP32 splits the 2**32 indexes in
 # half at 2**31, so an index is hardened when it reaches this value, and
@@ -43,27 +66,53 @@ _HARDENING = "h"
 _HARDENED_OFFSET = 0x80000000
 
 
-def int_from_index_str(s: str) -> int:
-    """Return one path step as its index: "0h" is 0x80000000.
+def _index_and_hardening_from_str(s: str, *, bip380_enforced: bool) -> tuple[int, str]:
+    """Return a step's index and the hardening symbol it was spelled with.
 
-    Any of the three hardening symbols is read; an index at or above
-    the hardened offset must be spelled with one, not as the number.
+    The symbol comes back rather than a bool because it is what writing
+    the step again takes: BIP380 gives "h" and "'" one meaning and two
+    spellings, and a descriptor is the string, so which one was read is
+    the difference between handing back the descriptor and handing back
+    a different one with the same meaning and another checksum.
     """
-    s.strip().lower()
-    hardened = False
-    if s[-1] in ("'", "h"):
-        s = s[:-1]
-        hardened = True
-
-    index = int(s)
+    symbols = _BIP380_HARDENINGS if bip380_enforced else _HARDENINGS
+    hardening = s[-1] if s and s[-1] in symbols else ""
+    number = s[:-1] if hardening else s
+    if bip380_enforced and not _BIP380_INDEX.fullmatch(number):
+        raise BTClibValueError(f"invalid derivation index: {s}")
+    try:
+        index = int(number)
+    # what `int` refuses is a step, so the error says so, and says it the
+    # way every other error here does: bare ValueError out of a public
+    # function is what "invalid literal for int() with base 10" was
+    except ValueError as e:
+        raise BTClibValueError(f"invalid derivation index: {s}") from e
     if not 0 <= index < _HARDENED_OFFSET:
         raise BTClibValueError(f"invalid index: {index}")
-    return index + (_HARDENED_OFFSET if hardened else 0)
+    return index + (_HARDENED_OFFSET if hardening else 0), hardening
+
+
+def int_from_index_str(s: str, *, bip380_enforced: bool = False) -> int:
+    """Return one path step as its index: "0h" is 0x80000000.
+
+    Any of the three hardening symbols is read, uppercase "H" included,
+    which is how BIP32 spells its own vectors. `bip380_enforced` reads
+    the two a descriptor may hold instead, and holds the number to
+    decimal digits; see the module docstring for why the two readings
+    differ. An index at or above the hardened offset must be spelled
+    with a symbol, not as the number.
+    """
+    return _index_and_hardening_from_str(s, bip380_enforced=bip380_enforced)[0]
 
 
 def str_from_index_int(i: int, hardening: str = _HARDENING) -> str:
-    """Return one index as a path step, the chosen symbol for hardened."""
-    if hardening not in ("'", "h", "H"):
+    """Return one index as a path step, the chosen symbol for hardened.
+
+    Two symbols, where the reader above takes three: an uppercase "H" is
+    a hardened indicator BIP380 lists as invalid and Bitcoin Core's
+    parsers refuse, so this writes no path a descriptor cannot hold.
+    """
+    if hardening not in _BIP380_HARDENINGS:
         raise BTClibValueError(f"invalid hardening symbol: {hardening}")
     # reachable without indexes_from_der_path, and str(True) is "True": a
     # path step of a boolean would be a path nothing derives
@@ -81,32 +130,84 @@ def str_from_index_int(i: int, hardening: str = _HARDENING) -> str:
     return str(index - _HARDENED_OFFSET) + hardening
 
 
-def _indexes_from_der_path_str(der_path: str, skip_m: bool = True) -> list[int]:
-    steps = [x.strip().lower() for x in der_path.split("/")]
-    if skip_m and steps[0] == "m":
+def _pairs_from_der_path_str(
+    der_path: str, skip_m: bool = True, *, bip380_enforced: bool = False
+) -> tuple[list[int], list[str]]:
+    """Return a path string's indexes, and the symbols it spelled them with.
+
+    The lenient reading drops an empty step, which is what makes a
+    trailing slash a path of the same depth, and skips a leading m. The
+    BIP380 one does neither: its grammar has no m and no empty step, so
+    each is an index that does not parse.
+    """
+    steps = [x.strip() for x in der_path.split("/")]
+    if skip_m and not bip380_enforced and steps[0].lower() == "m":
         steps = steps[1:]
+    if not bip380_enforced:
+        steps = [s for s in steps if s != ""]
 
-    indexes = [int_from_index_str(s) for s in steps if s != ""]
+    pairs = [
+        _index_and_hardening_from_str(s, bip380_enforced=bip380_enforced) for s in steps
+    ]
 
-    if len(indexes) > 255:
-        err_msg = f"depth greater than 255: {len(indexes)}"
+    if len(pairs) > 255:
+        err_msg = f"depth greater than 255: {len(pairs)}"
         raise BTClibValueError(err_msg)
-    return indexes
+    return [index for index, _ in pairs], [hardening for _, hardening in pairs]
+
+
+def _indexes_from_der_path_str(der_path: str, skip_m: bool = True) -> list[int]:
+    return _pairs_from_der_path_str(der_path, skip_m)[0]
 
 
 DerPath = str | Sequence[int] | int | bytes
 
 
-def indexes_from_der_path(der_path: DerPath) -> list[int]:
+def _pairs_from_der_path(
+    der_path: DerPath, *, bip380_enforced: bool = False
+) -> tuple[list[int], list[str]]:
+    """Return the indexes of a path, and the symbols it spelled them with.
+
+    Only a string spells anything, so every other DerPath answers with
+    an empty symbol per index: "the path did not say", which is what a
+    caller writing it out again defaults for.
+    """
+    if isinstance(der_path, str):
+        return _pairs_from_der_path_str(der_path, bip380_enforced=bip380_enforced)
+    indexes = _indexes_from_der_path(der_path)
+    return indexes, [""] * len(indexes)
+
+
+def indexes_from_der_path(
+    der_path: DerPath, *, bip380_enforced: bool = False
+) -> list[int]:
     """Return the path as a list of indexes, whatever spelling it came in.
 
     The DerPath spellings of the module docstring are all read: a
     string with or without the leading m, a single int, the 4-byte
     little-endian concatenation, or any iterable of ints.
+    `bip380_enforced` is the stricter reading of a string, and says
+    nothing about the spellings that are not text.
     """
-    if isinstance(der_path, str):
-        return _indexes_from_der_path_str(der_path)
+    return _pairs_from_der_path(der_path, bip380_enforced=bip380_enforced)[0]
 
+
+def hardenings_from_der_path(
+    der_path: DerPath, *, bip380_enforced: bool = False
+) -> list[str]:
+    """Return the hardening symbol each step of the path was spelled with.
+
+    One entry per index, and "" where the step is unhardened or the path
+    is not text. What it is for is writing the path out as it came in:
+    "0h" and "0'" are one index and two strings, and a descriptor is
+    the string -- BIP380's own valid vectors include the mixed
+    "[deadbeef/0'/0h/0']".
+    """
+    return _pairs_from_der_path(der_path, bip380_enforced=bip380_enforced)[1]
+
+
+def _indexes_from_der_path(der_path: Sequence[int] | int | bytes) -> list[int]:
+    """Return the indexes of every DerPath spelling that is not a string."""
     if isinstance(der_path, int):
         if not is_integer(der_path):
             err_msg = f"invalid derivation index type: {type(der_path).__name__}"

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -77,7 +77,7 @@ from typing import cast
 
 from btclib.alias import Octets, ScriptList, TaprootScriptTree
 from btclib.bip32.bip32 import BIP32KeyData, derive
-from btclib.bip32.der_path import int_from_index_str
+from btclib.bip32.der_path import indexes_from_der_path
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
 from btclib.psbt.psbt import Psbt
@@ -234,7 +234,6 @@ _UNIMPLEMENTED = {
 }
 
 _FINGERPRINT = re.compile("[0-9a-fA-F]{8}")
-_DERIVATION_INDEX = re.compile("[0-9]+[h']?")
 _HEX = re.compile("[0-9a-fA-F]*")
 _THRESHOLD = re.compile("[0-9]+")
 # the BIP389 multipath step, brackets included: re.split hands back what
@@ -1115,17 +1114,15 @@ def _one_argument(arguments: list[str], name: str) -> str:
 
 
 def _der_path(path: str) -> list[int]:
-    """Return the indexes of a `/`-separated derivation path."""
-    if not path:
-        return []
-    indexes = []
-    for step in path.split("/"):
-        if not _DERIVATION_INDEX.fullmatch(step):
-            raise BTClibValueError(f"invalid derivation index: {step}")
-        # int_from_index_str is what refuses 2**31 and above written
-        # unhardened, there being no such BIP32 index
-        indexes.append(int_from_index_str(step))
-    return indexes
+    """Return the indexes of a `/`-separated derivation path.
+
+    `bip380_enforced` is the whole of the difference from what a BIP32
+    path may spell: an uppercase "H", a "+1", a leading "m" and the
+    spaces of "0 h" are all read elsewhere in btclib and none of them is
+    a step BIP380 allows. It also refuses 2**31 and above written
+    unhardened, there being no such BIP32 index.
+    """
+    return indexes_from_der_path(path, bip380_enforced=True) if path else []
 
 
 def _key_origin(description: str) -> BIP32KeyOrigin:

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -265,9 +265,9 @@ def test_derive_exceptions() -> None:
         xkey = _derive(xprv, der_path)
         assert fingerprint == xkey.parent_fingerprint
 
-    err_msg = "invalid literal for int"
+    err_msg = "invalid derivation index: "
     for der_path in (";/0", "invalid index"):
-        with pytest.raises(ValueError, match=err_msg):
+        with pytest.raises(BTClibValueError, match=err_msg):
             derive(xprv, der_path)
 
     with pytest.raises(BTClibValueError, match="depth greater than 255: "):

--- a/tests/bip32/der_path_test.py
+++ b/tests/bip32/der_path_test.py
@@ -9,6 +9,7 @@ import pytest
 
 from btclib.bip32 import (
     bytes_from_der_path,
+    hardenings_from_der_path,
     indexes_from_der_path,
     int_from_index_str,
     str_from_der_path,
@@ -116,3 +117,74 @@ def test_str_from_der_path() -> None:
     err_msg = "invalid master fingerprint length: "
     with pytest.raises(BTClibValueError, match=err_msg):
         str_from_der_path(der_path, "baaaad")
+
+
+def test_three_symbols_are_read_and_two_are_written() -> None:
+    """Read h, H and ', write the two BIP380 allows."""
+    for symbol in ("h", "H", "'"):
+        assert int_from_index_str(f"0{symbol}") == 0x80000000
+
+    for hardening in ("h", "'"):
+        step = str_from_index_int(0x80000000, hardening)
+        assert step == f"0{hardening}"
+        assert int_from_index_str(step) == 0x80000000
+
+    # BIP380 lists an uppercase H among its invalid hardened indicators,
+    # so it is a step this module reads and never writes
+    with pytest.raises(BTClibValueError, match="invalid hardening symbol: "):
+        str_from_index_int(0x80000000, "H")
+
+
+def test_bip380_enforced_reads_two_symbols() -> None:
+    """Refuse under BIP380 what the BIP32 reading takes."""
+    for step in ("0h", "0'", "2147483647h", "0"):
+        assert int_from_index_str(step) == int_from_index_str(
+            step, bip380_enforced=True
+        )
+
+    # what the BIP32 reading takes and BIP380's grammar does not: its own
+    # invalid hardened indicators, and the numbers `int` alone accepts
+    for step in ("0H", "-0", "+1", "1_0", " 0 h"):
+        assert isinstance(int_from_index_str(step), int)
+        with pytest.raises(BTClibValueError, match="invalid derivation index: "):
+            int_from_index_str(step, bip380_enforced=True)
+
+    # and what neither reading takes, as an error of its own rather than
+    # as the bare ValueError of `int`
+    for step in ("0f", "", "0hh"):
+        for enforced in (False, True):
+            with pytest.raises(BTClibValueError, match="invalid derivation index: "):
+                int_from_index_str(step, bip380_enforced=enforced)
+
+    # the number is still held to a BIP32 index
+    with pytest.raises(BTClibValueError, match="invalid index: "):
+        int_from_index_str("2147483648", bip380_enforced=True)
+
+    # BIP380's grammar has neither a leading m nor an empty step, both of
+    # which the lenient reading of a whole path drops
+    assert indexes_from_der_path("m/0h/") == [0x80000000]
+    for path in ("m/0h", "0h/"):
+        with pytest.raises(BTClibValueError, match="invalid derivation index: "):
+            indexes_from_der_path(path, bip380_enforced=True)
+
+
+def test_hardenings_from_der_path() -> None:
+    """Report the symbol each step was spelled with, "" where there is none."""
+    # BIP380's own valid vector with mixed indicators
+    assert hardenings_from_der_path("0'/0h/0'") == ["'", "h", "'"]
+    assert indexes_from_der_path("0'/0h/0'") == [0x80000000] * 3
+
+    assert hardenings_from_der_path("m/44h/0'/1H/0/10") == ["h", "'", "H", "", ""]
+    assert hardenings_from_der_path("m/44h/0'/1h") == ["h", "'", "h"]
+    assert hardenings_from_der_path("0/1") == ["", ""]
+    assert hardenings_from_der_path("") == []
+
+    # only a string spells anything: every other DerPath says nothing,
+    # one entry per index all the same
+    for der_path in ([0x80000000, 1], 0x80000000, bytes.fromhex("00000080")):
+        indexes = indexes_from_der_path(der_path)
+        assert hardenings_from_der_path(der_path) == [""] * len(indexes)
+
+    assert hardenings_from_der_path("0h/1", bip380_enforced=True) == ["h", ""]
+    with pytest.raises(BTClibValueError, match="invalid derivation index: "):
+        hardenings_from_der_path("0H/1", bip380_enforced=True)

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -793,6 +793,16 @@ UNPARSABLE = [
     (f"pkh({XPUB}/2147483648)", "invalid index"),
     (f"pkh({XPUB}/1aa)", "invalid derivation index"),
     (f"pkh({XPUB}/+1)", "invalid derivation index"),
+    # BIP380's own invalid hardened indicators: the uppercase H that
+    # BIP32 writes its vectors with is not one a descriptor may hold
+    (f"pk([deadbeef/0H/0H/0H]{KEY})", "invalid derivation index"),
+    (f"pk([deadbeef/0f/0f/0f]{KEY})", "invalid derivation index"),
+    (f"pk([deadbeef/-0/-0/-0]{KEY})", "invalid derivation index"),
+    (f"pkh({XPUB}/3H/4h/5h)", "invalid derivation index"),
+    # what the lenient BIP32 reading takes and BIP380's grammar does not
+    (f"pkh({XPUB}/m/0)", "invalid derivation index"),
+    (f"pkh({XPUB}/0//1)", "invalid derivation index"),
+    (f"pkh({XPUB}/ 0 h)", "invalid derivation index"),
     # Core: an address that is not one, and a script that is not hex
     ("addr(asdf)", "base58"),
     ("raw(asdf)", "hex script"),


### PR DESCRIPTION
`int_from_index_str` opened with `s.strip().lower()` and dropped the
result on the floor — a statement with no effect. So it read two
hardening symbols where its own docstring promised three, and where
`_indexes_from_der_path_str`, which lowercases each step itself,
delivered three:

```
int_from_index_str("0H")        -> ValueError: invalid literal for int() with base 10: '0H'
indexes_from_der_path("m/0H/1") -> [2147483648, 1]
```

BIP32 spells its own test vectors `m/0H/1/2H`, and
`tests/bip32/_data/bip32_test_vectors.json` carries them, so three is
the right number to read and the uppercase one is read everywhere now.

**Written it is two.** BIP380 lists `[deadbeef/0H/0H/0H]` and
`…/3H/4h/5h/*H` among its invalid hardened indicators, beside `0f` and
`-0`, and neither of Bitcoin Core's two parsers takes an uppercase `H`:
the descriptor one accepts `'` and `h` (`ParseKeyPathNum`), and
`ParseHDKeypath` the apostrophe alone. `str_from_index_int(i, "H")`
returned `"0H"` and now raises — the one source-breaking change here,
with its bullet in HISTORY.md.

## What this is for

Issue #381's descriptor serializer. `0h` and `0'` are one index and two
strings, and a descriptor *is* the string — the two spellings have
different checksums:

```
wpkh([00000000/84h/0h/0h]xpub6Bos.../0/*)   ny9ympxj
wpkh([00000000/84'/0'/0']xpub6Bos.../0/*)   q46mpm33
```

Core keeps one `m_apostrophe` bool per key expression and so normalizes
a mixed path; `hardenings_from_der_path` reports the symbol each step
used, one entry per index and `""` where the step is unhardened or the
path is not text, which round-trips BIP380's own valid mixed vector
`[deadbeef/0'/0h/0']` too.

`bip380_enforced` is the stricter reading beside it, on
`int_from_index_str` and `indexes_from_der_path`: two symbols, and a
number of decimal digits rather than the `+1`, `1_0`, leading `m` and
`m / 0 h / 0` spaces that `int` and the BIP32 reader accept. The
descriptor parser delegates to it instead of matching a regular
expression of its own, so the rule is stated once — a pure refactor
there, the accepted language being unchanged.

A step that is no step now raises `BTClibValueError: invalid derivation
index: ;` where `int` raised `invalid literal for int() with base 10`.
`BTClibValueError` is a `ValueError`, so a caller catching that still
catches; one test asserted the old message and is updated.

## On the linters

No linter available here reports the discarded call. Measured, with
`--select ALL` — every rule ruff has:

```
deadline.py:3:5: B018 Found useless expression.   # s.strip        (attribute)
deadline.py:4:5: B018 Found useless expression.   # 42             (constant)
                                                  # s.strip().lower() — nothing
```

B018 skips calls, a call being allowed side effects, and `mypy --strict`
with `redundant-expr`, `truthy-bool`, `unused-ignore`,
`possibly-undefined` and `ignore-without-code` is silent. Not a
configuration gap to close, then; the defence is the test, which this
adds.

## Gates

- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0
- `pytest --cov=btclib --cov=tests` — 17236 passed, 100.00%

## Summary by Sourcery

Tighten derivation path parsing and serialization to distinguish lenient BIP32-style reading from stricter BIP380 descriptor grammar, and expose hardening symbol information alongside indexes.

New Features:
- Expose hardenings_from_der_path to report the hardening symbol used for each derivation path step.
- Add bip380_enforced mode to int_from_index_str and indexes_from_der_path for strict BIP380-compliant parsing of textual paths.

Bug Fixes:
- Fix int_from_index_str so it correctly accepts all three hardening symbols it was intended to read, including uppercase H, and raise btclib-specific errors for invalid steps.

Enhancements:
- Refactor derivation path parsing to return both indexes and hardening symbols internally, enabling faithful round-tripping of mixed hardened indicators in descriptors.
- Restrict str_from_index_int to write only the two BIP380-allowed hardening symbols, making output compatible with Bitcoin Core descriptor parsers.
- Unify descriptor derivation-path validation by delegating to the shared bip380_enforced path parser instead of a local regular expression.

Documentation:
- Document the new hardenings_from_der_path API, the bip380_enforced behavior, and the change in error reporting and accepted hardening symbols in CHANGELOG.md and HISTORY.md.

Tests:
- Extend bip32 and descriptor tests to cover three-symbol reading vs two-symbol writing, strict BIP380 parsing behavior, hardenings_from_der_path semantics, and the new btclib error messages for malformed derivation steps.