### PR TITLE
Sign and verify a BIP340 message of any size in libsecp256k1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,35 @@ edit.
 
 ### Security
 
+- **A BIP340 message of any size is signed and verified by libsecp256k1**,
+  where every size but 32 had been taking the Python arithmetic that
+  `SECURITY.md` publishes as not constant time. The size was one of three
+  conditions on the dispatch in `ecc.ssa.sign_` and `ecc.ssa.verify_`, and
+  the comment beside it said why: the bindings answer "the message hash
+  must be 32 bytes", measured on 0.7.1rc1. That is `ssa.sign`. Beside it
+  `ssa.sign_custom` takes BIP340's message of any size — it has been in
+  the bindings since 0.7.1, which is the floor `pyproject.toml` already
+  declares — and `ssa.verify` had never had the restriction at all: what
+  sent issue 169's four arbitrary-size vectors down the Python path was
+  the gate in front of the call, not the call. Both gates are gone, and
+  the secret-bearing half of the pair is what this buys: signing a message
+  of 0, 1, 17 or 100 octets no longer multiplies in Python.
+  No answer changes, which is the whole of the risk and was measured
+  rather than argued: over BIP340's own nineteen vectors the two
+  implementations produce the same signature octet for octet and the same
+  verdict, the four arbitrary-size ones included, and over a sweep of 47
+  message lengths from 0 to 4096 with three random keys each, every
+  signature agrees and each verifies under the other implementation.
+  `sign_custom` serves the 32-byte case too, rather than a branch keeping
+  `sign` for it: the two answer the same octets there, and the extraparams
+  struct costs 15.66 us against 15.43 (best of nine, 3000 calls each) of a
+  signature that is 15. A sign-to-contract commitment stays with the
+  Python path, its nonce being tweaked rather than derived.
+  `test_a_message_of_any_size_reaches_the_bindings` records the two calls
+  and asserts the record, because nothing in an answer says which
+  implementation produced it — which is how the gate went unnoticed in the
+  first place; put back, it fails while every assertion about the
+  signatures still passes.
 - **`btclib.fetch` follows no redirect, so an rpc credential reaches one
   host** (issue #358). `urlopen` uses urllib's default opener, whose
   `HTTPRedirectHandler` answered a 30x before this module saw a response,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,12 +39,13 @@ which is the single most important thing to know before touching
   recognized before the call and answered by the Python arithmetic of
   `curves/curve_group.py`, which is what every other curve runs
 - `ecc.dsa.sign` calls them for secp256k1 with sha256, lower-s, and no
-  caller-imposed nonce; `ecc.ssa.sign` for secp256k1 with sha256 **and a
-  32-byte message**. That last clause is issue 169: BIP340 accepts a
-  message of any size and so does btclib, but the bindings still answer
-  "the message hash must be 32 bytes", so any other length takes the
-  Python path — which makes it the only path that can verify four of
-  BIP340's own vectors
+  caller-imposed nonce; `ecc.ssa.sign` for secp256k1 with sha256, a
+  message of **any** size, and no sign-to-contract commitment. The size
+  used to be a third condition, which was issue 169 and the four
+  arbitrary-size vectors BIP340 gained in 2023-04: the bindings'
+  `ssa.sign` takes a 32-byte message, but `ssa.sign_custom` beside it
+  takes any, and `ssa.verify` always did — it was the gate in front of
+  them that sent those four down the Python path
 - the Python path is not dead code and not constant-time: it serves every
   other curve, other hash functions, and caller-supplied nonces, and the
   test suite validates it *against* the bindings, which are the authority

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,8 +70,8 @@ used to teach and to prototype as much as to build:
     zero scalar and the point at infinity excepted — libsecp256k1 has no
     scalar for the one and no public key for the other; `dsa.sign` for
     secp256k1 with sha256, the lower-s form, no caller-imposed nonce and
-    no commitment; `ssa.sign` for secp256k1 with sha256, a 32-byte
-    message and no commitment; `taproot.output_prvkey`,
+    no commitment; `ssa.sign` for secp256k1 with sha256, a message of
+    any size and no commitment; `taproot.output_prvkey`,
     `dh.diffie_hellman` and `commit_nonce.commit_nonce_` for secp256k1,
     the tweaking of a key, the shared point of a key agreement and the
     tweaking of a sign-to-contract nonce being three other places a
@@ -89,8 +89,8 @@ used to teach and to prototype as much as to build:
     Python path — which the test suite reaches by switching the dispatch
     off, and which no caller can.
     Anything else — another
-    curve, another hash function, another message size, a nonce of your
-    own — runs the Python implementation, whose scalar multiplication is
+    curve, another hash function, a nonce of your own — runs the Python
+    implementation, whose scalar multiplication is
     a double-and-add in Jacobian coordinates: it is validated against the
     bindings, which are the authority on the answer, but it is not
     constant-time. It tries, which is not the same claim. The Jacobian

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -381,18 +381,27 @@ def sign_(
     if commit_hash is not None:
         aux = commit_entropy_(aux + bytes_from_octets(commit_hash), _S2C_DATA_TAG, hf)
 
-    # len(msg) == 32 as well as the curve and the hash function: BIP340
-    # takes a message of any size, but the bindings require 32 bytes --
-    # "the message hash must be 32 bytes", measured on 0.7.1rc1 -- so
-    # anything else takes the Python path, which is the pattern already in
-    # place for a caller-supplied nonce and for every other curve.
-    # A commitment joins them: it tweaks the nonce, and the nonce is the
-    # bindings' own to derive
-    if len(msg) == 32 and _libsecp256k1_applicable(ec, hf) and commit_hash is None:
+    # the curve and the hash function decide this, and the size of the
+    # message does not. `libsecp256k1_ssa.sign` is the 32-byte entry point
+    # the length used to gate on -- "the message hash must be 32 bytes",
+    # measured on 0.7.1rc1 -- but `sign_custom` beside it takes BIP340's
+    # message of any size, so every length now reaches the constant-time C
+    # instead of the Python arithmetic SECURITY.md publishes as not being
+    # constant time.
+    #
+    # One call rather than a branch on the length: for a 32-byte message
+    # the two answer the same signature octet for octet, and the
+    # extraparams struct sign_custom fills costs 15.66 us against 15.43
+    # (best of nine, 3000 calls each) -- not a second code path's worth of
+    # a signature that is 15.
+    #
+    # A commitment stays with the Python path: it tweaks the nonce, and
+    # the nonce is the bindings' own to derive
+    if _libsecp256k1_applicable(ec, hf) and commit_hash is None:
         # the bindings take a scalar, not the many representations of a
         # private key btclib accepts
         q = int_from_prv_key(prv_key, ec)
-        return Sig.parse(libsecp256k1_ssa.sign(msg, q, aux))
+        return Sig.parse(libsecp256k1_ssa.sign_custom(msg, q, aux))
 
     # k is the nonce: an integer in the range 1..n-1.
     k, x_K, q, x_Q = bip340_nonce_(msg, prv_key, aux, ec, hf)
@@ -482,12 +491,12 @@ def _assert_as_valid_(c: int, QJ: JacPoint, r: int, s: int, ec: Curve) -> None:
     # Let K = sG - eQ.
     # in Jacobian coordinates, and through the dispatching double_mult of
     # curves.curve rather than the Python arithmetic under it: what
-    # reaches here is the verification the bindings' own declined -- a
-    # message that is not 32 bytes above all, which is issue 169 and four
-    # of BIP340's own vectors -- and on secp256k1 the multiplication is
-    # still theirs, 28 us against 1.02 ms. This whole verification is then
-    # 38 us against 1.17 ms, the two lifts around it -- the r of the
-    # signature and the x-only key -- being theirs as well
+    # reaches here is the verification the bindings' own declined, which
+    # is another curve or another hash function -- the size of the message
+    # was the third of those and is not any more -- and on secp256k1 the
+    # multiplication is still theirs, 28 us against 1.02 ms. This whole
+    # verification is then 38 us against 1.17 ms, the two lifts around it
+    # -- the r of the signature and the x-only key -- being theirs as well
     KJ = _jac_double_mult(ec.n - c, QJ, s, ec.GJ, ec)
 
     # The following check is prescribed by BIP340 but it is useless:
@@ -555,12 +564,12 @@ def assert_as_valid_(
     x_Q, y_Q = point_from_bip340pub_key(Q, sig.ec)
     msg = bytes_from_octets(msg)
 
-    # len(msg) == 32 as well as the curve and the hash function: see sign_.
-    # Reporting a message the bindings cannot take as a *failed
-    # verification* would answer False to four of BIP340's own TRUE
-    # vectors (issue 169), so the length decides which implementation
-    # runs, not whether the answer is no
-    if len(msg) == 32 and _libsecp256k1_applicable(sig.ec, hf):
+    # the curve and the hash function, and not the size of the message:
+    # see sign_. `libsecp256k1_ssa.verify` has always taken BIP340's
+    # message of any size -- what sent the four arbitrary-size vectors of
+    # issue 169 down the Python path was the 32-byte gate in front of it,
+    # never the call itself, and they are verified here now
+    if _libsecp256k1_applicable(sig.ec, hf):
         pubkey_bytes = x_Q.to_bytes(32, "big")
         # check_validity=False, because assert_valid has just run above --
         # on the Sig handed in, or inside the Sig.parse that made one. What

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -168,9 +168,11 @@ repository is LF throughout, which `mixed-line-ending` enforces with
 vectors, all eight columns.
 
 Four of the 19 are messages of 0, 1, 17 and 100 bytes: BIP340 accepts a
-message of any size, the bindings still insist on a 32-byte hash, so
-these four take the Python path (issue 169). All four pass: `verify_`
-accepts each, and `sign_` reproduces each signature byte for byte.
+message of any size, and so do the bindings — `sign_custom` and `verify`
+take one, and the 32-byte gate that used to send these four down the
+Python path (issue 169) is gone. All four pass on either arithmetic:
+`verify_` accepts each, and `sign_` reproduces each signature byte for
+byte.
 
 ### BIP327 (MuSig2): eight files under `tests/ecc/_data/`
 

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -97,7 +97,8 @@ def test_signature() -> None:
         ssa.assert_as_valid_(m_bytes[:31], x_Q, sig)
 
     # and signing it works, giving a signature over those 31 bytes and no
-    # other: the Python path serves it, the bindings taking 32 bytes only
+    # other -- through the bindings, `sign_custom` taking a message of any
+    # size, which is what the length used to gate on
     sig_31 = ssa.sign_(m_bytes[:31], q)
     assert ssa.verify_(m_bytes[:31], x_Q, sig_31)
     assert not ssa.verify_(m_bytes, x_Q, sig_31)
@@ -111,8 +112,9 @@ def bip340_vectors() -> list[Any]:
     """One case per BIP340 vector.
 
     Four of the nineteen are the arbitrary-size messages BIP340 gained in
-    2023-04, of 0, 1, 17 and 100 bytes: only the Python path can serve
-    them, the bindings taking a 32-byte message hash alone (issue 169).
+    2023-04, of 0, 1, 17 and 100 bytes. They were the Python path's alone
+    while a 32-byte gate stood in front of the bindings (issue 169); it
+    is gone, and all nineteen are signed and verified by libsecp256k1.
     """
     return [
         pytest.param(row, id=vector_id(int(row[0]), row[7]))
@@ -296,18 +298,66 @@ def test_low_cardinality() -> None:
                             ssa._assert_as_valid_(e, QJ, r, (s - 1) % ec.n, ec)
 
 
+def test_a_message_of_any_size_reaches_the_bindings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both calls are made whatever the size of the message.
+
+    Nothing in an answer says which implementation produced it, which is
+    how the 32-byte gate in front of the bindings went unnoticed until
+    four of BIP340's own vectors fell through it (issue 169). So the two
+    calls are recorded here and the record is asserted: a gate put back
+    would leave it empty for every size but 32, while every assertion
+    about the signatures still passed.
+
+    31, 32 and 33 are the boundary; 0, 1, 17 and 100 are the sizes of the
+    four vectors themselves.
+
+    Args:
+        monkeypatch: patches the two bindings functions with recorders.
+    """
+    sizes = (0, 1, 17, 31, 32, 33, 100)
+    calls: list[tuple[str, int]] = []
+    real_sign_custom = libsecp256k1_ssa.sign_custom
+    real_verify = libsecp256k1_ssa.verify
+
+    def sign_custom(msg: bytes, prvkey: int, aux: bytes) -> bytes:
+        calls.append(("sign_custom", len(msg)))
+        return real_sign_custom(msg, prvkey, aux)
+
+    def verify(msg: bytes, pubkey: bytes, sig: bytes) -> bool:
+        calls.append(("verify", len(msg)))
+        return real_verify(msg, pubkey, sig)
+
+    monkeypatch.setattr(libsecp256k1_ssa, "sign_custom", sign_custom)
+    monkeypatch.setattr(libsecp256k1_ssa, "verify", verify)
+
+    q, x_Q = ssa.gen_keys(0x1234567890ABCDEF)
+    for size in sizes:
+        msg = bytes(size)
+        sig = ssa.sign_(msg, q)
+        assert ssa.verify_(msg, x_Q, sig)
+
+    assert calls == [
+        (name, size) for size in sizes for name in ("sign_custom", "verify")
+    ]
+
+
 def test_verify_with_a_message_that_is_not_32_bytes_on_both_arithmetics(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Issue 169's path, on both arithmetics.
+    """Issue 169's message, on both arithmetics.
 
-    BIP340 takes a message of any size and so does btclib, while the
-    bindings answer "the message hash must be 32 bytes", so any other
-    length is verified by `_assert_as_valid_` -- the only path that can
-    verify four of BIP340's own vectors. Its multiplication is the
-    bindings' all the same on secp256k1, 183 us against the 1.17 ms of
-    the Python arithmetic, and the two must not disagree about a
-    signature.
+    BIP340 takes a message of any size, and so now does every path here:
+    `sign_custom` and `verify` take one, and the 32-byte gate that used
+    to stand in front of them -- which made `_assert_as_valid_` the only
+    path able to verify four of BIP340's own vectors -- is gone. So this
+    exercises the bindings first and the Python arithmetic second, under
+    `no_bindings`, because the two must not disagree about a signature
+    and only one of them is now reached by default. The Python one is
+    reached in earnest by another curve or another hash function; its
+    multiplication is still the bindings' on secp256k1, 183 us against
+    the 1.17 ms of the arithmetic under it.
     """
     msg = b"a message that is not 32 bytes"
     assert len(msg) != 32


### PR DESCRIPTION
The size of the message was one of three conditions on the dispatch in
`ecc.ssa.sign_` and `ecc.ssa.verify_`, and the comment beside it said
why: the bindings answer *"the message hash must be 32 bytes"*, measured
on 0.7.1rc1.

That is `ssa.sign`. Beside it `ssa.sign_custom` takes BIP340's message of
any size, and `ssa.verify` never had the restriction at all — what sent
issue 169's four arbitrary-size vectors down the Python path was the gate
in front of the call, not the call. Both gates are gone.

Nothing new is required of the bindings: `sign_custom` has been there
since 0.7.1, which is the floor `pyproject.toml` already declares.

## Why it is worth doing

The half that matters is signing. `SECURITY.md` publishes the Python
arithmetic as not constant time, and every BIP340 message that was not
32 octets was being **signed** with it — with the private key in Python
integers. A message of 0, 1, 17 or 100 octets now multiplies in C.

Verification moving over is a speed change, not a safety one, and it is
the same code either way.

## No answer changes, measured rather than argued

Over BIP340's own nineteen vectors, `sign_custom` reproduces the Python
path's signature octet for octet and `verify` agrees on every verdict —
the four arbitrary-size vectors included:

```text
idx len(m) result  sign agrees  verify agrees
 15      0   TRUE  YES          YES
 16      1   TRUE  YES          YES
 17     17   TRUE  YES          YES
 18    100   TRUE  YES          YES
```

Then a sweep past the vectors: 47 message lengths from 0 to 4096, three
random keys each. Every signature agrees, and each verifies under the
other implementation. No disagreements.

## The choices inside it

**One call, not a branch.** `sign_custom` serves the 32-byte case too:
the two answer the same octets there, and the extraparams struct costs
15.66 µs against 15.43 (best of nine, 3000 calls each) of a signature
that is 15 — not a second code path's worth.

**A sign-to-contract commitment stays with the Python path.** Its nonce
is tweaked rather than derived, and the receipt returned beside the
signature is not something the bindings expose.

## The test, because an answer does not say who produced it

`test_a_message_of_any_size_reaches_the_bindings` records the two calls
and asserts the record. That is the point: nothing in a signature says
which implementation made it, which is how a 32-byte gate stood in front
of four published vectors without being noticed. Put the gate back and
the test fails, while every assertion about the signatures still passes —
verified by doing exactly that.

## Prose that had to move with it

Four places said the old thing:

- `SECURITY.md`, in the list of what crosses the boundary, and in the
  "anything else" that follows it — message size is no longer on it
- `CLAUDE.md`'s architecture note
- `tests/_data/README.md`, on the four vectors
- the comment in `_assert_as_valid_` naming what still reaches it:
  another curve or another hash function, the size having been the third

## Verified

`uv run pre-commit run --all-files` exits 0. `sphinx-build -W` exits 0.
Suite 17507 → **17528** after the rebase, 5 skipped.

Coverage is 99.97% both before and after this change — the nine
uncovered lines are in `.github/scripts/mutation_counts.py`, and I
measured `dev` without my commit to be sure the ratchet was already
below 100 rather than pushed there by me. Worth a look on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Route all BIP340 Schnorr message sizes through the constant-time libsecp256k1 bindings instead of gating on 32-byte messages, and update tests and documentation to reflect the new behavior and coverage of the bindings.

Bug Fixes:
- Ensure BIP340 messages of any length are signed and verified via libsecp256k1 instead of falling back to the slower, non-constant-time Python arithmetic when not 32 bytes.

Enhancements:
- Use `libsecp256k1_ssa.sign_custom` as the unified signing entry point for eligible secp256k1/sha256 cases, eliminating a length-based branch while preserving support for sign-to-contract commitments in the Python path.
- Clarify and streamline comments explaining when verification falls back to the Python implementation, now based solely on curve and hash function rather than message size.

Documentation:
- Revise SECURITY, CLAUDE, CHANGELOG, and test data README prose to describe that libsecp256k1 now handles BIP340 messages of any size and that message length no longer controls the dispatch to the Python implementation.

Tests:
- Add a regression test that records libsecp256k1 sign/verify calls across various message lengths to ensure all sizes exercise the bindings, and adjust existing BIP340 vector and mixed-arithmetic tests to reflect the removal of the 32-byte gate.