### PR TITLE
Read multi_a() and sortedmulti_a() inside tr() (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2927,8 +2927,8 @@ edit.
   descriptor pays to at that index — with the address of each, where the
   script has one. The grammar is BIP380 to BIP386 and BIP389 minus
   miniscript: `pk`, `pkh`, `wpkh`, `combo`, `sh`, `wsh`, `multi`,
-  `sortedmulti`, `addr`, `raw`, and `tr` with a key path and a tree of
-  `pk()` leaves; key expressions cover hex keys compressed, uncompressed
+  `sortedmulti`, `addr`, `raw`, and `tr` with a key path and a script
+  tree; key expressions cover hex keys compressed, uncompressed
   and x-only, WIF, xpub/xprv with a derivation path, key origin, the `/*`
   and `/*h` wildcards and both hardened markers, and
   `multipath_descriptors` expands the BIP389 `<a;b>` form into the
@@ -2938,11 +2938,10 @@ edit.
   `sh()` at the top level only, no uncompressed key inside a witness
   program, x-only only inside `tr()` — and what is not implemented raises
   NotImplementedError naming what it is: miniscript is issue #187,
-  `multi_a` and `sortedmulti_a` are BIP387, `rawtr` is BIP386 and
-  `musig` is BIP390. The derivation is checked against Bitcoin Core's
-  own `descriptor_tests.cpp` vectors, both spellings of each, so a WIF
-  and an xprv are checked to reach the script their public halves reach
-  (issue #186)
+  `rawtr` is BIP386 and `musig` is BIP390. The derivation is checked
+  against Bitcoin Core's own `descriptor_tests.cpp` vectors, both
+  spellings of each, so a WIF and an xprv are checked to reach the script
+  their public halves reach (issue #186)
 - **`Descriptor.satisfy` spends what `script_pub_keys` receives into**:
   given a mapping from public key to signature — the shape
   `PsbtIn.partial_sigs` has — it returns the `script_sig` and the
@@ -2992,6 +2991,31 @@ edit.
   BIP341 tapleaf hash that `tree_helper`, `check_output_pubkey` and the
   psbt's own `leaf_script` each used to compute for themselves (issue
   #306)
+- **`multi_a()` and `sortedmulti_a()` are read inside `tr()`**, which is
+  BIP387 and what the parser refused by name until now. A leaf of a script
+  tree is either a `pk()`, which is the bare `KeyExpression` it always
+  was, or the new `MultiA` — a threshold, the keys, and whether they are
+  sorted — so `DescriptorTree` has two kinds of leaf and `DescriptorLeaf`
+  names them; neither is a `Descriptor`, no output paying to a
+  `multi_a()` on its own. The script is BIP387's: a CHECKSIG and one
+  CHECKSIGADD per further key, with the threshold pushed as OP_1 to OP_16
+  where an op code means it and as the number itself above that. The keys
+  of a `sortedmulti_a()` are sorted on the 32 x-only bytes the script
+  carries and not on their 33-byte SEC form, which for a key of odd y is
+  another order — and reachable, a KEY expression naming such a key by its
+  WIF or its xpub. Satisfaction puts one element per key, threshold of
+  them signatures and the rest the empty push, in the reverse of the key
+  order: OP_CHECKSIGADD counts every signature that verifies and
+  OP_NUMEQUAL compares that count with the threshold, so the first key's
+  signature has to be on top of the stack and a signature beyond the
+  threshold would make the count wrong — both the opposite of what
+  `multi()` needs. `tr()` walks its leaves and takes the first the
+  signatures open, a leaf they do not open no longer being an error but
+  the next leaf's turn. `TrDescriptor.taproot_hd_key_paths` reads the
+  keys off each leaf rather than off its script bytes, which a leaf of one
+  key allowed and a `multi_a()` does not. Checked against BIP387's own
+  vectors, and the satisfaction against btclib's script engine, which
+  runs it rather than reading its shape (issue #448)
 - **`btclib.fetch` is new, and is the one package that goes out to the
   network.** `Fetcher` is three questions the library cannot answer from
   bytes it was handed — the transaction with this id, the output an

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -31,13 +31,14 @@ knows about the outputs it holds.
 
 BIP380: https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki
 
-The grammar read is BIP380 to BIP386 and BIP389, minus miniscript:
+The grammar read is BIP380 to BIP387 and BIP389, minus miniscript:
 
 - ``pk``, ``pkh``, ``wpkh``, ``combo`` (BIP381, BIP382, BIP384)
 - ``sh``, ``wsh``, including ``sh(wpkh())`` and ``sh(wsh())``
 - ``multi``, ``sortedmulti`` (BIP383)
 - ``addr``, ``raw`` (BIP385)
-- ``tr``, with a key path and a script tree of ``pk()`` leaves (BIP386)
+- ``tr``, with a key path and a script tree whose leaves are ``pk()``,
+  ``multi_a()`` and ``sortedmulti_a()`` (BIP386, BIP387)
 - key expressions: hex public keys (compressed, uncompressed and, inside
   ``tr()``, x-only), WIF private keys, xpub/xprv with a derivation path,
   key origin, ``/*`` and ``/*h`` wildcards, both ``h`` and ``'`` hardened
@@ -45,9 +46,8 @@ The grammar read is BIP380 to BIP386 and BIP389, minus miniscript:
 - the ``<a;b>`` multipath form of BIP389, through `multipath_descriptors`
 
 What raises NotImplementedError, rather than being read wrong: every
-miniscript expression, which is issue #187; and ``multi_a``,
-``sortedmulti_a``, ``rawtr`` and ``musig``, which are BIP387, BIP386
-and BIP390 and belong with the work that adds them.
+miniscript expression, which is issue #187; and ``rawtr`` and ``musig``,
+which are BIP386 and BIP390 and belong with the work that adds them.
 
 The network is a parameter of `parse` and not part of a descriptor: a
 descriptor names keys and scripts, and the same one means something on
@@ -57,13 +57,13 @@ own prefix.
 
 What this module exports is the checksum functions, `parse` and
 `multipath_descriptors`, and the fragment classes a parsed descriptor is
-made of -- `KeyExpression` and `DescriptorTree` among them, both being
-names a caller reads off `Descriptor.key_expressions` and
-`TrDescriptor.tree`. `INPUT_CHARSET`, `CHECKSUM_CHARSET` and `GENERATOR`
-stay out: they are the three tables BIP380's checksum is computed from,
-which is what `checksum`, `add_checksum` and `strip_checksum` answer, and
-each is still importable from this module the way the test suite takes
-them.
+made of -- `KeyExpression`, `DescriptorTree` and the `MultiA` a tree leaf
+may be among them, all three being names a caller reads off
+`Descriptor.key_expressions` and `TrDescriptor.tree`. `INPUT_CHARSET`,
+`CHECKSUM_CHARSET` and `GENERATOR` stay out: they are the three tables
+BIP380's checksum is computed from, which is what `checksum`,
+`add_checksum` and `strip_checksum` answer, and each is still importable
+from this module the way the test suite takes them.
 """
 
 from __future__ import annotations
@@ -82,7 +82,7 @@ from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
 from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
-from btclib.script.script import serialize
+from btclib.script.script import op_int, serialize
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.script.taproot import input_script_sig, leaf_hash, tree_helper
 from btclib.script.witness import Witness
@@ -93,8 +93,10 @@ __all__ = [
     "AddrDescriptor",
     "ComboDescriptor",
     "Descriptor",
+    "DescriptorLeaf",
     "DescriptorTree",
     "KeyExpression",
+    "MultiA",
     "MultiDescriptor",
     "PkDescriptor",
     "PkhDescriptor",
@@ -227,11 +229,20 @@ _MINISCRIPT_FRAGMENTS = frozenset(
 # each is a specification of its own, and a script derived wrong is an
 # address that loses money
 _UNIMPLEMENTED = {
-    "multi_a": "BIP387",
-    "sortedmulti_a": "BIP387",
     "rawtr": "BIP386",
     "musig": "BIP390",
 }
+
+# BIP387's own bound on the keys of a multi_a(): the satisfaction puts one
+# stack element per key, and a script whose spend would push more than the
+# 1000 elements BIP342 allows is one nobody can spend
+_MAX_MULTI_A_KEYS = 999
+
+# the two functions BIP387 allows inside tr() and nowhere else. Not in
+# _PARSERS with the SCRIPT expressions: what they parse to is a leaf of a
+# script tree and not a descriptor, so `_parse_tree` reads them and this
+# is what refuses them anywhere a SCRIPT expression is expected
+_TREE_FUNCTIONS = ("multi_a", "sortedmulti_a")
 
 _FINGERPRINT = re.compile("[0-9a-fA-F]{8}")
 _HEX = re.compile("[0-9a-fA-F]*")
@@ -291,28 +302,162 @@ class KeyExpression:
         return pub_keyinfo_from_key(derive(self.xkey, der_path), network)[0]
 
 
-# a tr() script tree: a `pk()` leaf, or a branch of two subtrees. The
-# leaves are KEY expressions and not scripts because a ranged descriptor
-# has no script until an index is given
-DescriptorTree = KeyExpression | tuple["DescriptorTree", "DescriptorTree"]
+@dataclass(frozen=True)
+class MultiA:
+    """``multi_a(k,KEY,...)`` or ``sortedmulti_a(k,KEY,...)``: a leaf, BIP387.
+
+    A leaf of a ``tr()`` script tree, beside the bare `KeyExpression` that
+    is a ``pk()`` leaf, and not a `Descriptor`: BIP387 allows these two
+    functions inside ``tr()`` and nowhere else, so no output pays to one
+    of them -- what an output pays to is the ``tr()`` that commits to it
+    as one of its tapscripts.
+    """
+
+    threshold: int
+    keys: tuple[KeyExpression, ...]
+    # the ordering that is the whole difference between the two functions,
+    # as BIP67 is for sortedmulti(): the keys of a sortedmulti_a() are
+    # sorted in the script, so the participants need not agree on an order
+    # to agree on an address
+    sort: bool = False
+
+    def _pub_keys(self, index: int, network: str) -> list[bytes]:
+        """Return the SEC keys in the order the script holds them.
+
+        Sorted on the x-only bytes and not on these: what a tapscript
+        carries is 32 bytes per key, and the 33-byte form adds to them a
+        prefix saying the parity of y -- so sorting the SEC bytes would
+        order the keys by that parity first, and a ``sortedmulti_a()``
+        naming a key by its WIF would get another script than the same
+        key written x-only.
+        """
+        pub_keys = [key.sec(index, network) for key in self.keys]
+        return sorted(pub_keys, key=lambda sec: sec[1:]) if self.sort else pub_keys
+
+    def _script(self, index: int, network: str) -> ScriptList:
+        """Return the tapscript of BIP387: a CHECKSIG, then CHECKSIGADDs.
+
+        The threshold is pushed as OP_1 to OP_16 where an op code means
+        it and as the number itself above that, which is what BIP387 says
+        and the one place the two spellings differ.
+
+        The bounds are checked here, and not in the parser, for the reason
+        `multi()` has them in `ScriptPubKey.p2ms`: a threshold of none or
+        of more keys than there are describes a script nobody can spend,
+        and a descriptor built by hand reaches this and not the parser.
+        """
+        pub_keys = self._pub_keys(index, network)
+        if not 1 <= self.threshold <= len(pub_keys):
+            err_msg = f"invalid k in k-of-n multi_a: {self.threshold}"
+            raise BTClibValueError(err_msg)
+        if len(pub_keys) > _MAX_MULTI_A_KEYS:
+            err_msg = f"invalid n in k-of-n multi_a: {len(pub_keys)}"
+            raise BTClibValueError(err_msg)
+        script: ScriptList = [pub_keys[0][1:], "OP_CHECKSIG"]
+        for pub_key in pub_keys[1:]:
+            script += [pub_key[1:], "OP_CHECKSIGADD"]
+        threshold = op_int(self.threshold) if self.threshold <= 16 else self.threshold
+        return [*script, threshold, "OP_NUMEQUAL"]
+
+    def _stack(
+        self, signatures: Mapping[bytes, bytes], index: int, network: str
+    ) -> list[bytes] | None:
+        """Return one element per key, or None where the keys have not signed.
+
+        `threshold` of the elements are signatures and the rest the empty
+        push. A signature beyond the threshold is not spare, which is the
+        first difference from `multi()`: OP_CHECKSIGADD counts every
+        signature that verifies and OP_NUMEQUAL compares the count with
+        the threshold, where OP_CHECKMULTISIG stops at the signatures it
+        was built to pop.
+
+        The elements go in the reverse of the key order, which is the
+        second: the signature of the first key is popped first, so it is
+        the last element of the witness and the top of the stack. Bitcoin
+        Core's satisfier says the same in a comment of its own.
+
+        None rather than an error where fewer keys than the threshold have
+        signed: a leaf is one spending path of a tree, and which of them
+        the signatures at hand open is the question `TrDescriptor` walks
+        the leaves to answer.
+        """
+        offered = [
+            _offered_signature(signatures, sec, x_only=True)
+            for sec in self._pub_keys(index, network)
+        ]
+        if sum(signature is not None for signature in offered) < self.threshold:
+            return None
+        stack: list[bytes] = []
+        signed = 0
+        for signature in offered:
+            if signature is None or signed == self.threshold:
+                stack.append(b"")
+            else:
+                stack.append(signature)
+                signed += 1
+        stack.reverse()
+        return stack
+
+
+# a tr() script tree: a leaf, or a branch of two subtrees. A leaf is the
+# KEY expression a `pk()` leaf is, or the `MultiA` of BIP387's two
+# functions; a branch is a tuple, which is what tells a branch from a
+# leaf. The leaves hold KEY expressions and not scripts because a ranged
+# descriptor has no script until an index is given
+DescriptorLeaf = KeyExpression | MultiA
+DescriptorTree = DescriptorLeaf | tuple["DescriptorTree", "DescriptorTree"]
+
+
+def _leaf_keys(leaf: DescriptorLeaf) -> tuple[KeyExpression, ...]:
+    """Return the KEY expressions of one leaf, in the order it names them."""
+    return leaf.keys if isinstance(leaf, MultiA) else (leaf,)
+
+
+def _tree_leaves(tree: DescriptorTree) -> tuple[DescriptorLeaf, ...]:
+    """Return the leaves left to right, which is the order they are numbered.
+
+    `taproot.tree_helper` walks the left subtree before the right one, so
+    the n-th leaf here is the n-th leaf there, and that number is what
+    `taproot.input_script_sig` takes.
+    """
+    if isinstance(tree, tuple):
+        return _tree_leaves(tree[0]) + _tree_leaves(tree[1])
+    return (tree,)
 
 
 def _tree_keys(tree: DescriptorTree) -> tuple[KeyExpression, ...]:
-    if isinstance(tree, KeyExpression):
-        return (tree,)
-    return _tree_keys(tree[0]) + _tree_keys(tree[1])
+    keys: tuple[KeyExpression, ...] = ()
+    for leaf in _tree_leaves(tree):
+        keys += _leaf_keys(leaf)
+    return keys
+
+
+def _leaf_script(leaf: DescriptorLeaf, index: int, network: str) -> ScriptList:
+    """Return the tapscript of one leaf: a ``pk()``, or a ``multi_a()``."""
+    if isinstance(leaf, MultiA):
+        return leaf._script(index, network)
+    return [leaf.sec(index, network)[1:], "OP_CHECKSIG"]
+
+
+def _leaf_stack(
+    leaf: DescriptorLeaf, signatures: Mapping[bytes, bytes], index: int, network: str
+) -> list[bytes] | None:
+    """Return what satisfies one leaf, None where the signatures do not."""
+    if isinstance(leaf, MultiA):
+        return leaf._stack(signatures, index, network)
+    signature = _offered_signature(signatures, leaf.sec(index, network), x_only=True)
+    return None if signature is None else [signature]
 
 
 def _taproot_script_tree(
     tree: DescriptorTree, index: int, network: str
 ) -> TaprootScriptTree:
-    if isinstance(tree, KeyExpression):
-        script: ScriptList = [tree.sec(index, network)[1:], "OP_CHECKSIG"]
-        return [(_TAPSCRIPT_LEAF_VERSION, script)]
-    return [
-        _taproot_script_tree(tree[0], index, network),
-        _taproot_script_tree(tree[1], index, network),
-    ]
+    if isinstance(tree, tuple):
+        return [
+            _taproot_script_tree(tree[0], index, network),
+            _taproot_script_tree(tree[1], index, network),
+        ]
+    return [(_TAPSCRIPT_LEAF_VERSION, _leaf_script(tree, index, network))]
 
 
 def _offered_signature(
@@ -954,7 +1099,7 @@ class TrDescriptor(Descriptor):
             return {}
         script_tree = _taproot_script_tree(self.tree, index, self.network)
         leaf_scripts: dict[bytes, tuple[bytes, int]] = {}
-        for leaf in range(len(_tree_keys(self.tree))):
+        for leaf in range(len(_tree_leaves(self.tree))):
             script, control_block = self._leaf(script_tree, index, leaf)
             leaf_scripts[control_block] = (script, _TAPSCRIPT_LEAF_VERSION)
         return leaf_scripts
@@ -974,15 +1119,24 @@ class TrDescriptor(Descriptor):
         places of the tree and in one leaf of it, the tapleaf hash being
         of the script, and what a signer reads here is which scripts it
         has to sign for.
+
+        The leaves are walked rather than `taproot_leaf_scripts`, which is
+        keyed by control block: which keys a leaf commits to is what the
+        leaf says and no longer what its script bytes show, a
+        ``multi_a()`` leaf holding as many keys as it names.
         """
         leaf_hashes: dict[bytes, list[bytes]] = {}
-        for script, leaf_version in self.taproot_leaf_scripts(index).values():
-            # a leaf of this module's own making is a push of the key and
-            # OP_CHECKSIG, `pk()` being the only leaf BIP386 reads here,
-            # so the key is what the push holds
-            hashes = leaf_hashes.setdefault(script[1:-1], [])
-            if (hash_ := leaf_hash(leaf_version, script)) not in hashes:
-                hashes.append(hash_)
+        if self.tree is not None:
+            script_tree = _taproot_script_tree(self.tree, index, self.network)
+            for number, leaf in enumerate(_tree_leaves(self.tree)):
+                script = self._leaf(script_tree, index, number)[0]
+                hash_ = leaf_hash(_TAPSCRIPT_LEAF_VERSION, script)
+                for key in _leaf_keys(leaf):
+                    hashes = leaf_hashes.setdefault(
+                        key.sec(index, self.network)[1:], []
+                    )
+                    if hash_ not in hashes:
+                        hashes.append(hash_)
         hd_key_paths: dict[bytes, tuple[list[bytes], BIP32KeyOrigin]] = {}
         for key in self.key_expressions:
             origin = _derived_origin(key, index)
@@ -1005,12 +1159,19 @@ class TrDescriptor(Descriptor):
         under the internal key because that is the key the descriptor
         names.
 
-        A script path witness is the signature, the leaf script and the
-        control block, which is BIP341's order. Both the parity bit and
-        the merkle path in that control block are the descriptor's to
-        compute, holding the whole tree as it does, where a psbt has to
-        be handed them: it is the one thing satisfaction here knows that
-        finalization there cannot work out.
+        A script path witness is what satisfies the leaf, then the leaf
+        script and the control block, which is BIP341's order: one
+        signature for a ``pk()`` leaf, and one element per key for a
+        ``multi_a()`` one. Both the parity bit and the merkle path in that
+        control block are the descriptor's to compute, holding the whole
+        tree as it does, where a psbt has to be handed them: it is the one
+        thing satisfaction here knows that finalization there cannot work
+        out.
+
+        The first leaf the signatures satisfy, left to right, where they
+        satisfy several: they are all valid spends of the same output, and
+        which is the cheapest is a question about weights that this module
+        does not answer.
 
         The script_sig is empty whichever path is taken: BIP341 spends
         a witness v1 program with the witness alone.
@@ -1022,16 +1183,11 @@ class TrDescriptor(Descriptor):
         if self.tree is None:
             raise BTClibValueError("no signature for the tr() internal key")
         script_tree = _taproot_script_tree(self.tree, index, self.network)
-        # _tree_keys and taproot.tree_helper both walk the left subtree
-        # before the right one, so the n-th key is the n-th leaf and the
-        # number is the one input_script_sig takes
-        for leaf, key in enumerate(_tree_keys(self.tree)):
-            signature = _offered_signature(
-                signatures, key.sec(index, self.network), x_only=True
-            )
-            if signature is not None:
-                script, control_block = self._leaf(script_tree, index, leaf)
-                return b"", Witness([signature, script, control_block])
+        for number, leaf in enumerate(_tree_leaves(self.tree)):
+            stack = _leaf_stack(leaf, signatures, index, self.network)
+            if stack is not None:
+                script, control_block = self._leaf(script_tree, index, number)
+                return b"", Witness([*stack, script, control_block])
         err_msg = "no signature for the tr() internal key or for any of its leaves"
         raise BTClibValueError(err_msg)
 
@@ -1243,6 +1399,22 @@ def _parse_key(
     return key_expression
 
 
+def _parse_multi_a(name: str, args: list[str]) -> MultiA:
+    """Return the leaf of a BIP387 ``multi_a()`` or ``sortedmulti_a()``.
+
+    The keys are read as a ``pk()`` leaf's key is, which is what allows
+    BIP387's own vectors to name one by its WIF and the next by an xprv:
+    x-only is the spelling a tapscript holds and not the only spelling a
+    KEY expression has.
+    """
+    if len(args) < 2:
+        raise BTClibValueError(f"{name}() takes a threshold and at least one key")
+    if not _THRESHOLD.fullmatch(args[0]):
+        raise BTClibValueError(f"invalid {name}() threshold: {args[0]}")
+    keys = tuple(_parse_key(key, x_only=True, compressed=True) for key in args[1:])
+    return MultiA(int(args[0]), keys, sort=name == "sortedmulti_a")
+
+
 def _parse_tree(expression: str) -> DescriptorTree:
     """Return the script tree of a BIP386 TREE expression."""
     if expression.startswith("{"):
@@ -1255,10 +1427,12 @@ def _parse_tree(expression: str) -> DescriptorTree:
         return (_parse_tree(branches[0]), _parse_tree(branches[1]))
     name, arguments = _split_function(expression)
     _assert_implemented(name)
+    args = _split_arguments(arguments)
+    if name in _TREE_FUNCTIONS:
+        return _parse_multi_a(name, args)
     if name != "pk":
         raise NotImplementedError(f"{name}() inside tr() is not implemented")
-    key = _one_argument(_split_arguments(arguments), name)
-    return _parse_key(key, x_only=True, compressed=True)
+    return _parse_key(_one_argument(args, name), x_only=True, compressed=True)
 
 
 # inside a witness program an uncompressed key is unspendable, so
@@ -1374,6 +1548,12 @@ def _parse_expression(expression: str, context: str, network: str) -> Descriptor
     """Return the Descriptor of a SCRIPT expression, in its context."""
     name, arguments = _split_function(expression)
     _assert_implemented(name)
+    if name in _TREE_FUNCTIONS:
+        # a tree leaf and no SCRIPT expression, so reaching this is the
+        # position rule of BIP387 being broken: `_assert_position` says
+        # which position it was, where "unknown function" would say the
+        # language has no such word
+        _assert_position(name, context, (_P2TR,))
     if name not in _PARSERS:
         raise BTClibValueError(f"unknown descriptor function: {name}()")
     allowed, parser = _PARSERS[name]

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -39,6 +39,7 @@ from btclib.descriptors import (
     ComboDescriptor,
     Descriptor,
     KeyExpression,
+    MultiA,
     MultiDescriptor,
     PkDescriptor,
     RawDescriptor,
@@ -62,7 +63,8 @@ from btclib.psbt.psbt import (
     taproot_sig_hash,
 )
 from btclib.psbt.psbt_in import PsbtIn
-from btclib.script import taproot
+from btclib.script import sig_hash, taproot
+from btclib.script.engine import verify_transaction
 from btclib.script.script import serialize
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.script.witness import Witness
@@ -498,10 +500,6 @@ def test_doc_descriptor(descriptor: str) -> None:
     a notation for a script, and `ScriptPubKey.from_address` has to give
     back the very script the descriptor derived.
     """
-    if "sortedmulti_a(" in descriptor:
-        with pytest.raises(NotImplementedError, match="sortedmulti_a"):
-            parse(descriptor)
-        return
     script_pub_keys = parse(descriptor).script_pub_keys()
     assert script_pub_keys
     for script_pub_key in script_pub_keys:
@@ -509,19 +507,6 @@ def test_doc_descriptor(descriptor: str) -> None:
         # p2pk and bare multisig have no address, which is not a failure
         if address:
             assert ScriptPubKey.from_address(address) == script_pub_key
-
-
-def test_doc_descriptors_are_read_but_for_one() -> None:
-    """Seventeen of Core's eighteen documented descriptors expand here.
-
-    The eighteenth is a `sortedmulti_a()`, BIP387, refused rather than
-    guessed at. Counted rather than assumed, so that refreshing the
-    vendored file cannot move a descriptor from one group to the other
-    unnoticed.
-    """
-    unimplemented = [d for d in DOC_DESCRIPTORS if "sortedmulti_a(" in d]
-    assert len(DOC_DESCRIPTORS) == 18
-    assert len(unimplemented) == 1
 
 
 def test_sortedmulti_sorts_what_multi_leaves_alone() -> None:
@@ -764,6 +749,9 @@ def test_descriptor_is_abstract() -> None:
 
 KEY = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
 UNCOMPRESSED = "04a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd5b8dec5235a0fa8722476c7709c02559e3aa73aa03918ba2d492eea75abea235"
+# the same two keys as WIFs, which is how BIP387 writes them
+WIF = "L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1"
+UNCOMPRESSED_WIF = "5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss"
 XPUB = "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
 XONLY = "a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
 OFF_CURVE = "020000000000000000000000000000000000000000000000000000000000000005"
@@ -863,8 +851,6 @@ UNIMPLEMENTED = [
     ),
     (f"wsh(thresh(1,pk({KEY})))", "187"),
     (f"wsh(s:pk({KEY}))", "187"),
-    (f"tr({XONLY},multi_a(1,{XONLY}))", "BIP387"),
-    (f"tr({XONLY},sortedmulti_a(1,{XONLY}))", "BIP387"),
     (f"tr({XONLY},pkh({KEY}))", "inside tr"),
     (f"rawtr({XONLY})", "BIP386"),
     (f"tr(musig({KEY},{KEY}))", "BIP390"),
@@ -884,6 +870,179 @@ def test_unimplemented(descriptor: str, message: str) -> None:
         parse(descriptor)
 
 
+# BIP387's own test vectors, transcribed from `bip-0387.mediawiki`: a
+# valid descriptor and the scriptPubKey it produces, three of them where
+# the keys derive. The third and the fourth are the same two keys, ordered
+# and sorted, so the pair says both that the sorting happens and which
+# script each spelling means
+BIP387_VECTORS: list[tuple[str, list[str]]] = [
+    (
+        "tr(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1,multi_a(1,KzoAz5CanayRKex3fSLQ2BwJpN7U52gZvxMyk78nDMHuqrUxuSJy))",
+        ["5120eb5bd3894327d75093891cc3a62506df7d58ec137fcd104cdd285d67816074f3"],
+    ),
+    (
+        "tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,multi_a(1,669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0))",
+        ["5120eb5bd3894327d75093891cc3a62506df7d58ec137fcd104cdd285d67816074f3"],
+    ),
+    (
+        "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,multi_a(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))",
+        ["51202eea93581594a43c0c8423b70dc112e5651df63984d108d4fc8ccd3b63b4eafa"],
+    ),
+    (
+        "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,sortedmulti_a(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))",
+        ["512016fa6a6ba7e98c54b5bf43b3144912b78a61b60b02f6a74172b8dcb35b12bc30"],
+    ),
+    (
+        "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,sortedmulti_a(2,xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/*,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0/0/*))",
+        [
+            "5120abd47468515223f58a1a18edfde709a7a2aab2b696d59ecf8c34f0ba274ef772",
+            "5120fe62e7ed20705bd1d3678e072bc999acb014f07795fa02cb8f25a7aa787e8cbd",
+            "51201311093750f459039adaa2a5ed23b0f7a8ae2c2ffb07c5390ea37e2fb1050b41",
+        ],
+    ),
+    (
+        "tr(50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0,multi_a(2,xprv9s21ZrQH143K31xYSDQpPDxsXRTUcvj2iNHm5NUtrGiGG5e2DtALGdso3pGz6ssrdK4PFmM8NSpSBHNqPqm55Qn3LqFtT2emdEXVYsCzC2U/2147483647'/0,xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt/1/2/*,xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi/10/20/30/40/*'))",
+        [
+            "5120e4c8f2b0a7d3a688ac131cb03248c0d4b0a59bbd4f37211c848cfbd22a981192",
+            "5120827faedaa21e52fca2ac83b53afd1ab7d4d1e6ce67ff42b19f2723d48b5a19ab",
+            "5120647495ed09de61a3a324704f9203c130d655bf3141f9b748df8f7be7e9af55a4",
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "descriptor, scripts",
+    [
+        pytest.param(descriptor, scripts, id=vector_id(index, descriptor))
+        for index, (descriptor, scripts) in enumerate(BIP387_VECTORS)
+    ],
+)
+def test_bip387_vector(descriptor: str, scripts: list[str]) -> None:
+    """Reproduce BIP387's own vectors: the script at each index it lists."""
+    parsed = parse(descriptor)
+    assert parsed.is_ranged == (len(scripts) > 1)
+    for index, expected in enumerate(scripts):
+        assert parsed.script_pub_key(index).script.hex() == expected
+
+
+# BIP387's invalid descriptors, and what each is refused with. The
+# threshold bounds are checked where the script is built, as `multi()`'s
+# are in `ScriptPubKey.p2ms`, so for those the refusal comes from
+# `script_pub_key` and for the rest from `parse`
+BIP387_INVALID = [
+    (f"multi_a(1,{KEY})", "not allowed inside top level"),
+    (f"sh(multi_a(1,{KEY}))", "not allowed inside sh"),
+    (f"wsh(multi_a(1,{KEY}))", "not allowed inside wsh"),
+    (f"tr({XONLY},multi_a(a,{KEY}))", "invalid multi_a\\(\\) threshold"),
+    (f"tr({XONLY},multi_a(0,{KEY}))", "invalid k in k-of-n multi_a"),
+    (f"tr({XONLY},multi_a(1,{UNCOMPRESSED}))", "uncompressed"),
+    # BIP387's own "threshold larger than keys" case names two
+    # uncompressed WIFs, and an uncompressed key is refused before any
+    # threshold is read: it is the case below that reaches the bound
+    (f"tr({XONLY},multi_a(3,{WIF},{UNCOMPRESSED_WIF}))", "uncompressed"),
+    (f"tr({XONLY},multi_a(3,{KEY},{KEY}))", "invalid k in k-of-n multi_a"),
+    # and what BIP387 does not list: a threshold with no key after it
+    (f"tr({XONLY},multi_a(1))", "at least one key"),
+]
+
+
+@pytest.mark.parametrize(
+    "descriptor, message",
+    [
+        pytest.param(descriptor, message, id=vector_id(index, descriptor))
+        for index, (descriptor, message) in enumerate(BIP387_INVALID)
+    ],
+)
+def test_bip387_invalid(descriptor: str, message: str) -> None:
+    """Refuse each of BIP387's invalid descriptors, with the reason named."""
+    with pytest.raises(BTClibValueError, match=message):
+        parse(descriptor).script_pub_key()
+
+
+def leaf_script_of(descriptor: str) -> bytes:
+    """Return the one leaf script of a tr() whose tree is a single leaf."""
+    parsed = parse(descriptor)
+    assert isinstance(parsed, TrDescriptor)
+    ((script, _),) = parsed.taproot_leaf_scripts().values()
+    return script
+
+
+def test_multi_a_is_a_tree_leaf_and_not_a_descriptor() -> None:
+    """What a `multi_a()` parses to is a `MultiA` leaf, its keys and all."""
+    descriptor = parse(f"tr({XONLY},multi_a(2,{KEY},{XONLY}))")
+    assert isinstance(descriptor, TrDescriptor)
+    leaf = descriptor.tree
+    assert isinstance(leaf, MultiA)
+    assert leaf.threshold == 2
+    assert not leaf.sort
+    # the internal key and both of the leaf's keys, in that order
+    assert len(descriptor.key_expressions) == 3
+    assert descriptor.key_expressions[1:] == leaf.keys
+    sorted_ = parse(f"tr({XONLY},sortedmulti_a(2,{KEY},{XONLY}))")
+    assert isinstance(sorted_, TrDescriptor)
+    assert isinstance(sorted_.tree, MultiA)
+    assert sorted_.tree.sort
+
+
+def test_sortedmulti_a_sorts_on_the_x_only_keys() -> None:
+    """BIP387 sorts the 32 bytes the script holds, not the 33 SEC bytes.
+
+    The two spellings of a key differ by the prefix that says the parity
+    of y, so sorting the SEC form would order the keys by that parity
+    first. These two are chosen for it: the odd-y key is the smaller of
+    the two x-only and the larger of the two SEC, so one sort puts it
+    first and the other last.
+    """
+    odd_y = "032fa2104d6b38d11b0230010559879124e42ab8dfeff5ff29dc9cdadd4ecacc3f"
+    even_y = "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+    assert odd_y[2:] < even_y[2:]
+    assert odd_y > even_y
+    assert leaf_script_of(
+        f"tr({XONLY},sortedmulti_a(1,{even_y},{odd_y}))"
+    ) == serialize(
+        [
+            bytes.fromhex(odd_y[2:]),
+            "OP_CHECKSIG",
+            bytes.fromhex(even_y[2:]),
+            "OP_CHECKSIGADD",
+            "OP_1",
+            "OP_NUMEQUAL",
+        ]
+    )
+
+
+def test_a_multi_a_threshold_above_sixteen_is_pushed_as_a_number() -> None:
+    """OP_1 to OP_16 are the thresholds an op code means, and 17 has none.
+
+    Which is what BIP387 says about the script, and the only thing the
+    seventeenth key changes beyond the length: sixteen ends in the single
+    byte `60`, seventeen in the two-byte push `0111`, and `9c` is
+    OP_NUMEQUAL either way.
+    """
+    keys = ",".join([KEY] * 17)
+    assert leaf_script_of(f"tr({XONLY},multi_a(16,{keys}))").endswith(
+        bytes.fromhex("609c")
+    )
+    assert leaf_script_of(f"tr({XONLY},multi_a(17,{keys}))").endswith(
+        bytes.fromhex("01119c")
+    )
+
+
+def test_too_many_keys_for_a_multi_a() -> None:
+    """BIP387 stops at 999 keys, a satisfaction being one element per key.
+
+    Built rather than parsed: a thousand key expressions is a descriptor
+    nobody writes, and the bound is on what the leaf holds.
+    """
+    (key,) = parse(f"tr({XONLY})").key_expressions
+    with pytest.raises(BTClibValueError, match="invalid n in k-of-n multi_a"):
+        TrDescriptor(key, MultiA(1, (key,) * 1000)).script_pub_key()
+    # and the last count BIP387 allows is a script this builds
+    allowed = TrDescriptor(key, MultiA(1, (key,) * 999))
+    assert allowed.script_pub_key().script
+
+
 # three keys and a signature made with each. Real DER signatures rather
 # than placeholder bytes because the psbt finalizer that satisfaction is
 # checked against parses every partial signature it is handed, so a
@@ -898,6 +1057,10 @@ KEY_A, KEY_B, KEY_C = SEC_KEYS
 # the x-only spelling of the same three, which is what a tr() holds
 XONLY_A, XONLY_B, XONLY_C = (sec[2:] for sec in SEC_KEYS)
 SCHNORR = ssa.sign(bytes(32), 1).serialize().hex()
+# the same message signed by the other two keys: a stack holding several
+# signatures says which key's is where only if they differ
+SCHNORR_B = ssa.sign(bytes(32), 2).serialize().hex()
+SCHNORR_C = ssa.sign(bytes(32), 3).serialize().hex()
 
 MULTI = f"multi(2,{KEY_A},{KEY_B},{KEY_C})"
 SORTED_MULTI = f"sortedmulti(2,{KEY_A},{KEY_B},{KEY_C})"
@@ -1069,6 +1232,98 @@ def test_the_taproot_key_path_is_preferred() -> None:
     assert descriptor.satisfy({XONLY_A: SCHNORR}) == (b"", Witness([SCHNORR]))
 
 
+# a 2-of-3 `multi_a()` of the three keys above, under an internal key
+# nothing here can sign with: the key path is preferred wherever it is
+# open, so an internal key with no signature is what leaves the script
+# path to be exercised
+MULTI_A = f"tr({XONLY},multi_a(2,{XONLY_A},{XONLY_B},{XONLY_C}))"
+
+
+def test_satisfy_a_multi_a_leaf() -> None:
+    """One element per key, in the reverse of the order the script holds.
+
+    OP_CHECKSIG pops the first key's signature first, so that signature is
+    the last element of the witness and the top of the stack -- the
+    opposite of `multi()`, where the signatures go in key order. The key
+    that has not signed is the empty push, which `multi()` has nothing
+    standing for at all.
+    """
+    script_sig, witness = parse(MULTI_A).satisfy({XONLY_A: SCHNORR, XONLY_C: SCHNORR_C})
+    assert script_sig == b""
+    signatures = witness.stack[:3]
+    assert signatures == (bytes.fromhex(SCHNORR_C), b"", bytes.fromhex(SCHNORR))
+    assert witness.stack[3] == leaf_script_of(MULTI_A)
+
+
+def test_a_multi_a_signature_beyond_the_threshold_is_not_spare() -> None:
+    """The third signature of a 2-of-3 becomes the empty push, not a fourth.
+
+    Which is the other difference from `multi()`: OP_CHECKSIGADD counts
+    every signature that verifies and OP_NUMEQUAL compares that count with
+    the threshold, where OP_CHECKMULTISIG pops the signatures the script
+    was built for and leaves the rest alone.
+    """
+    witness = parse(MULTI_A).satisfy(
+        {XONLY_A: SCHNORR, XONLY_B: SCHNORR_B, XONLY_C: SCHNORR_C}
+    )[1]
+    # the three keys in reverse order, the third one's signature dropped
+    assert witness.stack[:3] == (
+        b"",
+        bytes.fromhex(SCHNORR_B),
+        bytes.fromhex(SCHNORR),
+    )
+
+
+def test_a_leaf_the_signatures_do_not_open_is_the_next_leaf_s_turn() -> None:
+    """A tree is several spending paths, and a leaf short of one is not one.
+
+    The 2-of-2 comes first in the tree and only one of its keys has
+    signed, so what satisfies the descriptor is the `pk()` beside it. No
+    error either, which is what a leaf answering "not with these
+    signatures" rather than raising is for.
+    """
+    descriptor = parse(f"tr({XONLY},{{multi_a(2,{XONLY_A},{XONLY_B}),pk({XONLY_C})}})")
+    script_sig, witness = descriptor.satisfy({XONLY_A: SCHNORR, XONLY_C: SCHNORR_C})
+    assert script_sig == b""
+    signature, script, _ = witness.stack
+    assert signature == bytes.fromhex(SCHNORR_C)
+    assert script == serialize([bytes.fromhex(XONLY_C), "OP_CHECKSIG"])
+
+
+def test_a_multi_a_leaf_spends_under_the_engine() -> None:
+    """The satisfaction is checked by running it, and not by its shape.
+
+    A stack in the wrong order is a witness that looks well formed and
+    that OP_CHECKSIGADD counts to something else, so the oracle here is
+    btclib's own script engine: the sig_hash, the tapleaf hash, the
+    control block, the two signatures and their places all have to agree
+    for it to accept the spend.
+    """
+    descriptor = parse(MULTI_A)
+    assert isinstance(descriptor, TrDescriptor)
+    script_pub_key = descriptor.script_pub_key()
+    prevouts = [TxOut(100_000, script_pub_key)]
+    ((control_block, (script, _)),) = descriptor.taproot_leaf_scripts().items()
+
+    vin = TxIn(OutPoint(b"\x11" * 32, 0))
+    # the sig_hash of a script path spend commits to the tapleaf hash, and
+    # sig_hash reads that off the witness: the leaf script and the control
+    # block are the whole of the stack it looks at, so a placeholder
+    # carrying them is enough to sign against
+    vin.script_witness = Witness([b"", b"", b"", script, control_block])
+    tx = Tx(vin=[vin], vout=[TxOut(90_000, script_pub_key)])
+    msg_hash = sig_hash.from_tx(prevouts, tx, 0, sig_hash.DEFAULT)
+
+    signatures: dict[Octets, Octets] = {
+        x_only: ssa.sign_(msg_hash, prv_key).serialize()
+        for x_only, prv_key in ((XONLY_A, 1), (XONLY_C, 3))
+    }
+    script_sig, witness = descriptor.satisfy(signatures)
+    assert script_sig == b""
+    tx.vin[0].script_witness = witness
+    verify_transaction(prevouts, tx)
+
+
 # what cannot be satisfied, and what says so. Each refusal is a
 # BTClibValueError rather than the NotImplementedError the parser raises
 # for miniscript: nothing a later release adds makes any of these
@@ -1084,6 +1339,11 @@ UNSATISFIABLE: list[tuple[str, dict[Octets, Octets], str]] = [
     ("raw(76a914000000000000000000000000000000000000000088ac)", {}, "raw\\(\\) cannot"),
     (f"tr({XONLY_A})", {}, "no signature for the tr\\(\\) internal key"),
     (f"tr({XONLY_A},pk({XONLY_B}))", {}, "or for any of its leaves"),
+    (
+        f"tr({XONLY_A},multi_a(2,{XONLY_B},{XONLY_C}))",
+        {XONLY_B: SCHNORR},
+        "or for any of its leaves",
+    ),
 ]
 
 
@@ -1326,6 +1586,31 @@ def test_a_taproot_key_origin_names_the_leaves_it_is_in() -> None:
     ):
         leaf_hashes, origin = psbt_in.taproot_hd_key_paths[key]
         script = taproot_leaf_of(psbt_in, key.hex())[0]
+        assert leaf_hashes == [taproot.leaf_hash(0xC0, script)]
+        assert origin.description == description
+
+
+def test_the_updater_names_the_leaf_a_multi_a_key_is_in() -> None:
+    """A leaf commits to as many keys as it names, and BIP371 to each.
+
+    The tapleaf hash is of the whole script, so both keys of one
+    `multi_a()` name one hash and the same one: what a signer reads there
+    is which scripts it has to sign for, and this is a script both of them
+    have to sign. The internal key carries no origin here, so what the
+    field holds is the leaf's two keys and nothing else.
+    """
+    left, right = f"[aabbccdd/1]{XPUB}/1", f"[11223344/2]{XPUB}/2"
+    descriptor = parse(f"tr({XONLY},multi_a(2,{left},{right}))")
+    assert isinstance(descriptor, TrDescriptor)
+    psbt_in = descriptor.update_psbt(psbt_spending(descriptor), 0).inputs[0]
+
+    assert psbt_in.taproot_leaf_scripts == descriptor.taproot_leaf_scripts()
+    ((script, version),) = psbt_in.taproot_leaf_scripts.values()
+    assert version == 0xC0
+    keys = [key.sec()[1:] for key in descriptor.key_expressions[1:]]
+    assert list(psbt_in.taproot_hd_key_paths) == keys
+    for key, description in zip(keys, ("aabbccdd/1/1", "11223344/2/2"), strict=True):
+        leaf_hashes, origin = psbt_in.taproot_hd_key_paths[key]
         assert leaf_hashes == [taproot.leaf_hash(0xC0, script)]
         assert origin.description == description
 


### PR DESCRIPTION
## What this changes

`multi_a()` and `sortedmulti_a()` are read inside `tr()`, which is BIP387
and what the parser refused by name until now. Closes #448.

A leaf of a script tree is either a `pk()`, the bare `KeyExpression` it
always was, or the new `MultiA` — a threshold, the keys, and whether they
are sorted — so `DescriptorTree` has two kinds of leaf and
`DescriptorLeaf` names them. Neither leaf is a `Descriptor`: no output
pays to a `multi_a()` on its own, what pays is the `tr()` above it.

The script is BIP387's: a CHECKSIG and one CHECKSIGADD per further key,
with the threshold pushed as OP_1 to OP_16 where an op code means it and
as the number itself above that. The keys of a `sortedmulti_a()` are
sorted on the 32 x-only bytes the script carries and not on their 33-byte
SEC form, which for a key of odd y is another order — and reachable, a KEY
expression naming such a key by its WIF or its xpub.

Satisfaction puts one element per key, threshold of them signatures and
the rest the empty push, in the reverse of the key order: OP_CHECKSIGADD
counts every signature that verifies and OP_NUMEQUAL compares that count
with the threshold, so the first key's signature has to be on top of the
stack and a signature beyond the threshold would make the count wrong —
both the opposite of what `multi()` needs. `tr()` walks its leaves and
takes the first the signatures open; a leaf they do not open is the next
leaf's turn rather than an error.

`TrDescriptor._taproot_hd_key_paths` reads the keys off each leaf instead
of off its script bytes, which a leaf of one key allowed and a
`multi_a()` does not: the two keys of one leaf name one tapleaf hash, and
the same one, the hash being of the whole script.

## How it was verified

- BIP387's own vectors, transcribed from `bip-0387.mediawiki`: six valid
  descriptors and the scriptPubKey each produces, three scripts for each
  of the ranged ones, plus the invalid list. Two of the valid ones are
  the same two keys ordered and sorted, so the pair says both that the
  sorting happens and which script each spelling means.
- the satisfaction against btclib's own script engine, which runs it
  rather than reading its shape: `test_a_multi_a_leaf_spends_under_the_engine`
  signs a 2-of-3 leaf against the BIP342 sig_hash and has
  `verify_transaction` accept the spend, so a stack in the wrong order is
  a failure and not a passing shape assertion.
- the eighteenth descriptor of Core's `doc/descriptors.md` — a
  `sortedmulti_a()` — is now read like the other seventeen, so the test
  that expected it to be refused is gone.
- `pytest --cov=btclib --cov=tests`: 17260 passed, coverage 100.00%.

## Checks

- [x] `uv run pre-commit run --all-files` is clean (ruff, mypy strict,
      markdownlint, the copyright notice, `uv.lock`)
- [x] `uv run pytest` passes
- [x] `CHANGELOG.md` has an entry, if a user would notice the change;
      `HISTORY.md` too, if it is one a user has to act on

`HISTORY.md` is untouched: the change adds a grammar the parser refused
and breaks no caller, so there is nothing to act on. The sphinx gate was
run too — `sphinx-build -W --keep-going` — since a docstring is what this
mostly adds.

## Anything the reviewer should know

- the k-of-n bounds and the 999-key limit are checked where the script is
  built and not in the parser, for the reason `multi()`'s are in
  `ScriptPubKey.p2ms`: a descriptor built by hand reaches the builder and
  not the parser. BIP387's invalid descriptors are therefore refused by
  `script_pub_key()` for the two bounds and by `parse()` for the rest,
  which is what the test asks of each.
- BIP387's own "threshold larger than keys" case names two uncompressed
  WIFs, and an uncompressed key is refused before any threshold is read.
  The vector is kept as written, with a compressed pair beside it that
  reaches the bound.
- `_assert_position(name, context, (_P2TR,))` in `_parse_expression`
  always raises: a tree leaf never arrives there with a `tr()` context,
  and the call is what makes the message say which position was wrong
  instead of "unknown descriptor function".
- the Finalizer is untouched, so `satisfy` can now spend a shape
  `finalize` cannot. That is not a new gap and not a silent one:
  `psbt.single_leaf_key` already refuses a leaf that is not a single key
  and OP_CHECKSIG, by name, and its docstring says why — a leaf asking
  for more than one signature is a stack the psbt says nothing about.
  Closing it means a Finalizer that reads the leaf script, which is
  miniscript's satisfier question and belongs with #187.

## Summary by Sourcery

Add support for BIP387 taproot script leaves multi_a() and sortedmulti_a() inside tr(), updating taproot descriptors, satisfaction, and PSBT key path handling accordingly.

New Features:
- Support parsing and construction of multi_a() and sortedmulti_a() leaves within tr() taproot descriptors, including script generation and satisfaction semantics aligned with BIP387.

Enhancements:
- Extend taproot descriptor tree representation to distinguish pk() leaves from multi_a() leaves via a new MultiA leaf type and DescriptorLeaf alias.
- Update taproot HD key path computation to derive tapleaf hashes from descriptor leaves rather than script bytes, correctly handling leaves with multiple keys.
- Adjust taproot satisfaction logic to walk leaves and satisfy either pk() or multi_a() leaves, treating unsatisfied leaves as fallthrough to the next path.

Documentation:
- Document BIP387 support and the new MultiA/DescriptorLeaf structures in descriptors.py and CHANGELOG, clarifying the descriptor grammar and supported taproot leaves.

Tests:
- Add comprehensive tests for BIP387 multi_a()/sortedmulti_a() vectors, invalid descriptors, script encoding details, satisfaction behaviour, interaction with the script engine, error cases, and PSBT updater key-path annotations while removing the previous expectation that sortedmulti_a() descriptors are rejected.