### PR TITLE
Pin the HWI surface btclib depends on, and read the flag it answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2786,6 +2786,34 @@ edit.
 
 ### The public API and the module layout
 
+- **`btclib.hwi` reads `signed`, and the surface it depends on is pinned**
+  (issue #381). Staying aligned with a project btclib does not import is
+  two things, and neither is a copy of it: `tests/hwi_test.py` writes out
+  the surface used — the five commands with their arguments, the three
+  global flags, the answer keys, the four chains, and all eighteen error
+  codes with the names HWI gives them — and `tests/_data/README.md` pins
+  `hwilib/_cli.py` and `hwilib/errors.py` to the revisions they were read
+  from, so the monthly upstream re-check reports a command line that
+  moved. The transcription catches btclib changing what it sends; the pin
+  catches HWI changing what it takes.
+
+  Writing it down caught the first one immediately: `signtx` has answered
+  `{"psbt": …, "signed": …}` since 2021 — HWI's own docstring still says
+  it answers a psbt alone — and `sign_psbt` read the first key only. It
+  now holds the flag to the two strings that crossed the boundary, which
+  is a check only this layer can make: HWI computes `signed` as "what I
+  return is not what I was given", and a device claiming it signed while
+  handing back the psbt it was sent has answered two things that cannot
+  both be true. `psbt_signer.request_signatures` compares psbts and never
+  sees the flag. A device that signed *nothing* is not an error and does
+  not raise: one signer of an m-of-n answers for its own key and no
+  other, which is the answer `psbt.sign` gives by adding nothing.
+
+  `pyproject.toml` gains one identifier for the `typos` hook:
+  `UNKNWON_DEVICE_TYPE` is HWI's own spelling of error code -4, and a
+  transcription that corrects its source is not one — the name a caller
+  reads in HWI's output would be one this repository never mentions.
+
 - **an integration suite, opt-in and off by default** (issue #381), in
   `tests/integration/`. A unit test can say a signature verifies; only a
   node can say it relays the transaction that carries it — so the regtest

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -41,6 +41,14 @@ is parsed rather than what is buffered.
 Failures come back as `exceptions.SignerError`, carrying HWI's own error
 code where there is one: -14 is the user pressing the button that says
 no, -3 is a cable, -9 is a model that will never do it.
+
+Staying aligned with a project this does not import is two things, and
+neither is a copy of it. `tests/hwi_test.py` writes out the surface used
+-- the commands, the flags, the answer keys, the error codes -- and
+`tests/_data/README.md` pins `hwilib/_cli.py` and `hwilib/errors.py` to
+the revisions it was read from, so the monthly upstream re-check reports
+a command line that moved. What that already caught: `signtx` answers
+`signed` beside the psbt, which `sign_psbt` now holds the two strings to.
 """
 
 from __future__ import annotations
@@ -345,11 +353,39 @@ class HwiSigner:
     def sign_psbt(self, psbt: Psbt) -> Psbt:
         """Return what `hwi signtx` answered, parsed and otherwise untouched.
 
-        Untouched deliberately: the answer is checked against the psbt
-        that was sent by `psbt_signer.request_signatures`, which is the
-        caller of this and the one place that comparison belongs.
+        Untouched deliberately: what the answer *contains* is checked
+        against the psbt that was sent by
+        `psbt_signer.request_signatures`, which is the caller of this and
+        the one place that comparison belongs.
+
+        What is checked here is the other thing, and only this layer can:
+        `signtx` answers `signed` beside the psbt -- HWI computes it as
+        "the base64 I return is not the base64 I was given" -- so the flag
+        and the two strings have to agree. A device claiming it signed
+        while handing back what it was sent, or denying it while handing
+        back something else, has answered inconsistently, and the psbt is
+        not the place that shows it: the comparison is over the very
+        strings that crossed the boundary.
+
+        A device that signed nothing is not an error and does not raise.
+        One signer of an m-of-n answers for its own key and for no other,
+        which is the same answer `psbt.sign` gives by adding nothing; what
+        a caller compares is the psbt it gets back.
         """
-        return Psbt.b64decode(self._answer(["signtx", psbt.b64encode()], "psbt"))
+        sent = psbt.b64encode()
+        answer = self._hwi("signtx", sent)
+        if not isinstance(answer, dict) or "psbt" not in answer:
+            raise SignerError(f"hwi signtx did not answer a psbt: {answer!r}")
+        returned = str(answer["psbt"])
+        # absent from HWI before the flag existed, and a caller may be
+        # running one of those: what is not answered is not checked
+        signed = answer.get("signed")
+        if signed is not None and bool(signed) != (returned != sent):
+            err_msg = f"hwi signtx answered signed={signed!r} and a psbt that"
+            err_msg += " was" if returned == sent else " was not"
+            err_msg += " the one it was given"
+            raise SignerError(err_msg)
+        return Psbt.b64decode(returned)
 
     def sign_message(self, message: Octets, der_path: DerPath) -> str:
         """Return the compact signature of a message: HWI's `signmessage`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,6 +351,12 @@ extend-ignore-re = ['[0-9A-Za-z+/]{26,}={0,2}']
 [tool.typos.default.extend-identifiers]
 # BIP342 spells it so, and the x is the placeholder for the opcode number
 OP_SUCCESSx = "OP_SUCCESSx"
+# HWI's own spelling of error code -4, refuse included: tests/hwi_test.py
+# transcribes its error table, and a transcription that corrects its
+# source is not one -- the name a caller reads in HWI's own output would
+# then be one this repository never mentions. Fixed upstream or not, the
+# pinned revision in tests/_data/README.md is what this has to match
+UNKNWON_DEVICE_TYPE = "UNKNWON_DEVICE_TYPE"
 # GitHub Pages' name-with-owner variable, read by the Jekyll layout
 repository_nwo = "repository_nwo"
 

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -856,6 +856,71 @@ with btclib's own messages, and the `musig()` cases of BIP390, which are
 transcribed from the BIP itself above rather than from here. Matched
 against the pinned file on 2026-08-06.
 
+## bitcoin-core/HWI
+
+Nothing is vendored from HWI and nothing is imported from it: `btclib.hwi`
+runs its JSON command line as a subprocess, which is what keeps its
+`hidapi`, `libusb1`, `cbor2`, `pyserial`, `noiseprotocol` and `protobuf`
+out of btclib's dependencies. What is pinned here is therefore not a file
+but an *interface*, and the two entries are the two halves of it: the
+commands and flags a caller sends, and the numbers it gets back.
+
+Which makes these pins do something the others do not. A vector file is
+refreshed or it is not; an interface that moves is code here that stops
+working against the next release somebody installs — so the monthly
+re-check is the alignment, and `tests/hwi_test.py` carries the
+transcription it is checked against.
+
+### Not vendored as a file: the commands and flags of HWI's JSON CLI
+
+```text
+repo    bitcoin-core/HWI
+path    hwilib/_cli.py
+commit  27c1b4272a137af1dfd6f4fd12db2cc9143e0b16  2024-03-30
+pulled  2026-08-07
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **transcribed**, and a subset by design. `tests/hwi_test.py`
+holds the five commands `btclib.hwi` runs — `enumerate`, `getxpub`,
+`signtx`, `signmessage`, `displayaddress` — with the positional arguments
+of each, the three global flags it passes (`--chain`, `--fingerprint`,
+`--emulators`), the `--desc` of `displayaddress`, the four chains
+`--chain` takes, and the keys read out of each answer. The other eleven
+commands are the device lifecycle — setup, wipe, restore, backup, the PIN
+and passphrase flows — which issue #381 keeps out of the signing surface
+deliberately, and `getdescriptors`, `getkeypool` and `getmasterxpub`,
+which btclib computes for itself: `descriptors.account_descriptors` and
+`btclib.core_import` are those three, on btclib's own types.
+
+The parser has moved twice since 2021 and both times additively:
+`--emulators` in 2024 (the pin), `--chain` and `--expert` on enumerate in
+2022. `signtx` gained a second answer key, `signed`, in 2021 — which is
+how this pin earned itself: btclib read only `psbt` until the surface was
+written down, and now checks the two against each other.
+
+### Not vendored as a file: HWI's error codes
+
+```text
+repo    bitcoin-core/HWI
+path    hwilib/errors.py
+commit  b209f369778aae0b441cb096e4afb7a2ea3717b4  2021-02-24
+pulled  2026-08-07
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **transcribed**, complete: all eighteen numbers with the names
+HWI gives them, in `tests/hwi_test.py`, and one test per number that a
+`{"error": …, "code": …}` answer arrives as an `exceptions.SignerError`
+carrying it. The numbers are what a caller acts on — -14 is somebody
+pressing the button that says no, -3 is a cable, -9 is a model that will
+never do it — so an adapter that dropped them would leave a caller
+matching on the text of a message.
+
+The last change to the values was in 2019, and the file has not been
+touched since a docstring pass in 2021: of everything btclib depends on
+here, this is the stillest.
+
 ## bitcoin-core/qa-assets
 
 ### `tests/script/_data/script_assets_test.json`

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -16,12 +16,19 @@ exist for these to run.
 is not how Windows runs anything, and the matrix has a Windows job.
 
 What the stand-in answers is HWI's own shapes, read from its `_cli.py`
-and `errors.py` at commit 5e0fd5e: a list for `enumerate`, `{"xpub": …}`,
-`{"psbt": …}`, `{"signature": …}`, `{"address": …}` for the rest, and
+and `errors.py`: a list for `enumerate`, `{"xpub": …}`, `{"psbt": …,
+"signed": …}`, `{"signature": …}`, `{"address": …}` for the rest, and
 `{"error": …, "code": …}` for a failure. The signing answers are made by
 `psbt_signer.SoftwareSigner`, so the psbt that comes back is one a real
-device could have sent -- which is what lets the checks in
-`psbt_signer` run over it here.
+device could have sent -- which is what lets the checks in `psbt_signer`
+run over it here.
+
+The tables below that transcription is written out in are the other half
+of staying aligned with a project btclib does not import: they say what
+btclib sends and reads, and `tests/_data/README.md` pins the two upstream
+paths they were read from, so the monthly re-check reports a command line
+that moved. The module cites, the README carries the revision -- the same
+split every vendored vector here has.
 """
 
 from __future__ import annotations
@@ -37,6 +44,7 @@ from btclib.bip32.bip32 import derive, xpub_from_xprv
 from btclib.descriptors import Descriptor, at_index, parse
 from btclib.exceptions import BTClibValueError, SignerError
 from btclib.hwi import (
+    _HWI_CHAIN,
     DEFAULT_MAX_OUTPUT,
     DEFAULT_TIMEOUT,
     HwiDevice,
@@ -101,6 +109,67 @@ elif command == "displayaddress":
 else:
     print(json.dumps({{"error": "unknown command " + command, "code": -13}}))
 """
+
+
+# The surface btclib depends on, transcribed from HWI's `_cli.py` and
+# `errors.py`; `tests/_data/README.md` carries the revision each is
+# pinned to, so the monthly upstream re-check reports a path that moved.
+#
+# Written out rather than derived from `btclib.hwi`: a table that read
+# the adapter would agree with it by construction and say nothing. This
+# is the other side of the comparison, and what it catches is btclib
+# changing what it sends -- upstream changing what it takes is what the
+# pin is for, and the two together are the whole of the alignment.
+#
+# Each command with the positional arguments it takes, in order.
+HWI_COMMANDS = {
+    "enumerate": (),
+    "getxpub": ("path",),
+    "signtx": ("psbt",),
+    "signmessage": ("message", "path"),
+    "displayaddress": (),
+}
+
+# the global flags, which HWI's parser takes before the command, and the
+# per-command one btclib passes
+HWI_GLOBAL_FLAGS = ("--chain", "--fingerprint", "--emulators")
+HWI_COMMAND_FLAGS = {"displayaddress": ("--desc",)}
+
+# what btclib reads out of each answer. `signed` is the second key of
+# signtx, added in 2021 and absent from HWI's own docstring for it
+HWI_ANSWER_KEYS = {
+    "getxpub": ("xpub",),
+    "signtx": ("psbt", "signed"),
+    "signmessage": ("signature",),
+    "displayaddress": ("address",),
+}
+
+# the chains `--chain` takes, which is what decides the version bytes of
+# every extended key HWI answers with
+HWI_CHAINS = ("main", "test", "signet", "regtest")
+
+# every error code HWI defines, with the name it gives it: the numbers a
+# caller acts on, and `exceptions.SignerError` carries them through
+HWI_ERROR_CODES = {
+    -1: "NO_DEVICE_TYPE",
+    -2: "MISSING_ARGUMENTS",
+    -3: "DEVICE_CONN_ERROR",
+    -4: "UNKNWON_DEVICE_TYPE",
+    -5: "INVALID_TX",
+    -6: "NO_PASSWORD",
+    -7: "BAD_ARGUMENT",
+    -8: "NOT_IMPLEMENTED",
+    -9: "UNAVAILABLE_ACTION",
+    -10: "DEVICE_ALREADY_INIT",
+    -11: "DEVICE_ALREADY_UNLOCKED",
+    -12: "DEVICE_NOT_READY",
+    -13: "UNKNOWN_ERROR",
+    -14: "ACTION_CANCELED",
+    -15: "DEVICE_BUSY",
+    -16: "NEED_TO_BE_ROOT",
+    -17: "HELP_TEXT",
+    -18: "DEVICE_NOT_INITIALIZED",
+}
 
 
 @pytest.fixture
@@ -443,6 +512,128 @@ def test_the_defaults_are_the_two_bounds(hwi: list[str]) -> None:
     assert device.max_output == DEFAULT_MAX_OUTPUT == 1 << 20
     # and nothing of hwilib is imported to get any of this
     assert not [name for name in sys.modules if name.startswith("hwilib")]
+
+
+def test_btclib_runs_the_commands_hwi_publishes(tmp_path: Path) -> None:
+    """Every command sent is one of the five, spelled as HWI takes it.
+
+    The argv is read back from what crossed the process boundary, so what
+    is compared with the table is what a device would have received: the
+    command name, the positional arguments in order, and the flags of
+    each -- `--desc` being the one that is per-command rather than global.
+    """
+    hwi = stand_in(tmp_path, {})
+    device = signer(hwi)
+    receive = export_account(device, "m/84h/0h/0h")[0]
+
+    ran = {}
+    enumerate_devices(executable=hwi)
+    ran["enumerate"] = last_argv(hwi)
+    device.xpub("m/84h/0h/0h")
+    ran["getxpub"] = last_argv(hwi)
+    device.sign_message(b"hello", "m/84h/0h/0h/0/0")
+    ran["signmessage"] = last_argv(hwi)
+    device.display_address(receive, 0)
+    ran["displayaddress"] = last_argv(hwi)
+
+    for command, argv in ran.items():
+        assert command in HWI_COMMANDS
+        # the global flags come first, as HWI's parser wants them, and
+        # each is one of the three btclib passes
+        flags = [arg for arg in argv[: argv.index(command)] if arg.startswith("-")]
+        assert set(flags) <= set(HWI_GLOBAL_FLAGS)
+        after = argv[argv.index(command) + 1 :]
+        positional = [arg for arg in after if not arg.startswith("-")]
+        command_flags = [arg for arg in after if arg.startswith("-")]
+        assert len(positional) == len(HWI_COMMANDS[command]) + len(command_flags)
+        assert tuple(command_flags) == HWI_COMMAND_FLAGS.get(command, ())
+
+    # and the chain is one of the four HWI names
+    assert set(_HWI_CHAIN.values()) == set(HWI_CHAINS)
+    assert ran["getxpub"][ran["getxpub"].index("--chain") + 1] in HWI_CHAINS
+
+
+def test_btclib_reads_the_keys_hwi_answers_with(tmp_path: Path) -> None:
+    """One key per command, and the refusal names the one that was missing.
+
+    An answer of the right shape with the wrong key is the drift this
+    catches on the btclib side: what the table says is read is what the
+    adapter asks for, and nothing else.
+    """
+    fixed = parse(f"wpkh({xpub_from_xprv(XPRV_ROOT)}/0)")
+    wrong = {"not-a": "key"}
+
+    with pytest.raises(SignerError, match="did not answer a xpub"):
+        signer(stand_in(tmp_path, {"getxpub": wrong})).xpub("m/0")
+    with pytest.raises(SignerError, match="did not answer a signature"):
+        signer(stand_in(tmp_path, {"signmessage": wrong})).sign_message(b"hi", "m/0")
+    with pytest.raises(SignerError, match="did not answer a address"):
+        signer(stand_in(tmp_path, {"displayaddress": wrong})).display_address(fixed)
+    # signtx's two keys are checked where the pair is, `signed` being read
+    # against the psbt rather than on its own
+    assert HWI_ANSWER_KEYS["signtx"] == ("psbt", "signed")
+    assert set(HWI_ANSWER_KEYS) == set(HWI_COMMANDS) - {"enumerate"}
+
+
+def test_signtx_answers_a_psbt_and_whether_it_signed(tmp_path: Path) -> None:
+    """HWI's `signed` is "what I return is not what I was given".
+
+    So it is checked rather than believed: only this layer holds both
+    strings, and a device that claims to have signed while handing back
+    the psbt it was sent has answered two things that cannot both be
+    true. Nothing else in the stack can see it -- `request_signatures`
+    compares psbts and never sees the flag.
+    """
+    device = signer(stand_in(tmp_path, {}))
+    psbt = account_psbt(device)[0]
+    sent = psbt.b64encode()
+
+    # the honest answers: signed with a different psbt, and not signed
+    # with the same one. Neither raises, and an answer with no flag at
+    # all is an older HWI and is not checked
+    for answer in (
+        {"psbt": device.sign_psbt(psbt).b64encode(), "signed": True},
+        {"psbt": sent, "signed": False},
+        {"psbt": sent},
+    ):
+        honest = signer(stand_in(tmp_path, {"signtx": answer}))
+        assert honest.sign_psbt(psbt).b64encode() == answer["psbt"]
+
+    # a device that signed nothing is not an error: one signer of an
+    # m-of-n answers for its own key and for no other
+    unchanged = signer(stand_in(tmp_path, {"signtx": {"psbt": sent, "signed": False}}))
+    assert unchanged.sign_psbt(psbt) == psbt
+
+    for answer, why in (
+        ({"psbt": sent, "signed": True}, "was the one it was given"),
+        (
+            {"psbt": device.sign_psbt(psbt).b64encode(), "signed": False},
+            "was not the one it was given",
+        ),
+    ):
+        lying = signer(stand_in(tmp_path, {"signtx": answer}))
+        with pytest.raises(SignerError, match=why):
+            lying.sign_psbt(psbt)
+
+    with pytest.raises(SignerError, match="did not answer a psbt"):
+        signer(stand_in(tmp_path, {"signtx": {"signed": True}})).sign_psbt(psbt)
+
+
+@pytest.mark.parametrize("code", sorted(HWI_ERROR_CODES))
+def test_every_error_code_arrives_with_its_number(tmp_path: Path, code: int) -> None:
+    """All eighteen, because the number is what a caller acts on.
+
+    -14 is somebody pressing the button that says no and is not worth a
+    retry, -3 is a cable and is worth one, -9 says this model will never
+    do it. An adapter that dropped the number would leave a caller
+    matching on the text of a message, which is what the field spares
+    them.
+    """
+    name = HWI_ERROR_CODES[code]
+    hwi = stand_in(tmp_path, {"enumerate": {"error": name, "code": code}})
+    with pytest.raises(SignerError, match=f"{name} .signer error code {code}") as e:
+        enumerate_devices(executable=hwi)
+    assert e.value.code == code
 
 
 def test_the_stand_in_is_a_subprocess_and_not_a_mock(hwi: list[str]) -> None:


### PR DESCRIPTION
Follows #465. The adapter talks to a project btclib does not import, and nothing
noticed if that project moved — the vectors got the monthly upstream check, the
command line did not.

## Alignment is two things, and neither is a copy

- **`tests/hwi_test.py` writes the surface out**: the five commands with their
  positional arguments, the three global flags, the `--desc` of
  `displayaddress`, the four chains, the keys read out of each answer, and all
  eighteen error codes with the names HWI gives them. Written out rather than
  derived from `btclib.hwi`, so it is the other side of the comparison: a table
  that read the adapter would agree with it by construction and say nothing.
- **`tests/_data/README.md` pins `hwilib/_cli.py` and `hwilib/errors.py`** to
  the revisions they were read from, so `check_vendored_vectors.py` reports a
  path that moved. Both are at upstream's tip today (`27c1b427`, 2024-03-30;
  `b209f369`, 2021-02-24) and the run confirms it.

The transcription catches btclib changing what it sends; the pin catches HWI
changing what it takes.

## What writing it down caught immediately

`signtx` has answered `{"psbt": …, "signed": …}` since 2021 — HWI's own
docstring for it still says it answers a psbt alone — and `sign_psbt` read the
first key only.

It is now a check, not information: HWI computes `signed` as "what I return is
not what I was given", so `sign_psbt` holds the flag to the two base64 strings
that actually crossed the boundary. A device claiming it signed while handing
back the psbt it was sent, or denying it while handing back something else, has
answered two things that cannot both be true — and only this layer can see it,
`request_signatures` comparing psbts and never seeing the flag. An older HWI
that answers no flag is not checked.

A device that signed **nothing** is not an error and does not raise: one signer
of an m-of-n answers for its own key and no other, which is the answer
`psbt.sign` gives by adding nothing.

## One line of configuration

`pyproject.toml` teaches the `typos` hook the identifier `UNKNWON_DEVICE_TYPE`
— HWI's own spelling of error code -4. The hook had "corrected" it in place; a
transcription that corrects its source is not one, and the name a caller reads
in HWI's output would be one this repository never mentions.

## Gates

Merged on the local gates alone; GitHub Actions is degraded.

- `pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests`: 17527 passed, 5 skipped, 100.00%
- `pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded
- `check_vendored_vectors.py`: every checked pin still at upstream's tip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align btclib’s HWI adapter with HWI’s current JSON CLI surface and tighten verification of signing responses.

Bug Fixes:
- Ensure `sign_psbt` validates HWI’s `signed` flag against the sent and returned PSBTs, raising when they disagree or no PSBT is returned.

Enhancements:
- Document and pin the HWI CLI and error-code interface in tests and data README so changes upstream are detected by the existing re-check process.
- Add explicit test coverage that btclib only uses HWI’s published commands, flags, answer keys, chains, and error codes, and that error codes are preserved on failures.
- Teach the spelling `UNKNWON_DEVICE_TYPE` to the typos hook so HWI’s error code name can be transcribed verbatim without being auto-corrected.

Documentation:
- Extend `tests/_data/README.md` and `btclib.hwi` docs to describe the pinned HWI interface and its role in keeping the adapter aligned with upstream.

Tests:
- Add tests that capture the exact HWI command/flag surface btclib uses, the keys read from responses (including `signtx`’s `signed`), the allowed chains, and all defined error codes.