### PR TITLE
Let a caller spend the scripts this finalizer would guess at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ documented at release-notes length in the first place, and are still in
 
 ### Transactions, blocks and PSBT
 
+- **`finalize` takes an `InputSolver`**, for the inputs whose spend is
+  the caller's to know. Two of the shapes it refuses are refusals -- a
+  taproot input carrying more than one script path signature, and a leaf
+  that is not a single-key one -- but a witness script of no standard
+  kind is not: it is built from the signatures and the script, which is
+  the satisfaction of a multisig and a guess for anything else, and a
+  psbt finalized from that guess fails when the network runs it rather
+  than when it is built. The solver is therefore asked before anything is
+  built and not only where this function refuses, which is where the
+  `SolutionSizer` of `psbt_size` differs. What it does not take over is
+  the bookkeeping: the clearing BIP174 asks for, what is kept, and the
+  verification of whatever signatures the input does carry stay
+  `finalize`'s, which is the half a caller should not have to reproduce
+  to spend a script of their own.
+
 - **`SoftwareSigner.from_accounts` builds a signer on the accounts a
   device exported**, for the master fingerprint they came from, where the
   constructor takes one key and answers that key's own fingerprint. What

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -38,6 +38,7 @@ half of that module from already.
 
 from btclib.psbt import musig2
 from btclib.psbt.psbt import (
+    InputSolver,
     KeyManager,
     Psbt,
     assert_signatures_only,
@@ -55,6 +56,7 @@ from btclib.psbt.psbt_out import PsbtOut
 from btclib.psbt.psbt_size import estimated_input_sizes
 
 __all__ = [
+    "InputSolver",
     "KeyManager",
     "Psbt",
     "PsbtIn",

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -102,6 +102,7 @@ __all__ = [
     "PSBT_MAGIC_BYTES",
     "PSBT_V0",
     "PSBT_V2",
+    "InputSolver",
     "KeyManager",
     "Psbt",
     "assert_signatures_only",
@@ -2430,7 +2431,32 @@ def _clear_finalized(psbt_in: PsbtIn) -> None:
             setattr(psbt_in, field.name, getattr(empty, field.name))
 
 
-def finalize(psbt: Psbt) -> Psbt:
+# the spend of one input, by the caller who knows: the final script_sig
+# and the final witness, and None for an input this caller leaves to the
+# generic finalizer
+InputSolver = Callable[[Psbt, int], "tuple[bytes, Witness] | None"]
+
+
+def _finalized_by_caller(
+    psbt: Psbt, vin_i: int, spend: tuple[bytes, Witness]
+) -> tuple[bytes, Witness]:
+    """Return the caller's spend, with the checks that still apply to it.
+
+    A solver says what satisfies the script; whether the signatures the
+    input carries are good is not a matter of opinion, so where there are
+    any they are verified exactly as they would have been. An input with
+    none -- a taproot script path, whose signatures travel in fields of
+    their own -- has nothing here to check, and the spend is the
+    caller's word.
+    """
+    psbt_in = psbt.inputs[vin_i]
+    if psbt_in.partial_sigs:
+        _assert_sig_hash_type(psbt_in)
+        _assert_partial_sigs_verify(psbt_in, psbt.tx, vin_i)
+    return spend
+
+
+def finalize(psbt: Psbt, *, solver: InputSolver | None = None) -> Psbt:
     """Finalize the Psbt.
 
     The Input Finalizer must only accept a PSBT.
@@ -2462,6 +2488,20 @@ def finalize(psbt: Psbt) -> Psbt:
     too. Refusing it would mean a psbt whose signer finalized one input
     could not be finalized at all -- the rest of it would raise "missing
     signatures" for the input that is already done.
+
+    A `solver` answers for the inputs whose spend is the caller's to
+    know. It is asked before this function builds anything, and not only
+    where this function refuses, which the sizer of `psbt_size` is: two
+    of the shapes below are refusals -- a taproot input with more than
+    one script path signature, and a leaf that is not a single-key one --
+    but a witness script of no standard kind is *not*. That one is built
+    from the signatures and the script, which is the satisfaction of a
+    multisig and a guess for anything else, so a caller with a script of
+    their own has to be able to answer over it rather than after it.
+
+    What the solver does not take over is the bookkeeping: the clearing
+    BIP174 asks for, what is kept, and the verification of whatever
+    signatures the input does carry are this function's either way.
     """
     psbt = deepcopy(psbt)
     psbt.assert_valid()
@@ -2473,12 +2513,15 @@ def finalize(psbt: Psbt) -> Psbt:
         if psbt_in.final_script_sig or psbt_in.final_script_witness:
             continue
 
+        answered = solver(psbt, vin_i) if solver else None
+        if answered is not None:
+            script_sig, witness = _finalized_by_caller(psbt, vin_i, answered)
         # a taproot input is finalized from its own fields and not from
         # partial_sigs, which is keyed by compressed key and holds ECDSA
         # signatures: a schnorr signature travels in PSBT_IN_TAP_KEY_SIG
         # or PSBT_IN_TAP_SCRIPT_SIG, and BIP373 is what writes the
         # aggregate signature of a MuSig2 session into them
-        if is_p2tr(_spent_script(psbt_in)):
+        elif is_p2tr(_spent_script(psbt_in)):
             script_sig, witness = _finalized_taproot_input(psbt, vin_i)
         else:
             if not psbt_in.partial_sigs:

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -462,6 +462,7 @@ def test_psbt_exports_the_format_not_its_plumbing() -> None:
     of the format.
     """
     assert sorted(btclib.psbt.__all__) == [
+        "InputSolver",
         "KeyManager",
         "Psbt",
         "PsbtIn",

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -3873,3 +3873,100 @@ def test_an_answer_that_is_not_a_valid_psbt_is_refused() -> None:
     err_msg = "invalid partial signature pub_key"
     with pytest.raises(BTClibValueError, match=err_msg):
         assert_signatures_only(request, returned)
+
+
+def test_a_solver_spends_a_script_this_finalizer_would_guess_at() -> None:
+    """A witness script of no standard kind, and the caller's own stack.
+
+    The generic construction is the satisfaction of a multisig -- the
+    signatures, the BIP147 dummy where one is popped, the witness script
+    -- which is a guess for any other script. It is not refused, so a
+    caller with a script of their own answers over it rather than after
+    it, and what they answer is used whole.
+    """
+    signed, prevouts_ = _single_key_psbt("p2wsh")
+    witness_script = signed.inputs[0].witness_script
+    ((_, signature),) = signed.inputs[0].partial_sigs.items()
+
+    # the guess: signature and script, which for a p2pk witness script is
+    # right, and is what makes this comparison meaningful
+    guessed = finalize(signed)
+    assert guessed.inputs[0].final_script_witness.stack == (signature, witness_script)
+
+    # the caller's own, with an element the finalizer had no reason to add
+    stack = Witness([b"", signature, witness_script])
+
+    def solver(_psbt: Psbt, _vin_i: int) -> tuple[bytes, Witness]:
+        return b"", stack
+
+    solved = finalize(signed, solver=solver)
+    assert solved.inputs[0].final_script_witness == stack
+    assert solved.inputs[0].final_script_sig == b""
+    # the bookkeeping is the finalizer's either way: what BIP174 says to
+    # clear is cleared, and the utxo it says to keep is kept
+    assert not solved.inputs[0].partial_sigs
+    assert not solved.inputs[0].witness_script
+    assert solved.inputs[0].witness_utxo or solved.inputs[0].non_witness_utxo
+    assert prevouts_
+
+
+def test_a_solver_answering_none_leaves_the_input_to_the_finalizer() -> None:
+    """The refusals and the answers are both what they were unasked."""
+    signed, _ = _single_key_psbt("p2wsh")
+
+    def abstain(_psbt: Psbt, _vin_i: int) -> tuple[bytes, Witness] | None:
+        return None
+
+    assert finalize(signed, solver=abstain) == finalize(signed)
+
+    # an input with nothing to finalize is refused as before
+    psbt = deepcopy(signed)
+    psbt.inputs[0].partial_sigs = {}
+    with pytest.raises(BTClibValueError, match="missing signatures"):
+        finalize(psbt, solver=abstain)
+
+
+def test_a_solver_spends_the_taproot_leaf_the_psbt_cannot_choose() -> None:
+    """Two script path signatures are two spends, and the caller picks one.
+
+    Which leaf to spend is a choice the psbt does not record, so the
+    finalizer refuses it. A caller that has chosen says so with the
+    witness BIP341 asks for -- the signature, the leaf script, the
+    control block -- and the refusal becomes their answer.
+    """
+    psbt = _taproot_signed(
+        "a key in a script is a MuSig2 Aggregate Pubkey, with all partial"
+    )
+    _, sig = next(iter(psbt.inputs[0].taproot_script_spend_signatures.items()))
+    psbt.inputs[0].taproot_script_spend_signatures[b"\x01" * 64] = sig
+    with pytest.raises(BTClibValueError, match="2 taproot script path signatures"):
+        finalize(psbt)
+
+    control_block, (leaf, _version) = next(
+        iter(psbt.inputs[0].taproot_leaf_scripts.items())
+    )
+    chosen = Witness([sig, leaf, control_block])
+
+    def solver(_psbt: Psbt, _vin_i: int) -> tuple[bytes, Witness]:
+        return b"", chosen
+
+    solved = finalize(psbt, solver=solver)
+    assert solved.inputs[0].final_script_witness == chosen
+    # an empty script_sig, which is what BIP341 spends a witness v1
+    # program with, and the caller's to get right
+    assert solved.inputs[0].final_script_sig == b""
+    assert not solved.inputs[0].taproot_script_spend_signatures
+
+
+def test_a_solver_does_not_take_over_checking_the_signatures() -> None:
+    """What satisfies the script is the caller's; a bad signature is not."""
+    signed, _ = _single_key_psbt("p2wsh")
+    psbt = deepcopy(signed)
+    ((pub_key, _),) = psbt.inputs[0].partial_sigs.items()
+    psbt.inputs[0].partial_sigs = {pub_key: b"\x30" * 71 + b"\x01"}
+
+    def solver(_psbt: Psbt, _vin_i: int) -> tuple[bytes, Witness]:
+        return b"", Witness([b"", psbt.inputs[0].witness_script])
+
+    with pytest.raises(BTClibValueError):
+        finalize(psbt, solver=solver)


### PR DESCRIPTION
Closes #492.

## What the issue said, and what implementing it found

The issue argued that a caller with a custom witness script has to finalize
its inputs itself, and with them comes the BIP174 bookkeeping — the
clearing, what is kept — which is not their domain.

Reading `_finalized_input` while implementing it made the case sharper than
the issue put it. For a witness script of no standard kind, `finalize` does
**not** refuse: it builds the signatures, the BIP147 dummy and the script,
which is the satisfaction of a multisig and a **guess** for anything else.
A psbt finalized from that guess is one the network drops when it runs the
script, not one that failed when it was built.

So the hook is not, as in #491, "asked only where the library refuses". A
caller with a script of their own has to answer **over** the guess rather
than after it, and the docstring says which of the two hooks is which and
why.

The refusals are still refusals, and the solver answers them too: a taproot
input carrying more than one script path signature, and a leaf that is not
a single-key one.

## What this adds

```python
InputSolver = Callable[[Psbt, int], tuple[bytes, Witness] | None]

finalize(psbt, *, solver=None)
```

`None` from the solver leaves the input to the generic finalizer, so
`solver=None` is today's behaviour exactly — asserted by a test that
finalizes the same psbt both ways and compares.

## What the solver does not take over

The bookkeeping stays `finalize`'s: the clearing BIP174 asks for, the utxo
it says to keep, and the verification of whatever signatures the input does
carry. What satisfies a script is a matter of the caller's knowledge;
whether a signature is good is not, and a test pins that a solver does not
buy an input past a bad one.

## Taproot

Asked for in the issue thread. A script path spend is answered by the same
hook: the test takes the psbt whose two script path signatures `finalize`
refuses to choose between, has the caller choose, and checks the witness
BIP341 asks for — signature, leaf script, control block — comes out whole.

## Gates

`uv run pytest` (whole suite), `uv run pre-commit run --all-files` and the
sphinx `-W` build, all green.

## Summary by Sourcery

Introduce an input-level solver hook to PSBT finalization so callers can supply custom spends while preserving existing validation and bookkeeping.

New Features:
- Add an InputSolver callable parameter to finalize to let callers provide final scriptSig and witness for specific inputs, including taproot script path spends.
- Export the InputSolver type from the psbt module and document its behavior in the changelog.

Enhancements:
- Ensure solver-provided spends still undergo signature verification where applicable, while leaving BIP174-mandated clearing and UTXO retention to the generic finalizer.

Tests:
- Add tests covering solver use for non-standard witness scripts, solver abstention behavior, taproot script path selection, and that solvers cannot bypass signature validation.