### PR TITLE
Give the Updater its output half, and check the script before claiming one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,37 @@ edit.
 
 ### The public API and the module layout
 
+- **the Updater has an output half: `Descriptor.update_psbt_output`**
+  (issue #381), and `update_psbt` is `update_psbt_input`. An input told a
+  psbt what it needed to be spent; nothing told a psbt what an output is,
+  which is what a signing device reads to tell change from a payment — it
+  derives the script itself and sees that the money comes back.
+
+  The same fields, on the map an output has: the redeem script of a
+  `sh()`, the witness script of a `wsh()`, the internal key of a `tr()`
+  and the origin of every key that carries one. One writer serves both,
+  BIP174 giving the two maps the same field wherever it means the same
+  thing, and `tr()` is the one that parts company: an input carries the
+  merkle root and the leaf it spends, an output carries
+  `PSBT_OUT_TAP_TREE` — every leaf with the depth it sits at, depth-first.
+  That is more than the root an input has, and deliberately: a root proves
+  nothing about the scripts under it, where the tree lets a reader fold
+  the leaves back up, tweak the internal key and land on the output key
+  itself, which is what the suite does with it. BIP373's participant list
+  is written on an output too, which is what tells a wallet that an output
+  comes back to a group it is in.
+
+  **The script is checked, where the input half checks nothing**: the
+  output being paid is in the psbt already, so this refuses unless the
+  descriptor derives exactly that script at that index. Marking an output
+  as one's own is a claim about where money goes, and the only evidence
+  for it is the whole script — never a key origin whose four-byte
+  fingerprint matches, which collides and which whoever wrote the psbt
+  chose. `Descriptor.index_of` is the same question the other way round,
+  answering which index of a descriptor pays to a script and None where
+  none does, over a range the caller bounds: how far ahead of its own gap
+  limit a wallet looks is not this module's policy.
+
 - **`btclib.core_import` is new: the requests Bitcoin Core's
   `importdescriptors` takes** (issue #381). `import_request` is one json
   object and `account_import_requests` the pair a BIP44 account is — the
@@ -3030,7 +3061,7 @@ edit.
 
   What that costs is the one thing an xpub cannot do, a hardened step,
   and it is why `script_pub_keys`, `script_pub_key`, `redeem_script`,
-  `address`, `addresses`, `satisfy`, `update_psbt`,
+  `address`, `addresses`, `satisfy`, the two `update_psbt` halves,
   `taproot_merkle_root`, `taproot_leaf_scripts` and
   `KeyExpression.sec` all end in an optional `prv_keys`: expansion takes
   the keys back for the call that needs them, the way Core's `Expand`
@@ -3220,8 +3251,8 @@ edit.
   against; the test suite checks it against `finalize_psbt`, which does
   have one, and the two build the same bytes for every shape both can
   express (issue #263)
-- **`Descriptor.update_psbt` is BIP174's Updater**: it returns the psbt
-  with one input told what the descriptor knows — the redeem script of a
+- **`Descriptor.update_psbt_input` is BIP174's Updater**: it returns the
+  psbt with one input told what the descriptor knows — the redeem script of a
   `sh()`, the witness script of a `wsh()`, the internal key, merkle root
   and leaf scripts of a `tr()`, and the origin of every key that carries
   one, which is what `KeyExpression.origin` is kept for and what nothing

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -26,8 +26,8 @@ against the `v2023.7.12` tag.
 - **A descriptor parsed from an xprv no longer derives a hardened step
   on its own.** `descriptors.parse` keeps no private key: it neuters the
   xprv and fills the `prv_keys` mapping handed to it, and
-  `script_pub_keys`, `satisfy`, `update_psbt` and their neighbours take
-  that mapping back as a last argument. `parse(d).script_pub_keys(0)`
+  `script_pub_keys`, `satisfy`, `update_psbt_input` and their neighbours
+  take that mapping back as a last argument. `parse(d).script_pub_keys(0)`
   becomes `keys = {}; parse(d, prv_keys=keys).script_pub_keys(0, keys)`
   where the path has a hardened step; everything else is unchanged.
 - **`str_from_index_int(i, "H")` raises.** A derivation path is written

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -21,13 +21,17 @@ the signatures are a parameter rather than something this module makes.
 `psbt.finalize` does have one and does check, and builds the same
 bytes from a psbt carrying the same signatures.
 
-`update_psbt` is the third answer, and the one for a spend the signers
-do not make all at once: BIP174's Updater, writing the scripts and the
-key origins into a psbt input, for signers to fill in at their own pace
-and `psbt.finalize` to assemble. This module imports `psbt` for it
-and nothing there imports back, which is the direction of the layering:
-a psbt is a transaction being built, and a descriptor is what a wallet
-knows about the outputs it holds.
+`update_psbt_input` and `update_psbt_output` are the third answer, and
+the one for a spend the signers do not make all at once: BIP174's Updater,
+writing the scripts and the key origins into a psbt, for signers to fill
+in at their own pace and `psbt.finalize` to assemble. The output half is
+also what tells change from a payment, and it makes that claim only where
+the descriptor derives the very script being paid -- `index_of` is the
+same question asked the other way round, and neither answers from a key
+origin whose fingerprint happens to match. This module imports `psbt` for
+all of it and nothing there imports back, which is the direction of the
+layering: a psbt is a transaction being built, and a descriptor is what a
+wallet knows about the outputs it holds.
 
 BIP380: https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki
 
@@ -65,7 +69,8 @@ back through the `prv_keys` mapping a caller passes in -- Bitcoin Core's
 `Parse(desc, out, error)`, whose descriptor keeps no reference to the
 `FlatSigningProvider` it filled. Expansion takes the mapping back for the
 one thing an xpub cannot do, a hardened step, which is why
-`script_pub_keys`, `satisfy`, `update_psbt` and the rest all end in an
+`script_pub_keys`, `satisfy`, the two `update_psbt` halves and the rest
+all end in an
 optional `prv_keys`. A WIF is not in that mapping: it was already reduced
 to its public key on the way in, this module deriving nothing from it and
 signing nothing with it.
@@ -150,6 +155,7 @@ from btclib.hashes import hash160
 from btclib.network import NETWORKS, network_from_xkeyversion
 from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
+from btclib.psbt.psbt_out import PsbtOut
 from btclib.script.script import op_int, serialize
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.script.taproot import input_script_sig, leaf_hash, tree_helper
@@ -689,6 +695,28 @@ def _leaf_script(
     return [leaf.sec(index, network, prv_keys)[1:], "OP_CHECKSIG"]
 
 
+def _leaf_scripts(
+    tree: DescriptorTree,
+    depth: int,
+    index: int,
+    network: str,
+    prv_keys: PrvKeys | None,
+) -> list[tuple[int, bytes]]:
+    """Return each leaf's depth and serialized script, left to right.
+
+    The depth is what BIP371's PSBT_OUT_TAP_TREE carries beside the
+    script, and the two together are the tree: a depth-first walk that
+    records how deep each leaf sits is enough to rebuild the shape it was
+    walked from. The order is `_tree_leaves`'s, which is the order
+    `taproot.tree_helper` numbers them in.
+    """
+    if isinstance(tree, tuple):
+        return _leaf_scripts(tree[0], depth + 1, index, network, prv_keys) + (
+            _leaf_scripts(tree[1], depth + 1, index, network, prv_keys)
+        )
+    return [(depth, serialize(_leaf_script(tree, index, network, prv_keys)))]
+
+
 def _leaf_stack(
     leaf: DescriptorLeaf,
     signatures: Mapping[bytes, bytes],
@@ -1024,7 +1052,37 @@ class Descriptor(ABC):
             cast(ScriptList, self._stack(signatures, index, prv_keys))
         ), Witness()
 
-    def update_psbt(
+    def index_of(
+        self,
+        script_pub_key: Octets,
+        last_index: int = 999,
+        prv_keys: PrvKeys | None = None,
+    ) -> int | None:
+        """Return the index whose script is this one, None where none is.
+
+        What makes an output *this wallet's*, and the only thing that
+        does: the script is derived and compared whole. A key origin whose
+        fingerprint matches is not an answer -- four bytes of a hash160
+        collide, and a psbt is written by whoever sends it, so an output
+        marked as change on a fingerprint is an output a wallet may hand
+        to somebody else believing it keeps it.
+
+        `last_index` bounds the search, both ends included, and is the
+        caller's: how far ahead of its own gap limit a wallet is willing
+        to look is a policy this module has no view on. A descriptor that
+        is not ranged has one script and answers 0 or None.
+        """
+        script = bytes_from_octets(script_pub_key)
+        last = last_index if self.is_ranged else 0
+        for index in range(last + 1):
+            if any(
+                candidate.script == script
+                for candidate in self.script_pub_keys(index, prv_keys)
+            ):
+                return index
+        return None
+
+    def update_psbt_input(
         self,
         psbt: Psbt,
         vin_i: int,
@@ -1065,7 +1123,57 @@ class Descriptor(ABC):
         psbt.assert_valid()
         return psbt
 
-    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
+    def update_psbt_output(
+        self,
+        psbt: Psbt,
+        vout_i: int,
+        index: int = 0,
+        prv_keys: PrvKeys | None = None,
+    ) -> Psbt:
+        """Return the psbt with output `vout_i` told what the descriptor knows.
+
+        The Updater's other half, and what makes an output recognizable as
+        the wallet's own: the redeem script of a ``sh()``, the witness
+        script of a ``wsh()``, the internal key and the whole script tree
+        of a ``tr()``, and the origin of every key that carries one. A
+        signing device reads them to tell change from a payment -- it can
+        derive the script itself and see that the money comes back -- and
+        a wallet reading a psbt somebody else built reads them for the same
+        reason.
+
+        Unlike the input half, the script *is* checked: the output being
+        paid is in the psbt already, so this refuses unless the descriptor
+        derives exactly that script at `index`. Marking an output as one's
+        own is a claim about where money goes, and the only evidence for it
+        is the whole script -- never a key origin whose four-byte
+        fingerprint matches, which is what `index_of` is for and what it
+        says.
+
+        The output tree is BIP371's PSBT_OUT_TAP_TREE and not the leaf
+        script an input carries: an output has no leaf being spent, so what
+        it publishes is every leaf, each with its depth, which is what lets
+        a reader rebuild the tree and check the output key for itself.
+        """
+        self._assert_index(index)
+        # an IndexError out of a public method is not an answer, and a
+        # negative index would quietly update the output at the other end
+        if not 0 <= vout_i < len(psbt.outputs):
+            raise BTClibValueError(f"invalid output index: {vout_i}")
+        paid = psbt.tx.vout[vout_i].script_pub_key.script
+        if all(
+            script.script != paid for script in self.script_pub_keys(index, prv_keys)
+        ):
+            err_msg = f"output {vout_i} pays to {paid.hex()}, which is not the"
+            err_msg += f" script this descriptor describes at index {index}"
+            raise BTClibValueError(err_msg)
+        psbt = deepcopy(psbt)
+        self._update_out(psbt.outputs[vout_i], index, prv_keys)
+        psbt.assert_valid()
+        return psbt
+
+    def _update_map(
+        self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
+    ) -> None:
         """Fill the key origins, which is what every fragment knows.
 
         And the whole of what ``pk()``, ``pkh()``, ``wpkh()`` and
@@ -1073,14 +1181,32 @@ class Descriptor(ABC):
         psbt has from the utxo rather than from here. The fragments that
         embed one of those add their scripts to this.
 
+        One method for an input and an output, because BIP174 gives the
+        two maps the same fields wherever they mean the same thing: a
+        redeem script, a witness script and a key origin say what they say
+        whether the psbt is spending the script or paying to it. Only a
+        ``tr()`` differs, an input carrying the leaf it spends and an
+        output the whole tree, and that is where the two methods below
+        part company.
+
         The mapping is added to and not replaced: BIP174 keys it by
         public key, so a psbt already carrying another signer's key keeps
         it, and this descriptor's entry wins for a key held by both.
         """
-        psbt_in.hd_key_paths = {
-            **psbt_in.hd_key_paths,
+        psbt_map.hd_key_paths = {
+            **psbt_map.hd_key_paths,
             **self._hd_key_paths(index, prv_keys),
         }
+
+    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
+        """Fill what an input of this descriptor's script carries."""
+        self._update_map(psbt_in, index, prv_keys)
+
+    def _update_out(
+        self, psbt_out: PsbtOut, index: int, prv_keys: PrvKeys | None
+    ) -> None:
+        """Fill what an output paying to this descriptor's script carries."""
+        self._update_map(psbt_out, index, prv_keys)
 
     def _hd_key_paths(
         self, index: int, prv_keys: PrvKeys | None
@@ -1236,7 +1362,9 @@ class ShDescriptor(Descriptor):
         redeem_script = self.inner.redeem_script(index, prv_keys)
         return script_sig + serialize(cast(ScriptList, [redeem_script])), witness
 
-    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
+    def _update_map(
+        self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
+    ) -> None:
         """Fill the redeem script, and let the argument fill its own fields.
 
         Delegated rather than dispatched on: the argument of a
@@ -1244,8 +1372,8 @@ class ShDescriptor(Descriptor):
         redeem script, and it is the same method that fills it for a
         native ``wsh()``.
         """
-        self.inner._update(psbt_in, index, prv_keys)
-        psbt_in.redeem_script = self.inner.redeem_script(index, prv_keys)
+        self.inner._update_map(psbt_map, index, prv_keys)
+        psbt_map.redeem_script = self.inner.redeem_script(index, prv_keys)
 
 
 @dataclass(frozen=True)
@@ -1281,15 +1409,17 @@ class WshDescriptor(Descriptor):
         stack = self.inner._stack(signatures, index, prv_keys)
         return b"", Witness([*stack, self.inner.redeem_script(index, prv_keys)])
 
-    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
+    def _update_map(
+        self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
+    ) -> None:
         """Fill the witness script; the redeem script is ``sh()``'s to fill.
 
         Which is the whole difference between a native ``wsh()`` and a
         wrapped one, in the psbt as in the spend: the same witness script,
         and a redeem script only where something wraps it.
         """
-        self.inner._update(psbt_in, index, prv_keys)
-        psbt_in.witness_script = self.inner.redeem_script(index, prv_keys)
+        self.inner._update_map(psbt_map, index, prv_keys)
+        psbt_map.witness_script = self.inner.redeem_script(index, prv_keys)
 
 
 @dataclass(frozen=True)
@@ -1408,7 +1538,9 @@ class ComboDescriptor(Descriptor):
         err_msg = "combo() is four scripts: satisfy the one being spent"
         raise BTClibValueError(err_msg)
 
-    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
+    def _update_map(
+        self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
+    ) -> None:
         """Refuse: the four scripts are updated into an input differently.
 
         One of them is p2sh and wants a redeem script, the other three
@@ -1453,7 +1585,9 @@ class AddrDescriptor(Descriptor):
         """
         raise BTClibValueError("addr() cannot be satisfied: it holds no key")
 
-    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
+    def _update_map(
+        self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
+    ) -> None:
         """Refuse: there is nothing of an address to write into an input.
 
         No key, so no origin; no script below the address, so no redeem or
@@ -1495,7 +1629,9 @@ class RawDescriptor(Descriptor):
         """
         raise BTClibValueError("raw() cannot be satisfied: it holds no key")
 
-    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
+    def _update_map(
+        self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
+    ) -> None:
         """Refuse, for the reason ``addr()`` does: bytes hold no key origin.
 
         Those bytes may be the script an input spends, and they are then
@@ -1673,8 +1809,32 @@ class TrDescriptor(Descriptor):
         err_msg = "no signature for the tr() internal key or for any of its leaves"
         raise BTClibValueError(err_msg)
 
-    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
-        """Fill the four taproot fields: internal key, root, leaves, origins.
+    def taproot_tree(
+        self, index: int = 0, prv_keys: PrvKeys | None = None
+    ) -> list[tuple[int, int, bytes]]:
+        """Return every leaf with its depth: BIP371's PSBT_OUT_TAP_TREE.
+
+        The whole tree, where an input publishes the one leaf it spends and
+        the control block that proves it: an output has no leaf being spent
+        yet, so what it carries is each script with the depth it sits at,
+        in the order a depth-first walk reaches them. A reader rebuilds the
+        tree from those two facts and can then check the output key itself
+        -- which is why the field is the tree and not the merkle root, a
+        root proving nothing about the scripts underneath it.
+
+        Empty for a ``tr(KEY)``, whose output key commits to no script at
+        all, and which BIP371 says so about by leaving the field out.
+        """
+        self._assert_index(index)
+        if self.tree is None:
+            return []
+        scripts = _leaf_scripts(self.tree, 0, index, self.network, prv_keys)
+        return [(depth, _TAPSCRIPT_LEAF_VERSION, script) for depth, script in scripts]
+
+    def _update_map(
+        self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
+    ) -> None:
+        """Fill the taproot fields an input and an output share.
 
         This replaces the base method rather than adding to it: a taproot
         key origin belongs in `taproot_hd_key_paths`, keyed by the x-only
@@ -1682,26 +1842,50 @@ class TrDescriptor(Descriptor):
         same key twice in two spellings, for a signer that signs with
         neither.
 
-        A fifth field where a key of the descriptor is a ``musig()``:
-        BIP373's participant list, which is what tells a signer that one of
-        the keys it holds is in the group this input is spent by.
+        The participant list of BIP373 goes here too where a key of the
+        descriptor is a ``musig()``: it tells a signer that one of the keys
+        it holds is in the group, which is as true of an output being paid
+        as of an input being spent.
         """
-        psbt_in.taproot_internal_key = self.internal_key.sec(
+        psbt_map.taproot_internal_key = self.internal_key.sec(
             index, self.network, prv_keys
         )[1:]
+        psbt_map.taproot_hd_key_paths = {
+            **psbt_map.taproot_hd_key_paths,
+            **self._taproot_hd_key_paths(index, prv_keys),
+        }
+        psbt_map.musig2_participant_pub_keys = {
+            **psbt_map.musig2_participant_pub_keys,
+            **_musig2_participants(self.key_expressions, index, self.network, prv_keys),
+        }
+
+    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
+        """Add what an input carries: the merkle root and the leaf scripts.
+
+        A control block is the field an Updater is needed for rather than
+        convenient -- it holds the merkle path from its leaf to the root,
+        which is the whole tree seen from that leaf -- and the merkle root
+        is what a verifier tweaks the internal key with.
+        """
+        self._update_map(psbt_in, index, prv_keys)
         psbt_in.taproot_merkle_root = self.taproot_merkle_root(index, prv_keys)
         psbt_in.taproot_leaf_scripts = {
             **psbt_in.taproot_leaf_scripts,
             **self.taproot_leaf_scripts(index, prv_keys),
         }
-        psbt_in.taproot_hd_key_paths = {
-            **psbt_in.taproot_hd_key_paths,
-            **self._taproot_hd_key_paths(index, prv_keys),
-        }
-        psbt_in.musig2_participant_pub_keys = {
-            **psbt_in.musig2_participant_pub_keys,
-            **_musig2_participants(self.key_expressions, index, self.network, prv_keys),
-        }
+
+    def _update_out(
+        self, psbt_out: PsbtOut, index: int, prv_keys: PrvKeys | None
+    ) -> None:
+        """Add what an output carries: the tree, every leaf of it at once.
+
+        BIP371 gives an output PSBT_OUT_TAP_TREE and no merkle root: the
+        root is computed from the tree and would be the same fact twice,
+        where the tree is what a reader needs to compute the output key and
+        find out that this output is one it can spend.
+        """
+        self._update_map(psbt_out, index, prv_keys)
+        psbt_out.taproot_tree = self.taproot_tree(index, prv_keys)
 
 
 @dataclass(frozen=True)
@@ -1762,7 +1946,9 @@ class RawTrDescriptor(Descriptor):
             raise BTClibValueError("no signature for the rawtr() output key")
         return b"", Witness([signature])
 
-    def _update(self, psbt_in: PsbtIn, index: int, prv_keys: PrvKeys | None) -> None:
+    def _update_map(
+        self, psbt_map: PsbtIn | PsbtOut, index: int, prv_keys: PrvKeys | None
+    ) -> None:
         """Fill the one taproot field a ``rawtr()`` has anything to say in.
 
         BIP371's PSBT_IN_TAP_BIP32_DERIVATION, keyed by the x-only key,
@@ -1782,12 +1968,12 @@ class RawTrDescriptor(Descriptor):
         reaching what is spent.
         """
         keys = self.key_expressions
-        psbt_in.taproot_hd_key_paths = {
-            **psbt_in.taproot_hd_key_paths,
+        psbt_map.taproot_hd_key_paths = {
+            **psbt_map.taproot_hd_key_paths,
             **_taproot_derivations(keys, {}, index, self.network, prv_keys),
         }
-        psbt_in.musig2_participant_pub_keys = {
-            **psbt_in.musig2_participant_pub_keys,
+        psbt_map.musig2_participant_pub_keys = {
+            **psbt_map.musig2_participant_pub_keys,
             **_musig2_participants(keys, index, self.network, prv_keys),
         }
 

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -69,7 +69,7 @@ from btclib.descriptors import (
 )
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
-from btclib.hashes import hash160
+from btclib.hashes import hash160, tagged_hash
 from btclib.psbt.musig2 import nonce_gen, partial_sign, partial_sigs_agg
 from btclib.psbt.psbt import (
     Psbt,
@@ -908,6 +908,8 @@ WIF = "L4rK1yDtCWekvXuE6oXD9jCYfFNV2cWRpVuPLBcCU2z8TrisoyY1"
 UNCOMPRESSED_WIF = "5KYZdUEo39z3FPrtuX2QbbwGnNP5zTd7yyr2SC1j299sBCnWjss"
 XPUB = "xpub661MyMwAqRbcFW31YEwpkMuc5THy2PSt5bDMsktWQcFF8syAmRUapSCGu8ED9W6oDMSgv6Zz8idoc4a6mr8BDzTJY47LJhkJ8UB7WEGuduB"
 XONLY = "a34b99f22c790c4e36b2b3c2c35a36db06226e41c692fc82b8b56ac1c540c5bd"
+# a second xpub, for the case where an origin agrees and a script does not
+XPUB_OTHER = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
 OFF_CURVE = "020000000000000000000000000000000000000000000000000000000000000005"
 
 # BIP390's own participants: three fixed keys, the first of them also
@@ -1304,7 +1306,7 @@ def test_a_musig_descriptor_builds_a_psbt_its_group_can_sign() -> None:
     prv_keys: dict[str, str] = {}
     descriptor = parse(f"tr(musig({XPRV_ROOT},{XPRV_SECOND})/0/*)", prv_keys=prv_keys)
     key = descriptor.key_expressions[0]
-    psbt = descriptor.update_psbt(psbt_spending(descriptor, 1), 0, 1)
+    psbt = descriptor.update_psbt_input(psbt_spending(descriptor, 1), 0, 1)
     psbt.assert_signable()
 
     aggregate = key.aggregate(1)
@@ -1338,7 +1340,7 @@ def test_the_updater_writes_a_musig_group_that_derives_nothing() -> None:
     participant = f"[d34db33f/0h]{MUSIG_XPUB_A}"
     descriptor = parse(f"tr(musig({participant},{MUSIG_XPUB_B}))")
     key = descriptor.key_expressions[0]
-    psbt_in = descriptor.update_psbt(psbt_spending(descriptor), 0).inputs[0]
+    psbt_in = descriptor.update_psbt_input(psbt_spending(descriptor), 0).inputs[0]
 
     aggregate = key.aggregate()
     assert psbt_in.taproot_internal_key == aggregate[1:]
@@ -1828,7 +1830,7 @@ def test_the_updater_fills_what_the_finalizer_dispatches_on(
     is the one the output being spent commits to.
     """
     parsed = parse(descriptor)
-    psbt = parsed.update_psbt(psbt_spending(parsed), 0)
+    psbt = parsed.update_psbt_input(psbt_spending(parsed), 0)
     psbt.assert_signable()
 
     psbt_in = psbt.inputs[0]
@@ -1853,7 +1855,7 @@ def test_the_updater_carries_the_key_origin_of_the_derived_key() -> None:
     descriptor = parse(f"wpkh([d34db33f/84h/0h/0h]{XPUB}/0/*)")
     key = descriptor.key_expressions[0]
     for index in (0, 7):
-        psbt = descriptor.update_psbt(psbt_spending(descriptor, index), 0, index)
+        psbt = descriptor.update_psbt_input(psbt_spending(descriptor, index), 0, index)
         hd_key_paths = psbt.inputs[0].hd_key_paths
         assert list(hd_key_paths) == [key.sec(index)]
         assert (
@@ -1868,7 +1870,7 @@ def test_a_key_without_an_origin_is_skipped_rather_than_refused() -> None:
     about where it came from costs is its own entry and not the field.
     """
     descriptor = parse(f"wsh(multi(2,[d34db33f/0h]{XPUB}/0,{KEY_B},{KEY_C}))")
-    psbt = descriptor.update_psbt(psbt_spending(descriptor), 0)
+    psbt = descriptor.update_psbt_input(psbt_spending(descriptor), 0)
     hd_key_paths = psbt.inputs[0].hd_key_paths
     assert list(hd_key_paths) == [descriptor.key_expressions[0].sec()]
     assert hd_key_paths[descriptor.key_expressions[0].sec()].description == (
@@ -1890,7 +1892,7 @@ def test_the_updater_adds_to_what_the_psbt_already_carries() -> None:
         bytes.fromhex(KEY_A): BIP32KeyOrigin("ffffffff", "m/1"),
         key: BIP32KeyOrigin("ffffffff", "m/2"),
     }
-    hd_key_paths = descriptor.update_psbt(psbt, 0).inputs[0].hd_key_paths
+    hd_key_paths = descriptor.update_psbt_input(psbt, 0).inputs[0].hd_key_paths
     assert hd_key_paths[bytes.fromhex(KEY_A)].description == "ffffffff/1"
     assert hd_key_paths[key].description == "d34db33f/0h/0"
 
@@ -1899,7 +1901,7 @@ def test_the_updater_leaves_the_psbt_it_was_given_alone() -> None:
     """A copy, as `finalize` returns one."""
     descriptor = parse(f"sh({MULTI})")
     psbt = psbt_spending(descriptor)
-    assert descriptor.update_psbt(psbt, 0).inputs[0].redeem_script
+    assert descriptor.update_psbt_input(psbt, 0).inputs[0].redeem_script
     assert not psbt.inputs[0].redeem_script
 
 
@@ -1913,9 +1915,9 @@ def test_the_updater_refuses_an_index_that_names_no_input() -> None:
     psbt = psbt_spending(descriptor)
     for vin_i in (-1, 1):
         with pytest.raises(BTClibValueError, match="invalid input index"):
-            descriptor.update_psbt(psbt, vin_i)
+            descriptor.update_psbt_input(psbt, vin_i)
     with pytest.raises(BTClibValueError, match="not a ranged descriptor"):
-        descriptor.update_psbt(psbt, 0, 1)
+        descriptor.update_psbt_input(psbt, 0, 1)
 
 
 def taproot_leaf_of(psbt_in: PsbtIn, x_only: str) -> tuple[bytes, bytes]:
@@ -1939,7 +1941,7 @@ def test_the_updater_fills_the_taproot_fields() -> None:
     """
     descriptor = parse(f"tr({XONLY_A},{{pk({XONLY_B}),pk({XONLY_C})}})")
     assert isinstance(descriptor, TrDescriptor)
-    psbt_in = descriptor.update_psbt(psbt_spending(descriptor), 0).inputs[0]
+    psbt_in = descriptor.update_psbt_input(psbt_spending(descriptor), 0).inputs[0]
 
     assert psbt_in.taproot_internal_key == bytes.fromhex(XONLY_A)
     assert psbt_in.taproot_merkle_root == descriptor.taproot_merkle_root()
@@ -1964,7 +1966,7 @@ def test_a_taproot_key_path_descriptor_has_no_root_and_no_leaf() -> None:
     assert descriptor.taproot_merkle_root() == b""
     assert descriptor.taproot_leaf_scripts() == {}
 
-    psbt_in = descriptor.update_psbt(psbt_spending(descriptor), 0).inputs[0]
+    psbt_in = descriptor.update_psbt_input(psbt_spending(descriptor), 0).inputs[0]
     assert psbt_in.taproot_internal_key == bytes.fromhex(XONLY_A)
     assert not psbt_in.taproot_merkle_root
     assert not psbt_in.taproot_leaf_scripts
@@ -1984,7 +1986,7 @@ def test_a_taproot_key_origin_names_the_leaves_it_is_in() -> None:
     # blocks are two entries of `taproot_leaf_scripts` -- and one leaf
     # hash here, the two leaves being the same script
     descriptor = parse(f"tr({internal},{{pk({left}),{{pk({right}),pk({left})}}}})")
-    psbt_in = descriptor.update_psbt(psbt_spending(descriptor), 0).inputs[0]
+    psbt_in = descriptor.update_psbt_input(psbt_spending(descriptor), 0).inputs[0]
 
     assert not psbt_in.hd_key_paths
     # the left key twice among the key expressions, and once here
@@ -2016,7 +2018,7 @@ def test_the_updater_names_the_leaf_a_multi_a_key_is_in() -> None:
     left, right = f"[aabbccdd/1]{XPUB}/1", f"[11223344/2]{XPUB}/2"
     descriptor = parse(f"tr({XONLY},multi_a(2,{left},{right}))")
     assert isinstance(descriptor, TrDescriptor)
-    psbt_in = descriptor.update_psbt(psbt_spending(descriptor), 0).inputs[0]
+    psbt_in = descriptor.update_psbt_input(psbt_spending(descriptor), 0).inputs[0]
 
     assert psbt_in.taproot_leaf_scripts == descriptor.taproot_leaf_scripts()
     ((script, version),) = psbt_in.taproot_leaf_scripts.values()
@@ -2038,7 +2040,7 @@ def test_a_taproot_script_path_is_finalizable_only_after_the_updater() -> None:
     finalizes to the very bytes `satisfy` builds from the same signature.
     """
     descriptor = parse(f"tr({XONLY_A},{{pk({XONLY_B}),pk({XONLY_C})}})")
-    psbt = descriptor.update_psbt(psbt_spending(descriptor), 0)
+    psbt = descriptor.update_psbt_input(psbt_spending(descriptor), 0)
     script, control_block = taproot_leaf_of(psbt.inputs[0], XONLY_B)
 
     # sign_ and not sign: what BIP341 signs is the hash BIP342 makes of
@@ -2079,14 +2081,234 @@ UNUPDATABLE = [
     ],
 )
 def test_what_cannot_update_a_psbt(descriptor: str, message: str) -> None:
-    """Refuse update_psbt on combo(), addr() and raw()."""
+    """Refuse update_psbt_input on combo(), addr() and raw()."""
     parsed = parse(descriptor)
     # combo() is four scripts and script_pub_key refuses to pick one, so
     # the psbt is built around the p2pkh of the same key: what is being
     # tested is the refusal, and it comes before anything reads the utxo
     psbt = psbt_spending(parse(f"pkh({KEY_A})"))
     with pytest.raises(BTClibValueError, match=message):
-        parsed.update_psbt(psbt, 0)
+        parsed.update_psbt_input(psbt, 0)
+
+
+def psbt_paying(script_pub_key: ScriptPubKey) -> Psbt:
+    """Return a psbt paying somebody else at output 0 and this at output 1.
+
+    Which is the shape change detection is about: one output is the
+    payment being made and the other comes back to the wallet, and nothing
+    but the script says which is which.
+    """
+    elsewhere = parse(f"wpkh({KEY_B})").script_pub_key()
+    tx = Tx(
+        vin=[TxIn(OutPoint(b"\x03" * 32, 0))],
+        vout=[TxOut(500, elsewhere), TxOut(400, script_pub_key)],
+    )
+    return Psbt.from_tx(tx)
+
+
+@pytest.mark.parametrize("descriptor, signing_keys, redeem, witness", FINALIZER_VECTORS)
+def test_the_output_updater_fills_the_scripts_and_the_origins(
+    descriptor: str, signing_keys: list[str], redeem: str, witness: str
+) -> None:
+    """The same fields as the input half, on the map an output has.
+
+    A redeem script, a witness script and a key origin say what they say
+    whether the psbt is spending the script or paying to it, so the two
+    updaters share the writer -- and these are the vectors the input half
+    is checked with.
+    """
+    parsed = parse(descriptor)
+    psbt = parsed.update_psbt_output(psbt_paying(parsed.script_pub_key()), 1)
+    psbt_out = psbt.outputs[1]
+
+    assert psbt_out.redeem_script == (parse(redeem).redeem_script() if redeem else b"")
+    assert psbt_out.witness_script == (
+        parse(witness).redeem_script() if witness else b""
+    )
+    assert list(psbt_out.hd_key_paths) == list(
+        parsed.update_psbt_input(psbt_spending(parsed), 0).inputs[0].hd_key_paths
+    )
+    # and the output the psbt pays to somebody else is left alone
+    assert psbt.outputs[0] == Psbt.from_tx(psbt.tx).outputs[0]
+
+
+def test_the_output_updater_refuses_an_output_it_does_not_describe() -> None:
+    """The claim is "this output is mine", and the evidence is the script.
+
+    Never the key origin: four bytes of a hash160 collide, and a psbt is
+    written by whoever sends it, so an output marked as change on a
+    fingerprint is one a wallet may hand to somebody else believing it
+    keeps it. The refusal names the script that was paid.
+    """
+    descriptor = parse(f"wpkh([d34db33f/84h/0h/0h]{XPUB}/1/*)")
+    psbt = psbt_paying(descriptor.script_pub_key(3))
+
+    assert descriptor.update_psbt_output(psbt, 1, 3).outputs[1].hd_key_paths
+    # output 0 pays elsewhere, and index 4 is another script of this very
+    # descriptor: both are the same refusal
+    with pytest.raises(BTClibValueError, match="which is not the script"):
+        descriptor.update_psbt_output(psbt, 0, 3)
+    with pytest.raises(BTClibValueError, match="which is not the script"):
+        descriptor.update_psbt_output(psbt, 1, 4)
+
+    # the same origin, another key: everything a fingerprint check would
+    # look at agrees, and the scripts do not
+    other = parse(f"wpkh([d34db33f/84h/0h/0h]{XPUB_OTHER}/1/*)")
+    with pytest.raises(BTClibValueError, match="which is not the script"):
+        other.update_psbt_output(psbt, 1, 3)
+
+
+def test_the_output_updater_refuses_an_index_that_names_no_output() -> None:
+    """An IndexError out of a public method is not an answer."""
+    descriptor = parse(f"wpkh({KEY_A})")
+    psbt = psbt_paying(descriptor.script_pub_key())
+    for vout_i in (-1, 2):
+        with pytest.raises(BTClibValueError, match="invalid output index"):
+            descriptor.update_psbt_output(psbt, vout_i)
+    with pytest.raises(BTClibValueError, match="not a ranged descriptor"):
+        descriptor.update_psbt_output(psbt, 1, 1)
+
+
+@pytest.mark.parametrize(
+    "descriptor, message",
+    [
+        pytest.param(descriptor, message, id=vector_id(index, descriptor))
+        for index, (descriptor, message) in enumerate(UNUPDATABLE)
+    ],
+)
+def test_what_cannot_update_an_output(descriptor: str, message: str) -> None:
+    """combo(), addr() and raw() have nothing to write into an output either.
+
+    The refusal comes from the same method the input half calls, which is
+    the point of there being one: what a fragment knows does not depend on
+    which side of the transaction is asking.
+    """
+    parsed = parse(descriptor)
+    # the psbt pays to a script of this very descriptor, so what refuses
+    # is the fragment and not the script check before it: combo() is the
+    # one with four, and any of the four is the same index
+    psbt = psbt_paying(parsed.script_pub_keys()[0])
+    with pytest.raises(BTClibValueError, match=message):
+        parsed.update_psbt_output(psbt, 1)
+
+
+def test_index_of_answers_with_the_whole_script() -> None:
+    """Which index of the descriptor pays here, None where none does.
+
+    The search is bounded by the caller, because how far ahead of its own
+    gap limit a wallet looks is a policy this module has no view on.
+    """
+    descriptor = parse(f"wpkh([d34db33f/84h/0h/0h]{XPUB}/1/*)")
+    for index in (0, 5, 999):
+        assert descriptor.index_of(descriptor.script_pub_key(index).script) == index
+    assert descriptor.index_of(descriptor.script_pub_key(7).script, 6) is None
+    assert descriptor.index_of(parse(f"wpkh({KEY_B})").script_pub_key().script) is None
+
+    # an unranged descriptor has one script and answers 0 or None, the
+    # bound being about a range it does not have
+    fixed = parse(f"wpkh({KEY_A})")
+    assert fixed.index_of(fixed.script_pub_key().script, 0) == 0
+    assert fixed.index_of(parse(f"wpkh({KEY_B})").script_pub_key().script) is None
+
+    # combo() is four scripts at one index, and any of them is that index
+    combo = parse(f"combo({KEY_A})")
+    for script_pub_key in combo.script_pub_keys():
+        assert combo.index_of(script_pub_key.script) == 0
+
+
+def taproot_merkle_root_of(tree: list[tuple[int, int, bytes]]) -> bytes:
+    """Return the merkle root a PSBT_OUT_TAP_TREE field folds up to.
+
+    What a reader does with the field, and the reason the field is the
+    tree rather than the root: the leaves arrive depth-first, each with
+    its depth, so two of the same depth in a row are siblings and fold
+    into their parent. BIP341's TapBranch hash sorts the two, which is
+    what makes the fold independent of the order they arrived in.
+    """
+    stack: list[tuple[int, bytes]] = []
+    for depth, leaf_version, script in tree:
+        stack.append((depth, taproot.leaf_hash(leaf_version, script)))
+        while len(stack) > 1 and stack[-1][0] == stack[-2][0]:
+            (depth_, right), (_, left) = stack.pop(), stack.pop()
+            branch = min(left, right) + max(left, right)
+            stack.append((depth_ - 1, tagged_hash(b"TapBranch", branch)))
+    ((depth, root),) = stack
+    assert depth == 0
+    return root
+
+
+def test_the_output_updater_publishes_the_whole_taproot_tree() -> None:
+    """PSBT_OUT_TAP_TREE, where an input carries the one leaf it spends.
+
+    An output has no leaf being spent, so what it publishes is every leaf
+    with the depth it sits at -- and that is enough to rebuild the tree,
+    which is what makes the field worth more than the merkle root an input
+    carries. The check is the rebuild: fold the leaves back up, tweak the
+    internal key with the root, and land on the output key the psbt pays.
+    """
+    descriptor = parse(
+        f"tr({XONLY_A},{{pk({XONLY_B}),{{pk({XONLY_C}),multi_a(1,{XONLY_A})}}}})"
+    )
+    assert isinstance(descriptor, TrDescriptor)
+    psbt_out = descriptor.update_psbt_output(
+        psbt_paying(descriptor.script_pub_key()), 1
+    ).outputs[1]
+
+    assert psbt_out.taproot_internal_key == bytes.fromhex(XONLY_A)
+    assert [depth for depth, _, _ in psbt_out.taproot_tree] == [1, 2, 2]
+    assert {version for _, version, _ in psbt_out.taproot_tree} == {0xC0}
+    assert [script for _, _, script in psbt_out.taproot_tree] == [
+        serialize([bytes.fromhex(XONLY_B), "OP_CHECKSIG"]),
+        serialize([bytes.fromhex(XONLY_C), "OP_CHECKSIG"]),
+        serialize([bytes.fromhex(XONLY_A), "OP_CHECKSIG", "OP_1", "OP_NUMEQUAL"]),
+    ]
+
+    root = taproot_merkle_root_of(psbt_out.taproot_tree)
+    assert root == descriptor.taproot_merkle_root()
+    output_key = taproot.output_pubkey_from_merkle_root(
+        psbt_out.taproot_internal_key, root
+    )[0]
+    assert output_key == descriptor.script_pub_key().script[2:]
+
+    # what an output does not carry: the merkle root is the fold of the
+    # tree and would be the same fact twice, and there is no leaf being
+    # spent, so no control block either
+    assert not hasattr(psbt_out, "taproot_merkle_root")
+    assert not hasattr(psbt_out, "taproot_leaf_scripts")
+
+
+def test_a_taproot_output_with_no_tree_publishes_none() -> None:
+    """`tr(KEY)` commits to no script, and BIP371 leaves the field out."""
+    descriptor = parse(f"tr({XONLY_A})")
+    assert isinstance(descriptor, TrDescriptor)
+    assert descriptor.taproot_tree() == []
+
+    psbt_out = descriptor.update_psbt_output(
+        psbt_paying(descriptor.script_pub_key()), 1
+    ).outputs[1]
+    assert psbt_out.taproot_internal_key == bytes.fromhex(XONLY_A)
+    assert not psbt_out.taproot_tree
+
+
+def test_the_output_updater_names_a_musig_group() -> None:
+    """BIP373 asks for the participants on an output too, for change.
+
+    A wallet reading a psbt it did not build finds out that an output
+    comes back to a group it is in, which is the same question the input
+    field answers on the way out.
+    """
+    descriptor = parse(f"tr(musig({MUSIG_XPUB_A},{MUSIG_XPUB_B})/0/*)")
+    key = descriptor.key_expressions[0]
+    psbt_out = descriptor.update_psbt_output(
+        psbt_paying(descriptor.script_pub_key(2)), 1, 2
+    ).outputs[1]
+
+    aggregate = key.aggregate(2)
+    assert psbt_out.musig2_participant_pub_keys == {aggregate: key.participant_keys(2)}
+    assert psbt_out.taproot_internal_key == key.sec(2)[1:]
+    ((leaf_hashes, origin),) = psbt_out.taproot_hd_key_paths.values()
+    assert leaf_hashes == []
+    assert origin.master_fingerprint == hash160(aggregate)[:4]
 
 
 ROUND_TRIP = [
@@ -2354,7 +2576,7 @@ def test_a_rawtr_spend_is_the_untweaked_key_path() -> None:
     tx.vin[0].script_witness = witness
     verify_transaction(prevouts, tx)
 
-    psbt = descriptor.update_psbt(psbt_spending(descriptor), 0)
+    psbt = descriptor.update_psbt_input(psbt_spending(descriptor), 0)
     psbt.assert_signable()
     psbt.inputs[0].taproot_key_spend_signature = ssa.sign_(
         taproot_sig_hash(psbt, 0), 1
@@ -2376,7 +2598,7 @@ def test_the_updater_writes_one_taproot_field_for_a_rawtr() -> None:
     """
     descriptor = parse(f"rawtr([d34db33f/86h/0h/0h]{XPUB}/0/*)")
     key = descriptor.key_expressions[0]
-    psbt_in = descriptor.update_psbt(psbt_spending(descriptor, 3), 0, 3).inputs[0]
+    psbt_in = descriptor.update_psbt_input(psbt_spending(descriptor, 3), 0, 3).inputs[0]
 
     assert not psbt_in.hd_key_paths
     assert not psbt_in.taproot_internal_key
@@ -2396,7 +2618,7 @@ def test_a_rawtr_without_an_origin_writes_nothing_at_all() -> None:
     saying nothing.
     """
     descriptor = parse(f"rawtr({XONLY_A})")
-    psbt = descriptor.update_psbt(psbt_spending(descriptor), 0)
+    psbt = descriptor.update_psbt_input(psbt_spending(descriptor), 0)
     assert psbt.inputs[0] == psbt_spending(descriptor).inputs[0]
 
 


### PR DESCRIPTION
Part of #381: the third and last of the pure consumers, the descriptor-to-psbt
output updater with exact change classification.

`Descriptor.update_psbt` is `update_psbt_input`, and `update_psbt_output` is
new. An input told a psbt what it needed to be spent; nothing told a psbt what
an *output* is — which is what a signing device reads to tell change from a
payment: it derives the script itself and sees that the money comes back.

## One writer, and where the two part company

BIP174 gives an input map and an output map the same field wherever it means
the same thing — a redeem script, a witness script and a key origin say what
they say whether the psbt spends the script or pays to it — so the fragments
write through one method. `tr()` is the exception:

| | input | output |
|---|---|---|
| `tr()` | merkle root + `PSBT_IN_TAP_LEAF_SCRIPT` (the leaf being spent, with its control block) | `PSBT_OUT_TAP_TREE`: every leaf with the depth it sits at, depth-first |

The tree is more than the root, deliberately: a root proves nothing about the
scripts under it, where the tree lets a reader fold the leaves back up, tweak
the internal key, and land on the output key. That fold is what the test does —
it rebuilds the tree from the psbt field alone and checks the output key the
psbt pays.

BIP373's participant list is written on an output too, which is what tells a
wallet that an output comes back to a group it is in.

## The security property the issue asks for

**The script is checked, where the input half checks nothing.** The output being
paid is in the psbt already, so `update_psbt_output` refuses unless the
descriptor derives exactly that script at that index:

```
BTClibValueError: output 1 pays to 0014…, which is not the script this
descriptor describes at index 3
```

Marking an output as one's own is a claim about where money goes, and the only
evidence for it is the whole script — never a key origin whose four-byte
fingerprint matches, which collides and which whoever wrote the psbt chose. A
test builds two descriptors with the *same* origin and different keys to say so.

`Descriptor.index_of(script_pub_key, last_index=999)` is the same question the
other way round: which index of this descriptor pays here, `None` where none
does. The range is the caller's, because how far ahead of its own gap limit a
wallet looks is not this module's policy.

## Rename

`update_psbt` → `update_psbt_input`, since a pair named `update_psbt` and
`update_psbt_output` reads as two different things. Both are new in the
unreleased v2026.8 (`update_psbt` landed with issue #306 this cycle), so nothing
released changes; CHANGELOG.md and HISTORY.md are updated where they named it.

## Gates

Merged on the local gates alone; GitHub Actions is degraded.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`: 17466 passed, 100.00%
- `pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an output-side PSBT updater for descriptors, with strict script matching, and rename the existing updater to clarify it operates on inputs.

New Features:
- Introduce Descriptor.update_psbt_output to annotate PSBT outputs with descriptor-derived scripts, taproot data, key origins, and MuSig participant metadata.
- Add Descriptor.index_of to locate the descriptor index corresponding to a given script pubkey over a caller-specified range.
- Expose TrDescriptor.taproot_tree to produce BIP371 PSBT_OUT_TAP_TREE entries from a descriptor's taproot script tree.

Enhancements:
- Refactor descriptor PSBT updating into shared input/output helpers so BIP174 fields common to both maps are written through a single code path.
- Extend taproot support so outputs publish full trees (PSBT_OUT_TAP_TREE) while inputs keep merkle roots and spent leaves, and propagate MuSig participant info to outputs as well.

Documentation:
- Update CHANGELOG and HISTORY to reflect the new Descriptor.update_psbt_input/output API and document the new script-checking behavior for outputs.

Tests:
- Add comprehensive tests for output updating, including script-based ownership checks, taproot tree reconstruction, MuSig participant propagation, and descriptor index_of behavior.