### PR TITLE
Report a vendored path upstream has deleted, rather than raising on it

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -20,6 +20,10 @@ commit moves it further, `behind`'s own count in the README goes stale
 in a way this script cannot see either, which is the reason it never
 tries to judge relevance, only tip-vs-pinned identity.
 
+A path upstream has renamed or deleted is reported rather than raising:
+it has no commit to name as a tip, and a pin standing on a file that is
+not there any more is the one drift nobody would otherwise notice.
+
 Two shapes in the README this script does not attempt: an entry with no
 `commit` at all (chain data self-identified by hash, files this project
 composed itself, a section heading with no pin of its own), and a path
@@ -85,6 +89,16 @@ class Drift:
     latest_commit: str
     latest_date: str
 
+    @property
+    def path_is_gone(self) -> bool:
+        """True where upstream has no commit touching the pinned path.
+
+        The empty `latest_commit` is what says so: there is no tip to
+        name, `_latest_commit` having answered None. Reading it through
+        a name keeps that encoding in one place.
+        """
+        return not self.latest_commit
+
 
 def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
     """Return the checkable entries, and the headings this skips.
@@ -122,8 +136,17 @@ def _entries_at_tip(readme: str) -> tuple[list[Entry], list[str]]:
     return entries, skipped
 
 
-def _latest_commit(repo: str, path: str) -> tuple[str, str]:
-    """Return the sha and date of the most recent commit touching path."""
+def _latest_commit(repo: str, path: str) -> tuple[str, str] | None:
+    """Return the sha and date of the most recent commit touching path.
+
+    None where upstream has no commit touching it at all, which means the
+    path has been renamed or deleted: the sharpest drift there is, a pin
+    naming a file that is not there any more. This used to unpack one
+    commit out of an empty list and raise `ValueError` instead, so the
+    monthly run went red and `report` was never reached -- no issue
+    opened, on the one kind of drift nobody would otherwise notice, which
+    is what this workflow exists for.
+    """
     result = subprocess.run(  # noqa: S603
         [
             _GH,
@@ -140,7 +163,10 @@ def _latest_commit(repo: str, path: str) -> tuple[str, str]:
         check=True,
         text=True,
     )
-    (commit,) = json.loads(result.stdout)
+    commits = json.loads(result.stdout)
+    if not commits:
+        return None
+    commit = commits[0]
     date: str = commit["commit"]["committer"]["date"][:10]
     sha: str = commit["sha"]
     return sha, date
@@ -151,9 +177,12 @@ def find_drift(readme_path: Path) -> tuple[list[Drift], list[str]]:
     entries, skipped = _entries_at_tip(readme_path.read_text(encoding="utf-8"))
     drifted = []
     for entry in entries:
-        latest_sha, latest_date = _latest_commit(entry.repo, entry.path)
-        if latest_sha != entry.commit:
-            drifted.append(Drift(entry, latest_sha, latest_date))
+        latest = _latest_commit(entry.repo, entry.path)
+        if latest is None:
+            # a path upstream no longer has: drift with no tip to name
+            drifted.append(Drift(entry, "", ""))
+        elif latest[0] != entry.commit:
+            drifted.append(Drift(entry, *latest))
     return drifted, skipped
 
 
@@ -164,6 +193,14 @@ def _issue_body(readme_path: Path, drifted: list[Drift], skipped: list[str]) -> 
         "",
     ]
     for drift in drifted:
+        if drift.path_is_gone:
+            lines.append(
+                f"- **{drift.entry.heading}**: pinned to"
+                f" `{drift.entry.commit[:12]}`, and `{drift.entry.repo}` has no"
+                f" commit touching `{drift.entry.path}` any more -- renamed,"
+                " moved or deleted upstream"
+            )
+            continue
         lines.append(
             f"- **{drift.entry.heading}**: pinned to `{drift.entry.commit[:12]}`,"
             f" upstream's tip of `{drift.entry.path}` is now"
@@ -240,6 +277,13 @@ def main() -> int:
     readme_path = Path(args[0])
     drifted, skipped = find_drift(readme_path)
     for drift in drifted:
+        if drift.path_is_gone:
+            print(
+                f"GONE: {drift.entry.heading} pinned to"
+                f" {drift.entry.commit[:12]}, and {drift.entry.repo} has no"
+                f" commit touching {drift.entry.path} any more"
+            )
+            continue
         print(
             f"BEHIND: {drift.entry.heading} pinned to {drift.entry.commit[:12]},"
             f" tip is {drift.latest_commit[:12]} ({drift.latest_date})"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ edit.
 
 ### Repository
 
+- **The vendored-vector re-checker reports a path upstream has deleted,
+  rather than raising on it.** `repos/{repo}/commits?path=` answers `[]`
+  with a 200 when no commit touches that path any more -- it was renamed,
+  moved or deleted -- and `(commit,) = json.loads(...)` unpacked one
+  commit out of that, raising `ValueError`. `find_drift` went down with
+  it and `report` was never reached: the monthly run turned red and no
+  issue was opened, which is the one outcome the workflow exists to
+  prevent, on the one kind of drift a vendored file nobody re-reads would
+  otherwise hide. `_latest_commit` answers None there now, `Drift`
+  carries a `path_is_gone` that reads the encoding in one place, and the
+  issue body and stdout say `GONE` with the reason rather than naming a
+  tip that does not exist. Three tests hold it, and each fails against
+  the old unpacking.
+
 - **the Bitcoin Core rpc client is a package of its own**, and btclib
   depends on it rather than carrying it. `btclib/bitcoin_core_rpc.py` was
   one standard-library-only source file that a project could copy whole

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -53,15 +53,17 @@ def checker(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
 class FakeGh:
     """A `subprocess.run` stand-in, answering by which `gh` call this is.
 
