### PR TITLE
Say "no answer" once, and record what the callback was asked

### DIFF
--- a/btclib/psbt/psbt_size.py
+++ b/btclib/psbt/psbt_size.py
@@ -81,11 +81,6 @@ COMPRESSED_PUB_KEY_SIZE = 33
 # multisig script are each written as its value plus this
 _OP_INT_OFFSET = 0x50
 
-# the types _solution_sizes answers for, named here so that the caller of
-# it can tell "this file knows" from "it raised", without asking by
-# catching what it raises
-_SOLVED = frozenset({"p2pkh", "p2pk", "p2wpkh", "p2ms"})
-
 
 def _script_pub_key(psbt_in: PsbtIn, tx_in: TxIn) -> bytes:
     """Return the script_pub_key of the output the input spends.
@@ -123,12 +118,21 @@ def _pub_key_size(psbt_in: PsbtIn, payload: bytes) -> int:
     return COMPRESSED_PUB_KEY_SIZE
 
 
-def _solution_sizes(script_type: str, payload: bytes, psbt_in: PsbtIn) -> list[int]:
+def _solution_sizes(
+    script_type: str, payload: bytes, psbt_in: PsbtIn
+) -> list[int] | None:
     """Return the size of each element that will satisfy the script.
 
     In the order the elements go on the stack, so this is the witness
     stack of a segwit input and the pushes of a legacy script_sig, one
     list because it is one list of signatures either way.
+
+    None for a type this file has no answer for, which is the word a
+    `SolutionSizer` uses for the same thing: the caller of both tells
+    "no answer" from an answer by looking at what came back, and a
+    second spelling of it -- a raise, a set of the types answered for,
+    a caller catching what it does not want -- would be one more thing
+    to keep in agreement with the branches below.
     """
     if script_type == "p2pkh":
         return [SIG_SIZE, _pub_key_size(psbt_in, payload)]
@@ -151,7 +155,7 @@ def _solution_sizes(script_type: str, payload: bytes, psbt_in: PsbtIn) -> list[i
         m = payload[0] - _OP_INT_OFFSET
         return [0, *[SIG_SIZE] * m]
 
-    raise BTClibValueError(f"no estimate for a script of type '{script_type}'")
+    return None
 
 
 def _asked(
@@ -194,13 +198,11 @@ def _p2wsh_witness_sizes(
     if not witness_script:
         raise BTClibValueError("no witness script")
     inner_type, inner_payload = type_and_payload(witness_script)
-    if inner_type in _SOLVED:
-        return [
-            *_solution_sizes(inner_type, inner_payload, psbt_in),
-            len(witness_script),
-        ]
-    err_msg = f"no estimate for a script of type '{inner_type}'"
-    return _asked(sizer, psbt_in, tx_in, err_msg)
+    sizes = _solution_sizes(inner_type, inner_payload, psbt_in)
+    if sizes is None:
+        err_msg = f"no estimate for a script of type '{inner_type}'"
+        return _asked(sizer, psbt_in, tx_in, err_msg)
+    return [*sizes, len(witness_script)]
 
 
 def _taproot_witness_sizes(
@@ -271,15 +273,15 @@ def estimated_input_sizes(
         # is not an estimate
         return len(serialize(wrapper)), _taproot_witness_sizes(psbt_in, tx_in, sizer)
 
-    if script_type == "p2wpkh":
-        return len(serialize(wrapper)), _solution_sizes(script_type, payload, psbt_in)
-
-    # a legacy script takes the whole of what unlocks it in the script_sig
-    if script_type in _SOLVED:
-        sizes = _solution_sizes(script_type, payload, psbt_in)
-    else:
+    sizes = _solution_sizes(script_type, payload, psbt_in)
+    if sizes is None:
         err_msg = f"no estimate for a script of type '{script_type}'"
         sizes = _asked(sizer, psbt_in, tx_in, err_msg)
+
+    if script_type == "p2wpkh":
+        return len(serialize(wrapper)), sizes
+
+    # a legacy script takes the whole of what unlocks it in the script_sig
     # the pushes are measured rather than counted: how a push is written
     # -- a one-byte length below 76, OP_PUSHDATA1 above it -- is
     # script.serialize's rule, and a second implementation of it here is

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -526,14 +526,28 @@ def test_a_sizer_answers_for_a_taproot_script_path() -> None:
 
 
 def test_a_sizer_is_never_asked_where_this_file_knows() -> None:
-    """A key path spend and a multisig: neither of them is asked about."""
+    """A key path spend and a multisig: neither of them is asked about.
 
