### PR TITLE
Let a caller size the inputs this library refuses to estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ documented at release-notes length in the first place, and are still in
   the key a signer was built on where it was built on one, and raises
   for a signer of accounts, there being no key of which the others are
   derivations.
+- **`estimated_input_sizes` takes a `SolutionSizer`**, and `Psbt` grows
+  `weight_estimate` and `vsize_estimate` to pass one, a property being
+  unable to take it. Two inputs were refused not for want of data but for
+  want of knowledge nobody but the caller has -- a script of no standard
+  type, and a taproot script path, where which leaf will be spent is not
+  in the psbt -- and a caller who does not have to guess had nothing to
+  say so with, so the fee arithmetic beyond the estimate was theirs to
+  write again. The sizer is asked exactly at those two refusals and never
+  in place of an answer this library can work out; what it returns is the
+  whole of what the input will push, the witness script of a p2wsh and
+  the control block of a taproot leaf included, one rule so that neither
+  side appends the other's element. A sizer answering None is the refusal
+  that was there before it was asked.
 
 ### Packaging, linting and CI
 

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -52,13 +52,14 @@ from btclib.psbt.psbt import (
 )
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
-from btclib.psbt.psbt_size import estimated_input_sizes
+from btclib.psbt.psbt_size import SolutionSizer, estimated_input_sizes
 
 __all__ = [
     "KeyManager",
     "Psbt",
     "PsbtIn",
     "PsbtOut",
+    "SolutionSizer",
     "assert_signatures_only",
     "combine",
     "ecdsa_sig_hash",

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -47,7 +47,7 @@ from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
-from btclib.psbt.psbt_size import estimated_input_sizes
+from btclib.psbt.psbt_size import SolutionSizer, estimated_input_sizes
 from btclib.psbt.psbt_utils import (
     LEAF_HASH_SIZE,
     PSBT_SEPARATOR,
@@ -729,6 +729,17 @@ class Psbt:
         transaction is once they are in place is one arithmetic, written
         once, in the class whose serialization it is.
         """
+        return self.weight_estimate()
+
+    def weight_estimate(self, sizer: SolutionSizer | None = None) -> int:
+        """Return the weight once signed, asking a sizer where needed.
+
+        What `estimated_weight` is, with the one thing a property cannot
+        take: a `psbt_size.SolutionSizer`, for the inputs this library
+        refuses to estimate because what they will push is knowledge only
+        the caller has -- a script of no standard type, a taproot script
+        path. Without one this is that property exactly.
+        """
         vin: list[TxIn] = []
         # read once: the transaction is computed at every access, being
         # the psbt's fields put together rather than a field of its own
@@ -737,7 +748,9 @@ class Psbt:
         # the two are of one length by construction
         for i, (psbt_in, tx_in) in enumerate(zip(self.inputs, tx.vin, strict=True)):
             try:
-                script_sig_size, witness_sizes = estimated_input_sizes(psbt_in, tx_in)
+                script_sig_size, witness_sizes = estimated_input_sizes(
+                    psbt_in, tx_in, sizer=sizer
+                )
             except BTClibValueError as e:
                 raise BTClibValueError(f"input {i}: {e}") from e
             vin.append(
@@ -762,7 +775,16 @@ class Psbt:
         The name Bitcoin Core's `analyzepsbt` reports it under, and the
         `Tx.vsize` arithmetic: a quarter of the weight, rounded up.
         """
-        return ceil(self.estimated_weight / 4)
+        return self.vsize_estimate()
+
+    def vsize_estimate(self, sizer: SolutionSizer | None = None) -> int:
+        """Return the virtual size once signed, asking a sizer where needed.
+
+        `estimated_vsize` over `weight_estimate`, so that a fee computed
+        from a caller's own solution sizes is the same arithmetic as one
+        computed from this library's.
+        """
+        return ceil(self.weight_estimate(sizer) / 4)
 
     def __init__(
         self,

--- a/btclib/psbt/psbt_size.py
+++ b/btclib/psbt/psbt_size.py
@@ -28,9 +28,22 @@ script, the witness script and the derivation data are what the type is
 read from, and an input that carries too little of them has no estimate:
 guessing costs bytes in one direction only, and a fee computed from a
 guess is a transaction that does not relay.
+
+A caller who does not have to guess says so, with a `SolutionSizer`.
+Two inputs are refused above not for want of data but for want of
+knowledge nobody but the caller has -- a script of no standard type, and
+a taproot script path, where which leaf will be spent is not in the psbt
+-- and a sizer is asked exactly there, never in place of an answer this
+file can work out. What it returns is the whole of what the input will
+push, the witness script of a p2wsh and the control block of a taproot
+leaf included: a caller who knows the solution holds those too, and one
+rule with no exceptions is what keeps the two sides from each appending
+the other's element.
 """
 
 from __future__ import annotations
+
+from collections.abc import Callable
 
 from btclib.alias import Command
 from btclib.exceptions import BTClibValueError
@@ -43,8 +56,14 @@ __all__ = [
     "COMPRESSED_PUB_KEY_SIZE",
     "SCHNORR_SIG_SIZE",
     "SIG_SIZE",
+    "SolutionSizer",
     "estimated_input_sizes",
 ]
+
+# what an input will push, by the caller who knows: the size of every
+# element of the witness stack, or of every push of a legacy script_sig,
+# and None for an input this caller cannot answer for either
+SolutionSizer = Callable[[PsbtIn, TxIn], "list[int] | None"]
 
 # a DER signature and its sig_hash byte, at the largest a low-s signature
 # can be; see the module docstring, which is where the assumption is
@@ -61,6 +80,11 @@ COMPRESSED_PUB_KEY_SIZE = 33
 # OP_1 is 0x51 and OP_16 is 0x60, so the m and the n of an m-of-n
 # multisig script are each written as its value plus this
 _OP_INT_OFFSET = 0x50
+
+# the types _solution_sizes answers for, named here so that the caller of
+# it can tell "this file knows" from "it raised", without asking by
+# catching what it raises
+_SOLVED = frozenset({"p2pkh", "p2pk", "p2wpkh", "p2ms"})
 
 
 def _script_pub_key(psbt_in: PsbtIn, tx_in: TxIn) -> bytes:
@@ -130,6 +154,26 @@ def _solution_sizes(script_type: str, payload: bytes, psbt_in: PsbtIn) -> list[i
     raise BTClibValueError(f"no estimate for a script of type '{script_type}'")
 
 
+def _asked(
+    sizer: SolutionSizer | None,
+    psbt_in: PsbtIn,
+    tx_in: TxIn,
+    err_msg: str,
+) -> list[int]:
+    """Return what the sizer says the input pushes, or raise what it cannot.
+
+    The one place a sizer is consulted, so the rule that it answers only
+    where this file cannot is this function existing rather than a
+    condition repeated at each site. A sizer answering None is a caller
+    saying "not this input either", which is the refusal that was there
+    before it was asked.
+    """
+    sizes = sizer(psbt_in, tx_in) if sizer else None
+    if sizes is None:
+        raise BTClibValueError(err_msg)
+    return sizes
+
+
 def _taproot_sig_size(psbt_in: PsbtIn) -> int:
     """Return the size of the BIP341 key path signature.
 
@@ -137,17 +181,53 @@ def _taproot_sig_size(psbt_in: PsbtIn) -> int:
     the default one: that type is the byte appended to the signature, and
     SIGHASH_DEFAULT is the absence of it.
     """
-    if psbt_in.taproot_leaf_scripts:
-        # a script path witness is the script's own inputs, the leaf
-        # script and the control block, and which leaf will be spent is
-        # not something the psbt says: an input carrying three of them has
-        # three different answers and no way to choose
-        raise BTClibValueError("no estimate for a taproot script path")
-
     return SCHNORR_SIG_SIZE + (1 if psbt_in.sig_hash_type else 0)
 
 
-def estimated_input_sizes(psbt_in: PsbtIn, tx_in: TxIn) -> tuple[int, list[int]]:
+def _p2wsh_witness_sizes(
+    psbt_in: PsbtIn,
+    tx_in: TxIn,
+    sizer: SolutionSizer | None,
+) -> list[int]:
+    """Return the witness stack of a p2wsh input, asking where it cannot."""
+    witness_script = psbt_in.witness_script
+    if not witness_script:
+        raise BTClibValueError("no witness script")
+    inner_type, inner_payload = type_and_payload(witness_script)
+    if inner_type in _SOLVED:
+        return [
+            *_solution_sizes(inner_type, inner_payload, psbt_in),
+            len(witness_script),
+        ]
+    err_msg = f"no estimate for a script of type '{inner_type}'"
+    return _asked(sizer, psbt_in, tx_in, err_msg)
+
+
+def _taproot_witness_sizes(
+    psbt_in: PsbtIn,
+    tx_in: TxIn,
+    sizer: SolutionSizer | None,
+) -> list[int]:
+    """Return the witness stack of a taproot input, asking for a script path.
+
+    A script path witness is the script's own inputs, the leaf script and
+    the control block, and which leaf will be spent is not something the
+    psbt says: an input carrying three of them has three different
+    answers and no way to choose. A caller that has chosen answers all
+    three.
+    """
+    if psbt_in.taproot_leaf_scripts:
+        err_msg = "no estimate for a taproot script path"
+        return _asked(sizer, psbt_in, tx_in, err_msg)
+    return [_taproot_sig_size(psbt_in)]
+
+
+def estimated_input_sizes(
+    psbt_in: PsbtIn,
+    tx_in: TxIn,
+    *,
+    sizer: SolutionSizer | None = None,
+) -> tuple[int, list[int]]:
     """Return the script_sig size and the witness stack of a signed input.
 
     The second element is the size of each element the witness stack will
@@ -156,7 +236,8 @@ def estimated_input_sizes(psbt_in: PsbtIn, tx_in: TxIn) -> tuple[int, list[int]]
     one place that knows.
 
     A signature is assumed to be 72 bytes; an input whose type cannot be
-    read raises. Both rules, and why, are in the module docstring.
+    read raises, unless `sizer` answers for it. All three rules, and why,
+    are in the module docstring.
     """
     if psbt_in.final_script_sig or psbt_in.final_script_witness:
         # nothing to estimate: a Finalizer has been here, and what it
@@ -182,27 +263,23 @@ def estimated_input_sizes(psbt_in: PsbtIn, tx_in: TxIn) -> tuple[int, list[int]]
     wrapper: list[Command] = [redeem_script] if redeem_script else []
 
     if script_type == "p2wsh":
-        witness_script = psbt_in.witness_script
-        if not witness_script:
-            raise BTClibValueError("no witness script")
-        inner_type, inner_payload = type_and_payload(witness_script)
-        witness_sizes = [
-            *_solution_sizes(inner_type, inner_payload, psbt_in),
-            len(witness_script),
-        ]
-        return len(serialize(wrapper)), witness_sizes
+        return len(serialize(wrapper)), _p2wsh_witness_sizes(psbt_in, tx_in, sizer)
 
     if script_type == "p2tr":
         # a witness v1 program wrapped in p2sh is not refused here: it is
         # unspendable by consensus, so what a psbt carrying one is missing
         # is not an estimate
-        return len(serialize(wrapper)), [_taproot_sig_size(psbt_in)]
+        return len(serialize(wrapper)), _taproot_witness_sizes(psbt_in, tx_in, sizer)
 
     if script_type == "p2wpkh":
         return len(serialize(wrapper)), _solution_sizes(script_type, payload, psbt_in)
 
     # a legacy script takes the whole of what unlocks it in the script_sig
-    sizes = _solution_sizes(script_type, payload, psbt_in)
+    if script_type in _SOLVED:
+        sizes = _solution_sizes(script_type, payload, psbt_in)
+    else:
+        err_msg = f"no estimate for a script of type '{script_type}'"
+        sizes = _asked(sizer, psbt_in, tx_in, err_msg)
     # the pushes are measured rather than counted: how a push is written
     # -- a one-byte length below 76, OP_PUSHDATA1 above it -- is
     # script.serialize's rule, and a second implementation of it here is

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -466,6 +466,7 @@ def test_psbt_exports_the_format_not_its_plumbing() -> None:
         "Psbt",
         "PsbtIn",
         "PsbtOut",
+        "SolutionSizer",
         "assert_signatures_only",
         "combine",
         "ecdsa_sig_hash",

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -31,7 +31,11 @@ from btclib.block import Block
 from btclib.ecc import dsa
 from btclib.exceptions import BTClibValueError
 from btclib.psbt import Psbt, PsbtIn, PsbtOut, extract_tx
-from btclib.psbt.psbt_size import SIG_SIZE, estimated_input_sizes
+from btclib.psbt.psbt_size import (
+    SCHNORR_SIG_SIZE,
+    SIG_SIZE,
+    estimated_input_sizes,
+)
 from btclib.script import ScriptPubKey, Witness, is_p2ms, parse, serialize
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests import load, load_bin, vector_id
@@ -454,3 +458,82 @@ def test_every_bip174_vector_answers(test_vector: dict[str, str]) -> None:
     else:
         # the unsigned transaction plus what the signatures will take
         assert vsize >= psbt.tx.vsize
+
+
+def test_a_sizer_answers_for_the_scripts_this_file_cannot_read() -> None:
+    """What a caller who does not have to guess says, and where it is asked.
+
+    A p2wsh of no standard type -- the shape a custody script has, a
+    branch chosen by CHECKSEQUENCEVERIFY -- and the whole of what it will
+    push, the witness script included: one rule, so that neither side
+    appends the other's element.
+    """
+    witness_script = serialize(["OP_IF", "OP_1", "OP_ELSE", "OP_2", "OP_ENDIF"])
+    psbt = Psbt.b64decode(BIP174_SIGNED_PSBT)
+    tx_in = psbt.tx.vin[0]
+    psbt.inputs[0].non_witness_utxo = None
+    psbt.inputs[0].witness_utxo = TxOut(1000, ScriptPubKey.p2wsh(witness_script))
+    psbt.inputs[0].witness_script = witness_script
+    psbt.inputs[0].redeem_script = b""
+
+    # unasked, the refusal is the one that was there before
+    with pytest.raises(BTClibValueError, match="type 'unknown'"):
+        estimated_input_sizes(psbt.inputs[0], tx_in)
+
+    stack = [SIG_SIZE, SIG_SIZE, len(witness_script)]
+    script_sig_size, witness_sizes = estimated_input_sizes(
+        psbt.inputs[0], tx_in, sizer=lambda _in, _tx: list(stack)
+    )
+    assert witness_sizes == stack
+    assert script_sig_size == 0
+
+    # a sizer that does not answer for this input is the refusal again
+    with pytest.raises(BTClibValueError, match="type 'unknown'"):
+        estimated_input_sizes(psbt.inputs[0], tx_in, sizer=lambda _in, _tx: None)
+
+
+def test_a_sizer_answers_for_a_taproot_script_path() -> None:
+    """Which leaf will be spent is the caller's to say, and then all of it.
+
+    The solution, the leaf script and the control block are one answer
+    because one choice decides the three, and the psbt carries every leaf
+    it could have been.
+    """
+    psbt = bip371_psbt(3)
+    psbt_in = psbt.inputs[0]
+    assert psbt_in.taproot_leaf_scripts
+
+    with pytest.raises(BTClibValueError, match="taproot script path"):
+        _ = psbt.estimated_vsize
+
+    ((leaf_script, leaf_version),) = list(psbt_in.taproot_leaf_scripts.values())[:1]
+    # the control block of a tree of one leaf: the version byte with the
+    # parity, and the internal key
+    control_block_size = 33
+    stack = [SCHNORR_SIG_SIZE, len(leaf_script), control_block_size]
+    assert leaf_version is not None
+
+    def sizer(_in: PsbtIn, _tx: TxIn) -> list[int]:
+        return list(stack)
+
+    _, witness_sizes = estimated_input_sizes(psbt_in, psbt.tx.vin[0], sizer=sizer)
+    assert witness_sizes == stack
+
+    # and the same answer reaches the weight, which is what a fee is
+    # computed from: the placeholder witness is the one the sizer named
+    asked = psbt.vsize_estimate(sizer)
+    assert asked > psbt.vsize_estimate(lambda _in, _tx: [SCHNORR_SIG_SIZE])
+
+
+def test_a_sizer_is_never_asked_where_this_file_knows() -> None:
+    """A key path spend and a multisig: neither of them is asked about."""
+
+    def refuse(_in: PsbtIn, _tx: TxIn) -> list[int]:
+        msg = "the sizer was asked about an input this file can read"
+        raise AssertionError(msg)
+
+    psbt = Psbt.b64decode(BIP174_SIGNED_PSBT)
+    assert psbt.vsize_estimate(refuse) == psbt.estimated_vsize
+
+    key_path = bip371_psbt(0)
+    assert key_path.vsize_estimate(refuse) == key_path.estimated_vsize


### PR DESCRIPTION
Closes #491.

`estimated_input_sizes` refuses two inputs not for want of data but for
want of knowledge nobody but the caller has:

- a script of **no standard type** — `no estimate for a script of type
  'unknown'`;
- a **taproot script path**, where which leaf will be spent is not in the
  psbt: an input carrying three leaves has three answers and no way to
  choose.

The refusal is right, and the module docstring argues it well: guessing
costs bytes in one direction only, and a fee computed from a guess is a
transaction that does not relay. What was missing is a way for a caller who
does **not** have to guess to say so — and without it the fee arithmetic
past the estimate (`ceil(feerate * vsize)`, the CPFP correction) is theirs
to write again beside yours.

## What this adds

```python
SolutionSizer = Callable[[PsbtIn, TxIn], list[int] | None]

estimated_input_sizes(psbt_in, tx_in, *, sizer=None)
Psbt.weight_estimate(sizer=None)
Psbt.vsize_estimate(sizer=None)
```

The sizer is asked **exactly at those two refusals** and never in place of
an answer this library can work out — one `_asked` function rather than a
condition repeated at each site, and a test asserts a sizer is not called
for a key path spend or a multisig. A sizer answering `None` is the refusal
that was there before it was asked, so `sizer=None` is today's behaviour
to the byte.

What it returns is **the whole of what the input will push**: the witness
script of a p2wsh and the control block of a taproot leaf included. One
rule with no exceptions, so that neither side appends the other's element —
a caller who knows the solution holds those too, both being in the psbt.

`weight_estimate` and `vsize_estimate` exist because a property cannot take
an argument; `estimated_weight` and `estimated_vsize` are those methods
unasked.

## Taproot

Asked for in the issue thread, and it is the second refusal above: a script
path spend is answered by the same hook, the caller naming the solution,
the leaf script and the control block together because one choice decides
the three. Covered by a test that also checks the answer reaches the
weight, which is what a fee is computed from.

## Gates

`uv run pytest` (whole suite), `uv run pre-commit run --all-files`, and the
sphinx `-W` build — the last one wanted a real type alias rather than an
inline `Callable[[PsbtIn, TxIn], ...]`, whose `PsbtIn` and `TxIn` autodoc
could not resolve to one target.

## Summary by Sourcery

Introduce caller-provided solution sizing for PSBT inputs the library cannot estimate, and expose new PSBT methods for fee calculations based on these sizes.

New Features:
- Add the SolutionSizer callable type to let callers specify witness/script_sig element sizes for inputs the library cannot infer, including non-standard scripts and taproot script paths.
- Extend estimated_input_sizes to optionally use a SolutionSizer for unresolved script types and taproot script-path spends while preserving existing behavior when no sizer is provided.
- Add Psbt.weight_estimate and Psbt.vsize_estimate methods that accept a SolutionSizer, enabling end-to-end fee and size calculations using caller-supplied solutions.

Enhancements:
- Refactor PSBT size estimation logic to centralize sizer invocation and keep built-in handling for supported script types distinct from caller-supplied solutions.

Documentation:
- Update module and changelog documentation to describe SolutionSizer, its role in input size estimation, and the new Psbt weight/vsize estimation APIs.

Tests:
- Add tests covering SolutionSizer usage for non-standard p2wsh scripts and taproot script-path spends, including ensuring its impact on estimated weight/vsize.
- Add tests asserting that SolutionSizer is not invoked for inputs whose sizes the library can already determine, such as key-path spends and multisig.