### PR TITLE
Refuse the importdescriptors arguments Core refuses, as claimed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -997,6 +997,23 @@ edit.
 
 ### Malformed input and the exception contract
 
+- **`core_import` refuses the three `importdescriptors` arguments Core
+  refuses and it took.** Its docstring said "every rule Core enforces on
+  a request is enforced here" and named five; these are the rules that
+  were not among them, each one a request the node rejects whole. Two
+  are `ParseDescriptorRange`'s bounds on the field, in
+  `src/rpc/util.cpp`: an end at or above `2**31` is "End of range is too
+  high", and a span of a million indexes or more is "Range is too large"
+  -- `key_range=(0, 2**62)` and `key_range=(0, 1_000_000)` were both
+  built without a word. The third is `GetImportTimestamp`'s: a timestamp
+  is a number or the exact string `now`, so `"NOW"` and `"yesterday"`
+  were passed through to fail at the node. What the module exists for is
+  that the error names the field before a rescan rather than after one,
+  which is what these three did not get. The five rules already checked
+  had a test each, written from the same list the code was, so the
+  agreement between code, docstring and suite is what kept the gap
+  invisible at 100% coverage. `UniValue::getInt<int64_t>` is deliberately
+  not repeated: after the bounds above no number here can reach it.
 - **a derivation path step that is not one raises btclib's own error**,
   where `int_from_index_str` let `int` raise: `derive(xprv, ";/0")` died
   with `invalid literal for int() with base 10: ';'` and now raises

--- a/btclib/core_import.py
+++ b/btclib/core_import.py
@@ -30,8 +30,13 @@ half a rescan later:
 - an `active` descriptor is ranged, an unranged one having no keypool to
   be the active source of;
 - a `range` belongs to a ranged descriptor and to no other;
+- both ends of a `range` are what `ParseRange` and `ParseDescriptorRange`
+  in `src/rpc/util.cpp` take: ordered, non-negative, an end below 2**31,
+  and fewer than a million indexes between them;
 - `next_index` is inside that range;
-- a `label` goes with neither `internal` nor a range.
+- a `label` goes with neither `internal` nor a range;
+- a `timestamp` is a number or the exact string `now`, which is what
+  `GetImportTimestamp` accepts and nothing else -- `"NOW"` is not it.
 
 Two things are not written, where HWI's `getkeypool` writes them:
 `watchonly` and `keypool` are `importmulti` fields -- the other rpc that
@@ -52,6 +57,7 @@ from typing import Any
 
 from btclib.descriptors import Descriptor, add_checksum, parse
 from btclib.exceptions import BTClibValueError
