### PR TITLE
Drop the Twitter badge from the README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -247,6 +247,12 @@ edit.
   either tracked or produced by the current tooling — a rule matching
   nothing reads as still enforcing something, the same shape CLAUDE.md and
   `check-useless-excludes` already treat as worth removing elsewhere.
+- **The README's Conversations row loses its Twitter badge, keeping
+  Slack.** bitcoin-core-rpc and btclib_libsecp256k1 are dropping theirs
+  too, in the same pass that brings their own badge sets and order in
+  line with this one's -- three READMEs reading the same way is the
+  point, and a platform this project does not otherwise mention was the
+  one thing among them not worth carrying into all three.
 
 ### Security
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | Type checking | [![type check: mypy](https://img.shields.io/badge/type_check-mypy-yellowgreen.svg?logo=mypy)](https://mypy-lang.org/) |
 | Documentation | [![docs](https://readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io) [![lint: ruff](https://img.shields.io/badge/docstrings-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/rules/#pydocstyle-d) |
 | CI/CD | [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit) [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib/master.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib/master) [![lint](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml) [![test](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/test.yml) |
-| Conversations | [![slack](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES) [![Follow on Twitter](https://img.shields.io/twitter/follow/btclib?style=social&logo=twitter)](https://twitter.com/intent/follow?screen_name=btclib) |
+| Conversations | [![slack](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES) |
 
 [Browse GitHub Code Repository](https://github.com/btclib-org/btclib/)
 


### PR DESCRIPTION
## Summary
- Drops the `Follow on Twitter` badge from the Conversations row,
  keeping `slack`.
- Companion PRs on bitcoin-core-rpc and btclib_libsecp256k1 bring their
  own badge sets and order in line with this README's, and are dropping
  their Twitter badges (bitcoin-core-rpc never had one) in the same
  pass — three READMEs reading the same way is the point, and Twitter
  was the one thing among them not worth keeping in all three.
- CHANGELOG.md entry under the existing `Repository` group for v2026.8.

## Test plan
- [x] `uv run pre-commit run --all-files` passes
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
  --keep-going -b html docs/source docs/build/html` builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the Twitter conversations badge from the README and document the change in the changelog.

Documentation:
- Update the README conversations section to only advertise the Slack channel.
- Add a CHANGELOG entry describing the removal of the Twitter badge and alignment with related repositories.