### PR TITLE
Hold a toml comment to the 80 columns the same prose keeps elsewhere

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -234,8 +234,9 @@ repos:
         args: [--fix]
   # the width of a yaml line, which nothing else here measured: the hook
   # above holds markdown to 80 columns and ruff holds Python comments and
-  # docstrings to the same, and the workflows were the one place prose
-  # could grow without a limit -- 117 columns at the worst.
+  # docstrings to the same, and the workflows were a place prose could
+  # grow without a limit -- 117 columns at the worst. Toml was the other,
+  # and the hook below is what closed it.
   # Configured in .yamllint.yaml rather than in args here, as codespell
   # and typos are configured in pyproject.toml: the two rules enabled and
   # the two left off need a paragraph each, and the width is not 80 for a
@@ -247,6 +248,34 @@ repos:
     hooks:
       - id: yamllint
         name: yamllint (line width and document start)
+  # the width of a toml comment, which was the last prose here held to
+  # nothing. pyproject.toml carries more reasoning than any single file
+  # the rules above cover, and one of its comments had reached 118
+  # columns -- found by reading, which is the only thing that was
+  # looking.
+  # A local pygrep rule because nothing off the shelf does it: taplo
+  # formats values and leaves comments alone, by design, a formatter that
+  # reflowed prose being a formatter that rewrites it.
+  # `.{80}\S*[ \t]` reports a line only when whitespace is left past
+  # column 80, which is MD013's amnesty and ruff's: a comment ending in a
+  # link that cannot be broken is not a defect, and every Python comment
+  # here over 80 columns is exactly that. Without the amnesty this would
+  # be stricter on toml prose than the rules it mirrors are on the same
+  # sentences in a .py or a .md.
+  # The `#` after optional indent selects a comment and not a long value:
+  # `addopts` and `skip` in pyproject.toml are single tokens no width can
+  # break, and a value is not prose.
+  # pygrep matches bytes, so a non-ascii character would count as its
+  # utf-8 length. Every toml file here is ascii today, and the error is
+  # in the safe direction anyway -- a line reported one column early is
+  # rewrapped, never a line silently let through
+  - repo: local
+    hooks:
+      - id: toml-comment-width
+        name: toml comment width (80 columns, unbreakable links exempt)
+        language: pygrep
+        entry: '^(?=[ \t]*#).{80}\S*[ \t]'
+        files: \.toml$
   # .github/dependabot.yml is validated by nothing else here: check-yaml
   # above asks whether it is yaml, and actionlint below reads workflows
   # and not this. A typo in a package-ecosystem or a directory is not an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -377,8 +377,9 @@ ands = "ands"
 # and identifiers are what this hook is here for.
 # Not a preference either: with --write-changes and without this section,
 # the hook corrects three such quotations into nonsense -- prose saying
-# `lenght` is now `length` reads as prose saying nothing. Narrow enough that `y-simmetry`, unquoted in HISTORY.md, was
-# still found and fixed with the rule already in place
+# `lenght` is now `length` reads as prose saying nothing. Narrow enough
+# that `y-simmetry`, unquoted in HISTORY.md, was still found and fixed
+# with the rule already in place
 extend-glob = ["CHANGELOG.md", "HISTORY.md", ".pre-commit-config.yaml"]
 extend-ignore-re = ['`[^`]*`']
 


### PR DESCRIPTION
markdownlint holds markdown to 80, ruff's `max-doc-length` holds Python
comments and docstrings to 80, yamllint holds yaml to 100 for the pinning
convention. Toml was held to nothing — and pyproject.toml carries more
reasoning than any single file the other three cover.

One of its comments had reached 118 columns, wrapped nowhere. It was
found by reading it, which was the only thing looking.

## The rule

A local `pygrep` hook, because nothing off the shelf does this: taplo
formats values and leaves comments alone by design, a formatter that
reflowed prose being a formatter that rewrites it.

```yaml
entry: '^(?=[ \t]*#).{80}\S*[ \t]'
files: \.toml$
```

**The amnesty is MD013's and ruff's, not a weaker rule.** `.{80}\S*[ \t]`
reports a line only when whitespace is left past column 80, so a comment
ending in a link that cannot be broken passes. That is not hypothetical:
every full-line Python comment in this tree over 80 columns is such a
link, all sixteen of them. Without the amnesty this hook would be
stricter on a sentence in a `.toml` than the existing rules are on the
same sentence in a `.py` or a `.md`.

The `#` after optional indent selects a comment and not a long value:
`addopts` and `skip` in pyproject.toml are single tokens no width can
break, and a value is not prose.

`pygrep` matches bytes, so a non-ascii character counts as its utf-8
length. Every toml file here is ascii, and the error is in the safe
direction regardless — a line reported one column early gets rewrapped,
where the other direction is a line let through in silence.

## Measured

The hook passes on the tree with the one line rewrapped, and putting that
line back fails it, naming `pyproject.toml:380`:

```
pyproject.toml:380:# `lenght` is now `length` reads as prose saying nothing. Narrow enough that ...
```

The rewrap changes no wording. Every toml comment here is now at most 77
columns. `pre-commit run --all-files`, `pytest` and the `-W` sphinx build
all exit 0.

The yamllint comment above said the workflows "were the one place prose
could grow without a limit"; toml was the other, so that sentence is
corrected rather than left half-true.

No CHANGELOG entry: nothing a user of the library can observe, matching
the other lint-config-only commits on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce an 80-column limit for TOML comments and align pyproject.toml prose with existing documentation width rules.

Enhancements:
- Add a local pygrep-based pre-commit hook to enforce 80-column width for TOML comments with exemptions for unbreakable links.
- Update linting documentation comments in the pre-commit configuration to describe TOML comment width enforcement and refine the YAML prose-width explanation.
- Rewrap an overlong comment in pyproject.toml to comply with the new TOML comment width rule.