+from btclib.utils import is_integer
 
 __all__ = [
     "DEFAULT_RANGE",
@@ -72,6 +78,11 @@ NOW = "now"
 # cannot tell which indexes were imported
 DEFAULT_RANGE = (0, 999)
 
+# `high >= low + 1000000` is "Range is too large" in ParseDescriptorRange,
+# so a million indexes is what a range may hold and 999_999 the widest
+# gap between its inclusive ends
+_MAX_RANGE_SPAN = 1_000_000
+
 
 def _is_ranged(descriptor: Descriptor | str) -> bool:
     """Answer whether the descriptor describes a range of scripts.
@@ -84,6 +95,28 @@ def _is_ranged(descriptor: Descriptor | str) -> bool:
     if isinstance(descriptor, Descriptor):
         return descriptor.is_ranged
     return parse(descriptor).is_ranged
+
+
+def _assert_timestamp(timestamp: int | str) -> None:
+    """Refuse a timestamp Core's GetImportTimestamp would refuse.
+
+    A number, or the string `now` and no other string: Core compares the
+    text against "now" and answers `Expected number or "now" timestamp
+    value for key` to everything else, so `"NOW"` and `"yesterday"` fail
+    the whole request. A refusal here names the field, where the rpc
+    error names the key it was importing.
+
+    `is_integer` rather than `isinstance(timestamp, int)`, which is the
+    predicate every integer field of the library is held to: `True` is an
+    `int` to Python and a boolean to json, and Core reads a json boolean
+    as neither a number nor a string.
+    """
+    if is_integer(timestamp):
+        return
+    if timestamp == NOW:
+        return
+    err_msg = f'expected a number or "{NOW}" as timestamp: {timestamp!r}'
+    raise BTClibValueError(err_msg)
 
 
 def _assert_no_label(label: str, why: str) -> None:
@@ -100,6 +133,20 @@ def _range_fields(
     Both ends of the range are inclusive, which is how Core reads them --
     it adds one to the second itself -- and `next_index` is where the
     wallet carries on from, so it is inside the range or it is nothing.
+
+    The two bounds are `ParseDescriptorRange`'s, which `importdescriptors`
+    calls on this field: an end of 2**31 or above is "End of range is too
+    high", and a span of a million indexes or more is "Range is too
+    large". Neither is a shape a keypool has any use for -- Core's own
+    default is a thousand -- so what they catch is an argument computed
+    wrongly, and catching it here is the difference between naming the
+    field and reading an rpc failure after a rescan.
+
+    A rule of Core's that is deliberately not repeated: every numeric
+    field arrives through `UniValue::getInt<int64_t>`, which refuses what
+    does not fit. After the bounds above, `start` and `end` are inside
+    [0, 2**31) and `next_index` is between them, so nothing here can
+    reach it.
     """
     if key_range is None:
         if next_index is not None:
@@ -109,6 +156,12 @@ def _range_fields(
     start, end = key_range
     if not 0 <= start <= end:
         raise BTClibValueError(f"invalid range: [{start}, {end}]")
+    if end >> 31:
+        raise BTClibValueError(f"end of range is too high: {end}")
+    if end - start >= _MAX_RANGE_SPAN:
+        err_msg = f"range is too large: {end - start + 1} indexes, "
+        err_msg += f"max is {_MAX_RANGE_SPAN}"
+        raise BTClibValueError(err_msg)
     fields: dict[str, Any] = {"range": [start, end]}
     if next_index is not None:
         if not start <= next_index <= end:
@@ -140,6 +193,8 @@ def import_request(
     the time of the wallet's first use is what finds its history. `NOW` is
     the default for the reason there is no default restore date -- this
     module cannot know one, and a silent 0 would rescan the whole chain.
+    A number or `NOW` itself, and no other string: Core takes those two
+    and refuses the rest, `"NOW"` included.
 
     `internal` marks the change chain, which Core then keeps out of what
     it reports as incoming payments.
@@ -151,7 +206,9 @@ def import_request(
 
     `key_range` is the inclusive pair Core takes, both ends included --
     Core adds one to the second itself. None leaves the field out, which
-    is what an unranged descriptor takes.
+    is what an unranged descriptor takes. Ordered, non-negative, an end
+    below 2**31 and fewer than a million indexes wide, which are
+    `ParseDescriptorRange`'s bounds.
 
     `next_index` is where an active ranged descriptor hands out its next
     address, and has to be inside the range, as Core checks.
@@ -161,6 +218,8 @@ def import_request(
     """
     text = add_checksum(descriptor if isinstance(descriptor, str) else str(descriptor))
     is_ranged = _is_ranged(descriptor)
+
+    _assert_timestamp(timestamp)
 
     if active and not is_ranged:
         err_msg = "an active descriptor must be ranged: one script is no keypool"

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -555,11 +555,20 @@ def _session_key_agg_coeff(session_ctx: SessionContext, pub_key: bytes) -> int:
 def sign(sec_nonce: bytearray, prv_key: PrvKey, session_ctx: SessionContext) -> bytes:
     """Return the 32-byte partial signature of one signer.
 
-    The secnonce is consumed: its first 64 bytes are zeroed before
-    anything else happens, so that calling this twice with the same
-    bytearray raises instead of handing out the private key. That is why
+    The secnonce is consumed: its first 64 bytes are zeroed the moment
+    they are read, before either is used for anything, so that calling
+    this twice with the same bytearray reads two zero scalars and raises
+    "out of range" instead of handing out the private key. That is why
     the argument is a bytearray and not bytes -- an immutable secnonce
     is one nothing can spend -- and why a caller must not keep a copy.
+
+    `session_values` runs first, and that is the one thing this order
+    leaves spendable: a session that does not assemble -- a pubnonce that
+    is no point, a tweak out of range -- raises before the nonce is
+    touched, so the same bytearray may be used for the corrected session.
+    Nothing was signed with it, which is what makes reuse safe there and
+    only there, and BIP327's reference implementation has the two calls
+    in this order for the same reason.
     """
     values = session_values(session_ctx)
     k_1_ = int.from_bytes(sec_nonce[:_SCALAR_SIZE], "big")

--- a/tests/core_import_test.py
+++ b/tests/core_import_test.py
@@ -121,6 +121,25 @@ def test_the_timestamp_is_where_the_rescan_starts() -> None:
     assert import_request(receive, 0)["timestamp"] == 0
 
 
+def test_the_timestamp_is_a_number_or_the_word_now() -> None:
+    """`GetImportTimestamp` takes those two and refuses every other value.
+
+    Core compares the string against "now" and answers `Expected number
+    or "now" timestamp value for key` to anything else, which fails the
+    whole request: the case of the letters is the whole difference
+    between a working import and an rpc error after the descriptors were
+    built.
+
+    A bool is refused for the reason every integer field of the library
+    refuses one: `True` is an `int` to Python, and Core reads a json
+    boolean as neither a number nor a string.
+    """
+    receive = account_pair()[0]
+    for timestamp in ("NOW", "Now", "yesterday", "", "1455191478", True):
+        with pytest.raises(BTClibValueError, match="expected a number"):
+            import_request(receive, timestamp)
+
+
 def test_an_active_descriptor_must_be_ranged() -> None:
     """Core's own rule: an unranged descriptor is no source of addresses.
 
@@ -155,6 +174,32 @@ def test_a_range_belongs_to_a_ranged_descriptor() -> None:
     for key_range in ((5, 1), (-1, 5)):
         with pytest.raises(BTClibValueError, match="invalid range"):
             import_request(receive, key_range=key_range)
+
+
+def test_both_ends_of_the_range_are_bounded_as_core_bounds_them() -> None:
+    """`ParseDescriptorRange`'s two bounds, on the widths either side of them.
+
+    `high >> 31` is "End of range is too high" and `high >= low + 1000000`
+    is "Range is too large", so 2**31 - 1 is the highest end and a million
+    indexes the widest span -- both of them accepted here, and the next
+    value along refused. Core's own keypool default is a thousand, so what
+    these catch is a range computed wrongly rather than one meant.
+    """
+    receive = account_pair()[0]
+
+    top = 2**31 - 1
+    assert import_request(receive, key_range=(top - 1, top))["range"] == [top - 1, top]
+    with pytest.raises(BTClibValueError, match="end of range is too high"):
+        import_request(receive, key_range=(0, 2**31))
+
+    widest = 999_999
+    assert import_request(receive, key_range=(0, widest))["range"] == [0, widest]
+    assert import_request(receive, key_range=(7, 7 + widest))["range"] == [7, 1_000_006]
+    with pytest.raises(BTClibValueError, match="range is too large: 1000001 indexes"):
+        import_request(receive, key_range=(0, 1_000_000))
+    # the span and not the end: a range high up is refused for its width
+    with pytest.raises(BTClibValueError, match="range is too large"):
+        import_request(receive, key_range=(1000, 1000 + 1_000_000))
 
 
 def test_next_index_is_inside_the_range() -> None:


### PR DESCRIPTION
`core_import`'s docstring opens with

> Every rule Core enforces on a request is enforced here, where the error
> can still say which field it was rather than arriving as an rpc failure
> half a rescan later.

and then names five. Three rules were not among them. Each one is a
request the node rejects whole, built here without a word.

| Core's rule | where | before |
|---|---|---|
| `low < 0` | `ParseDescriptorRange` | ✅ |
| `low > high` | `ParseRange` | ✅ |
| `(high >> 31) != 0` → *End of range is too high* | `ParseDescriptorRange` | ❌ |
| `high >= low + 1000000` → *Range is too large* | `ParseDescriptorRange` | ❌ |
| a number, or the string `now` compared exactly | `GetImportTimestamp` | ❌ |

The first two are `src/rpc/util.cpp`, which `importdescriptors` calls on
the `range` field; the third is `src/wallet/rpc/backup.cpp`.

`key_range=(0, 2**62)` and `key_range=(0, 1_000_000)` were accepted. So
were `timestamp="NOW"` and `timestamp="yesterday"` — the cheapest of the
three to trip on, a working request being one capital letter away.

## Checked on both sides, not asserted

`2**31 - 1` is accepted as the highest end and `2**31` refused; a span of
a million indexes accepted and one more refused; a wide range high up
refused for its **width** and not its end. `-1` stays a valid timestamp,
Core reading any number as one.

A bool is refused as a timestamp for the reason every integer field here
refuses one: `True` is an `int` to Python, and Core reads a json boolean
as neither a number nor a string. `is_integer` is the predicate the rest
of the library already uses.

`UniValue::getInt<int64_t>` is deliberately **not** repeated, and the
reason sits next to the bounds: after them `start` and `end` are inside
`[0, 2**31)` and `next_index` is between the two, so no number this
module builds can reach it.

## Why 100% coverage did not see it

The five rules already checked have one test each, written from the same
list the code was. Code, docstring and suite agreed with each other and
omitted the same three — agreement is not coverage of the thing being
mirrored. These three came from reading Core, not from the list.

## Measured

`pre-commit run --all-files`, `pytest --cov` and the `-W` sphinx build
all exit 0. Suite at 17535, coverage 100.00%. Every probe that Core
refuses is now refused, and every one it accepts still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align core_import’s validation with Bitcoin Core by enforcing the same range and timestamp rules importdescriptors uses, and documenting these constraints.

Bug Fixes:
- Reject key ranges whose end is ≥ 2**31, matching Core’s "End of range is too high" rule.
- Reject key ranges spanning one million or more indexes, matching Core’s "Range is too large" rule.
- Reject timestamps that are neither numeric nor the exact string "now", preventing requests Core would later fail.

Enhancements:
- Document the additional range and timestamp constraints in core_import’s docstring and the changelog to reflect the stricter validation.

Tests:
- Add tests covering the new range upper-bound and span limits, and the stricter timestamp acceptance rules.

---

## Second commit: a docstring that claimed more than the code does

Same shape as the first — a sentence that overstated what the function
guarantees — so it rides along rather than opening a second review.

`musig2.sign` said its secnonce is zeroed "before anything else
happens". It is not: `session_values` runs first. What holds is
narrower and more useful — the two halves are zeroed *the moment they are
read*, before either is used, so a second call reads two zero scalars and
raises "out of range".

The order is now documented rather than merely un-overclaimed, because it
is the one path that leaves a secnonce spendable: a session that does not
assemble (a pubnonce that is no point, a tweak out of range) raises before
the bytearray is touched, so the same one may be used for the corrected
session. Nothing was signed with it, which is what makes reuse safe there
and nowhere else. BIP327's reference calls `get_session_values` first for
the same reason — this is the order matching it, not a deviation.

Measured, not read off the source:

- a session with an out-of-range tweak raises and leaves the secnonce byte-identical
- that secnonce then signs the corrected session, and its partial signature verifies
- a second `sign` with it raises `first secnonce value is out of range.`
- the two partial signatures aggregate to a signature `ssa.verify_` accepts

Documentation only, no behaviour change, no CHANGELOG entry.