### PR TITLE
Say how to call the vendored-vector re-checker when it is not called that way

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -274,6 +274,15 @@ def main() -> int:
     """
     args = [a for a in sys.argv[1:] if a != "--dry-run"]
     dry_run = len(args) != len(sys.argv) - 1
+    if len(args) != 1:
+        # a human running this by hand is the only way here, the workflow
+        # passing the path every time: an IndexError naming a list is
+        # what they used to get
+        print(
+            f"usage: {Path(sys.argv[0]).name} <README path> [--dry-run]",
+            file=sys.stderr,
+        )
+        return 2
     readme_path = Path(args[0])
     drifted, skipped = find_drift(readme_path)
     for drift in drifted:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ edit.
   issue body and stdout say `GONE` with the reason rather than naming a
   tip that does not exist. Three tests hold it, and each fails against
   the old unpacking.
+- **And it says how to be called when it is not.** `Path(args[0])` with
+  no README named answered `IndexError: list index out of range`, about a
+  list the caller never saw; two READMEs named took the first silently.
+  Only a human running the script by hand reaches either, the workflow
+  passing the path every time, which is the whole argument for the
+  message being a usage line rather than a traceback.
 
 - **the Bitcoin Core rpc client is a package of its own**, and btclib
   depends on it rather than carrying it. `btclib/bitcoin_core_rpc.py` was

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -292,6 +292,30 @@ def test_find_drift_reports_a_path_upstream_no_longer_has(
     assert "renamed, moved or deleted upstream" in body
 
 
+@pytest.mark.parametrize("argv", [["prog"], ["prog", "a.md", "b.md"]])
+def test_main_says_how_to_be_called_when_it_is_not(
+    checker: ModuleType,
+    argv: list[str],
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """No README, or two of them, is the usage rather than an IndexError.
+
+    Only a human running this by hand reaches it -- the workflow passes
+    the path every time -- and what they used to get was `IndexError:
+    list index out of range` naming a list they never saw.
+    """
+    monkeypatch.setattr(sys, "argv", argv)
+
+    assert checker.main() == 2
+
+    captured = capsys.readouterr()
+    # argv[0] is what names the program, so the fixture's own "prog" is
+    # what comes back here rather than the script's file name
+    assert captured.err == "usage: prog <README path> [--dry-run]\n"
+    assert captured.out == ""
+
+
 def test_main_says_gone_rather_than_behind_for_a_vanished_path(
     checker: ModuleType,
     fake_gh: FakeGh,


### PR DESCRIPTION
The second half of #471, which merged while this was being written.

`Path(args[0])` with no README named answered `IndexError: list index out
of range` — about a list the caller never saw. Two READMEs named took the
first one silently.

Only a human running the script by hand reaches either: the workflow
passes the path every time. That is the whole argument for the answer
being a usage line on stderr and exit 2 rather than a traceback, and for
it being worth so little code.

```text
usage: check_vendored_vectors.py <README path> [--dry-run]
```

Two parametrized cases hold it — none, and two — and assert stderr and
the empty stdout. `uv run pre-commit run --all-files` exits 0; coverage
is unchanged at 99.97%, the nine uncovered lines being
`.github/scripts/mutation_counts.py`'s and not this script's.

The same guard goes to `btclib-libsecp256k1`, whose copy of the script is
the same code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure the vendored vector checker script provides a clear usage message and exit code when invoked with an invalid number of README arguments.

Bug Fixes:
- Handle missing or multiple README arguments in the vendored vector checker by emitting a usage message instead of raising an IndexError.

Documentation:
- Document the new usage behavior of the vendored vector checker in the changelog.

Tests:
- Add parametrized tests to verify the checker prints usage and exits with code 2 when called with zero or multiple README arguments.