### PR TITLE
Read musig() key expressions, which is BIP390

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,64 @@ edit.
 
 ### The public API and the module layout
 
+- **`musig()` is read: BIP390's key expression** (issue #454), which was
+  the last descriptor function the parser refused by name. The
+  cryptography was already here — `btclib.ecc.musig2` is BIP327 function
+  for function, `bip32.pub_key_derivation_tweaks` is BIP328 derivation of
+  a key with no private half, and `btclib.psbt.musig2` is BIP373's three
+  roles — so what was missing was the descriptor.
+
+  `KeyExpression` widens rather than gaining a sibling: a KEY expression
+  is now one fixed key, or one extended key with a path, or the
+  `participants` an aggregate is made of with a path of its own. Every
+  holder of a key expression therefore reads a `musig()` without knowing
+  it is one — a ``tr()`` internal key, a ``rawtr()`` output key, a
+  ``pk()`` leaf and a ``multi_a()`` key, which are the positions BIP390
+  allows and the positions Bitcoin Core's own parse context allows.
+  `Descriptor.key_expressions` answers with the aggregate, the
+  participants being reachable through it: what the scripts are built from
+  is the aggregate key, and `participant_keys` is the list underneath.
+
+  `KeySort` before `KeyAgg`, which is BIP390's rule and its rationale: a
+  set of keys is what MuSig2 is about, so the order the descriptor writes
+  them in changes neither the key nor the script — and a descriptor that
+  was not backed up does not need the order guessed as well. The text
+  keeps the order it was read in all the same, as Core's `ToString` does.
+  A path after the `musig()` derives the *aggregate* key, through BIP328's
+  synthetic xpub: the aggregate at depth zero with the fixed chain code an
+  aggregate has instead of one of its own, so `derive` is what refuses a
+  hardened step there. That chain code moved to
+  `bip32.BIP328_CHAIN_CODE`, beside the tweaks that walk it, and
+  `psbt.musig2` takes it from there rather than declaring a second copy.
+
+  The Updater writes what BIP373 asks for, which is what makes a
+  `musig()` descriptor more than a way to compute an address:
+  `PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS` keyed by the aggregate key — the
+  undervied one, as BIP373 requires — the BIP328 path from that key to the
+  one in the script, filed under the fingerprint of the synthetic xpub,
+  and each participant's own key origin. `psbt.musig2` reads all three
+  back, so a psbt a `tr(musig(...)/0/*)` updated is one its group can sign:
+  the suite runs both rounds over one and `finalize` verifies the
+  aggregate signature against the output key.
+
+  Checked against BIP390's own vectors, both lists: the six valid
+  descriptors with the scripts they produce, and all fourteen invalid ones
+  with the message each is refused with. Five refusals are btclib's own,
+  for what the BIP states in prose — no nesting, no key origin in front of
+  one, at least one participant, no x-only participant (a point is what is
+  aggregated, and x-only drops the byte that says which), and a `musig()`
+  where a tree leaf belongs. One of the fourteen is refused for a reason
+  of btclib's own rather than the BIP's: a multipath `musig()` holding
+  multipath participants cannot exist here, `parse` taking no `<a;b>` step
+  at all and `multipath_descriptors` expanding them textually as BIP389
+  defines. BIP328's three vectors are read too, in
+  `tests/bip32/bip32_test.py`, and they say what BIP390's cannot: BIP328
+  aggregates the keys as written, where BIP390 sorts them first.
+
+  `_UNIMPLEMENTED` is gone with the entry it held, and `musig()` in a
+  position that takes no key expression now answers the position rule
+  rather than "not implemented".
+
 - **`rawtr()` is read, and the specification it was filed under was the
   wrong one** (issue #453). `_UNIMPLEMENTED` named BIP386, which
   specifies `tr()`, its tree expression and the x-only key inside them and
@@ -3063,9 +3121,9 @@ edit.
   two halves of the checksum a caller needs, and `parse` verifies one
   that is there. Every position rule is enforced rather than assumed —
   `sh()` at the top level only, no uncompressed key inside a witness
-  program, x-only only inside `tr()` — and what is not implemented raises
-  NotImplementedError naming what it is: miniscript is issue #187,
-  `rawtr` is BIP386 and `musig` is BIP390. The derivation is checked
+  program, x-only only where a taproot key expression goes — and the one
+  thing not implemented raises NotImplementedError naming itself:
+  miniscript, which is issue #187. The derivation is checked
   against Bitcoin Core's own `descriptor_tests.cpp` vectors, both
   spellings of each, so a WIF and an xprv are checked to reach the script
   their public halves reach (issue #186)

--- a/btclib/bip32/__init__.py
+++ b/btclib/bip32/__init__.py
@@ -6,6 +6,7 @@
 """BIP32 extended keys, derivation, and key origins."""
 
 from btclib.bip32.bip32 import (
+    BIP328_CHAIN_CODE,
     BIP32Key,
     BIP32KeyData,
     crack_prv_key,
@@ -33,6 +34,7 @@ from btclib.bip32.key_origin import (
 )
 
 __all__ = [
+    "BIP328_CHAIN_CODE",
     "BIP32Key",
     "BIP32KeyData",
     "BIP32KeyOrigin",

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -55,6 +55,7 @@ from btclib.utils import (
 )
 
 __all__ = [
+    "BIP328_CHAIN_CODE",
     "BIP32Key",
     "BIP32KeyData",
     "crack_prv_key",
@@ -496,6 +497,18 @@ def _pub_key_offset(chain_code: bytes, key: bytes, index: int) -> tuple[int, byt
     if offset >= secp256k1.n:
         raise _invalid_child(index, "the hmac left half is not a valid scalar")
     return offset, hmac_[32:]
+
+
+# BIP328's chain code, which is the sha256 of "MuSig2MuSig2MuSig2": an
+# aggregate key has no chain code of its own, so a synthetic xpub is the
+# key plus this constant, and every implementation deriving from an
+# aggregate key has to use the same one or derive other children. It sits
+# beside the tweaks below because it is the other half of one fact: the
+# derivation BIP328 defines is this chain code walked by that function,
+# and both `psbt.musig2` and a `musig()` descriptor key expression need it
+BIP328_CHAIN_CODE = bytes.fromhex(
+    "868087ca02a6f974c4598924c36b57762d32cb45717167e300622c7167e38965"
+)
 
 
 def pub_key_derivation_tweaks(

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -45,11 +45,19 @@ The grammar read is BIP380 to BIP387 and BIP389, minus miniscript:
   ``tr()`` and ``rawtr()``, x-only), WIF private keys, xpub/xprv with a
   derivation path, key origin, ``/*`` and ``/*h`` wildcards, both ``h``
   and ``'`` hardened markers
+- ``musig``, the BIP390 key expression: the BIP327 aggregate of its
+  participants, inside a ``tr()`` or a ``rawtr()`` and nowhere else, with
+  BIP328 derivation of the aggregate key where it has a path of its own
 - the ``<a;b>`` multipath form of BIP389, through `multipath_descriptors`
 
 What raises NotImplementedError, rather than being read wrong: every
-miniscript expression, which is issue #187; and ``musig``, which is
-BIP390 and belongs with the work that adds it.
+miniscript expression, which is issue #187.
+
+BIP390's rule that a multipath ``musig()`` may not hold multipath
+participants has no counterpart here, and cannot: `parse` refuses a
+``<a;b>`` step anywhere, `multipath_descriptors` expands it textually as
+BIP389 defines, and what reaches a `Descriptor` is one path per key. Such
+a descriptor is refused, and for the more general reason.
 
 A parsed descriptor holds no key that signs. `parse` neuters an xprv to
 the xpub the `KeyExpression` then carries, and hands the private spelling
@@ -98,13 +106,18 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, fields, replace
 from typing import Any, cast
 
 from btclib.alias import Octets, ScriptList, TaprootScriptTree
-from btclib.bip32.bip32 import BIP32KeyData, derive, xpub_from_xprv
+from btclib.bip32.bip32 import (
+    BIP328_CHAIN_CODE,
+    BIP32KeyData,
+    derive,
+    xpub_from_xprv,
+)
 from btclib.bip32.der_path import (
     _HARDENED_OFFSET,
     _HARDENING,
@@ -114,7 +127,12 @@ from btclib.bip32.der_path import (
     str_from_index_int,
 )
 from btclib.bip32.key_origin import BIP32KeyOrigin
+from btclib.curves import secp256k1
+from btclib.curves.sec_point import bytes_from_point
+from btclib.ecc.musig2 import key_agg, key_sort
 from btclib.exceptions import BTClibValueError
+from btclib.hashes import hash160
+from btclib.network import NETWORKS
 from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.script.script import op_int, serialize
@@ -263,13 +281,6 @@ _MINISCRIPT_FRAGMENTS = frozenset(
     )
 )
 
-# descriptor functions read as such and refused rather than guessed at:
-# each is a specification of its own, and a script derived wrong is an
-# address that loses money
-_UNIMPLEMENTED = {
-    "musig": "BIP390",
-}
-
 # BIP387's own bound on the keys of a multi_a(): the satisfaction puts one
 # stack element per key, and a script whose spend would push more than the
 # 1000 elements BIP342 allows is one nobody can spend
@@ -302,11 +313,14 @@ PrvKeys = Mapping[str, str]
 class KeyExpression:
     """A BIP380 KEY expression: an origin, a key, a derivation path.
 
-    Either `pub_key` is the key the descriptor fixes, in SEC bytes, or
-    `xkey` is the extended key that `der_path` and `wildcard` derive
-    from. An x-only key is held as its even-y SEC form, which is what
-    BIP340 says those 32 bytes mean, so that everything downstream sees
-    one representation of a public key.
+    One of three things is the key. Either `pub_key` is the one the
+    descriptor fixes, in SEC bytes; or `xkey` is the extended key that
+    `der_path` and `wildcard` derive from; or `participants` are the KEY
+    expressions BIP390's ``musig()`` aggregates, `der_path` and `wildcard`
+    then deriving from the aggregate key as BIP328 prescribes. An x-only
+    key is held as its even-y SEC form, which is what BIP340 says those 32
+    bytes mean, so that everything downstream sees one representation of a
+    public key.
 
     `origin` never changes the script. It says which master key and which
     path the key came from, which is what a hardware signer needs and
@@ -330,6 +344,11 @@ class KeyExpression:
     # is only meaningful when there is a wildcard to harden
     wildcard: int | None = None
     x_only: bool = False
+    # BIP390's ``musig()``: the participants whose keys aggregate to this
+    # one, in the order the descriptor writes them. `KeySort` is applied
+    # at aggregation and not here, so what is kept is the text's order and
+    # what is computed does not depend on it
+    participants: tuple[KeyExpression, ...] = ()
     # the symbol every hardened step of this expression is written with:
     # BIP380 gives "h" and "'" one meaning and two spellings, and the two
     # are different strings with different checksums, so a descriptor
@@ -342,8 +361,20 @@ class KeyExpression:
 
     @property
     def is_ranged(self) -> bool:
-        """Answer whether the key has a wildcard to derive at an index."""
-        return self.wildcard is not None
+        """Answer whether the key has a wildcard to derive at an index.
+
+        A ``musig()`` is ranged where its own path has one and where a
+        participant has one: BIP390 forbids both at once, so whichever it
+        is, the index is read in one place.
+        """
+        return self.wildcard is not None or any(
+            key.is_ranged for key in self.participants
+        )
+
+    @property
+    def is_aggregate(self) -> bool:
+        """Answer whether the key is the aggregate of BIP390 participants."""
+        return bool(self.participants)
 
     @property
     def is_compressed(self) -> bool:
@@ -367,7 +398,31 @@ class KeyExpression:
         from the xpub the descriptor holds. A key it does not name is
         left as it is, so a mapping covering some of a multisig's keys
         answers for those and no more.
+
+        A ``musig()`` answers with the key its participants aggregate to,
+        derived along its own path where it has one: BIP328's synthetic
+        xpub is that key at depth zero with the fixed chain code an
+        aggregate has instead of one of its own, and `derive` is then what
+        refuses a hardened step -- there being no aggregate private key to
+        take one with. The index derives the participants or the aggregate
+        and never both, BIP390 allowing a wildcard on one side only.
         """
+        if self.participants:
+            aggregate = self.aggregate(index, network, prv_keys)
+            musig_path = list(self.der_path)
+            if self.wildcard is not None:
+                musig_path.append(self.wildcard + index)
+            if not musig_path:
+                return aggregate
+            synthetic = BIP32KeyData(
+                version=NETWORKS[network].bip32_pub,
+                depth=0,
+                parent_fingerprint=b"\x00" * 4,
+                index=0,
+                chain_code=BIP328_CHAIN_CODE,
+                key=aggregate,
+            )
+            return pub_keyinfo_from_key(derive(synthetic, musig_path), network)[0]
         if self.pub_key is not None:
             return self.pub_key
         der_path = list(self.der_path)
@@ -375,6 +430,45 @@ class KeyExpression:
             der_path.append(self.wildcard + index)
         xkey = prv_keys.get(self.xkey, self.xkey) if prv_keys else self.xkey
         return pub_keyinfo_from_key(derive(xkey, der_path), network)[0]
+
+    def participant_keys(
+        self,
+        index: int = 0,
+        network: str = "mainnet",
+        prv_keys: PrvKeys | None = None,
+    ) -> list[bytes]:
+        """Return the participant keys in the order they are aggregated in.
+
+        Which is `KeySort`'s order and not the descriptor's: BIP390 sorts
+        after all derivation and before aggregation, so that the order the
+        keys were written in does not change the key -- a set of keys is
+        what MuSig2 is about, and a descriptor that was not backed up does
+        not need the order guessed as well. BIP373 stores the participants
+        of a psbt in aggregation order too, which is what makes this the
+        list that goes into `PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS`.
+        """
+        derived = [key.sec(index, network, prv_keys) for key in self.participants]
+        return key_sort(derived)
+
+    def aggregate(
+        self,
+        index: int = 0,
+        network: str = "mainnet",
+        prv_keys: PrvKeys | None = None,
+    ) -> bytes:
+        """Return the key BIP390's participants aggregate to, derived.
+
+        `KeyAgg` over the sorted participants, and nothing more: the
+        ``/NUM/.../*`` path of the expression derives *from* this key, and
+        `sec` is what walks it. The two are separate because BIP373 keys
+        its MuSig2 psbt fields by the aggregate key itself even where what
+        the script holds is a child of it -- an aggregate key is what the
+        participants make, and a derivation of it is a key the same group
+        answers for.
+        """
+        return bytes_from_point(
+            key_agg(self.participant_keys(index, network, prv_keys)).Q, secp256k1
+        )
 
     def __str__(self) -> str:
         """Return the KEY expression, in the spelling it was read in.
@@ -387,7 +481,18 @@ class KeyExpression:
 
         An x-only key is written as the 32 bytes a ``tr()`` holds, which
         is the spelling it was read in and the only one allowed there.
+
+        A ``musig()`` writes its participants in the order they were read,
+        which is not the order they aggregate in: `KeySort` is applied when
+        the key is computed, so the text keeps what the descriptor said.
         """
+        if self.participants:
+            text = _expression("musig", *(str(key) for key in self.participants))
+            for index in self.der_path:
+                text += "/" + str_from_index_int(index, self.hardening)
+            if self.wildcard is not None:
+                text += "/*"
+            return text
         text = ""
         if self.origin is not None:
             path = str_from_der_path(
@@ -641,6 +746,93 @@ def _derived_origin(key: KeyExpression, index: int) -> BIP32KeyOrigin | None:
     if key.wildcard is not None:
         der_path.append(key.wildcard + index)
     return BIP32KeyOrigin(key.origin.master_fingerprint, der_path)
+
+
+def _aggregate_origin(
+    key: KeyExpression, index: int, network: str, prv_keys: PrvKeys | None
+) -> BIP32KeyOrigin | None:
+    """Return where a derived aggregate key came from, None where it is one.
+
+    BIP373's answer to "how does this key relate to the aggregate the
+    participants make": the derivation path, under the fingerprint of
+    BIP328's synthetic xpub, which is hash160 of the aggregate key -- and
+    which is what lets a signer recognize the field as BIP328 derivation
+    without a `PSBT_GLOBAL_XPUB` naming that synthetic key.
+    `psbt.musig2` reads it back exactly that way.
+
+    None where the expression derives nothing, the key in the script then
+    being the aggregate itself and the psbt having nothing to say about how
+    to get from one to the other.
+    """
+    der_path = [*key.der_path]
+    if key.wildcard is not None:
+        der_path.append(key.wildcard + index)
+    if not der_path:
+        return None
+    aggregate = key.aggregate(index, network, prv_keys)
+    return BIP32KeyOrigin(hash160(aggregate)[:4], der_path)
+
+
+def _taproot_derivations(
+    keys: Sequence[KeyExpression],
+    leaf_hashes: Mapping[bytes, list[bytes]],
+    index: int,
+    network: str,
+    prv_keys: PrvKeys | None,
+) -> dict[bytes, tuple[list[bytes], BIP32KeyOrigin]]:
+    """Return BIP371's derivation field for a set of taproot key expressions.
+
+    Keyed by the 32 bytes a tapscript holds, and carrying the tapleaf hash
+    of every leaf the key appears in, which the caller has worked out: none
+    for a key that is only the internal one, and one per leaf otherwise.
+
+    A ``musig()`` puts two kinds of entry here, both of which BIP373 asks
+    the Updater for: the key in the script, under the synthetic origin
+    `_aggregate_origin` computes, and each participant that carries an
+    origin of its own -- the second being how a signer finds out that one
+    of the keys it holds is in this group at all. A participant is in no
+    leaf, so its leaf hashes are empty; what says which leaves the group
+    signs for is the aggregate's own entry.
+    """
+    derivations: dict[bytes, tuple[list[bytes], BIP32KeyOrigin]] = {}
+    for key in keys:
+        origin = (
+            _aggregate_origin(key, index, network, prv_keys)
+            if key.is_aggregate
+            else _derived_origin(key, index)
+        )
+        if origin is not None:
+            x_only = key.sec(index, network, prv_keys)[1:]
+            derivations[x_only] = (list(leaf_hashes.get(x_only, [])), origin)
+        for participant in key.participants:
+            participant_origin = _derived_origin(participant, index)
+            if participant_origin is None:
+                continue
+            x_only = participant.sec(index, network, prv_keys)[1:]
+            derivations[x_only] = ([], participant_origin)
+    return derivations
+
+
+def _musig2_participants(
+    keys: Sequence[KeyExpression],
+    index: int,
+    network: str,
+    prv_keys: PrvKeys | None,
+) -> dict[bytes, list[bytes]]:
+    """Return BIP373's participant field: each aggregate key's own list.
+
+    Keyed by the 33-byte aggregate key rather than by what the script
+    holds, which BIP373 requires and which is the whole use of the field:
+    the participants are what a signer checks its own keys against, and a
+    child of the aggregate is a key the same list answers for.
+    """
+    return {
+        key.aggregate(index, network, prv_keys): key.participant_keys(
+            index, network, prv_keys
+        )
+        for key in keys
+        if key.is_aggregate
+    }
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -1413,14 +1605,9 @@ class TrDescriptor(Descriptor):
                     )
                     if hash_ not in hashes:
                         hashes.append(hash_)
-        hd_key_paths: dict[bytes, tuple[list[bytes], BIP32KeyOrigin]] = {}
-        for key in self.key_expressions:
-            origin = _derived_origin(key, index)
-            if origin is None:
-                continue
-            x_only = key.sec(index, self.network, prv_keys)[1:]
-            hd_key_paths[x_only] = (leaf_hashes.get(x_only, []), origin)
-        return hd_key_paths
+        return _taproot_derivations(
+            self.key_expressions, leaf_hashes, index, self.network, prv_keys
+        )
 
     def _satisfy(
         self,
@@ -1478,6 +1665,10 @@ class TrDescriptor(Descriptor):
         key, and a 33-byte entry in `hd_key_paths` beside it would be the
         same key twice in two spellings, for a signer that signs with
         neither.
+
+        A fifth field where a key of the descriptor is a ``musig()``:
+        BIP373's participant list, which is what tells a signer that one of
+        the keys it holds is in the group this input is spent by.
         """
         psbt_in.taproot_internal_key = self.internal_key.sec(
             index, self.network, prv_keys
@@ -1490,6 +1681,10 @@ class TrDescriptor(Descriptor):
         psbt_in.taproot_hd_key_paths = {
             **psbt_in.taproot_hd_key_paths,
             **self._taproot_hd_key_paths(index, prv_keys),
+        }
+        psbt_in.musig2_participant_pub_keys = {
+            **psbt_in.musig2_participant_pub_keys,
+            **_musig2_participants(self.key_expressions, index, self.network, prv_keys),
         }
 
 
@@ -1564,14 +1759,20 @@ class RawTrDescriptor(Descriptor):
         through its internal key and therefore leaves this input alone
         rather than tweaking a key it should not: an input with no
         internal key is one that role skips.
+
+        BIP373's participant list is written beside it where the key is a
+        ``musig()``, as it is under a ``tr()``: an aggregate key that is
+        the output key itself is the first of the four ways BIP373 has of
+        reaching what is spent.
         """
-        origin = _derived_origin(self.key, index)
-        if origin is None:
-            return
-        x_only = self.key.sec(index, self.network, prv_keys)[1:]
+        keys = self.key_expressions
         psbt_in.taproot_hd_key_paths = {
             **psbt_in.taproot_hd_key_paths,
-            x_only: ([], origin),
+            **_taproot_derivations(keys, {}, index, self.network, prv_keys),
+        }
+        psbt_in.musig2_participant_pub_keys = {
+            **psbt_in.musig2_participant_pub_keys,
+            **_musig2_participants(keys, index, self.network, prv_keys),
         }
 
 
@@ -1611,12 +1812,16 @@ def _split_function(expression: str) -> tuple[str, str]:
     return expression[:open_bracket], expression[open_bracket + 1 : -1]
 
 
-def _assert_implemented(name: str) -> None:
+def _assert_not_miniscript(name: str) -> None:
+    """Refuse a miniscript fragment, which is the one thing left unread.
+
+    A wrapper is caught by its colon, and every other function this module
+    does not read is answered "unknown descriptor function": miniscript is
+    named on its own because it is a language of its own rather than a
+    function missing from a table (issue #187).
+    """
     if ":" in name or name in _MINISCRIPT_FRAGMENTS:
         err_msg = f"miniscript is not implemented: {name} (issue #187)"
-        raise NotImplementedError(err_msg)
-    if name in _UNIMPLEMENTED:
-        err_msg = f"{name}() is not implemented ({_UNIMPLEMENTED[name]})"
         raise NotImplementedError(err_msg)
 
 
@@ -1679,7 +1884,11 @@ def _pub_key_from_hex(key: str, *, x_only: bool) -> tuple[bytes, bool]:
     length = len(key)
     if length == 64:
         if not x_only:
-            raise BTClibValueError("x-only public keys are allowed inside tr() only")
+            # "inside tr()" would not be true of every position that
+            # refuses one: a musig() participant is inside a tr() and is
+            # aggregated as a point, so it needs the byte an x-only key drops
+            err_msg = "x-only public keys are allowed in a taproot key expression only"
+            raise BTClibValueError(err_msg)
         # the even-y lift of BIP340, which is what an x-only key means
         pub_key = b"\x02" + bytes_from_octets(key)
     elif length in (66, 130):
@@ -1744,6 +1953,23 @@ def _origin_and_rest(expression: str) -> tuple[BIP32KeyOrigin | None, str, str]:
     return origin, hardening, expression[end + 1 :]
 
 
+def _assert_musig_allowed(*, musig_allowed: bool) -> None:
+    """Refuse a ``musig()`` anywhere BIP390 does not put one.
+
+    Which is everywhere but a ``tr()`` and a ``rawtr()``: their internal
+    or output key, and the keys of the ``pk()``, ``multi_a()`` and
+    ``sortedmulti_a()`` leaves of a script tree. A participant is one of
+    the places it is refused, which is BIP390's "cannot be nested within
+    another musig()", and the message names both -- Bitcoin Core's own,
+    and the same sentence answers a nested one and a ``wpkh(musig())``.
+
+    BIP390 names ``sp()`` as a third position; btclib does not read
+    ``sp()`` at all, so there is nothing here to allow it in.
+    """
+    if not musig_allowed:
+        raise BTClibValueError("musig() is only allowed in tr() and rawtr()")
+
+
 def _assert_key_characters(rest: str) -> None:
     """Refuse what a KEY expression cannot hold once the origin is off."""
     if "]" in rest:
@@ -1752,9 +1978,12 @@ def _assert_key_characters(rest: str) -> None:
         err_msg = "multipath key expression: use multipath_descriptors first"
         raise BTClibValueError(err_msg)
     if "(" in rest:
-        # the one KEY expression that is a function is BIP390's musig(),
-        # and a key nothing reads is not a key to guess at
-        _assert_implemented(rest[: rest.index("(")])
+        # a function where a key belongs. BIP390's musig() is the one that
+        # is a key expression, and reaching here means it was written
+        # behind a key origin, which is not where it may be nested
+        if rest.startswith("musig("):
+            raise BTClibValueError("musig() cannot be nested inside a key origin")
+        _assert_not_miniscript(rest[: rest.index("(")])
         raise BTClibValueError("not a key expression")
 
 
@@ -1787,12 +2016,76 @@ def _fixed_pub_key(key: str, *, x_only: bool) -> tuple[bytes, bool]:
         raise BTClibValueError("invalid key expression") from e
 
 
+def _musig_der_path(suffix: str) -> tuple[tuple[int, ...], int | None]:
+    """Return the path and wildcard a ``musig()`` derives the aggregate by.
+
+    Every one of BIP390's rules about it is a refusal here: no hardened
+    step and no hardened wildcard, an aggregate key having no private half
+    to take either with, which is BIP328's own restriction.
+    """
+    if not suffix:
+        return (), None
+    if not suffix.startswith("/"):
+        raise BTClibValueError(f"not a musig() derivation path: {suffix}")
+    steps, wildcard, wildcard_hardening = _split_wildcard(suffix[1:].split("/"))
+    if wildcard_hardening:
+        raise BTClibValueError("musig() cannot have a hardened wildcard")
+    der_path = _der_path("/".join(steps))
+    if any(index >= _HARDENED_OFFSET for index in der_path):
+        raise BTClibValueError("musig() cannot have hardened derivation steps")
+    return tuple(der_path), wildcard
+
+
+def _parse_musig(expression: str, prv_keys: dict[str, str]) -> KeyExpression:
+    """Return the KeyExpression of a BIP390 ``musig()`` expression.
+
+    The participants are KEY expressions read as any other key in a
+    ``tr()`` is, except that none of them may be x-only: MuSig2
+    aggregation is over points, so it needs the evenness byte an x-only
+    spelling drops -- which is Bitcoin Core's rule too, its own parse
+    context allowing 32-byte keys under ``tr()`` and not under
+    ``musig()``.
+
+    Derivation on the aggregate key costs three further conditions, all
+    BIP390's: every participant an extended key, none of them ranged, and
+    no hardened step. The first two are what make one aggregate key per
+    index well defined -- with both sides ranged there would be two
+    indexes and one wildcard to read them from.
+    """
+    close = expression.rfind(")")
+    inner = expression[len("musig(") : close]
+    arguments = _split_arguments(inner)
+    if arguments == [""]:
+        raise BTClibValueError("musig() takes at least one key")
+    try:
+        participants = tuple(
+            _parse_key(key, prv_keys, compressed=True) for key in arguments
+        )
+    # which of several participants was wrong is half the answer, and the
+    # inner message names neither the function nor the position. Bitcoin
+    # Core prefixes its own the same way, "musig(): ..."
+    except BTClibValueError as e:
+        raise BTClibValueError(f"musig(): {e}") from e
+    der_path, wildcard = _musig_der_path(expression[close + 1 :])
+    if der_path or wildcard is not None:
+        if any(not key.xkey for key in participants):
+            err_msg = "musig() derivation requires every participant to be extended"
+            raise BTClibValueError(err_msg)
+        if any(key.is_ranged for key in participants):
+            err_msg = "musig() cannot have a ranged participant and derivation too"
+            raise BTClibValueError(err_msg)
+    return KeyExpression(
+        participants=participants, der_path=der_path, wildcard=wildcard
+    )
+
+
 def _parse_key(
     expression: str,
     prv_keys: dict[str, str],
     *,
     x_only: bool = False,
     compressed: bool = False,
+    musig_allowed: bool = False,
 ) -> KeyExpression:
     """Return the KeyExpression of a BIP380 KEY expression.
 
@@ -1804,7 +2097,15 @@ def _parse_key(
     order it is written: the origin's path, then the key's, then the
     wildcard. A fixed key hardens nothing and keeps the default, there
     being no step of it to write.
+
+    A ``musig()`` is read before the key origin and not after it, which is
+    Bitcoin Core's order and where BIP390's "cannot be nested" comes from:
+    the expression is a musig one or it is not, so an origin in front of it
+    is not a musig expression with an origin -- it is a key that is no key.
     """
+    if expression.startswith("musig("):
+        _assert_musig_allowed(musig_allowed=musig_allowed)
+        return _parse_musig(expression, prv_keys)
     origin, origin_hardening, rest = _origin_and_rest(expression)
     _assert_key_characters(rest)
     key, separator, path = rest.partition("/")
@@ -1850,7 +2151,8 @@ def _parse_multi_a(name: str, args: list[str], prv_keys: dict[str, str]) -> Mult
     if not _THRESHOLD.fullmatch(args[0]):
         raise BTClibValueError(f"invalid {name}() threshold: {args[0]}")
     keys = tuple(
-        _parse_key(key, prv_keys, x_only=True, compressed=True) for key in args[1:]
+        _parse_key(key, prv_keys, x_only=True, compressed=True, musig_allowed=True)
+        for key in args[1:]
     )
     return MultiA(int(args[0]), keys, sort=name == "sortedmulti_a")
 
@@ -1869,10 +2171,15 @@ def _parse_tree(expression: str, prv_keys: dict[str, str]) -> DescriptorTree:
             _parse_tree(branches[1], prv_keys),
         )
     name, arguments = _split_function(expression)
-    _assert_implemented(name)
+    _assert_not_miniscript(name)
     args = _split_arguments(arguments)
     if name in _TREE_FUNCTIONS:
         return _parse_multi_a(name, args, prv_keys)
+    if name == "musig":
+        # allowed inside tr(), and as a key rather than as a leaf: a leaf
+        # is a script, and what a musig() aggregates to is one key of one
+        err_msg = "musig() is a key expression: pk(musig(...)) is the leaf"
+        raise BTClibValueError(err_msg)
     if name in _PARSERS:
         # a SCRIPT function where a leaf is expected: a position rule and
         # not something a later release adds, which is what the position
@@ -1881,7 +2188,13 @@ def _parse_tree(expression: str, prv_keys: dict[str, str]) -> DescriptorTree:
         _assert_position(name, _P2TR, _PARSERS[name][0])
     if name != "pk":
         raise BTClibValueError(f"unknown descriptor function: {name}()")
-    return _parse_key(_one_argument(args, name), prv_keys, x_only=True, compressed=True)
+    return _parse_key(
+        _one_argument(args, name),
+        prv_keys,
+        x_only=True,
+        compressed=True,
+        musig_allowed=True,
+    )
 
 
 # inside a witness program an uncompressed key is unspendable, so
@@ -1979,7 +2292,9 @@ def _parse_tr(
     if len(args) > 2:
         err_msg = f"tr() takes a key and at most one tree, {len(args)} given"
         raise BTClibValueError(err_msg)
-    internal_key = _parse_key(args[0], prv_keys, x_only=True, compressed=True)
+    internal_key = _parse_key(
+        args[0], prv_keys, x_only=True, compressed=True, musig_allowed=True
+    )
     tree = None if len(args) == 1 else _parse_tree(args[1], prv_keys)
     return TrDescriptor(internal_key, tree, network=network)
 
@@ -1990,7 +2305,11 @@ def _parse_rawtr(
     # one key and no tree: what Core's error says too, "rawtr(): only one
     # key expected", the function having nothing to put a second key in
     key = _parse_key(
-        _one_argument(args, "rawtr"), prv_keys, x_only=True, compressed=True
+        _one_argument(args, "rawtr"),
+        prv_keys,
+        x_only=True,
+        compressed=True,
+        musig_allowed=True,
     )
     return RawTrDescriptor(key, network=network)
 
@@ -2045,7 +2364,12 @@ def _parse_expression(
 ) -> Descriptor:
     """Return the Descriptor of a SCRIPT expression, in its context."""
     name, arguments = _split_function(expression)
-    _assert_implemented(name)
+    _assert_not_miniscript(name)
+    if name == "musig":
+        # a key expression where a SCRIPT one is expected: BIP390's own
+        # invalid vectors write it as sh(musig()) and wsh(musig()), and
+        # what is wrong with both is the position rather than the word
+        _assert_musig_allowed(musig_allowed=False)
     if name in _TREE_FUNCTIONS:
         # a tree leaf and no SCRIPT expression, so reaching this is the
         # position rule of BIP387 being broken: `_assert_position` says
@@ -2085,7 +2409,20 @@ def _normalized_key(key: KeyExpression, prv_keys: PrvKeys | None) -> KeyExpressi
     Bitcoin Core's first branch too, and for the same reason -- the step
     that needs the private key is the one taken at every index, so there
     is no point to re-root to.
+
+    A ``musig()`` is its participants normalized: its own path cannot
+    harden, BIP390 forbidding it, so there is nothing else of it to
+    re-root.
     """
+    if key.participants:
+        return replace(
+            key,
+            participants=tuple(
+                _normalized_key(participant, prv_keys)
+                for participant in key.participants
+            ),
+            hardening=_HARDENING,
+        )
     if key.pub_key is not None or key.wildcard == _HARDENED_OFFSET:
         return replace(key, hardening=_HARDENING)
     hardened = [i for i, step in enumerate(key.der_path) if step >= _HARDENED_OFFSET]

--- a/btclib/psbt/musig2.py
+++ b/btclib/psbt/musig2.py
@@ -58,7 +58,7 @@ from collections.abc import Sequence
 from typing import NamedTuple
 
 from btclib.alias import Octets
-from btclib.bip32 import pub_key_derivation_tweaks
+from btclib.bip32 import BIP328_CHAIN_CODE, pub_key_derivation_tweaks
 from btclib.curves import secp256k1
 from btclib.curves.sec_point import bytes_from_point
 from btclib.ecc import musig2, ssa
@@ -90,14 +90,6 @@ __all__ = [
     "partial_sigs_agg",
     "session_context",
 ]
-
-# BIP328's chain code, which is the sha256 of "MuSig2MuSig2MuSig2": an
-# aggregate key has no chain code of its own, so a synthetic xpub is the
-# key plus this constant, and every implementation deriving from an
-# aggregate key has to use the same one or derive other children
-_BIP328_CHAIN_CODE = bytes.fromhex(
-    "868087ca02a6f974c4598924c36b57762d32cb45717167e300622c7167e38965"
-)
 
 
 def add_participant_pub_keys(
@@ -141,8 +133,8 @@ def _derivation_tweaks(psbt_in: PsbtIn, aggregate_pub_key: bytes) -> list[bytes]
 
     The path is the one `PSBT_IN_TAP_BIP32_DERIVATION` files the internal
     key under, and what says it starts at the aggregate key is the master
-    fingerprint: BIP328's synthetic xpub is the aggregate key with the
-    fixed chain code above, so its fingerprint is hash160 of that key.
+    fingerprint: BIP328's synthetic xpub is the aggregate key with
+    `BIP328_CHAIN_CODE`, so its fingerprint is hash160 of that key.
     BIP373 lets that field be assumed to be BIP328 derivation whenever no
     `PSBT_GLOBAL_XPUB` names a synthetic xpub, which is what makes the
     fingerprint enough to recognize it.
@@ -156,7 +148,7 @@ def _derivation_tweaks(psbt_in: PsbtIn, aggregate_pub_key: bytes) -> list[bytes]
         err_msg += internal_key.hex()
         raise BTClibValueError(err_msg)
     return pub_key_derivation_tweaks(
-        aggregate_pub_key, _BIP328_CHAIN_CODE, derivation[1].der_path
+        aggregate_pub_key, BIP328_CHAIN_CODE, derivation[1].der_path
     )
 
 

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -569,6 +569,74 @@ and their five p2sh addresses — appear verbatim in the pinned text, and
 re-checking against the tip on 2026-07-30 and again on 2026-08-06 found no
 sixth group. Nothing to refresh.
 
+### Not vendored as a file: BIP387's `multi_a()` vectors
+
+```text
+repo    bitcoin/bips
+path    bip-0387.mediawiki
+commit  24e96e870fffaa257b465ce1f0370c14aac588e8  2026-01-12
+pulled  2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **transcribed**, and cited inline rather than vendored: they are
+descriptors and scripts read where they are used, in
+`tests/descriptors_test.py`'s `BIP387_VECTORS` and `BIP387_INVALID`. Every
+descriptor of the BIP's Test Vectors section is there with the
+scriptPubKey it produces, at each index the BIP lists, and every invalid
+one with the message btclib refuses it with — two of those refusals
+answering the uncompressed key before the threshold the BIP was
+illustrating, which the entries say. Each value was matched against the
+pinned text on 2026-08-06.
+
+### Not vendored as a file: BIP390's `musig()` vectors
+
+```text
+repo    bitcoin/bips
+path    bip-0390.mediawiki
+commit  7517a8b2ac8fdb13e586d0e139a7f5b87ceab994  2026-08-06
+pulled  2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **transcribed**, complete for both lists and cited inline, in
+`tests/descriptors_test.py`'s `BIP390_VECTORS` and `BIP390_INVALID`: the
+six valid descriptors with the scripts they produce at each index listed,
+and all fourteen invalid ones with the message each is refused with. Five
+further invalid cases there are btclib's own, for what the BIP states in
+prose rather than listing — no nesting, no key origin in front of one, at
+least one participant, no x-only participant, and a `musig()` where a tree
+leaf belongs.
+
+The pin is the tip and it is the day it was taken: that commit is
+`bip390: fix missing parenthesis in test vector`, which closed the last
+invalid descriptor's brackets, so a copy taken a day earlier would hold a
+descriptor upstream no longer publishes. Ours is the fixed one.
+
+One of the fourteen is refused for a reason of btclib's own rather than
+the BIP's, and the entry in the module says so: a multipath `musig()`
+holding multipath participants is refused because `parse` takes no `<a;b>`
+step at all, `multipath_descriptors` being what expands them textually as
+BIP389 defines.
+
+### Not vendored as a file: BIP328's synthetic xpub vectors
+
+```text
+repo    bitcoin/bips
+path    bip-0328.mediawiki
+commit  24e96e870fffaa257b465ce1f0370c14aac588e8  2026-01-12
+pulled  2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **transcribed**, complete: all three aggregate keys, the
+synthetic xpub each becomes and the participant keys each aggregates, in
+`tests/bip32/bip32_test.py`'s `BIP328_VECTORS`. The keys of those vectors
+aggregate **as written**, unsorted, which is what makes them worth holding
+beside BIP390's: sorting before aggregation is BIP390's rule and not
+BIP328's, and a `key_sort` applied here reaches none of the three
+published keys. Matched against the pinned text on 2026-08-06.
+
 ## bitcoin/bitcoin
 
 ### `tests/script/_data/sig_hash_legacy_test_vectors.json`
@@ -759,6 +827,34 @@ concrete descriptors we do not hold (a `tr(musig(...))`, a
 being syntax templates like `sh(SCRIPT)`), and each would need a checksum
 computed by something that is not btclib. That is a decision to take with
 a tool at hand, not a refresh.
+
+### Not vendored as a file: Core's descriptor derivation vectors
+
+```text
+repo    bitcoin/bitcoin
+path    src/test/descriptor_tests.cpp
+commit  8ecbe270f0dee68b7eec6cea1714f453c5e215ad  2026-07-29
+pulled  2026-08-02, rawtr() added 2026-08-06
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **transcribed**, a subset by design. `tests/descriptors_test.py`
+holds the `Check(prv, pub, ...)` cases of the `descriptor_test` case as
+`CORE_VECTORS` — the descriptor in both spellings and the scriptPubKey
+each expands to, at every index the case lists — plus the public spellings
+of the four Core expands from the private form alone, and the two
+`rawtr()` cases, which no BIP publishes and only this file has.
+
+Not vendored as a file because there is no file: the values are literals
+in C++ source, so a copy of it would be a copy of a test program. What
+this pin buys instead is the upstream re-check: a case added to that
+function moves the commit, and the monthly run says so.
+
+The subset is deliberate and is what a refresh would revisit: Core's file
+also holds `CheckUnparsable` cases, which this module has as `UNPARSABLE`
+with btclib's own messages, and the `musig()` cases of BIP390, which are
+transcribed from the BIP itself above rather than from here. Matched
+against the pinned file on 2026-08-06.
 
 ## bitcoin-core/qa-assets
 

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -14,6 +14,7 @@ import pytest
 from btclib import base58
 from btclib.b58 import p2pkh
 from btclib.bip32 import (
+    BIP328_CHAIN_CODE,
     BIP32KeyData,
     crack_prv_key,
     derive,
@@ -31,8 +32,10 @@ from btclib.curves import (
     point_from_octets,
 )
 from btclib.curves import secp256k1 as ec
+from btclib.ecc.musig2 import key_agg
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
+from btclib.network import NETWORKS
 from btclib.to_pub_key import pub_keyinfo_from_key
 from tests import load, vector_id
 
@@ -656,3 +659,73 @@ def test_the_tweaks_of_a_public_derivation_are_the_derivation() -> None:
     err_msg = "invalid hardened derivation from public key"
     with pytest.raises(BTClibValueError, match=err_msg):
         pub_key_derivation_tweaks(xpub.key, xpub.chain_code, "m/1h")
+
+
+# BIP328's own test vectors: a MuSig2 aggregate public key, the synthetic
+# xpub it becomes, and the participant keys it aggregates. The keys are
+# *not* sorted here -- BIP328 aggregates the list as written, where BIP390
+# sorts it first, so the three vectors say which of the two rules is whose
+BIP328_VECTORS = [
+    (
+        "0354240c76b8f2999143301a99c7f721ee57eee0bce401df3afeaa9ae218c70f23",
+        "xpub661MyMwAqRbcFt6tk3uaczE1y6EvM1TqXvawXcYmFEWijEM4PDBnuCXwwXEKGEouzXE6QLLRxjatMcLLzJ5LV5Nib1BN7vJg6yp45yHHRbm",
+        [
+            "03935F972DA013F80AE011890FA89B67A27B7BE6CCB24D3274D18B2D4067F261A9",
+            "02F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9",
+        ],
+    ),
+    (
+        "0290539eede565f5d054f32cc0c220126889ed1e5d193baf15aef344fe59d4610c",
+        "xpub661MyMwAqRbcFt6tk3uaczE1y6EvM1TqXvawXcYmFEWijEM4PDBnuCXwwVk5TFJk8Tw5WAdV3DhrGfbFA216sE9BsQQiSFTdudkETnKdg8k",
+        [
+            "02F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9",
+            "03DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659",
+            "023590A94E768F8E1815C2F24B4D80A8E3149316C3518CE7B7AD338368D038CA66",
+        ],
+    ),
+    (
+        "022479f134cdb266141dab1a023cbba30a870f8995b95a91fc8464e56a7d41f8ea",
+        "xpub661MyMwAqRbcFt6tk3uaczE1y6EvM1TqXvawXcYmFEWijEM4PDBnuCXwwUvaZYpysLX4wN59tjwU5pBuDjNrPEJbfxjLwn7ruzbXTcUTHkZ",
+        [
+            "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659",
+            "023590A94E768F8E1815C2F24B4D80A8E3149316C3518CE7B7AD338368D038CA66",
+            "02F9308A019258C31049344F85F89D5229B531C845836F99B08601F113BCE036F9",
+            "03935F972DA013F80AE011890FA89B67A27B7BE6CCB24D3274D18B2D4067F261A9",
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "aggregate_pub_key, synthetic_xpub, participants",
+    [
+        pytest.param(aggregate, xpub, keys, id=vector_id(index, aggregate))
+        for index, (aggregate, xpub, keys) in enumerate(BIP328_VECTORS)
+    ],
+)
+def test_bip328_synthetic_xpub(
+    aggregate_pub_key: str, synthetic_xpub: str, participants: list[str]
+) -> None:
+    """Reproduce BIP328's vectors: an aggregate key made derivable.
+
+    The construction is the whole of the specification -- depth zero, child
+    number zero, and `BIP328_CHAIN_CODE` where an aggregate key has no
+    chain code of its own -- and the xpub it produces is what a
+    ``musig()`` descriptor derives from and what BIP373 lets a psbt leave
+    out, the fingerprint of that xpub being enough to recognize it.
+    """
+    aggregate = bytes.fromhex(aggregate_pub_key)
+    assert bytes_from_point(key_agg(participants).Q, ec) == aggregate
+
+    xkey = BIP32KeyData(
+        version=NETWORKS["mainnet"].bip32_pub,
+        depth=0,
+        parent_fingerprint=b"\x00" * 4,
+        index=0,
+        chain_code=BIP328_CHAIN_CODE,
+        key=aggregate,
+    )
+    assert xkey.b58encode() == synthetic_xpub
+    # and a child of it is a child of the group: what the tweaks above
+    # reach, which is the arithmetic a signer does instead of deriving
+    assert derive(synthetic_xpub, "m/0") == derive(xkey, "m/0")

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -6,15 +6,19 @@
 """Tests for the `btclib.descriptors` module.
 
 The derivation vectors are Bitcoin Core's own, transcribed from the
-`descriptor_test` case of `src/test/descriptor_tests.cpp` at commit
-8ecbe270f0dee68b7eec6cea1714f453c5e215ad (2026-07-29): each `Check(prv,
-pub, ...)` there gives a descriptor in its private and its public
-spelling and the scriptPubKey each expands to, at index 0, 1 and 2 where
-the descriptor is ranged. Both spellings are exercised, so a WIF and an
-xprv are checked to reach the script the public key and the xpub beside
-them reach. Not vendored as a file: the values are extracted from C++
-source rather than copied from a data file, so the citation is the
-commit and the case, and `tests/_data/README.md` covers what is vendored.
+`descriptor_test` case of `src/test/descriptor_tests.cpp`: each
+`Check(prv, pub, ...)` there gives a descriptor in its private and its
+public spelling and the scriptPubKey each expands to, at index 0, 1 and 2
+where the descriptor is ranged. Both spellings are exercised, so a WIF
+and an xprv are checked to reach the script the public key and the xpub
+beside them reach. The two ``rawtr()`` vectors are read there too, no BIP
+having any.
+
+Not vendored as files, those and BIP387's and BIP390's alike: the values
+are read out of C++ source and mediawiki prose rather than copied from a
+data file, so what this module cites is the path and the case, and
+`tests/_data/README.md` carries the revision each is pinned to -- which
+is also what the monthly upstream re-check reads.
 
 Four of those descriptors have no public spelling to check, and Core's
 own flags say why: HARDENED and DERIVE_HARDENED mark a derivation that
@@ -60,6 +64,8 @@ from btclib.descriptors import (
 )
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
+from btclib.hashes import hash160
+from btclib.psbt.musig2 import nonce_gen, partial_sign, partial_sigs_agg
 from btclib.psbt.psbt import (
     Psbt,
     _finalized_input,
@@ -899,6 +905,17 @@ XPUB = "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSg
 XONLY = "a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
 OFF_CURVE = "020000000000000000000000000000000000000000000000000000000000000005"
 
+# BIP390's own participants: three fixed keys, the first of them also
+# written as the WIF its vectors use, and two xpubs. MUSIG_A[2:] is the
+# x-only spelling of the first, which two of those vectors write as a
+# plain taproot key beside the musig() rather than inside it
+MUSIG_A = "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
+MUSIG_B = "03dff1d77f2a671c5f36183726db2341be58feae1da2deced843240f7b502ba659"
+MUSIG_C = "023590a94e768f8e1815c2f24b4d80a8e3149316c3518ce7b7ad338368d038ca66"
+MUSIG_A_WIF = "KwDiBf89QgGbjEhKnhXJuH7LrciVrZi3qYjgd9M7rFU74sHUHy8S"
+MUSIG_XPUB_A = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+MUSIG_XPUB_B = "xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y"
+
 # what a descriptor cannot be, and the message that says so. The first
 # group is Bitcoin Core's own CheckUnparsable cases, from the same
 # descriptor_test; the rest are the position rules of BIP381 to BIP386
@@ -1004,7 +1021,6 @@ UNIMPLEMENTED = [
     ),
     (f"wsh(thresh(1,pk({KEY})))", "187"),
     (f"wsh(s:pk({KEY}))", "187"),
-    (f"tr(musig({KEY},{KEY}))", "BIP390"),
 ]
 
 
@@ -1114,6 +1130,242 @@ def test_bip387_invalid(descriptor: str, message: str) -> None:
     """Refuse each of BIP387's invalid descriptors, with the reason named."""
     with pytest.raises(BTClibValueError, match=message):
         parse(descriptor).script_pub_key()
+
+
+# BIP390's own test vectors: a valid descriptor and the scriptPubKey it
+# produces, three of them where the keys derive. The first two are the same
+# three participants under rawtr() and tr(), so the pair says which key is
+# the output key and which is tweaked into it; the last aggregates one key
+# with itself, participants being allowed to repeat
+BIP390_VECTORS: list[tuple[str, list[str]]] = [
+    (
+        f"rawtr(musig({MUSIG_A_WIF},{MUSIG_B},{MUSIG_C}))",
+        ["5120789d937bade6673538f3e28d8368dda4d0512f94da44cf477a505716d26a1575"],
+    ),
+    (
+        f"tr(musig({MUSIG_A},{MUSIG_B},{MUSIG_C}))",
+        ["512079e6c3e628c9bfbce91de6b7fb28e2aec7713d377cf260ab599dcbc40e542312"],
+    ),
+    (
+        f"rawtr(musig({MUSIG_XPUB_A},{MUSIG_XPUB_B})/0/*)",
+        [
+            "51209508c08832f3bb9d5e8baf8cb5cfa3669902e2f2da19acea63ff47b93faa9bfc",
+            "51205ca1102663025a83dd9b5dbc214762c5a6309af00d48167d2d6483808525a298",
+            "51207dbed1b89c338df6a1ae137f133a19cae6e03d481196ee6f1a5c7d1aeb56b166",
+        ],
+    ),
+    (
+        f"tr(musig({MUSIG_XPUB_A},{MUSIG_XPUB_B})/0/*,pk({MUSIG_A[2:]}))",
+        [
+            "51201d377b637b5c73f670f5c8a96a2c0bb0d1a682a1fca6aba91fe673501a189782",
+            "51208950c83b117a6c208d5205ffefcf75b187b32512eb7f0d8577db8d9102833036",
+            "5120a49a477c61df73691b77fcd563a80a15ea67bb9c75470310ce5c0f25918db60d",
+        ],
+    ),
+    (
+        f"tr({MUSIG_A[2:]},pk(musig({MUSIG_XPUB_A},{MUSIG_XPUB_B})/0/*))",
+        [
+            "512068983d461174afc90c26f3b2821d8a9ced9534586a756763b68371a404635cc8",
+            "5120368e2d864115181bdc8bb5dc8684be8d0760d5c33315570d71a21afce4afd43e",
+            "512097a1e6270b33ad85744677418bae5f59ea9136027223bc6e282c47c167b471d5",
+        ],
+    ),
+    (
+        f"tr(musig({MUSIG_XPUB_A}/1,{MUSIG_XPUB_A}/1)/2)",
+        ["5120a17ceacd6422bd5ffd9f165807b254b7d68ad39f179cc4f11545a6835227e97c"],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "descriptor, scripts",
+    [
+        pytest.param(descriptor, scripts, id=vector_id(index, descriptor))
+        for index, (descriptor, scripts) in enumerate(BIP390_VECTORS)
+    ],
+)
+def test_bip390_vector(descriptor: str, scripts: list[str]) -> None:
+    """Reproduce BIP390's own vectors: the script at each index it lists.
+
+    Nothing here needs the private material `parse` hands back: a
+    ``musig()`` derives from xpubs and from the aggregate of them, neither
+    of which can take a hardened step.
+    """
+    parsed = parse(descriptor)
+    assert parsed.is_ranged == (len(scripts) > 1)
+    for index, expected in enumerate(scripts):
+        assert parsed.script_pub_key(index).script.hex() == expected
+
+
+# BIP390's invalid descriptors, and what each is refused with. The first
+# eight are one rule -- a musig() is a key expression of tr() and rawtr()
+# and of nothing else -- and the rest are the conditions derivation from
+# the aggregate key comes with
+BIP390_INVALID = [
+    (f"pk(musig({MUSIG_A},{MUSIG_B},{MUSIG_C}))", "only allowed in tr"),
+    (f"pkh(musig({MUSIG_A},{MUSIG_B},{MUSIG_C}))", "only allowed in tr"),
+    (f"wpkh(musig({MUSIG_A},{MUSIG_B},{MUSIG_C}))", "only allowed in tr"),
+    (f"combo(musig({MUSIG_A},{MUSIG_B},{MUSIG_C}))", "only allowed in tr"),
+    (f"sh(wpkh(musig({MUSIG_A},{MUSIG_B},{MUSIG_C})))", "only allowed in tr"),
+    (f"sh(wsh(pk(musig({MUSIG_A},{MUSIG_B},{MUSIG_C}))))", "only allowed in tr"),
+    (f"wsh(musig({MUSIG_A},{MUSIG_B},{MUSIG_C}))", "only allowed in tr"),
+    (f"sh(musig({MUSIG_A},{MUSIG_B},{MUSIG_C}))", "only allowed in tr"),
+    (
+        f"tr(musig({MUSIG_A},{MUSIG_B},{MUSIG_C})/0/0)",
+        "requires every participant to be extended",
+    ),
+    (
+        f"tr(musig({MUSIG_XPUB_A}/*,{MUSIG_XPUB_B})/0/*)",
+        "ranged participant and derivation",
+    ),
+    # BIP390 refuses a multipath musig() holding multipath participants;
+    # btclib refuses the whole shape earlier and for the general reason,
+    # `parse` taking one path per key and `multipath_descriptors` being
+    # what expands the <a;b> steps textually, as BIP389 defines them
+    (
+        f"tr(musig({MUSIG_XPUB_A}/<0;1>,{MUSIG_XPUB_B})/<2;3>)",
+        "multipath key expression",
+    ),
+    (f"tr(musig({MUSIG_XPUB_A},{MUSIG_XPUB_B})/0h/*)", "hardened derivation steps"),
+    (f"tr(musig({MUSIG_XPUB_A},{MUSIG_XPUB_B})/0/*h)", "hardened wildcard"),
+    (
+        f"tr(musig({MUSIG_XPUB_A}/*,{MUSIG_XPUB_B}/*)/1/2)",
+        "ranged participant and derivation",
+    ),
+    # and what BIP390 states in prose rather than listing: no nesting, no
+    # origin in front of one, and at least one participant. A musig() as a
+    # tree leaf is refused too: what a leaf holds is a script
+    (f"tr(musig(musig({MUSIG_A},{MUSIG_B}),{MUSIG_XPUB_A}))", "only allowed in tr"),
+    (f"tr([deadbeef/0]musig({MUSIG_A},{MUSIG_B}))", "nested inside a key origin"),
+    ("tr(musig())", "at least one key"),
+    (f"tr({XONLY},musig({MUSIG_A},{MUSIG_B}))", "pk\\(musig\\(...\\)\\) is the leaf"),
+    # a participant is aggregated as a point, so an x-only one is short of
+    # the byte that says which point it is
+    (f"tr(musig({XONLY},{MUSIG_B}))", "musig\\(\\): x-only"),
+    # and characters after the closing bracket that are no path at all
+    (f"tr(musig({MUSIG_A},{MUSIG_B})x)", "not a musig\\(\\) derivation path"),
+]
+
+
+@pytest.mark.parametrize(
+    "descriptor, message",
+    [
+        pytest.param(descriptor, message, id=vector_id(index, descriptor))
+        for index, (descriptor, message) in enumerate(BIP390_INVALID)
+    ],
+)
+def test_bip390_invalid(descriptor: str, message: str) -> None:
+    """Refuse each of BIP390's invalid descriptors, with the reason named."""
+    with pytest.raises(BTClibValueError, match=message):
+        parse(descriptor)
+
+
+def test_the_order_participants_are_written_in_is_not_the_key() -> None:
+    """BIP390 sorts before aggregating, and that is the whole rationale.
+
+    MuSig2 is about a set of keys, so a descriptor written in another order
+    describes the same output -- which is also what makes a descriptor
+    recoverable without the order having been backed up. What is *not*
+    normalized is the text: the participants are written back in the order
+    they were read, as Bitcoin Core writes them.
+    """
+    written = f"tr(musig({MUSIG_A},{MUSIG_B},{MUSIG_C}))"
+    reordered = f"tr(musig({MUSIG_C},{MUSIG_A},{MUSIG_B}))"
+    assert parse(written).script_pub_key() == parse(reordered).script_pub_key()
+    assert str(parse(reordered)) == reordered
+
+    # and the aggregation order is the sorted one, which is the list BIP373
+    # stores in a psbt
+    keys = parse(written).key_expressions[0].participant_keys()
+    assert keys == sorted(keys)
+    assert [key.hex() for key in keys] == sorted((MUSIG_A, MUSIG_B, MUSIG_C))
+
+
+def test_a_musig_descriptor_builds_a_psbt_its_group_can_sign() -> None:
+    """The whole point of naming an aggregate key: BIP373's rounds can run.
+
+    What the Updater has to write for that is three things, and all three
+    come from the descriptor: the internal key, which is the aggregate key
+    derived at this index; the participants, under the *undervied*
+    aggregate key, which is what BIP373 keys its field by; and the BIP328
+    path from that key to this one, under the fingerprint of the synthetic
+    xpub, which is how `psbt.musig2` recognizes the derivation.
+
+    Then the two signers play BIP373's two rounds and the Finalizer adds
+    their partial signatures up. `finalize` is the oracle: it verifies the
+    aggregate signature against the output key it reads out of the script,
+    so it accepts only if every tweak on the way agreed.
+    """
+    prv_keys: dict[str, str] = {}
+    descriptor = parse(f"tr(musig({XPRV_ROOT},{XPRV_SECOND})/0/*)", prv_keys=prv_keys)
+    key = descriptor.key_expressions[0]
+    psbt = descriptor.update_psbt(psbt_spending(descriptor, 1), 0, 1)
+    psbt.assert_signable()
+
+    aggregate = key.aggregate(1)
+    psbt_in = psbt.inputs[0]
+    assert psbt_in.taproot_internal_key == key.sec(1)[1:]
+    assert psbt_in.musig2_participant_pub_keys == {aggregate: key.participant_keys(1)}
+    ((leaf_hashes, origin),) = psbt_in.taproot_hd_key_paths.values()
+    assert leaf_hashes == []
+    assert origin.master_fingerprint == hash160(aggregate)[:4]
+    assert origin.description.endswith("/0/1")
+
+    signers = [prv_keyinfo_from_prv_key(xprv)[0] for xprv in (XPRV_ROOT, XPRV_SECOND)]
+    sec_nonces = [nonce_gen(psbt, 0, signer, aggregate) for signer in signers]
+    for signer, sec_nonce in zip(signers, sec_nonces, strict=True):
+        partial_sign(psbt, 0, sec_nonce, signer, aggregate)
+    signature = partial_sigs_agg(psbt, 0, aggregate)
+
+    witness = finalize(psbt).inputs[0].final_script_witness
+    assert witness == Witness([signature.serialize()])
+
+
+def test_the_updater_writes_a_musig_group_that_derives_nothing() -> None:
+    """An aggregate key that *is* the internal key has no path to report.
+
+    Which is the first of BIP373's four ways for an aggregate key to reach
+    what is spent, and the field that would say how to get from one to the
+    other is left out rather than filled with an empty path. What is still
+    written is the participants, and the origin of each participant that
+    carries one -- the entry a signer looks itself up in.
+    """
+    participant = f"[d34db33f/0h]{MUSIG_XPUB_A}"
+    descriptor = parse(f"tr(musig({participant},{MUSIG_XPUB_B}))")
+    key = descriptor.key_expressions[0]
+    psbt_in = descriptor.update_psbt(psbt_spending(descriptor), 0).inputs[0]
+
+    aggregate = key.aggregate()
+    assert psbt_in.taproot_internal_key == aggregate[1:]
+    assert psbt_in.musig2_participant_pub_keys == {aggregate: key.participant_keys()}
+    # the aggregate key is the internal key, so no derivation of it, and
+    # the one entry there is is the participant that named an origin
+    x_only = key.participants[0].sec()[1:]
+    ((leaf_hashes, origin),) = psbt_in.taproot_hd_key_paths.values()
+    assert list(psbt_in.taproot_hd_key_paths) == [x_only]
+    assert leaf_hashes == []
+    assert origin.description == "d34db33f/0h"
+
+
+def test_the_normalized_form_of_a_musig_is_its_participants() -> None:
+    """Its own path cannot harden, so there is nothing else to re-root.
+
+    A participant with a hardened step is re-rooted as any other key is,
+    and the result computes every script with no private key at all --
+    which is what an export to a watch-only wallet needs, aggregate key or
+    not.
+    """
+    prv_keys: dict[str, str] = {}
+    descriptor = parse(
+        f"tr(musig({XPRV_ROOT}/44h/0h/0h/0,{MUSIG_XPUB_B})/0/*)", prv_keys=prv_keys
+    )
+    canonical = normalized(descriptor, prv_keys)
+
+    assert f"[{fingerprint(XPRV_ROOT).hex()}/44h/0h/0h]" in str(canonical)
+    for index in (0, 5):
+        assert canonical.script_pub_keys(index) == descriptor.script_pub_keys(
+            index, prv_keys
+        )
 
 
 def leaf_script_of(descriptor: str) -> bytes:
@@ -1835,6 +2087,7 @@ def test_what_cannot_update_a_psbt(descriptor: str, message: str) -> None:
 ROUND_TRIP = [
     *(d for private, public, _ in CORE_VECTORS for d in (private, public) if d),
     *(descriptor for descriptor, _ in BIP387_VECTORS),
+    *(descriptor for descriptor, _ in BIP390_VECTORS),
     *DOC_DESCRIPTORS,
     *HARDENED_PUBLIC,
 ]
@@ -1948,6 +2201,11 @@ def test_a_wif_in_a_taproot_position_is_written_x_only() -> None:
 XPRV_ROOT = (
     "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvv"
     "NKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
+)
+# a second one, so that a MuSig2 group of two has two keys to hold
+XPRV_SECOND = (
+    "xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWP"
+    "rS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L"
 )
 
 


### PR DESCRIPTION
Closes #454.

The last descriptor function the parser refused by name. The cryptography was
already here — `btclib.ecc.musig2` is BIP327 function for function,
`bip32.pub_key_derivation_tweaks` is BIP328 derivation of a key with no private
half, `btclib.psbt.musig2` is BIP373's three roles — so what was missing was
the descriptor.

## The shape, which is the decision the issue asked for

`KeyExpression` **widens** rather than gaining a sibling: a KEY expression is
now one fixed key, or one extended key with a path, or the `participants` an
aggregate is made of with a path of its own. Every holder of a key expression
therefore reads a `musig()` without knowing it is one — the `tr()` internal
key, the `rawtr()` output key, a `pk()` leaf and a `multi_a()` key, which are
BIP390's positions and exactly Bitcoin Core's `ctx == P2TR`.

`Descriptor.key_expressions` answers with the **aggregate**: what the scripts
are built from is that key, and `participant_keys()` is the list underneath, in
`KeySort` order — the order BIP373 stores in a psbt.

`KeySort` before `KeyAgg` is BIP390's rule and its rationale: the order the
descriptor writes the keys in changes neither the key nor the script, so a
descriptor that was not backed up needs no order guessed either. The text keeps
the order it was read in, as Core's `ToString` does.

A path after the `musig()` derives the aggregate key through BIP328's synthetic
xpub — the aggregate at depth zero with the fixed chain code an aggregate has
instead of one of its own — so `derive` is what refuses a hardened step there.
`BIP328_CHAIN_CODE` moved to `btclib.bip32`, beside the tweaks that walk it, and
`psbt.musig2` takes it from there rather than declaring a second copy.

## What the Updater writes

Which is what makes a `musig()` descriptor more than a way to compute an
address. All three are BIP373's asks:

- `PSBT_IN_MUSIG2_PARTICIPANT_PUBKEYS`, keyed by the **undervied** aggregate
  key, as BIP373 requires;
- the BIP328 path from that key to the one in the script, filed under the
  fingerprint of the synthetic xpub, which is how `psbt.musig2` recognizes the
  derivation without a `PSBT_GLOBAL_XPUB`;
- each participant's own key origin, the entry a signer looks itself up in.

The suite runs both BIP373 rounds over a psbt that a `tr(musig(...)/0/*)`
updated, and `finalize` is the oracle: it verifies the aggregate signature
against the output key it reads out of the script, so it accepts only if every
tweak on the way agreed.

## Vectors, and their upstream pins

- **BIP390**, both lists: the six valid descriptors with the scripts they
  produce at each index, and all fourteen invalid ones with the message each is
  refused with. Five further refusals are btclib's own, for what the BIP states
  in prose — no nesting, no key origin in front of one, at least one
  participant, no x-only participant (a point is what is aggregated), and a
  `musig()` where a tree leaf belongs.
- One of the fourteen is refused for a reason of btclib's own: a multipath
  `musig()` holding multipath participants cannot exist here, `parse` taking no
  `<a;b>` step at all and `multipath_descriptors` expanding them textually as
  BIP389 defines. The module docstring and the test say so.
- **BIP328**'s three vectors, in `tests/bip32/bip32_test.py`: they say what
  BIP390's cannot, BIP328 aggregating the keys **as written** where BIP390 sorts
  them first.

The four inline vector blocks are now pinned in `tests/_data/README.md` —
BIP328, BIP387, BIP390 and Core's `descriptor_tests.cpp` — so the monthly
upstream re-check covers them; `check_vendored_vectors.py` reports every checked
pin still at upstream's tip. Worth noting: BIP390's pin is today's commit,
`bip390: fix missing parenthesis in test vector`, which closed the last invalid
descriptor's brackets — a copy taken yesterday would hold a descriptor upstream
no longer publishes.

`_UNIMPLEMENTED` is gone with its last entry, and a `musig()` in a position
that takes no key expression now answers the position rule rather than "not
implemented".

## Gates

Merged on the local gates alone; GitHub Actions is degraded today.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`: 17419 passed, 100.00%
- `pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for BIP390 musig() key expressions in descriptors and wire them into PSBT MuSig2 flows, backed by new BIP328/BIP390 test vectors and shared chain-code constants.

New Features:
- Parse and represent musig() BIP390 key expressions within KeyExpression and descriptor parsing, including participant handling and aggregate key derivation via BIP328 synthetic xpubs.
- Populate PSBT MuSig2 fields from taproot descriptors that use musig(), enabling end-to-end MuSig2 signing and finalization from descriptors.

Enhancements:
- Generalize taproot key-derivation handling to account for aggregate keys and participants, and relax x-only key checks to cover all taproot key-expression contexts.
- Centralize the BIP328 synthetic chain code as BIP328_CHAIN_CODE in the bip32 module and reuse it from musig2 PSBT helpers and descriptor derivation logic.
- Refine miniscript and musig() position/validation errors to follow BIP390 rules and Bitcoin Core behavior, including clearer messages for invalid placements and nesting.
- Extend descriptor normalization to handle musig() expressions by normalizing their participants while preserving text order.

Documentation:
- Update changelog and test data README to describe musig() descriptor support, BIP328/BIP387/BIP390 vector pinning, and the use of Core descriptor tests including rawtr() cases.

Tests:
- Add BIP390 descriptor vectors (valid and invalid) to descriptor tests, plus end-to-end PSBT/MuSig2 signing and updater behavior tests for musig() descriptors.
- Add BIP328 synthetic xpub test vectors to bip32 tests to verify aggregate-key derivation semantics and alignment with the spec.
- Expand round-trip descriptor tests to cover new musig() descriptors and document/pin all upstream vector sources in tests/_data/README.md.