### PR TITLE
Add the software signer the contract is testable through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,28 @@ edit.
 
 ### The public API and the module layout
 
+- **`psbt_signer.SoftwareSigner` is the reference implementation** (issue
+  #381): one extended key, in this process, answering all three protocols.
+  What it is for is a signer whose answers a test can predict, so every
+  psbt shape the library builds is signed end to end before any device is
+  involved — the suite exports an account of each BIP44 encoding, builds a
+  psbt of it, updates both halves, sends it through `request_signatures`,
+  finalizes, and runs the spend under btclib's own script engine.
+
+  It is not a way to sign with a key you hold — `psbt.sign` over a
+  `KeyManager` is that, and this calls it. What it adds is the boundary:
+  it answers only what the protocol asks. A key is answered for when the
+  origin's fingerprint is its own *and* the path derives to the very
+  public key the psbt names, which is the check a device makes too — a
+  psbt is written by somebody else, and its claim about which key sits at
+  which path is not evidence. A watch-only signer (an xpub) answers the
+  fingerprint, an unhardened path and an address to display, and refuses
+  the two questions that need a key rather than answering "none of these
+  keys are mine"; it cannot export an account either, every level of a
+  BIP44 account path being hardened. `close` releases nothing and exists
+  for the contract: a caller that closes every signer it opens works with
+  a device too, and asking a closed one raises.
+
 - **`btclib.psbt_signer` is new: the contract an external signer answers,
   and the checks on its answers** (issue #381). A hardware wallet, a
   signing service, another process — something that holds keys btclib does

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -45,22 +45,28 @@ module's: this is the contract such an adapter implements (issue #381).
 
 from __future__ import annotations
 
+from base64 import b64encode
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from btclib.alias import BIP44ScriptType, Octets, String
-from btclib.bip32.bip32 import BIP32KeyData
+from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, derive, xpub_from_xprv
 from btclib.bip32.der_path import DerPath
+from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.descriptors import Descriptor, account_descriptors
-from btclib.ecc import bms
+from btclib.ecc import bms, dsa, ssa
 from btclib.exceptions import BTClibValueError
-from btclib.psbt.psbt import Psbt, assert_signatures_only, combine
+from btclib.psbt.psbt import Psbt, assert_signatures_only, combine, sign
+from btclib.script.taproot import output_prvkey_from_merkle_root
+from btclib.to_prv_key import prv_keyinfo_from_prv_key
+from btclib.to_pub_key import fingerprint, pub_keyinfo_from_key
 
 __all__ = [
     "AddressDisplay",
     "MessageSigner",
     "PsbtSigner",
     "SignerCapabilities",
+    "SoftwareSigner",
     "assert_public",
     "display_address",
     "export_account",
@@ -270,3 +276,198 @@ def sign_message(
     signature = signer.sign_message(message, der_path)
     bms.assert_as_valid(message, address, signature)
     return signature
+
+
+class SoftwareSigner:
+    """One extended key, in this process, answering the contract above.
+
+    The reference implementation of `PsbtSigner`, `AddressDisplay` and
+    `MessageSigner`, and what makes the contract testable without
+    hardware: a deterministic signer is a signer whose answers a test can
+    predict, so every psbt shape the library builds can be signed end to
+    end here before any device is involved.
+
+    It is not a way to sign with a key you hold -- `psbt.sign` over a
+    `KeyManager` is that, and this calls it. What this adds is the
+    boundary: it answers only what the protocol asks, by deriving what it
+    is told to derive, and it holds nothing about the caller. Which is why
+    it is worth having beside a device rather than instead of one -- an
+    adapter and this answer the same questions, so a caller can be
+    developed against this and run against that.
+
+    A key is answered for when the origin's fingerprint is this key's own
+    and the path derives to the very public key the psbt names. That
+    second half is the check a device makes too: a psbt saying "this key
+    is at that path" is a psbt somebody else wrote, and signing with what
+    the path derives to without looking would sign with a key the caller
+    was not told about.
+    """
+
+    def __init__(self, xkey: BIP32Key, *, musig2: bool = False) -> None:
+        # held as the b58 text whatever came in, which is what `derive`
+        # takes and what the two key answers below hand back: one spelling
+        # inside, rather than a branch at every use. The round trip is
+        # also what refuses a key that is no key, at construction rather
+        # than at the first question asked
+        self.xkey = (
+            xkey.b58encode()
+            if isinstance(xkey, BIP32KeyData)
+            else BIP32KeyData.b58decode(xkey).b58encode()
+        )
+        self._musig2 = musig2
+        self._fingerprint = fingerprint(self.xkey)
+        self._closed = False
+
+    @property
+    def is_watch_only(self) -> bool:
+        """Answer whether this signer holds no key that signs."""
+        return not BIP32KeyData.b58decode(self.xkey).is_private
+
+    def master_fingerprint(self) -> bytes:
+        """Return the fingerprint of the key this signer was built on.
+
+        The *master* fingerprint of the contract, which is this key's own
+        and is therefore a claim only as true as the key handed in: a
+        signer built on an account xpub answers that account's
+        fingerprint, and a key origin naming it would send another signer
+        looking for a master key nobody has.
+        """
+        return self._fingerprint
+
+    def xpub(self, der_path: DerPath) -> str:
+        """Return the extended public key at a path, neutered whatever it is.
+
+        Public whether this signer holds a private key or not: what the
+        contract asks for is an xpub, and answering an xprv would put a
+        key that signs where a caller expects one that cannot.
+        """
+        self._assert_open()
+        derived = derive(self.xkey, der_path)
+        if BIP32KeyData.b58decode(derived).is_private:
+            return xpub_from_xprv(derived)
+        return derived
+
+    def sign_psbt(self, psbt: Psbt) -> Psbt:
+        """Return the psbt with a signature for every key this one holds.
+
+        `psbt.sign` over a `KeyManager` this class implements, which is
+        the whole of it: the roles are btclib's already, and a reference
+        signer that re-derived the sig_hash itself would be a second
+        implementation to keep right.
+
+        A watch-only signer raises rather than answering the psbt
+        unchanged: "I hold none of these keys" and "I hold no key at all"
+        are different answers, and only the first is a psbt somebody else
+        can carry on with.
+        """
+        self._assert_open()
+        if self.is_watch_only:
+            raise BTClibValueError("watch-only signer: it holds no key that signs")
+        return sign(psbt, self)[0]
+
+    def capabilities(self) -> SignerCapabilities:
+        """Return what this signer can be asked to sign.
+
+        Taproot always: `psbt.sign` signs the key path, which is what a
+        BIP341 output with no script tree is spent by. MuSig2 is a
+        constructor argument and defaults to False, because the rounds of
+        BIP373 are `psbt.musig2`'s and are played by a caller holding the
+        secret nonce between them -- this signer signs in one call and
+        cannot answer for a session it does not hold.
+        """
+        return SignerCapabilities(taproot=True, musig2=self._musig2)
+
+    def close(self) -> None:
+        """Mark the signer closed; there is nothing to release.
+
+        A software signer holds no handle and no process, so this exists
+        for the contract: a caller that closes every signer it opens is a
+        caller that works with a device too. Asking a closed signer
+        anything raises, which is what makes the difference visible in a
+        test rather than only against hardware.
+        """
+        self._closed = True
+
+    def _assert_open(self) -> None:
+        """Refuse to answer once closed, as a device would."""
+        if self._closed:
+            raise BTClibValueError("the signer is closed")
+
+    def display_address(self, descriptor: Descriptor, index: int = 0) -> str:
+        """Return the address the descriptor describes, as a screen would.
+
+        There is no screen here, so what this answers is what a device
+        would show if it agreed -- which makes `display_address` above a
+        check of the descriptor against itself when this signer is the
+        one asked. That is what a reference implementation is for: the
+        caller's flow runs unchanged, and the check that matters is the
+        one made against a device that could have disagreed.
+        """
+        self._assert_open()
+        return descriptor.address(index)
+
+    def sign_message(self, message: Octets, der_path: DerPath) -> str:
+        """Return the BIP137 compact signature of a message, base64.
+
+        The address the signature opens to is the p2pkh one of the key at
+        the path, which is what `ecc.bms` signs with by default and what
+        a caller checks it against.
+        """
+        self._assert_open()
+        if self.is_watch_only:
+            raise BTClibValueError("watch-only signer: it holds no key that signs")
+        prv_key = derive(self.xkey, der_path)
+        return b64encode(bms.sign(message, prv_key).serialize()).decode("ascii")
+
+    def _prv_key(self, pub_key: bytes, origin: BIP32KeyOrigin | None) -> int | None:
+        """Return the key at the origin, where it is one this signer holds.
+
+        Three conditions and each is a refusal: an origin at all, whose
+        fingerprint is this signer's, and whose path derives to the public
+        key the psbt names. The last is what a device checks too -- a psbt
+        is written by somebody else, and its claim about which key sits at
+        which path is not evidence.
+
+        The x-only spelling is accepted for the taproot candidates, whose
+        `pub_key` is 32 bytes where an ECDSA one is 33.
+        """
+        if origin is None or origin.master_fingerprint != self._fingerprint:
+            return None
+        try:
+            derived = derive(self.xkey, origin.der_path)
+        # a path this key cannot walk is a key this signer does not hold:
+        # a hardened step under an xpub, or an index BIP32 refuses
+        except BTClibValueError:
+            return None
+        sec = pub_keyinfo_from_key(derived)[0]
+        if pub_key not in (sec, sec[1:]):
+            return None
+        return prv_keyinfo_from_prv_key(derived)[0]
+
+    def sign_ecdsa(
+        self, pub_key: bytes, origin: BIP32KeyOrigin | None, msg_hash: bytes
+    ) -> bytes | None:
+        """Return the DER signature of msg_hash by pub_key, or None."""
+        prv_key = self._prv_key(pub_key, origin)
+        if prv_key is None:
+            return None
+        return dsa.sign_(msg_hash, prv_key).serialize()
+
+    def sign_schnorr(
+        self,
+        pub_key: bytes,
+        origin: BIP32KeyOrigin | None,
+        msg_hash: bytes,
+        merkle_root: bytes,
+    ) -> bytes | None:
+        """Return the BIP340 signature of msg_hash by pub_key, or None.
+
+        Tweaked by the merkle root before signing, which is the
+        `KeyManager` contract: the signature has to be the *output* key's,
+        and `sign` never holds what tweaking a private key needs.
+        """
+        prv_key = self._prv_key(pub_key, origin)
+        if prv_key is None:
+            return None
+        tweaked = output_prvkey_from_merkle_root(prv_key, merkle_root)
+        return ssa.sign_(msg_hash, tweaked).serialize()

--- a/tests/software_signer_test.py
+++ b/tests/software_signer_test.py
@@ -1,0 +1,273 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for `psbt_signer.SoftwareSigner`, the reference implementation.
+
+The other test module of that file exercises the checks with doubles that
+lie; this one runs the real thing end to end, which is what the signer is
+for: a psbt built by btclib's own Updater, signed through the contract,
+checked by `request_signatures` and finalized -- with no device and
+nothing mocked, so a failure anywhere in that chain is a failure here.
+
+The key is BIP84's published root, so the addresses the account exports
+are the ones `tests/bip44_test.py` checks against the BIP.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from btclib.bip32.bip32 import BIP32KeyData, derive, xpub_from_xprv
+from btclib.bip32.key_origin import BIP32KeyOrigin
+from btclib.core_import import account_import_requests
+from btclib.descriptors import Descriptor, add_checksum
+from btclib.exceptions import BTClibValueError
+from btclib.psbt.psbt import Psbt, finalize
+from btclib.psbt_signer import (
+    AddressDisplay,
+    MessageSigner,
+    PsbtSigner,
+    SignerCapabilities,
+    SoftwareSigner,
+    display_address,
+    export_account,
+    request_signatures,
+    sign_message,
+)
+from btclib.script.engine import verify_transaction
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
+
+# the "abandon abandon ... about" root of BIP39, which BIP84 publishes
+XPRV_ROOT = (
+    "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRR"
+    "uL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
+)
+
+
+def spending(
+    receive: Descriptor, change: Descriptor, index: int = 0
+) -> tuple[Psbt, list[TxOut]]:
+    """Return a psbt spending one address and paying change to another.
+
+    The shape a wallet builds: an input of its own, a payment out, and
+    change back. Both halves are updated from the descriptors, which is
+    what makes the psbt one a signer can answer -- the input for the key
+    origins it signs by, the output for the change a device recognizes.
+    """
+    prev_out = TxOut(100_000, receive.script_pub_key(index))
+    prev_tx = Tx(vin=[TxIn(OutPoint(b"\x06" * 32, 0))], vout=[prev_out])
+    tx = Tx(
+        vin=[TxIn(OutPoint(prev_tx.id, 0))],
+        vout=[
+            TxOut(60_000, receive.script_pub_key(index + 1)),
+            TxOut(39_000, change.script_pub_key(index)),
+        ],
+    )
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    psbt = receive.update_psbt_input(psbt, 0, index)
+    psbt = change.update_psbt_output(psbt, 1, index)
+    return psbt, [prev_out]
+
+
+def test_the_software_signer_answers_every_protocol() -> None:
+    """One class, the three contracts, and taproot among its capabilities."""
+    signer = SoftwareSigner(XPRV_ROOT)
+    assert isinstance(signer, PsbtSigner)
+    assert isinstance(signer, AddressDisplay)
+    assert isinstance(signer, MessageSigner)
+
+    assert signer.capabilities() == SignerCapabilities(taproot=True, musig2=False)
+    assert SoftwareSigner(XPRV_ROOT, musig2=True).capabilities().musig2
+    assert not signer.is_watch_only
+    assert signer.master_fingerprint().hex() == "73c5da0a"
+    assert signer.xpub("m/84h/0h/0h") == xpub_from_xprv(
+        derive(XPRV_ROOT, "m/84h/0h/0h")
+    )
+
+    # every spelling of a BIP32Key is one key: the b58 text, its bytes,
+    # and the decoded object, held here as the text whichever came in
+    decoded = BIP32KeyData.b58decode(XPRV_ROOT)
+    for xkey in (decoded, XPRV_ROOT.encode("ascii")):
+        assert SoftwareSigner(xkey).xpub("m/0") == signer.xpub("m/0")
+    # and a key that is no key is refused where it was handed in
+    with pytest.raises(BTClibValueError):
+        SoftwareSigner("not a key")
+
+
+@pytest.mark.parametrize("purpose", [44, 49, 84, 86])
+def test_a_psbt_of_an_exported_account_is_signed_and_spends(purpose: int) -> None:
+    """The whole flow, once per BIP44 encoding, and the engine is the oracle.
+
+    Export the account, build a psbt of it, update both halves, send it
+    through the contract, check what came back, finalize, and run the
+    spend under btclib's own script engine. Every role BIP174 names is a
+    btclib call and the last one is checked by executing it, so a
+    signature made under the wrong sig_hash, a key origin that derives to
+    another key or a witness assembled wrong all fail here.
+    """
+    signer = SoftwareSigner(XPRV_ROOT)
+    receive, change = export_account(signer, f"m/{purpose}h/0h/0h")
+    psbt, prevouts = spending(receive, change)
+
+    signed = request_signatures(signer, psbt)
+    assert signed != psbt
+
+    final = finalize(signed)
+    tx = final.tx
+    tx.vin[0].script_sig = final.inputs[0].final_script_sig
+    tx.vin[0].script_witness = final.inputs[0].final_script_witness
+    verify_transaction(prevouts, tx)
+
+
+def test_the_change_output_carries_what_a_device_reads() -> None:
+    """What the signer is told about the output that comes back.
+
+    The origin of the change key, under the same master fingerprint the
+    signer answers with -- which is what lets a device show a payment and
+    a change output differently -- and the script it was checked against
+    before the claim was made.
+    """
+    signer = SoftwareSigner(XPRV_ROOT)
+    receive, change = export_account(signer, "m/84h/0h/0h")
+    psbt, _ = spending(receive, change, 5)
+
+    psbt_out = psbt.outputs[1]
+    ((pub_key, origin),) = psbt_out.hd_key_paths.items()
+    assert pub_key == change.key_expressions[0].sec(5)
+    assert origin.master_fingerprint == signer.master_fingerprint()
+    assert origin.description == "73c5da0a/84h/0h/0h/1/5"
+    # the payment is not the wallet's, so nothing was written on it
+    assert not psbt.outputs[0].hd_key_paths
+
+
+def test_the_signer_answers_for_its_own_keys_only() -> None:
+    """A key at a path this signer cannot walk is somebody else's.
+
+    Three ways for that, and each answers None rather than raising: an
+    origin under another master fingerprint, a path this key cannot
+    derive, and an input naming a public key the path does not lead to --
+    which is the check a device makes too, a psbt being written by
+    whoever sends it.
+    """
+    signer = SoftwareSigner(XPRV_ROOT)
+    receive, change = export_account(signer, "m/84h/0h/0h")
+    psbt, _ = spending(receive, change)
+    origin = next(iter(psbt.inputs[0].hd_key_paths.values()))
+    pub_key = next(iter(psbt.inputs[0].hd_key_paths))
+    msg_hash = b"\x07" * 32
+
+    assert signer.sign_ecdsa(pub_key, origin, msg_hash) is not None
+    assert signer.sign_ecdsa(pub_key, None, msg_hash) is None
+
+    stranger = BIP32KeyOrigin("deadbeef", origin.der_path)
+    assert signer.sign_ecdsa(pub_key, stranger, msg_hash) is None
+
+    # a hardened step under an xpub, which no derivation can take
+    watch_only = SoftwareSigner(xpub_from_xprv(derive(XPRV_ROOT, "m/84h/0h/0h")))
+    hardened = BIP32KeyOrigin(watch_only.master_fingerprint(), "m/0h")
+    assert watch_only.sign_ecdsa(pub_key, hardened, msg_hash) is None
+
+    # the path walks, and leads to another key than the one named
+    elsewhere = BIP32KeyOrigin(origin.master_fingerprint, "m/84h/0h/0h/0/9")
+    assert signer.sign_ecdsa(pub_key, elsewhere, msg_hash) is None
+
+    # the same three answers for a taproot candidate, whose key is the
+    # x-only spelling of the same 33 bytes
+    taproot = export_account(signer, "m/86h/0h/0h")[0]
+    x_only = taproot.key_expressions[0].sec(0)[1:]
+    tr_origin = BIP32KeyOrigin(signer.master_fingerprint(), "m/86h/0h/0h/0/0")
+    assert signer.sign_schnorr(x_only, tr_origin, msg_hash, b"") is not None
+    assert signer.sign_schnorr(x_only, None, msg_hash, b"") is None
+    assert signer.sign_schnorr(x_only, elsewhere, msg_hash, b"") is None
+
+
+def test_a_watch_only_signer_shows_and_derives_but_does_not_sign() -> None:
+    """Watching is most of what a signer does, and it is not a broken state.
+
+    An xpub answers the fingerprint, an unhardened path and an address to
+    display; what it refuses is the two questions that need a key, and it
+    says which of the two states it is in rather than answering "none of
+    these keys are mine".
+
+    What it also cannot answer is an *account*: every level of a BIP44
+    account path is hardened, so no xpub can walk one, and a watch-only
+    signer is therefore one that was handed the account key rather than
+    one that derives it. The refusal is `bip32`'s own.
+    """
+    root_xpub = xpub_from_xprv(XPRV_ROOT)
+    signer = SoftwareSigner(root_xpub)
+    assert signer.is_watch_only
+    assert signer.master_fingerprint() == SoftwareSigner(XPRV_ROOT).master_fingerprint()
+    assert signer.xpub("m/0") == derive(root_xpub, "m/0")
+
+    with pytest.raises(BTClibValueError, match="hardened derivation from public key"):
+        export_account(signer, "m/84h/0h/0h")
+
+    holder = SoftwareSigner(XPRV_ROOT)
+    receive, change = export_account(holder, "m/84h/0h/0h")
+    assert display_address(signer, receive, 2) == receive.address(2)
+
+    psbt = spending(receive, change)[0]
+    with pytest.raises(BTClibValueError, match="watch-only signer"):
+        signer.sign_psbt(psbt)
+    with pytest.raises(BTClibValueError, match="watch-only signer"):
+        sign_message(signer, b"hello", "m/0/0", receive.address(0))
+
+
+def test_a_closed_signer_answers_nothing() -> None:
+    """There is nothing to release, so this exists for the contract.
+
+    A caller that closes every signer it opens is one that works with a
+    device too, and a closed signer raising is what makes that visible in
+    a test rather than only against hardware. The fingerprint is the one
+    answer left: it is what a caller selects a signer *by*, and it is a
+    fact about the key rather than about the connection.
+    """
+    signer = SoftwareSigner(XPRV_ROOT)
+    receive = export_account(signer, "m/84h/0h/0h")[0]
+    signer.close()
+    signer.close()
+
+    assert signer.master_fingerprint().hex() == "73c5da0a"
+    with pytest.raises(BTClibValueError, match="the signer is closed"):
+        signer.xpub("m/0")
+    with pytest.raises(BTClibValueError, match="the signer is closed"):
+        signer.display_address(receive)
+    with pytest.raises(BTClibValueError, match="the signer is closed"):
+        signer.sign_message(b"hello", "m/0")
+
+
+def test_a_message_signature_opens_to_the_address_asked_for() -> None:
+    """The p2pkh address of the key at the path, which `bms` signs with."""
+    signer = SoftwareSigner(XPRV_ROOT)
+    der_path = "m/44h/0h/0h/0/0"
+    address = export_account(signer, "m/44h/0h/0h")[0].address(0)
+
+    assert sign_message(signer, b"hello", der_path, address)
+    # the address of another key of the same signer: a signature that is
+    # valid and opens to somebody else
+    other = export_account(signer, "m/44h/0h/0h")[0].address(1)
+    with pytest.raises(BTClibValueError):
+        sign_message(signer, b"hello", der_path, other)
+
+
+def test_the_account_a_signer_exports_is_the_one_core_imports() -> None:
+    """The end of the pure half: two answers in, two rpc requests out.
+
+    Nothing in this chain is about a device -- the signer is software and
+    the node is not there -- which is the point: the requests a caller
+    would send are built and checked without either.
+    """
+    signer = SoftwareSigner(XPRV_ROOT)
+    receive, change = export_account(signer, "m/84h/0h/0h")
+    requests = account_import_requests(receive, change, key_range=(0, 24))
+
+    assert [request["desc"] for request in requests] == [
+        add_checksum(str(receive)),
+        add_checksum(str(change)),
+    ]
+    assert [request["internal"] for request in requests] == [False, True]
+    assert all(request["range"] == [0, 24] for request in requests)


### PR DESCRIPTION
Part of #381: the software/fake reference signer, which is the last of the pure
work packages.

`psbt_signer.SoftwareSigner` is one extended key, in this process, answering all
three protocols — `PsbtSigner`, `AddressDisplay` and `MessageSigner`. What it is
for is deterministic tests: a signer whose answers a test can predict, so every
psbt shape the library builds is signed end to end before any device is
involved.

```python
signer = SoftwareSigner(master_xprv)
receive, change = export_account(signer, "m/84h/0h/0h")
psbt = ...                                    # updated from both descriptors
signed = request_signatures(signer, psbt)     # sent, checked, combined
verify_transaction(prevouts, extracted(finalize(signed)))
```

That is the suite's main test, once per BIP44 encoding (44, 49, 84, 86), and
btclib's own **script engine is the oracle**: a signature made under the wrong
sig_hash, a key origin that derives to another key, or a witness assembled wrong
all fail there.

## What it adds over `psbt.sign`

It is not a way to sign with a key you hold — `psbt.sign` over a `KeyManager` is
that, and this calls it. What it adds is the boundary:

- **a key is answered for** when the origin's fingerprint is its own *and* the
  path derives to the very public key the psbt names. That second half is the
  check a device makes too: a psbt is written by somebody else, and its claim
  about which key sits at which path is not evidence.
- **watch-only is a first-class state.** An xpub answers the fingerprint, an
  unhardened path and an address to display; it refuses the two questions that
  need a key, rather than answering "none of these keys are mine". It cannot
  export an account either — every level of a BIP44 account path is hardened —
  and that refusal is `bip32`'s own.
- **`close` releases nothing** and exists for the contract: a caller that closes
  every signer it opens works with a device too, and asking a closed one raises,
  which makes the difference visible in a test rather than only against
  hardware. The fingerprint is the one answer left, being a fact about the key
  rather than about the connection.

The last test walks the whole pure half in one go: two answers from a signer in,
two `importdescriptors` requests out, with no device and no node.

## Gates

Merged on the local gates alone; GitHub Actions is degraded.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`: 17488 passed, 100.00%
- `pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a reference software signer implementation to exercise the external signer contract end-to-end without hardware, and document and test it as part of the PSBT signer module.

New Features:
- Add psbt_signer.SoftwareSigner as a deterministic BIP32-based implementation of the PsbtSigner, AddressDisplay, and MessageSigner protocols, including ECDSA and Schnorr signing support and watch-only handling.

Enhancements:
- Extend psbt_signer with helper imports and functionality needed to derive keys, compute fingerprints, and support taproot/MuSig2 capability reporting.
- Document SoftwareSigner in the changelog as the reference implementation for testing PSBT signing flows and external signer behavior.

Tests:
- Add comprehensive tests for SoftwareSigner covering PSBT signing across BIP44 script types, change output metadata, key-origin and path validation, watch-only behavior, closed-signer behavior, message signing, and descriptor import request generation.