### PR TITLE
Speak to a hardware wallet through HWI's command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,46 @@ edit.
 
 ### The public API and the module layout
 
+- **`btclib.hwi` is new: a `PsbtSigner` over Bitcoin Core HWI's JSON
+  command line** (issue #381), which is the first integration that issue
+  calls for and the one that needs no vendor driver in btclib. Five
+  commands — `enumerate`, `getxpub`, `signtx`, `signmessage`,
+  `displayaddress` — become the contract, and `HwiSigner` answers all
+  three protocols.
+
+  **Nothing is imported from hwilib and nothing has to be installed.** HWI
+  declares `hidapi`, `libusb1`, `cbor2`, `pyserial`, `noiseprotocol`,
+  `protobuf` and vendor libraries, and a narrower Python range than
+  btclib's: a mandatory dependency on that is what the issue rules out. An
+  executable named by the caller is the whole of the runtime requirement,
+  so the import costs `json` and `subprocess`, and the tests run against a
+  stand-in with no HWI present at all.
+
+  A device is named by its fingerprint, and selection is not optional:
+  HWI's `--device-type` connects to "the first device of this type
+  enumerated", so with two of one vendor which one signs would be a
+  question of enumeration order. Passing none enumerates and refuses
+  unless exactly one device is usable, naming the fingerprints where there
+  are two and what was wrong with each where there is none; every command
+  then carries `--fingerprint`. The subprocess is bounded by a timeout —
+  on a person pressing a button, so two minutes by default — and by a
+  limit on the answer it accepts.
+
+  `exceptions.SignerError` is new with it, and carries HWI's own error
+  code: -14 is somebody pressing the button that says no, -3 is a cable,
+  -9 is a model that will never do it. A caller writing a retry policy
+  needs the number, and matching on the text of a message is what a field
+  spares them; it is None where the failure produced no number, which is a
+  failure of the exchange rather than of the device.
+
+  `descriptors.at_index` is new beside it: the descriptor of one index,
+  with the wildcard written into the path — `.../0/*` at 5 becomes
+  `.../0/5`. HWI derives a ranged descriptor at index 0 whatever was
+  meant, so a caller asking to display index 5 would be shown index 0 and
+  told it was 5; what goes out is the descriptor of the one script. It is
+  Bitcoin Core's `deriveaddresses` with the descriptor as its answer
+  rather than the address, and `normalized` now shares its walker.
+
 - **`psbt_signer.SoftwareSigner` is the reference implementation** (issue
   #381): one extended key, in this process, answering all three protocols.
   What it is for is a signer whose answers a test can predict, so every

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -92,6 +92,7 @@ __all__ = [
     "fee",
     "fetch",
     "hashes",
+    "hwi",
     "keystore",
     "mnemonic",
     "network",

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -183,6 +183,7 @@ __all__ = [
     "WshDescriptor",
     "account_descriptors",
     "add_checksum",
+    "at_index",
     "checksum",
     "from_address",
     "multipath_descriptors",
@@ -2649,19 +2650,38 @@ def _normalized_key(key: KeyExpression, prv_keys: PrvKeys | None) -> KeyExpressi
     )
 
 
-def _normalized(value: object, prv_keys: PrvKeys | None) -> object:
-    """Return one field of a descriptor with every key in it normalized."""
+def _mapped_field(
+    value: object, key_map: Callable[[KeyExpression], KeyExpression]
+) -> object:
+    """Return one field of a descriptor with every key in it mapped.
+
+    Where a key can be: the field itself, a key of a ``multi_a()`` leaf, a
+    key of a fragment another one wraps, or an element of a script tree,
+    which is a tuple of tuples. Nothing else in a fragment holds one, and
+    a field added later that does will be walked here by construction --
+    which is the whole reason this is one function rather than a method
+    per fragment.
+    """
     if isinstance(value, KeyExpression):
-        return _normalized_key(value, prv_keys)
+        return key_map(value)
     if isinstance(value, MultiA):
-        return replace(
-            value, keys=tuple(_normalized_key(k, prv_keys) for k in value.keys)
-        )
+        return replace(value, keys=tuple(key_map(key) for key in value.keys))
     if isinstance(value, Descriptor):
-        return normalized(value, prv_keys)
+        return _mapped_keys(value, key_map)
     if isinstance(value, tuple):
-        return tuple(_normalized(item, prv_keys) for item in value)
+        return tuple(_mapped_field(item, key_map) for item in value)
     return value
+
+
+def _mapped_keys(
+    descriptor: Descriptor, key_map: Callable[[KeyExpression], KeyExpression]
+) -> Descriptor:
+    """Return the descriptor with `key_map` applied to every key it holds."""
+    changed: dict[str, Any] = {
+        field.name: _mapped_field(getattr(descriptor, field.name), key_map)
+        for field in fields(descriptor)
+    }
+    return replace(descriptor, **changed)
 
 
 def normalized(descriptor: Descriptor, prv_keys: PrvKeys | None = None) -> Descriptor:
@@ -2682,14 +2702,40 @@ def normalized(descriptor: Descriptor, prv_keys: PrvKeys | None = None) -> Descr
     that came in, which is Core's rule -- "always use h for hardened
     derivation" is how its own interface states it.
     """
-    changed: dict[str, Any] = {
-        field.name: _normalized(getattr(descriptor, field.name), prv_keys)
-        for field in fields(descriptor)
-    }
-    # `replace` is what keeps this one function rather than a method per
-    # fragment: every field is walked, so a field added later carries its
-    # keys through here by default
-    return replace(descriptor, **changed)
+    return _mapped_keys(descriptor, lambda key: _normalized_key(key, prv_keys))
+
+
+def at_index(descriptor: Descriptor, index: int = 0) -> Descriptor:
+    """Return the descriptor of one index, with no wildcard left in it.
+
+    A ranged descriptor describes a range of scripts and names none of
+    them; this names one, by writing the index the wildcard stands for
+    into the derivation path -- ``.../0/*`` at index 5 becomes ``.../0/5``.
+    The scripts are the same scripts: what changes is that the answer is
+    a descriptor of one, which is what a reader wanting *this* script has
+    to be given, an external signer displaying an address among them.
+
+    Bitcoin Core's `deriveaddresses` is the same operation with the
+    address as its answer rather than the descriptor.
+
+    A descriptor with no wildcard comes back unchanged, index 0 being the
+    only index it has; the participants of a ``musig()`` are walked too,
+    the range being on either side of the aggregation and never on both.
+    """
+    descriptor._assert_index(index)
+
+    def fixed(key: KeyExpression) -> KeyExpression:
+        if key.participants:
+            key = replace(
+                key, participants=tuple(fixed(one) for one in key.participants)
+            )
+        if key.wildcard is None:
+            return key
+        return replace(
+            key, der_path=(*key.der_path, key.wildcard + index), wildcard=None
+        )
+
+    return _mapped_keys(descriptor, fixed)
 
 
 def multipath_descriptors(descriptor: str) -> list[str]:

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -52,6 +52,7 @@ __all__ = [
     "NotAPrvKeyError",
     "RpcError",
     "ScriptError",
+    "SignerError",
 ]
 
 
@@ -144,6 +145,39 @@ class RpcError(FetchError):
 
     def __str__(self) -> str:
         return f"{self.args[0]} (rpc error code {self.code})"
+
+
+class SignerError(BTClibRuntimeError):
+    """An external signer failed, and `code` is the number it gave.
+
+    What `btclib.psbt_signer`'s contract fails with, and what
+    `btclib.hwi` raises around HWI's structured errors: the JSON CLI
+    answers `{"error": <msg>, "code": <n>}`, and the number is the part a
+    caller acts on. -14 is ACTION_CANCELED, which is somebody pressing the
+    button that says no and is not worth a retry; -3 is DEVICE_CONN_ERROR,
+    which is a cable and is worth one; -9 is UNAVAILABLE_ACTION, which
+    says this model will never do it. Matching on the text of a message is
+    what a field spares a caller writing that policy.
+
+    A RuntimeError for the reason `FetchError` is one: nothing the caller
+    passed is wrong. The device is unplugged, locked, busy, or its owner
+    said no -- retrying can work, and correcting an argument cannot. The
+    numbers HWI reserves for a bad argument (-2, -7) arrive here too, that
+    being the one thing the code says and the class cannot.
+
+    `code` is None where the failure produced no number: a backend that
+    could not be started, an answer that was not JSON, an output past the
+    limit. Those are failures of the exchange rather than of the device.
+    """
+
+    def __init__(self, message: str, code: int | None = None) -> None:
+        self.code = code
+        super().__init__(message, code)
+
+    def __str__(self) -> str:
+        if self.code is None:
+            return str(self.args[0])
+        return f"{self.args[0]} (signer error code {self.code})"
 
 
 class ScriptError(BTClibValueError):

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -1,0 +1,409 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""A `PsbtSigner` over Bitcoin Core HWI's JSON command line.
+
+https://github.com/bitcoin-core/HWI
+
+HWI speaks to Trezor, Ledger, KeepKey, Digital Bitbox, Coldcard, BitBox02
+and Jade over HID, USB, serial and emulator transports, and publishes a
+JSON command line so that other software need not. This module is that
+other software: it runs `hwi` as a subprocess and turns five of its
+commands into the contract `btclib.psbt_signer` defines.
+
+**Nothing is imported from hwilib, and nothing has to be installed for
+btclib to work.** HWI declares `hidapi`, `libusb1`, `cbor2`, `pyserial`,
+`noiseprotocol`, `protobuf` and vendor libraries, and a Python range
+narrower than btclib's; a mandatory dependency on that is the thing issue
+#381 rules out. What this module needs at runtime is an executable, named
+by the caller and absent until a device is actually being used, so the
+import costs `json` and `subprocess` and the tests run with no HWI at
+all.
+
+`enumerate_devices` is the one call that names no device; everything else
+is `HwiSigner`, which is selected by fingerprint and passes `--fingerprint`
+to every command it runs. That is issue #381's own rule, and the reason
+selection is not optional: HWI's `--device-type` connects to "the first
+device of this type enumerated", so two devices of one vendor make which
+one signs a question of enumeration order.
+
+The subprocess is bounded twice. `timeout` is how long a command may run
+-- a device waiting for a button press is the ordinary case, so the
+default is generous and a caller signing unattended should lower it --
+and `max_output` is how much of its answer is accepted: HWI answers with
+one json object, and a backend that sends megabytes is one whose output
+is not read to the end. The timeout is what stops it in the meantime,
+`subprocess.communicate` reading to EOF, so what the limit bounds is what
+is parsed rather than what is buffered.
+
+Failures come back as `exceptions.SignerError`, carrying HWI's own error
+code where there is one: -14 is the user pressing the button that says
+no, -3 is a cable, -9 is a model that will never do it.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from btclib.alias import Octets
+from btclib.bip32.der_path import DerPath, str_from_der_path
+from btclib.descriptors import Descriptor, add_checksum, at_index
+from btclib.exceptions import BTClibValueError, SignerError
+from btclib.network import NETWORKS
+from btclib.psbt.psbt import Psbt
+from btclib.psbt_signer import SignerCapabilities
+from btclib.utils import bytes_from_octets
+
+__all__ = [
+    "DEFAULT_MAX_OUTPUT",
+    "DEFAULT_TIMEOUT",
+    "NO_CAPABILITIES",
+    "HwiDevice",
+    "HwiSigner",
+    "enumerate_devices",
+]
+
+# a button press is what a signing command waits for, so the bound is on
+# a person and not on a computation: two minutes is long enough for a
+# device that asks to confirm every output of a large transaction, and
+# short enough that an unattended caller is not hung for an afternoon
+DEFAULT_TIMEOUT = 120.0
+
+# one json object, and the largest is a signed psbt: a megabyte is past
+# any transaction standardness relays, and a backend that sends more is
+# not one whose answer should be parsed to find out
+DEFAULT_MAX_OUTPUT = 1 << 20
+
+# what a caller that has not said gets: nothing supported, which is the
+# honest default when the answer is not in any json HWI prints. A module
+# global rather than a call in the signature, which is a mutable default
+# in every language that has them and a ruff finding in this one
+NO_CAPABILITIES = SignerCapabilities()
+
+# btclib names five networks and HWI takes four chains: `--chain` is what
+# decides the version bytes of the xpubs it answers with, so the mapping
+# is what makes `account_descriptors` agree with the device about which
+# chain the account is on. testnet4 has no HWI chain of its own
+_HWI_CHAIN = {
+    "mainnet": "main",
+    "testnet": "test",
+    "regtest": "regtest",
+    "signet": "signet",
+}
+
+
+@dataclass(frozen=True)
+class HwiDevice:
+    """One entry of what `hwi enumerate` answers.
+
+    `fingerprint` is None for a device that cannot be asked for one yet --
+    a locked Trezor, a Ledger with no app open -- and `error` says why,
+    with HWI's own `code` beside it. Such a device is enumerated on
+    purpose: what a caller does about a locked device is unlock it, and a
+    list that left it out would say it is not there.
+    """
+
+    type: str
+    model: str
+    path: str
+    fingerprint: bytes | None = None
+    needs_pin_sent: bool = False
+    needs_passphrase_sent: bool = False
+    error: str = ""
+    code: int | None = None
+
+    @property
+    def is_usable(self) -> bool:
+        """Answer whether the device answered a fingerprint and no error."""
+        return self.fingerprint is not None and not self.error
+
+
+def _executable(executable: str | Sequence[str]) -> list[str]:
+    """Return the argv prefix that runs HWI, from a name or a whole argv.
+
+    A sequence is what a caller passes for anything that is not a bare
+    executable on the PATH -- `python -m hwilib`, an interpreter and a
+    script, a wrapper with flags of its own -- and it is what the tests
+    use to run a stand-in with no HWI installed.
+    """
+    return [executable] if isinstance(executable, str) else list(executable)
+
+
+def _run(
+    argv: list[str],
+    *,
+    timeout: float,
+    max_output: int,
+) -> Any:
+    """Run HWI and return the json it answered, or raise what it failed with.
+
+    Every failure is a `SignerError`: a backend that cannot be started, an
+    answer that is not json, an answer past the limit, and the error
+    object HWI itself returns. The last is the one carrying a code, which
+    is why the others explicitly carry None -- "no number" is a fact about
+    the exchange rather than a device that answered zero.
+    """
+    try:
+        completed = subprocess.run(  # noqa: S603
+            argv,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise SignerError(f"{argv[0]} timed out after {timeout} s") from e
+    except OSError as e:
+        raise SignerError(f"cannot run {argv[0]}: {e}") from e
+
+    if len(completed.stdout) > max_output:
+        err_msg = f"{argv[0]} answered more than {max_output} bytes"
+        raise SignerError(err_msg)
+    if not completed.stdout.strip():
+        # a command that printed nothing has failed in its own way, and
+        # stderr is where it said so: HWI prints a traceback there when it
+        # cannot even build the parser
+        message = completed.stderr.decode("utf-8", "replace").strip()
+        raise SignerError(f"{argv[0]} answered nothing: {message or 'no output'}")
+
+    try:
+        answer = json.loads(completed.stdout)
+    except json.JSONDecodeError as e:
+        raise SignerError(f"{argv[0]} did not answer json: {e}") from e
+
+    if isinstance(answer, dict) and "error" in answer:
+        raise SignerError(str(answer["error"]), answer.get("code"))
+    return answer
+
+
+def _device(entry: dict[str, Any]) -> HwiDevice:
+    """Return one enumerate entry as an `HwiDevice`, fingerprint decoded."""
+    fingerprint = entry.get("fingerprint")
+    return HwiDevice(
+        type=str(entry.get("type", "")),
+        model=str(entry.get("model", "")),
+        path=str(entry.get("path", "")),
+        fingerprint=None if fingerprint is None else bytes_from_octets(fingerprint, 4),
+        needs_pin_sent=bool(entry.get("needs_pin_sent", False)),
+        needs_passphrase_sent=bool(entry.get("needs_passphrase_sent", False)),
+        error=str(entry.get("error", "")),
+        code=entry.get("code"),
+    )
+
+
+def enumerate_devices(
+    *,
+    executable: str | Sequence[str] = "hwi",
+    network: str = "mainnet",
+    timeout: float = DEFAULT_TIMEOUT,
+    max_output: int = DEFAULT_MAX_OUTPUT,
+    emulators: bool = False,
+) -> list[HwiDevice]:
+    """Return the devices HWI can see, the ones it cannot talk to included.
+
+    `emulators` is HWI's own `--emulators`, off by default: an emulator is
+    a device with no secure element and no owner, and enumerating one
+    without being asked would make a test fixture look like a signer.
+    """
+    argv = [*_executable(executable), *_chain_args(network), "enumerate"]
+    if emulators:
+        argv.insert(-1, "--emulators")
+    answer = _run(argv, timeout=timeout, max_output=max_output)
+    if not isinstance(answer, list):
+        raise SignerError(f"hwi enumerate did not answer a list: {answer!r}")
+    return [_device(entry) for entry in answer]
+
+
+def _chain_args(network: str) -> list[str]:
+    """Return HWI's `--chain` flag for a btclib network name."""
+    chain = _HWI_CHAIN.get(network)
+    if chain is None:
+        known = ", ".join(sorted(_HWI_CHAIN))
+        raise BTClibValueError(f"no HWI chain for network {network}: not in ({known})")
+    return ["--chain", chain]
+
+
+class HwiSigner:
+    """One device, selected by fingerprint, answering the signer contract.
+
+    `btclib.psbt_signer`'s three protocols over five HWI commands:
+    `getxpub`, `signtx`, `signmessage`, `displayaddress`, and `enumerate`
+    for the selection. Everything a caller should check about the answers
+    is checked by the functions of that module -- `request_signatures`,
+    `display_address`, `sign_message` -- and not here: this is the
+    transport, and a transport that also decided what to trust would be
+    two things.
+
+    The fingerprint is what a device is named by. Passing one selects it;
+    passing none enumerates and refuses unless exactly one device is
+    usable, because "the first one enumerated" is not a choice a library
+    makes for a caller holding two.
+
+    `capabilities` is the caller's word: HWI's JSON CLI does not report
+    what a model supports, and the matrix that does is maintained per
+    vendor and per firmware in HWI's own documentation. A default of
+    nothing supported is the honest one, and a caller that knows its
+    device says so.
+    """
+
+    def __init__(
+        self,
+        fingerprint: Octets | None = None,
+        *,
+        executable: str | Sequence[str] = "hwi",
+        network: str = "mainnet",
+        timeout: float = DEFAULT_TIMEOUT,
+        max_output: int = DEFAULT_MAX_OUTPUT,
+        emulators: bool = False,
+        capabilities: SignerCapabilities = NO_CAPABILITIES,
+    ) -> None:
+        if network not in NETWORKS:
+            raise BTClibValueError(f"unknown network: {network}")
+        self.executable = _executable(executable)
+        self.network = network
+        self.timeout = timeout
+        self.max_output = max_output
+        self.emulators = emulators
+        self._capabilities = capabilities
+        self._fingerprint = (
+            self._select() if fingerprint is None else bytes_from_octets(fingerprint, 4)
+        )
+        self._closed = False
+
+    def _select(self) -> bytes:
+        """Return the fingerprint of the one usable device, refusing two.
+
+        A device that could not be asked for a fingerprint is not a
+        candidate and is named in the refusal: "no device" and "one device,
+        locked" are different things to be told, and the second is fixed by
+        unlocking it rather than by plugging something in.
+        """
+        devices = enumerate_devices(
+            executable=self.executable,
+            network=self.network,
+            timeout=self.timeout,
+            max_output=self.max_output,
+            emulators=self.emulators,
+        )
+        usable = [device for device in devices if device.is_usable]
+        if len(usable) == 1:
+            assert usable[0].fingerprint is not None  # noqa: S101
+            return usable[0].fingerprint
+        if not usable:
+            unusable = ", ".join(
+                f"{device.type} ({device.error or 'no fingerprint'})"
+                for device in devices
+            )
+            err_msg = f"no usable device: {unusable}" if unusable else "no device"
+            raise SignerError(err_msg)
+        fingerprints = ", ".join(
+            device.fingerprint.hex() for device in usable if device.fingerprint
+        )
+        err_msg = f"{len(usable)} usable devices ({fingerprints}):"
+        err_msg += " name the one to use by its fingerprint"
+        raise SignerError(err_msg)
+
+    def _hwi(self, *args: str) -> Any:
+        """Run one command against this device, by fingerprint."""
+        if self._closed:
+            raise SignerError("the signer is closed")
+        argv = [
+            *self.executable,
+            *_chain_args(self.network),
+            "--fingerprint",
+            self._fingerprint.hex(),
+            *args,
+        ]
+        return _run(argv, timeout=self.timeout, max_output=self.max_output)
+
+    def _answer(self, command: list[str], field: str) -> str:
+        """Return one string field of an answer, refusing one without it."""
+        answer = self._hwi(*command)
+        if not isinstance(answer, dict) or field not in answer:
+            err_msg = f"hwi {command[0]} did not answer a {field}: {answer!r}"
+            raise SignerError(err_msg)
+        return str(answer[field])
+
+    def master_fingerprint(self) -> bytes:
+        """Return the fingerprint this signer was selected by.
+
+        Not asked of the device again: it is what every command carries as
+        `--fingerprint`, so HWI has refused to talk to a device answering
+        anything else before any of them ran.
+        """
+        return self._fingerprint
+
+    def xpub(self, der_path: DerPath) -> str:
+        """Return the extended public key at a path: HWI's `getxpub`."""
+        return self._answer(["getxpub", str_from_der_path(der_path)], "xpub")
+
+    def sign_psbt(self, psbt: Psbt) -> Psbt:
+        """Return what `hwi signtx` answered, parsed and otherwise untouched.
+
+        Untouched deliberately: the answer is checked against the psbt
+        that was sent by `psbt_signer.request_signatures`, which is the
+        caller of this and the one place that comparison belongs.
+        """
+        return Psbt.b64decode(self._answer(["signtx", psbt.b64encode()], "psbt"))
+
+    def sign_message(self, message: Octets, der_path: DerPath) -> str:
+        """Return the compact signature of a message: HWI's `signmessage`.
+
+        `Octets` as everywhere else in btclib, so a `str` is the hex of the
+        message and bytes are the message: `ecc.bms` reads it that way and
+        the two have to agree, a signature being verified here against
+        what was signed there.
+
+        What goes on the command line is text, HWI's `signmessage` taking
+        a string and passing it to its own signer as one. The bytes are
+        decoded as utf-8 for that, and a message that is not utf-8 is one
+        this backend cannot be asked for -- which is a limit of the
+        command line rather than of the device, and is said as such.
+        """
+        octets = bytes_from_octets(message)
+        try:
+            text = octets.decode("utf-8")
+        except UnicodeDecodeError as e:
+            err_msg = "hwi signmessage takes text on a command line:"
+            err_msg += " this message is not utf-8"
+            raise BTClibValueError(err_msg) from e
+        return self._answer(
+            ["signmessage", text, str_from_der_path(der_path)], "signature"
+        )
+
+    def display_address(self, descriptor: Descriptor, index: int = 0) -> str:
+        """Return the address the device shows: HWI's `displayaddress`.
+
+        The descriptor is sent with the index written into it rather than
+        as the ranged one it may be: HWI derives a ranged descriptor at
+        index 0 whatever was meant, so a caller asking for index 5 would
+        be shown index 0 and told it was 5. `descriptors.at_index` is what
+        names the one script, and `psbt_signer.display_address` is what
+        then compares the answer with the address that descriptor
+        describes.
+
+        Checksummed, which is what HWI's `--desc` parser requires of
+        anything it is given.
+        """
+        text = add_checksum(str(at_index(descriptor, index)))
+        return self._answer(["displayaddress", "--desc", text], "address")
+
+    def capabilities(self) -> SignerCapabilities:
+        """Return what the caller said this device can be asked to sign."""
+        return self._capabilities
+
+    def close(self) -> None:
+        """Refuse further commands; there is no connection to release.
+
+        A subprocess per command is what a command line is, so nothing is
+        held open between two of them and closing is a decision rather
+        than a release. Making it refuse afterwards is what gives a caller
+        the same shape as a signer that does hold something -- and
+        `contextlib.closing` then works over either.
+        """
+        self._closed = True

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -111,6 +111,13 @@ btclib.hashes module
    :members:
    :show-inheritance:
 
+btclib.hwi module
+-----------------
+
+.. automodule:: btclib.hwi
+   :members:
+   :show-inheritance:
+
 btclib.keystore module
 ----------------------
 

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -60,6 +60,7 @@ from btclib.descriptors import (
     __descsum_expand,
     account_descriptors,
     add_checksum,
+    at_index,
     checksum,
     from_address,
     multipath_descriptors,
@@ -2620,6 +2621,54 @@ def test_a_rawtr_without_an_origin_writes_nothing_at_all() -> None:
     descriptor = parse(f"rawtr({XONLY_A})")
     psbt = descriptor.update_psbt_input(psbt_spending(descriptor), 0)
     assert psbt.inputs[0] == psbt_spending(descriptor).inputs[0]
+
+
+def test_a_descriptor_at_one_index_names_one_script() -> None:
+    """The wildcard written out, which is what a reader of one script needs.
+
+    `.../0/*` at index 5 is `.../0/5`: the same script the ranged
+    descriptor describes at that index, said as a descriptor of its own —
+    which is what an external signer displaying an address has to be given,
+    and what Bitcoin Core's `deriveaddresses` answers the address of.
+    """
+    descriptor = parse(f"wpkh([d34db33f/84h/0h/0h]{XPUB}/0/*)")
+    for index in (0, 5):
+        fixed = at_index(descriptor, index)
+        assert not fixed.is_ranged
+        assert str(fixed).endswith(f"/0/{index})")
+        assert fixed.script_pub_key() == descriptor.script_pub_key(index)
+        assert fixed.key_expressions[0].origin == descriptor.key_expressions[0].origin
+        # and it is a descriptor like any other: written back and read again
+        assert parse(str(fixed)).script_pub_key() == fixed.script_pub_key()
+
+    # a descriptor with no wildcard has one index, and comes back as it was
+    unranged = parse(f"wpkh({KEY_A})")
+    assert str(at_index(unranged)) == str(unranged)
+    with pytest.raises(BTClibValueError, match="not a ranged descriptor"):
+        at_index(unranged, 1)
+    with pytest.raises(BTClibValueError, match="invalid derivation index"):
+        at_index(descriptor, -1)
+
+
+def test_the_index_of_a_musig_is_written_where_the_range_is() -> None:
+    """Either side of the aggregation, and BIP390 forbids both at once.
+
+    So the walk reaches the participants and the aggregate alike, and what
+    comes back has no wildcard on either side.
+    """
+    aggregate = parse(f"tr(musig({MUSIG_XPUB_A},{MUSIG_XPUB_B})/0/*)")
+    participants = parse(f"tr(musig({MUSIG_XPUB_A}/*,{MUSIG_XPUB_B}/*))")
+    for descriptor in (aggregate, participants):
+        fixed = at_index(descriptor, 3)
+        assert not fixed.is_ranged
+        assert "*" not in str(fixed)
+        assert fixed.script_pub_key() == descriptor.script_pub_key(3)
+
+    # a tree leaf is walked too, being where the other keys of a tr() are
+    tree = parse(f"tr({XONLY_A},{{pk({XPUB}/0/*),multi_a(1,{XPUB}/1/*)}})")
+    fixed = at_index(tree, 2)
+    assert not fixed.is_ranged
+    assert fixed.script_pub_key() == tree.script_pub_key(2)
 
 
 def test_the_account_descriptor_pair() -> None:

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -1,0 +1,462 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.hwi` module, with no HWI installed.
+
+The device is a stand-in: a Python script this module writes out, run as
+`[sys.executable, script]`, which answers each command from a table the
+test wrote into it. That is the whole point of a subprocess adapter being
+testable -- HWI declares `hidapi`, `libusb1`, `cbor2`, `pyserial`,
+`noiseprotocol`, `protobuf` and vendor libraries, and none of them has to
+exist for these to run.
+
+`[sys.executable, script]` rather than a shebang and a chmod: a shebang
+is not how Windows runs anything, and the matrix has a Windows job.
+
+What the stand-in answers is HWI's own shapes, read from its `_cli.py`
+and `errors.py` at commit 5e0fd5e: a list for `enumerate`, `{"xpub": …}`,
+`{"psbt": …}`, `{"signature": …}`, `{"address": …}` for the rest, and
+`{"error": …, "code": …}` for a failure. The signing answers are made by
+`psbt_signer.SoftwareSigner`, so the psbt that comes back is one a real
+device could have sent -- which is what lets the checks in
+`psbt_signer` run over it here.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from btclib.bip32.bip32 import derive, xpub_from_xprv
+from btclib.descriptors import Descriptor, at_index, parse
+from btclib.exceptions import BTClibValueError, SignerError
+from btclib.hwi import (
+    DEFAULT_MAX_OUTPUT,
+    DEFAULT_TIMEOUT,
+    HwiDevice,
+    HwiSigner,
+    enumerate_devices,
+)
+from btclib.psbt.psbt import Psbt
+from btclib.psbt_signer import (
+    AddressDisplay,
+    MessageSigner,
+    PsbtSigner,
+    SignerCapabilities,
+    display_address,
+    export_account,
+    request_signatures,
+    sign_message,
+)
+from btclib.to_pub_key import fingerprint
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
+
+# the "abandon abandon ... about" root of BIP39, which BIP84 publishes
+XPRV_ROOT = (
+    "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRR"
+    "uL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
+)
+FINGERPRINT = fingerprint(XPRV_ROOT).hex()
+
+# what the stand-in prints for a command, before any test changes it: the
+# device is the software signer of the same key, so every answer is one
+# btclib can check rather than a fixture that only looks right
+_STAND_IN = """
+import json, pathlib, sys
+from btclib.psbt.psbt import Psbt
+from btclib.psbt_signer import SoftwareSigner
+
+ANSWERS = json.loads({answers!r})
+# what it was run with, for the tests that are about the argv itself
+pathlib.Path(__file__).with_suffix(".argv.json").write_text(json.dumps(sys.argv[1:]))
+signer = SoftwareSigner({xprv!r})
+args = [arg for arg in sys.argv[1:]]
+command = next(arg for arg in args if not arg.startswith("-") and arg not in
+               ("main", "test", "regtest", "signet", {fingerprint!r}))
+
+if command in ANSWERS:
+    print(json.dumps(ANSWERS[command]))
+elif command == "enumerate":
+    print(json.dumps([{{"type": "stand-in", "model": "stand_in_simulator",
+                        "path": "/dev/null", "fingerprint": {fingerprint!r}}}]))
+elif command == "getxpub":
+    print(json.dumps({{"xpub": signer.xpub(args[args.index("getxpub") + 1])}}))
+elif command == "signtx":
+    psbt = Psbt.b64decode(args[args.index("signtx") + 1])
+    print(json.dumps({{"psbt": signer.sign_psbt(psbt).b64encode()}}))
+elif command == "signmessage":
+    i = args.index("signmessage")
+    message = args[i + 1].encode("utf-8")
+    print(json.dumps({{"signature": signer.sign_message(message, args[i + 2])}}))
+elif command == "displayaddress":
+    from btclib.descriptors import parse
+    descriptor = parse(args[args.index("--desc") + 1])
+    print(json.dumps({{"address": signer.display_address(descriptor)}}))
+else:
+    print(json.dumps({{"error": "unknown command " + command, "code": -13}}))
+"""
+
+
+@pytest.fixture
+def hwi(tmp_path: Path) -> list[str]:
+    """Return the argv of a stand-in device answering HWI's own shapes."""
+    return stand_in(tmp_path, {})
+
+
+def stand_in(tmp_path: Path, answers: dict[str, object]) -> list[str]:
+    """Return the argv of a stand-in answering `answers` for those commands.
+
+    A command not in the mapping is answered by signing with the key: the
+    canned ones are how a device that fails, lies or floods is written.
+    """
+    script = tmp_path / f"hwi_stand_in_{len(list(tmp_path.iterdir()))}.py"
+    script.write_text(
+        _STAND_IN.format(
+            answers=json.dumps(answers), xprv=XPRV_ROOT, fingerprint=FINGERPRINT
+        ),
+        encoding="ascii",
+    )
+    return [sys.executable, str(script)]
+
+
+def signer(hwi: list[str], **kwargs: object) -> HwiSigner:
+    """Return an HwiSigner over the stand-in, selected by its fingerprint."""
+    return HwiSigner(FINGERPRINT, executable=hwi, **kwargs)  # type: ignore[arg-type]
+
+
+def test_the_adapter_answers_the_signer_contract(hwi: list[str]) -> None:
+    """The three protocols, over five commands of a command line."""
+    device = signer(hwi)
+    assert isinstance(device, PsbtSigner)
+    assert isinstance(device, AddressDisplay)
+    assert isinstance(device, MessageSigner)
+
+    assert device.master_fingerprint() == bytes.fromhex(FINGERPRINT)
+    assert device.xpub("m/84h/0h/0h") == xpub_from_xprv(
+        derive(XPRV_ROOT, "m/84h/0h/0h")
+    )
+    assert device.capabilities() == SignerCapabilities()
+    # what a model supports is not in the json a command line answers, so
+    # a caller that knows its device is what says so
+    taproot = signer(hwi, capabilities=SignerCapabilities(taproot=True))
+    assert taproot.capabilities().taproot
+
+
+def test_enumerate_reads_hwi_s_own_shape(tmp_path: Path) -> None:
+    """A list of devices, the ones that cannot be talked to included.
+
+    A locked device is enumerated on purpose: what a caller does about it
+    is unlock it, and leaving it out would say it is not there.
+    """
+    locked = {
+        "type": "trezor",
+        "model": "trezor_1",
+        "path": "usb:1",
+        "needs_pin_sent": True,
+        "error": "Could not open client or get fingerprint information: Trezor is locked",
+        "code": -12,
+    }
+    hwi = stand_in(tmp_path, {"enumerate": [locked]})
+    (device,) = enumerate_devices(executable=hwi)
+
+    assert device == HwiDevice(
+        type="trezor",
+        model="trezor_1",
+        path="usb:1",
+        fingerprint=None,
+        needs_pin_sent=True,
+        error=locked["error"],  # type: ignore[arg-type]
+        code=-12,
+    )
+    assert not device.is_usable
+
+
+def test_a_device_is_named_by_its_fingerprint(tmp_path: Path) -> None:
+    """Selection is not optional, and two devices are not a choice to make.
+
+    HWI's `--device-type` connects to "the first device of this type
+    enumerated", so with two of one vendor the answer would depend on
+    enumeration order. One usable device is selected; two are refused with
+    both fingerprints named, and none is refused with what was wrong with
+    each.
+    """
+    one = {"type": "stand-in", "model": "m", "path": "a", "fingerprint": FINGERPRINT}
+    other = {**one, "path": "b", "fingerprint": "deadbeef"}
+
+    assert HwiSigner(executable=stand_in(tmp_path, {})).master_fingerprint().hex() == (
+        FINGERPRINT
+    )
+    hwi = stand_in(tmp_path, {"enumerate": [one, other]})
+    with pytest.raises(
+        SignerError, match=f"2 usable devices \\({FINGERPRINT}, deadbeef"
+    ):
+        HwiSigner(executable=hwi)
+
+    locked = {
+        "type": "trezor",
+        "model": "t",
+        "path": "c",
+        "error": "locked",
+        "code": -12,
+    }
+    hwi = stand_in(tmp_path, {"enumerate": [locked]})
+    with pytest.raises(SignerError, match="no usable device: trezor \\(locked\\)"):
+        HwiSigner(executable=hwi)
+    hwi = stand_in(tmp_path, {"enumerate": []})
+    with pytest.raises(SignerError, match="no device"):
+        HwiSigner(executable=hwi)
+
+    # and every command carries the fingerprint, so HWI refuses to talk to
+    # another device before btclib has to notice
+    hwi = stand_in(tmp_path, {})
+    signer(hwi).xpub("m/0")
+    argv = last_argv(hwi)
+    assert argv[argv.index("--fingerprint") + 1] == FINGERPRINT
+
+
+def last_argv(hwi: list[str]) -> list[str]:
+    """Return the arguments the stand-in was last run with.
+
+    Written out by the stand-in itself, so what is read here is what
+    crossed the process boundary rather than what this module thinks the
+    adapter would have built.
+    """
+    recorded = Path(hwi[-1]).with_suffix(".argv.json")
+    return json.loads(recorded.read_text())  # type: ignore[no-any-return]
+
+
+def test_the_network_is_the_chain_hwi_is_told(tmp_path: Path) -> None:
+    """`--chain` decides the version bytes of the xpubs that come back.
+
+    So a btclib network name is translated rather than passed on, and the
+    one btclib has and HWI has not — testnet4 — is named rather than sent
+    as a chain the command line would refuse.
+    """
+    for network, chain in (
+        ("mainnet", "main"),
+        ("testnet", "test"),
+        ("regtest", "regtest"),
+    ):
+        hwi = stand_in(tmp_path, {})
+        HwiSigner(FINGERPRINT, executable=hwi, network=network).xpub("m/0")
+        argv = last_argv(hwi)
+        assert argv[argv.index("--chain") + 1] == chain
+
+    with pytest.raises(BTClibValueError, match="unknown network"):
+        HwiSigner(FINGERPRINT, executable=stand_in(tmp_path, {}), network="nosuchnet")
+    with pytest.raises(BTClibValueError, match="no HWI chain for network testnet4"):
+        HwiSigner(
+            FINGERPRINT, executable=stand_in(tmp_path, {}), network="testnet4"
+        ).xpub("m/0")
+
+
+def account_psbt(device: HwiSigner) -> tuple[Psbt, Descriptor]:
+    """Return a psbt spending the first address of the device's account."""
+    receive = export_account(device, "m/84h/0h/0h")[0]
+    prev_out = TxOut(100_000, receive.script_pub_key(0))
+    prev_tx = Tx(vin=[TxIn(OutPoint(b"\x08" * 32, 0))], vout=[prev_out])
+    psbt = Psbt.from_tx(
+        Tx(
+            vin=[TxIn(OutPoint(prev_tx.id, 0))],
+            vout=[TxOut(90_000, prev_out.script_pub_key)],
+        )
+    )
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    return receive.update_psbt_input(psbt, 0, 0), receive
+
+
+def test_a_psbt_goes_out_and_comes_back_checked(hwi: list[str]) -> None:
+    """The whole exchange, with the checks of `psbt_signer` over it.
+
+    The stand-in signs with the same key the account was exported from, so
+    what comes back is what a device would send: `request_signatures` then
+    holds it to the psbt that went out before combining.
+    """
+    device = signer(hwi)
+    psbt, _ = account_psbt(device)
+
+    signed = request_signatures(device, psbt)
+    assert signed.inputs[0].partial_sigs
+    assert not psbt.inputs[0].partial_sigs
+
+
+def test_an_answer_that_changed_the_transaction_is_refused(tmp_path: Path) -> None:
+    """The adapter parses and does not judge; `request_signatures` judges.
+
+    A device answering with a psbt of another transaction is caught there,
+    which is why the adapter hands back what it was given rather than
+    checking it twice in two places.
+    """
+    device = signer(stand_in(tmp_path, {}))
+    psbt, receive = account_psbt(device)
+
+    elsewhere = Psbt.from_tx(
+        Tx(
+            vin=[TxIn(OutPoint(b"\x09" * 32, 0))],
+            vout=[TxOut(1_000, receive.script_pub_key(0))],
+        )
+    )
+    lying = signer(stand_in(tmp_path, {"signtx": {"psbt": elsewhere.b64encode()}}))
+    with pytest.raises(BTClibValueError, match="the transaction being signed"):
+        request_signatures(lying, psbt)
+
+
+def test_an_address_is_asked_for_at_the_index_it_is_wanted(tmp_path: Path) -> None:
+    """HWI derives a ranged descriptor at index 0, whatever was meant.
+
+    So the descriptor goes out with the index written into it: a caller
+    asking for index 5 and shown index 0 would be told the wrong address
+    is the right one. `psbt_signer.display_address` then compares the
+    answer with what the descriptor describes, which is the check that
+    catches a device disagreeing.
+    """
+    device = signer(stand_in(tmp_path, {}))
+    receive = export_account(device, "m/84h/0h/0h")[0]
+
+    assert display_address(device, receive, 5) == receive.address(5)
+    # what went out is the descriptor of that one script, wildcard gone
+    text = str(at_index(receive, 5))
+    assert text.endswith("/0/5)")
+    assert parse(text).script_pub_key() == receive.script_pub_key(5)
+
+    lying = signer(
+        stand_in(tmp_path, {"displayaddress": {"address": receive.address(0)}})
+    )
+    with pytest.raises(BTClibValueError, match="the signer displayed"):
+        display_address(lying, receive, 5)
+
+
+def test_a_message_signature_is_verified_against_the_address(hwi: list[str]) -> None:
+    """And a message that is not text is one this cannot ask for.
+
+    The command line takes text, so bytes are decoded as utf-8 -- what the
+    device displays and what HWI passes on. Anything else is refused here
+    rather than mangled on the way.
+    """
+    device = signer(hwi)
+    address = export_account(device, "m/44h/0h/0h")[0].address(0)
+    der_path = "m/44h/0h/0h/0/0"
+
+    signature = sign_message(device, b"hello", der_path, address)
+    # `Octets` as everywhere else in btclib: the hex of those bytes is the
+    # same message, and the command line carries the text either way
+    assert sign_message(device, b"hello".hex(), der_path, address) == signature
+    with pytest.raises(BTClibValueError, match="not utf-8"):
+        device.sign_message(b"\xff\xfe", der_path)
+
+
+def test_what_the_subprocess_can_do_wrong(tmp_path: Path) -> None:
+    """Every failure is a SignerError, with HWI's code where there is one.
+
+    Five ways for a command line to fail and one for the device to: an
+    executable that is not there, an answer that is not json, an answer
+    past the limit, a command that prints nothing, and the error object
+    HWI itself returns — the last being the one that carries a number.
+    """
+    with pytest.raises(SignerError, match="cannot run"):
+        enumerate_devices(executable=str(tmp_path / "nowhere"))
+
+    not_json = tmp_path / "not_json.py"
+    not_json.write_text("print('hello')\n", encoding="ascii")
+    with pytest.raises(SignerError, match="did not answer json"):
+        enumerate_devices(executable=[sys.executable, str(not_json)])
+
+    silent = tmp_path / "silent.py"
+    silent.write_text("import sys; sys.stderr.write('boom')\n", encoding="ascii")
+    with pytest.raises(SignerError, match="answered nothing: boom"):
+        enumerate_devices(executable=[sys.executable, str(silent)])
+
+    flood = tmp_path / "flood.py"
+    flood.write_text("print('x' * 100)\n", encoding="ascii")
+    with pytest.raises(SignerError, match="answered more than 10 bytes"):
+        enumerate_devices(executable=[sys.executable, str(flood)], max_output=10)
+
+    slow = tmp_path / "slow.py"
+    slow.write_text("import time; time.sleep(5)\n", encoding="ascii")
+    with pytest.raises(SignerError, match="timed out after"):
+        enumerate_devices(executable=[sys.executable, str(slow)], timeout=0.2)
+
+    # the device said no, which is HWI's ACTION_CANCELED
+    cancelled = stand_in(tmp_path, {"signtx": {"error": "Canceled", "code": -14}})
+    device = signer(cancelled)
+    psbt = account_psbt(signer(stand_in(tmp_path, {})))[0]
+    with pytest.raises(SignerError, match=r"Canceled \(signer error code -14\)") as e:
+        device.sign_psbt(psbt)
+    assert e.value.code == -14
+
+
+def test_an_answer_of_the_wrong_shape_is_a_failure(tmp_path: Path) -> None:
+    """A json object without the field asked for is not an answer."""
+    device = signer(stand_in(tmp_path, {"getxpub": {"nothing": "here"}}))
+    with pytest.raises(SignerError, match="did not answer a xpub"):
+        device.xpub("m/0")
+
+    listed = stand_in(tmp_path, {"enumerate": {"not": "a list"}})
+    with pytest.raises(SignerError, match="did not answer a list"):
+        enumerate_devices(executable=listed)
+
+
+def test_a_closed_signer_runs_nothing(hwi: list[str]) -> None:
+    """A subprocess per command holds nothing open, so closing is a decision.
+
+    Making it refuse afterwards is what gives a caller the same shape as a
+    signer that does hold something, so `contextlib.closing` works over
+    either.
+    """
+    device = signer(hwi)
+    device.close()
+    device.close()
+
+    assert device.master_fingerprint() == bytes.fromhex(FINGERPRINT)
+    with pytest.raises(SignerError, match="the signer is closed"):
+        device.xpub("m/0")
+
+
+def test_an_emulator_is_enumerated_only_when_asked(tmp_path: Path) -> None:
+    """HWI's own `--emulators`, off by default.
+
+    An emulator is a device with no secure element and no owner, so
+    enumerating one without being asked would make a test fixture look
+    like a signer to a caller that did not want one.
+    """
+    hwi = stand_in(tmp_path, {})
+    enumerate_devices(executable=hwi)
+    assert "--emulators" not in last_argv(hwi)
+
+    enumerate_devices(executable=hwi, emulators=True)
+    argv = last_argv(hwi)
+    assert "--emulators" in argv
+    # a global flag, so it goes before the command as HWI's parser wants
+    assert argv.index("--emulators") < argv.index("enumerate")
+
+
+def test_the_defaults_are_the_two_bounds(hwi: list[str]) -> None:
+    """A person pressing a button, and one json object: the two are unlike."""
+    device = signer(hwi)
+    assert device.timeout == DEFAULT_TIMEOUT == 120.0
+    assert device.max_output == DEFAULT_MAX_OUTPUT == 1 << 20
+    # and nothing of hwilib is imported to get any of this
+    assert not [name for name in sys.modules if name.startswith("hwilib")]
+
+
+def test_the_stand_in_is_a_subprocess_and_not_a_mock(hwi: list[str]) -> None:
+    """What is under test is the exchange, so there is a process at the end.
+
+    The stand-in runs as its own interpreter and answers over a pipe: a
+    monkeypatched `subprocess.run` would test the code that builds an
+    argv, and this tests the argv.
+    """
+    completed = subprocess.run(  # noqa: S603
+        [*hwi, "--chain", "main", "enumerate"],
+        capture_output=True,
+        check=True,
+        timeout=DEFAULT_TIMEOUT,
+    )
+    (device,) = json.loads(completed.stdout)
+    assert device["fingerprint"] == FINGERPRINT


### PR DESCRIPTION
Part of #381: the optional HWI adapter, which the issue calls the preferred
first integration.

`btclib.hwi` turns five commands of HWI's JSON CLI — `enumerate`, `getxpub`,
`signtx`, `signmessage`, `displayaddress` — into the contract
`btclib.psbt_signer` defines. `HwiSigner` answers all three protocols, so
everything written against `SoftwareSigner` runs against a device unchanged.

```python
device = HwiSigner("73c5da0a")                    # or none, if only one is plugged in
receive, change = export_account(device, "m/84h/0h/0h")
display_address(device, receive, 5)               # shown, and compared
signed = request_signatures(device, psbt)         # sent, checked, combined
```

## Why it can live in btclib

**Nothing is imported from hwilib and nothing has to be installed.** HWI
declares `hidapi`, `libusb1`, `cbor2`, `pyserial`, `noiseprotocol`, `protobuf`
and vendor libraries, and a narrower Python range than btclib's — a mandatory
dependency on that is what #381's non-goals rule out. An executable named by
the caller is the whole of the runtime requirement, so the import costs `json`
and `subprocess`, and the tests run against a **stand-in** (a script executed as
`[sys.executable, script]`, answering HWI's own shapes) with no HWI present.

The stand-in signs with `SoftwareSigner` over the same key, so what comes back
is a psbt a device could have sent — which is what lets `request_signatures`
actually check something in these tests.

## The security properties #381 lists

- **a device is named by its fingerprint.** Selection is not optional: HWI's
  `--device-type` connects to "the first device of this type enumerated", so
  with two of one vendor which one signs would be a question of enumeration
  order. Passing none enumerates and refuses unless exactly one device is
  usable — naming both fingerprints where there are two, and what was wrong
  with each where there is none — and every command carries `--fingerprint`.
- **timeouts and an output limit.** The timeout bounds a person pressing a
  button (two minutes by default; lower it when signing unattended), the limit
  what is accepted as an answer.
- **no private key leaves.** A psbt has no field for one and a `Descriptor`
  holds none; `psbt_signer.assert_public` is what says so of one built by hand.
- **the answers are checked by `psbt_signer`**, not here: this is the
  transport, and a transport that also decided what to trust would be two
  things.

## Two things that came with it

- **`exceptions.SignerError`**, carrying HWI's own error code — -14 is somebody
  pressing the button that says no, -3 is a cable, -9 is a model that will never
  do it. A caller writing a retry policy needs the number; it is `None` where
  the failure produced none, which is a failure of the exchange rather than of
  the device.
- **`descriptors.at_index`**: the descriptor of one index, with the wildcard
  written into the path (`.../0/*` at 5 → `.../0/5`). HWI derives a ranged
  descriptor at index 0 whatever was meant, so a caller asking to display index
  5 would be shown index 0 and told it was 5. It is Core's `deriveaddresses`
  with the descriptor as its answer rather than the address; `normalized` now
  shares its walker.

## Gates

Merged on the local gates alone; GitHub Actions is degraded.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`: 17506 passed, 100.00%
- `pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce an HWI-based external signer integration and descriptor helper to support hardware wallet signing via Bitcoin Core’s HWI CLI without adding hwilib as a dependency.

New Features:
- Add btclib.hwi module providing an HwiSigner implementation of the PsbtSigner contract over Bitcoin Core HWI’s JSON command line, including device enumeration and fingerprint-based selection.
- Expose descriptors.at_index to materialize a single-index descriptor from a ranged one for use with external signers and address display workflows.
- Introduce SignerError to represent failures from external signers, carrying HWI error codes where available.

Enhancements:
- Refactor descriptor key walking into a reusable mapping helper so normalized and at_index share the same traversal logic.

Documentation:
- Update CHANGELOG with the new btclib.hwi module, SignerError, descriptors.at_index, and the security and dependency properties of the HWI integration.

Tests:
- Add comprehensive tests for the btclib.hwi adapter using a subprocess stand-in, covering device selection, network/chain mapping, PSBT signing, address display, message signing, error handling, and emulator enumeration.
- Add tests for descriptors.at_index, including musig participants and taproot trees, to ensure correct index derivation and script consistency.