### PR TITLE
Build a SoftwareSigner on the accounts a device exported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### Transactions, blocks and PSBT
+
+- **`SoftwareSigner.from_accounts` builds a signer on the accounts a
+  device exported**, for the master fingerprint they came from, where the
+  constructor takes one key and answers that key's own fingerprint. What
+  a psbt names in a key origin is the master's four bytes and a path from
+  it, so a signer built on an account answered for no origin of the
+  psbts that account's device writes -- the class docstring said so, and
+  left the caller to write the lookup. An origin is answered by the
+  account whose path is a prefix of it, the longest one where several
+  are, with the public key check unchanged: the fingerprint is told
+  rather than computed and is therefore a claim, and an account paired
+  with the wrong master is refused one derivation later. `xkey` is now
+  the key a signer was built on where it was built on one, and raises
+  for a signer of accounts, there being no key of which the others are
+  derivations.
+
 ### Packaging, linting and CI
 
 - **RELEASING.md says what `griffe check` actually reports**: breakage

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -46,11 +46,11 @@ from __future__ import annotations
 
 from base64 import b64encode
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from btclib.alias import BIP44ScriptType, Octets, String
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, derive, xpub_from_xprv
-from btclib.bip32.der_path import DerPath
+from btclib.bip32.der_path import DerPath, indexes_from_der_path, str_from_der_path
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.descriptors import Descriptor, account_descriptors
 from btclib.ecc import bms, dsa, ssa
@@ -59,6 +59,10 @@ from btclib.psbt.psbt import Psbt, assert_signatures_only, combine, sign
 from btclib.script.taproot import output_prvkey_from_merkle_root
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
 from btclib.to_pub_key import fingerprint, pub_keyinfo_from_key
