### PR TITLE
Make the repository link a badge, like the channel beside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,8 +58,14 @@ documented at release-notes length in the first place, and are still in
   reported no state at all — `uv`, `cal_ver`, `pre-commit enabled`, three
   ruff badges, mypy, markdownlint-cli2 — so they are in CONTRIBUTING.md's
   "Getting started", beside the prose that says how each choice is
-  enforced, and the Slack badge is down with the repository link, "where
-  do I ask" being a question the reader has after reading. The table that
+  enforced, and the Slack badge is down with the repository, "where do I
+  ask" being a question the reader has after reading. The repository is a
+  badge there too, where it was the sentence "Browse GitHub Code
+  Repository": the two links out of this page answer "where do I read the
+  code" and "where do I ask", so they are one kind of thing and now look
+  like it — and the badge names `btclib-org/btclib`, which the sentence
+  did not, the organization being what tells this repository from the
+  forks a search returns. The table that
   held them is gone with them: its left column was the taxonomy, and
   nine self-describing badges do not need one — `pypi`, `python`, `test`
   read as their own labels, which is also why the alternative text is now

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ kramdown having hard_wrap off. -->
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib/master.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib/master)
 [![documentation build](https://readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
 
-[Browse GitHub Code Repository](https://github.com/btclib-org/btclib/)
+<!-- the two places to go, in the same form as each other: the repository
+and the channel. Neither reports state, which is why they are here and not
+in the lines above -- what they answer is "where do I read the code" and
+"where do I ask", both questions the reader has after reading. -->
+[![GitHub repository: btclib-org/btclib](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib-181717?logo=github)](https://github.com/btclib-org/btclib/)
 [![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)
 
 ---


### PR DESCRIPTION
"Browse GitHub Code Repository" was a sentence on the line the Slack badge is on, so the two links out of the page looked like two different kinds of thing. They are one kind: *where do I read the code*, *where do I ask*. Both are badges now, and neither reports state — which is why they sit below the two lines that do, rather than in them.

```text
GitHub | btclib-org/btclib     slack | btclib_dev
```

The badge names `btclib-org/btclib`, which the sentence did not: the organization is what tells this repository from the forks a search returns, and it is the slug every other badge on the page already spells inside its url.

The CHANGELOG entry of this unreleased version is amended rather than answered by a second one — it says where the badges of v2026.9 ended up, and this is where one of them ended up.

Gates run on this tree: `uv run --locked --only-group lint pre-commit run --all-files`, the docs build with `-W` (README.md is a page of it, and the built page carries the two badges as one paragraph), and `uv run pytest --cov` — 17534 passed, 5 integration tests skipped as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Convert the GitHub repository link in the README into a badge aligned with the Slack badge, and update release notes to describe this badge change.

Enhancements:
- Clarify CHANGELOG entry to document the relocation and badge formatting of repository and Slack links in the unreleased version.

Documentation:
- Update README to present the GitHub repository and Slack channel as matching badges that direct readers to code and support respectively.