### PR TITLE
Run the whole flow against a node, opt-in and off by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,36 @@ edit.
 
 ### The public API and the module layout
 
+- **an integration suite, opt-in and off by default** (issue #381), in
+  `tests/integration/`. A unit test can say a signature verifies; only a
+  node can say it relays the transaction that carries it — so the regtest
+  flow runs the whole pure half against `bitcoind` and lets Core decide:
+  `account_descriptors` builds the pair, `core_import` hands it to
+  `importdescriptors`, Core derives the same addresses and pays one,
+  btclib builds the psbt and updates both halves,
+  `psbt_signer.request_signatures` signs it through the contract, and
+  `sendrawtransaction` accepts the result or the test fails. A second
+  test reads the output updater's fields back through `decodepsbt`, which
+  is the interoperability half of that work package.
+
+  Off unless `BTCLIB_INTEGRATION` is set, and skipped with the reason
+  named where the program is missing: these start processes, listen on a
+  socket and write to disk, which is not what `uv run pytest` should do
+  to somebody who asked for the unit suite. The node is the session's
+  own — a data directory under `tmp_path`, an ephemeral port, a cookie —
+  so nothing reaches a node the maintainer is running. `tests/README.md`
+  carries the commands, and `pyproject.toml` leaves the package out of
+  the coverage ratchet: a body that skips itself would be an uncovered
+  line at every commit rather than a defect.
+
+  The HWI tests take a device rather than shipping one. HWI's own suite
+  starts a simulator per device family, each with its binary, image and
+  udev rules, and vendoring that is the surface #381 rules out; so
+  `BTCLIB_HWI` names the executable — `hwi --emulators` reaches an
+  emulator — and `BTCLIB_HWI_SIGN` is the second switch for the one test
+  that needs a person to press a button. Nothing there is destructive:
+  enumerate, an xpub, an address on a screen, a signature.
+
 - **`btclib.hwi` is new: a `PsbtSigner` over Bitcoin Core HWI's JSON
   command line** (issue #381), which is the first integration that issue
   calls for and the one that needs no vendor driver in btclib. Five

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,6 +242,13 @@ addopts = "-ra --durations=8 -n auto --dist worksteal --strict-config --strict-m
 # a test that was expected to fail and passed is a fixed bug still marked
 # as broken: strict turns it red instead of reporting xpass
 xfail_strict = true
+# --strict-markers is on, so a marker is declared here or it is a typo.
+# `integration` is what needs something this repository does not ship: a
+# bitcoind to talk to, an HWI to run. Those tests skip themselves without
+# BTCLIB_INTEGRATION in the environment, so the marker is for selecting
+# them (`-m integration`) and for excluding them from a run that has the
+# variable set for other reasons
+markers = ["integration: needs an external program, opt-in via BTCLIB_INTEGRATION"]
 # a deprecation warning is the early form of a break, emitted years before
 # the removal that will fail the suite: on a 3.10 to 3.14 spread, plus
 # pypy, there is time to act on it only if it is not silent.
@@ -385,7 +392,13 @@ extend-glob = ["electrum_test.py"]
 extend-ignore-re = ['\w*[a-z][A-Z]\w*']
 
 [tool.coverage.run]
-omit = ["*/site-packages/*"]
+# tests/integration is omitted because the ratchet measures what an
+# ordinary run executes, and those tests skip themselves without
+# BTCLIB_INTEGRATION: their bodies would be uncovered lines of tests/ at
+# every commit, which is the ratchet reporting the switch rather than a
+# defect. What covers them is the opt-in run, and the module docstrings
+# carry the command
+omit = ["*/site-packages/*", "tests/integration/*"]
 
 [tool.coverage.report]
 show_missing = true

--- a/tests/README.md
+++ b/tests/README.md
@@ -35,6 +35,41 @@ Finally, the fastest test execution can be accomplished running pytest only
 uv run pytest
 ```
 
+## The integration tests, and why they are off by default
+
+`tests/integration/` is the only part of the suite that needs something
+this repository does not ship: a `bitcoind` to talk to, an `hwi` to run,
+a device to press a button on. Each test skips itself without the switch
+that asks for it, so an ordinary run reports them skipped and says which
+switch was off:
+
+```shell
+BTCLIB_INTEGRATION=1 uv run pytest tests/integration
+```
+
+That runs the regtest flow — btclib exports an account, Core imports it,
+Core pays it, btclib builds and signs the spend, and the node accepts the
+transaction or the test fails. The node is this session's own: a data
+directory under pytest's `tmp_path` and an ephemeral port, so nothing
+reaches a node you are running. Name another binary with
+`BTCLIB_BITCOIND=/path/to/bitcoind`.
+
+The HWI tests need a device as well, and a second switch for the one that
+asks it to sign:
+
+```shell
+BTCLIB_INTEGRATION=1 BTCLIB_HWI=hwi BTCLIB_HWI_SIGN=1 uv run pytest tests/integration
+```
+
+`BTCLIB_HWI` is the executable, split on spaces, so an emulator is
+reached with `BTCLIB_HWI="hwi --emulators"`. Nothing there is
+destructive: enumerate, an xpub, an address on a screen, a signature.
+
+These tests are outside the coverage ratchet, which `pyproject.toml`
+says where it omits them: the ratchet measures what an ordinary run
+executes, and a body that skips itself would be an uncovered line at
+every commit rather than a defect.
+
 ## There is no `slow` marker, and that is a measurement
 
 `addopts` in pyproject.toml passes `--strict-markers`, so a marker has to

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,0 +1,12 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The tests that need something this repository does not ship.
+
+A bitcoind to talk to, an HWI to run, a device to press a button on.
+Each skips itself without `BTCLIB_INTEGRATION` in the environment, and
+the conftest beside this says which switch was off; `pyproject.toml`
+leaves this package out of the coverage ratchet for the same reason.
+"""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,227 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""What the integration tests need, and what makes them skip.
+
+Two switches, and both have to be on. `BTCLIB_INTEGRATION` in the
+environment is the opt-in: these tests start programs, listen on a
+socket and write to disk, which is not what `uv run pytest` should do to
+somebody who asked for the unit suite. The second is the program itself
+-- `bitcoind` here -- because an opt-in that fails for a missing binary
+would report a defect that is not one.
+
+So the ordinary run reports them skipped and says which switch was off,
+and the whole flow is one command:
+
+    BTCLIB_INTEGRATION=1 uv run pytest tests/integration
+
+The node is this session's own: a regtest data directory under pytest's
+tmp_path, an ephemeral port, and a cookie file for the credentials. It
+never touches a node the maintainer is running, which is the reason none
+of the defaults -- port 18443, ~/.bitcoin -- is used.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import time
+from collections.abc import Iterator
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from bitcoin_core_rpc import BitcoinCoreRpcClient
+
+from btclib.amount import sats_from_btc
+from btclib.descriptors import Descriptor, add_checksum, parse
+from btclib.psbt.psbt import Psbt, extract_tx, finalize
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
+
+# how long the node is given to answer its first rpc call: a regtest
+# bitcoind is up in well under a second on any machine that can run this
+# suite, and the wait is a poll rather than a sleep, so this bounds only
+# the failure case
+_STARTUP_TIMEOUT = 30.0
+
+
+def _free_port() -> int:
+    """Return a port nothing is listening on, by letting the OS pick one.
+
+    Bound and closed rather than guessed: a fixed port is what makes two
+    runs of a test suite fight each other, and the maintainer's own
+    regtest node is exactly the kind of thing already on 18443.
+    """
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+@pytest.fixture(scope="session")
+def bitcoind_path() -> str:
+    """Return the bitcoind to run, skipping the whole module without one."""
+    if not os.environ.get("BTCLIB_INTEGRATION"):
+        pytest.skip("set BTCLIB_INTEGRATION=1 to run the integration tests")
+    path = os.environ.get("BTCLIB_BITCOIND") or shutil.which("bitcoind")
+    if path is None:
+        pytest.skip("no bitcoind: name one in BTCLIB_BITCOIND or put it on PATH")
+    return path
+
+
+@pytest.fixture(scope="session")
+def node(
+    bitcoind_path: str, tmp_path_factory: pytest.TempPathFactory
+) -> Iterator[BitcoinCoreRpcClient]:
+    """Yield an rpc client of a regtest node started for this session.
+
+    `-fallbackfee` because a regtest chain has no fee history to estimate
+    from, and Core refuses to fund a transaction without one; the wallet
+    calls here fund nothing, but a caller reading this as a recipe would
+    meet that on the first `walletcreatefundedpsbt`.
+    """
+    datadir = tmp_path_factory.mktemp("regtest")
+    port = _free_port()
+    process = subprocess.Popen(  # noqa: S603
+        [
+            bitcoind_path,
+            "-regtest",
+            f"-datadir={datadir}",
+            f"-rpcport={port}",
+            "-rpcbind=127.0.0.1",
+            "-listen=0",
+            "-fallbackfee=0.0002",
+            # so that `getrawtransaction` answers for a confirmed
+            # transaction of any wallet: what a psbt needs is the previous
+            # transaction whole, and a node without the index answers only
+            # for what is still in its mempool
+            "-txindex=1",
+            "-printtoconsole=0",
+        ],
+    )
+    client = BitcoinCoreRpcClient(
+        f"http://127.0.0.1:{port}", cookie_path=datadir / "regtest" / ".cookie"
+    )
+    try:
+        _wait_for(client, process)
+        yield client
+    finally:
+        process.terminate()
+        process.wait(timeout=_STARTUP_TIMEOUT)
+
+
+def _wait_for(client: BitcoinCoreRpcClient, process: subprocess.Popen[bytes]) -> None:
+    """Poll until the node answers, or fail with what it did instead."""
+    deadline = time.monotonic() + _STARTUP_TIMEOUT
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            pytest.fail(f"bitcoind exited with {process.returncode}")
+        try:
+            client.call("getblockchaininfo")
+        # every failure before the node is up is the same failure: the
+        # cookie file is not written yet, or the socket is not listening
+        except Exception:  # noqa: BLE001
+            time.sleep(0.1)
+        else:
+            return
+    pytest.fail(f"bitcoind did not answer within {_STARTUP_TIMEOUT} s")
+
+
+@pytest.fixture
+def wallets(
+    node: BitcoinCoreRpcClient,
+) -> tuple[BitcoinCoreRpcClient, BitcoinCoreRpcClient]:
+    """Return a client of a funded wallet and one of a watch-only wallet.
+
+    Two, because they are the two halves of what is being tested: the
+    first holds keys and coins and stands for the rest of the world, and
+    the second holds descriptors btclib built and no key at all -- which
+    is what a wallet watching a hardware signer is.
+
+    Named after the moment they were made, so that a session running
+    several tests has no wallet of one still open in another; and
+    `for_wallet` is the client's own way of naming the endpoint, the
+    wallet being a path on the url rather than an argument.
+    """
+    suffix = f"{time.monotonic_ns():x}"
+    miner, watcher = f"miner-{suffix}", f"watch-{suffix}"
+    node.call("createwallet", [miner])
+    # disable_private_keys, which is what makes the second wallet one that
+    # can only watch: it is the third parameter of createwallet
+    node.call("createwallet", [watcher, True])
+    return node.for_wallet(miner), node.for_wallet(watcher)
+
+
+def as_regtest(descriptor: Descriptor) -> Descriptor:
+    """Return the descriptor read again as a regtest one.
+
+    Version bytes cannot say which test chain a key is for -- btclib's
+    four test networks share them, which `bip44` documents where it
+    refuses to guess -- so `account_descriptors` answers with the first,
+    testnet, and its addresses are `tb1`. The scripts are the same
+    scripts; what differs is the human encoding, and regtest spells it
+    `bcrt1`. Reading the text back with the network named is how a caller
+    gets the addresses this node prints.
+    """
+    return parse(add_checksum(str(descriptor)), "regtest")
+
+
+def fund(miner: BitcoinCoreRpcClient, address: str, amount: str = "1.5") -> str:
+    """Mine a spendable balance, pay an address, and confirm the payment.
+
+    101 blocks because a coinbase output is spendable after 100, and the
+    amount is a string because json carries no exact decimal -- the rpc
+    client refuses a `Decimal` rather than rounding one.
+    """
+    miner.call("generatetoaddress", [101, miner.call("getnewaddress")])
+    tx_id = miner.call("sendtoaddress", [address, amount])
+    miner.call("generatetoaddress", [1, miner.call("getnewaddress")])
+    return str(tx_id)
+
+
+def spending_psbt(
+    node: BitcoinCoreRpcClient,
+    utxo: dict[str, Any],
+    receive: Descriptor,
+    change: Descriptor,
+    pay_to: str,
+    fee: int = 1_000,
+) -> Psbt:
+    """Return the psbt spending one utxo: a payment out, and change back.
+
+    Built and updated by btclib alone -- the node is asked for the
+    previous transaction and for nothing else -- so what a signer sees is
+    a psbt no Core call composed.
+    """
+    amount = sats_from_btc(Decimal(str(utxo["amount"])))
+    prev_tx = Tx.parse(node.call("getrawtransaction", [utxo["txid"]]))
+    tx = Tx(
+        vin=[TxIn(OutPoint(bytes.fromhex(str(utxo["txid"])), int(utxo["vout"])))],
+        vout=[
+            TxOut(amount // 2, parse(f"addr({pay_to})", "regtest").script_pub_key()),
+            TxOut(amount - amount // 2 - fee, change.script_pub_key(0)),
+        ],
+    )
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    psbt = receive.update_psbt_input(psbt, 0, 0)
+    return change.update_psbt_output(psbt, 1, 0)
+
+
+def broadcast(node: BitcoinCoreRpcClient, psbt: Psbt) -> str:
+    """Finalize a signed psbt and hand the transaction to the network.
+
+    Which is the oracle these tests are here for: a signature that does
+    not verify, a witness assembled wrong or a fee that is not there are
+    all this call failing.
+    """
+    final = extract_tx(finalize(psbt), check_validity=True)
+    # with the witness, which is the whole point of what was just signed:
+    # `serialize` asks rather than assuming, a txid being the other one
+    raw = final.serialize(include_witness=True).hex()
+    tx_id = str(node.call("sendrawtransaction", [raw]))
+    assert tx_id == final.id.hex()
+    return tx_id

--- a/tests/integration/hwi_device_test.py
+++ b/tests/integration/hwi_device_test.py
@@ -1,0 +1,170 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""`btclib.hwi` against a real HWI, and whatever it is plugged into.
+
+`tests/hwi_test.py` runs the adapter against a stand-in and answers every
+question about the argv, the bounds and the failures. What it cannot
+answer is whether HWI itself accepts what btclib sends: the descriptor
+`displayaddress` is given, the path spelling of `getxpub`, the psbt
+`signtx` reads. That is what this is for, and there is no way to ask it
+without an HWI and a device.
+
+Bring your own, which is what the emulator item of issue #381 comes down
+to: HWI's own suite starts a simulator per device family, each with its
+own binary, image and udev rules, and vendoring that is the "large
+security and maintenance surface unrelated to btclib's Bitcoin
+primitives" the issue rules out. So the switches are two:
+
+    BTCLIB_INTEGRATION=1 BTCLIB_HWI=hwi uv run pytest tests/integration
+
+with `BTCLIB_HWI` naming the executable -- `hwi`, a path, or a command
+with flags of its own, split on spaces, which is how an emulator is
+reached: `hwi --emulators`. Signing is asked for only where
+`BTCLIB_HWI_SIGN` says so, because a device that signs is a device
+somebody is standing in front of, pressing a button.
+
+Nothing here is destructive: enumerate, an xpub, an address on a screen.
+Setup, wipe, restore, backup and the PIN flows are deliberately outside
+this and outside `btclib.hwi` altogether.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from bitcoin_core_rpc import BitcoinCoreRpcClient
+
+from btclib.core_import import account_import_requests
+from btclib.descriptors import at_index
+from btclib.hwi import HwiSigner, enumerate_devices
+from btclib.psbt_signer import (
+    AddressDisplay,
+    PsbtSigner,
+    display_address,
+    export_account,
+    request_signatures,
+)
+from tests.integration.conftest import as_regtest, broadcast, fund, spending_psbt
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="session")
+def hwi_executable() -> list[str]:
+    """Return the HWI to run, skipping without both switches."""
+    if not os.environ.get("BTCLIB_INTEGRATION"):
+        pytest.skip("set BTCLIB_INTEGRATION=1 to run the integration tests")
+    named = os.environ.get("BTCLIB_HWI")
+    if not named:
+        pytest.skip("set BTCLIB_HWI to the hwi executable to run these")
+    return named.split()
+
+
+def _one_device(hwi_executable: list[str], network: str) -> HwiSigner:
+    """Return a signer over the one device HWI can see, or skip.
+
+    The refusal of two devices is `btclib.hwi`'s own and is tested against
+    the stand-in; here a session with two plugged in is one that cannot
+    say which the operator meant, so it skips rather than picking.
+    """
+    devices = enumerate_devices(executable=hwi_executable, network=network)
+    usable = [one for one in devices if one.is_usable]
+    if len(usable) != 1:
+        pytest.skip(f"{len(usable)} usable devices of {len(devices)} enumerated")
+    return HwiSigner(usable[0].fingerprint, executable=hwi_executable, network=network)
+
+
+@pytest.fixture(scope="session")
+def device(hwi_executable: list[str]) -> HwiSigner:
+    """Return a mainnet signer over the device, for the read-only asks."""
+    return _one_device(hwi_executable, "mainnet")
+
+
+@pytest.fixture(scope="session")
+def regtest_device(hwi_executable: list[str]) -> HwiSigner:
+    """Return a regtest signer over the same device, for the spend.
+
+    A separate one because `--chain` is what decides the version bytes of
+    the xpubs HWI answers with, and an account of a chain is not an
+    account of another: the coin type of the path says which, and BIP44
+    gives every test chain 1.
+    """
+    return _one_device(hwi_executable, "regtest")
+
+
+def test_hwi_answers_the_contract(device: HwiSigner) -> None:
+    """The three read-only questions, against whatever is plugged in.
+
+    The fingerprint is what the device was selected by, so what this adds
+    is that HWI accepts the path spelling `getxpub` is given and answers
+    an extended key btclib reads back.
+    """
+    assert isinstance(device, PsbtSigner)
+    assert len(device.master_fingerprint()) == 4
+
+    receive, change = export_account(device, "m/84h/0h/0h")
+    origin = receive.key_expressions[0].origin
+    assert origin is not None
+    assert origin.master_fingerprint == device.master_fingerprint()
+    assert receive.address(0) != change.address(0)
+
+
+def test_the_device_shows_the_address_the_descriptor_describes(
+    device: HwiSigner,
+) -> None:
+    """Somebody has to look at the screen; what this checks is the answer.
+
+    `display_address` compares what HWI returns with what the descriptor
+    describes, so a device deriving another index -- which is what a
+    ranged descriptor would get, HWI applying index 0 to it -- fails here
+    rather than being believed.
+    """
+    if not isinstance(device, AddressDisplay):
+        pytest.skip("this signer does not display addresses")
+    receive = export_account(device, "m/84h/0h/0h")[0]
+
+    for index in (0, 3):
+        shown = display_address(device, receive, index)
+        assert shown == receive.address(index)
+        assert shown == at_index(receive, index).address()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("BTCLIB_HWI_SIGN"),
+    reason="set BTCLIB_HWI_SIGN=1 to ask a device to sign: it needs a button press",
+)
+def test_the_device_signs_what_btclib_built(
+    regtest_device: HwiSigner,
+    node: BitcoinCoreRpcClient,
+    wallets: tuple[BitcoinCoreRpcClient, BitcoinCoreRpcClient],
+) -> None:
+    """The same flow as the software signer's, with a device in its place.
+
+    Which is the whole claim of the contract: `request_signatures` does
+    not know what is at the other end, so the only line that changes is
+    which signer is passed. What this adds is the device -- whether HWI
+    accepts the fields btclib's Updater wrote, and whether the signature
+    that comes back is one the network takes.
+
+    Behind a switch of its own because it needs a person: a device asks
+    before it signs, and nothing here can press the button.
+    """
+    miner, watcher = wallets
+    receive, change = export_account(regtest_device, "m/84h/1h/0h")
+    watcher.call(
+        "importdescriptors",
+        [account_import_requests(receive, change, key_range=(0, 5))],
+    )
+
+    fund(miner, as_regtest(receive).address(0), "0.5")
+    utxo = watcher.call("listunspent", [1, 9999999])[0]
+    psbt = spending_psbt(node, utxo, receive, change, miner.call("getnewaddress"))
+
+    signed = request_signatures(regtest_device, psbt)
+    tx_id = broadcast(node, signed)
+    miner.call("generatetoaddress", [1, miner.call("getnewaddress")])
+    assert node.call("getrawtransaction", [tx_id, True])["confirmations"] == 1

--- a/tests/integration/regtest_test.py
+++ b/tests/integration/regtest_test.py
@@ -1,0 +1,134 @@
+# Copyright (c) The btclib developers
+#
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The whole flow against a real node: btclib builds, Core agrees.
+
+Every part of issue #381's pure half meets its counterparty here, and the
+counterparty is the one that decides:
+
+- `descriptors.account_descriptors` builds the pair, and Bitcoin Core
+  imports it through `core_import.account_import_requests` — so Core's
+  own parser, checksum rule and range handling are what accept it;
+- Core derives the addresses of that account itself and pays one, so the
+  scripts btclib computes are the scripts Core watches;
+- btclib builds the psbt, updates both halves, and
+  `psbt_signer.request_signatures` sends it to a `SoftwareSigner` and
+  checks what comes back;
+- `psbt.finalize` assembles the witness, and the network is the oracle:
+  `sendrawtransaction` accepts it or the test fails.
+
+A unit test can say a signature verifies; only this can say a node
+relays the transaction it is in.
+
+Skipped unless `BTCLIB_INTEGRATION=1` and a `bitcoind` is available; the
+conftest beside this says which switch was off.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from bitcoin_core_rpc import BitcoinCoreRpcClient
+
+from btclib.amount import sats_from_btc
+from btclib.bip32.bip32 import rootxprv_from_seed
+from btclib.core_import import account_import_requests
+from btclib.network import NETWORKS
+from btclib.psbt_signer import SoftwareSigner, export_account, request_signatures
+from tests.integration.conftest import as_regtest, broadcast, fund, spending_psbt
+
+pytestmark = pytest.mark.integration
+
+# regtest keys, so that the coin type of the account path is 1 as BIP44
+# has it for every test chain. The seed is this file's own: a key that
+# signs for coins mined in a directory pytest deletes
+ROOT = rootxprv_from_seed("0f" * 16, NETWORKS["regtest"].bip32_prv)
+ACCOUNT = "m/84h/1h/0h"
+
+
+def test_core_imports_what_btclib_exports_and_relays_what_it_signs(
+    node: BitcoinCoreRpcClient,
+    wallets: tuple[BitcoinCoreRpcClient, BitcoinCoreRpcClient],
+) -> None:
+    """The pure half of issue #381, end to end, with a node as the judge."""
+    miner, watcher = wallets
+    signer = SoftwareSigner(ROOT)
+    receive, change = export_account(signer, ACCOUNT)
+
+    # Core imports the pair, and answers one result per request
+    requests = account_import_requests(receive, change, key_range=(0, 20))
+    results = watcher.call("importdescriptors", [requests])
+    assert [result["success"] for result in results] == [True, True]
+    assert not [result for result in results if result.get("error")]
+
+    # and derives the same addresses from them as btclib does
+    derived = node.call("deriveaddresses", [requests[0]["desc"], [0, 2]])
+    assert derived == [as_regtest(receive).address(index) for index in range(3)]
+
+    # the rest of the world pays the first receiving address
+    paid = fund(miner, as_regtest(receive).address(0))
+
+    # which the watch-only wallet sees, because the descriptor said so
+    unspent = watcher.call("listunspent", [1, 9999999])
+    assert [utxo["txid"] for utxo in unspent] == [paid]
+    utxo = unspent[0]
+    assert utxo["desc"].startswith("wpkh([")
+
+    psbt = spending_psbt(node, utxo, receive, change, miner.call("getnewaddress"))
+    signed = request_signatures(signer, psbt)
+
+    # the network is the oracle: it accepts the transaction or it does not
+    tx_id = broadcast(node, signed)
+    miner.call("generatetoaddress", [1, miner.call("getnewaddress")])
+    assert node.call("getrawtransaction", [tx_id, True])["confirmations"] == 1
+
+    # and the change came back to the wallet, which is what the output
+    # updater's exact match is for: Core recognised it as its own
+    change_utxo = [
+        candidate
+        for candidate in watcher.call("listunspent", [1, 9999999])
+        if candidate["txid"] == tx_id
+    ]
+    assert len(change_utxo) == 1
+    assert change_utxo[0]["address"] == as_regtest(change).address(0)
+    # and Core names the path it came down: the change chain, index zero,
+    # which is the descriptor imported as `internal`
+    assert "/1/0]" in change_utxo[0]["desc"]
+
+
+def test_the_change_output_is_what_the_node_calls_change(
+    node: BitcoinCoreRpcClient,
+    wallets: tuple[BitcoinCoreRpcClient, BitcoinCoreRpcClient],
+) -> None:
+    """`decodepsbt` reads back the fields the output updater wrote.
+
+    Which is the interoperability half of that work package: a key origin
+    written by btclib is one Core reads, and the descriptor it belongs to
+    is the change chain the wallet imported as `internal`.
+    """
+    miner, watcher = wallets
+    signer = SoftwareSigner(ROOT)
+    receive, change = export_account(signer, ACCOUNT)
+    watcher.call(
+        "importdescriptors",
+        [account_import_requests(receive, change, key_range=(0, 5))],
+    )
+
+    fund(miner, as_regtest(receive).address(0), "0.5")
+    utxo = watcher.call("listunspent", [1, 9999999])[0]
+
+    psbt = spending_psbt(node, utxo, receive, change, miner.call("getnewaddress"))
+    decoded = node.call("decodepsbt", [psbt.b64encode()])
+
+    ((origin,),) = [output["bip32_derivs"] for output in decoded["outputs"] if output]
+    assert origin["master_fingerprint"] == signer.master_fingerprint().hex()
+    assert origin["path"] == "m/84h/1h/0h/1/0"
+    assert decoded["outputs"][0] == {}
+
+    # and the amount is what btclib put there, read back by Core
+    assert sats_from_btc(Decimal(str(decoded["tx"]["vout"][1]["value"]))) == (
+        psbt.tx.vout[1].value
+    )


### PR DESCRIPTION
Closes the last box of #381: the integration tests.

A unit test can say a signature verifies; only a node can say it relays the
transaction that carries it. `tests/integration/regtest_test.py` runs the whole
pure half against a real `bitcoind` and lets Core decide every step:

1. `descriptors.account_descriptors` builds the pair;
2. `core_import.account_import_requests` hands it to `importdescriptors` — Core's
   own parser, checksum rule and range handling accept it or not;
3. `deriveaddresses` gives the same addresses btclib computes;
4. Core pays the first receiving address;
5. btclib builds the psbt and updates both halves;
6. `psbt_signer.request_signatures` signs it through the contract and checks the
   answer;
7. `sendrawtransaction` accepts it — or the test fails.

A second test reads the output updater's fields back through `decodepsbt`: the
key origin, the `m/84h/1h/0h/1/0` path, and nothing at all on the payment
output.

**Verified here against bitcoind v31.1.0**: both pass; the three HWI tests skip
for want of a device.

## Two switches, and off by default

```shell
BTCLIB_INTEGRATION=1 uv run pytest tests/integration
```

Nothing runs without it: these start processes, listen on a socket and write to
disk, which is not what `uv run pytest` should do to somebody who asked for the
unit suite. A missing program is a second skip with its own reason, so an opt-in
run never reports a defect that is a missing binary. The node is the session's
own — a data directory under `tmp_path`, an ephemeral port, a cookie file — so
nothing reaches a node the maintainer is running.

The HWI tests **take a device rather than shipping one**. HWI's own suite starts
a simulator per device family, each with its binary, image and udev rules, and
vendoring that is the surface #381's non-goals rule out. `BTCLIB_HWI` names the
executable (split on spaces, so `hwi --emulators` reaches an emulator) and
`BTCLIB_HWI_SIGN` is a second switch for the one test that needs a person to
press a button. Nothing there is destructive: enumerate, an xpub, an address on
a screen, a signature.

## The coverage ratchet

`pyproject.toml` omits `tests/integration/*` and says why: the ratchet measures
what an ordinary run executes, and a body that skips itself would be an
uncovered line at every commit rather than a defect. `tests/README.md` gains the
section with the commands.

One thing the flow made explicit, and the test says it where it does it: version
bytes cannot tell regtest from testnet — btclib's four test networks share them,
which `bip44` documents where it refuses to guess — so `account_descriptors`
answers `tb1` addresses for a regtest key. The scripts are the same; reading the
text back with the network named is how a caller gets the `bcrt1` spelling the
node prints.

## Gates

Merged on the local gates alone; GitHub Actions is degraded.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`: 17506 passed, 5 skipped, 100.00%
- `BTCLIB_INTEGRATION=1 pytest tests/integration`: 2 passed, 3 skipped
- `pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add an opt-in integration test suite that exercises btclib end-to-end against a real bitcoind node and HWI devices, controlled via environment switches.

Enhancements:
- Configure a pytest `integration` marker and adjust coverage settings to exclude integration tests from the coverage ratchet while keeping them selectable by marker.

Documentation:
- Document how to run the new integration tests, their environment switches, and why they are excluded from default runs and coverage.

Tests:
- Introduce pytest-based integration tests that run btclib’s descriptor, PSBT, and signing flow against a regtest bitcoind node.
- Add integration tests that validate btclib’s HWI adapter against real or emulated hardware devices, including optional signing flows guarded by environment flags.