+from btclib.utils import bytes_from_octets
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 __all__ = [
     "AddressDisplay",
@@ -72,6 +76,13 @@ __all__ = [
     "request_signatures",
     "sign_message",
 ]
+
+
+def _b58_text(xkey: BIP32Key) -> str:
+    """Return the b58 spelling of a key, whatever spelling came in."""
+    if isinstance(xkey, BIP32KeyData):
+        return xkey.b58encode()
+    return BIP32KeyData.b58decode(xkey).b58encode()
 
 
 @dataclass(frozen=True)
@@ -278,7 +289,7 @@ def sign_message(
 
 
 class SoftwareSigner:
-    """One extended key, in this process, answering the contract above.
+    """Keys in this process, at known paths, answering the contract above.
 
     The reference implementation of `PsbtSigner`, `AddressDisplay` and
     `MessageSigner`, and what makes the contract testable without
@@ -294,12 +305,19 @@ class SoftwareSigner:
     adapter and this answer the same questions, so a caller can be
     developed against this and run against that.
 
-    A key is answered for when the origin's fingerprint is this key's own
+    A key is answered for when the origin's fingerprint is this signer's
     and the path derives to the very public key the psbt names. That
     second half is the check a device makes too: a psbt saying "this key
     is at that path" is a psbt somebody else wrote, and signing with what
     the path derives to without looking would sign with a key the caller
     was not told about.
+
+    One key or several is the same model: what is held is a key at a path
+    from the master, and `SoftwareSigner(xkey)` is the case where that
+    path is empty and the key *is* the master. `from_accounts` is the
+    other case, where a device exported accounts and kept its master --
+    the shape a psbt names, its key origins being a master fingerprint
+    and a path from it.
     """
 
     def __init__(self, xkey: BIP32Key, *, musig2: bool = False) -> None:
@@ -308,19 +326,108 @@ class SoftwareSigner:
         # inside, rather than a branch at every use. The round trip is
         # also what refuses a key that is no key, at construction rather
         # than at the first question asked
-        self.xkey = (
-            xkey.b58encode()
-            if isinstance(xkey, BIP32KeyData)
-            else BIP32KeyData.b58decode(xkey).b58encode()
-        )
+        key = _b58_text(xkey)
         self._musig2 = musig2
-        self._fingerprint = fingerprint(self.xkey)
+        self._fingerprint = fingerprint(key)
+        # the empty path is the master itself: every origin descends from
+        # it, so the lookup below finds this key for any of them
+        self._keys: dict[tuple[int, ...], str] = {(): key}
         self._closed = False
+
+    @classmethod
+    def from_accounts(
+        cls,
+        master_fingerprint: Octets,
+        accounts: Mapping[DerPath, BIP32Key],
+        *,
+        musig2: bool = False,
+    ) -> SoftwareSigner:
+        """Return a signer holding accounts, for the master they came from.
+
+        What a device that exported its accounts leaves behind, and what
+        `SoftwareSigner(xkey)` cannot express: the fingerprint a psbt
+        names is the *master*'s, and an account key's own is a different
+        four bytes, so a signer built on an account would answer for no
+        origin the device's psbts carry.
+
+        The fingerprint is therefore told rather than computed, and is a
+        claim: nothing in an extended key records where it came from, so
+        an account paired with the wrong master answers for origins whose
+        keys it does not hold -- and the public key check refuses each of
+        them, one derivation later.
+
+        Each path is the account's own, from that master. An origin is
+        answered by the account whose path is a prefix of it, the
+        remainder being what is derived; where two accounts prefix the
+        same origin the longer one answers, having less left to derive.
+        Fingerprint, then prefix, then the public key: the three are what
+        HWI's ledger driver matches on and what electrum's keystore tries
+        first, which is the shape a psbt written by a wallet has.
+
+        An origin naming an *account's* own fingerprint rather than the
+        master's is the other thing a wallet writes, and it is
+        `SoftwareSigner(account_xkey)`: a signer answers one fingerprint,
+        `master_fingerprint` being a single question, so which of the two
+        a psbt carries decides which constructor reads it.
+
+        What is not done is electrum's third attempt, which ignores the
+        fingerprint and tries the last few indexes against the public key
+        anyway. It is a search for a key the psbt did not say is there,
+        and a match found that way is a coincidence a signature would
+        make binding.
+        """
+        if not accounts:
+            raise BTClibValueError("no account: the signer would hold no key")
+        signer = cls.__new__(cls)
+        signer._musig2 = musig2
+        signer._fingerprint = bytes_from_octets(master_fingerprint, 4)
+        signer._keys = {
+            tuple(indexes_from_der_path(path)): _b58_text(key)
+            for path, key in accounts.items()
+        }
+        signer._closed = False
+        return signer
+
+    @property
+    def xkey(self) -> str:
+        """Return the key this signer was built on, where it was built on one.
+
+        A signer holding accounts was built on none: there is no key of
+        which the others are derivations, and answering one of them would
+        be answering a key the caller did not ask about.
+        """
+        try:
+            return self._keys[()]
+        except KeyError:
+            err_msg = "this signer holds accounts, not one key"
+            raise BTClibValueError(err_msg) from None
+
+    def _at(self, der_path: DerPath) -> str:
+        """Return the key at a path from the master, derived from what is held.
+
+        The account whose path is a prefix of the one asked for is the one
+        that can reach it; the longest such account is the one with the
+        least left to derive, and where the signer holds a master that
+        account is the master.
+        """
+        indexes = tuple(indexes_from_der_path(der_path))
+        candidates = [
+            (len(path), key)
+            for path, key in self._keys.items()
+            if indexes[: len(path)] == path
+        ]
+        if not candidates:
+            err_msg = f"no key held for the path {str_from_der_path(der_path)}"
+            raise BTClibValueError(err_msg)
+        depth, key = max(candidates)
+        return derive(key, list(indexes[depth:])) if indexes[depth:] else key
 
     @property
     def is_watch_only(self) -> bool:
         """Answer whether this signer holds no key that signs."""
-        return not BIP32KeyData.b58decode(self.xkey).is_private
+        return not any(
+            BIP32KeyData.b58decode(key).is_private for key in self._keys.values()
+        )
 
     def master_fingerprint(self) -> bytes:
         """Return the fingerprint of the key this signer was built on.
@@ -341,7 +448,7 @@ class SoftwareSigner:
         key that signs where a caller expects one that cannot.
         """
         self._assert_open()
-        derived = derive(self.xkey, der_path)
+        derived = self._at(der_path)
         if BIP32KeyData.b58decode(derived).is_private:
             return xpub_from_xprv(derived)
         return derived
@@ -415,7 +522,7 @@ class SoftwareSigner:
         self._assert_open()
         if self.is_watch_only:
             raise BTClibValueError("watch-only signer: it holds no key that signs")
-        prv_key = derive(self.xkey, der_path)
+        prv_key = self._at(der_path)
         return b64encode(bms.sign(message, prv_key).serialize()).decode("ascii")
 
     def _prv_key(self, pub_key: bytes, origin: BIP32KeyOrigin | None) -> int | None:
@@ -433,9 +540,10 @@ class SoftwareSigner:
         if origin is None or origin.master_fingerprint != self._fingerprint:
             return None
         try:
-            derived = derive(self.xkey, origin.der_path)
-        # a path this key cannot walk is a key this signer does not hold:
-        # a hardened step under an xpub, or an index BIP32 refuses
+            derived = self._at(origin.der_path)
+        # a path this signer cannot walk is a key it does not hold: an
+        # origin no account of it prefixes, a hardened step under an
+        # xpub, or an index BIP32 refuses
         except BTClibValueError:
             return None
         sec = pub_keyinfo_from_key(derived)[0]

--- a/tests/software_signer_test.py
+++ b/tests/software_signer_test.py
@@ -270,3 +270,121 @@ def test_the_account_a_signer_exports_is_the_one_core_imports() -> None:
     ]
     assert [request["internal"] for request in requests] == [False, True]
     assert all(request["range"] == [0, 24] for request in requests)
+
+
+def test_a_signer_of_accounts_answers_for_the_master_it_names() -> None:
+    """What a device that exported its accounts and kept its master leaves.
+
+    The same flow as the whole-flow test above, signed by a signer that
+    holds the account key alone: the origins a wallet writes name the
+    master fingerprint, so the fingerprint is told rather than computed
+    and the account path is what the remainder is derived from. Built on
+    that account key the ordinary way, the signer answers the account's
+    own fingerprint and therefore for no origin of this psbt.
+    """
+    account_path = "m/84h/0h/0h"
+    account = derive(XPRV_ROOT, account_path)
+    master = SoftwareSigner(XPRV_ROOT)
+    signer = SoftwareSigner.from_accounts(
+        master.master_fingerprint(), {account_path: account}
+    )
+
+    assert signer.master_fingerprint() == master.master_fingerprint()
+    assert signer.xpub(account_path) == master.xpub(account_path)
+    assert not signer.is_watch_only
+    assert isinstance(signer, PsbtSigner)
+
+    receive, change = export_account(signer, account_path)
+    psbt, prevouts = spending(receive, change)
+    signed = request_signatures(signer, psbt)
+    assert signed != psbt
+
+    final = finalize(signed)
+    tx = final.tx
+    tx.vin[0].script_sig = final.inputs[0].final_script_sig
+    tx.vin[0].script_witness = final.inputs[0].final_script_witness
+    verify_transaction(prevouts, tx)
+
+    # the same key, built on the ordinary way: its own fingerprint is
+    # four other bytes, and no origin of this psbt names them
+    plain = SoftwareSigner(account)
+    assert plain.master_fingerprint() != master.master_fingerprint()
+    assert plain.sign_psbt(psbt) == psbt
+
+
+def test_the_longest_account_prefixing_an_origin_answers() -> None:
+    """Two accounts on one path, and the deeper one has less left to derive."""
+    signer = SoftwareSigner.from_accounts(
+        SoftwareSigner(XPRV_ROOT).master_fingerprint(),
+        {
+            "m/84h/0h": derive(XPRV_ROOT, "m/84h/0h"),
+            "m/84h/0h/0h": derive(XPRV_ROOT, "m/84h/0h/0h"),
+        },
+    )
+    # both could reach it; what matters is that the answer is the key the
+    # path names, whichever account was walked to get there
+    assert signer.xpub("m/84h/0h/0h/0/7") == xpub_from_xprv(
+        derive(XPRV_ROOT, "m/84h/0h/0h/0/7")
+    )
+    # a path no account of it prefixes is a key it does not hold
+    with pytest.raises(BTClibValueError, match="no key held for the path"):
+        signer.xpub("m/44h/0h/0h")
+
+
+def test_a_signer_of_accounts_has_no_single_key() -> None:
+    """`xkey` is the key a signer was built on, and there was none."""
+    account_path = "m/84h/0h/0h"
+    signer = SoftwareSigner.from_accounts(
+        SoftwareSigner(XPRV_ROOT).master_fingerprint(),
+        {account_path: derive(XPRV_ROOT, account_path)},
+    )
+    with pytest.raises(BTClibValueError, match="holds accounts, not one key"):
+        _ = signer.xkey
+    # built on one key, the property is that key, and the empty path
+    # reaches it as any other account path reaches its own
+    assert (
+        SoftwareSigner(XPRV_ROOT).xkey == BIP32KeyData.b58decode(XPRV_ROOT).b58encode()
+    )
+
+    with pytest.raises(BTClibValueError, match="the signer would hold no key"):
+        SoftwareSigner.from_accounts(b"\x00" * 4, {})
+
+
+def test_an_account_paired_with_the_wrong_master_answers_for_nothing() -> None:
+    """The fingerprint is a claim, and the public key is what checks it.
+
+    Nothing in an extended key records the master it came from, so an
+    account told the wrong one matches origins whose keys it does not
+    hold. One derivation later the public key is not the one the psbt
+    names, and the key is refused there rather than signed with.
+    """
+    account_path = "m/84h/0h/0h"
+    honest = SoftwareSigner(XPRV_ROOT)
+    receive, change = export_account(honest, account_path)
+    psbt, _ = spending(receive, change)
+
+    # another master's account, told this master's fingerprint
+    other_root = derive(XPRV_ROOT, "m/9h")
+    liar = SoftwareSigner.from_accounts(
+        honest.master_fingerprint(), {account_path: derive(other_root, account_path)}
+    )
+    assert liar.sign_psbt(psbt) == psbt
+
+
+def test_a_signer_of_watch_only_accounts_derives_but_does_not_sign() -> None:
+    """Accounts exported as xpubs hold no key that signs."""
+    account_path = "m/84h/0h/0h"
+    account = xpub_from_xprv(derive(XPRV_ROOT, account_path))
+    signer = SoftwareSigner.from_accounts(
+        SoftwareSigner(XPRV_ROOT).master_fingerprint(), {account_path: account}
+    )
+
+    assert signer.is_watch_only
+    assert signer.xpub(f"{account_path}/0/0") == xpub_from_xprv(
+        derive(XPRV_ROOT, f"{account_path}/0/0")
+    )
+    # the account it was handed is what a watch-only signer cannot
+    # derive for itself: every level of the path is hardened
+    receive, change = export_account(SoftwareSigner(XPRV_ROOT), account_path)
+    with pytest.raises(BTClibValueError, match="watch-only signer"):
+        signer.sign_psbt(spending(receive, change)[0])


### PR DESCRIPTION
Closes #493.

`SoftwareSigner` takes one key and answers that key's own fingerprint,
which its docstring already named as a hazard:

> a signer built on an account xpub answers that account's fingerprint, and
> a key origin naming it would send another signer looking for a master key
> nobody has.

What a psbt names in a key origin is the **master's** four bytes and a path
from it, so a signer built on the account a device exported answered for no
origin of that device's psbts. Measured on a p2wsh psbt whose origins name
`0b82026e/44h/1h/0h/0/0`, with the signer built on that device's account key
at `m/44h/1h/0h`: fingerprint `31a91a40`, **0** signatures. Built on the
master key of the same device: 1.

## What this adds

`SoftwareSigner.from_accounts(master_fingerprint, {path: account_key})`.

The fingerprint is told rather than computed — nothing in an extended key
records where it came from, so it is a claim, and an account paired with
the wrong master is refused one derivation later by the public key check
that was already there.

One key or several is now **one model**: what is held is a key at a path
from the master, and the constructor is the case where that path is empty
and the key *is* the master. `xpub`, `sign_message` and `_prv_key` walk the
same lookup, which is where the account-prefix rule lives.

## Following the implementations that talk to hardware

Fingerprint, then prefix, then the public key is what HWI's ledger driver
matches on:

```python
if (xpub_origin.fingerprint == pk_origin.fingerprint) and (
    xpub_origin.path == pk_origin.path[:len(xpub_origin.path)]):
```

and what electrum's keystore tries first, its `test_der_suffix_against_pubkey`
being the same third condition.

Electrum's **third** attempt is deliberately not here: it ignores the
fingerprint and tries the last few indexes against the public key anyway,
which electrum's own comment calls a "hack/bruteforce". It searches for a
key the psbt did not say is there, and a match found that way is a
coincidence a signature would make binding.

An origin naming an *account's* own fingerprint rather than the master's —
electrum's second attempt — is what `SoftwareSigner(account_xkey)` already
does. A signer answers one fingerprint, `master_fingerprint` being a single
question, so which of the two a psbt carries decides which constructor
reads it. The docstring says so.

## Source-breaking

`xkey` becomes a property: the key a signer was built on where it was built
on one, raising for a signer of accounts, there being no key of which the
others are derivations. Attribute access is unchanged for every signer
built the existing way.

## Gates

`uv run pytest` (whole suite), `uv run pre-commit run --all-files` and the
sphinx `-W` build, all green.

## Summary by Sourcery

Support building SoftwareSigner instances from multiple exported account keys tied to a master fingerprint, unifying master and account-based signing behavior and key lookup.

New Features:
- Add SoftwareSigner.from_accounts to construct a signer from one or more account extended keys and an explicit master fingerprint.

Enhancements:
- Change SoftwareSigner to manage a set of keys keyed by derivation paths from a master, so master and account-based signers share the same lookup model.
- Update xkey to be a property that exposes the underlying key only for single-key signers and raises for account-based signers.
- Make watch-only detection and derivation logic operate over all held keys via a shared path resolution helper.

Documentation:
- Document the new SoftwareSigner.from_accounts behavior and the changed xkey semantics in the changelog.

Tests:
- Add tests covering account-based signing behavior, longest-prefix account selection, absence of a single xkey for account signers, mismatched master fingerprint handling, and watch-only account scenarios.