-    def refuse(_in: PsbtIn, _tx: TxIn) -> list[int]:
-        msg = "the sizer was asked about an input this file can read"
-        raise AssertionError(msg)
+    What the sizer was asked about is recorded, and the same recorder
+    then meets the input that has to be asked about: the two halves of
+    the rule -- asked exactly where this file has no answer, and
+    nowhere else -- are one list either way. A sizer that raised would
+    state the first half by never running, which is a body no run
+    executes and an assertion no test makes.
+    """
+    asked: list[PsbtIn] = []
+
+    def record(psbt_in: PsbtIn, _tx: TxIn) -> list[int]:
+        asked.append(psbt_in)
+        return [SCHNORR_SIG_SIZE]
 
     psbt = Psbt.b64decode(BIP174_SIGNED_PSBT)
-    assert psbt.vsize_estimate(refuse) == psbt.estimated_vsize
+    assert psbt.vsize_estimate(record) == psbt.estimated_vsize
 
     key_path = bip371_psbt(0)
-    assert key_path.vsize_estimate(refuse) == key_path.estimated_vsize
+    assert key_path.vsize_estimate(record) == key_path.estimated_vsize
+    assert not asked
+
+    script_path = bip371_psbt(3)
+    _ = script_path.vsize_estimate(record)
+    assert asked == [script_path.inputs[0]]

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -3959,14 +3959,31 @@ def test_a_solver_spends_the_taproot_leaf_the_psbt_cannot_choose() -> None:
 
 
 def test_a_solver_does_not_take_over_checking_the_signatures() -> None:
-    """What satisfies the script is the caller's; a bad signature is not."""
+    """What satisfies the script is the caller's; a bad signature is not.
+
+    The solver is never reached, which is the fact: a caller cannot
+    finalize an invalid signature by answering over it. What the solver
+    was asked is recorded rather than refused, so that the very same
+    solver can then finalize the psbt whose signature is good -- what
+    stopped the first call was the signature, and this is what says so.
+    """
     signed, _ = _single_key_psbt("p2wsh")
     psbt = deepcopy(signed)
     ((pub_key, _),) = psbt.inputs[0].partial_sigs.items()
     psbt.inputs[0].partial_sigs = {pub_key: b"\x30" * 71 + b"\x01"}
 
-    def solver(_psbt: Psbt, _vin_i: int) -> tuple[bytes, Witness]:
-        return b"", Witness([b"", psbt.inputs[0].witness_script])
+    asked: list[int] = []
+
+    def solver(psbt_: Psbt, vin_i: int) -> tuple[bytes, Witness]:
+        asked.append(vin_i)
+        return b"", Witness([b"", psbt_.inputs[vin_i].witness_script])
 
     with pytest.raises(BTClibValueError):
         finalize(psbt, solver=solver)
+    assert not asked
+
+    solved = finalize(signed, solver=solver)
+    assert asked == [0]
+    assert solved.inputs[0].final_script_witness.stack[-1] == (
+        signed.inputs[0].witness_script
+    )


### PR DESCRIPTION
`dev` is red on coverage: three lines the suite cannot reach, all of
them arrived with the two callback PRs. Each is a way of saying
something that leaves nothing to run.

## `_solution_sizes` said it twice

It ended in a `raise` for a script type it has no branch for, guarded
by a `_SOLVED` frozenset naming the types it does have one for. Every
caller consulted the set first, so the raise was unreachable — and the
set was a second copy of the branches below it, to be kept in
agreement with them by hand.

The function returns `None` now, which is the word a `SolutionSizer`
already uses for the same thing a few lines up: the caller of both
tells "no answer" from an answer by looking at what came back. The set
and the raise are gone, and the p2wpkh path no longer needs to know it
is one of the types answered for.

No user-visible change, so no CHANGELOG entry.

## Two tests said "never reached" by not running

`test_a_sizer_is_never_asked_where_this_file_knows` and
`test_a_solver_does_not_take_over_checking_the_signatures` each passed
a callback whose body raises. That states the fact by never executing
— which is exactly a body no run executes, and an assertion no test
makes.

Both record what they were asked instead, and both then meet the case
that *does* reach the callback, with the same callback object:

- the sizer is handed a multisig and a taproot key path (`asked` stays
  empty), then a taproot script path (`asked` is that input);
- the solver is handed a psbt with an invalid signature (`asked` stays
  empty), then the same psbt with its signature intact (`asked` is
  input 0, and the stack it returned is the one that was used).

So the rule is one list either way — consulted exactly where the
answer is the caller's, and nowhere else — and the second half also
pins down *why* the first call stopped: the signature, not the solver.

## Verification

- `uv run --locked --no-default-groups --group test pytest --cov`:
  17546 passed, 100.00%, `fail_under` met;
- `uv run pre-commit run --all-files`: clean;
- the sphinx `-W --keep-going` build: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify callback handling in PSBT size estimation by returning a "no answer" sentinel instead of raising, and adjust tests to assert which inputs actually trigger callbacks.

Bug Fixes:
- Ensure PSBT size estimation consistently falls back to callbacks only for script types that lack built-in size estimates, avoiding unreachable error paths.

Enhancements:
- Change `_solution_sizes` to return `None` for unsupported script types and remove the redundant `_SOLVED` set and unreachable exception.
- Simplify `estimated_input_sizes` and p2wsh handling by using the `None` sentinel to decide when to delegate to the sizer callback.

Tests:
- Update PSBT sizing and solving tests to record which inputs are passed to callbacks and verify that callbacks are only invoked when the core code has no answer, and that invalid signatures prevent solver use.