### PR TITLE
Put the xpub at the last hardened step: the normalized descriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,28 @@ edit.
 
 ### The public API and the module layout
 
+- **`descriptors.normalized` puts the xpub at each last hardened step**
+  (issue #381), which is Bitcoin Core's `ToNormalizedString` and what
+  `getdescriptorinfo` answers with. A descriptor written with hardened
+  derivation cannot be expanded by a wallet holding no private key; the
+  normalized one can, the extended key becoming the xpub at that step and
+  the hardened prefix moving into the key origin, where it says where the
+  key came from rather than naming a derivation anybody has to perform.
+  It is what an export to a watch-only wallet wants.
+
+  Three keys come back with the symbol canonicalized and nothing else:
+  one that is not extended, one whose path hardens nothing, and one whose
+  wildcard is the hardened `/*h` — the last because the step needing the
+  private key is the one taken at every index, so there is no point to
+  re-root to, which is Core's first branch and its reason. An origin
+  already there keeps its fingerprint and has the prefix appended; one
+  absent is the extended key's own. The symbol is `h` throughout the
+  result whichever was read, a normalized descriptor being a canonical
+  spelling rather than the one that came in — "always use h for hardened
+  derivation", as Core's own interface puts it. A hardened step whose
+  private key the caller did not hand in raises, rather than handing back
+  a descriptor that quietly still needs one.
+
 - **a descriptor writes itself back: `str(descriptor)`** (issue #381).
   `btclib.descriptors` parsed, derived, satisfied and updated a psbt, and
   had no way back to the text — the one thing every workflow that talks

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -73,6 +73,13 @@ where HWI and Electrum name the checksummed form `to_string`. What it
 writes is public by construction, there being no private material left
 in a parsed descriptor to write.
 
+`normalized` is the other direction Bitcoin Core has, its
+`ToNormalizedString`: the same descriptor with the xpub at each last
+hardened step and the hardened prefix moved into the key origin, so that
+a holder of no private key can compute every script it describes. That is
+what `getdescriptorinfo` answers with, and what an export to a watch-only
+wallet wants.
+
 What this module exports is the checksum functions, `parse` and
 `multipath_descriptors`, and the fragment classes a parsed descriptor is
 made of -- `KeyExpression`, `DescriptorTree` and the `MultiA` a tree leaf
@@ -91,8 +98,8 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping
 from copy import deepcopy
-from dataclasses import dataclass
-from typing import cast
+from dataclasses import dataclass, fields, replace
+from typing import Any, cast
 
 from btclib.alias import Octets, ScriptList, TaprootScriptTree
 from btclib.bip32.bip32 import BIP32KeyData, derive, xpub_from_xprv
@@ -112,7 +119,7 @@ from btclib.script.script import op_int, serialize
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.script.taproot import input_script_sig, leaf_hash, tree_helper
 from btclib.script.witness import Witness
-from btclib.to_pub_key import point_from_pub_key, pub_keyinfo_from_key
+from btclib.to_pub_key import fingerprint, point_from_pub_key, pub_keyinfo_from_key
 from btclib.utils import bytes_from_octets
 
 __all__ = [
@@ -136,6 +143,7 @@ __all__ = [
     "checksum",
     "from_address",
     "multipath_descriptors",
+    "normalized",
     "parse",
     "strip_checksum",
 ]
@@ -1949,6 +1957,89 @@ def parse(
     if prv_keys is None:
         prv_keys = {}
     return _parse_expression(strip_checksum(descriptor), _TOP, network, prv_keys)
+
+
+def _normalized_key(key: KeyExpression, prv_keys: PrvKeys | None) -> KeyExpression:
+    """Return the key expression re-rooted at its last hardened step.
+
+    What makes a descriptor written with hardened derivation useful to a
+    wallet that holds no private key: the extended key becomes the xpub
+    at that step, and the hardened prefix moves into the key origin,
+    where it is a statement about where the key came from rather than a
+    derivation anybody has to perform.
+
+    Three keys are returned as they are, with the symbol normalized and
+    nothing else: one that is not extended, one whose path hardens
+    nothing, and one whose wildcard is the hardened `/*h`. The last is
+    Bitcoin Core's first branch too, and for the same reason -- the step
+    that needs the private key is the one taken at every index, so there
+    is no point to re-root to.
+    """
+    if key.pub_key is not None or key.wildcard == _HARDENED_OFFSET:
+        return replace(key, hardening=_HARDENING)
+    hardened = [i for i, step in enumerate(key.der_path) if step >= _HARDENED_OFFSET]
+    if not hardened:
+        return replace(key, hardening=_HARDENING)
+
+    xprv = prv_keys.get(key.xkey) if prv_keys else None
+    if xprv is None:
+        err_msg = "no private key to normalize the hardened derivation of a key"
+        raise BTClibValueError(err_msg)
+    last = hardened[-1] + 1
+    prefix = list(key.der_path[:last])
+    return replace(
+        key,
+        origin=BIP32KeyOrigin(
+            key.origin.master_fingerprint if key.origin else fingerprint(key.xkey),
+            [*(key.origin.der_path if key.origin else []), *prefix],
+        ),
+        xkey=xpub_from_xprv(derive(xprv, prefix)),
+        der_path=key.der_path[last:],
+        hardening=_HARDENING,
+    )
+
+
+def _normalized(value: object, prv_keys: PrvKeys | None) -> object:
+    """Return one field of a descriptor with every key in it normalized."""
+    if isinstance(value, KeyExpression):
+        return _normalized_key(value, prv_keys)
+    if isinstance(value, MultiA):
+        return replace(
+            value, keys=tuple(_normalized_key(k, prv_keys) for k in value.keys)
+        )
+    if isinstance(value, Descriptor):
+        return normalized(value, prv_keys)
+    if isinstance(value, tuple):
+        return tuple(_normalized(item, prv_keys) for item in value)
+    return value
+
+
+def normalized(descriptor: Descriptor, prv_keys: PrvKeys | None = None) -> Descriptor:
+    """Return the descriptor with the xpub at each last hardened step.
+
+    Bitcoin Core's `ToNormalizedString`, which is what `getdescriptorinfo`
+    answers with and what an export to a watch-only wallet wants: every
+    key of it derives from an xpub, so a holder of no private key can
+    compute every script the descriptor describes.
+
+    The private material is the caller's, as everywhere else here, and is
+    needed for exactly the keys that have a hardened step to re-root at.
+    Where one of those is missing this raises rather than handing back a
+    descriptor that quietly still needs a key.
+
+    The hardening symbol is `h` throughout the result, whichever was
+    read: a normalized descriptor is a canonical spelling and not the one
+    that came in, which is Core's rule -- "always use h for hardened
+    derivation" is how its own interface states it.
+    """
+    changed: dict[str, Any] = {
+        field.name: _normalized(getattr(descriptor, field.name), prv_keys)
+        for field in fields(descriptor)
+    }
+    # `replace` is what keeps this one function rather than a method per
+    # fragment: every field is walked, so a field added later carries its
+    # keys through here by default
+    return replace(descriptor, **changed)
 
 
 def multipath_descriptors(descriptor: str) -> list[str]:

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -229,8 +229,8 @@ def pub_keyinfo_from_prv_key(
 def fingerprint(key: Key, network: str | None = None) -> bytes:
     """Return the public key fingerprint from a private/public key.
 
-    The fingerprint is the last four bytes of the compressed public key
-    HASH160.
+    The fingerprint is the first four bytes of the compressed public key
+    HASH160, which is what BIP32 defines it as.
     """
     pub_key, _ = pub_keyinfo_from_key(key, network, compressed=True)
     return hash160(pub_key)[:4]

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -53,6 +53,7 @@ from btclib.descriptors import (
     checksum,
     from_address,
     multipath_descriptors,
+    normalized,
     parse,
     strip_checksum,
 )
@@ -71,7 +72,7 @@ from btclib.script.script import serialize
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.script.witness import Witness
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
-from btclib.to_pub_key import pub_keyinfo_from_key
+from btclib.to_pub_key import fingerprint, pub_keyinfo_from_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests import load, vector_id
 
@@ -1898,3 +1899,88 @@ def test_every_fragment_writes_its_own_function() -> None:
     ]
     for descriptor in written:
         assert str(parse(descriptor)) == descriptor
+
+
+XPRV_ROOT = (
+    "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvv"
+    "NKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
+)
+
+
+def test_the_normalized_form_derives_from_an_xpub_alone() -> None:
+    """The point of it: a hardened descriptor a watch-only wallet can use.
+
+    The extended key becomes the xpub at the last hardened step and the
+    hardened prefix moves into the origin, so every script the descriptor
+    describes is computable with no private key at all -- which is what
+    `getdescriptorinfo` answers with and what an export wants.
+    """
+    for descriptor in (
+        f"wpkh({XPRV_ROOT}/44h/0h/0h/0/*)",
+        f"wpkh([deadbeef/84h]{XPRV_ROOT}/0h/1/*)",
+        f"sh(wsh(multi(1,{XPRV_ROOT}/1h/2,{XPRV_ROOT}/3/4)))",
+        f"tr({XPRV_ROOT}/86h/0h/0h/0/*)",
+        f"tr({XPRV_ROOT}/1h/0,multi_a(1,{XPRV_ROOT}/2h/0))",
+    ):
+        prv_keys: dict[str, str] = {}
+        parsed = parse(descriptor, prv_keys=prv_keys)
+        canonical = normalized(parsed, prv_keys)
+
+        for index in (0, 5):
+            if index and not parsed.is_ranged:
+                continue
+            # no prv_keys at all on the normalized side: that is the claim
+            assert canonical.script_pub_keys(index) == parsed.script_pub_keys(
+                index, prv_keys
+            )
+        # and it is a descriptor, so it writes itself back and parses again
+        assert str(parse(str(canonical))) == str(canonical)
+
+
+def test_what_the_normalized_form_leaves_alone() -> None:
+    """Three keys have no hardened step to re-root at, and one cannot."""
+    xpub = xpub_from_xprv(XPRV_ROOT)
+
+    # a path that hardens nothing, and a key that is not extended
+    for descriptor in (f"wpkh({xpub}/0/1/*)", f"pk({KEY})"):
+        assert str(normalized(parse(descriptor))) == descriptor
+
+    # a hardened wildcard: the step that needs the private key is the one
+    # taken at every index, so there is no point to re-root to. Bitcoin
+    # Core's first branch, and for the same reason
+    hardened_range = f"wpkh({xpub}/0/*h)"
+    assert str(normalized(parse(hardened_range))) == hardened_range
+
+    # the symbol is h throughout, whichever was read: a normalized
+    # descriptor is a canonical spelling and not the one that came in
+    assert str(normalized(parse(f"wpkh({xpub}/0/*')"))) == f"wpkh({xpub}/0/*h)"
+    prv_keys: dict[str, str] = {}
+    apostrophes = parse(f"wpkh([deadbeef/84']{XPRV_ROOT}/0'/1/*)", prv_keys=prv_keys)
+    assert "'" not in str(normalized(apostrophes, prv_keys))
+
+
+def test_normalizing_without_the_key_says_so() -> None:
+    """A hardened step and no private key is refused, not quietly kept."""
+    xpub = xpub_from_xprv(XPRV_ROOT)
+    err_msg = "no private key to normalize the hardened derivation"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        normalized(parse(f"wpkh({xpub}/0h/1/*)"))
+
+    # and the mapping has to name this key, not merely be non-empty
+    with pytest.raises(BTClibValueError, match=err_msg):
+        normalized(parse(f"wpkh({xpub}/0h/1/*)"), {"somebody-else": XPRV_ROOT})
+
+
+def test_the_normalized_origin_keeps_the_fingerprint_that_was_given() -> None:
+    """An origin already there is extended; one absent is the key's own."""
+    prv_keys: dict[str, str] = {}
+    given = parse(f"wpkh([deadbeef/84h]{XPRV_ROOT}/0h/1/*)", prv_keys=prv_keys)
+    origin = normalized(given, prv_keys).key_expressions[0].origin
+    assert origin is not None
+    assert origin.description == "deadbeef/84h/0h"
+
+    absent = parse(f"wpkh({XPRV_ROOT}/44h/0h/0h/0/*)", prv_keys=prv_keys)
+    origin = normalized(absent, prv_keys).key_expressions[0].origin
+    assert origin is not None
+    assert origin.master_fingerprint == fingerprint(XPRV_ROOT)
+    assert origin.description == f"{fingerprint(XPRV_ROOT).hex()}/44h/0h/0h"


### PR DESCRIPTION
Work package 4 of #381, and the last of the descriptor half.

Bitcoin Core's `ToNormalizedString` (`src/script/descriptor.cpp:535`),
which is what `getdescriptorinfo` answers with. A descriptor written
with hardened derivation cannot be expanded by a wallet holding no
private key; the normalized one can:

```
in  : wpkh(xprv9s21ZrQH143K3QTDL.../44h/0h/0h/0/*)
norm: wpkh([3442193e/44h/0h/0h]xpub6CDEarkRoiwWPj3n3gYygGwgo.../0/*)
      scripts match, and derive from the xpub alone
```

The extended key becomes the xpub at the last hardened step and the
hardened prefix moves into the key origin, where it says where the key
came from rather than naming a derivation somebody has to perform. That
is what an export to a watch-only wallet wants, and it is not formatting
— it is a derivation, which is why it needed the private material of
#451 to exist first.

## What is left alone

Three keys come back with the symbol canonicalized and nothing else: one
that is not extended, one whose path hardens nothing, and one whose
wildcard is the hardened `/*h`. The last is Core's own first branch and
for its reason — the step that needs the private key is the one taken at
*every* index, so there is no point to re-root to.

## The details that are Core's

- an origin already there keeps its fingerprint and has the prefix
  appended to its path, which is what `OriginPubkeyProvider` does by
  stripping the fingerprint off the inner provider's answer; one absent
  is the extended key's own fingerprint
- the symbol is `h` throughout the result whichever was read: a
  normalized descriptor is a canonical spelling and not the one that came
  in — "always use h for hardened derivation" is how Core's interface
  states it
- a hardened step whose private key the caller did not hand in raises,
  where Core returns false; either way it is not a descriptor that
  quietly still needs a key

## Shape

One function and not a method per fragment: `dataclasses.replace` over
every field, so a field added later carries its keys through by default.

## Also

`to_pub_key.fingerprint`, which this uses, said "the last four bytes"
where it takes the first four — BIP32's definition, and what the code
already did. One word.

## Gates

- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0
- `pytest --cov=btclib --cov=tests` — 17362 passed, 100.00%

## Summary by Sourcery

Add support for producing a normalized descriptor form that re-roots keys at their last hardened step so watch-only wallets can derive scripts from xpubs alone.

New Features:
- Expose a descriptors.normalized function that returns descriptors with xpubs at each last hardened step and hardened prefixes moved into key origins, matching Bitcoin Core's ToNormalizedString behavior.

Bug Fixes:
- Correct the fingerprint helper documentation to state that BIP32 fingerprints use the first four bytes of HASH160, matching the existing implementation.

Enhancements:
- Normalize hardened-derivation symbols to a canonical 'h' form and preserve or infer key origins when constructing normalized descriptors.

Documentation:
- Document the new descriptors.normalized API and its semantics in the module docstring and CHANGELOG.

Tests:
- Add tests covering normalized descriptor behavior, including round-tripping, unchanged cases, origin handling, error conditions when private keys are missing, and derivation from xpub-only descriptors.