### PR TITLE
Align the PyPI keywords with the GitHub repository topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+<!-- markdownlint-configure-file
+  {
+    // MD024/no-duplicate-heading - a group heading repeats under every
+    // release with an entry in that group ("Packaging, linting and CI",
+    // "Tests", "Repository"), which is what keeps the page readable
+    // scrolling down it; only a duplicate under the same release heading
+    // would be the accident this rule looks for
+    "MD024": { "siblings_only": true }
+  }
+-->
+
 Every change of a release, in full: what changed, why, and what it cost.
 [HISTORY.md](./HISTORY.md) has the release notes, which say what a user has
 to act on; this file is the record behind them, and is where a claim in
@@ -10,6 +21,33 @@ documented at release-notes length in the first place, and are still in
 [HISTORY.md](./HISTORY.md) rather than duplicated here.
 
 ## v2026.9 (work in progress, not released yet)
+
+### Packaging, linting and CI
+
+- **`keywords` and the GitHub repository topics name the same features.**
+  The keyword list had neither `psbt` nor `taproot`, and none of what
+  v2026.8.7 added: `secp256k1` for the libsecp256k1 bindings every wheel
+  requires, `musig2` for BIP327 and the BIP373 psbt fields, `slip39` for
+  the Shamir backup, `output-descriptors` for the BIP380 grammar
+  `descriptors.py` reads, and `hardware-wallet` for the HWI signer behind
+  `psbt_signer`. `RFC-6979` is `rfc-6979` with them: a GitHub topic is
+  lowercase or it is not a topic, and one spelling across the two lists is
+  what lets them be compared. The order is by relevance rather than
+  alphabetical, PyPI showing keywords as the metadata gives them; GitHub
+  sorts its own, so there the order decides only which topic goes when the
+  twenty GitHub allows are full -- which is why `rfc-6979`, `mnemonic`,
+  `merkle-proof`, `bip44` and `bitcoin-script` are keywords with no topic
+  beside them.
+- **this file relaxes MD024 (no-duplicate-heading) for itself**, a group
+  heading repeating under every release that has an entry in that group:
+  the rule reads that repeat as the accident it usually is, and
+  `siblings_only` is what tells the two apart, a duplicate under one
+  release heading still failing. It is a `markdownlint-configure-file`
+  comment here rather than a line in `.markdownlint.jsonc`, which is
+  shared with btclib-libsecp256k1 and bitcoin-core-rpc and says so
+  itself: a rule one file needs belongs to that file, not to a config
+  read by files that never trip it. bitcoin-core-rpc's CHANGELOG.md
+  carries the same comment for the same reason.
 
 ## v2026.8.7
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,20 +80,39 @@ dependencies = [
     "bitcoin-core-rpc>=2026.8.7",
 ]
 keywords = [
+    # The GitHub repository topics, in the same order, and the order is by
+    # relevance rather than alphabetical: PyPI shows keywords as they are
+    # given, and the first few are read as what the package is. GitHub
+    # sorts its own alphabetically and takes lowercase only, which is the
+    # spelling here too, so the two lists differ in nothing but length.
     "bitcoin",
     "cryptography",
     "elliptic-curves",
+    "secp256k1",
     "ecdsa",
     "schnorr",
-    "RFC-6979",
+    "bip340",
+    "musig2",
     "bip32",
     "bip39",
+    "slip39",
     "electrum",
+    "psbt",
+    "taproot",
+    "segwit",
     "base58",
     "bech32",
-    "segwit",
+    "output-descriptors",
+    "hardware-wallet",
     "message-signing",
-    "bip340",
+    # Past the twenty topics GitHub allows, so these are keywords and not
+    # topics. Nothing caps this list, and a keyword for a feature the
+    # library has costs nothing.
+    "rfc-6979",
+    "mnemonic",
+    "merkle-proof",
+    "bip44",
+    "bitcoin-script",
 ]
 classifiers = [
     "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
`keywords` in `pyproject.toml` had neither `psbt` nor `taproot`, and none
of what v2026.8.7 added. It now carries the twenty GitHub repository
topics, in the same order, plus the five that the twenty-topic cap leaves
out.

The order is by relevance rather than alphabetical: PyPI shows keywords as
the metadata gives them, and GitHub sorts its own, so there the order
decides only which topic goes when the cap is reached. `RFC-6979` is
`rfc-6979` with the rest — a GitHub topic is lowercase or it is not a
topic, and one spelling across the two lists is what lets them be
compared.

Added: `secp256k1` for the bindings every wheel requires, `musig2` for
BIP327 and the BIP373 psbt fields, `slip39` for the Shamir backup,
`output-descriptors` for the BIP380 grammar `descriptors.py` reads,
`hardware-wallet` for the HWI signer behind `psbt_signer`, and `psbt` and
`taproot`, which the topics already had. Keywords with no topic beside
them: `rfc-6979`, `mnemonic`, `merkle-proof`, `bip44`, `bitcoin-script`.

`CHANGELOG.md` also relaxes MD024 for itself: the entry above is the first
under a second release heading, so every group heading now repeats.
`siblings_only` tells that repeat from a duplicate under one release,
which still fails, and the setting is a `markdownlint-configure-file`
comment in the file rather than a line in the `.markdownlint.jsonc` shared
with btclib-libsecp256k1 and bitcoin-core-rpc — which says itself that a
rule one file needs belongs to that file. bitcoin-core-rpc's CHANGELOG.md
carries the same comment.

The GitHub topics themselves are set in the repository settings, not in
this branch.

Gates run on the branch: `uv run pre-commit run --all-files`, `uv run
pytest --cov` (17534 passed, 5 integration tests skipped as documented),
and the docs build with `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align package metadata keywords with GitHub repository topics and document the change along with a local markdownlint rule override in the changelog.

Enhancements:
- Synchronize pyproject.toml keywords with the GitHub repository topics and add additional relevant keywords beyond GitHub's topic limit.
- Document the metadata keyword alignment and relax the MD024 duplicate-heading markdownlint rule locally within CHANGELOG.md.