### PR TITLE
Refuse a legacy sig_hash from a witness utxo, and combine the fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2196,6 +2196,31 @@ edit.
 
 ### Transactions, blocks and PSBT
 
+- **no role reads a legacy sig_hash out of a witness utxo alone** (issue
+  #381). `PSBT_IN_WITNESS_UTXO` "should only be present for inputs which
+  spend segwit outputs, including P2SH embedded ones", and nothing ties
+  one to the outpoint it claims to be: BIP174's Signer checks
+  `sha256d(non_witness_utxo)` against that outpoint and has no such line
+  to write for the other field, so its own algorithm signs from a
+  witness utxo only where the script is p2wpkh or p2wsh. A legacy
+  sig_hash taken from those bytes commits to a script_pub_key nobody
+  vouched for. `psbt.ecdsa_sig_hash` computed one and now raises, and so
+  do `finalize` and `assert_signatures_only`, which read the same
+  dispatch: the Finalizer skips an input whose message it cannot
+  compute, and skipping is what would finalize exactly the signature
+  that cannot be believed. Bitcoin Core stops for the same reason,
+  `require_witness_sig` in `SignPSBTInput`. `assert_signable` already
+  refused the input; the message function is what a caller reaches
+  without it.
+- **the Combiner keeps a fallback lock time whichever copy holds it.**
+  `PSBT_GLOBAL_FALLBACK_LOCKTIME` was not merged at all, so
+  `combine([a, b])` and `combine([b, a])` answered differently — the
+  copy merged into is the first one, and the field of the others was
+  dropped. It is reached only when no input requires a lock time, which
+  is what lets two psbts differ in it and still be one transaction by
+  the unique id BIP370 defines. Bitcoin Core's `Merge` takes it under
+  the same rule every other combined field follows: the one already
+  there is kept.
 - **`psbt.assert_signatures_only` is the check that belongs before
   `combine` when the psbt came from somebody else** (issue #381).
   BIP174 gives the Combiner no such role: it takes the union of what it

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -1421,6 +1421,12 @@ def combine(psbts: Sequence[Psbt]) -> Psbt:
 
         _combine_field(psbt, final_psbt, "hd_key_paths")
         _combine_field(psbt, final_psbt, "unknown")
+        # the fallback is reached only when no input requires a lock time,
+        # so two psbts that differ in it can still be one transaction and
+        # reach here -- and a Combiner that dropped it answered one thing
+        # for combine([a, b]) and another for combine([b, a]), the copy
+        # merged into being the one that happened to come first
+        _combine_optional_field(psbt, final_psbt, "fallback_lock_time")
 
     return final_psbt
 
@@ -1832,6 +1838,21 @@ def _sig_hash_from_psbt_in(
     and travel in the taproot fields, so a partial signature beside a
     p2tr script_pub_key is not a signature this hash would check.
 
+    A non-witness spend described by a witness utxo alone is the case
+    that raises instead, being neither of those: the input says what is
+    signed and says it on no authority. `PSBT_IN_WITNESS_UTXO` "should
+    only be present for inputs which spend segwit outputs, including P2SH
+    embedded ones", and nothing ties one to the outpoint it claims to be
+    -- BIP174's Signer checks `sha256d(non_witness_utxo)` against that
+    outpoint and has no such line to write for the other field, so its
+    own algorithm signs from a witness utxo only where the script is
+    p2wpkh or p2wsh. Bitcoin Core's `SignPSBTInput` says it as
+    `require_witness_sig`, and refuses the input when the signature it
+    produced is not a witness one. A legacy sig_hash taken from those
+    bytes commits to a script_pub_key nobody vouched for, so the answer
+    is an error rather than a hash, and rather than the None that would
+    have the Finalizer skip the very signature it is checking.
+
     sig_hash.from_tx is the same dispatch for a *signed* transaction, and
     cannot serve here: it reads the redeem script out of the input's
     script_sig and the witness script off its witness stack, and a psbt's
@@ -1854,6 +1875,10 @@ def _sig_hash_from_psbt_in(
 
     if not script or is_p2tr(script):
         return None
+    if psbt_in.non_witness_utxo is None:
+        err_msg = f"input {vin_i}: a witness utxo alone does not say what a "
+        err_msg += "non-witness spend signs"
+        raise BTClibValueError(err_msg)
     return sig_hash.legacy(script, tx, vin_i, hash_type)
 
 
@@ -1877,7 +1902,9 @@ def ecdsa_sig_hash(psbt: Psbt, vin_i: int, *, hash_type: int | None = None) -> b
     Where it answers None this raises, and the difference is the caller:
     a Finalizer checking a signature it was handed learns nothing from a
     psbt that does not say what was signed, while a Signer about to make
-    one has to stop.
+    one has to stop. Where it raises -- a non-witness spend described by
+    a witness utxo alone -- every caller stops, that being an input no
+    role may sign, verify or finalize.
     """
     psbt_in = psbt.inputs[vin_i]
     if hash_type is None:
@@ -2308,7 +2335,11 @@ def _assert_partial_sigs_verify(psbt_in: PsbtIn, tx: Tx, vin_i: int) -> None:
 
     An input whose sig_hash is not computable is left alone rather than
     refused: what is missing there is the utxo or a script, which is not
-    evidence against the signature.
+    evidence against the signature. A non-witness spend carrying a
+    witness utxo alone is the exception, and raises out of
+    `_sig_hash_from_psbt_in`: there the input does say what was signed,
+    on bytes nothing vouches for, so skipping the check would finalize
+    exactly the input whose signature cannot be believed.
 
     lower_s=False because the question here is whether that key made that
     signature: the low-s rule is policy, applied by the script engine

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -506,6 +506,34 @@ def test_the_identifier_of_a_v2_psbt_ignores_the_sequences() -> None:
         combine([psbt, psbt.to_v0()])
 
 
+def test_combining_keeps_a_fallback_lock_time_whichever_copy_holds_it() -> None:
+    """The Combiner answers the same whichever psbt came first.
+
+    The fallback is only reached when no input requires a lock time, so
+    two psbts differing in it can compute the same lock time, be the same
+    transaction by the unique id, and still disagree about the field --
+    which is the case Bitcoin Core's Merge takes it in.
+    """
+    psbt = _bip370_psbt("1 input, 2 output updated PSBTv2")
+    psbt.inputs[0].required_height_lock_time = 700_000
+    psbt.fallback_lock_time = None
+    other = deepcopy(psbt)
+    other.fallback_lock_time = 500_000
+
+    assert psbt.unique_id == other.unique_id
+    assert psbt.lock_time == other.lock_time == 700_000
+
+    for psbts in ([psbt, other], [other, psbt]):
+        combined = combine([deepcopy(p) for p in psbts])
+        assert combined.fallback_lock_time == 500_000
+        assert combined.lock_time == 700_000
+
+    # and the one already there is kept, as every other combined field is
+    both = deepcopy(other)
+    both.fallback_lock_time = 400_000
+    assert combine([both, deepcopy(other)]).fallback_lock_time == 400_000
+
+
 def test_combining_keeps_the_flags_no_more_permissive_than_they_were() -> None:
     """A combine cannot hand back what a Signer took away.
 
@@ -2762,6 +2790,55 @@ def test_what_a_signer_cannot_be_given_a_hash_for() -> None:
 
     with pytest.raises(BTClibValueError, match="invalid sig_hash type: 0x4"):
         ecdsa_sig_hash(psbt, 0, hash_type=4)
+
+
+def test_a_witness_utxo_alone_signs_no_non_witness_spend() -> None:
+    """No role reads a legacy sig_hash out of a witness utxo.
+
+    BIP174 puts `PSBT_IN_WITNESS_UTXO` on segwit inputs alone, and its
+    Signer checks a non-witness utxo against the outpoint it claims to
+    be -- a line it has none of for the other field, whose script_pub_key
+    is therefore unvouched for. Bitcoin Core stops for the same reason,
+    `require_witness_sig`. Signing, verifying an answer and finalizing
+    all raise, rather than the Signer alone: skipping the check is what
+    would finalize the input whose signature cannot be believed.
+    """
+    signed, _ = _single_key_psbt("p2pkh")
+    prev_tx = signed.inputs[0].non_witness_utxo
+    assert prev_tx is not None
+    prev_out = prev_tx.vout[0]
+
+    unvouched = deepcopy(signed)
+    unvouched.inputs[0].non_witness_utxo = None
+    unvouched.inputs[0].witness_utxo = prev_out
+
+    err_msg = "input 0: a witness utxo alone does not say what a non-witness"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        ecdsa_sig_hash(unvouched, 0)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        finalize(unvouched)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_signatures_only(_stripped_of_signatures(unvouched), unvouched)
+
+    # the same psbt is refused before that, where a caller runs the check
+    # BIP174 wrote for the Updater's output
+    with pytest.raises(BTClibValueError, match="script type not in"):
+        unvouched.assert_signable()
+
+    # and the very same input, with the transaction it is spent against,
+    # signs and finalizes
+    assert ecdsa_sig_hash(signed, 0) == sig_hash.legacy(
+        prev_out.script_pub_key.script, signed.tx, 0, 1
+    )
+    assert finalize(signed).inputs[0].final_script_sig
+
+
+def _stripped_of_signatures(psbt: Psbt) -> Psbt:
+    """Return the psbt as it was before a Signer answered."""
+    request = deepcopy(psbt)
+    for psbt_in in request.inputs:
+        psbt_in.partial_sigs = {}
+    return request
 
 
 def test_the_outpoint_names_an_output_of_the_non_witness_utxo() -> None:


### PR DESCRIPTION
The two defects the comparison with Bitcoin Core in #381 turned up. Both
small, both independent of the descriptor work that follows.

## A legacy sig_hash from a witness utxo alone

`PSBT_IN_WITNESS_UTXO` "should only be present for inputs which spend
segwit outputs, including P2SH embedded ones", and nothing ties one to
the outpoint it claims to be. BIP174's own Signer algorithm says it by
what it does not write:

```
    if witness_utxo.exists:
        ...
        if IsP2WPKH(script):   sign_witness(...)
        else if IsP2WSH(script): sign_witness(...)
    else if non_witness_utxo.exists:
        assert(sha256d(non_witness_utxo) == psbt.tx.input[i].prevout.hash)
```

There is no `sign_non_witness` under the witness utxo, and no assertion
that could put one there. Bitcoin Core stops for the same reason —
`require_witness_sig` in `SignPSBTInput`, which refuses the input when
the signature produced is not a witness one.

btclib built the hash anyway. Measured on `dev` before this change:

```
assert_signable: BTClibValueError script type not in ('p2wpkh', 'p2wsh', 'p2tr')
ecdsa_sig_hash : returns a hash: 294ab41f90b9ceb59b081d1c1679962d ...
```

`sign` was safe, `assert_signable` refusing the input; the exported
message function is what the guide's Signer paragraph tells a caller to
use without it.

**The refusal is in the shared dispatch, not in the message function.**
`_sig_hash_from_psbt_in` feeds three callers, and its `None` means "the
psbt does not say what was signed" — which `_assert_partial_sigs_verify`
answers by *skipping* that signature. Returning `None` here would have
skipped the check on exactly the signature that cannot be believed, and
finalized it. So it raises, and `ecdsa_sig_hash`, `finalize` and
`assert_signatures_only` all stop.

## The Combiner dropped the fallback lock time

`PSBT_GLOBAL_FALLBACK_LOCKTIME` was not merged at all, so the answer
depended on the argument order. Measured on `dev`:

```
same unique_id: True
combine([a,b]).fallback_lock_time: None      # b's 500000 is lost
combine([b,a]).fallback_lock_time: 500000
```

The field is reached only when no input requires a lock time, which is
what lets two psbts differ in it and still be one transaction by the
unique id BIP370 defines — the case Core's `Merge` takes it in
(`src/psbt.cpp:68`), under the rule every other combined field follows:
the one already there is kept.

## Gates

- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0
- `pytest --cov=btclib --cov=tests` — 17238 passed, 100.00%

## Summary by Sourcery

Disallow using witness UTXO data alone to compute or verify legacy signature hashes in PSBT inputs and ensure PSBT combiners consistently merge fallback lock times regardless of input order.

Bug Fixes:
- Raise an error when a non-witness spend is described only by a witness UTXO, preventing any role from computing, verifying, or finalizing a legacy signature hash based on unvouched script data.
- Fix PSBT combination so that the global fallback lock time is preserved consistently and independent of PSBT order, keeping the existing value when merging multiple PSBTs.

Documentation:
- Document the new behavior around rejecting legacy signature hashes derived from witness UTXOs alone and the corrected fallback lock time merge semantics in the changelog.

Tests:
- Add regression tests covering fallback lock time preservation when combining PSBTs in different orders and when both PSBTs define a fallback lock time.
- Add regression tests ensuring that attempts to sign, verify, or finalize a non-witness spend described only by a witness UTXO now raise errors rather than producing or accepting a legacy signature hash.