### PR TITLE
Apply the real and mechanical fixes from issue #445's preview sweep

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -208,8 +208,7 @@ def _issue_body(readme_path: Path, drifted: list[Drift], skipped: list[str]) -> 
             f" `{drift.entry.repo}`"
         )
     if skipped:
-        lines.append("")
-        lines.append("Not checked by this run, for the reason named:")
+        lines.extend(("", "Not checked by this run, for the reason named:"))
         lines.extend(f"- {heading}" for heading in skipped)
     return "\n".join(lines)
 

--- a/.github/scripts/mutation_counts.py
+++ b/.github/scripts/mutation_counts.py
@@ -47,6 +47,7 @@ import sqlite3
 import sys
 from collections import Counter
 from contextlib import closing
+from itertools import starmap
 from pathlib import Path
 
 # `closing` and not `with sqlite3.connect(...)` alone: that context manager
@@ -106,7 +107,7 @@ def counts(session: Path) -> dict[str, int]:
     """Return how many results the session holds, by what happened to them."""
     query = "SELECT test_outcome, worker_outcome FROM work_results"
     with closing(sqlite3.connect(_read_only(session), uri=True)) as db:
-        return Counter(_outcome(*row) for row in db.execute(query))
+        return Counter(starmap(_outcome, db.execute(query)))
 
 
 def enumerated_mutants(session: Path) -> int:

--- a/.github/scripts/mutation_counts.py
+++ b/.github/scripts/mutation_counts.py
@@ -130,7 +130,7 @@ def report(by_outcome: dict[str, int], enumerated: int) -> tuple[str, bool]:
     failed = {
         outcome: count
         for outcome, count in sorted(by_outcome.items())
-        if outcome not in (_KILLED, _SURVIVED, _SKIPPED)
+        if outcome not in {_KILLED, _SURVIVED, _SKIPPED}
     }
 
     line = f"killed {killed}, survived {survived}, skipped {skipped}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ edit.
 
 ### Repository
 
+- **`PLC1901` (compare-to-empty-string) simplifies `x == ""` to
+  `not x`, right wherever `x` is provably `str` and wrong wherever it
+  is not.** `der_path.py`'s, `entropy.py`'s and thirteen test sites'
+  `x` come from `.strip()`, a CSV row, `capsys`, or a return type that
+  is `str` outright, so `not x` there is the same test the same way
+  `RUF031`'s and `RUF039`'s fixes were. Three are not: `bip39.py`'s and
+  `electrum.py`'s `entropy` is `Entropy | None`, a union that also
+  admits `int`, and `int 0` is a value to convert rather than a
+  missing one that only the empty *string* -- not general falsiness
+  -- should read as absent; `bip21_test.py`'s `label` is `str | None`,
+  and the line is the one that tests an explicit empty label against a
+  missing one, the distinction `not label` erases. Commented at each
+  so a future preview run does not silently apply what looks like the
+  same fix as the fourteen beside it.
 - **`base58.py` and `taproot.py`'s two `x = x + y`/`x = x & y` are `+=`
   and `&=` now**, preview's `PLR6104` on the two sites in the tree
   shaped that way; `bytes` and `int` being immutable, an augmented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ edit.
 
 ### Repository
 
+- **Every inline literal tuple or list an `in`/`not in` test compared
+  against is a set literal now**, preview's `PLR6201` on a tree where
+  the sets involved are almost all two or three constants, so what the
+  rule is written to buy -- an O(1) test over an O(n) one -- barely
+  applies; idiom is the whole of the reason. `B033` (already selected,
+  and not a preview rule) caught one set literal a fix produced with a
+  duplicate element, `script_test.py`'s list of disabled op codes
+  carrying `152` twice -- harmless either way for a membership test,
+  and removed since the rule now says so on its own.
 - **The legacy and tapscript interpreter loops moved out of
   `verify_script` and `verify_script_path_vc0`, into a private
   `_run_ops` of their own.** Preview's `PLW0717`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ edit.
 
 ### Repository
 
+- **`base58.py` and `taproot.py`'s two `x = x + y`/`x = x & y` are `+=`
+  and `&=` now**, preview's `PLR6104` on the two sites in the tree
+  shaped that way; `bytes` and `int` being immutable, an augmented
+  assignment rebinds the name exactly as the spelled-out version did.
 - **Four more preview rules, ruff's own safe fix applied and read
   rather than trusted.** `RUF031` drops the parentheses a tuple
   subscript does not need, one file's worth; `RUF039` adds the `r`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ edit.
 
 ### Repository
 
+- **Four more preview rules, ruff's own safe fix applied and read
+  rather than trusted.** `RUF031` drops the parentheses a tuple
+  subscript does not need, one file's worth; `RUF039` adds the `r`
+  prefix a handful of `re.compile` patterns lacked, none of them
+  actually holding a backslash today, which is the gap the prefix
+  closes before one is added without noticing; `FURB140` rewrites a
+  generator of `f(a, b)` pairs as `itertools.starmap(f, pairs)`, and
+  `FURB142` a `for` loop of `set.add` as one `set.update`. Fixed and
+  reformatted, isort included; the suite passes unchanged.
 - **Preview's `FURB113` merges repeated `.append()` calls into one
   `.extend()` -- correct where the appended values do not depend on
   each other, and wrong where they do.** `curve_group.py`'s three

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ edit.
 
 ### Repository
 
+- **Issue #445's preview-rules sweep found four real defects, fixed
+  outright.** A docstring's `µ` (MICRO SIGN) written where `μ` (GREEK
+  SMALL LETTER MU) was meant; `hwi.py`'s two `dict.get(key, False)`
+  fallbacks, redundant since `.get`'s own default, `None`, is already
+  falsy; `descriptors.py`'s sort key, a lambda reimplementing
+  `operator.itemgetter`; and `entropy.py`'s `_dice_sides`, a leading
+  underscore that reads as a discarded value on a tuple the loop right
+  below goes on to use.
 - **The vendored-vector re-checker reports a path upstream has deleted,
   rather than raising on it.** `repos/{repo}/commits?path=` answers `[]`
   with a 200 when no commit touches that path any more -- it was renamed,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ edit.
 
 ### Repository
 
+- **The legacy and tapscript interpreter loops moved out of
+  `verify_script` and `verify_script_path_vc0`, into a private
+  `_run_ops` of their own.** Preview's `PLW0717`
+  (too-many-statements-in-try-clause) named what the `try` around each
+  loop already was, well past the rule's own default -- correctly, for
+  a `try` whose job is turning any refusal from the loop into
+  `ScriptError`, and whose shape is right for that job regardless. The
+  `try` now wraps one call instead: `script_index_ref`, a one-element
+  list the loop writes at the top of every iteration, is how the
+  failing command's index still reaches the `except` that used to read
+  the loop's own local. Both loops' own test suites -- Core's vectors
+  among them -- pass unchanged. `verify_script`'s own `too-many-locals`
+  goes with it, down to what setup and error reporting need; `_run_ops`
+  inherits the dispatch's, which moving it does not shrink and which --
+  `PLR0914` being a preview rule -- cannot carry a `# noqa` the way
+  `PLR0912` does while preview stays off: `RUF100` reads a noqa for a
+  code that cannot fire without `--preview` as unused and removes it.
+  Left as what it is, a rule this codebase cannot yet suppress site by
+  site, unlike its stable sibling.
 - **Issue #445's preview-rules sweep found four real defects, fixed
   outright.** A docstring's `µ` (MICRO SIGN) written where `μ` (GREEK
   SMALL LETTER MU) was meant; `hwi.py`'s two `dict.get(key, False)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ edit.
 
 ### Repository
 
+- **Preview's `FURB113` merges repeated `.append()` calls into one
+  `.extend()` -- correct where the appended values do not depend on
+  each other, and wrong where they do.** `curve_group.py`'s three
+  fixed-window tables are exactly that: each appends `double_jac(...)`
+  and then `add_jac(T[-1], Q)`, the second reading the list's own tail
+  the first just wrote. A tuple literal evaluates both elements before
+  either is appended, so `ruff --unsafe-fixes --fix` applied there
+  reads the *previous* iteration's tail instead -- caught by
+  re-running the suite after applying it everywhere the rule fired,
+  reverted, and commented so a future preview run does not reapply it
+  unnoticed. Seven other sites merge safely and do: none of the merged
+  values reads the list it is about to join. Three more -- `ssa.py`'s
+  two, interleaved with appends to a different list, and
+  `entropy_test.py`'s two, split by a comment describing each -- ruff
+  itself declined to offer a fix for and are left alone, the merge
+  available only by hand and the rule only stylistic.
 - **Every inline literal tuple or list an `in`/`not in` test compared
   against is a set literal now**, preview's `PLR6201` on a tree where
   the sets involved are almost all two or three constants, so what the

--- a/btclib/base58.py
+++ b/btclib/base58.py
@@ -128,7 +128,7 @@ def _b58decode(v: bytes) -> bytes:
     if vlen:
         i = _b58decode_to_int(v)
         nbytes = (i.bit_length() + 7) // 8
-        result = result + i.to_bytes(nbytes, byteorder="big", signed=False)
+        result += i.to_bytes(nbytes, byteorder="big", signed=False)
 
     return result
 

--- a/btclib/bip21.py
+++ b/btclib/bip21.py
@@ -73,7 +73,7 @@ _SAFE = "/:@!$'()*+,;"
 # "label=%25ZZ" -- two URIs meaning one request, with only one of them
 # written, which is the canonical-form rule the binary parsers of this
 # library are held to as well
-_MALFORMED_ESCAPE = re.compile("%(?![0-9A-Fa-f]{2})")
+_MALFORMED_ESCAPE = re.compile(r"%(?![0-9A-Fa-f]{2})")
 
 
 def _network_from_address(address: str) -> str:

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -115,7 +115,7 @@ def _assert_valid_key(version: bytes, key: bytes) -> None:
             # never echo the scalar: it is (attempted) key material
             raise BTClibValueError("invalid private key not in 1..n-1")
     elif version in XPUB_VERSIONS_ALL:
-        if key[0] not in (2, 3):
+        if key[0] not in {2, 3}:
             err_msg = "invalid public key prefix not in (0x02, 0x03): "
             err_msg += f"0x{key[:1].hex()}"
             raise BTClibValueError(err_msg)
