### PR TITLE
Keep the hardening symbol a key expression was written with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,25 @@ edit.
 
 ### The public API and the module layout
 
+- **a key expression remembers which hardening symbol spelled it**
+  (issue #381). `KeyExpression.hardening` is ``h`` or ``'``, whichever
+  the expression used, defaulting to ``h`` where it hardened nothing.
+  BIP380 gives the two one meaning, and they are two strings with two
+  checksums — `wpkh([00000000/84h/0h/0h]xpub…/0/*)` checksums to
+  `ny9ympxj` and the apostrophe spelling to `q46mpm33` — so a serializer
+  that cannot tell them apart hands back a descriptor that is not the
+  one it read.
+
+  One symbol for the whole expression, origin included, which is Bitcoin
+  Core's single `m_apostrophe` per key: the last hardened step read wins,
+  in the order the expression writes them — the origin's path, then the
+  key's, then the wildcard. A path spelled both ways, which is BIP380's
+  own valid `[deadbeef/0'/0h/0']`, is written back in the second symbol.
+  `BIP32KeyOrigin` does not carry it and does not change: an origin is a
+  fingerprint and a path whichever way the path was spelled, so two that
+  differ in nothing else stay equal, stay one hash and serialize to the
+  same bytes.
+
 - **a parsed descriptor holds no key that signs** (issue #381).
   `KeyExpression.xkey` kept the xprv the descriptor was written with, so
   a `repr()`, a log line or a bug report could carry it, and every

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -89,7 +89,12 @@ from typing import cast
 
 from btclib.alias import Octets, ScriptList, TaprootScriptTree
 from btclib.bip32.bip32 import BIP32KeyData, derive, xpub_from_xprv
-from btclib.bip32.der_path import indexes_from_der_path
+from btclib.bip32.der_path import (
+    _HARDENED_OFFSET,
+    _HARDENING,
+    hardenings_from_der_path,
+    indexes_from_der_path,
+)
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
 from btclib.psbt.psbt import Psbt
@@ -306,6 +311,15 @@ class KeyExpression:
     # is only meaningful when there is a wildcard to harden
     wildcard: int | None = None
     x_only: bool = False
+    # the symbol every hardened step of this expression is written with:
+    # BIP380 gives "h" and "'" one meaning and two spellings, and the two
+    # are different strings with different checksums, so a descriptor
+    # handed back in the other one is not the descriptor that was read.
+    # One symbol for the whole expression, origin included, which is
+    # Bitcoin Core's single `m_apostrophe` per key: a path spelled both
+    # ways -- BIP380's own valid `[deadbeef/0'/0h/0']` -- is read and
+    # written back in the symbol its last hardened step used
+    hardening: str = _HARDENING
 
     @property
     def is_ranged(self) -> bool:
@@ -1426,12 +1440,34 @@ def _der_path(path: str) -> list[int]:
     return indexes_from_der_path(path, bip380_enforced=True) if path else []
 
 
-def _key_origin(description: str) -> BIP32KeyOrigin:
-    """Return the key origin of a `[fingerprint/path]` prefix."""
+def _hardening(path: str) -> str:
+    """Return the symbol the last hardened step of a path was written with.
+
+    Empty where the path hardens nothing, so that a caller choosing
+    between two paths can tell "no opinion" from "an apostrophe". The
+    last and not the first, which is Bitcoin Core's rule by construction:
+    its parser assigns the bool per hardened element, so the one it ends
+    on is the one that is written back.
+    """
+    if not path:
+        return ""
+    symbols = [s for s in hardenings_from_der_path(path, bip380_enforced=True) if s]
+    return symbols[-1] if symbols else ""
+
+
+def _key_origin(description: str) -> tuple[BIP32KeyOrigin, str]:
+    """Return the key origin of a `[fingerprint/path]` prefix, and its symbol.
+
+    The symbol is the origin's alone, and the caller picks between it and
+    the key path's: `BIP32KeyOrigin` does not carry it, an origin being a
+    fingerprint and a path whichever way the path was spelled -- two
+    origins that differ in nothing else are the same origin, and equality
+    and `serialize` both have to keep saying so.
+    """
     fingerprint, _, path = description.partition("/")
     if not _FINGERPRINT.fullmatch(fingerprint):
         raise BTClibValueError(f"invalid key origin fingerprint: {fingerprint}")
-    return BIP32KeyOrigin(fingerprint, _der_path(path))
+    return BIP32KeyOrigin(fingerprint, _der_path(path)), _hardening(path)
 
 
 def _pub_key_from_hex(key: str, *, x_only: bool) -> tuple[bytes, bool]:
@@ -1491,16 +1527,17 @@ def _neutered(xkey: str, prv_keys: dict[str, str]) -> str:
     return xpub
 
 
-def _origin_and_rest(expression: str) -> tuple[BIP32KeyOrigin | None, str]:
+def _origin_and_rest(expression: str) -> tuple[BIP32KeyOrigin | None, str, str]:
     """Split the `[fingerprint/path]` prefix off a KEY expression."""
     if not expression.startswith("["):
         if "]" in expression:
             raise BTClibValueError("']' without the '[' that opens a key origin")
-        return None, expression
+        return None, "", expression
     end = expression.find("]")
     if end < 0:
         raise BTClibValueError("missing ']' in the key origin")
-    return _key_origin(expression[1:end]), expression[end + 1 :]
+    origin, hardening = _key_origin(expression[1:end])
+    return origin, hardening, expression[end + 1 :]
 
 
 def _assert_key_characters(rest: str) -> None:
@@ -1517,11 +1554,12 @@ def _assert_key_characters(rest: str) -> None:
         raise BTClibValueError("not a key expression")
 
 
-def _split_wildcard(steps: list[str]) -> tuple[list[str], int | None]:
-    """Split the final `/*` step, if any, off a derivation path."""
+def _split_wildcard(steps: list[str]) -> tuple[list[str], int | None, str]:
+    """Split the final `/*` step off a path: its offset, and its symbol."""
     if steps and steps[-1] in ("*", "*'", "*h"):
-        return steps[:-1], 0 if steps[-1] == "*" else 0x80000000
-    return steps, None
+        offset = 0 if steps[-1] == "*" else _HARDENED_OFFSET
+        return steps[:-1], offset, steps[-1][1:]
+    return steps, None, ""
 
 
 def _fixed_pub_key(key: str, *, x_only: bool) -> tuple[bytes, bool]:
@@ -1548,22 +1586,39 @@ def _parse_key(
     Never echo the key in an error message: a KEY expression is a WIF or
     an xprv as often as it is a public key, and an error message ends up
     in logs and in bug reports.
+
+    The hardening symbol is the last one the expression used, read in the
+    order it is written: the origin's path, then the key's, then the
+    wildcard. A fixed key hardens nothing and keeps the default, there
+    being no step of it to write.
     """
-    origin, rest = _origin_and_rest(expression)
+    origin, origin_hardening, rest = _origin_and_rest(expression)
     _assert_key_characters(rest)
     key, separator, path = rest.partition("/")
     if _is_extended_key(key):
-        steps, wildcard = _split_wildcard(path.split("/") if separator else [])
+        steps, wildcard, wildcard_hardening = _split_wildcard(
+            path.split("/") if separator else []
+        )
+        der_path = "/".join(steps)
+        hardening = origin_hardening
+        for symbol in (_hardening(der_path), wildcard_hardening):
+            hardening = symbol or hardening
         return KeyExpression(
             origin=origin,
             xkey=_neutered(key, prv_keys),
-            der_path=tuple(_der_path("/".join(steps))),
+            der_path=tuple(_der_path(der_path)),
             wildcard=wildcard,
+            hardening=hardening or _HARDENING,
         )
     if separator:
         raise BTClibValueError("derivation path after a key that cannot derive")
     pub_key, was_x_only = _fixed_pub_key(key, x_only=x_only)
-    key_expression = KeyExpression(origin=origin, pub_key=pub_key, x_only=was_x_only)
+    key_expression = KeyExpression(
+        origin=origin,
+        pub_key=pub_key,
+        x_only=was_x_only,
+        hardening=origin_hardening or _HARDENING,
+    )
     if compressed and not key_expression.is_compressed:
         raise BTClibValueError("uncompressed public keys are not allowed here")
     return key_expression

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -35,6 +35,7 @@ from hypothesis import strategies as st
 from btclib.alias import Octets
 from btclib.bip32 import BIP32KeyOrigin
 from btclib.bip32.bip32 import xpub_from_xprv
+from btclib.bip32.der_path import _HARDENING
 from btclib.descriptors import (
     AddrDescriptor,
     ComboDescriptor,
@@ -739,6 +740,58 @@ def test_a_hardened_step_takes_the_keys_back() -> None:
     # hardened step is refused the way it is with no mapping at all
     with pytest.raises(BTClibValueError, match="hardened derivation"):
         hardened.script_pub_keys(0, {"xpub-of-somebody-else": xprv})
+
+
+def test_the_hardening_symbol_that_was_read_is_the_one_kept() -> None:
+    """A key expression remembers which of the two spellings it was written in.
+
+    BIP380 gives ``h`` and ``'`` one meaning, and the two are different
+    strings with different checksums, so which one was read is what
+    writing the descriptor back again takes.
+    """
+    key = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+
+    for symbol in ("h", "'"):
+        parsed = parse(f"pkh([deadbeef/1/2{symbol}/3]{key})")
+        assert parsed.key_expressions[0].hardening == symbol
+
+    # BIP380's own valid vector with mixed indicators: one symbol for the
+    # expression, and it is the last hardened step's, which is Bitcoin
+    # Core's single m_apostrophe by construction
+    mixed = parse(f"pk([deadbeef/0'/0h/0']{key})")
+    assert mixed.key_expressions[0].hardening == "'"
+    assert parse(f"pk([deadbeef/0'/0h/0h]{key})").key_expressions[0].hardening == "h"
+
+    # the key's own path is written after the origin's, and the wildcard
+    # after both, so each in turn has the last word
+    assert parse(f"wpkh([deadbeef/0']{XPUB}/1h/2)").key_expressions[0].hardening == "h"
+    assert parse(f"wpkh([deadbeef/0h]{XPUB}/1'/2)").key_expressions[0].hardening == "'"
+    assert parse(f"wpkh([deadbeef/0h]{XPUB}/1/*')").key_expressions[0].hardening == "'"
+    assert parse(f"wpkh([deadbeef/0']{XPUB}/1/*h)").key_expressions[0].hardening == "h"
+
+    # a path that hardens nothing, and a key that has no path at all,
+    # keep the default rather than an answer they were never given
+    assert parse(f"wpkh({XPUB}/1/2)").key_expressions[0].hardening == _HARDENING
+    assert parse(f"pk({key})").key_expressions[0].hardening == _HARDENING
+
+
+def test_the_origin_is_the_same_whichever_symbol_spelled_it() -> None:
+    """The spelling is the key expression's, and never the origin's.
+
+    `BIP32KeyOrigin` is a fingerprint and a path: two that differ in
+    nothing else are equal, serialize to the same bytes and hash the
+    same, whichever way the descriptor wrote the path. Which is why the
+    symbol is a field of the KeyExpression around it.
+    """
+    key = "03a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+    apostrophes = parse(f"pkh([deadbeef/1/2'/3]{key})").key_expressions[0]
+    aitches = parse(f"pkh([deadbeef/1/2h/3]{key})").key_expressions[0]
+
+    assert apostrophes.origin == aitches.origin
+    assert hash(apostrophes.origin) == hash(aitches.origin)
+    assert apostrophes.hardening != aitches.hardening
+    # and so the two key expressions are not the same key expression
+    assert apostrophes != aitches
 
 
 def test_key_origin_is_kept() -> None:


### PR DESCRIPTION
Work package 2 of #381, and the last one before the serializer itself.

BIP380 gives `h` and `'` one meaning and two spellings, and the two are
two strings with two checksums:

```
wpkh([00000000/84h/0h/0h]xpub6Bos.../0/*)   ny9ympxj
wpkh([00000000/84'/0'/0']xpub6Bos.../0/*)   q46mpm33
```

So a serializer that cannot tell them apart hands back a descriptor that
is not the one it read. `KeyExpression.hardening` is which one it was —
`h` or `'`, defaulting to `h` where the expression hardens nothing.

## One symbol, not a sequence

Which is Bitcoin Core's single `m_apostrophe` per key: `ParseKeyPathNum`
assigns it per hardened element, so the last one parsed is what
`ToString` writes back. Here the rule is the same, read in the order the
expression writes them — the origin's path, then the key's, then the
wildcard. A path spelled both ways, which is BIP380's own valid
`[deadbeef/0'/0h/0']`, comes back in the second symbol, as it does from
Core.

`hardenings_from_der_path` from #447 is what reads them; taking the last
non-empty one is the whole of the reduction.

## `BIP32KeyOrigin` does not carry it

An origin is a fingerprint and a path whichever way the path was
spelled: two that differ in nothing else have to stay equal, stay one
hash and serialize to the same bytes. `__hash__` is `hash(serialize())`
there, so a field that changed equality without changing the bytes would
put two unequal objects in one bucket. The spelling belongs to the
descriptor text around the origin, which is the KeyExpression —
`test_the_origin_is_the_same_whichever_symbol_spelled_it` pins both
halves.

## Gates

- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0
- `pytest --cov=btclib --cov=tests` — 17264 passed, 100.00%

## Summary by Sourcery

Preserve and expose the hardening symbol used in BIP380 key expressions so that descriptors round-trip with their original spelling while keeping BIP32 origins spelling-agnostic.

New Features:
- Add a hardening field to KeyExpression to record whether hardened steps were written with h or an apostrophe, defaulting to h when nothing is hardened.

Enhancements:
- Derive the effective hardening symbol from origin path, key path, and wildcard in descriptor parsing, following Bitcoin Core’s last-hardened-step rule without changing BIP32KeyOrigin semantics.

Documentation:
- Document the new KeyExpression.hardening behavior and round-trip guarantees in the changelog.

Tests:
- Add tests ensuring key expressions retain their original hardening symbol, that mixed-symbol paths resolve to the last hardened step, and that BIP32KeyOrigin equality and hashing remain independent of spelling.