### PR TITLE
Give the README the badges that can turn red

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,32 @@ documented at release-notes length in the first place, and are still in
   read by files that never trip it. bitcoin-core-rpc's CHANGELOG.md
   carries the same comment for the same reason.
 
+### Documentation and the website
+
+- **The README badges are the ones that can turn red**, in the order the
+  reader asks for them: version, downloads, development status, license
+  and supported interpreters on the first line; test, lint, pre-commit.ci
+  and the documentation build on the second. Eight of the eighteen
+  reported no state at all — `uv`, `cal_ver`, `pre-commit enabled`, three
+  ruff badges, mypy, markdownlint-cli2 — so they are in CONTRIBUTING.md's
+  "Getting started", beside the prose that says how each choice is
+  enforced, and the Slack badge is down with the repository link, "where
+  do I ask" being a question the reader has after reading. The table that
+  held them is gone with them: its left column was the taxonomy, and
+  nine self-describing badges do not need one — `pypi`, `python`, `test`
+  read as their own labels, which is also why the alternative text is now
+  "PyPI version" and "test workflow status" rather than the name of the
+  site serving the image. Two defects went with the table: `calver:
+  yyy.m.d` was missing a `y`, and the badge for the docstring rules
+  carried "lint: ruff", copied from the row above it, so a screen reader
+  announced two different links identically. One badge per source line
+  now, which puts a badge change in one line of a diff and keeps every
+  line inside MD013 — its 80 columns bind only where a space follows
+  them, and in a bare URL none does, so the file no longer disables the
+  rule to hold a 900-character row. The line break renders as a space:
+  `_config.yml` leaves kramdown's `hard_wrap` at Jekyll's default, which
+  is off, as btclib.org's own `<p>` for a wrapped paragraph shows.
+
 ## v2026.8.7
 
 Grouped, and the order runs from what breaks a caller to what only

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,19 @@ Here are some resources to help you get started with open source contributions:
 
 ## Getting started
 