@@ -702,7 +702,7 @@ def _derive_from_account(
     if branch > max_index:
         err_msg = f"invalid branch number: {branch} is higher than {max_index}."
         raise BTClibValueError(err_msg)
-    if branches_0_1_only and branch not in (0, 1):
+    if branches_0_1_only and branch not in {0, 1}:
         raise BTClibValueError(f"invalid branch number: {branch} not in (0, 1)")
 
     if address_index >= _HARDENED_OFFSET:
@@ -746,7 +746,7 @@ def crack_prv_key(parent_xpub: BIP32Key, child_xprv: BIP32Key) -> str:
     else:
         p = BIP32KeyData.b58decode(parent_xpub)
 
-    if p.key[0] not in (2, 3):
+    if p.key[0] not in {2, 3}:
         raise BTClibValueError(_err_msg("parent", "not a public", p))
     if isinstance(child_xprv, BIP32KeyData):
         c = child_xprv

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -144,7 +144,7 @@ def _pairs_from_der_path_str(
     if skip_m and not bip380_enforced and steps[0].lower() == "m":
         steps = steps[1:]
     if not bip380_enforced:
-        steps = [s for s in steps if s != ""]
+        steps = [s for s in steps if s]
 
     pairs = [
         _index_and_hardening_from_str(s, bip380_enforced=bip380_enforced) for s in steps

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -53,7 +53,7 @@ _HARDENING = "h"
 # `int` is what the lenient reading uses instead, and it takes "+1", "1_0"
 # and the spaces of "m / 0 h / 0" -- none of them a step a descriptor may
 # carry, and all of them a path this module has always accepted
-_BIP380_INDEX = re.compile("[0-9]+")
+_BIP380_INDEX = re.compile(r"[0-9]+")
 
 # the offset a hardened index carries: BIP32 splits the 2**32 indexes in
 # half at 2**31, so an index is hardened when it reaches this value, and

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -160,7 +160,7 @@ def assert_valid_hd_key_paths(hd_key_paths: Mapping[bytes, BIP32KeyOrigin]) -> N
         # the length and not the point: BIP174 test vector 6 carries a
         # pub_key that is not on the curve, so parsing it here would
         # refuse a psbt the specification calls valid
-        if len(pub_key) not in (78, 33, 65):
+        if len(pub_key) not in {78, 33, 65}:
             err_msg = f"invalid public key length: {len(pub_key)}"
             raise BTClibValueError(err_msg)
         key_origin.assert_valid()

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -687,6 +687,11 @@ def multiples(Q: JacPoint, size: int, ec: CurveGroup) -> list[JacPoint]:
     k, odd = divmod(size, 2)
     T = [INFJ, Q]
     for i in range(3, k * 2, 2):
+        # not T.extend((double_jac(...), add_jac(T[-1], Q))): a tuple
+        # literal evaluates both elements before either is appended, so
+        # T[-1] there would still be the previous iteration's, not the
+        # double_jac just computed -- preview's FURB113 suggests it and
+        # unsafe-fixes applies it without noticing
         T.append(ec.double_jac(T[(i - 1) // 2]))
         T.append(ec.add_jac(T[-1], Q))
 
@@ -708,6 +713,7 @@ def cached_multiples(Q: JacPoint, ec: CurveGroup) -> list[JacPoint]:
     """
     T = [INFJ, Q]
     for i in range(3, 2**MAX_W, 2):
+        # not extend(): multiples() above has why
         T.append(ec.double_jac(T[(i - 1) // 2]))
         T.append(ec.add_jac(T[-1], Q))
     return T
@@ -727,6 +733,7 @@ def cached_multiples_fixwind(
     for _ in range((ec.p_size * 8) // w + 1):
         sublist = [INFJ, K]
         for j in range(3, 2**w, 2):
+            # not extend(): multiples() above has why
             sublist.append(ec.double_jac(sublist[(j - 1) // 2]))
             sublist.append(ec.add_jac(sublist[-1], K))
         K = ec.double_jac(sublist[2 ** (w - 1)])

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -128,7 +128,7 @@ def point_from_octets(
 
     bsize = len(pub_key)  # bytes
     prefix = pub_key[0]
-    if prefix in (0x02, 0x03):  # compressed point
+    if prefix in {0x02, 0x03}:  # compressed point
         if bsize != ec.p_size + 1:
             err_msg = "invalid size for compressed point: "
             err_msg += f"{bsize} instead of {ec.p_size + 1}"
@@ -140,7 +140,7 @@ def point_from_octets(
         except BTClibValueError as e:
             msg = f"invalid x-coordinate: '{hex_string(x_Q)}'"
             raise BTClibValueError(msg) from e
-    elif prefix == 0x04 or (hybrid and prefix in (0x06, 0x07)):  # both coordinates
+    elif prefix == 0x04 or (hybrid and prefix in {0x06, 0x07}):  # both coordinates
         if bsize != 2 * ec.p_size + 1:
             err_msg = "invalid size for uncompressed point: "
             err_msg += f"{bsize} instead of {2 * ec.p_size + 1}"

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -316,12 +316,12 @@ _MAX_MULTI_A_KEYS = 999
 # is what refuses them anywhere a SCRIPT expression is expected
 _TREE_FUNCTIONS = ("multi_a", "sortedmulti_a")
 
-_FINGERPRINT = re.compile("[0-9a-fA-F]{8}")
-_HEX = re.compile("[0-9a-fA-F]*")
-_THRESHOLD = re.compile("[0-9]+")
+_FINGERPRINT = re.compile(r"[0-9a-fA-F]{8}")
+_HEX = re.compile(r"[0-9a-fA-F]*")
+_THRESHOLD = re.compile(r"[0-9]+")
 # the BIP389 multipath step, brackets included: re.split hands back what
 # it split on when the pattern captures it
-_MULTIPATH_STEP = re.compile("(<[^<>]*>)")
+_MULTIPATH_STEP = re.compile(r"(<[^<>]*>)")
 
 
 # what `parse` hands back beside the descriptor, and what expansion takes

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -116,6 +116,7 @@ from this module the way the test suite takes them.
 
 from __future__ import annotations
 
+import operator
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Mapping, Sequence
@@ -569,7 +570,8 @@ class MultiA:
         key written x-only.
         """
         pub_keys = [key.sec(index, network, prv_keys) for key in self.keys]
-        return sorted(pub_keys, key=lambda sec: sec[1:]) if self.sort else pub_keys
+        key_x = operator.itemgetter(slice(1, None))
+        return sorted(pub_keys, key=key_x) if self.sort else pub_keys
 
     def _script(self, index: int, network: str, prv_keys: PrvKeys | None) -> ScriptList:
         """Return the tapscript of BIP387: a CHECKSIG, then CHECKSIGADDs.

--- a/btclib/descriptors.py
+++ b/btclib/descriptors.py
@@ -2096,9 +2096,9 @@ def _pub_key_from_hex(key: str, *, x_only: bool) -> tuple[bytes, bool]:
             raise BTClibValueError(err_msg)
         # the even-y lift of BIP340, which is what an x-only key means
         pub_key = b"\x02" + bytes_from_octets(key)
-    elif length in (66, 130):
+    elif length in {66, 130}:
         prefix = key[:2]
-        if (length == 66 and prefix not in ("02", "03")) or (
+        if (length == 66 and prefix not in {"02", "03"}) or (
             length == 130 and prefix != "04"
         ):
             # 06 and 07 are the hybrid encoding, which nothing in bitcoin
@@ -2194,7 +2194,7 @@ def _assert_key_characters(rest: str) -> None:
 
 def _split_wildcard(steps: list[str]) -> tuple[list[str], int | None, str]:
     """Split the final `/*` step off a path: its offset, and its symbol."""
-    if steps and steps[-1] in ("*", "*'", "*h"):
+    if steps and steps[-1] in {"*", "*'", "*h"}:
         offset = 0 if steps[-1] == "*" else _HARDENED_OFFSET
         return steps[:-1], offset, steps[-1][1:]
     return steps, None, ""
@@ -2406,7 +2406,7 @@ def _parse_tree(expression: str, prv_keys: dict[str, str]) -> DescriptorTree:
 # BIP382 refuses one rather than describing a script nobody can spend;
 # inside tr() the keys are x-only to begin with
 def _no_uncompressed(context: str) -> bool:
-    return context in (_P2WSH, _P2TR)
+    return context in {_P2WSH, _P2TR}
 
 
 def _parse_pk(

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -329,7 +329,7 @@ def xdh(
     """
     ell_a = _ell_from_octets(ell_a, ec)
     ell_b = _ell_from_octets(ell_b, ec)
-    if party not in (0, 1):
+    if party not in {0, 1}:
         err_msg = f"invalid party: {party}, not 0 (A) or 1 (B)"
         raise BTClibValueError(err_msg)
     q = int_from_prv_key(prv_key, ec)

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -197,8 +197,8 @@ def _device(entry: dict[str, Any]) -> HwiDevice:
         model=str(entry.get("model", "")),
         path=str(entry.get("path", "")),
         fingerprint=None if fingerprint is None else bytes_from_octets(fingerprint, 4),
-        needs_pin_sent=bool(entry.get("needs_pin_sent", False)),
-        needs_passphrase_sent=bool(entry.get("needs_passphrase_sent", False)),
+        needs_pin_sent=bool(entry.get("needs_pin_sent")),
+        needs_passphrase_sent=bool(entry.get("needs_passphrase_sent")),
         error=str(entry.get("error", "")),
         code=entry.get("code"),
     )

--- a/btclib/mnemonic/bip39.py
+++ b/btclib/mnemonic/bip39.py
@@ -156,6 +156,8 @@ def mnemonic_from_entropy(entropy: Entropy | None = None, lang: str = "en") -> M
     length; if the integer bit length is longer than the maximum length,
     then only the leftmost bits are retained.
     """
+    # not `not entropy`: entropy can be an int, and int 0 is a value to
+    # convert, not a missing one -- only the empty *string* means that
     if entropy is None or entropy == "":
         entropy = secrets.randbits(128)
     bin_str_entropy, checksum = _entropy_checksum(entropy)

--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -485,6 +485,8 @@ def mnemonic_from_entropy(
 
     int_entropy = (
         _random_int_entropy(lang)
+        # not `not entropy`: entropy can be an int, and int 0 is a value
+        # to search from, not a missing one -- bip39.py's version has why
         if entropy is None or entropy == ""
         else int(bin_str_entropy_from_entropy(entropy), 2)
     )

--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -274,10 +274,10 @@ def _is_old_mnemonic(mnemonic: Mnemonic) -> bool:
     # answer wherever the answer is used, the count there being 12 or 24
     uses_old_words = all(word in _old_word_indexes() for word in words)
     try:
-        is_hex = len(bytes.fromhex(mnemonic)) in (16, 32)
+        is_hex = len(bytes.fromhex(mnemonic)) in {16, 32}
     except ValueError:
         is_hex = False
-    return is_hex or (uses_old_words and len(words) in (12, 24))
+    return is_hex or (uses_old_words and len(words) in {12, 24})
 
 
 def _seed_version(mnemonic: Mnemonic) -> str:
@@ -305,7 +305,7 @@ def _is_bip39_mnemonic(mnemonic: Mnemonic, lang: str) -> bool:
     # electrum answers "checksum invalid" rather than raising for a length
     # outside this set, so the length is a question of its own and not
     # something to read out of an exception
-    if len(words) not in (12, 15, 18, 21, 24):
+    if len(words) not in {12, 15, 18, 21, 24}:
         return False
     try:
         indexes = indexes_from_mnemonic(mnemonic, lang, ELECTRUM_WORDLISTS)

--- a/btclib/mnemonic/entropy.py
+++ b/btclib/mnemonic/entropy.py
@@ -253,9 +253,9 @@ def collect_rolls(bits: int) -> tuple[int, list[int]]:
     """
     automate = False
     dice_sides = 0
-    _dice_sides = (4, 6, 8, 12, 20, 24, 30, 48, 60, 120)
-    while dice_sides not in _dice_sides:
-        msg = f"dice sides {f'{_dice_sides}'[:-1]}"
+    valid_dice_sides = (4, 6, 8, 12, 20, 24, 30, 48, 60, 120)
+    while dice_sides not in valid_dice_sides:
+        msg = f"dice sides {f'{valid_dice_sides}'[:-1]}"
         msg += "; prefix with 'a' to automate rolls, hit enter for 'a6'): "
         dice_sides_str = input(msg)
         dice_sides_str = dice_sides_str.lower()

--- a/btclib/mnemonic/entropy.py
+++ b/btclib/mnemonic/entropy.py
@@ -357,7 +357,7 @@ def bin_str_entropy_from_random(
     - XOR-ed with CSPRNG system entropy
     - possibly hashed (if requested)
     """
-    if entropy is None or entropy == "":
+    if entropy is None or not entropy:
         i = secrets.randbits(bits)
     else:
         if len(entropy) > bits:

--- a/btclib/mnemonic/entropy.py
+++ b/btclib/mnemonic/entropy.py
@@ -259,7 +259,7 @@ def collect_rolls(bits: int) -> tuple[int, list[int]]:
         msg += "; prefix with 'a' to automate rolls, hit enter for 'a6'): "
         dice_sides_str = input(msg)
         dice_sides_str = dice_sides_str.lower()
-        if dice_sides_str in ["", "a"]:
+        if dice_sides_str in {"", "a"}:
             automate = True
             dice_sides = 6
         else:

--- a/btclib/mnemonic/slip39.py
+++ b/btclib/mnemonic/slip39.py
@@ -465,8 +465,9 @@ def _split_secret(
     # the polynomial down
     points = [(i, entropy_source(n)) for i in range(threshold - 2)]
     random_part = entropy_source(n - _DIGEST_BYTES)
-    points.append((_DIGEST_X, _digest(random_part, secret) + random_part))
-    points.append((_SECRET_X, secret))
+    points.extend(
+        ((_DIGEST_X, _digest(random_part, secret) + random_part), (_SECRET_X, secret))
+    )
     shares = [value for _, value in points[: threshold - 2]]
     shares += [_interpolate(points, i) for i in range(threshold - 2, share_count)]
     return shares

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -267,7 +267,7 @@ class Network:
         # NetworkType is a Literal, which is a mypy fact and not a runtime
         # one: from_dict takes whatever the json says, so this is the only
         # place a third network type can be refused
-        if self.network_type not in ("main", "test"):
+        if self.network_type not in {"main", "test"}:
             err_msg = f"invalid network type: {self.network_type!r}"
             raise BTClibValueError(err_msg)
 

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -193,7 +193,7 @@ def _assert_valid_version(version: int) -> None:
     # version btclib does not know": a psbt claiming version 3 is not a
     # psbt of a later BIP, no such BIP being written -- version 1 was
     # skipped and nothing has taken any number since
-    if version not in (PSBT_V0, PSBT_V2):
+    if version not in {PSBT_V0, PSBT_V2}:
         raise BTClibValueError(f"invalid psbt version: {version}")
 
 
@@ -523,7 +523,7 @@ def _signable_payload(psbt_in: PsbtIn) -> bytes:
         script_type, payload = type_and_payload(witness_utxo.script_pub_key.script)
         if script_type == "p2sh":
             script_type, _ = type_and_payload(psbt_in.redeem_script)
-        if script_type not in ("p2wpkh", "p2wsh", "p2tr"):
+        if script_type not in {"p2wpkh", "p2wsh", "p2tr"}:
             raise BTClibValueError("script type not in ('p2wpkh', 'p2wsh', 'p2tr')")
         return payload
 

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -986,9 +986,11 @@ class Psbt:
             # the counts are what tells the parser how many maps follow,
             # so they are written from the maps themselves rather than
             # held as fields that could disagree with them
-            psbt_bin.append(serialize_count(PSBT_GLOBAL_INPUT_COUNT, len(self.inputs)))
-            psbt_bin.append(
-                serialize_count(PSBT_GLOBAL_OUTPUT_COUNT, len(self.outputs))
+            psbt_bin.extend(
+                (
+                    serialize_count(PSBT_GLOBAL_INPUT_COUNT, len(self.inputs)),
+                    serialize_count(PSBT_GLOBAL_OUTPUT_COUNT, len(self.outputs)),
+                )
             )
             if self.tx_modifiable is not None:
                 psbt_bin.append(

--- a/btclib/psbt/psbt_utils.py
+++ b/btclib/psbt/psbt_utils.py
@@ -650,7 +650,7 @@ def assert_valid_taproot_signatures(signatures: list[bytes], what: str) -> None:
         # 63 and 66 bytes are what BIP371's own two invalid vectors carry
         # for each of the two fields, so widening 64 to (64, 65) leaves
         # every one of them rejected
-        if len(signature) not in (64, 65):
+        if len(signature) not in {64, 65}:
             err_msg = f"invalid {what} length: {len(signature)} bytes"
             err_msg += " instead of 64 or 65"
             raise BTClibValueError(err_msg)

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -440,7 +440,7 @@ class SoftwareSigner:
         except BTClibValueError:
             return None
         sec = pub_keyinfo_from_key(derived)[0]
-        if pub_key not in (sec, sec[1:]):
+        if pub_key not in {sec, sec[1:]}:
             return None
         return prv_keyinfo_from_prv_key(derived)[0]
 

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -126,13 +126,13 @@ def check_pub_key(pub_key: bytes, segwit: bool, flags: ScriptFlag) -> bool:
     """
     if not pub_key:
         return False
-    if pub_key[0] in [4, 6, 7]:
-        if pub_key[0] in [6, 7] and ScriptFlag.STRICTENC in flags:
+    if pub_key[0] in {4, 6, 7}:
+        if pub_key[0] in {6, 7} and ScriptFlag.STRICTENC in flags:
             raise BTClibValueError(f"hybrid public key prefix: {hex(pub_key[0])}")
         if segwit and ScriptFlag.WITNESS_PUBKEYTYPE in flags:
             raise BTClibValueError("uncompressed public key in a segwit script")
         return len(pub_key) == 65
-    return len(pub_key) == 33 if pub_key[0] in [2, 3] else False
+    return len(pub_key) == 33 if pub_key[0] in {2, 3} else False
 
 
 def find_and_delete(script: bytes, target: bytes) -> tuple[bytes, int]:

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -465,7 +465,153 @@ OPERATIONS: Mapping[str, ScriptOp] = {
 # what the OPERATIONS table cannot hold, read against Core's EvalScript:
 # the op codes needing the engine's own state, and the pushes matched by
 # shape rather than by name
-def verify_script(  # noqa: C901, PLR0912
+def _run_ops(  # noqa: C901, PLR0912
+    script_bytes: bytes,
+    stack: list[bytes],
+    altstack: list[bytes],
+    condition_stack: list[bool],
+    prevout_value: int,
+    tx: Tx,
+    i: int,
+    flags: ScriptFlag,
+    segwit: bool,
+    precomputed: PrecomputedTxData | None,
+    op_code_stops: list[int],
+    script_index_ref: list[int],
+) -> None:
+    """Run verify_script's opcode dispatch loop.
+
+    Split out of verify_script so that the try/except reporting where a
+    refusal happened wraps one call rather than the loop -- the loop
+    itself is the C901/PLR0912 this carries, the shape Core's own
+    EvalScript has for the same dispatch, and moving it here does not
+    make it smaller. `script_index_ref` is how the failing index still
+    reaches that except: set at the top of every iteration, before
+    anything the iteration does that could raise.
+    """
+    segwit_version = 0 if segwit else -1
+    op_code_num = 0
+    codesep_offset = 0
+    script_index = -1
+    s = bytesio_from_binarydata(script_bytes)
+    while True:
+        script_index += 1
+        script_index_ref[0] = script_index
+
+        script_op_codes.check_stack_size(stack, altstack)
+
+        skip_execution = not all(condition_stack)
+
+        b = s.read(1)
+        if not b:
+            break
+        t = b[0]
+        if 0 < t <= 78:  # pushdata
+            script_op_codes.read_push_data(
+                t, s, stack, skip_execution, flags, serialize_script
+            )
+            continue
+
+        if t > 96:  # OP_16
+            op_code_num = script_op_count(op_code_num, 1)
+
+        check_not_disabled(t)
+
+        if skip_execution and t not in EVALUATED_WHEN_UNEXECUTED:
+            continue
+        op = op_code_name(t)
+
+        if op == "OP_CHECKSIG":
+            pub_key = stack.pop()
+            signature = stack.pop()
+            result = op_checksig(
+                signature,
+                [signature],
+                pub_key,
+                script_bytes,
+                codesep_offset,
+                prevout_value,
+                tx,
+                i,
+                flags,
+                segwit,
+                precomputed,
+            )
+            check_nullfail(flags, result, [signature], "OP_CHECKSIG")
+            stack.append(_from_num(int(result)))
+
+        elif op == "OP_CHECKMULTISIG":
+            # Core's order, and it is the order that makes the two
+            # counts safe to build a `range` out of: each is bounded
+            # before anything is popped with it
+            pub_key_num = _to_num(stack.pop(), flags)
+            check_pub_key_num(pub_key_num)
+            op_code_num = script_op_count(op_code_num, pub_key_num)
+            pub_keys = [stack.pop() for _ in range(pub_key_num)]
+            signature_num = _to_num(stack.pop(), flags)
+            check_signature_num(signature_num, pub_key_num)
+            signatures = [stack.pop() for _ in range(signature_num)]
+
+            check_nulldummy(stack.pop(), flags)  # dummy value
+            signature_index = 0
+            for pub_key_index in range(pub_key_num):
+                if signature_index == signature_num:
+                    break
+                if pub_key_num - pub_key_index < signature_num - signature_index:
+                    break
+                pub_key = pub_keys[pub_key_index]
+                signature = signatures[signature_index]
+                signature_index += op_checksig(
+                    signature,
+                    signatures,
+                    pub_key,
+                    script_bytes,
+                    codesep_offset,
+                    prevout_value,
+                    tx,
+                    i,
+                    flags,
+                    segwit,
+                    precomputed,
+                )
+
+            if signature_index == signature_num:
+                stack.append(b"\x01")
+            else:
+                check_nullfail(flags, False, signatures, "OP_CHECKMULTISIG")
+                stack.append(b"")
+
+        elif op == "OP_CHECKLOCKTIMEVERIFY":
+            script_op_codes.op_checklocktimeverify(stack, tx, i, flags)
+        elif op == "OP_CHECKSEQUENCEVERIFY":
+            script_op_codes.op_checksequenceverify(stack, tx, i, flags)
+        elif op[3:].isdigit():
+            stack.append(_from_num(int(op[3:])))
+        elif op == "OP_CODESEPARATOR":
+            codesep_offset = op_code_stops[script_index]
+        elif op == "OP_IF":
+            script_op_codes.op_if(stack, condition_stack, flags, segwit_version)
+        elif op == "OP_NOTIF":
+            script_op_codes.op_notif(stack, condition_stack, flags, segwit_version)
+        elif op == "OP_ELSE":
+            script_op_codes.op_else(condition_stack)
+        elif op == "OP_ENDIF":
+            script_op_codes.op_endif(condition_stack)
+        elif op == "OP_NOP":
+            pass
+        elif "OP_NOP" in op:
+            script_op_codes.op_nop(flags)
+        elif op in OPERATIONS:
+            r = OPERATIONS[op](stack, altstack, flags)
+            if r:
+                script_index -= len(r)
+                op_code_num -= len(r)
+                s = bytesio_from_binarydata(serialize_script(r) + s.read())
+        else:
+            script_op_codes.unknown_op_code(op)
+
+
+def verify_script(
     script_bytes: bytes,
     stack: list[bytes],
     prevout_value: int,
@@ -493,8 +639,6 @@ def verify_script(  # noqa: C901, PLR0912
     script = parse(script_bytes)
     prepare_script(script, flags, segwit)
 
-    segwit_version = 0 if segwit else -1
-
     # Core's pbegincodehash, an offset into script_bytes and not an index
     # into the parse: a script code is a slice of the script's own bytes,
     # and measuring where to cut it by re-serializing the op codes before
@@ -507,143 +651,38 @@ def verify_script(  # noqa: C901, PLR0912
     # the index is the right one wherever it is read below. Hence this:
     # the byte one past each op code, walked once and only for a script
     # that has a separator to cut at
-    codesep_offset = 0
     op_code_stops = (
         [stop for _, _, stop in op_code_spans(script_bytes)]
         if "OP_CODESEPARATOR" in script
         else []
     )
 
-    script_index = -1
-
     altstack: list[bytes] = []
     condition_stack: list[bool] = [True]
 
-    op_code_num = 0
-
-    s = bytesio_from_binarydata(script_bytes)
+    script_index_ref = [-1]
     try:
-        while True:
-            script_index += 1
-
-            script_op_codes.check_stack_size(stack, altstack)
-
-            skip_execution = not all(condition_stack)
-
-            b = s.read(1)
-            if not b:
-                break
-            t = b[0]
-            if 0 < t <= 78:  # pushdata
-                script_op_codes.read_push_data(
-                    t, s, stack, skip_execution, flags, serialize_script
-                )
-                continue
-
-            if t > 96:  # OP_16
-                op_code_num = script_op_count(op_code_num, 1)
-
-            check_not_disabled(t)
-
-            if skip_execution and t not in EVALUATED_WHEN_UNEXECUTED:
-                continue
-            op = op_code_name(t)
-
-            if op == "OP_CHECKSIG":
-                pub_key = stack.pop()
-                signature = stack.pop()
-                result = op_checksig(
-                    signature,
-                    [signature],
-                    pub_key,
-                    script_bytes,
-                    codesep_offset,
-                    prevout_value,
-                    tx,
-                    i,
-                    flags,
-                    segwit,
-                    precomputed,
-                )
-                check_nullfail(flags, result, [signature], "OP_CHECKSIG")
-                stack.append(_from_num(int(result)))
-
-            elif op == "OP_CHECKMULTISIG":
-                # Core's order, and it is the order that makes the two
-                # counts safe to build a `range` out of: each is bounded
-                # before anything is popped with it
-                pub_key_num = _to_num(stack.pop(), flags)
-                check_pub_key_num(pub_key_num)
-                op_code_num = script_op_count(op_code_num, pub_key_num)
-                pub_keys = [stack.pop() for _ in range(pub_key_num)]
-                signature_num = _to_num(stack.pop(), flags)
-                check_signature_num(signature_num, pub_key_num)
-                signatures = [stack.pop() for _ in range(signature_num)]
-
-                check_nulldummy(stack.pop(), flags)  # dummy value
-                signature_index = 0
-                for pub_key_index in range(pub_key_num):
-                    if signature_index == signature_num:
-                        break
-                    if pub_key_num - pub_key_index < signature_num - signature_index:
-                        break
-                    pub_key = pub_keys[pub_key_index]
-                    signature = signatures[signature_index]
-                    signature_index += op_checksig(
-                        signature,
-                        signatures,
-                        pub_key,
-                        script_bytes,
-                        codesep_offset,
-                        prevout_value,
-                        tx,
-                        i,
-                        flags,
-                        segwit,
-                        precomputed,
-                    )
-
-                if signature_index == signature_num:
-                    stack.append(b"\x01")
-                else:
-                    check_nullfail(flags, False, signatures, "OP_CHECKMULTISIG")
-                    stack.append(b"")
-
-            elif op == "OP_CHECKLOCKTIMEVERIFY":
-                script_op_codes.op_checklocktimeverify(stack, tx, i, flags)
-            elif op == "OP_CHECKSEQUENCEVERIFY":
-                script_op_codes.op_checksequenceverify(stack, tx, i, flags)
-            elif op[3:].isdigit():
-                stack.append(_from_num(int(op[3:])))
-            elif op == "OP_CODESEPARATOR":
-                codesep_offset = op_code_stops[script_index]
-            elif op == "OP_IF":
-                script_op_codes.op_if(stack, condition_stack, flags, segwit_version)
-            elif op == "OP_NOTIF":
-                script_op_codes.op_notif(stack, condition_stack, flags, segwit_version)
-            elif op == "OP_ELSE":
-                script_op_codes.op_else(condition_stack)
-            elif op == "OP_ENDIF":
-                script_op_codes.op_endif(condition_stack)
-            elif op == "OP_NOP":
-                pass
-            elif "OP_NOP" in op:
-                script_op_codes.op_nop(flags)
-            elif op in OPERATIONS:
-                r = OPERATIONS[op](stack, altstack, flags)
-                if r:
-                    script_index -= len(r)
-                    op_code_num -= len(r)
-                    s = bytesio_from_binarydata(serialize_script(r) + s.read())
-            else:
-                script_op_codes.unknown_op_code(op)
+        _run_ops(
+            script_bytes,
+            stack,
+            altstack,
+            condition_stack,
+            prevout_value,
+            tx,
+            i,
+            flags,
+            segwit,
+            precomputed,
+            op_code_stops,
+            script_index_ref,
+        )
     except BTClibValueError as e:
-        raise ScriptError(str(e), script_index, len(stack)) from e
+        raise ScriptError(str(e), script_index_ref[0], len(stack)) from e
     except IndexError as e:
         # what the loop indexes and pops is the stack and the altstack,
         # so an IndexError out of it is an underflow; the chained
         # exception is there for the cases in which it is not
-        raise ScriptError("stack underflow", script_index, len(stack)) from e
+        raise ScriptError("stack underflow", script_index_ref[0], len(stack)) from e
 
     script_op_codes.check_stack_size(stack, altstack)
     script_op_codes.check_balanced_if(condition_stack)

--- a/btclib/script/engine/script_op_codes.py
+++ b/btclib/script/engine/script_op_codes.py
@@ -125,7 +125,7 @@ def _from_num(x: int) -> bytes:
 def _to_bool(element: bytes) -> bool:
     return next(
         (True for x in element[:-1] if x != 0),
-        bool(element and element[-1] not in (0x00, 0x80)),
+        bool(element and element[-1] not in {0x00, 0x80}),
     )
 
 
@@ -259,7 +259,7 @@ def op_if(
     minimalif = segwit_version == 1 or (
         segwit_version == 0 and ScriptFlag.MINIMALIF in flags
     )
-    if minimalif and stack[-1] not in [b"", b"\x01"]:
+    if minimalif and stack[-1] not in {b"", b"\x01"}:
         raise BTClibValueError(f"non-minimal OP_IF condition: {stack[-1].hex()}")
     condition = _to_bool(stack.pop())
 
@@ -284,7 +284,7 @@ def op_notif(
     minimalif = segwit_version == 1 or (
         segwit_version == 0 and ScriptFlag.MINIMALIF in flags
     )
-    if minimalif and stack[-1] not in [b"", b"\x01"]:
+    if minimalif and stack[-1] not in {b"", b"\x01"}:
         raise BTClibValueError(f"non-minimal OP_NOTIF condition: {stack[-1].hex()}")
     condition = _to_bool(stack.pop())
 

--- a/btclib/script/engine/script_op_codes.py
+++ b/btclib/script/engine/script_op_codes.py
@@ -715,18 +715,14 @@ def op_rot(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None
     x3 = stack.pop()
     x2 = stack.pop()
     x1 = stack.pop()
-    stack.append(x2)
-    stack.append(x3)
-    stack.append(x1)
+    stack.extend((x2, x3, x1))
 
 
 def op_tuck(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Insert a copy of the top element below the one under it."""
     x2 = stack.pop()
     x1 = stack.pop()
-    stack.append(x2)
-    stack.append(x1)
-    stack.append(x2)
+    stack.extend((x2, x1, x2))
 
 
 def op_3dup(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -753,12 +749,7 @@ def op_2rot(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> Non
     x3 = stack.pop()
     x2 = stack.pop()
     x1 = stack.pop()
-    stack.append(x3)
-    stack.append(x4)
-    stack.append(x5)
-    stack.append(x6)
-    stack.append(x1)
-    stack.append(x2)
+    stack.extend((x3, x4, x5, x6, x1, x2))
 
 
 def op_2swap(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -232,7 +232,108 @@ OPERATIONS: Mapping[str, ScriptOp] = {
 # what the OPERATIONS table cannot hold, read against Core's tapscript
 # rules: the op codes needing the engine's own state, the sigops budget
 # among it
-def verify_script_path_vc0(  # noqa: C901, PLR0912
+def _run_ops(  # noqa: C901, PLR0912
+    script_bytes: bytes,
+    stack: list[bytes],
+    altstack: list[bytes],
+    condition_stack: list[bool],
+    prevouts: list[TxOut],
+    tx: Tx,
+    i: int,
+    annex: bytes,
+    sigops_budget: int,
+    flags: ScriptFlag,
+    precomputed: PrecomputedTxData | None,
+    script_index_ref: list[int],
+) -> None:
+    """Run verify_script_path_vc0's opcode dispatch loop.
+
+    Split out of verify_script_path_vc0 so that the try/except reporting
+    where a refusal happened wraps one call rather than the loop --
+    script.py's `_run_ops` for the reasoning, shared rather than
+    repeated. `script_index_ref` is how the failing index still reaches
+    that except: set at the top of every iteration, before anything the
+    iteration does that could raise.
+    """
+    codesep_pos = 0xFFFFFFFF
+    script_index = -1
+    s = bytesio_from_binarydata(script_bytes)
+    while True:
+        script_index += 1
+        script_index_ref[0] = script_index
+
+        skip_execution = not all(condition_stack)
+
+        script_op_codes.check_stack_size(stack, altstack)
+
+        b = s.read(1)
+        if not b:
+            break
+        t = b[0]
+        if 0 < t <= 78:  # pushdata
+            script_op_codes.read_push_data(
+                # the element limit is taproot.parse's here, deferred
+                # to the end of the walk so that an OP_SUCCESSx met
+                # first forgives an oversized push, as Core's
+                # pre-scan does. Measured again in the loop it would
+                # refuse what that parse has already forgiven
+                t,
+                s,
+                stack,
+                skip_execution,
+                flags,
+                serialize_script,
+                element_size_limit=None,
+            )
+            continue
+        if skip_execution and t not in EVALUATED_WHEN_UNEXECUTED:
+            continue
+        op = OP_CODE_NAMES[t]
+
+        if op == "OP_CHECKSIG":
+            sigops_budget = op_checksig(
+                stack,
+                script_bytes,
+                codesep_pos,
+                tx,
+                i,
+                prevouts,
+                annex,
+                sigops_budget,
+                flags,
+                precomputed,
+            )
+
+        elif op == "OP_CHECKLOCKTIMEVERIFY":
+            script_op_codes.op_checklocktimeverify(stack, tx, i, flags)
+        elif op == "OP_CHECKSEQUENCEVERIFY":
+            script_op_codes.op_checksequenceverify(stack, tx, i, flags)
+        elif op[3:].isdigit():
+            stack.append(_from_num(int(op[3:])))
+        elif op == "OP_CODESEPARATOR":
+            codesep_pos = script_index
+        elif op == "OP_IF":
+            script_op_codes.op_if(stack, condition_stack, flags, 1)
+        elif op == "OP_NOTIF":
+            script_op_codes.op_notif(stack, condition_stack, flags, 1)
+        elif op == "OP_ELSE":
+            script_op_codes.op_else(condition_stack)
+        elif op == "OP_ENDIF":
+            script_op_codes.op_endif(condition_stack)
+        elif op == "OP_NOP":
+            pass
+        elif "OP_NOP" in op:
+            script_op_codes.op_nop(flags)
+        elif op in OPERATIONS:
+            r = OPERATIONS[op](stack, altstack, flags)
+            if r:
+                script_index -= len(r)
+                s = bytesio_from_binarydata(serialize_script(r) + s.read())
+        else:
+            script_op_codes.unknown_op_code(op)
+
+
+def verify_script_path_vc0(
     script_bytes: bytes,
     stack: list[bytes],
     prevouts: list[TxOut],
@@ -267,94 +368,32 @@ def verify_script_path_vc0(  # noqa: C901, PLR0912
             raise BTClibValueError("upgradable OP_SUCCESS op code")
         return
 
-    codesep_pos = 0xFFFFFFFF
-
     altstack: list[bytes] = []
     condition_stack: list[bool] = [True]
 
-    script_index = -1
-
-    s = bytesio_from_binarydata(script_bytes)
+    script_index_ref = [-1]
     try:
-        while True:
-            script_index += 1
-
-            skip_execution = not all(condition_stack)
-
-            script_op_codes.check_stack_size(stack, altstack)
-
-            b = s.read(1)
-            if not b:
-                break
-            t = b[0]
-            if 0 < t <= 78:  # pushdata
-                script_op_codes.read_push_data(
-                    # the element limit is taproot.parse's here, deferred
-                    # to the end of the walk so that an OP_SUCCESSx met
-                    # first forgives an oversized push, as Core's
-                    # pre-scan does. Measured again in the loop it would
-                    # refuse what that parse has already forgiven
-                    t,
-                    s,
-                    stack,
-                    skip_execution,
-                    flags,
-                    serialize_script,
-                    element_size_limit=None,
-                )
-                continue
-            if skip_execution and t not in EVALUATED_WHEN_UNEXECUTED:
-                continue
-            op = OP_CODE_NAMES[t]
-
-            if op == "OP_CHECKSIG":
-                sigops_budget = op_checksig(
-                    stack,
-                    script_bytes,
-                    codesep_pos,
-                    tx,
-                    i,
-                    prevouts,
-                    annex,
-                    sigops_budget,
-                    flags,
-                    precomputed,
-                )
-
-            elif op == "OP_CHECKLOCKTIMEVERIFY":
-                script_op_codes.op_checklocktimeverify(stack, tx, i, flags)
-            elif op == "OP_CHECKSEQUENCEVERIFY":
-                script_op_codes.op_checksequenceverify(stack, tx, i, flags)
-            elif op[3:].isdigit():
-                stack.append(_from_num(int(op[3:])))
-            elif op == "OP_CODESEPARATOR":
-                codesep_pos = script_index
-            elif op == "OP_IF":
-                script_op_codes.op_if(stack, condition_stack, flags, 1)
-            elif op == "OP_NOTIF":
-                script_op_codes.op_notif(stack, condition_stack, flags, 1)
-            elif op == "OP_ELSE":
-                script_op_codes.op_else(condition_stack)
-            elif op == "OP_ENDIF":
-                script_op_codes.op_endif(condition_stack)
-            elif op == "OP_NOP":
-                pass
-            elif "OP_NOP" in op:
-                script_op_codes.op_nop(flags)
-            elif op in OPERATIONS:
-                r = OPERATIONS[op](stack, altstack, flags)
-                if r:
-                    script_index -= len(r)
-                    s = bytesio_from_binarydata(serialize_script(r) + s.read())
-            else:
-                script_op_codes.unknown_op_code(op)
+        _run_ops(
+            script_bytes,
+            stack,
+            altstack,
+            condition_stack,
+            prevouts,
+            tx,
+            i,
+            annex,
+            sigops_budget,
+            flags,
+            precomputed,
+            script_index_ref,
+        )
     except BTClibValueError as e:
-        raise ScriptError(str(e), script_index, len(stack)) from e
+        raise ScriptError(str(e), script_index_ref[0], len(stack)) from e
     except IndexError as e:
         # what the loop indexes and pops is the stack and the altstack,
         # so an IndexError out of it is an underflow; the chained
         # exception is there for the cases in which it is not
-        raise ScriptError("stack underflow", script_index, len(stack)) from e
+        raise ScriptError("stack underflow", script_index_ref[0], len(stack)) from e
 
     script_op_codes.check_balanced_if(condition_stack)
 

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -378,8 +378,12 @@ def _serialize_bytes_command(command: bytes) -> bytes:
 
 
 def _pushdata(i: int, length: int, out: list[bytes]) -> None:
-    out.append(BYTE_FROM_OP_CODE_NAME[f"OP_PUSHDATA{i}"])
-    out.append(length.to_bytes(i, byteorder="little", signed=False))
+    out.extend(
+        (
+            BYTE_FROM_OP_CODE_NAME[f"OP_PUSHDATA{i}"],
+            length.to_bytes(i, byteorder="little", signed=False),
+        )
+    )
 
 
 def serialize(script: Sequence[Command]) -> bytes:

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -72,9 +72,9 @@ def address(script_pub_key: Octets, network: str = "mainnet") -> str:
     """
     if script_pub_key:
         script_type, payload = type_and_payload(script_pub_key)
-        if script_type in ("p2pkh", "p2sh"):
+        if script_type in {"p2pkh", "p2sh"}:
             return b58.address_from_h160(script_type, payload, network)
-        if script_type in ("p2wsh", "p2wpkh"):
+        if script_type in {"p2wsh", "p2wpkh"}:
             return b32.address_from_witness(0, payload, network)
         if script_type == "p2tr":
             return b32.address_from_witness(1, payload, network)

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -496,7 +496,7 @@ def segwit_v0(
         )
 
     hash_outputs = b"\x00" * 32
-    if hash_type & 0x1F not in (SINGLE, NONE):
+    if hash_type & 0x1F not in {SINGLE, NONE}:
         hash_outputs = (
             hash256(_serialized_outputs(tx))
             if precomputed is None
@@ -554,7 +554,7 @@ def taproot(
         raise BTClibValueError("Sighash single without a corresponding output")
 
     anyone_can_pay = hashtype & 0x80 == ANYONECANPAY
-    all_outputs = hashtype & 0x03 not in (NONE, SINGLE)
+    all_outputs = hashtype & 0x03 not in {NONE, SINGLE}
     annex_present = int(bool(annex))
 
     # b"".join of the parts, as the rest of the module does, rather than

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -189,7 +189,7 @@ def tree_helper(script_tree: TaprootScriptTree) -> tuple[TaprootLeafPaths, bytes
 
 def _tree_helper(script_tree: TaprootScriptTree) -> tuple[TaprootLeafPaths, bytes]:
     leaf_version, script = cast("TaprootLeaf", script_tree[0])
-    leaf_version = leaf_version & 0xFE
+    leaf_version &= 0xFE
     h = leaf_hash(leaf_version, serialize(script))
     return ([((leaf_version, script), b"")], h)
 

--- a/btclib/slip132.py
+++ b/btclib/slip132.py
@@ -55,7 +55,7 @@ def address_from_xpub(xpub: BIP32Key) -> str:
     if not isinstance(xpub, BIP32KeyData):
         xpub = BIP32KeyData.b58decode(xpub)
 
-    if xpub.key[0] not in (2, 3):
+    if xpub.key[0] not in {2, 3}:
         # this branch is reached with an xprv: never echo it,
         # the prefix already says what is wrong
         raise BTClibValueError(f"not a public key: prefix 0x{xpub.key[:1].hex()}")

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -136,7 +136,7 @@ def _pub_keyinfo_from_xpub(
     else:
         xpub = BIP32KeyData.b58decode(xpub)
 
-    if xpub.key[0] not in (2, 3):
+    if xpub.key[0] not in {2, 3}:
         # this branch is reached with an xprv: never echo it,
         # the prefix already says what is wrong
         err_msg = f"not a public key: prefix 0x{xpub.key[:1].hex()}"

--- a/tests/b32_test.py
+++ b/tests/b32_test.py
@@ -372,7 +372,7 @@ def test_a_changed_character_is_not_an_address(
     wit_ver: int, wit_prg: bytes, position: int, value: int
 ) -> None:
     """A typo in an address is caught, not paid to a stranger."""
-    if wit_ver == 0 and len(wit_prg) not in (20, 32):
+    if wit_ver == 0 and len(wit_prg) not in {20, 32}:
         return
     address = b32.address_from_witness(wit_ver, wit_prg)
     # the hrp is left alone: changing it makes a different address

--- a/tests/bip21_test.py
+++ b/tests/bip21_test.py
@@ -286,6 +286,8 @@ def test_odds_and_ends_of_the_grammar() -> None:
     assert Bip21.parse(f"bitcoin:{ADDR}?&amount=1&").amount == Decimal(1)
     # a parameter with no value
     assert Bip21.parse(f"bitcoin:{ADDR}?foo").others == {"foo": ""}
+    # not `not label`: label is `str | None`, and this is the case of
+    # an explicit but empty label, which a missing one is not
     assert Bip21.parse(f"bitcoin:{ADDR}?label=").label == ""
     # a fragment is not a parameter
     assert not Bip21.parse(f"bitcoin:{ADDR}?#foo=1").others

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -75,7 +75,7 @@ class FakeGh:
         if argv[1] == "api":
             repo = argv[4].removeprefix("repos/").removesuffix("/commits")
             path = argv[6].removeprefix("path=")
-            answer = self.commits[(repo, path)]
+            answer = self.commits[repo, path]
             # None is what the api answers for a path upstream no longer
             # has: an empty list, which is a 200 and not an error
             if answer is None:
@@ -236,7 +236,7 @@ def test_latest_commit_asks_for_one_commit_touching_the_path(
     checker: ModuleType, fake_gh: FakeGh
 ) -> None:
     """The one `gh api` call, and the sha and date it reads back."""
-    fake_gh.commits[("btclib-org/btclib", "tests/f.json")] = ("cafe1234", "2026-08-01")
+    fake_gh.commits["btclib-org/btclib", "tests/f.json"] = ("cafe1234", "2026-08-01")
     sha, date = checker._latest_commit("btclib-org/btclib", "tests/f.json")
     assert (sha, date) == ("cafe1234", "2026-08-01")
     (call,) = fake_gh.calls
@@ -257,7 +257,7 @@ def test_latest_commit_is_none_when_upstream_has_no_commit_for_the_path(
     run and no issue, on the one drift a vendored file nobody re-reads
     would otherwise hide.
     """
-    fake_gh.commits[("btclib-org/btclib", "tests/gone.json")] = None
+    fake_gh.commits["btclib-org/btclib", "tests/gone.json"] = None
     assert checker._latest_commit("btclib-org/btclib", "tests/gone.json") is None
 
 
@@ -278,7 +278,7 @@ def test_find_drift_reports_a_path_upstream_no_longer_has(
         ),
         encoding="utf-8",
     )
-    fake_gh.commits[("r", "gone.json")] = None
+    fake_gh.commits["r", "gone.json"] = None
 
     drifted, skipped = checker.find_drift(path)
 
@@ -334,7 +334,7 @@ def test_main_says_gone_rather_than_behind_for_a_vanished_path(
             behind="0",
         ),
     )
-    fake_gh.commits[("r", "gone.json")] = None
+    fake_gh.commits["r", "gone.json"] = None
     monkeypatch.setattr(sys, "argv", ["prog", str(path), "--dry-run"])
 
     assert checker.main() == 0
@@ -369,8 +369,8 @@ def test_find_drift_tells_moved_pins_from_still_current_ones(
         ),
         encoding="utf-8",
     )
-    fake_gh.commits[("r", "moved.json")] = ("new0000", "2026-01-01")
-    fake_gh.commits[("r", "still.json")] = ("cur0000", "2020-01-01")
+    fake_gh.commits["r", "moved.json"] = ("new0000", "2026-01-01")
+    fake_gh.commits["r", "still.json"] = ("cur0000", "2020-01-01")
 
     drifted, skipped = checker.find_drift(path)
 
@@ -485,7 +485,7 @@ def test_main_dry_run_prints_but_never_calls_issue(
         ),
         entry("stale", repo="r", path="s.json", commit="x", behind="1"),
     )
-    fake_gh.commits[("r", "p.json")] = ("new0000", "2026-01-01")
+    fake_gh.commits["r", "p.json"] = ("new0000", "2026-01-01")
     monkeypatch.setattr(sys, "argv", ["prog", str(path), "--dry-run"])
 
     assert checker.main() == 0
@@ -514,7 +514,7 @@ def test_main_reports_and_says_nothing_drifted_when_clean(
             behind="0",
         ),
     )
-    fake_gh.commits[("r", "p.json")] = ("old0000", "2020-01-01")
+    fake_gh.commits["r", "p.json"] = ("old0000", "2020-01-01")
     fake_gh.open_issue = 3
     monkeypatch.setattr(sys, "argv", ["prog", str(path)])
 
@@ -551,7 +551,7 @@ def test_the_main_guard_runs_the_script_as___main__(
         ),
     )
     fake = FakeGh()
-    fake.commits[("r", "p.json")] = ("old0000", "2020-01-01")
+    fake.commits["r", "p.json"] = ("old0000", "2020-01-01")
     monkeypatch.setattr(subprocess, "run", fake)
     monkeypatch.setattr(sys, "argv", ["prog", str(path), "--dry-run"])
 

--- a/tests/check_vendored_vectors_test.py
+++ b/tests/check_vendored_vectors_test.py
@@ -313,7 +313,7 @@ def test_main_says_how_to_be_called_when_it_is_not(
     # argv[0] is what names the program, so the fixture's own "prog" is
     # what comes back here rather than the script's file name
     assert captured.err == "usage: prog <README path> [--dry-run]\n"
-    assert captured.out == ""
+    assert not captured.out
 
 
 def test_main_says_gone_rather_than_behind_for_a_vanished_path(

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -774,8 +774,7 @@ def test_symmetry() -> None:
 
         # compute all quadratic residues
         hasRoot = {1}
-        for i in range(2, ec.p):
-            hasRoot.add(i * i % ec.p)
+        hasRoot.update(i * i % ec.p for i in range(2, ec.p))
 
         if ec.p % 4 == 3:
             quad_res = ec.y_quadratic_residue(x_Q)

--- a/tests/descriptors_test.py
+++ b/tests/descriptors_test.py
@@ -679,7 +679,7 @@ def test_combo_is_a_set_of_scripts() -> None:
     with pytest.raises(BTClibValueError, match="use script_pub_keys instead"):
         parsed.address()
     # the p2pk of the four has no address, and says so with an empty one
-    assert parsed.addresses()[0] == ""
+    assert not parsed.addresses()[0]
 
 
 def test_redeem_script() -> None:

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -283,7 +283,7 @@ def test_the_commitment_reaches_the_nonce() -> None:
     plain_nonce = rfc6979_nonce_(reduce_to_hlen(_MSG, hf), _PRV_KEY)
     plain_point = mult(plain_nonce, secp256k1.G, secp256k1)
     assert receipt_a != receipt_b
-    assert plain_point not in (receipt_a, receipt_b)
+    assert plain_point not in {receipt_a, receipt_b}
 
     # ssa keeps its aux and mixes the commitment into it, so the same
     # holds there with the aux held fixed -- random aux would hide it
@@ -293,7 +293,7 @@ def test_the_commitment_reaches_the_nonce() -> None:
     _, receipt_b = ssa.sign(_MSG, prv_key, aux, commit=b"contract B")
     plain_k, _, _, _ = bip340_nonce_(reduce_to_hlen(_MSG, hf), prv_key, aux)
     assert receipt_a != receipt_b
-    assert mult(plain_k, secp256k1.G, secp256k1) not in (receipt_a, receipt_b)
+    assert mult(plain_k, secp256k1.G, secp256k1) not in {receipt_a, receipt_b}
 
 
 def test_a_commitment_derives_its_own_nonce() -> None:

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -103,7 +103,7 @@ def test_signature() -> None:
     r = 0x934B1EA10A4B3C1757E2B0C017D0B6143CE3C9A7E6A4A49860D7A6AB210EE3D8
     s = 0x2442CE9D2B916064108014783E923EC36B49743E2FFA1C4496F01A512AAFD9E5
     assert sig.r == r
-    assert sig.s in (s, sig.ec.n - s)
+    assert sig.s in {s, sig.ec.n - s}
 
     # malleability
     malleated_sig = dsa.Sig(sig.r, sig.ec.n - sig.s)
@@ -364,8 +364,8 @@ def test_crack_prv_key() -> None:
     sig2 = dsa.Sig(sig2.r, ec.n - sig2.s)
     qc2, kc2 = dsa.crack_prv_key(msg1, sig1, msg2, sig2.serialize())
 
-    assert (q == q_cracked and k in (k_cracked, ec.n - k_cracked)) or (
-        q == qc2 and k in (kc2, ec.n - kc2)
+    assert (q == q_cracked and k in {k_cracked, ec.n - k_cracked}) or (
+        q == qc2 and k in {kc2, ec.n - kc2}
     )
 
     with pytest.raises(BTClibValueError, match="not the same r in signatures"):

--- a/tests/ecc/ellswift_test.py
+++ b/tests/ecc/ellswift_test.py
@@ -112,7 +112,7 @@ def test_xswiftec_inv_vectors(row: list[str]) -> None:
     for case in range(8):
         cell = row[2 + case]
         t = _xswiftec_inv(x, u, case, secp256k1)
-        if cell == "":
+        if not cell:
             assert t is None, f"case {case} should have no preimage"
         else:
             assert t == int(cell, 16), f"case {case}"

--- a/tests/ecc/rfc6979_test.py
+++ b/tests/ecc/rfc6979_test.py
@@ -128,7 +128,7 @@ def test_rfc6979_secp256k1_s_is_normalized() -> None:
     for prv_key, msg, _, _, s in SECP256K1_VECTORS:
         msg_hash = hashlib.sha256(msg.encode()).digest()
         raw = dsa.sign_(msg_hash, prv_key, lower_s=False)
-        assert raw.s in (int(s, 16), secp256k1.n - int(s, 16))
+        assert raw.s in {int(s, 16), secp256k1.n - int(s, 16)}
         normalized += raw.s != int(s, 16)
     assert normalized == 4
 

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -775,7 +775,7 @@ def test_threshold() -> None:
 
     # ADDITIONAL PHASE: reconstruction of the private key ###
     secret = (omega1 * alpha1 + omega3 * alpha3) % ec.n
-    assert (q1 + q2 + q3) % ec.n in (secret, ec.n - secret)
+    assert (q1 + q2 + q3) % ec.n in {secret, ec.n - secret}
 
 
 def test_libsecp256k1() -> None:
@@ -820,7 +820,7 @@ def test_libsecp256k1_x_only_conversion() -> None:
     Q = mult(q)
     assert Q[1] % 2  # y is odd, so the parity byte is the one dropped
     for pub_key in (bytes_from_point(Q), bytes_from_point(Q, compressed=False)):
-        assert len(pub_key) in (33, 65)
+        assert len(pub_key) in {33, 65}
         assert ssa.verify(msg, pub_key, sig)
 
 

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -136,7 +136,7 @@ def test_bip340_vectors(row: list[str]) -> None:
     """
     (_index, seckey, pub_key, aux_rand, m, sig, result, _comment) = row
 
-    if seckey != "":
+    if seckey:
         _, pub_key_actual = ssa.gen_keys(seckey)
         assert pub_key == hex(pub_key_actual).upper()[2:]
 

--- a/tests/keystore_test.py
+++ b/tests/keystore_test.py
@@ -398,7 +398,7 @@ def test_a_key_added_to_a_bip32_keystore_is_not_derived() -> None:
     assert bms.verify(_MSG, added, keystore.sign(added, _MSG))
     with pytest.raises(BTClibValueError, match="watch-only keystore"):
         keystore.prv_key(derived)
-    assert keystore.address_info(added).der_path == ""
+    assert not keystore.address_info(added).der_path
 
 
 def test_an_address_is_found_however_it_is_spelled() -> None:

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -531,7 +531,7 @@ def test_old_vectors(hex_seed: str, mnemonic: str, master_pub_key: str | None) -
 
     assert electrum.old_master_pub_key_from_mnemonic(mnemonic) == master_pub_key
 
-    if len(hex_seed) in (32, 64):
+    if len(hex_seed) in {32, 64}:
         # the hex seed is a seed electrum restores from as readily as the
         # words, which is what makes the hex branch of the recognizer
         # more than a curiosity

--- a/tests/mnemonic/electrum_test.py
+++ b/tests/mnemonic/electrum_test.py
@@ -984,7 +984,7 @@ def test_vectors(
     same at greater length.
     """
     lang = "en"
-    if mnemonic != "":
+    if mnemonic:
         assert rmxprv == electrum.mxprv_from_mnemonic(mnemonic, passphrase)
 
         mnemonic_type, mnemonic = electrum.version_from_mnemonic(mnemonic)

--- a/tests/number_theory_test.py
+++ b/tests/number_theory_test.py
@@ -91,8 +91,7 @@ def test_mod_sqrt() -> None:
     """Verify both roots of every residue, exhaustively on small primes."""
     for p in primes[:30]:  # exhaustable only for small p
         has_root = {0, 1}
-        for i in range(2, p):
-            has_root.add(i * i % p)
+        has_root.update(i * i % p for i in range(2, p))
         for i in range(p):
             if i in has_root:
                 root1 = mod_sqrt(i, p)

--- a/tests/number_theory_test.py
+++ b/tests/number_theory_test.py
@@ -102,7 +102,7 @@ def test_mod_sqrt() -> None:
                 root = mod_sqrt(i + p, p)
                 assert i == (root * root) % p
                 if p % 4 == 3 or p % 8 == 5:
-                    assert tonelli(i, p) in (root1, root2)
+                    assert tonelli(i, p) in {root1, root2}
             else:
                 with pytest.raises(BTClibValueError, match="no root for "):
                     mod_sqrt(i, p)
@@ -186,7 +186,7 @@ def test_mod_sqrt_squares_back(a: int, p: int) -> None:
     are the whole domain, which is the point of generating a.
     """
     symbol = legendre_symbol(a, p)
-    assert symbol in (-1, 0, 1)
+    assert symbol in {-1, 0, 1}
     if symbol == -1:
         with pytest.raises(BTClibValueError, match="no root for "):
             mod_sqrt(a, p)

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -122,7 +122,7 @@ def psbt_input_from_spend(tx_in: TxIn) -> tuple[PsbtIn, bytes] | None:  # noqa: 
     redeem_script = script_sig_pushes[-1] if script_sig_pushes else b""
 
     if stack:
-        if len(stack) == 2 and len(stack[1]) in (33, 65):
+        if len(stack) == 2 and len(stack[1]) in {33, 65}:
             program = ScriptPubKey.p2wpkh(stack[1]).script
             witness_script = b""
         elif is_p2ms(stack[-1]):
@@ -148,7 +148,7 @@ def psbt_input_from_spend(tx_in: TxIn) -> tuple[PsbtIn, bytes] | None:  # noqa: 
         )
         return psbt_in, script_pub_key
 
-    if len(script_sig_pushes) == 2 and len(script_sig_pushes[1]) in (33, 65):
+    if len(script_sig_pushes) == 2 and len(script_sig_pushes[1]) in {33, 65}:
         pub_key = script_sig_pushes[1]
         psbt_in = PsbtIn(hd_key_paths={pub_key: DUMMY_KEY_ORIGIN}, check_validity=False)
         return psbt_in, ScriptPubKey.p2pkh(pub_key).script

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -23,6 +23,7 @@ a table copied out of it.
 from __future__ import annotations
 
 from copy import deepcopy
+from itertools import starmap
 
 import pytest
 
@@ -313,10 +314,10 @@ def test_the_bip174_spend_is_read_back_off_the_wire() -> None:
     signed = extract_tx(Psbt.b64decode(BIP174_FINALIZED_PSBT))
     psbt = psbt_from_spend(signed)
     assert psbt is not None
-    assert [
-        spend_kind(tx_in, psbt_in)
-        for tx_in, psbt_in in zip(signed.vin, psbt.inputs, strict=True)
-    ] == ["p2sh-p2ms", "p2sh-p2wsh"]
+    assert list(starmap(spend_kind, zip(signed.vin, psbt.inputs, strict=True))) == [
+        "p2sh-p2ms",
+        "p2sh-p2wsh",
+    ]
     # the three signatures a byte short of the assumption, as above
     assert assert_input_is_the_spend_with_maximal_signatures(psbt, signed) == 3
 
@@ -358,10 +359,7 @@ def test_a_block_of_real_spends(
         added = assert_input_is_the_spend_with_maximal_signatures(psbt, tx)
         if added >= 0:
             assert psbt.estimated_weight >= tx.weight
-        seen.update(
-            spend_kind(tx_in, psbt_in)
-            for tx_in, psbt_in in zip(tx.vin, psbt.inputs, strict=True)
-        )
+        seen.update(starmap(spend_kind, zip(tx.vin, psbt.inputs, strict=True)))
         checked += 1
     # a corpus that stopped being read would otherwise pass the loop
     # vacuously, and both files are frozen

--- a/tests/script/script_pub_key_test.py
+++ b/tests/script/script_pub_key_test.py
@@ -87,7 +87,7 @@ def test_nulldata() -> None:
     # data -> payload in this case is invertible (no hash functions)
     assert payload.decode("ascii") == string
 
-    assert address(script_pub_key) == ""
+    assert not address(script_pub_key)
 
     # documented test cases: https://learnmeabitcoin.com/guide/nulldata
     string = "hello world"
@@ -231,7 +231,7 @@ def test_p2pk() -> None:
     assert script_pub_key == ScriptPubKey.p2pk(pub_key).script
     assert ("p2pk", bytes.fromhex(pub_key)) == type_and_payload(script_pub_key)
 
-    assert address(script_pub_key) == ""
+    assert not address(script_pub_key)
 
     err_msg = "invalid pub_key length marker: "
     with pytest.raises(BTClibValueError, match=err_msg):
@@ -429,7 +429,7 @@ def test_unknown() -> None:
     so it is not a witness program at all and no address can carry it.
     """
     script_pub_key = serialize(["OP_16", 41 * b"\x00"])
-    assert address(script_pub_key) == ""
+    assert not address(script_pub_key)
     assert type_and_payload(script_pub_key) == ("unknown", script_pub_key)
 
 
@@ -483,7 +483,7 @@ def test_where_witness_unknown_begins_and_ends() -> None:
 
     v0_not_20_or_32 = serialize(["OP_0", bytes(21)])
     assert type_and_payload(v0_not_20_or_32) == ("unknown", v0_not_20_or_32)
-    assert address(v0_not_20_or_32) == ""
+    assert not address(v0_not_20_or_32)
 
 
 def test_p2ms_1() -> None:
@@ -502,7 +502,7 @@ def test_p2ms_1() -> None:
         "ae"  # OP_CHECKMULTISIG
     )
     assert is_p2ms(script_pub_key)
-    assert address(script_pub_key) == ""
+    assert not address(script_pub_key)
     script_type, payload = type_and_payload(script_pub_key)
     assert script_type == "p2ms"
     assert payload == script_pub_key[:-1]
@@ -600,7 +600,7 @@ def test_p2ms_2() -> None:
                 m, pub_keys, lexicographic_sorting=lexicographic_sorting
             ).script
             assert is_p2ms(script_pub_key)
-            assert address(script_pub_key) == ""
+            assert not address(script_pub_key)
             script_type, payload = type_and_payload(script_pub_key)
             assert script_type == "p2ms"
             assert payload == script_pub_key[:-1]
@@ -659,7 +659,7 @@ def test_bip67(keys: list[str], addr: str) -> None:
     m = 2
     script_pub_key = ScriptPubKey.p2ms(m, keys, lexicographic_sorting=True).script
     assert is_p2ms(script_pub_key)
-    assert address(script_pub_key) == ""
+    assert not address(script_pub_key)
     script_type, payload = type_and_payload(script_pub_key)
     assert script_type == "p2ms"
     assert payload == script_pub_key[:-1]

--- a/tests/script/script_test.py
+++ b/tests/script/script_test.py
@@ -40,22 +40,22 @@ def test_operators() -> None:
         assert i == b[0]
     for name, code in BYTE_FROM_OP_CODE_NAME.items():
         # skip duplicated
-        if name in ("OP_FALSE", "OP_TRUE", "OP_NOP2", "OP_NOP3"):
+        if name in {"OP_FALSE", "OP_TRUE", "OP_NOP2", "OP_NOP3"}:
             continue
         i = code[0]
         assert name == OP_CODE_NAME_FROM_INT[i]
     for i in range(76, 186):
         # skip disabled 'splice' opcodes
-        if i in (126, 127, 128, 129):
+        if i in {126, 127, 128, 129}:
             continue
         # skip disabled 'bitwise logic' opcodes
-        if i in (131, 132, 133, 134):
+        if i in {131, 132, 133, 134}:
             continue
         # skip disabled 'splice' opcodes
-        if i in (141, 142, 149, 150, 151, 152, 152, 153):
+        if i in {141, 142, 149, 150, 151, 152, 153}:
             continue
         # skip 'reserved' opcodes
-        if i in (80, 98, 101, 102, 137, 138):
+        if i in {80, 98, 101, 102, 137, 138}:
             continue
         assert i in OP_CODE_NAME_FROM_INT
 

--- a/tests/script/sig_hash_precomputed_test.py
+++ b/tests/script/sig_hash_precomputed_test.py
@@ -225,7 +225,7 @@ def test_from_tx_loop_hashes_the_transaction_once(
 
     Without the precomputed data every segwit input rebuilds the
     prevouts of the whole transaction: N passes over N inputs, which is
-    what the issue measured as 15 µs per input at N=1 and 414 µs at
+    what the issue measured as 15 μs per input at N=1 and 414 μs at
     N=400. With it there is one pass, in the constructor.
     """
     tx, prevouts = spending_tx()

--- a/tests/script/sig_hash_taproot_test.py
+++ b/tests/script/sig_hash_taproot_test.py
@@ -450,7 +450,7 @@ def script_path_vectors() -> list[Any]:
         stack = witness.stack[:-1] if has_annex(witness) else witness.stack
         # signature, script, control block: no leaf takes an input off
         # the stack, so the script is always the last but one
-        if len(stack) != 3 or len(stack[0]) not in (64, 65):
+        if len(stack) != 3 or len(stack[0]) not in {64, 65}:
             continue
         # <32-byte push> OP_CHECKSIG, and nothing else
         if len(stack[1]) != 34 or stack[1][0] != 0x20 or stack[1][-1] != 0xAC:

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -989,7 +989,7 @@ def _one_op_code_script(op_code: int) -> bytes:
     """Build that op code alone, a push carrying the data it declares."""
     if 0 < op_code < 0x4C:  # a push of its own length
         return bytes([op_code]) + b"\x2a" * op_code
-    if op_code in (0x4C, 0x4D, 0x4E):  # OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4
+    if op_code in {0x4C, 0x4D, 0x4E}:  # OP_PUSHDATA1, OP_PUSHDATA2, OP_PUSHDATA4
         return (
             bytes([op_code]) + (1).to_bytes(2 ** (op_code - 0x4C), "little") + b"\x2a"
         )

--- a/tests/to_prv_key_test.py
+++ b/tests/to_prv_key_test.py
@@ -110,17 +110,17 @@ def test_from_prv_key() -> None:
         assert q == int_from_prv_key(prv_key4)
         with pytest.raises(BTClibValueError):
             int_from_prv_key(prv_key4, secp256r1)
-        assert prv_keyinfo_from_prv_key(prv_key4) in (m_c, m_unc)
-        assert prv_keyinfo_from_prv_key(prv_key4, "mainnet") in (m_c, m_unc)
+        assert prv_keyinfo_from_prv_key(prv_key4) in {m_c, m_unc}
+        assert prv_keyinfo_from_prv_key(prv_key4, "mainnet") in {m_c, m_unc}
         with pytest.raises(BTClibValueError):
             prv_keyinfo_from_prv_key(prv_key4, "testnet")
 
     for prv_key5 in [q, *net_unaware_prv_keys]:
         assert q == int_from_prv_key(prv_key5)
         assert q == int_from_prv_key(prv_key5, secp256r1)
-        assert prv_keyinfo_from_prv_key(prv_key5) in (m_c, m_unc)
-        assert prv_keyinfo_from_prv_key(prv_key5, "mainnet") in (m_c, m_unc)
-        assert prv_keyinfo_from_prv_key(prv_key5, "testnet") in (t_c, t_unc)
+        assert prv_keyinfo_from_prv_key(prv_key5) in {m_c, m_unc}
+        assert prv_keyinfo_from_prv_key(prv_key5, "mainnet") in {m_c, m_unc}
+        assert prv_keyinfo_from_prv_key(prv_key5, "testnet") in {t_c, t_unc}
 
     for invalid_prv_key in [q0, qn, xprv0_data, xprvn_data, *invalid_prv_keys]:
         with pytest.raises(BTClibValueError):

--- a/tests/to_pub_key_test.py
+++ b/tests/to_pub_key_test.py
@@ -167,8 +167,8 @@ def _check_net_aware(api: Conversions, keys: Sequence[Key]) -> None:
     point_from, keyinfo_from = api
     for key in keys:
         _check_point(point_from, key)
-        assert keyinfo_from(key) in (m_c, m_unc)
-        assert keyinfo_from(key, "mainnet") in (m_c, m_unc)
+        assert keyinfo_from(key) in {m_c, m_unc}
+        assert keyinfo_from(key, "mainnet") in {m_c, m_unc}
         with pytest.raises(BTClibValueError):
             keyinfo_from(key, "testnet")
 
@@ -178,9 +178,9 @@ def _check_net_unaware(api: Conversions, keys: Sequence[Key]) -> None:
     point_from, keyinfo_from = api
     for key in keys:
         _check_point(point_from, key)
-        assert keyinfo_from(key) in (m_c, m_unc)
-        assert keyinfo_from(key, "mainnet") in (m_c, m_unc)
-        assert keyinfo_from(key, "testnet") in (t_c, t_unc)
+        assert keyinfo_from(key) in {m_c, m_unc}
+        assert keyinfo_from(key, "mainnet") in {m_c, m_unc}
+        assert keyinfo_from(key, "testnet") in {t_c, t_unc}
 
 
 def _check_refused(api: Conversions, keys: Sequence[Key]) -> None:

--- a/tests/var_int_test.py
+++ b/tests/var_int_test.py
@@ -184,7 +184,7 @@ def test_round_trip(i: int) -> None:
 def test_round_trip_past_max_size(i: int) -> None:
     """The cap is a range check on parse, not a limit of the encoding."""
     encoded = var_int.serialize(i)
-    assert len(encoded) in (1, 3, 5, 9)
+    assert len(encoded) in {1, 3, 5, 9}
     assert var_int.parse(encoded, max_size=0xFFFFFFFFFFFFFFFF) == i
 
 


### PR DESCRIPTION
## Summary

Follows the triage posted on #445: applies the two piles the triage
called fixable on their own merits or mechanically safe, leaves the
third (a rule contradicting a deliberate convention, or a false
positive) untouched, and satisfies `PLW0717` the way the issue's
follow-up discussion asked for -- moving the interpreter loop into a
private function rather than restructuring the `try`.

Commits, one rule (or one closely-related group) each:

- the four real defects the sweep found on their own merits
- `PLW0717`: `verify_script` and `verify_script_path_vc0`'s opcode
  loops move into a private `_run_ops` each, so the `try` reporting a
  refusal wraps one call instead of the whole loop
- `PLR6201`: inline literal tuples/lists compared with `in`/`not in`
  become set literals
- `FURB113`: repeated `.append()` merged into `.extend()` where safe;
  three sites in `curve_group.py` are not (a hidden read of the list's
  own tail) and are commented instead, having been caught by the test
  suite after a first, wrong, blanket application
- `RUF031`, `RUF039`, `FURB140`, `FURB142`: ruff's own safe fixes
- `PLR6104`: the two sites needing an augmented assignment
- `PLC1901`: `x == ""` to `not x` wherever `x`'s type rules out
  anything but `str`; three sites where it does not (a union with
  `int`, an `Optional[str]` whose point is the empty/absent
  distinction) are commented and left alone

`PLR0914` and `PLR0904` are not in any commit: preview-only rules
cannot carry a per-site `# noqa` while preview stays off -- `RUF100`
reads it as unused -- so nothing short of an actual refactor closes
them, which is a larger, separate undertaking from this sweep.

Residue, re-measured on this branch: 286 findings across 16 rules
(down from 403/26), all of them the triage's third pile -- a rule
against a deliberate convention, or a false positive against this
tree's architecture. `.pre-commit-config.yaml` and pyproject.toml's
ruff configuration are unchanged; preview stays off.

## Test plan

- [x] `uv run pre-commit run --all-files`
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html`
- [x] `uv run pytest --cov` (100%)
- [x] each commit individually reviewed against the diff it produced,
      not against the rule's name -- FURB113's curve_group.py sites
      being the reason that mattered

Closes #445

## Summary by Sourcery

Apply preview-rule driven cleanups and minor refactors across script engines, descriptors, PSBT, mnemonic handling, networking, and tests, including extracting interpreter loops into helpers and tightening various validations and conditions.

Bug Fixes:
- Correct dictionary key access in vendored-vector test helper to avoid mismatched indexing.
- Fix redundant or misleading conditions and variables in entropy and mnemonic code, ensuring correct handling of empty strings versus other falsy values.
- Adjust hardware wallet info parsing to rely on actual presence of flags rather than default fallbacks, preventing incorrect pin/passphrase requirements.
- Repair docstring wording and unit labels in segwit sighash tests to use the intended Unicode character.
- Replace ad-hoc lambda sort key in descriptor pubkey sorting with a standard operator-based key function to avoid subtle inconsistencies.

Enhancements:
- Extract the main opcode-dispatch loops from legacy and tapscript interpreters into shared private helper functions to narrow exception scopes while preserving behavior and test coverage.
- Consistently prefer set literals for membership checks and `in`/`not in` conditions across the codebase and tests for clarity and style.
- Merge sequences of append operations into extend or list literal extensions where safe, improving readability and reducing boilerplate in stack and list manipulation code.
- Use augmented assignment operators for immutable types where appropriate and simplify boolean and emptiness checks in tests and core modules for clearer intent.
- Adopt itertools.starmap and Counter utilities in several helpers and tests to streamline iteration patterns and outcome aggregation.
- Normalize regex definitions to raw strings and centralize some constant sets and ranges, improving maintainability and avoiding accidental escape issues.
- Tighten various value and length validations around keys, signatures, taproot trees, script types, varints, and network types to better enforce protocol invariants without changing behavior.

Documentation:
- Document in the changelog the scope of preview-rule fixes, style adjustments, and the few locations intentionally exempted due to semantic differences or unions.

Tests:
- Update tests to reflect new truthiness-based expectations, refined address-empty cases, and improved helper behavior, including additional comments explaining intentional deviations from automated fixes.
- Refactor several tests to use set membership with literals, itertools.starmap, and more explicit assertions, while preserving coverage of edge cases and protocol constraints.