### PR TITLE
Build the requests Bitcoin Core's importdescriptors takes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,35 @@ edit.
 
 ### The public API and the module layout
 
+- **`btclib.core_import` is new: the requests Bitcoin Core's
+  `importdescriptors` takes** (issue #381). `import_request` is one json
+  object and `account_import_requests` the pair a BIP44 account is — the
+  receiving chain, and the change chain marked `internal`. That mark is
+  why the pair is a function of its own: change imported as a receiving
+  chain is money the wallet reports as incoming payments, and the mistake
+  is invisible until a balance is wrong.
+
+  No rpc call and no client, deliberately: the caller already has one,
+  `bitcoin-core-rpc` being a package of its own that
+  `btclib.fetch.bitcoin_core` builds on, and a second way to reach a node
+  would be a second thing to keep working. What this module adds is the
+  object, and every rule `ProcessDescriptorImport` enforces on one is
+  enforced here, where the error can still name the field rather than
+  arriving as an rpc failure half a rescan later: the descriptor carries
+  its checksum, which Core requires; an `active` descriptor is ranged; a
+  `range` belongs to a ranged descriptor and to no other, both ends
+  inclusive as Core reads them; `next_index` is inside it; and a `label`
+  goes with neither `internal` nor a range.
+
+  Two fields HWI's `getkeypool` writes are not written: `watchonly` and
+  `keypool` are `importmulti`'s, the other rpc that dict targets, and
+  `importdescriptors` declares neither. A descriptor wallet is watch-only
+  by holding no private key, which is what `descriptors.parse` guarantees
+  of every descriptor it returns. A multipath descriptor is not built
+  either — Core reads the second element of a two-element step as the
+  internal descriptor, while `parse` refuses a ``<a;b>`` step outright —
+  so the pair of requests is what says the same thing here.
+
 - **`descriptors.account_descriptors` builds the pair a wallet exports**
   (issue #381): the receive and change descriptors of a BIP44 account,
   from an account xpub and the master fingerprint of the key it came from.

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -84,6 +84,7 @@ __all__ = [
     "bip32",
     "bip44",
     "block",
+    "core_import",
     "curves",
     "descriptors",
     "ecc",

--- a/btclib/core_import.py
+++ b/btclib/core_import.py
@@ -1,0 +1,213 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The requests Bitcoin Core's `importdescriptors` takes.
+
+https://github.com/bitcoin/bitcoin/blob/master/src/wallet/rpc/backup.cpp
+
+What a wallet does with the descriptors `descriptors.account_descriptors`
+builds: hand them to a node, which then watches every script they
+describe. A request is one json object per descriptor, and this module is
+the object -- no rpc call and no client, deliberately. The caller already
+has one, `bitcoin-core-rpc` being a package of its own that
+`btclib.fetch.bitcoin_core` builds on, and a second way to reach a node
+would be a second thing to keep working.
+
+`import_request` is one object; `account_import_requests` is the pair a
+BIP44 account is, the receiving chain and the change chain marked
+`internal`. That mark is why the pair is a function of its own: change
+imported as a receiving chain is money the wallet reports as incoming
+payments, and the mistake is invisible until a balance is wrong.
+
+Every rule Core enforces on a request is enforced here, where the error
+can still say which field it was rather than arriving as an rpc failure
+half a rescan later:
+
+- the descriptor carries its checksum, `Parse` being called there with
+  ``require_checksum = true``;
+- an `active` descriptor is ranged, an unranged one having no keypool to
+  be the active source of;
+- a `range` belongs to a ranged descriptor and to no other;
+- `next_index` is inside that range;
+- a `label` goes with neither `internal` nor a range.
+
+Two things are not written, where HWI's `getkeypool` writes them:
+`watchonly` and `keypool` are `importmulti` fields -- the other rpc that
+dict targets -- and `importdescriptors` defines neither. A descriptor
+wallet is watch-only by holding no private key, which `descriptors.parse`
+guarantees of every descriptor it returns.
+
+A multipath descriptor is not built here either: Core takes one and reads
+the second element of a two-element step as the internal descriptor, while
+`descriptors.parse` refuses a ``<a;b>`` step outright and
+`multipath_descriptors` is what expands one. So the pair of requests is
+what this module has, and it says the same thing in two objects.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from btclib.descriptors import Descriptor, add_checksum, parse
+from btclib.exceptions import BTClibValueError
+
+__all__ = [
+    "DEFAULT_RANGE",
+    "NOW",
+    "account_import_requests",
+    "import_request",
+]
+
+# what Core substitutes the current chain time for, and what a caller
+# means by "these scripts were never used": the string bypasses the
+# rescan, where a timestamp of 0 scans the whole chain
+NOW = "now"
+
+# Core's own default keypool size, which is what it falls back to for a
+# ranged descriptor imported without a range. Written out rather than left
+# out: a request with no range makes Core answer "Range not given, using
+# default keypool range" as a warning, and a caller reading that back
+# cannot tell which indexes were imported
+DEFAULT_RANGE = (0, 999)
+
+
+def _is_ranged(descriptor: Descriptor | str) -> bool:
+    """Answer whether the descriptor describes a range of scripts.
+
+    A `Descriptor` answers for itself; text is parsed for the answer, and
+    that parse is also what refuses text which is no descriptor at all --
+    a request built around it would be refused by the node instead, which
+    is a rescan away.
+    """
+    if isinstance(descriptor, Descriptor):
+        return descriptor.is_ranged
+    return parse(descriptor).is_ranged
+
+
+def _assert_no_label(label: str, why: str) -> None:
+    """Refuse a label where Core refuses one, naming which rule it was."""
+    if label:
+        raise BTClibValueError(f"a {why} descriptor takes no label")
+
+
+def _range_fields(
+    key_range: tuple[int, int] | None, next_index: int | None
+) -> dict[str, Any]:
+    """Return the range fields of a request, checked against each other.
+
+    Both ends of the range are inclusive, which is how Core reads them --
+    it adds one to the second itself -- and `next_index` is where the
+    wallet carries on from, so it is inside the range or it is nothing.
+    """
+    if key_range is None:
+        if next_index is not None:
+            raise BTClibValueError("next_index without a range to be inside of")
+        return {}
+
+    start, end = key_range
+    if not 0 <= start <= end:
+        raise BTClibValueError(f"invalid range: [{start}, {end}]")
+    fields: dict[str, Any] = {"range": [start, end]}
+    if next_index is not None:
+        if not start <= next_index <= end:
+            err_msg = f"next_index {next_index} is not in [{start}, {end}]"
+            raise BTClibValueError(err_msg)
+        fields["next_index"] = next_index
+    return fields
+
+
+def import_request(
+    descriptor: Descriptor | str,
+    timestamp: int | str = NOW,
+    *,
+    internal: bool = False,
+    active: bool = True,
+    key_range: tuple[int, int] | None = DEFAULT_RANGE,
+    next_index: int | None = None,
+    label: str = "",
+) -> dict[str, Any]:
+    """Return the `importdescriptors` request for one descriptor.
+
+    `descriptor` is a `Descriptor` or the text of one; either way what the
+    request carries is the checksummed text, which is what Core requires of
+    a descriptor it imports.
+
+    `timestamp` is where the rescan starts, in Unix time, `NOW` being
+    Core's own way of saying "do not rescan": right for a descriptor whose
+    scripts have never been used, and wrong for one being restored, where
+    the time of the wallet's first use is what finds its history. `NOW` is
+    the default for the reason there is no default restore date -- this
+    module cannot know one, and a silent 0 would rescan the whole chain.
+
+    `internal` marks the change chain, which Core then keeps out of what
+    it reports as incoming payments.
+
+    `active` makes the descriptor the wallet's source of new addresses for
+    that output type and externality, which is what an import for spending
+    wants and a bare watch of some scripts does not. Core requires an
+    active descriptor to be ranged, so this does too.
+
+    `key_range` is the inclusive pair Core takes, both ends included --
+    Core adds one to the second itself. None leaves the field out, which
+    is what an unranged descriptor takes.
+
+    `next_index` is where an active ranged descriptor hands out its next
+    address, and has to be inside the range, as Core checks.
+
+    `label` names the address, and Core allows one only for a single
+    unranged receiving descriptor: not for change, and not for a range.
+    """
+    text = add_checksum(descriptor if isinstance(descriptor, str) else str(descriptor))
+    is_ranged = _is_ranged(descriptor)
+
+    if active and not is_ranged:
+        err_msg = "an active descriptor must be ranged: one script is no keypool"
+        raise BTClibValueError(err_msg)
+    if key_range is not None and not is_ranged:
+        raise BTClibValueError("an unranged descriptor takes no range")
+    if internal:
+        _assert_no_label(label, "change")
+    if is_ranged:
+        _assert_no_label(label, "ranged")
+
+    request: dict[str, Any] = {
+        "desc": text,
+        "timestamp": timestamp,
+        "internal": internal,
+        "active": active,
+        **_range_fields(key_range, next_index),
+    }
+    if label:
+        request["label"] = label
+    return request
+
+
+def account_import_requests(
+    receive: Descriptor,
+    change: Descriptor,
+    timestamp: int | str = NOW,
+    *,
+    active: bool = True,
+    key_range: tuple[int, int] = DEFAULT_RANGE,
+) -> list[dict[str, Any]]:
+    """Return the two requests a BIP44 account is imported with.
+
+    The pair `descriptors.account_descriptors` builds, with the second
+    marked `internal`: that mark is what keeps a wallet from reporting its
+    own change as incoming payments, and it is the one thing a caller
+    writing the two requests by hand gets wrong.
+
+    Both chains or neither: a wallet holding the receiving chain alone
+    cannot recognize the change it makes itself, which is an output it
+    stops seeing rather than a feature it lacks.
+    """
+    return [
+        import_request(
+            receive, timestamp, internal=False, active=active, key_range=key_range
+        ),
+        import_request(
+            change, timestamp, internal=True, active=active, key_range=key_range
+        ),
+    ]

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -76,6 +76,13 @@ btclib.bip44 module
    :members:
    :show-inheritance:
 
+btclib.core_import module
+-------------------------
+
+.. automodule:: btclib.core_import
+   :members:
+   :show-inheritance:
+
 btclib.descriptors module
 -------------------------
 

--- a/tests/core_import_test.py
+++ b/tests/core_import_test.py
@@ -1,0 +1,226 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.core_import` module.
+
+The oracle is Bitcoin Core's `ProcessDescriptorImport`, in
+`src/wallet/rpc/backup.cpp`: every refusal here is one it makes, and the
+field names and defaults are the ones its `importdescriptors` help
+declares. No value is copied from it -- what is mirrored is a set of
+rules, so there is nothing to pin in `tests/_data/README.md` and nothing
+to refresh; a rule that changes there is a rule this module gets wrong,
+which is what the citations in the module docstring are for.
+
+Every request built here is checked to be json, because that is what it is
+for: a dict Python is happy with and `json.dumps` refuses is a request
+that fails at the rpc boundary rather than here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from btclib.core_import import (
+    DEFAULT_RANGE,
+    NOW,
+    account_import_requests,
+    import_request,
+)
+from btclib.descriptors import (
+    Descriptor,
+    account_descriptors,
+    add_checksum,
+    from_address,
+    parse,
+)
+from btclib.exceptions import BTClibValueError
+
+# the "abandon abandon ... about" root of BIP39, which BIP84 publishes:
+# the same key `tests/bip44_test.py` walks, so the account descriptors
+# below are the ones whose addresses are checked against BIP84's vectors
+XPRV_ROOT = (
+    "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRR"
+    "uL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
+)
+ADDRESS = "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+
+
+def account_pair() -> tuple[Descriptor, Descriptor]:
+    """Return the BIP84 account pair of the root key above."""
+    return account_descriptors(XPRV_ROOT, "m/84h/0h/0h")
+
+
+def as_json(request: dict[str, Any]) -> dict[str, Any]:
+    """Return the request as it arrives at a node: through json."""
+    return json.loads(json.dumps(request))  # type: ignore[no-any-return]
+
+
+def test_the_account_pair_is_two_requests() -> None:
+    """The receiving chain, and the change chain marked internal.
+
+    Which is the whole reason the pair is one function: change imported as
+    a receiving chain is money the wallet reports as incoming payments,
+    and nothing about the two requests otherwise differs.
+    """
+    receive, change = account_pair()
+    requests = account_import_requests(receive, change)
+
+    assert [as_json(request) for request in requests] == [
+        {
+            "desc": add_checksum(str(receive)),
+            "timestamp": NOW,
+            "internal": False,
+            "active": True,
+            "range": [0, 999],
+        },
+        {
+            "desc": add_checksum(str(change)),
+            "timestamp": NOW,
+            "internal": True,
+            "active": True,
+            "range": [0, 999],
+        },
+    ]
+    # the two descriptors differ in the chain step and in nothing else
+    assert requests[0]["desc"].replace("/0/*", "/1/*") != requests[1]["desc"]
+    assert parse(requests[1]["desc"]).key_expressions[0].der_path == (1,)
+
+
+def test_the_descriptor_carries_its_checksum() -> None:
+    """Core parses an imported descriptor with require_checksum = true.
+
+    Text is taken as well as a `Descriptor`, and a checksum already there
+    is verified rather than appended twice -- `add_checksum` being what
+    does both.
+    """
+    receive = account_pair()[0]
+    checksummed = add_checksum(str(receive))
+    for descriptor in (receive, str(receive), checksummed):
+        assert import_request(descriptor)["desc"] == checksummed
+
+    with pytest.raises(BTClibValueError, match="invalid descriptor checksum"):
+        import_request(f"{receive!s}#00000000")
+    # and text that is no descriptor at all is refused here rather than by
+    # the node, which is a rescan away
+    with pytest.raises(BTClibValueError, match="unknown descriptor function"):
+        import_request("nope(0)")
+
+
+def test_the_timestamp_is_where_the_rescan_starts() -> None:
+    """A number is Unix time and the string is Core's "do not rescan"."""
+    receive = account_pair()[0]
+    assert import_request(receive)["timestamp"] == "now"
+    assert import_request(receive, 1455191478)["timestamp"] == 1455191478
+    # 0 is a whole-chain rescan, which is a caller's decision and not a
+    # default: it is passed through as given
+    assert import_request(receive, 0)["timestamp"] == 0
+
+
+def test_an_active_descriptor_must_be_ranged() -> None:
+    """Core's own rule: an unranged descriptor is no source of addresses.
+
+    So a watch of one script is imported with active=False, which is what
+    `addr()` and any fixed-key descriptor take.
+    """
+    single = from_address(ADDRESS)
+    with pytest.raises(BTClibValueError, match="active descriptor must be ranged"):
+        import_request(single)
+
+    request = import_request(single, active=False, key_range=None)
+    assert as_json(request) == {
+        "desc": add_checksum(single),
+        "timestamp": NOW,
+        "internal": False,
+        "active": False,
+    }
+    assert "range" not in request
+
+
+def test_a_range_belongs_to_a_ranged_descriptor() -> None:
+    """And it is inclusive at both ends, as Core reads it."""
+    receive = account_pair()[0]
+    assert import_request(receive, key_range=(5, 20))["range"] == [5, 20]
+    assert import_request(receive)["range"] == list(DEFAULT_RANGE)
+    # None leaves the field out, which makes Core fall back to its keypool
+    # size with a warning -- allowed, and only for an unranged descriptor
+    assert "range" not in import_request(receive, active=False, key_range=None)
+
+    with pytest.raises(BTClibValueError, match="unranged descriptor takes no range"):
+        import_request(from_address(ADDRESS), active=False)
+    for key_range in ((5, 1), (-1, 5)):
+        with pytest.raises(BTClibValueError, match="invalid range"):
+            import_request(receive, key_range=key_range)
+
+
+def test_next_index_is_inside_the_range() -> None:
+    """Where an active ranged descriptor hands out its next address."""
+    receive = account_pair()[0]
+    assert import_request(receive, key_range=(0, 20), next_index=5)["next_index"] == 5
+    assert "next_index" not in import_request(receive, key_range=(0, 20))
+
+    with pytest.raises(BTClibValueError, match=r"next_index 21 is not in \[0, 20\]"):
+        import_request(receive, key_range=(0, 20), next_index=21)
+    with pytest.raises(BTClibValueError, match="next_index without a range"):
+        import_request(
+            from_address(ADDRESS), active=False, key_range=None, next_index=0
+        )
+
+
+def test_a_label_goes_with_neither_change_nor_a_range() -> None:
+    """Core refuses both, and a ranged descriptor is what an account is."""
+    receive = account_pair()[0]
+    with pytest.raises(BTClibValueError, match="ranged descriptor takes no label"):
+        import_request(receive, label="account")
+    # internal is the mark and not the descriptor: what a request says is
+    # change is what Core keeps out of its incoming payments
+    with pytest.raises(BTClibValueError, match="change descriptor takes no label"):
+        import_request(
+            from_address(ADDRESS),
+            active=False,
+            key_range=None,
+            internal=True,
+            label="account",
+        )
+
+    labelled = import_request(
+        from_address(ADDRESS), active=False, key_range=None, label="cold"
+    )
+    assert labelled["label"] == "cold"
+    # an empty label is no label: Core takes "" as the default and a field
+    # carrying it would be a label on a descriptor that has none
+    assert "label" not in import_request(
+        from_address(ADDRESS), active=False, key_range=None
+    )
+
+
+def test_a_multipath_descriptor_is_the_pair_instead() -> None:
+    """Core takes one; btclib splits one, and says which function does it.
+
+    `parse` refuses a `<a;b>` step outright, so a request cannot be built
+    around one here: what this module has is the two objects, which say the
+    same thing as the one Core would read.
+    """
+    receive, change = account_pair()
+    multipath = str(receive).replace("/0/*", "/<0;1>/*")
+    with pytest.raises(BTClibValueError, match="multipath key expression"):
+        import_request(multipath)
+
+    requests = account_import_requests(receive, change)
+    assert [request["internal"] for request in requests] == [False, True]
+
+
+def test_the_pair_passes_its_arguments_through() -> None:
+    """One timestamp, one range, one active flag, for both chains."""
+    receive, change = account_pair()
+    requests = account_import_requests(
+        receive, change, 1455191478, active=False, key_range=(3, 8)
+    )
+    for request in requests:
+        assert request["timestamp"] == 1455191478
+        assert request["active"] is False
+        assert request["range"] == [3, 8]


### PR DESCRIPTION
Part of #381: the second of the three consumers, the `importdescriptors` payload
builder.

`btclib.core_import` is the object and not the call. `import_request` builds one
json object; `account_import_requests` builds the pair a BIP44 account is — the
receiving chain, and the change chain marked `internal`. That mark is why the
pair is a function of its own: change imported as a receiving chain is money the
wallet reports as incoming payments, and the mistake is invisible until a
balance is wrong.

```python
>>> receive, change = account_descriptors(master_xprv, "m/84h/0h/0h")
>>> account_import_requests(receive, change)
[{'desc': 'wpkh([73c5da0a/84h/0h/0h]xpub6CatW…/0/*)#afwvtk2s', 'timestamp': 'now',
  'internal': False, 'active': True, 'range': [0, 999]},
 {'desc': 'wpkh([73c5da0a/84h/0h/0h]xpub6CatW…/1/*)#vatdkr6g', 'timestamp': 'now',
  'internal': True, 'active': True, 'range': [0, 999]}]
```

**No rpc client here, deliberately**: the caller already has one —
`bitcoin-core-rpc` is a package of its own that `btclib.fetch.bitcoin_core`
builds on — and the issue asks for these helpers to stay pure. A second way to
reach a node would be a second thing to keep working.

## Core's rules, enforced where the error can still name the field

Each is one `ProcessDescriptorImport` makes, so a refusal arrives here rather
than as an rpc failure half a rescan later:

- the descriptor carries its checksum (`Parse` is called there with
  `require_checksum = true`);
- an `active` descriptor is ranged — one script is no keypool;
- a `range` belongs to a ranged descriptor and to no other, both ends inclusive
  as Core reads them (it adds one to the second itself);
- `next_index` is inside that range;
- a `label` goes with neither `internal` nor a range.

Text is accepted as well as a `Descriptor`, and it is parsed — which is also
what refuses text that is no descriptor at all.

## Two departures from HWI's dict, and why

- **`watchonly` and `keypool` are not written.** They are `importmulti` fields —
  the other rpc HWI's `getkeypool` dict targets — and `importdescriptors`
  declares neither. (#381's work-package text lists `watchonly`; Core's help
  does not have it.) A descriptor wallet is watch-only by holding no private
  key, which `descriptors.parse` guarantees of every descriptor it returns.
- **no multipath request.** Core reads the second element of a two-element
  `<a;b>` step as the internal descriptor; `descriptors.parse` refuses such a
  step outright and `multipath_descriptors` is what expands one, so the pair of
  requests is what says the same thing here.

## Oracle

Core's `src/wallet/rpc/backup.cpp` — the `importdescriptors` help for the field
names and defaults, `ProcessDescriptorImport` for the rules. No value is copied,
so there is nothing to pin in `tests/_data/README.md`; the test module says so.
Every request the tests build is round-tripped through `json.dumps`, since a
dict that json refuses is a request that fails at the rpc boundary.

## Gates

Merged on the local gates alone; GitHub Actions is degraded today.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`: 17444 passed, 100.00%
- `pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a helper module to build validated Bitcoin Core `importdescriptors` request objects and expose it as part of the public API.

New Features:
- Introduce the `btclib.core_import` module to construct JSON requests compatible with Bitcoin Core's `importdescriptors` RPC, including single-descriptor and BIP44 account (receive/change) helpers.

Documentation:
- Document the new `btclib.core_import` public module and its behavior in the changelog.

Tests:
- Add comprehensive tests for `btclib.core_import` covering descriptor checksum handling, ranges, timestamps, labels, and BIP44 account import semantics.