### PR TITLE
Name the coverage scope once, where a local run reads it too

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,10 +161,15 @@ jobs:
           # the fail_under comment in pyproject.toml names this version,
           # and the two have to move together
           python-version: "3.14"
+      # `--cov` and nothing after it: what is measured is tool.coverage.run's
+      # source and how it is reported is tool.coverage.report, so naming
+      # either here would be a second copy of a list that already exists --
+      # and the copy a contributor cannot run, this file not being what
+      # anyone types locally. One command, one scope, one report
       - name: Run pytest under coverage
         run: >
           uv run --locked --no-default-groups --group test
-          pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests
+          pytest --cov
 
   # the packaging metadata is checked on every pull request, not only on
   # the tag that ships it: a release is the one place where finding a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,9 +236,13 @@ touching `.venv`. The command is what CI runs, verbatim, and CI has no
 The `coverage-py` job, gated by `fail_under` in pyproject.toml:
 
 ```shell
-uv run --locked --no-default-groups --group test \
-    pytest --cov=btclib --cov=tests
+uv run --locked --no-default-groups --group test pytest --cov
 ```
+
+What `--cov` measures and how it reports are `tool.coverage.run`'s
+`source` and `tool.coverage.report` in pyproject.toml, so this command
+and the `pytest --cov` above are the same measurement: the job cannot
+gate on a scope a contributor's run does not have.
 
 The `dist-py` job, which inspects what would be published and then
 installs it. The last commands ask for the wheel and nothing else, so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -398,6 +398,21 @@ extend-glob = ["electrum_test.py"]
 extend-ignore-re = ['\w*[a-z][A-Z]\w*']
 
 [tool.coverage.run]
+# what the ratchet measures, named here rather than on the command line
+# that starts it. Unnamed, `--cov` measures every file the run imports,
+# and that reaches .github/scripts/mutation_counts.py through the test
+# importing it by path: the script's `main()` then reads as uncovered,
+# nothing running it but a test spawning it as a subprocess, and
+# subprocess coverage is not collected. So a bare `uv run pytest --cov`
+# fails on a pristine checkout while the coverage-py job passes -- a
+# local gate stricter than the one it exists to reproduce, which is the
+# worse of the two directions: it asks for a fix that CI does not want.
+# Named, the job and the local run are the same command, and the scripts
+# lose nothing by it, mypy taking them as CONTRIBUTING.md's command says.
+# Covering that `main()` instead would mean either coverage's subprocess
+# handshake for one script, or a test calling it in-process for the sake
+# of the measurement
+source = ["btclib", "tests"]
 # tests/integration is omitted because the ratchet measures what an
 # ordinary run executes, and those tests skip themselves without
 # BTCLIB_INTEGRATION: their bodies would be uncovered lines of tests/ at


### PR DESCRIPTION
`tool.coverage.run` set `omit` and no `source`, so what the ratchet
measured was decided by whichever command started it.

The `coverage-py` job passes `--cov=btclib --cov=tests` and reaches
100.00%. The bare `uv run pytest --cov` that CONTRIBUTING.md's coverage
paragraph recommends measures every file the run imports instead, so it
picks up `.github/scripts/mutation_counts.py` through the test that
imports it by path — and exits 1. `main()` and `enumerated_mutants` are
run only by a test spawning the script as a *subprocess*, and subprocess
coverage is not collected.

That is red on a pristine `origin/dev`. It is the worse of the two
directions for a gate to be wrong in: it does not hide a defect, it
invents one, and the fix it asks for is a fix CI does not want.

## What changed

`source = ["btclib", "tests"]` in pyproject.toml, where both readers
look. The job's flags then go, both being second copies of a list that
already exists:

- `--cov=btclib --cov=tests` duplicated `tool.coverage.run`
- `--cov-report term-missing:skip-covered` duplicated
  `tool.coverage.report`'s `show_missing` and `skip_covered`

What is left is `pytest --cov`, which CONTRIBUTING.md now quotes
verbatim and a contributor can type.

Covering that `main()` instead would mean coverage's subprocess handshake
for one script, or a test calling it in-process for the measurement's
sake. Either way the scripts are not left unchecked: mypy takes
`.github/scripts`, as CONTRIBUTING.md's own command shows.

## Measured

Both exit 0 at 100.00% over 17533 tests — the bare `uv run pytest --cov`
and the job's command. Before this, the first exited 1 at 99.97% with 9
misses. `pre-commit run --all-files` and the `-W` sphinx build both exit
0.

No CHANGELOG entry: nothing a user of the library can observe, matching
the other lint- and config-only commits on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align coverage configuration so local and CI coverage runs measure the same code scope.

Enhancements:
- Centralize coverage source configuration in pyproject.toml via tool.coverage.run.source to define the measured scope for all runs.

CI:
- Simplify the coverage workflow step to use a single pytest --cov invocation that relies on shared coverage config instead of duplicating options in CI.

Documentation:
- Update CONTRIBUTING instructions to reference the simplified coverage command and explain how its scope is configured.