### PR TITLE
Give a descriptor its way back to text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,31 @@ edit.
 
 ### The public API and the module layout
 
+- **a descriptor writes itself back: `str(descriptor)`** (issue #381).
+  `btclib.descriptors` parsed, derived, satisfied and updated a psbt, and
+  had no way back to the text — the one thing every workflow that talks
+  to Bitcoin Core needs, from `importdescriptors` to an address display.
+  Every fragment answers, the nested ones by writing their argument with
+  the same method, and `MultiA` and a ``tr()`` script tree with it.
+
+  Without the checksum, because a fragment inside another one is written
+  by that very method and a checksum there would be part of the outer
+  text: `add_checksum(str(descriptor))` is the checksummed form. Core
+  splits it the same way, `ToString` writing none and the rpc layer
+  appending it; HWI and Electrum instead name the checksummed one
+  `to_string`, and are not followed.
+
+  Two spellings are normalized rather than echoed, both because the parse
+  keeps the meaning and not the characters: a WIF and an uppercase hex
+  key come back as lowercase hex, and an xprv as the xpub it was neutered
+  to. Core's `ToString` writes the same, having only the public key to
+  write. The hardening symbol is not one of them, `KeyExpression`
+  remembering which of ``h`` and ``'`` was read. Every descriptor the
+  suite reads — Bitcoin Core's derivation vectors, BIP387's, and the ones
+  the Core documentation lists — is written back, read again and checked
+  against itself, and the ones whose text differs from the input differ
+  only by those two normalizations.
+
 - **a key expression remembers which hardening symbol spelled it**
   (issue #381). `KeyExpression.hardening` is ``h`` or ``'``, whichever
   the expression used, defaulting to ``h`` where it hardened nothing.

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -66,6 +66,13 @@ any chain, which is why Bitcoin Core takes the chain from its own context
 too. ``addr()`` is the exception, an address carrying the network in its
 own prefix.
 
+`str(descriptor)` is the way back: the descriptor as text, without its
+checksum, `add_checksum` being what appends one. Bitcoin Core splits it
+the same way -- `ToString` writes none and the rpc layer appends it --
+where HWI and Electrum name the checksummed form `to_string`. What it
+writes is public by construction, there being no private material left
+in a parsed descriptor to write.
+
 What this module exports is the checksum functions, `parse` and
 `multipath_descriptors`, and the fragment classes a parsed descriptor is
 made of -- `KeyExpression`, `DescriptorTree` and the `MultiA` a tree leaf
@@ -94,6 +101,8 @@ from btclib.bip32.der_path import (
     _HARDENING,
     hardenings_from_der_path,
     indexes_from_der_path,
+    str_from_der_path,
+    str_from_index_int,
 )
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
@@ -357,6 +366,33 @@ class KeyExpression:
         xkey = prv_keys.get(self.xkey, self.xkey) if prv_keys else self.xkey
         return pub_keyinfo_from_key(derive(xkey, der_path), network)[0]
 
+    def __str__(self) -> str:
+        """Return the KEY expression, in the spelling it was read in.
+
+        Public whatever was read: an xprv is the xpub `parse` neutered it
+        to, and a WIF is the hex of the public key it was reduced to.
+        Bitcoin Core writes the same, `ToString` having only the public
+        key to write and `ToPrivateString` taking the private material
+        back from the caller.
+
+        An x-only key is written as the 32 bytes a ``tr()`` holds, which
+        is the spelling it was read in and the only one allowed there.
+        """
+        text = ""
+        if self.origin is not None:
+            path = str_from_der_path(
+                self.origin.der_path, self.origin.master_fingerprint, self.hardening
+            )
+            text = f"[{path}]"
+        if self.pub_key is not None:
+            return text + (self.pub_key[1:] if self.x_only else self.pub_key).hex()
+        text += self.xkey
+        for index in self.der_path:
+            text += "/" + str_from_index_int(index, self.hardening)
+        if self.wildcard is not None:
+            text += "/*" + (self.hardening if self.wildcard else "")
+        return text
+
 
 @dataclass(frozen=True)
 class MultiA:
@@ -376,6 +412,11 @@ class MultiA:
     # sorted in the script, so the participants need not agree on an order
     # to agree on an address
     sort: bool = False
+
+    def __str__(self) -> str:
+        """Return the ``multi_a()`` or ``sortedmulti_a()`` leaf as text."""
+        name = "sortedmulti_a" if self.sort else "multi_a"
+        return _expression(name, str(self.threshold), *map(str, self.keys))
 
     def _pub_keys(
         self, index: int, network: str, prv_keys: PrvKeys | None
@@ -462,6 +503,20 @@ class MultiA:
 
 
 # a tr() script tree: a leaf, or a branch of two subtrees. A leaf is the
+def _expression(name: str, *args: str) -> str:
+    """Return a descriptor function written out: its name and its arguments."""
+    return f"{name}({','.join(args)})"
+
+
+def _tree_expression(tree: DescriptorTree) -> str:
+    """Return a BIP386 TREE as text: a leaf, or two subtrees in braces."""
+    if isinstance(tree, tuple):
+        return f"{{{_tree_expression(tree[0])},{_tree_expression(tree[1])}}}"
+    if isinstance(tree, MultiA):
+        return str(tree)
+    return _expression("pk", str(tree))
+
+
 # KEY expression a `pk()` leaf is, or the `MultiA` of BIP387's two
 # functions; a branch is a tuple, which is what tells a branch from a
 # leaf. The leaves hold KEY expressions and not scripts because a ranged
@@ -593,6 +648,30 @@ class Descriptor(ABC):
     @abstractmethod
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return every KEY expression the descriptor holds."""
+
+    @abstractmethod
+    def __str__(self) -> str:
+        """Return the descriptor as text, without its checksum.
+
+        Public by construction, `parse` having kept no private material
+        to write: the same guarantee Bitcoin Core's `ToString` gives by
+        holding only a neutered key, where its `ToPrivateString` has to
+        be handed the keys back.
+
+        Without the checksum because a fragment inside another one is
+        written by this very method, and a checksum there would be part
+        of the outer descriptor's text. `add_checksum(str(descriptor))`
+        is the checksummed form, which is the split Core has too --
+        `ToString` writes none and the rpc layer appends it. HWI and
+        Electrum instead name the checksummed one `to_string`.
+
+        Two things are normalized rather than echoed, both because the
+        parse keeps the meaning and not the characters: a WIF and an
+        uppercase hex key come back as lowercase hex, and an xprv as its
+        xpub. The hardening symbol is not one of them -- `KeyExpression`
+        remembers which of `h` and `'` was read, the two spellings being
+        two checksums.
+        """
 
     @abstractmethod
     def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
@@ -808,6 +887,9 @@ class PkDescriptor(Descriptor):
 
     key: KeyExpression
 
+    def __str__(self) -> str:
+        return _expression("pk", str(self.key))
+
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the one KEY expression, as the base class's tuple."""
@@ -835,6 +917,9 @@ class PkhDescriptor(Descriptor):
 
     key: KeyExpression
 
+    def __str__(self) -> str:
+        return _expression("pkh", str(self.key))
+
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the one KEY expression, as the base class's tuple."""
@@ -860,6 +945,9 @@ class WpkhDescriptor(Descriptor):
     """``wpkh(KEY)``: a p2wpkh output, BIP382."""
 
     key: KeyExpression
+
+    def __str__(self) -> str:
+        return _expression("wpkh", str(self.key))
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
@@ -898,6 +986,9 @@ class ShDescriptor(Descriptor):
     """``sh(SCRIPT)``: the argument, p2sh-embedded, BIP381."""
 
     inner: Descriptor
+
+    def __str__(self) -> str:
+        return _expression("sh", str(self.inner))
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
@@ -945,6 +1036,9 @@ class WshDescriptor(Descriptor):
 
     inner: Descriptor
 
+    def __str__(self) -> str:
+        return _expression("wsh", str(self.inner))
+
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the wrapped SCRIPT's KEY expressions."""
@@ -990,6 +1084,10 @@ class MultiDescriptor(Descriptor):
     # functions: the keys of a sortedmulti() are sorted in the script, so
     # the participants need not agree on an order to agree on an address
     sort: bool = False
+
+    def __str__(self) -> str:
+        name = "sortedmulti" if self.sort else "multi"
+        return _expression(name, str(self.threshold), *map(str, self.keys))
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
@@ -1057,6 +1155,9 @@ class ComboDescriptor(Descriptor):
 
     key: KeyExpression
 
+    def __str__(self) -> str:
+        return _expression("combo", str(self.key))
+
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return the one KEY expression, as the base class's tuple."""
@@ -1108,6 +1209,9 @@ class AddrDescriptor(Descriptor):
 
     addr: str
 
+    def __str__(self) -> str:
+        return _expression("addr", self.addr)
+
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
         """Return no KEY expression, the descriptor fixing none."""
@@ -1146,6 +1250,9 @@ class RawDescriptor(Descriptor):
     """``raw(HEX)``: the script those bytes are, BIP385."""
 
     script: bytes
+
+    def __str__(self) -> str:
+        return _expression("raw", self.script.hex())
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:
@@ -1186,6 +1293,11 @@ class TrDescriptor(Descriptor):
 
     internal_key: KeyExpression
     tree: DescriptorTree | None = None
+
+    def __str__(self) -> str:
+        if self.tree is None:
+            return _expression("tr", str(self.internal_key))
+        return _expression("tr", str(self.internal_key), _tree_expression(self.tree))
 
     @property
     def key_expressions(self) -> tuple[KeyExpression, ...]:

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -1804,3 +1804,97 @@ def test_what_cannot_update_a_psbt(descriptor: str, message: str) -> None:
     psbt = psbt_spending(parse(f"pkh({KEY_A})"))
     with pytest.raises(BTClibValueError, match=message):
         parsed.update_psbt(psbt, 0)
+
+
+ROUND_TRIP = [
+    *(d for private, public, _ in CORE_VECTORS for d in (private, public) if d),
+    *(descriptor for descriptor, _ in BIP387_VECTORS),
+    *DOC_DESCRIPTORS,
+    *HARDENED_PUBLIC,
+]
+
+
+@pytest.mark.parametrize(
+    "descriptor",
+    [
+        pytest.param(descriptor, id=vector_id(index, descriptor))
+        for index, descriptor in enumerate(ROUND_TRIP)
+    ],
+)
+def test_a_descriptor_writes_itself_back(descriptor: str) -> None:
+    """Every descriptor the suite reads is written back and read again.
+
+    Writing is idempotent, and what it writes parses to the same scripts:
+    the text may differ from the input, `parse` keeping the meaning and
+    not the characters, but it cannot differ from itself.
+    """
+    prv_keys: dict[str, str] = {}
+    parsed = parse(descriptor, prv_keys=prv_keys)
+    text = str(parsed)
+
+    assert "#" not in text
+    assert str(parse(text)) == text
+    assert add_checksum(text) == add_checksum(str(parse(add_checksum(text))))
+
+    reparsed = parse(text)
+    assert reparsed.is_ranged == parsed.is_ranged
+    # HARDENED_PUBLIC is the corpus that derives nothing, by construction
+    if descriptor not in HARDENED_PUBLIC:
+        assert reparsed.script_pub_keys(0, prv_keys) == parsed.script_pub_keys(
+            0, prv_keys
+        )
+
+
+def test_what_writing_a_descriptor_normalizes() -> None:
+    """Two spellings are not echoed back, and one that could be is.
+
+    A WIF and an xprv are gone by the time there is anything to write:
+    the first was reduced to its public key on the way in and the second
+    neutered. Bitcoin Core writes the same, `ToString` holding the public
+    key alone. The hardening symbol is the one that *is* echoed, being
+    the one whose two spellings are two checksums.
+    """
+    wif = "L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1"
+    pub_key = pub_keyinfo_from_key(wif)[0].hex()
+    assert str(parse(f"pkh({wif})")) == f"pkh({pub_key})"
+    assert str(parse(f"pkh({pub_key.upper()})")) == f"pkh({pub_key})"
+
+    xprv = (
+        "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvv"
+        "NKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
+    )
+    xpub = xpub_from_xprv(xprv)
+    assert str(parse(f"wpkh({xprv}/0/*)")) == f"wpkh({xpub}/0/*)"
+
+    aitches = f"wpkh([deadbeef/84h]{xpub}/1h/*h)"
+    apostrophes = f"wpkh([deadbeef/84']{xpub}/1'/*')"
+    assert str(parse(aitches)) == aitches
+    assert str(parse(apostrophes)) == apostrophes
+    # which matters because the two spellings are two descriptors: one
+    # meaning, two strings, two checksums
+    assert checksum(aitches) != checksum(apostrophes)
+
+
+def test_every_fragment_writes_its_own_function() -> None:
+    """One case per grammar function, the nested ones included."""
+    xonly = XONLY
+    written = [
+        f"pk({KEY})",
+        f"pkh({KEY})",
+        f"wpkh({KEY})",
+        f"combo({KEY})",
+        f"sh(wpkh({KEY}))",
+        f"wsh(pk({KEY}))",
+        f"sh(wsh(pk({KEY})))",
+        f"multi(1,{KEY})",
+        f"sortedmulti(2,{KEY},{KEY_B})",
+        f"tr({xonly})",
+        f"tr({xonly},pk({xonly}))",
+        f"tr({xonly},{{pk({xonly}),pk({KEY_B})}})",
+        f"tr({xonly},multi_a(1,{xonly}))",
+        f"tr({xonly},{{sortedmulti_a(2,{xonly},{KEY_B}),pk({KEY_C})}})",
+        "addr(1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH)",
+        "raw(76a914f8c62e9b7c0e7e1e6e3f0e2c1e6e6a0e6e6e6e6e88ac)",
+    ]
+    for descriptor in written:
+        assert str(parse(descriptor)) == descriptor


### PR DESCRIPTION
Work package 3 of #381: the canonical public serializer, which led that
list from the start.

`btclib.descriptors` parsed, derived, satisfied and updated a psbt, and
had no way back to the string — the one thing every workflow that talks
to Bitcoin Core needs, from `importdescriptors` to an address display.
`str(descriptor)` is that way. Every fragment answers for its own
function; the nested ones write their argument with the same method, and
`MultiA` and a `tr()` script tree with it.

## Three decisions, each recorded in #381

**No checksum.** A fragment inside another one is written by that very
method, and a checksum there would be part of the outer descriptor's
text — so the unchecksummed form is what `__str__` has to be, and
`add_checksum(str(descriptor))` is the other. Core splits it the same
way (`ToString` writes none, the rpc layer appends it); HWI and Electrum
name the checksummed form `to_string`, and are not followed.

**Public by construction, not by care.** Since #451 there is no private
material in a parsed descriptor to write — which is what Core's
`ToString` gets from holding a neutered key, and what `ToPrivateString`
has to be handed the keys back for.

**The hardening symbol is echoed.** #452 made the KeyExpression remember
which of `h` and `'` it read, because the two are two strings with two
checksums.

## What is normalized

Two spellings, both because the parse keeps the meaning and not the
characters: a WIF and an uppercase hex key come back as lowercase hex,
and an xprv as the xpub it was neutered to. Core's `ToString` writes the
same, having only the public key to write.

## Tests

Every descriptor the suite already reads — Core's derivation vectors,
BIP387's, the ones the Core documentation lists, and the four hardened
public spellings — is written back, read again, and held to itself and
to its own scripts. The ones whose text differs from the input differ
only by the two normalizations above; that is checked rather than
asserted. One case per grammar function pins the exact text, nesting and
tree braces included.

## Gates

- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0
- `pytest --cov=btclib --cov=tests` — 17358 passed, 100.00%

## Summary by Sourcery

Add a canonical string serialization for descriptors so parsed descriptors can be converted back to normalized, checksum-free text.

New Features:
- Expose a public string representation for descriptors and their fragments via __str__ that returns the descriptor text without checksum.

Enhancements:
- Normalize descriptor output to always use public-only material and consistent key spelling while preserving hardening symbol choice.

Documentation:
- Document the new descriptor string serialization behavior and normalization rules in the changelog.

Tests:
- Add comprehensive round-trip tests ensuring all existing descriptor vectors serialize and parse consistently, including explicit checks for normalization and per-fragment formatting.