### PR TITLE
Stop trusting the release body, and record what griffe and latest found

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -197,6 +197,16 @@ against a pin about to be a version behind.
    what a reader should not have to discover at the button belongs there
    too.
 
+   The previous cycle's last step opened this pull request asking for the
+   body to fill in one merged pull request at a time, and said so itself:
+   "a promise kept only if someone remembers to keep it." Check it against
+   `git log v<previous version>..dev --oneline` regardless of how current
+   it looks, rather than trust that every line landed when it should have.
+   Griffe's result and `latest`'s run belong here too, each a line rather
+   than a screenshot — both are steps nothing else enforces, and a pull
+   request that never mentions them reads exactly like one that skipped
+   them.
+
    And merge it with **"Rebase and merge"**, never *"Squash and merge"*.
    All three methods are enabled here and GitHub preselects whichever was
    used last, so which button it is has to be read before it is pressed.


### PR DESCRIPTION
btclib-bitcoin-core-rpc's own RELEASING.md, modeled on this file's
sections of the same names, surfaced a gap this file has too during its
v2026.8.7 release walkthrough. The last step already admits the
release-body mechanism is "a promise kept only if someone remembers to
keep it," and nothing asks to check it against anything when that
promise was not kept -- the sibling's cycle carried seventeen commits
and the body was still unwritten at release time. This adds that check,
against the merged-commit log rather than trust.

Griffe and `latest` are both steps "nothing gates" or "nothing
automates" by this file's own words, and neither result was ever asked
to land anywhere -- a release that skipped either looked identical on
the record to one that ran them. Both now belong in the release pull
request's body, beside the title/body paragraph that already asks for
the rest of it.

Not ported from the sibling: its TestPyPI rehearsal fix does not apply
here. This file's own placeholder (`2026.8`, two components) is already
shaped unlike a release, unlike the sibling's fourth-number one -- a
rehearsal dispatched before the version bump reads as `2026.8.dev7`,
visibly a placeholder rather than a wrong release.

Gates run on this tree:

- `uv run pre-commit run --all-files` -- every hook passes
- `uv run pytest` -- 17533 passed, 5 integration tests skipped as documented

## Summary by Sourcery

Documentation:
- Document the requirement to cross-check the release pull request body against the merged commit log and to include Griffe and `latest` results in the release notes.