### PR TITLE
Define the contract an external signer answers, and check its answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,50 @@ edit.
 
 ### The public API and the module layout
 
+- **`btclib.psbt_signer` is new: the contract an external signer answers,
+  and the checks on its answers** (issue #381). A hardware wallet, a
+  signing service, another process — something that holds keys btclib does
+  not have. `PsbtSigner` is the four questions such a thing answers
+  (master fingerprint, xpub at a path, a signed psbt, its capabilities,
+  plus `close`), `AddressDisplay` and `MessageSigner` the two optional
+  ones, all three runtime-checkable so a caller asks rather than being
+  told.
+
+  This is **not** `psbt.sign`, which plays the Signer role over a
+  `KeyManager` btclib calls in-process: that one derives keys and signs,
+  and its answers are btclib's own. Here the psbt goes out and comes back
+  untrusted, so the two are two contracts with two trust models — and the
+  functions beside the protocols are the point of the module, a protocol
+  alone being an interface:
+
+    - `request_signatures` sends the psbt, holds the answer to it with
+    `psbt.assert_signatures_only`, and only then combines the two.
+    Skipping that is not a smaller version of the call: `combine` takes
+    the union of what it is given and resolves a conflict by picking a
+    side, so an answer that changed an amount or somebody else's signature
+    would be merged without a word.
+    - `export_account` composes the fingerprint and the xpub into the
+    account pair, `descriptors.account_descriptors` being what refuses an
+    xpub that is not the account the path names. What no check can see is
+    an xpub of another *master* key at the right path — an extended key
+    records nothing about where it came from — and the docstring says so,
+    naming the independent answer that does catch it.
+    - `display_address` compares what the device shows with what the
+    descriptor describes, which is the whole point of asking: the screen
+    is the one part a compromised host cannot rewrite, and a caller
+    showing the user its own answer has checked nothing.
+    - `sign_message` verifies the signature against the address the caller
+    says it must open to; which address that is, is a fact about the key
+    that was asked for rather than about the signature that came back.
+
+  `SignerCapabilities` is two flags, `taproot` and `musig2`, and not a
+  device matrix: which model supports what is a table HWI maintains per
+  vendor and firmware, and a library copying it would be wrong the week
+  after. Which *operations* a signer offers is what the optional protocols
+  say. `assert_public` refuses to send a descriptor holding a key that
+  signs — nothing `descriptors.parse` returns can fail it, and a
+  hand-built `KeyExpression` can, `musig()` participants included.
+
 - **the Updater has an output half: `Descriptor.update_psbt_output`**
   (issue #381), and `update_psbt` is `update_psbt_input`. An input told a
   psbt what it needed to be spent; nothing told a psbt what an output is,

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -97,6 +97,7 @@ __all__ = [
     "network",
     "number_theory",
     "psbt",
+    "psbt_signer",
     "script",
     "slip132",
     "to_prv_key",

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -1,0 +1,272 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The contract an external signer answers, and the checks on its answers.
+
+A hardware wallet, a signing service, another process: something that
+holds keys btclib does not have and answers questions about them. The
+protocols here are what it implements; the functions beside them are what
+a caller should run over its answers, and they are the point of the module
+-- a protocol alone is an interface, and every one of these answers
+arrives from outside and can be wrong.
+
+This is **not** `psbt.sign`, which is the Signer role played over a
+`KeyManager` btclib calls in-process: that one derives keys and signs, and
+its answers are btclib's own. Here the psbt goes out and comes back
+untrusted, so the two need different trust models and are two contracts.
+
+What each function checks, which is what the caller would otherwise have
+to remember:
+
+- `request_signatures` holds the returned psbt to the one that was sent --
+  `psbt.assert_signatures_only`, so nothing but signatures came back --
+  and only then combines the two;
+- `export_account` builds the descriptors of an account from the
+  fingerprint and the xpub a signer answers with, and
+  `descriptors.account_descriptors` is what refuses an xpub that is not
+  the account the path names;
+- `display_address` compares the address a device shows with the one the
+  descriptor describes, which is the whole point of asking a device to
+  show one;
+- `sign_message` verifies the signature against the address the caller
+  says it must open to.
+
+Nothing here sends a private key anywhere, and nothing can: a `Descriptor`
+holds no key that signs, `descriptors.parse` having neutered what it read,
+and `assert_public` is what says so of one built by hand rather than
+parsed. A psbt has no field for a private key at all.
+
+Selecting *which* device answers, the transport it answers over, and the
+timeouts and output limits a subprocess needs are the adapter's, not this
+module's: this is the contract such an adapter implements (issue #381).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+from btclib.alias import BIP44ScriptType, Octets, String
+from btclib.bip32.bip32 import BIP32KeyData
+from btclib.bip32.der_path import DerPath
+from btclib.descriptors import Descriptor, account_descriptors
+from btclib.ecc import bms
+from btclib.exceptions import BTClibValueError
+from btclib.psbt.psbt import Psbt, assert_signatures_only, combine
+
+__all__ = [
+    "AddressDisplay",
+    "MessageSigner",
+    "PsbtSigner",
+    "SignerCapabilities",
+    "assert_public",
+    "display_address",
+    "export_account",
+    "request_signatures",
+    "sign_message",
+]
+
+
+@dataclass(frozen=True)
+class SignerCapabilities:
+    """What a signer can be asked to sign, in the terms btclib acts on.
+
+    Two flags and not a device matrix: which models support what is a
+    table HWI maintains per vendor and per firmware version, and a library
+    that copied it would be wrong the week after. What belongs in a
+    contract is what a caller does differently on the answer, and there
+    are two such facts -- a taproot input needs a signer that knows
+    BIP341, and a MuSig2 session needs one that knows BIP327 and BIP373.
+
+    Which *operations* a signer offers is not here either: that is what
+    the optional protocols below say, and a caller asks with `isinstance`,
+    both being runtime-checkable. A flag saying "I can display an address"
+    beside a `display_address` method would be the same fact twice, and
+    the two would disagree.
+    """
+
+    taproot: bool = False
+    musig2: bool = False
+
+
+@runtime_checkable
+class PsbtSigner(Protocol):
+    """What every external signer answers: keys, a signature, an end.
+
+    The three questions a caller cannot answer for itself and one piece of
+    housekeeping. Nothing here is about a device in particular -- a
+    subprocess adapter, a signing service and a software signer implement
+    the same four -- which is what makes it the boundary rather than a
+    driver.
+    """
+
+    def master_fingerprint(self) -> bytes:
+        """Return the four bytes identifying the master key, BIP32's own."""
+        ...
+
+    def xpub(self, der_path: DerPath) -> str:
+        """Return the extended public key at a derivation path."""
+        ...
+
+    def sign_psbt(self, psbt: Psbt) -> Psbt:
+        """Return the psbt with the signatures this signer can add.
+
+        The answer is untrusted, whatever the transport: what a caller
+        does with it is `request_signatures`, which holds it to the psbt
+        that was sent before merging anything.
+        """
+        ...
+
+    def capabilities(self) -> SignerCapabilities:
+        """Return what this signer can be asked to sign."""
+        ...
+
+    def close(self) -> None:
+        """Release whatever the signer holds: a handle, a process, a socket.
+
+        Idempotent, so that a caller may close a signer it is not sure
+        about; `contextlib.closing` is the customary way to run one.
+        """
+        ...
+
+
+@runtime_checkable
+class AddressDisplay(Protocol):
+    """A signer that can show an address on a screen of its own.
+
+    Optional, and separate from `PsbtSigner` for the reason the issue
+    behind this module gives: a signer that cannot show anything is still
+    a signer, and a caller asks with `isinstance` rather than being told.
+    """
+
+    def display_address(self, descriptor: Descriptor, index: int = 0) -> str:
+        """Return the address the signer shows for a descriptor at an index."""
+        ...
+
+
+@runtime_checkable
+class MessageSigner(Protocol):
+    """A signer that can sign a message with a key it holds.
+
+    Optional in the same way, and the message is not a transaction: what
+    comes back is a BIP137 compact signature, which `sign_message` checks
+    against the address the caller says it must open to.
+    """
+
+    def sign_message(self, message: Octets, der_path: DerPath) -> str:
+        """Return the compact signature of a message, by the key at a path."""
+        ...
+
+
+def assert_public(descriptor: Descriptor) -> None:
+    """Raise if any key of the descriptor is one that signs.
+
+    Nothing `descriptors.parse` returns can fail this: it neuters every
+    xprv it reads and hands the private spelling back to its caller. What
+    this catches is a descriptor built by hand, which the fragment classes
+    are public enough to allow -- and the moment before it is sent to
+    something outside the process is the moment to catch it.
+    """
+    for key in descriptor.key_expressions:
+        keys = [key.xkey] if key.xkey else []
+        keys += [participant.xkey for participant in key.participants]
+        for xkey in keys:
+            if xkey and BIP32KeyData.b58decode(xkey).is_private:
+                err_msg = "the descriptor holds a private key: it cannot be sent"
+                raise BTClibValueError(err_msg)
+
+
+def request_signatures(signer: PsbtSigner, psbt: Psbt) -> Psbt:
+    """Return the psbt with what the signer added, checked and merged.
+
+    Three steps and the middle one is why this exists: the psbt goes out,
+    the answer is held to it -- everything that is not a signature comes
+    back as it was sent, the signature fields may only have gained
+    entries, and every signature that arrived verifies -- and only then
+    are the two combined.
+
+    Skipping that check is not a smaller version of this call: `combine`
+    takes the union of what it is given and resolves a conflict by picking
+    a side, so an answer that changed an amount, an outpoint or somebody
+    else's signature would be merged in without a word.
+
+    The psbt handed in is left alone, `combine` returning a copy of its
+    own, so a caller can ask several signers with the same request and
+    combine the answers itself.
+    """
+    returned = signer.sign_psbt(psbt)
+    assert_signatures_only(psbt, returned)
+    return combine([psbt, returned])
+
+
+def export_account(
+    signer: PsbtSigner,
+    der_path: DerPath,
+    script_type: BIP44ScriptType | None = None,
+) -> tuple[Descriptor, Descriptor]:
+    """Return the receive and change descriptors of an account of a signer.
+
+    Two questions to the signer and one composition:
+    `descriptors.account_descriptors` builds the pair from the master
+    fingerprint and the xpub at the account path, and is what refuses an
+    xpub that is not the account the path names -- its depth and its own
+    index say which account it is, and a purpose the mapping does not know
+    is refused rather than guessed.
+
+    What cannot be checked here is that the xpub descends from that
+    fingerprint at all: an extended key records nothing about where it
+    came from, and a signer that answered with another key would need a
+    second, independent path to be caught -- an address the device shows
+    for the same descriptor, which is `display_address`.
+    """
+    return account_descriptors(
+        signer.xpub(der_path), der_path, signer.master_fingerprint(), script_type
+    )
+
+
+def display_address(
+    signer: AddressDisplay,
+    descriptor: Descriptor,
+    index: int = 0,
+) -> str:
+    """Return the address the signer shows, having checked it is the right one.
+
+    The whole point of asking a device to display an address is that the
+    screen is the one part of it a compromised host cannot rewrite -- so
+    what the device says has to be compared with what the descriptor
+    describes, and a caller that shows the user its own answer instead has
+    checked nothing.
+
+    The descriptor is checked to hold no key that signs before it is sent
+    anywhere, which is `assert_public`.
+    """
+    assert_public(descriptor)
+    expected = descriptor.address(index)
+    shown = signer.display_address(descriptor, index)
+    if shown != expected:
+        err_msg = f"the signer displayed {shown}, where the descriptor describes"
+        err_msg += f" {expected}"
+        raise BTClibValueError(err_msg)
+    return shown
+
+
+def sign_message(
+    signer: MessageSigner,
+    message: Octets,
+    der_path: DerPath,
+    address: String,
+) -> str:
+    """Return the signature of a message, verified against an address.
+
+    The address is a parameter and not something this works out: a BIP137
+    signature carries a recovery flag that says which address type it is
+    for, and which address a caller means is a fact about the key it asked
+    for rather than about the signature that came back. What is checked is
+    the one thing that matters -- the signature opens to that address --
+    and `ecc.bms.assert_as_valid` is the check.
+    """
+    signature = signer.sign_message(message, der_path)
+    bms.assert_as_valid(message, address, signature)
+    return signature

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -132,6 +132,13 @@ btclib.number\_theory module
    :members:
    :show-inheritance:
 
+btclib.psbt\_signer module
+--------------------------
+
+.. automodule:: btclib.psbt_signer
+   :members:
+   :show-inheritance:
+
 btclib.slip132 module
 ---------------------
 

--- a/tests/psbt_signer_test.py
+++ b/tests/psbt_signer_test.py
@@ -1,0 +1,386 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.psbt_signer` module.
+
+What is under test is the checking, so the signers here are doubles that
+answer wrongly on purpose: a device that changes an amount, one that
+shows another address, one that signs a message with the wrong key.
+Nothing in this file is a reference implementation -- that is the
+software signer of its own module -- and the honest double below is as
+small as it can be while still producing a signature to be checked.
+"""
+
+from __future__ import annotations
+
+from base64 import b64encode
+from copy import deepcopy
+
+import pytest
+
+from btclib.alias import Octets
+from btclib.bip32.bip32 import derive, rootxprv_from_seed, xpub_from_xprv
+from btclib.bip32.der_path import DerPath
+from btclib.bip32.key_origin import BIP32KeyOrigin
+from btclib.descriptors import (
+    Descriptor,
+    KeyExpression,
+    TrDescriptor,
+    WpkhDescriptor,
+    parse,
+)
+from btclib.ecc import bms, dsa
+from btclib.exceptions import BTClibValueError
+from btclib.psbt.psbt import Psbt, sign
+from btclib.psbt_signer import (
+    AddressDisplay,
+    MessageSigner,
+    PsbtSigner,
+    SignerCapabilities,
+    assert_public,
+    display_address,
+    export_account,
+    request_signatures,
+    sign_message,
+)
+from btclib.to_prv_key import prv_keyinfo_from_prv_key
+from btclib.to_pub_key import fingerprint
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
+
+# the "abandon abandon ... about" root of BIP39, which BIP84 publishes
+XPRV_ROOT = (
+    "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRR"
+    "uL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
+)
+ACCOUNT = "m/84h/0h/0h"
+# another extended key, for a musig() group of two
+XPUB_OTHER = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+
+
+class _KeyManager:
+    """A `KeyManager` over one extended key: the honest half of a signer.
+
+    Keys are answered by origin and not by public key, which is what a
+    device does: it derives the path it is told and signs with what comes
+    out, having no list of its own children to look one up in.
+    """
+
+    def __init__(self, xprv: str) -> None:
+        self.xprv = xprv
+
+    def _prv_key(self, origin: BIP32KeyOrigin | None) -> int | None:
+        if origin is None or origin.master_fingerprint != fingerprint(self.xprv):
+            return None
+        return prv_keyinfo_from_prv_key(derive(self.xprv, origin.der_path))[0]
+
+    def sign_ecdsa(
+        self, pub_key: bytes, origin: BIP32KeyOrigin | None, msg_hash: bytes
+    ) -> bytes | None:
+        """Return the DER signature of the key at the origin, or None."""
+        prv_key = self._prv_key(origin)
+        if prv_key is None:
+            return None
+        return dsa.sign_(msg_hash, prv_key).serialize()
+
+    def sign_schnorr(
+        self,
+        pub_key: bytes,
+        origin: BIP32KeyOrigin | None,
+        msg_hash: bytes,
+        merkle_root: bytes,
+    ) -> bytes | None:
+        """Answer for no taproot key: this double signs ECDSA only."""
+        return None
+
+
+class _Signer:
+    """A `PsbtSigner` double holding one extended private key.
+
+    `answer` is what it hands back instead of the psbt it signed, which is
+    how a lying device is written here: every check `request_signatures`
+    makes has a case, and each case is one field changed on the way home.
+    """
+
+    def __init__(self, xprv: str = XPRV_ROOT) -> None:
+        self.xprv = xprv
+        self.answer: Psbt | None = None
+        self.closed = False
+
+    def master_fingerprint(self) -> bytes:
+        """Return the fingerprint of the key this signer holds."""
+        return fingerprint(self.xprv)
+
+    def xpub(self, der_path: DerPath) -> str:
+        """Return the extended public key at the path."""
+        return xpub_from_xprv(derive(self.xprv, der_path))
+
+    def sign_psbt(self, psbt: Psbt) -> Psbt:
+        """Return the psbt signed, or whatever `answer` was set to."""
+        if self.answer is not None:
+            return self.answer
+        return sign(psbt, _KeyManager(self.xprv))[0]
+
+    def capabilities(self) -> SignerCapabilities:
+        """Return what this double can sign: no taproot, no musig2."""
+        return SignerCapabilities()
+
+    def close(self) -> None:
+        """Record that it was closed, twice being no different from once."""
+        self.closed = True
+
+
+def account_psbt(signer: _Signer, index: int = 0) -> tuple[Psbt, Descriptor]:
+    """Return a psbt spending the receiving address of a signer's account."""
+    receive = export_account(signer, ACCOUNT)[0]
+    script_pub_key = receive.script_pub_key(index)
+    prev_tx = Tx(
+        vin=[TxIn(OutPoint(b"\x04" * 32, 0))], vout=[TxOut(10_000, script_pub_key)]
+    )
+    psbt = Psbt.from_tx(
+        Tx(vin=[TxIn(OutPoint(prev_tx.id, 0))], vout=[TxOut(9_000, script_pub_key)])
+    )
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    return receive.update_psbt_input(psbt, 0, index), receive
+
+
+def test_the_protocols_are_what_a_signer_is_asked_for() -> None:
+    """Runtime-checkable, so a caller asks rather than being told.
+
+    Which is also why the optional operations are protocols and not flags
+    on `SignerCapabilities`: a flag beside a method would be the same fact
+    twice, and the two would disagree.
+    """
+    signer = _Signer()
+    assert isinstance(signer, PsbtSigner)
+    assert not isinstance(signer, AddressDisplay)
+    assert not isinstance(signer, MessageSigner)
+
+    assert signer.capabilities() == SignerCapabilities(taproot=False, musig2=False)
+    signer.close()
+    signer.close()
+    assert signer.closed
+
+
+def test_a_signature_comes_back_checked_and_merged() -> None:
+    """The psbt goes out, the answer is held to it, and the two combine.
+
+    The request itself is left alone, so a caller can ask several signers
+    with one psbt and combine the answers itself.
+    """
+    signer = _Signer()
+    psbt, _ = account_psbt(signer)
+    request = deepcopy(psbt)
+
+    signed = request_signatures(signer, psbt)
+    assert signed.inputs[0].partial_sigs
+    assert psbt == request
+    assert not request.inputs[0].partial_sigs
+
+
+def test_an_answer_that_changed_anything_but_a_signature_is_refused() -> None:
+    """`combine` would merge each of these without a word.
+
+    It takes the union of what it is given and resolves a conflict by
+    picking a side, so the check is what stands between a caller and an
+    answer that rewrote the transaction it was asked to sign.
+    """
+    signer = _Signer()
+    psbt, _ = account_psbt(signer)
+
+    # the transaction itself: another amount, and the signature is of the
+    # transaction that was sent rather than of this one
+    tampered = sign(deepcopy(psbt), _KeyManager(signer.xprv))[0]
+    tampered.outputs[0].amount = 1
+    signer.answer = tampered
+    with pytest.raises(BTClibValueError, match="the transaction being signed"):
+        request_signatures(signer, psbt)
+
+    # a field that is not a signature, added on the way home
+    tampered = sign(deepcopy(psbt), _KeyManager(signer.xprv))[0]
+    tampered.inputs[0].unknown = {b"\xfc\x01": b"vendor"}
+    signer.answer = tampered
+    with pytest.raises(BTClibValueError, match="unknown"):
+        request_signatures(signer, psbt)
+
+    # a signature that does not verify, which the validator checks before
+    # anything is merged
+    tampered = sign(deepcopy(psbt), _KeyManager(signer.xprv))[0]
+    pub_key, signature = next(iter(tampered.inputs[0].partial_sigs.items()))
+    tampered.inputs[0].partial_sigs[pub_key] = signature[:-2] + b"\x00\x01"
+    signer.answer = tampered
+    with pytest.raises(BTClibValueError, match="signature"):
+        request_signatures(signer, psbt)
+
+
+def test_a_signer_holding_none_of_the_keys_adds_nothing() -> None:
+    """Which is not an error: an input somebody else signs is not this one's.
+
+    Two ways to hold none of them, and both answer the same way. The psbt
+    of another master key is one -- the origin names a fingerprint this
+    signer is not -- and a taproot input is the other, this double being
+    one whose capabilities say it cannot sign one. The answer passes the
+    check and combines into a psbt that gained nothing, which is what a
+    caller then sees.
+    """
+    signer = _Signer()
+    stranger = _Signer(rootxprv_from_seed("000102030405060708090a0b0c0d0e0f"))
+    psbt, _ = account_psbt(stranger)
+    assert not request_signatures(signer, psbt).inputs[0].partial_sigs
+
+    taproot = export_account(signer, "m/86h/0h/0h")[0]
+    script_pub_key = taproot.script_pub_key(0)
+    prev_tx = Tx(
+        vin=[TxIn(OutPoint(b"\x05" * 32, 0))], vout=[TxOut(10_000, script_pub_key)]
+    )
+    taproot_psbt = Psbt.from_tx(
+        Tx(vin=[TxIn(OutPoint(prev_tx.id, 0))], vout=[TxOut(9_000, script_pub_key)])
+    )
+    taproot_psbt.inputs[0].witness_utxo = TxOut(10_000, script_pub_key)
+    taproot_psbt = taproot.update_psbt_input(taproot_psbt, 0)
+
+    assert not signer.capabilities().taproot
+    signed = request_signatures(signer, taproot_psbt)
+    assert not signed.inputs[0].taproot_key_spend_signature
+
+
+def test_an_account_is_exported_from_two_answers() -> None:
+    """The fingerprint and the xpub at the path, composed into the pair.
+
+    And the pair is the one `descriptors.account_descriptors` builds from
+    the same two facts, which is what says this is a composition rather
+    than a second implementation.
+    """
+    signer = _Signer()
+    receive, change = export_account(signer, ACCOUNT)
+
+    assert str(receive).startswith("wpkh([73c5da0a/84h/0h/0h]")
+    assert receive.key_expressions[0].der_path == (0,)
+    assert change.key_expressions[0].der_path == (1,)
+    assert receive.address(0) == "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
+    # the purpose selects the encoding, and an override is passed through
+    assert str(export_account(signer, "m/44h/0h/0h")[0]).startswith("pkh(")
+    assert str(export_account(signer, "m/48h/0h/0h", "p2wpkh")[0]).startswith("wpkh(")
+
+
+def test_an_xpub_that_is_not_the_account_is_refused() -> None:
+    """A signer answering with another key is caught where it can be.
+
+    The depth and the index of the xpub say which account it is, and
+    `account_descriptors` refuses one that is not the path's. What no
+    check can see is an xpub of another *master* key at the right path:
+    an extended key records nothing about where it came from, so the
+    second, independent answer is what catches that -- an address the
+    device shows for the same descriptor.
+    """
+
+    class _WrongAccount(_Signer):
+        def xpub(self, der_path: DerPath) -> str:
+            """Answer with the next account, whatever was asked."""
+            return xpub_from_xprv(derive(self.xprv, "m/84h/0h/1h"))
+
+    with pytest.raises(BTClibValueError, match="is not the path's 0h"):
+        export_account(_WrongAccount(), ACCOUNT)
+
+
+class _Display(_Signer):
+    """A signer that shows an address, honestly unless told otherwise."""
+
+    def __init__(self, shown: str | None = None) -> None:
+        super().__init__()
+        self.shown = shown
+
+    def display_address(self, descriptor: Descriptor, index: int = 0) -> str:
+        """Return the address, or the one this was built to lie with."""
+        return self.shown if self.shown is not None else descriptor.address(index)
+
+
+def test_a_displayed_address_is_compared_with_the_descriptor_s() -> None:
+    """The screen is what a compromised host cannot rewrite.
+
+    So the answer is compared with what the descriptor describes, and a
+    caller that showed the user its own answer instead would have checked
+    nothing at all.
+    """
+    signer = _Display()
+    assert isinstance(signer, AddressDisplay)
+    receive = export_account(signer, ACCOUNT)[0]
+
+    assert display_address(signer, receive, 3) == receive.address(3)
+
+    lying = _Display("bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu")
+    with pytest.raises(BTClibValueError, match="the signer displayed"):
+        display_address(lying, receive, 3)
+
+
+def test_a_descriptor_that_holds_a_private_key_is_not_sent() -> None:
+    """Nothing `parse` returns can fail this, and a hand-built one can.
+
+    `parse` neuters every xprv it reads, so the case is a `KeyExpression`
+    built by hand -- which the fragment classes are public enough to allow
+    -- and the moment before it goes to something outside the process is
+    the moment to catch it.
+    """
+    assert_public(parse(f"wpkh({xpub_from_xprv(XPRV_ROOT)}/0/*)"))
+
+    private = WpkhDescriptor(KeyExpression(xkey=XPRV_ROOT, der_path=(0,), wildcard=0))
+    with pytest.raises(BTClibValueError, match="holds a private key"):
+        assert_public(private)
+    with pytest.raises(BTClibValueError, match="holds a private key"):
+        display_address(_Display(), private)
+
+    # a participant of a musig() is a key expression like any other, and
+    # `key_expressions` answers with the aggregate rather than with them,
+    # so the participants are walked here explicitly
+    assert_public(parse(f"tr(musig({xpub_from_xprv(XPRV_ROOT)},{XPUB_OTHER}))"))
+    smuggled = TrDescriptor(
+        KeyExpression(
+            participants=(
+                KeyExpression(xkey=XPRV_ROOT),
+                KeyExpression(xkey=XPUB_OTHER),
+            )
+        )
+    )
+    with pytest.raises(BTClibValueError, match="holds a private key"):
+        assert_public(smuggled)
+
+
+class _MessageSigner(_Signer):
+    """A signer that signs a message, with the key at the path or another."""
+
+    def __init__(self, der_path: DerPath | None = None) -> None:
+        super().__init__()
+        self.der_path = der_path
+
+    def sign_message(self, message: Octets, der_path: DerPath) -> str:
+        """Return the compact signature, by the key this was built with.
+
+        Base64, which is how a signature travels and what `bms` reads
+        back: the serialization is 65 bytes and no encoding of its own.
+        """
+        path = self.der_path if self.der_path is not None else der_path
+        prv_key = derive(self.xprv, path)
+        return b64encode(bms.sign(message, prv_key).serialize()).decode("ascii")
+
+
+def test_a_signed_message_is_verified_against_the_address_asked_for() -> None:
+    """Which address a caller means is a fact about the key it asked for.
+
+    So the address is a parameter rather than something this works out,
+    and what is checked is the one thing that matters: the signature opens
+    to it.
+    """
+    signer = _MessageSigner()
+    assert isinstance(signer, MessageSigner)
+    der_path = "m/84h/0h/0h/0/0"
+    address = export_account(signer, ACCOUNT)[0].address(0)
+
+    signature = sign_message(signer, b"hello", der_path, address)
+    assert bms.verify(b"hello", address, signature)
+
+    # the same message signed with another key of the same device: a
+    # signature that verifies, under an address nobody asked about
+    elsewhere = _MessageSigner("m/84h/0h/0h/0/1")
+    with pytest.raises(BTClibValueError):
+        sign_message(elsewhere, b"hello", der_path, address)


### PR DESCRIPTION
Part of #381: the vendor-neutral `PsbtSigner` protocol, which is the *external*
contract the HWI adapter will implement.

`btclib.psbt_signer` holds three runtime-checkable protocols and, beside them,
the checks a caller should run over what they answer — the point of the module,
since a protocol alone is an interface and every one of these answers arrives
from outside.

```python
class PsbtSigner(Protocol):
    def master_fingerprint(self) -> bytes: ...
    def xpub(self, der_path: DerPath) -> str: ...
    def sign_psbt(self, psbt: Psbt) -> Psbt: ...
    def capabilities(self) -> SignerCapabilities: ...
    def close(self) -> None: ...

class AddressDisplay(Protocol): ...   # optional
class MessageSigner(Protocol): ...    # optional
```

**Not `psbt.sign`.** That plays the Signer role over a `KeyManager` btclib calls
in-process: it derives keys and signs, and its answers are btclib's own. Here
the psbt goes out and comes back untrusted — two trust models, two contracts, as
#381 asks.

## The checks, which are the feature

- **`request_signatures`** sends the psbt, holds the answer to it with
  `psbt.assert_signatures_only`, and only then combines. Skipping that is not a
  smaller version of the call: `combine` takes the union of what it is given and
  resolves a conflict by picking a side, so an answer that changed an amount or
  somebody else's signature would be merged without a word. Tested with a device
  double that lies in each of those ways.
- **`export_account`** composes the fingerprint and the xpub into the account
  pair; `descriptors.account_descriptors` refuses an xpub that is not the
  account the path names. What no check can see — another *master* key's xpub at
  the right path — is named in the docstring, with the independent answer that
  does catch it.
- **`display_address`** compares what the device shows with what the descriptor
  describes. The screen is the one part of a device a compromised host cannot
  rewrite, so a caller that showed the user its own answer has checked nothing.
- **`sign_message`** verifies the signature against the address the caller says
  it must open to; which address that is, is a fact about the key that was asked
  for rather than about the signature that came back.
- **`assert_public`** refuses to send a descriptor holding a key that signs.
  Nothing `descriptors.parse` returns can fail it — it neuters what it reads —
  and a hand-built `KeyExpression` can, `musig()` participants included.

## `SignerCapabilities` is two flags

`taproot` and `musig2`, and not a device matrix: which model supports what is a
table HWI maintains per vendor and per firmware, and a library copying it would
be wrong the week after. What belongs in a contract is what a caller does
differently on the answer. Which *operations* a signer offers is what the
optional protocols say, asked with `isinstance` — a flag beside a
`display_address` method would be the same fact twice, and the two would
disagree.

Selecting *which* device answers, the transport, and the timeouts and output
limits a subprocess needs stay with the adapter; this is what such an adapter
implements. The reference software signer is the next item of #381, so the
signers in the tests here are doubles that answer wrongly on purpose.

## Gates

Merged on the local gates alone; GitHub Actions is degraded.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`: 17477 passed, 100.00%
- `pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new vendor-neutral external PSBT signer contract with safety checks around its untrusted responses and expose it as part of the public API.

New Features:
- Add the btclib.psbt_signer module defining a runtime-checkable PsbtSigner protocol plus optional AddressDisplay and MessageSigner protocols for external signers.
- Provide high-level helper functions (request_signatures, export_account, display_address, sign_message, assert_public) to validate and safely consume responses from external signers, including message signing and address display flows.

Documentation:
- Document the new btclib.psbt_signer module and reference it in the public btclib package and changelog entry describing the external signer contract and its capabilities.

Tests:
- Add comprehensive tests for btclib.psbt_signer covering honest and malicious signer doubles, PSBT tampering scenarios, descriptor export and validation, address display mismatches, private key leakage prevention, and message signing verification.