### PR TITLE
Read rawtr(), which Bitcoin Core specifies and no BIP does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,44 @@ edit.
 
 ### The public API and the module layout
 
+- **`rawtr()` is read, and the specification it was filed under was the
+  wrong one** (issue #453). `_UNIMPLEMENTED` named BIP386, which
+  specifies `tr()`, its tree expression and the x-only key inside them and
+  never mentions `rawtr()`; no BIP does. What defines it is Bitcoin Core's
+  own `doc/descriptors.md`, added by Core PR #23480, and the label was
+  wrong whether or not the function was implemented.
+
+  `RawTrDescriptor` is the fragment, top level only and one key. That key
+  is BIP341's *output* key, written into `OP_1 <32 bytes>` as it is with
+  no tweak at all: the whole difference from `tr(KEY)`, which tweaks its
+  internal key with an empty merkle root, and the reason this is not a
+  `TrDescriptor` carrying `tree=None`. Satisfaction is a key path witness
+  whose signature verifies against the key as written, so a signer must
+  not tweak what it holds — the opposite of the `tr()` lookup, which
+  expects a signature the *tweaked* key verifies. The Updater writes one
+  taproot field, PSBT_IN_TAP_BIP32_DERIVATION: an output key has no
+  internal key a verifier could tweak, so there is no merkle root and no
+  leaf script either, and `psbt.sign` therefore leaves such an input alone
+  rather than tweaking a key it should not. The docstring carries Core's
+  own warning with it — an output key whose internal key nobody knows
+  cannot be shown to have no hidden script path — because a `rawtr()`
+  describes an output a wallet already holds rather than one to build.
+  Checked against Core's two `descriptor_tests.cpp` vectors, in all three
+  of the spellings each has, and the spend against btclib's script engine.
+
+  Two things measured on the way. A WIF in a taproot position is written
+  back as 32 bytes and not 33: a private key has no spelling of its own to
+  echo, so the position decides, which is Core's own bool per key —
+  `false` for a hex key it read whole, `ctx == P2TR` for a private one —
+  and what makes its `tr(WIF)` and `rawtr(WIF)` vectors come back x-only.
+  btclib wrote 33 bytes there. And a SCRIPT function where a tree leaf is
+  expected is refused by the position rule rather than as unimplemented:
+  `tr(KEY,pkh(KEY))` said "pkh() inside tr() is not implemented", which
+  was never going to be implemented, and now says it is not allowed there
+  — a `BTClibValueError`, as every other position error is, with an
+  unknown function inside `tr()` answered the way it is answered anywhere
+  else.
+
 - **`descriptors.normalized` puts the xpub at each last hardened step**
   (issue #381), which is Bitcoin Core's `ToNormalizedString` and what
   `getdescriptorinfo` answers with. A descriptor written with hardened

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -39,15 +39,17 @@ The grammar read is BIP380 to BIP387 and BIP389, minus miniscript:
 - ``addr``, ``raw`` (BIP385)
 - ``tr``, with a key path and a script tree whose leaves are ``pk()``,
   ``multi_a()`` and ``sortedmulti_a()`` (BIP386, BIP387)
+- ``rawtr``, which no BIP specifies: Bitcoin Core's `doc/descriptors.md`
+  is what defines it, and the key it takes is the output key itself
 - key expressions: hex public keys (compressed, uncompressed and, inside
-  ``tr()``, x-only), WIF private keys, xpub/xprv with a derivation path,
-  key origin, ``/*`` and ``/*h`` wildcards, both ``h`` and ``'`` hardened
-  markers
+  ``tr()`` and ``rawtr()``, x-only), WIF private keys, xpub/xprv with a
+  derivation path, key origin, ``/*`` and ``/*h`` wildcards, both ``h``
+  and ``'`` hardened markers
 - the ``<a;b>`` multipath form of BIP389, through `multipath_descriptors`
 
 What raises NotImplementedError, rather than being read wrong: every
-miniscript expression, which is issue #187; and ``rawtr`` and ``musig``,
-which are BIP386 and BIP390 and belong with the work that adds them.
+miniscript expression, which is issue #187; and ``musig``, which is
+BIP390 and belongs with the work that adds it.
 
 A parsed descriptor holds no key that signs. `parse` neuters an xprv to
 the xpub the `KeyExpression` then carries, and hands the private spelling
@@ -135,6 +137,7 @@ __all__ = [
     "PkhDescriptor",
     "PrvKeys",
     "RawDescriptor",
+    "RawTrDescriptor",
     "ShDescriptor",
     "TrDescriptor",
     "WpkhDescriptor",
@@ -264,7 +267,6 @@ _MINISCRIPT_FRAGMENTS = frozenset(
 # each is a specification of its own, and a script derived wrong is an
 # address that loses money
 _UNIMPLEMENTED = {
-    "rawtr": "BIP386",
     "musig": "BIP390",
 }
 
@@ -510,7 +512,6 @@ class MultiA:
         return stack
 
 
-# a tr() script tree: a leaf, or a branch of two subtrees. A leaf is the
 def _expression(name: str, *args: str) -> str:
     """Return a descriptor function written out: its name and its arguments."""
     return f"{name}({','.join(args)})"
@@ -525,6 +526,7 @@ def _tree_expression(tree: DescriptorTree) -> str:
     return _expression("pk", str(tree))
 
 
+# a tr() script tree: a leaf, or a branch of two subtrees. A leaf is the
 # KEY expression a `pk()` leaf is, or the `MultiA` of BIP387's two
 # functions; a branch is a tuple, which is what tells a branch from a
 # leaf. The leaves hold KEY expressions and not scripts because a ranged
@@ -1491,6 +1493,88 @@ class TrDescriptor(Descriptor):
         }
 
 
+@dataclass(frozen=True)
+class RawTrDescriptor(Descriptor):
+    """``rawtr(KEY)``: the key as the output key itself, no tweak at all.
+
+    No BIP specifies this function. BIP386 specifies ``tr()``, the tree
+    expression and the x-only key inside them and never mentions
+    ``rawtr()``; what defines it is Bitcoin Core's own
+    `doc/descriptors.md`, which also carries the warning this docstring
+    keeps: an output key whose internal key nobody knows cannot be shown
+    to have no hidden script path, so a ``rawtr()`` describes an output a
+    wallet already holds rather than one to build.
+
+    The key is BIP341's *output* key, written into ``OP_1 <32 bytes>`` as
+    it is. That is the whole difference from ``tr(KEY)``, which tweaks its
+    internal key with an empty merkle root, and it is why this is not a
+    `TrDescriptor` carrying ``tree=None``.
+    """
+
+    key: KeyExpression
+
+    def __str__(self) -> str:
+        return _expression("rawtr", str(self.key))
+
+    @property
+    def key_expressions(self) -> tuple[KeyExpression, ...]:
+        """Return the one KEY expression, as the base class's tuple."""
+        return (self.key,)
+
+    def _scripts(self, index: int, prv_keys: PrvKeys | None) -> list[bytes]:
+        # not ScriptPubKey.p2tr, which computes an output key from an
+        # internal one: here the key already is the output key, and
+        # tweaking it would describe an output nobody named
+        output_key = self.key.sec(index, self.network, prv_keys)[1:]
+        return [serialize(["OP_1", output_key])]
+
+    def _satisfy(
+        self,
+        signatures: Mapping[bytes, bytes],
+        index: int,
+        prv_keys: PrvKeys | None,
+    ) -> tuple[bytes, Witness]:
+        """Return the witness of a BIP341 key path spend: one signature.
+
+        Looked up under the key the descriptor names, as ``tr()`` does,
+        and the two lookups mean opposite things: there the signature is
+        one the *tweaked* key verifies, made by a signer that tweaked the
+        internal key it holds, while here it must verify against the key
+        as written, so a signer must not tweak anything.
+
+        The script_sig is empty: BIP341 spends a witness v1 program with
+        the witness alone.
+        """
+        output_key = self.key.sec(index, self.network, prv_keys)
+        signature = _offered_signature(signatures, output_key, x_only=True)
+        if signature is None:
+            raise BTClibValueError("no signature for the rawtr() output key")
+        return b"", Witness([signature])
+
+    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
+        """Fill the one taproot field a ``rawtr()`` has anything to say in.
+
+        BIP371's PSBT_IN_TAP_BIP32_DERIVATION, keyed by the x-only key,
+        which is the origin of the key the script holds. The other three
+        fields are `TrDescriptor`'s and not this one's: PSBT_IN_TAP_
+        INTERNAL_KEY names the key a verifier tweaks and a ``rawtr()`` has
+        none, so it has no merkle root and no leaf script either.
+
+        What that costs is `psbt.sign`, which signs a taproot input
+        through its internal key and therefore leaves this input alone
+        rather than tweaking a key it should not: an input with no
+        internal key is one that role skips.
+        """
+        origin = _derived_origin(self.key, index)
+        if origin is None:
+            return
+        x_only = self.key.sec(index, self.network, prv_keys)[1:]
+        psbt_in.taproot_hd_key_paths = {
+            **psbt_in.taproot_hd_key_paths,
+            x_only: ([], origin),
+        }
+
+
 def _split_arguments(arguments: str) -> list[str]:
     """Split a comma-separated argument list, at nesting depth zero.
 
@@ -1683,13 +1767,22 @@ def _split_wildcard(steps: list[str]) -> tuple[list[str], int | None, str]:
 
 
 def _fixed_pub_key(key: str, *, x_only: bool) -> tuple[bytes, bool]:
-    """Return the SEC bytes of a hex or WIF key, and whether x-only."""
+    """Return the SEC bytes of a hex or WIF key, and whether x-only.
+
+    A hex key is x-only when it was written in 32 bytes, and a WIF when it
+    sits where only an x-only key is written: it has no spelling of its
+    own to echo, so what is written back is the spelling the position
+    takes. Bitcoin Core makes the same distinction with one bool per key
+    -- `false` for a hex key it read whole, `ctx == ParseScriptContext::
+    P2TR` for a private one -- which is what makes its ``tr(WIF)`` and
+    ``rawtr(WIF)`` vectors come back in 32 bytes and not 33.
+    """
     if _HEX.fullmatch(key):
         return _pub_key_from_hex(key, x_only=x_only)
     # what is left is a WIF, and pub_keyinfo_from_key answers both for it
     # and for characters that are no key expression at all
     try:
-        return pub_keyinfo_from_key(key)[0], False
+        return pub_keyinfo_from_key(key)[0], x_only
     except (TypeError, ValueError) as e:
         raise BTClibValueError("invalid key expression") from e
 
@@ -1780,8 +1873,14 @@ def _parse_tree(expression: str, prv_keys: dict[str, str]) -> DescriptorTree:
     args = _split_arguments(arguments)
     if name in _TREE_FUNCTIONS:
         return _parse_multi_a(name, args, prv_keys)
+    if name in _PARSERS:
+        # a SCRIPT function where a leaf is expected: a position rule and
+        # not something a later release adds, which is what the position
+        # table says and Bitcoin Core's own message says too. ``pk()``
+        # allows tr() among its positions and falls through to be read
+        _assert_position(name, _P2TR, _PARSERS[name][0])
     if name != "pk":
-        raise NotImplementedError(f"{name}() inside tr() is not implemented")
+        raise BTClibValueError(f"unknown descriptor function: {name}()")
     return _parse_key(_one_argument(args, name), prv_keys, x_only=True, compressed=True)
 
 
@@ -1885,6 +1984,17 @@ def _parse_tr(
     return TrDescriptor(internal_key, tree, network=network)
 
 
+def _parse_rawtr(
+    args: list[str], context: str, network: str, prv_keys: dict[str, str]
+) -> Descriptor:
+    # one key and no tree: what Core's error says too, "rawtr(): only one
+    # key expected", the function having nothing to put a second key in
+    key = _parse_key(
+        _one_argument(args, "rawtr"), prv_keys, x_only=True, compressed=True
+    )
+    return RawTrDescriptor(key, network=network)
+
+
 def _parse_addr(
     args: list[str], context: str, network: str, prv_keys: dict[str, str]
 ) -> Descriptor:
@@ -1924,6 +2034,7 @@ _PARSERS: dict[
     "multi": ((_TOP, _P2SH, _P2WSH), _parse_ordered_multi),
     "sortedmulti": ((_TOP, _P2SH, _P2WSH), _parse_sorted_multi),
     "tr": ((_TOP,), _parse_tr),
+    "rawtr": ((_TOP,), _parse_rawtr),
     "addr": ((_TOP,), _parse_addr),
     "raw": ((_TOP,), _parse_raw),
 }

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -45,6 +45,7 @@ from btclib.descriptors import (
     MultiDescriptor,
     PkDescriptor,
     RawDescriptor,
+    RawTrDescriptor,
     ShDescriptor,
     TrDescriptor,
     WshDescriptor,
@@ -434,11 +435,26 @@ CORE_VECTORS: list[tuple[str, str | None, list[list[str]]]] = [
         "tr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd,pk(669b8afcec803a0d323e9a17f3ea8e68e8abe5a278020a929adbec52421adbd0))",
         [["512017cf18db381d836d8923b1bdb246cfcd818da1a9f0e6e7907f187f0b2f937754"]],
     ),
+    (
+        "rawtr(xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt/86'/1'/0'/1/*)",
+        None,
+        [
+            ["51205172af752f057d543ce8e4a6f8dcf15548ec6be44041bfa93b72e191cfc8c1ee"],
+            ["51201b66f20b86f700c945ecb9ad9b0ad1662b73084e2bfea48bee02126350b8a5b1"],
+            ["512063e70f66d815218abcc2306aa930aaca07c5cde73b75127eb27b5e8c16b58a25"],
+        ],
+    ),
+    (
+        "rawtr(L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1)",
+        "rawtr(a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd)",
+        [["5120a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"]],
+    ),
 ]
 
-# the public spelling of the four descriptors that derive hardened: Core
+# the public spelling of the five descriptors that derive hardened: Core
 # flags them HARDENED or DERIVE_HARDENED and expands the private one only
 HARDENED_PUBLIC = [
+    "rawtr(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/86'/1'/0'/1/*)",
     "pkh(xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/2147483647'/0)",
     "sh(wpkh(xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8/10/20/30/40/*'))",
     "pkh([01234567/10/20]xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB/2147483647'/0)",
@@ -928,6 +944,16 @@ UNPARSABLE = [
     (f"sh(tr({XONLY}))", "not allowed inside"),
     ("sh(addr(1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH))", "not allowed inside"),
     ("sh(raw(00))", "not allowed inside"),
+    # Core: rawtr() is top level only, and a SCRIPT function where a tree
+    # leaf is expected is that same rule and not an unimplemented one
+    (f"sh(rawtr({XONLY}))", "not allowed inside"),
+    (f"wsh(rawtr({XONLY}))", "not allowed inside"),
+    (f"tr({XONLY},rawtr({XONLY}))", "not allowed inside"),
+    (f"tr({XONLY},pkh({KEY}))", "not allowed inside"),
+    (f"tr({XONLY},nope({KEY}))", "unknown descriptor function"),
+    # Core refuses a second key too, as rawtr(): only one key expected
+    (f"rawtr({XONLY},{XONLY})", "takes one argument"),
+    (f"rawtr({UNCOMPRESSED})", "uncompressed"),
     # a key expression written for another position, or not at all
     (f"pk({XONLY})", "x-only"),
     (f"pk({KEY}/0)", "cannot derive"),
@@ -978,8 +1004,6 @@ UNIMPLEMENTED = [
     ),
     (f"wsh(thresh(1,pk({KEY})))", "187"),
     (f"wsh(s:pk({KEY}))", "187"),
-    (f"tr({XONLY},pkh({KEY}))", "inside tr"),
-    (f"rawtr({XONLY})", "BIP386"),
     (f"tr(musig({KEY},{KEY}))", "BIP390"),
 ]
 
@@ -1470,6 +1494,7 @@ UNSATISFIABLE: list[tuple[str, dict[Octets, Octets], str]] = [
     ("addr(1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH)", {}, "addr\\(\\) cannot be satisfied"),
     ("raw(76a914000000000000000000000000000000000000000088ac)", {}, "raw\\(\\) cannot"),
     (f"tr({XONLY_A})", {}, "no signature for the tr\\(\\) internal key"),
+    (f"rawtr({XONLY_A})", {}, "no signature for the rawtr\\(\\) output key"),
     (f"tr({XONLY_A},pk({XONLY_B}))", {}, "or for any of its leaves"),
     (
         f"tr({XONLY_A},multi_a(2,{XONLY_B},{XONLY_C}))",
@@ -1894,11 +1919,30 @@ def test_every_fragment_writes_its_own_function() -> None:
         f"tr({xonly},{{pk({xonly}),pk({KEY_B})}})",
         f"tr({xonly},multi_a(1,{xonly}))",
         f"tr({xonly},{{sortedmulti_a(2,{xonly},{KEY_B}),pk({KEY_C})}})",
+        f"rawtr({xonly})",
         "addr(1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH)",
         "raw(76a914f8c62e9b7c0e7e1e6e3f0e2c1e6e6a0e6e6e6e6e88ac)",
     ]
     for descriptor in written:
         assert str(parse(descriptor)) == descriptor
+
+
+def test_a_wif_in_a_taproot_position_is_written_x_only() -> None:
+    """A private key has no spelling of its own, so the position decides.
+
+    Bitcoin Core writes the same and says so with one bool per key: a hex
+    key carries whether it was written in 32 bytes, a WIF carries whether
+    it sits where only 32 are written. Its own ``tr()`` and ``rawtr()``
+    vectors are what pin it -- the WIF below is the one they use, and it
+    comes back in 32 bytes there and in 33 everywhere else.
+    """
+    assert str(parse(f"tr({WIF})")) == f"tr({XONLY})"
+    assert str(parse(f"rawtr({WIF})")) == f"rawtr({XONLY})"
+    assert str(parse(f"tr({XONLY},pk({WIF}))")) == f"tr({XONLY},pk({XONLY}))"
+    assert str(parse(f"tr({XONLY},multi_a(1,{WIF}))")) == (
+        f"tr({XONLY},multi_a(1,{XONLY}))"
+    )
+    assert str(parse(f"wpkh({WIF})")) == f"wpkh({KEY})"
 
 
 XPRV_ROOT = (
@@ -1969,6 +2013,128 @@ def test_normalizing_without_the_key_says_so() -> None:
     # and the mapping has to name this key, not merely be non-empty
     with pytest.raises(BTClibValueError, match=err_msg):
         normalized(parse(f"wpkh({xpub}/0h/1/*)"), {"somebody-else": XPRV_ROOT})
+
+
+def test_the_three_spellings_of_core_s_rawtr_vector() -> None:
+    """Core gives that vector in three forms, and each is a different answer.
+
+    The private one is what is read, the public one is `ToString` -- the
+    xprv neutered and the apostrophes echoed -- and the third is
+    `ToNormalizedString`, the xpub at the last hardened step with the
+    hardened prefix moved into the key origin. The scripts are checked by
+    `test_core_derivation_vector`, which reads the same vector; what is
+    checked here is the text, `rawtr()` being a function whose only oracle
+    is Core.
+    """
+    private = "rawtr(xprv9vHkqa6EV4sPZHYqZznhT2NPtPCjKuDKGY38FBWLvgaDx45zo9WQRUT3dKYnjwih2yJD9mkrocEZXo1ex8G81dwSM1fwqWpWkeS3v86pgKt/86'/1'/0'/1/*)"
+    public = "rawtr(xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH/86'/1'/0'/1/*)"
+    canonical = "rawtr([5a61ff8e/86h/1h/0h]xpub6DtZpc9PRL2B6pwoNGysmHAaBofDmWv5S6KQEKKGPKhf5fV62ywDtSziSApYVK3JnYY5KUSgiCwiXW5wtd8z7LNBxT9Mu5sEro8itdGfTeA/1/*)"
+    # Core's own checksums, which is the whole descriptor being compared
+    assert add_checksum(private) == f"{private}#a5gn3t7k"
+    assert add_checksum(public) == f"{public}#4ur3xhft"
+    assert add_checksum(canonical) == f"{canonical}#vwgx7hj9"
+
+    prv_keys: dict[str, str] = {}
+    parsed = parse(private, prv_keys=prv_keys)
+    assert str(parsed) == public
+    assert str(normalized(parsed, prv_keys)) == canonical
+
+
+def test_a_rawtr_key_is_the_output_key_and_a_tr_key_is_not() -> None:
+    """The whole difference between the two functions, in one comparison.
+
+    ``rawtr(KEY)`` writes the key into ``OP_1 <32 bytes>`` as it is, where
+    ``tr(KEY)`` tweaks it with an empty merkle root: same key, two
+    scripts, two addresses. Which is also why a `RawTrDescriptor` is not
+    a `TrDescriptor` carrying no tree.
+    """
+    raw_tr = parse(f"rawtr({XONLY_A})")
+    assert isinstance(raw_tr, RawTrDescriptor)
+    assert raw_tr.script_pub_key().script == serialize(["OP_1", bytes.fromhex(XONLY_A)])
+    assert raw_tr.script_pub_key().script[2:] == bytes.fromhex(XONLY_A)
+
+    # the even-y SEC form of the same key, which is what a KeyExpression
+    # holds an x-only one as and what the tweak is computed from
+    sec = bytes.fromhex(f"02{XONLY_A}")
+    tweaked = parse(f"tr({XONLY_A})")
+    assert tweaked.script_pub_key().script[2:] == taproot.output_pubkey(sec)[0]
+    assert raw_tr.script_pub_key() != tweaked.script_pub_key()
+
+
+def test_a_rawtr_spend_is_the_untweaked_key_path() -> None:
+    """A signature by the key as written, which the engine is the oracle for.
+
+    The signer must not tweak what it holds -- the opposite of a ``tr()``
+    key path spend, where the signature the output key verifies is made by
+    a signer that tweaked the internal key. `psbt.finalize` verifies
+    against the output key it reads out of the script, so the same
+    signature finalizes the psbt to the same witness `satisfy` builds.
+    """
+    descriptor = parse(f"rawtr({XONLY_A})")
+    script_pub_key = descriptor.script_pub_key()
+    prevouts = [TxOut(100_000, script_pub_key)]
+    tx = Tx(
+        vin=[TxIn(OutPoint(b"\x11" * 32, 0))],
+        vout=[TxOut(90_000, script_pub_key)],
+    )
+    # a key path witness is one element and the hash does not commit to
+    # it, so a placeholder of the right shape is what there is to sign
+    # against: sig_hash reads the stack to tell the two paths apart
+    tx.vin[0].script_witness = Witness([b"\x00" * 64])
+    msg_hash = sig_hash.from_tx(prevouts, tx, 0, sig_hash.DEFAULT)
+    # key 1 is XONLY_A itself, signing with no tweak at all
+    signature = ssa.sign_(msg_hash, 1).serialize()
+
+    script_sig, witness = descriptor.satisfy({XONLY_A: signature})
+    assert script_sig == b""
+    assert witness == Witness([signature])
+    tx.vin[0].script_witness = witness
+    verify_transaction(prevouts, tx)
+
+    psbt = descriptor.update_psbt(psbt_spending(descriptor), 0)
+    psbt.assert_signable()
+    psbt.inputs[0].taproot_key_spend_signature = ssa.sign_(
+        taproot_sig_hash(psbt, 0), 1
+    ).serialize()
+    assert finalize(psbt).inputs[0].final_script_witness == Witness(
+        [psbt.inputs[0].taproot_key_spend_signature]
+    )
+
+
+def test_the_updater_writes_one_taproot_field_for_a_rawtr() -> None:
+    """The derivation, and none of the other three.
+
+    PSBT_IN_TAP_INTERNAL_KEY names the key a verifier tweaks and a
+    ``rawtr()`` has none, so it has no merkle root and no leaf script
+    either; what it does have is a key with an origin, keyed by the 32
+    bytes the script holds. `hd_key_paths` stays empty for the reason it
+    does under a ``tr()``: the same key in its 33-byte spelling would be a
+    second entry for a signer that signs with neither.
+    """
+    descriptor = parse(f"rawtr([d34db33f/86h/0h/0h]{XPUB}/0/*)")
+    key = descriptor.key_expressions[0]
+    psbt_in = descriptor.update_psbt(psbt_spending(descriptor, 3), 0, 3).inputs[0]
+
+    assert not psbt_in.hd_key_paths
+    assert not psbt_in.taproot_internal_key
+    assert not psbt_in.taproot_merkle_root
+    assert not psbt_in.taproot_leaf_scripts
+    leaf_hashes, origin = psbt_in.taproot_hd_key_paths[key.sec(3)[1:]]
+    assert leaf_hashes == []
+    assert origin.description == "d34db33f/86h/0h/0h/0/3"
+
+
+def test_a_rawtr_without_an_origin_writes_nothing_at_all() -> None:
+    """There is no other field of it to fill, so the input is left as it is.
+
+    Which is not a refusal: the script an input spends is its
+    script_pub_key and the psbt has that from the utxo, so a ``rawtr()``
+    naming a key with no origin has told the psbt everything it knows by
+    saying nothing.
+    """
+    descriptor = parse(f"rawtr({XONLY_A})")
+    psbt = descriptor.update_psbt(psbt_spending(descriptor), 0)
+    assert psbt.inputs[0] == psbt_spending(descriptor).inputs[0]
 
 
 def test_the_normalized_origin_keeps_the_fingerprint_that_was_given() -> None:


### PR DESCRIPTION
Closes #453.

`_UNIMPLEMENTED` filed `rawtr()` under BIP386, which specifies `tr()`, its
tree expression and the x-only key inside them and never mentions it. No BIP
does: what defines it is Bitcoin Core's own
[`doc/descriptors.md`](https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md),
added by Core PR #23480, so the label was wrong whether or not the function
was implemented.

## What it is

`RawTrDescriptor`, top level only, one key, x-only permitted and an
uncompressed key refused. That key is BIP341's **output** key, written into
`OP_1 <32 bytes>` as it is with no tweak at all — the whole difference from
`tr(KEY)`, which tweaks its internal key with an empty merkle root, and the
reason it is not a `TrDescriptor` carrying `tree=None`.

- **satisfaction** is a key path witness whose signature verifies against the
  key as written, so a signer must *not* tweak what it holds. `tr()` looks a
  signature up under its internal key for the opposite reason, and the two
  lookups are not the same one.
- **the Updater** writes one taproot field, `PSBT_IN_TAP_BIP32_DERIVATION`.
  An output key has no internal key a verifier could tweak, so there is no
  merkle root and no leaf script either; `psbt.sign` consequently leaves such
  an input alone rather than tweaking a key it should not.
- **the docstring keeps Core's warning**: an output key whose internal key
  nobody knows cannot be shown to have no hidden script path, so a `rawtr()`
  describes an output a wallet already holds rather than one to build.

## Two things measured on the way

- **a WIF in a taproot position is written back in 32 bytes**, where btclib
  wrote 33. A private key has no spelling of its own to echo, so the position
  decides — Core's own bool per key, `false` for a hex key it read whole and
  `ctx == P2TR` for a private one, which is what makes its `tr(WIF)` and
  `rawtr(WIF)` vectors come back x-only. `tr(WIF)`'s public spelling was
  already in the suite as Core writes it, and nothing compared the text.
- **a SCRIPT function where a tree leaf is expected is a position rule**, not
  an unimplemented one: `tr(KEY,pkh(KEY))` said "pkh() inside tr() is not
  implemented" for something that never will be, and an unknown function
  inside `tr()` now answers the way it does anywhere else.

## Oracle

Core's `src/test/descriptor_tests.cpp` has two `rawtr()` vectors, no BIP
having any, and both are reproduced whole: the ranged hardened one in all
three of its spellings (private, `ToString`, `ToNormalizedString`, each with
Core's checksum) and its scripts at index 0, 1 and 2; the WIF one with its
x-only public spelling and its script. The refusals are Core's too — a second
key, a non-top-level position — and the spend is checked by running it under
btclib's own script engine, plus once more through `psbt.finalize`, which
verifies the signature against the output key it reads out of the script.

## Gates

Merged on the local gates alone; GitHub Actions is degraded today.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`: 17381 passed, 100.00%
- `pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for the Bitcoin Core-defined rawtr() descriptor and align taproot descriptor behavior with Core’s semantics.

New Features:
- Introduce RawTrDescriptor to represent rawtr(KEY) taproot output-key descriptors at the top level.
- Parse and serialize rawtr() descriptors, including satisfaction logic for untweaked taproot key-path spends and PSBT updates keyed by the output key.

Enhancements:
- Align key-expression handling so WIF keys in taproot positions are rendered as x-only keys, matching Bitcoin Core behavior.
- Treat script functions inside taproot trees as position errors rather than unimplemented features, and return a consistent error for unknown functions inside tr().

Documentation:
- Document rawtr() support, its semantics, and its non-BIP specification origin in the changelog and module docstring.

Tests:
- Add test vectors mirroring Bitcoin Core’s rawtr() descriptor tests, including multiple descriptor spellings and derived scripts.
- Add tests for rawtr() satisfaction, PSBT finalization, PSBT field population, and no-op behavior when no origin is present.
- Extend descriptor roundtrip, error-handling, and taproot/WIF normalization tests to cover rawtr() and updated taproot semantics.