### PR TITLE
Say why the slip39 digest is compared with != and not compare_digest

### DIFF
--- a/btclib/mnemonic/slip39.py
+++ b/btclib/mnemonic/slip39.py
@@ -435,6 +435,22 @@ def _recover_secret(threshold: int, shares: Sequence[tuple[int, bytes]]) -> byte
     secret = _interpolate(shares, _SECRET_X)
     digest_share = _interpolate(shares, _DIGEST_X)
     random_part = digest_share[_DIGEST_BYTES:]
+    # `!=` and not hmac.compare_digest, which ecies.assert_valid_mac does
+    # use: the two comparisons look alike and are not the same question.
+    # There the mac key comes from an ECDH secret the attacker does not
+    # hold, so the expected mac is not computable by whoever submits the
+    # envelope, and a byte-at-a-time early exit is a forgery oracle --
+    # the comment there says so.
+    # Here both operands come out of the shares the caller just passed
+    # in: `random_part` and `secret` are interpolated from them, so the
+    # expected digest is something the caller can compute offline, for
+    # any shares, without calling this at all. A timing signal can only
+    # hand back what its observer already has, which is why the constant
+    # time version buys nothing -- and it is why this check is an
+    # integrity test that the shares belong together, not a security
+    # boundary against somebody who chooses them: such an attacker forges
+    # a passing digest directly rather than searching for one.
+    # SLIP-0039's reference implementation compares with `!=` too.
     if digest_share[:_DIGEST_BYTES] != _digest(random_part, secret):
         raise BTClibValueError("invalid digest: the shares do not belong together")
     return secret


### PR DESCRIPTION
`ecies.assert_valid_mac` compares a mac with `hmac.compare_digest` and
carries a comment saying why. Twenty lines of a different module compare
a digest with `!=` and carried nothing.

The two look like the same question and are not, so a reader who notices
both has to work out which one is the oversight. The answer is neither,
and that is now written down where the question gets asked.

## The distinction

**ecies**: the mac key comes from an ECDH secret the submitter does not
hold, so the expected mac is not computable by whoever hands over the
envelope. A byte-at-a-time early exit is a forgery oracle. Hence
`compare_digest`.

**slip39**: both operands come out of the shares the caller just passed
in — `random_part` and `secret` are interpolated from them — so the
expected digest is something that caller can compute offline, for any
shares, without calling this at all. A timing signal can only return what
its observer already has.

Which also settles what the check *is*: an integrity test that the shares
belong together, not a boundary against somebody who chooses them.

## Measured, not argued

Interpolating backwards from a chosen `(digest_share, secret)` pair to the
two share values that produce them yields shares this accepts on the first
try — no search, no timing, no oracle:

```
digest accettato: True   segreto recuperato: 000102030405060708090a0b0c0d0e0f
share estranee -> invalid digest: the shares do not belong together
```

The second line is the check still doing its job.

SLIP-0039's reference implementation (`shamir_mnemonic/shamir.py`)
compares with `!=` too, so this is the spelling that matches it rather
than a deviation needing justification — and the reason nothing is being
reported upstream.

No behaviour change: a comment, and nothing else. `pre-commit run
--all-files`, `pytest --cov` and the `-W` sphinx build all exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add an explanatory comment justifying the use of standard inequality comparison for SLIP-0039 digest verification and clarifying the integrity vs. security boundary distinction.