-    `commits` maps a (repo, path) pair to the sha and date `_latest_commit`
-    should read back; `open_issue` is the number `_open_issue_number`
-    should report open, or None for no issue open. Every call is recorded
-    in `calls`, argv and all, so a test can assert what was asked for
-    rather than only what came back.
+    `commits` maps a (repo, path) pair to the sha and date
+    `_latest_commit` should read back, or to None for a path upstream no
+    longer has -- which the api answers with an empty list rather than an
+    error. `open_issue` is the number `_open_issue_number` should report
+    open, or None for no issue open. Every call is recorded in `calls`,
+    argv and all, so a test can assert what was asked for rather than
+    only what came back.
     """
 
     def __init__(self) -> None:
-        self.commits: dict[tuple[str, str], tuple[str, str]] = {}
+        self.commits: dict[tuple[str, str], tuple[str, str] | None] = {}
         self.open_issue: int | None = None
         self.calls: list[list[str]] = []
 
@@ -73,7 +75,12 @@ class FakeGh:
         if argv[1] == "api":
             repo = argv[4].removeprefix("repos/").removesuffix("/commits")
             path = argv[6].removeprefix("path=")
-            sha, date = self.commits[(repo, path)]
+            answer = self.commits[(repo, path)]
+            # None is what the api answers for a path upstream no longer
+            # has: an empty list, which is a 200 and not an error
+            if answer is None:
+                return subprocess.CompletedProcess(argv, 0, stdout="[]")
+            sha, date = answer
             commit = {
                 "sha": sha,
                 "commit": {"committer": {"date": f"{date}T00:00:00Z"}},
@@ -236,6 +243,81 @@ def test_latest_commit_asks_for_one_commit_touching_the_path(
     assert call[1:5] == ["api", "--method", "GET", "repos/btclib-org/btclib/commits"]
     assert "path=tests/f.json" in call
     assert "per_page=1" in call
+
+
+def test_latest_commit_is_none_when_upstream_has_no_commit_for_the_path(
+    checker: ModuleType, fake_gh: FakeGh
+) -> None:
+    """An empty answer is None, not an unpacking error.
+
+    `repos/{repo}/commits?path=` answers `[]` with a 200 when upstream
+    has no commit touching that path -- it was renamed, moved or deleted.
+    Unpacking one commit out of that raised `ValueError`, which took
+    `find_drift` down with it and left `report` unreached: a red monthly
+    run and no issue, on the one drift a vendored file nobody re-reads
+    would otherwise hide.
+    """
+    fake_gh.commits[("btclib-org/btclib", "tests/gone.json")] = None
+    assert checker._latest_commit("btclib-org/btclib", "tests/gone.json") is None
+
+
+def test_find_drift_reports_a_path_upstream_no_longer_has(
+    checker: ModuleType, fake_gh: FakeGh, tmp_path: Path
+) -> None:
+    """A pin whose path is gone is drift, and says so rather than a tip."""
+    path = tmp_path / "README.md"
+    path.write_text(
+        readme(
+            entry(
+                "`gone.json`",
+                repo="r",
+                path="gone.json",
+                commit="old0000  2020-01-01",
+                behind="0",
+            )
+        ),
+        encoding="utf-8",
+    )
+    fake_gh.commits[("r", "gone.json")] = None
+
+    drifted, skipped = checker.find_drift(path)
+
+    assert skipped == []
+    (drift,) = drifted
+    assert drift.path_is_gone
+    assert (drift.latest_commit, drift.latest_date) == ("", "")
+
+    body = checker._issue_body(path, drifted, [])
+    assert "commit touching `gone.json` any more" in body
+    assert "renamed, moved or deleted upstream" in body
+
+
+def test_main_says_gone_rather_than_behind_for_a_vanished_path(
+    checker: ModuleType,
+    fake_gh: FakeGh,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Stdout distinguishes a moved pin from one whose path is gone."""
+    path = _write_readme(
+        tmp_path,
+        entry(
+            "`gone.json`",
+            repo="r",
+            path="gone.json",
+            commit="old0000  2020-01-01",
+            behind="0",
+        ),
+    )
+    fake_gh.commits[("r", "gone.json")] = None
+    monkeypatch.setattr(sys, "argv", ["prog", str(path), "--dry-run"])
+
+    assert checker.main() == 0
+
+    out = capsys.readouterr().out
+    assert "GONE: `gone.json` pinned to old0000" in out
+    assert "BEHIND" not in out
 
 
 def test_find_drift_tells_moved_pins_from_still_current_ones(


### PR DESCRIPTION
`repos/{repo}/commits?path=` answers `[]` with a **200** when no commit
touches that path any more — renamed, moved or deleted upstream — and
`_latest_commit` unpacked one commit out of that:

```text
a path that still exists:
  ('200f9b26fe0a2f235a2af8b30c4be9f12f6bc9cb', '2023-04-20')
a path upstream has renamed or deleted:
  !! ValueError: not enough values to unpack (expected 1, got 0)
```

The `ValueError` took `find_drift` down with it, so `report` was never
reached: **the monthly run turned red and no issue was opened.**

That is the one outcome this workflow exists to prevent, on the one kind
of drift it exists to catch. Its own comment makes the point: *"a link is
noticed the next time somebody follows it, where a vendored vector is
trusted without anybody looking at it again, and that is exactly what a
monthly issue is for"*. A pin standing on a file that is not there any
more is precisely the thing nobody would notice.

## The change

- `_latest_commit` answers `None` for an empty result instead of
  unpacking it
- `Drift` carries a `path_is_gone` property, so the encoding — an empty
  `latest_commit`, there being no tip to name — is read through a name
  rather than spelled out at each use
- the issue body and stdout say `GONE` with the reason, instead of naming
  a tip that does not exist

## Tests

Three, and `FakeGh` gained the shape that provokes it: a `(repo, path)`
mapped to `None` answers the empty list a real `gh api` would. Each of
the three fails against the old unpacking and passes against this —
verified by reverting the four lines and running them.

`uv run pre-commit run --all-files` exits 0. Suite at **17531**.

## Also on the bindings

`btclib-libsecp256k1`'s copy of this script is the same code, with a
docstring of its own; it gets the same fix in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Handle vendored vector paths that no longer exist upstream without failing the monthly drift check, and report them explicitly as gone.

Bug Fixes:
- Avoid ValueError when querying commits for a path that has been renamed or deleted upstream by treating an empty commit list as no latest commit.

Enhancements:
- Track drift for paths that have disappeared upstream via a dedicated flag, and surface this state in both the generated issue body and CLI output as GONE rather than BEHIND.
- Extend the FakeGh test helper to model GitHub’s empty-commit-list response for missing paths and add tests covering the new drift detection and reporting behavior.

Documentation:
- Document in the changelog and script docstring that deleted or renamed vendored paths are now reported instead of causing the workflow to fail.