+<!-- The toolchain badges are here rather than in the README because they
+report no state: each names a choice, and this is the section that says how
+the choice is enforced and what the command for it is. The README keeps the
+badges that can turn red. -->
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![calendar versioning: yyyy.m.d](https://img.shields.io/badge/cal_ver-yyyy.m.d-1674b1.svg?logo=calver)](https://calver.org/)
+[![pre-commit enabled](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
+[![format: ruff](https://img.shields.io/badge/format-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/formatter/)
+[![lint: ruff](https://img.shields.io/badge/lint-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/)
+[![docstrings: ruff](https://img.shields.io/badge/docstrings-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/rules/#pydocstyle-d)
+[![type check: mypy](https://img.shields.io/badge/type_check-mypy-yellowgreen.svg?logo=mypy)](https://mypy-lang.org/)
+[![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2)
+
 btclib is managed with [uv](https://docs.astral.sh/uv/), the only tool that
 must be installed on the development machine: see the
 [uv installation instructions](https://docs.astral.sh/uv/getting-started/installation/).

--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
 # A Python library for 'bitcoin cryptography'
 
-<!-- markdownlint-disable MD013 -->
-| | |
-| --- | --- |
-| Project | [![status](https://img.shields.io/pypi/status/btclib.svg)](https://pypi.python.org/pypi/btclib/) [![license](https://img.shields.io/github/license/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/blob/master/LICENSE) |
-| Package | [![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv) [![calver: yyy.m.d](https://img.shields.io/badge/cal_ver-yyyy.m.d-1674b1.svg?logo=calver)](https://calver.org/) [![pypi](https://img.shields.io/pypi/v/btclib.svg?logo=pypi)](https://pypi.python.org/pypi/btclib/) [![downloads](https://static.pepy.tech/badge/btclib)](https://pepy.tech/project/btclib) |
-| Supported platforms | [![python](https://img.shields.io/pypi/pyversions/btclib.svg?logo=python)](https://pypi.python.org/pypi/btclib/) |
-| Formatting standards | [![format: ruff](https://img.shields.io/badge/format-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/formatter/) [![lint: markdownlint-cli2](https://img.shields.io/badge/lint-markdownlint--cli2-yellowgreen.svg?logo=markdown)](https://github.com/DavidAnson/markdownlint-cli2) |
-| Coding standards | [![lint: ruff](https://img.shields.io/badge/lint-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/) |
-| Type checking | [![type check: mypy](https://img.shields.io/badge/type_check-mypy-yellowgreen.svg?logo=mypy)](https://mypy-lang.org/) |
-| Documentation | [![docs](https://readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io) [![lint: ruff](https://img.shields.io/badge/docstrings-ruff-yellowgreen.svg?logo=ruff)](https://docs.astral.sh/ruff/rules/#pydocstyle-d) |
-| CI/CD | [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit) [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib/master.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib/master) [![lint](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml) [![test](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/test.yml) |
-| Conversations | [![slack](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES) |
+<!-- The badges are what the reader decides with: the first line says what
+this is and whether it can be used, the second whether it works. A badge
+that reports no state -- "we use ruff", "we use uv" -- reports a choice
+instead, and those are in CONTRIBUTING.md, beside the prose that says how
+the choice is enforced. One badge per line keeps a change to one line and
+every line inside MD013; the site renders the line break as a space, its
+kramdown having hard_wrap off. -->
+[![PyPI version](https://img.shields.io/pypi/v/btclib.svg?logo=pypi)](https://pypi.python.org/pypi/btclib/)
+[![downloads](https://static.pepy.tech/badge/btclib)](https://pepy.tech/project/btclib)
+[![development status](https://img.shields.io/pypi/status/btclib.svg)](https://pypi.python.org/pypi/btclib/)
+[![license](https://img.shields.io/github/license/btclib-org/btclib.svg)](https://github.com/btclib-org/btclib/blob/master/LICENSE)
+[![supported Python versions](https://img.shields.io/pypi/pyversions/btclib.svg?logo=python)](https://pypi.python.org/pypi/btclib/)
+
+[![test workflow status](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/test.yml)
+[![lint workflow status](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml)
+[![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib/master.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib/master)
+[![documentation build](https://readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
 
 [Browse GitHub Code Repository](https://github.com/btclib-org/btclib/)
+[![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
 
 ---
-<!-- markdownlint-enable MD013 -->
 
 [btclib](https://btclib.org) is a
 Python3 [type annotated](https://docs.python.org/3/library/typing.html)


### PR DESCRIPTION
The badge table held eighteen badges and its left column was their taxonomy — "Project", "Package", "Formatting standards", "Type checking". Eight of those badges report no state: `uv`, `cal_ver`, "pre-commit enabled", three ruff badges, mypy and markdownlint-cli2 name a choice. The table gave a choice and a measurement the same weight, and inside the CI/CD row "pre-commit enabled" came first while `test` came last.

**The nine that report state stay in the README**, in the order the reader asks for them: version, downloads, development status, license and supported interpreters on the first line; test, lint, pre-commit.ci and the documentation build on the second. Version and downloads are adjacent, both being PyPI reading back the same project; `test` precedes `lint`, a red suite and a red linter not weighing the same.

**The eight that report a choice move to CONTRIBUTING.md**, under "Getting started" — the section that says how each choice is enforced and what the command for it is. The Slack badge moves to the repository link at the top of the README: "where do I ask" is a question the reader has after reading.

The table goes with them. Nine self-describing badges need no taxonomy, `pypi`, `python`, `test` and `docs` reading as their own labels; and the alternative text now says "PyPI version", "supported Python versions", "test workflow status" instead of naming the site that serves the image, that text being the accessible name of the link.

Two defects went with the table: `calver: yyy.m.d` was a `y` short, and the badge for the docstring rules carried "lint: ruff" copied from the row above it, so two links with different destinations were announced identically.

One badge per source line puts a badge change in one line of a diff, and every line is inside MD013 without the disable the file carried for its 900-character rows — the rule binds at 80 columns only where a space follows them, and in a bare URL none does. The line break renders as a space: `_config.yml` leaves kramdown’s `hard_wrap` at Jekyll’s default of off, which btclib.org confirms by serving a wrapped paragraph as one `<p>` with no `<br>`.

Gates run on this tree: `uv run pre-commit run --all-files`, the docs build with `-W` (README.md is a page of it, through `docs/source/readme_link.md`), and `uv run pytest --cov` — 17534 passed, 5 integration tests skipped as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rework project badges so the README only shows status-indicating badges while toolchain choice badges move to CONTRIBUTING, improving readability and accessibility.

Enhancements:
- Relocate toolchain and configuration badges (uv, calver, pre-commit, ruff, mypy, markdownlint-cli2) from the README to CONTRIBUTING’s Getting started section, next to their explanatory prose.
- Fix badge labels and alt text (including the calver pattern and docstring lint badge) and adopt one-badge-per-line formatting to satisfy markdownlint and aid diff readability.

Documentation:
- Restructure README badges into two status-focused lines and move the Slack link near the repository link for clearer reader context.
- Document the new badge layout and rationale in the changelog under documentation and website changes.