### PR TITLE
Say in SECURITY.md that verification is delegated whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,21 @@ edit.
 
 ### Security
 
+- **`SECURITY.md` says that verification is delegated whole**, where it
+  had named `dsa.sign` and `ssa.sign` and left verification to be
+  inferred from the sentence after -- *"the verification equation of both
+  `dsa` and `ssa` through `double_mult`, so those multiplications are
+  delegated"*, which is about a signature the bindings **decline** and
+  reads, out of that context, as though only the multiplication were ever
+  delegated. It is not: `dsa.verify` and `ssa.verify` are one libsecp256k1
+  call each for secp256k1 with sha256, the first normalizing a high-s
+  signature where the lower-s form is not enforced. Batch verification is
+  the exception and is named as one, libsecp256k1 having no call for it.
+  Found by reading the paragraph and drawing the wrong conclusion from
+  it, then measuring: a recorder in front of both bindings functions says
+  `dsa.verify_` and `ssa.verify_` reach them and `batch_verify_` does
+  not.
+
 - **A BIP340 message of any size is signed and verified by libsecp256k1**,
   where every size but 32 had been taking the Python arithmetic that
   `SECURITY.md` publishes as not constant time. The size was one of three

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -76,6 +76,15 @@ used to teach and to prototype as much as to build:
     the tweaking of a key, the shared point of a key agreement and the
     tweaking of a sign-to-contract nonce being three other places a
     secret meets the curve.
+    Verification crosses it whole, not only in its multiplication:
+    `dsa.verify` and `ssa.verify` are one libsecp256k1 call each for
+    secp256k1 with sha256, a high-s signature being normalized first
+    where the lower-s form is not being enforced. Batch verification is
+    the exception, libsecp256k1 having no call for it, so
+    `ssa.batch_verify` is the Python equation over delegated
+    multiplications. This paragraph is about a secret meeting the curve
+    and verification holds none, which is why it is named here only to
+    say that the sentence below is not about it.
     A signature the bindings decline is not all Python for that:
     `dsa.gen_keys` and the nonce point of `dsa._sign_` go through `mult`,
     and the verification equation of both `dsa` and `ssa` through


### PR DESCRIPTION
**No code changes.** I suggested that `ecc.dsa.verify_` delegated only
its multiplication and should be made to delegate outright, the way #470
did for `ssa`. That was wrong, and this is the residue: the prose that
made it look true.

## What I got wrong, and how

`SECURITY.md`'s paragraph on what crosses the boundary names `dsa.sign`
and `ssa.sign`. Verification is left to be inferred from the sentence
after it:

> A signature the bindings decline is not all Python for that:
> `dsa.gen_keys` and the nonce point of `dsa._sign_` go through `mult`,
> and the verification equation of both `dsa` and `ssa` through
> `double_mult`, so those multiplications are delegated whatever else the
> signature asks for.

In context that is about a signature the bindings **decline**. Out of
context it reads as the general rule — that only the multiplication is
ever delegated — which is the opposite of the truth.

## What is actually true, measured

A recorder in front of both bindings functions:

```text
dsa.verify_       -> ['btclib_libsecp256k1.dsa.verify']
ssa.verify_       -> ['btclib_libsecp256k1.ssa.verify']
ssa.batch_verify_ -> python
```

`dsa.assert_as_valid_` delegates outright for secp256k1 with sha256, and
it is more complete than I credited: it normalizes a high-s signature
first where `lower_s` is not being enforced, so the bindings' refusal of
non-lower-s never leaks out as a failed verification. Batch verification
is the one exception, libsecp256k1 having no batch call.

The paragraph now says so, and says which sentence is not about
verification.

## The other thing checked in the same pass

The `bytes_from_octets(msg_hash, 32)` inside the delegated branch looked
like a bindings restriction leaking out — the shape of issue 169. It is
not: the 32 octets are btclib's own ECDSA rule.

```text
another curve, where the bindings never apply (secp192k1):
  20 bytes !! invalid size: 20 bytes instead of 32
  24 bytes !! invalid size: 24 bytes instead of 32
secp256k1 with the dispatch patched off, i.e. btclib arithmetic:
  20 bytes !! invalid size: 20 bytes instead of 32
  32 bytes -> signed, verify_ True
  48 bytes !! invalid size: 48 bytes instead of 32
```

`sign_` refuses the same lengths where no binding is involved, so there is
nothing asymmetric to close. No change.

## Verified

`uv run pre-commit run --all-files` exits 0. `sphinx-build -W` exits 0.
Suite at 17533.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify security documentation to state that ECDSA and Schnorr verification are fully delegated to libsecp256k1, with batch verification as a documented exception.

Documentation:
- Update SECURITY.md to explain that dsa.verify and ssa.verify delegate whole verification to libsecp256k1, while batch verification remains implemented in Python.
- Document this clarification in the changelog under the Security section.