### PR TITLE
Slice the last BIP32 field with the length the parse was read at

### DIFF
--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -293,7 +293,10 @@ class BIP32KeyData:
             parent_fingerprint=key_bin[5:9],
             index=int.from_bytes(key_bin[9:13], byteorder="big", signed=False),
             chain_code=key_bin[13:45],
-            key=key_bin[45:78],
+            # the constant the read and the length check above are written
+            # in, rather than a second spelling of it: the offsets are this
+            # field's own, the total is the format's
+            key=key_bin[45:_REQUIRED_LENGTH],
             check_validity=check_validity,
         )
 


### PR DESCRIPTION
`BIP32KeyData.parse` reads `_REQUIRED_LENGTH` octets, refuses anything else
with that same constant, and then slices its last field with `78` written
out again:

```python
key_bin = stream.read(_REQUIRED_LENGTH)
if len(key_bin) != _REQUIRED_LENGTH:
    ...
    key=key_bin[45:78],
```

The three sibling parsers already do it the other way: `ssa.parse` slices at
`ec.p_size`, `bms.parse` at `1 + n_size` and `1 + 2 * n_size`, and
`BlockHeader.parse` at `4 + _HF_LEN` with its last field left open —
`_REQUIRED_LENGTH` there being itself a sum of the field sizes. This is the
one place in btclib where the total length of a format is spelled twice.

**It closes no hole, and that is worth stating.** `key_bin[45:77]` fails 53
tests of `tests/bip32`, and `[45:79]` cannot happen at all, the length check
above having refused anything longer. Nothing here was untested; what
changes is that the two spellings cannot drift apart.

The offsets stay literal. They are the field's own — where the key begins
inside the 78 octets — and deriving them from one another would trade a
number a reader checks against BIP32 for arithmetic they would have to run.

## Where it comes from

Reading the survivors of a mutation session in btclib-libsecp256k1, where
the same shape was **not** harmless. There a size written twice is a
capacity handed to C: the buffer is declared `char[33]` and the capacity
`33` again, so a wrong capacity is absorbed by the library instead of
reaching the caller, and the mutants were unkillable until the second
spelling was derived from the first. Six survivors of that session were that
shape.

That reasoning does not transfer to pure Python — a wrong number lands in
the return value, where a test sees it — which is why this pull request is
one line of code and not a sweep. The two sibling repositories were checked
for the same shape: `bitcoin_core_rpc` has none (its own configuration
records its seven survivors, all equivalent), and in btclib this was the
single instance.

Suite at 17506, `pre-commit run --all-files` green.

## Summary by Sourcery

Enhancements:
- Align BIP32KeyData.parse behavior with other parsers by reusing the shared _REQUIRED_LENGTH constant for slicing the key field, reducing risk of drift between size checks and field slicing.