### PR TITLE
Build the receive and change descriptors of a BIP44 account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,46 @@ edit.
 
 ### The public API and the module layout
 
+- **`descriptors.account_descriptors` builds the pair a wallet exports**
+  (issue #381): the receive and change descriptors of a BIP44 account,
+  from an account xpub and the master fingerprint of the key it came from.
+  It is what HWI's `getdescriptors` answers with and what a Bitcoin Core
+  import takes, and every piece of it was already here — the purpose
+  mapping in `bip44`, the fragments and the serializer in `descriptors` —
+  with nothing composing them.
+
+  The purpose selects the fragment as it selects the encoding: 44 is
+  `pkh()`, 49 `sh(wpkh())`, 84 `wpkh()`, 86 `tr()`, read from
+  `bip44.SCRIPT_TYPE_FROM_PURPOSE` rather than from a second copy, so a
+  purpose added to that data file is a pair this builds. `script_type`
+  overrides it for a purpose the mapping does not name — BIP48 multisig,
+  say — and a purpose with no override raises rather than guessing p2pkh.
+
+  Both chains come back because a wallet is both: BIP44 puts receiving
+  addresses under `/0` and change under `/1`, and a wallet that imported
+  one and not the other cannot recognize its own change, which is a lost
+  output rather than a missing feature. The path is the three hardened
+  levels of the account, which is exactly as much as an xpub is useful for
+  — nothing below it hardens — and the key may be the master one or
+  anything down to the account itself, the depth saying how much is left
+  to derive.
+
+  Two things it will not guess. The master fingerprint is a parameter,
+  because a key at depth three carries its own and its parent's and
+  neither is the master's: it is computed only where the key *is* the
+  master one, and a value handed in beside it has to agree. And a SLIP132
+  `ypub` or `zpub` comes back as the BIP32 xpub of the same key: the
+  version bytes would say what the descriptor function already says, and a
+  descriptor holding a zpub is one no other implementation reads, Bitcoin
+  Core decoding the BIP32 versions and no others.
+
+  The addresses the pair describes are checked against
+  `bip44.address_from_der_path` over the published SLIP132, BIP49, BIP84
+  and BIP86 vectors: two entry points, one mapping, the same addresses.
+  `bip44._indexes_left_to_derive` bounds the key's depth by the path's own
+  length now rather than by BIP44's five, an account path being three of
+  them.
+
 - **`musig()` is read: BIP390's key expression** (issue #454), which was
   the last descriptor function the parser refused by name. The
   cryptography was already here — `btclib.ecc.musig2` is BIP327 function

--- a/btclib/bip44.py
+++ b/btclib/bip44.py
@@ -20,8 +20,14 @@ address encodes the *tweaked* output key of BIP341, which
 and may not import it. `slip132` sits beside it at the top level for a
 narrower version of the same shape: it needs `b58` and `b32`, which
 import `bip32`, so it cannot live inside the package whose keys it
-derives addresses from either. Nothing in the library imports this
-module.
+derives addresses from either.
+
+What imports this module is what the mapping and the checks are for, and
+in one direction only: `keystore` takes the encoders and the purpose
+lookup rather than keeping a second copy of either, and `descriptors`
+takes the path checks and the same lookup for the account descriptor pair
+it builds. Neither is imported back -- a descriptor is what a wallet
+exports, and this is what a path means.
 """
 
 from __future__ import annotations
@@ -52,6 +58,10 @@ __all__ = [
 # purpose, coin type, account, change, address index: BIP44 fixes the
 # meaning of each level, so a path of any other length is not one
 _LEVELS = 5
+# the first three of them, which are the hardened ones and as much of the
+# path as an account xpub stands for: what a wallet exports, and what a
+# descriptor's key origin names
+_ACCOUNT_LEVELS = 3
 
 # the mapping is data and lives with the network data, not in this file:
 # it is the canonical row of the wallet-format table electrum ships as
@@ -124,12 +134,36 @@ def _assert_valid_path(indexes: list[int]) -> None:
         err_msg = f"invalid BIP44 path: {len(indexes)} levels instead of {_LEVELS}"
         raise BTClibValueError(err_msg)
 
-    if any(index < _HARDENED_OFFSET for index in indexes[:3]):
+    if any(index < _HARDENED_OFFSET for index in indexes[:_ACCOUNT_LEVELS]):
         err_msg = "invalid BIP44 path: purpose, coin type and account must be hardened"
         raise BTClibValueError(err_msg)
 
-    if any(index >= _HARDENED_OFFSET for index in indexes[3:]):
+    if any(index >= _HARDENED_OFFSET for index in indexes[_ACCOUNT_LEVELS:]):
         err_msg = "invalid BIP44 path: change and address index must not be hardened"
+        raise BTClibValueError(err_msg)
+
+
+def _assert_valid_account_path(indexes: list[int]) -> None:
+    """Raise unless the indexes are the three hardened levels of an account.
+
+    m/purpose'/coin_type'/account', which is what a wallet exports and what
+    a descriptor names in its key origin: the two levels below it are the
+    unhardened ones public derivation can walk, so an account path is
+    exactly as much as an xpub is useful for.
+
+    The hardening is checked for the reason the five-level check gives, and
+    one more: the whole point of stopping here is that nothing below needs
+    a private key, and an unhardened account level would make the level
+    above it -- not this path -- the last one that did.
+    """
+    if len(indexes) != _ACCOUNT_LEVELS:
+        err_msg = f"invalid BIP44 account path: {len(indexes)} levels"
+        err_msg += f" instead of {_ACCOUNT_LEVELS}"
+        raise BTClibValueError(err_msg)
+
+    if any(index < _HARDENED_OFFSET for index in indexes):
+        err_msg = "invalid BIP44 account path: purpose, coin type and account"
+        err_msg += " must be hardened"
         raise BTClibValueError(err_msg)
 
 
@@ -202,10 +236,14 @@ def _indexes_left_to_derive(xkey: BIP32KeyData, indexes: list[int]) -> list[int]
     the path of another account; it cannot catch a key from another
     purpose or another coin, nothing in an extended key recording where
     it came from, so the caller's word is taken for the levels above.
+
+    The bound is the path's own length rather than BIP44's five, because
+    an account path is three of them: a key deeper than the path it is
+    handed has walked past its end, whichever of the two paths it is.
     """
-    if xkey.depth > _LEVELS:
-        err_msg = f"invalid key depth: {xkey.depth} is past the {_LEVELS}"
-        err_msg += " levels of a BIP44 path"
+    if xkey.depth > len(indexes):
+        err_msg = f"invalid key depth: {xkey.depth} is past the {len(indexes)}"
+        err_msg += " levels of the path"
         raise BTClibValueError(err_msg)
 
     if xkey.depth and xkey.index != indexes[xkey.depth - 1]:

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -83,6 +83,13 @@ where HWI and Electrum name the checksummed form `to_string`. What it
 writes is public by construction, there being no private material left
 in a parsed descriptor to write.
 
+`account_descriptors` is the other way in, for the one shape a wallet
+exports rather than reads: the receive and change descriptors of a BIP44
+account, built from an account xpub and the master fingerprint of the key
+it came from. The purpose says which of the four encodings the account
+means, which is `bip44`'s mapping and is taken from there rather than
+copied -- this module imports that one and `bip44` imports nothing back.
+
 `normalized` is the other direction Bitcoin Core has, its
 `ToNormalizedString`: the same descriptor with the xpub at each last
 hardened step and the hardened prefix moved into the key origin, so that
@@ -111,9 +118,10 @@ from copy import deepcopy
 from dataclasses import dataclass, fields, replace
 from typing import Any, cast
 
-from btclib.alias import Octets, ScriptList, TaprootScriptTree
+from btclib.alias import BIP44ScriptType, Octets, ScriptList, TaprootScriptTree
 from btclib.bip32.bip32 import (
     BIP328_CHAIN_CODE,
+    BIP32Key,
     BIP32KeyData,
     derive,
     xpub_from_xprv,
@@ -121,18 +129,25 @@ from btclib.bip32.bip32 import (
 from btclib.bip32.der_path import (
     _HARDENED_OFFSET,
     _HARDENING,
+    DerPath,
     hardenings_from_der_path,
     indexes_from_der_path,
     str_from_der_path,
     str_from_index_int,
 )
 from btclib.bip32.key_origin import BIP32KeyOrigin
+from btclib.bip44 import (
+    _assert_valid_account_path,
+    _assert_valid_coin_type,
+    _indexes_left_to_derive,
+    _script_type_from_purpose,
+)
 from btclib.curves import secp256k1
 from btclib.curves.sec_point import bytes_from_point
 from btclib.ecc.musig2 import key_agg, key_sort
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160
-from btclib.network import NETWORKS
+from btclib.network import NETWORKS, network_from_xkeyversion
 from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.script.script import op_int, serialize
@@ -160,6 +175,7 @@ __all__ = [
     "TrDescriptor",
     "WpkhDescriptor",
     "WshDescriptor",
+    "account_descriptors",
     "add_checksum",
     "checksum",
     "from_address",
@@ -2521,3 +2537,147 @@ def multipath_descriptors(descriptor: str) -> list[str]:
         pieces[1::2] = [step[i] for step in steps]
         descriptors.append(add_checksum("".join(pieces)))
     return descriptors
+
+
+# BIP44's fourth level, the two chains every wallet keeps: 0 receives and
+# 1 is change, which is the only difference between the pair below
+_RECEIVE_CHAIN = 0
+_CHANGE_CHAIN = 1
+
+# what a standard account descriptor is, per script type: the fragment
+# built around one ranged key expression. Keyed by BIP44ScriptType, so
+# this table and `bip44`'s two are checked against each other -- a fifth
+# script type is a key mypy does not know.
+#
+# Lambdas because `network` is keyword-only on `Descriptor`, so a fragment
+# class cannot be the value directly, and because ``sh(wpkh())`` is two
+# fragments where the others are one
+_DESCRIPTOR_FROM_SCRIPT_TYPE: dict[
+    BIP44ScriptType, Callable[[KeyExpression, str], Descriptor]
+] = {
+    "p2pkh": lambda key, network: PkhDescriptor(key, network=network),
+    "p2wpkh-p2sh": lambda key, network: ShDescriptor(
+        WpkhDescriptor(key, network=network), network=network
+    ),
+    "p2wpkh": lambda key, network: WpkhDescriptor(key, network=network),
+    "p2tr": lambda key, network: TrDescriptor(key, network=network),
+}
+
+
+def _account_xpub(xkey: BIP32KeyData, indexes: list[int]) -> str:
+    """Return the account xpub, derived from the key if it is above it.
+
+    Neutered whatever was handed in, as `parse` neuters what it reads: a
+    descriptor holds no key that signs, and nothing below an account level
+    hardens, so the xpub computes every script the pair describes.
+
+    The version bytes are BIP32's, whichever the key arrived in. A SLIP132
+    ypub or zpub says which script type its keys are for, which is what the
+    descriptor function says: the two spellings would then be one claim
+    made twice, and a descriptor holding a zpub is one no other
+    implementation reads -- Bitcoin Core decodes the BIP32 versions and
+    nothing else. Same key, same scripts, one spelling of it.
+    """
+    network = NETWORKS[network_from_xkeyversion(xkey.version)]
+    version = network.bip32_prv if xkey.is_private else network.bip32_pub
+    derived = derive(xkey, _indexes_left_to_derive(xkey, indexes), version)
+    return xpub_from_xprv(derived) if xkey.is_private else derived
+
+
+def _account_fingerprint(
+    xkey: BIP32KeyData, master_fingerprint: Octets | None
+) -> bytes:
+    """Return the master fingerprint of the key origin, checking what it can.
+
+    Computed from the key only when the key *is* the master one, at depth
+    zero: the fingerprint of a key at any other depth is that key's, not
+    its master's, and a key origin naming it would send a signer looking
+    for a master key nobody has. So a key already below the root has to be
+    told, and where the caller says it too the two must agree -- one of
+    them would otherwise be silently preferred, and neither is more likely
+    to be right.
+    """
+    own = fingerprint(xkey.b58encode()) if xkey.depth == 0 else None
+    if master_fingerprint is None:
+        if own is None:
+            err_msg = "no master fingerprint: a key below the root cannot say"
+            err_msg += " which master key it came from"
+            raise BTClibValueError(err_msg)
+        return own
+    given = bytes_from_octets(master_fingerprint, 4)
+    if own is not None and own != given:
+        err_msg = f"master fingerprint {given.hex()} is not the key's own"
+        err_msg += f" {own.hex()}"
+        raise BTClibValueError(err_msg)
+    return given
+
+
+def account_descriptors(
+    xkey: BIP32Key,
+    der_path: DerPath,
+    master_fingerprint: Octets | None = None,
+    script_type: BIP44ScriptType | None = None,
+) -> tuple[Descriptor, Descriptor]:
+    """Return the receive and change descriptors of a BIP44 account.
+
+    der_path is the three-level account path,
+    m/purpose'/coin_type'/account', in any spelling `bip32.derive`
+    accepts; xkey is the extended key it starts from, which may be the
+    master key or any key already partway down it -- the account xpub
+    itself, typically, which is what a wallet exports and what a hardware
+    signer answers with.
+
+    The purpose selects the encoding, as it does for a BIP44 address: 44
+    is ``pkh()``, 49 ``sh(wpkh())``, 84 ``wpkh()``, 86 ``tr()``. A purpose
+    outside `bip44.SCRIPT_TYPE_FROM_PURPOSE` raises unless script_type
+    names one of those four, which then overrides the mapping for known
+    purposes too. The network is the extended key's own, and the coin type
+    has to agree with it.
+
+    Both chains come back because a wallet is both: BIP44 puts receiving
+    addresses under `/0` and change under `/1`, and a wallet that imported
+    one and not the other cannot recognize its own change -- which is a
+    lost output rather than a missing feature. They differ in that step
+    and in nothing else, the key origin and the wildcard being the same.
+
+    The master fingerprint is what the key origin needs and what an
+    extended key below the root cannot supply, so it is a parameter; where
+    xkey is the master key it is computed, and a value handed in beside it
+    has to match.
+
+    `add_checksum(str(descriptor))` is the text Bitcoin Core takes. The
+    BIP389 spelling of the pair -- one descriptor with a ``<0;1>`` step --
+    is text and not a parsed descriptor: `multipath_descriptors` expands
+    one and `parse` refuses one, so what this returns is the two.
+    """
+    if not isinstance(xkey, BIP32KeyData):
+        xkey = BIP32KeyData.b58decode(xkey)
+
+    indexes = indexes_from_der_path(der_path)
+    _assert_valid_account_path(indexes)
+    if script_type is None:
+        script_type = _script_type_from_purpose(indexes[0] - _HARDENED_OFFSET)
+    # the lookup and not an isinstance, for `bip44`'s reason: the table is
+    # the list of script types this module can build, so missing from it
+    # and unknown are one thing, and a Literal is a mypy fact rather than
+    # a runtime one
+    build = _DESCRIPTOR_FROM_SCRIPT_TYPE.get(script_type)
+    if build is None:
+        known = ", ".join(sorted(_DESCRIPTOR_FROM_SCRIPT_TYPE))
+        raise BTClibValueError(f"unknown script type: {script_type} not in ({known})")
+    _assert_valid_coin_type(indexes[1] - _HARDENED_OFFSET, xkey)
+
+    # the xpub first, and the fingerprint after it: a key that does not fit
+    # the path is about the two arguments the caller passed together, where
+    # a missing fingerprint is about a third
+    account_xpub = _account_xpub(xkey, indexes)
+    origin = BIP32KeyOrigin(_account_fingerprint(xkey, master_fingerprint), indexes)
+    network = network_from_xkeyversion(xkey.version)
+
+    def chain(index: int) -> Descriptor:
+        key = KeyExpression(
+            origin=origin, xkey=account_xpub, der_path=(index,), wildcard=0
+        )
+        return build(key, network)
+
+    return chain(_RECEIVE_CHAIN), chain(_CHANGE_CHAIN)

--- a/tests/bip44_test.py
+++ b/tests/bip44_test.py
@@ -3,7 +3,14 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Tests for the `btclib.bip44` module."""
+"""Tests for the `btclib.bip44` module.
+
+`descriptors.account_descriptors` is read here as well, against the same
+vectors: it answers with the receive and change descriptors of an account
+and reads the purpose off the same table, so the addresses it describes
+have to be the addresses this module derives. What is tested there is the
+function; what is tested here is that the two agree on published values.
+"""
 
 from __future__ import annotations
 
@@ -19,7 +26,9 @@ from btclib.bip44 import (
     SCRIPT_TYPE_FROM_PURPOSE,
     address_from_der_path,
 )
+from btclib.descriptors import account_descriptors
 from btclib.exceptions import BTClibValueError
+from btclib.to_pub_key import fingerprint
 
 # the "abandon abandon ... about" seed of BIP39, which BIP84 and BIP86
 # publish as a root key: the same key, spelled with two versions
@@ -119,6 +128,35 @@ def test_bip44_vectors(mxkey: str, xpub: str, der_path: str, address: str) -> No
     )
 
 
+@pytest.mark.parametrize("mxkey, xpub, der_path, address", _VECTORS)
+def test_the_account_descriptors_reach_the_same_addresses(
+    mxkey: str, xpub: str, der_path: str, address: str
+) -> None:
+    """`descriptors.account_descriptors` and this module are one mapping.
+
+    The purpose says which encoding a path means and both read it from the
+    same table, so the pair a wallet exports has to describe the addresses
+    this module answers for the same path: the change chain of the pair at
+    an index is the `/1/index` address, and the receive chain the `/0/`
+    one. The vectors above are published addresses, so this is the
+    descriptor half of them.
+
+    The account level is where the two split: `address_from_der_path`
+    walks all five levels, while a descriptor names the first three in its
+    key origin and derives the last two -- which is why the descriptors
+    are built from the account path alone.
+    """
+    account, chain, index = der_path.rsplit("/", 2)
+    pair = account_descriptors(mxkey, account)
+    assert pair[int(chain)].address(int(index)) == address
+
+    # and from the account xpub, which cannot say which master key it came
+    # from, so the fingerprint the origin needs is handed in
+    master_fingerprint = fingerprint(mxkey)
+    from_account = account_descriptors(xpub, account, master_fingerprint)
+    assert str(from_account[int(chain)]) == str(pair[int(chain)])
+
+
 def test_purpose_mapping() -> None:
     """The mapping is the one BIP44, BIP49, BIP84 and BIP86 define."""
     assert SCRIPT_TYPE_FROM_PURPOSE == {
@@ -212,9 +250,10 @@ def test_key_depth() -> None:
     with pytest.raises(BTClibValueError, match=err_msg):
         address_from_der_path(xpub, der_path)
 
-    # a key deeper than the path itself has no tail left to walk
+    # a key deeper than the path itself has no tail left to walk, and the
+    # bound is the path's own length: an account path is three levels
     xkey = bip32.derive(_ZPRV_ROOT, "m/84h/0h/0h/0/0/0")
-    err_msg = "invalid key depth: 6 is past the 5 levels of a BIP44 path"
+    err_msg = "invalid key depth: 6 is past the 5 levels of the path"
     with pytest.raises(BTClibValueError, match=err_msg):
         address_from_der_path(xkey, der_path)
 

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -32,14 +32,17 @@ the parser test asks is that each one expands and that every address it
 produces is the address of that very script.
 """
 
+from typing import get_args
+
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from btclib.alias import Octets
+from btclib.alias import BIP44ScriptType, Octets
 from btclib.bip32 import BIP32KeyOrigin
-from btclib.bip32.bip32 import xpub_from_xprv
+from btclib.bip32.bip32 import derive, xpub_from_xprv
 from btclib.bip32.der_path import _HARDENING
+from btclib.bip44 import SCRIPT_TYPE_FROM_PURPOSE
 from btclib.descriptors import (
     AddrDescriptor,
     ComboDescriptor,
@@ -52,8 +55,10 @@ from btclib.descriptors import (
     RawTrDescriptor,
     ShDescriptor,
     TrDescriptor,
+    WpkhDescriptor,
     WshDescriptor,
     __descsum_expand,
+    account_descriptors,
     add_checksum,
     checksum,
     from_address,
@@ -2393,6 +2398,151 @@ def test_a_rawtr_without_an_origin_writes_nothing_at_all() -> None:
     descriptor = parse(f"rawtr({XONLY_A})")
     psbt = descriptor.update_psbt(psbt_spending(descriptor), 0)
     assert psbt.inputs[0] == psbt_spending(descriptor).inputs[0]
+
+
+def test_the_account_descriptor_pair() -> None:
+    """One account, two chains, and one difference between them.
+
+    BIP44 puts receiving addresses under `/0` and change under `/1`, and a
+    wallet is both: what the pair says about the account -- the key origin,
+    the account xpub, the wildcard, the script type the purpose means -- is
+    the same on both sides, and the chain step is not. The addresses those
+    descriptors describe are checked against `bip44.address_from_der_path`
+    in `tests/bip44_test.py`, which holds the published vectors.
+    """
+    receive, change = account_descriptors(XPRV_ROOT, "m/84h/0h/0h")
+    account_xpub = xpub_from_xprv(derive(XPRV_ROOT, "m/84h/0h/0h"))
+    master_fingerprint = fingerprint(XPRV_ROOT).hex()
+
+    for descriptor, chain in ((receive, 0), (change, 1)):
+        assert isinstance(descriptor, WpkhDescriptor)
+        assert descriptor.is_ranged
+        assert descriptor.network == "mainnet"
+        (key,) = descriptor.key_expressions
+        assert key.xkey == account_xpub
+        assert key.der_path == (chain,)
+        assert key.wildcard == 0
+        assert key.origin is not None
+        assert key.origin.description == f"{master_fingerprint}/84h/0h/0h"
+        assert str(descriptor) == (
+            f"wpkh([{master_fingerprint}/84h/0h/0h]{account_xpub}/{chain}/*)"
+        )
+
+    assert receive.address(7) != change.address(7)
+    # and each is a descriptor like any other: it writes itself back and
+    # parses again to the same scripts
+    for descriptor in (receive, change):
+        assert parse(str(descriptor)).script_pub_keys(3) == descriptor.script_pub_keys(
+            3
+        )
+
+
+def test_the_account_descriptors_of_each_purpose() -> None:
+    """The purpose selects the fragment, as it selects the encoding.
+
+    Four purposes, four shapes, and the table is checked against
+    `bip44`'s own: a fifth script type would be a purpose this cannot
+    build, which is a refusal rather than a guess.
+    """
+    for purpose, expected in (
+        (44, "pkh("),
+        (49, "sh(wpkh("),
+        (84, "wpkh("),
+        (86, "tr("),
+    ):
+        receive, change = account_descriptors(XPRV_ROOT, f"m/{purpose}h/0h/0h")
+        assert str(receive).startswith(expected)
+        assert str(change).startswith(expected)
+    assert set(SCRIPT_TYPE_FROM_PURPOSE.values()) == set(get_args(BIP44ScriptType))
+
+    # a purpose the mapping does not name is refused, and script_type is
+    # the override -- BIP48 multisig, whose script type an account key does
+    # not determine
+    with pytest.raises(BTClibValueError, match="unknown BIP44 purpose: 48"):
+        account_descriptors(XPRV_ROOT, "m/48h/0h/0h")
+    overridden = account_descriptors(XPRV_ROOT, "m/48h/0h/0h", None, "p2wpkh")[0]
+    assert str(overridden).startswith("wpkh(")
+    with pytest.raises(BTClibValueError, match="unknown script type: p2wsh"):
+        account_descriptors(XPRV_ROOT, "m/48h/0h/0h", None, "p2wsh")  # type: ignore[arg-type]
+
+
+def test_an_account_descriptor_needs_a_fingerprint_it_cannot_compute() -> None:
+    """The origin names the *master* key, and only the master key says so.
+
+    A key at depth three carries its own fingerprint and its parent's, and
+    neither is the master's, so an account xpub has to be told. Where the
+    key is the master one it is computed instead — and a value handed in
+    beside it has to agree, neither being more likely to be right.
+    """
+    account_xpub = xpub_from_xprv(derive(XPRV_ROOT, "m/84h/0h/0h"))
+    with pytest.raises(BTClibValueError, match="no master fingerprint"):
+        account_descriptors(account_xpub, "m/84h/0h/0h")
+
+    master_fingerprint = fingerprint(XPRV_ROOT)
+    told = account_descriptors(account_xpub, "m/84h/0h/0h", master_fingerprint)
+    computed = account_descriptors(XPRV_ROOT, "m/84h/0h/0h")
+    assert str(told[0]) == str(computed[0])
+    # the same key with the fingerprint named too, which is what it is
+    assert str(
+        account_descriptors(XPRV_ROOT, "m/84h/0h/0h", master_fingerprint)[0]
+    ) == (str(computed[0]))
+    with pytest.raises(BTClibValueError, match="is not the key's own"):
+        account_descriptors(XPRV_ROOT, "m/84h/0h/0h", "deadbeef")
+
+
+def test_an_account_descriptor_holds_a_bip32_version() -> None:
+    """A SLIP132 zpub says what the descriptor function already says.
+
+    Same key, one spelling of it: the version bytes come back BIP32's, so
+    the descriptor is one every implementation reads -- Bitcoin Core
+    decodes those versions and no others -- and the script type is stated
+    once, by `wpkh()`.
+    """
+    zprv = (
+        "zprvAWgYBBk7JR8Gjrh4UJQ2uJdG1r3WNRRfURiABBE3RvMXYSrRJL62XuezvGdPv"
+        "G6GFBZduosCc1YP5wixPox7zhZLfiUm8aunE96BBa4Kei5"
+    )
+    receive = account_descriptors(zprv, "m/84h/0h/0h")[0]
+    (key,) = receive.key_expressions
+    assert key.xkey.startswith("xpub")
+    # the same account key, spelled with BIP32's own private version and
+    # then neutered: 0488ade4 is xprv and 0488b21e the xpub it becomes
+    assert key.xkey == xpub_from_xprv(derive(zprv, "m/84h/0h/0h", b"\x04\x88\xad\xe4"))
+    # and the scripts are the ones the SLIP132 spelling describes
+    assert receive.address(0) == "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+
+
+def test_an_account_path_is_three_hardened_levels() -> None:
+    """What an account xpub stands for, and what the coin type has to say.
+
+    The two levels below an account are the unhardened ones, so an account
+    path is exactly as much as a wallet exports -- a fourth level is
+    already a chain, and an unhardened account level would leave the level
+    above it the last that needed a private key.
+    """
+    for der_path, err_msg in (
+        ("m/84h/0h", "2 levels instead of 3"),
+        ("m/84h/0h/0h/0", "4 levels instead of 3"),
+        ("m/84h/0h/0", "must be hardened"),
+        ("m/84/0h/0h", "must be hardened"),
+    ):
+        with pytest.raises(BTClibValueError, match=err_msg):
+            account_descriptors(XPRV_ROOT, der_path)
+
+    # the coin type is a claim about the chain and the key is the chain
+    with pytest.raises(BTClibValueError, match="coin type 1 is test"):
+        account_descriptors(XPRV_ROOT, "m/84h/1h/0h")
+    with pytest.raises(BTClibValueError, match="unregistered BIP44 coin type: 2"):
+        account_descriptors(XPRV_ROOT, "m/84h/2h/0h")
+
+    # a key below the account level has walked past the path
+    deeper = derive(XPRV_ROOT, "m/84h/0h/0h/0")
+    with pytest.raises(BTClibValueError, match="past the 3 levels of the path"):
+        account_descriptors(deeper, "m/84h/0h/0h")
+    # and one at the account level has to be *that* account
+    other = xpub_from_xprv(derive(XPRV_ROOT, "m/84h/0h/1h"))
+    with pytest.raises(BTClibValueError, match="is not the path's 0h"):
+        account_descriptors(other, "m/84h/0h/0h", "deadbeef")
 
 
 def test_the_normalized_origin_keeps_the_fingerprint_that_was_given() -> None:


### PR DESCRIPTION
Part of #381: the first of the three consumers the descriptor work left, the
receive/change pair.

`descriptors.account_descriptors(xkey, der_path, master_fingerprint, script_type)`
answers with the two descriptors a wallet exports — what HWI's `getdescriptors`
returns and what a Bitcoin Core import takes. Every piece was already here (the
purpose mapping in `bip44`, the fragments and the serializer in `descriptors`)
with nothing composing them.

```python
>>> receive, change = account_descriptors(master_xprv, "m/84h/0h/0h")
>>> add_checksum(str(receive))
'wpkh([73c5da0a/84h/0h/0h]xpub6CatWdiZ…/0/*)#7yg7wxlp'
>>> change.address(0)
'bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el'
```

## What it decides

- **the purpose selects the fragment**, as it selects the encoding: 44 `pkh()`,
  49 `sh(wpkh())`, 84 `wpkh()`, 86 `tr()`, read from
  `bip44.SCRIPT_TYPE_FROM_PURPOSE` rather than a second copy — so a purpose
  added to that data file is a pair this builds. `script_type` overrides it
  (BIP48 multisig, say); a purpose with no override raises rather than guessing
  p2pkh.
- **both chains**, because a wallet is both: a wallet that imported the receive
  chain and not the change one cannot recognize its own change, which is a lost
  output rather than a missing feature.
- **three hardened levels** for the path, which is exactly as much as an xpub is
  useful for — nothing below an account hardens — and the key may be the master
  one or anything down to the account itself.
- **the master fingerprint is a parameter.** A key at depth three carries its
  own fingerprint and its parent's and neither is the master's, so an account
  xpub has to be told; it is computed only where the key *is* the master one,
  and a value handed in beside it has to agree.
- **a SLIP132 `ypub`/`zpub` comes back as the BIP32 xpub of the same key.** The
  version bytes would say what the descriptor function already says, and a
  descriptor holding a zpub is one no other implementation reads — Core decodes
  the BIP32 versions and no others.

The BIP389 `<0;1>` spelling of the pair is text and not a parsed descriptor
(`parse` refuses such a step, `multipath_descriptors` expands one), so what this
returns is the two; the docstring says so.

## Oracle

`tests/bip44_test.py` walks its published vectors — SLIP132's, BIP49's, BIP84's
and BIP86's — through the pair as well: the change chain at an index is the
`/1/index` address, the receive chain the `/0/` one. Two entry points, one
mapping, the same published addresses, from the master key and from the account
xpub alike.

One behaviour change next door: `bip44._indexes_left_to_derive` bounds the key's
depth by the path's own length rather than by BIP44's five, an account path
being three of them — the message it raises moves from "the 5 levels of a BIP44
path" to "the 5 levels of the path".

## Gates

Merged on the local gates alone; GitHub Actions is degraded today.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`: 17433 passed, 100.00%
- `pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce descriptor construction for BIP44 accounts and align BIP44 path handling with account-level usage.

New Features:
- Add account_descriptors API to build receive and change descriptors for a BIP44 account from an extended key and master fingerprint.

Enhancements:
- Map BIP44 script types to descriptor fragments in descriptors, reusing the shared SCRIPT_TYPE_FROM_PURPOSE mapping.
- Normalize SLIP132 extended keys to standard BIP32 xpubs when constructing account descriptors.
- Add validation helpers for BIP44 account paths and update index-derivation bounds to depend on the given path length rather than a fixed BIP44 depth.

Documentation:
- Document the new account_descriptors API and describe its relationship to BIP44 paths and wallet-exported descriptors in the module docstrings and changelog.

Tests:
- Add descriptor-focused tests covering account_descriptors behaviour, including purpose mapping, fingerprint handling, SLIP132 handling, and account path validation.
- Extend BIP44 tests to verify that account_descriptors-derived addresses match published SLIP132/BIP49/BIP84/BIP86 vectors.