### PR TITLE
Lower the uv required-version floor to >=0.11.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,16 @@ documented at release-notes length in the first place, and are still in
   comment rather than in `.markdownlint.jsonc`, which three repositories
   share: a rule one file needs belongs to that file. bitcoin-core-rpc's
   CHANGELOG.md carries the same comment.
+- **`[tool.uv]`'s `required-version` floor drops to `>=0.11.31`, from
+  `>=0.12.0`** (issue #485). Dependabot's own uv-ecosystem updater bundles
+  exactly 0.11.31 and does not self-update to satisfy a higher floor, so
+  it failed every update it attempted -- security updates included --
+  with `tool_version_not_supported` before a single one started. The
+  floor exists to stop an uv old enough to rewrite `uv.lock` in a format
+  a newer one cannot read; 0.11.31 is not that uv -- its lock schema
+  revision is unchanged from the rev the uv-lock hook of
+  `.pre-commit-config.yaml` pins, which is what actually regenerates the
+  committed file and keeps its own newer pin regardless of this floor.
 
 ### Documentation and the website
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,17 +117,21 @@ dev = [
 ]
 
 [tool.uv]
-# the oldest uv allowed to touch uv.lock, matching the rev the uv-lock
-# hook of .pre-commit-config.yaml pins: that hook is what regenerates the
-# file, and its rev is something pre-commit.ci moves on its own schedule.
-# Declared here the floor holds for every uv command rather than for the
-# hook alone, so an older uv on a developer's machine says so instead of
-# rewriting the lock in a format the runners then fail to read -- uv is
+# the oldest uv Dependabot's own uv-ecosystem updater bundles: it runs
+# `uv lock` with exactly that version regardless of this key, so any
+# higher floor fails every update it attempts before it starts. That
+# version already understands the lock format the uv-lock hook of
+# .pre-commit-config.yaml writes -- the hook pins a newer rev that
+# pre-commit.ci moves on its own schedule, and regenerates the committed
+# file, so this floor only has to stay low enough for Dependabot rather
+# than match the hook. Declared here the floor still holds for every uv
+# command, not the hook alone, so an uv older than this refuses rather
+# than rewriting the lock in a format a newer one cannot read -- uv is
 # pre-1.0 and has changed that format before. It also reaches CI without
 # a second pin: setup-uv, given no version input, reads this key, and a
 # bare minimum specifier makes it install the latest uv, so the runners
 # are never behind the floor and there is nothing here to go stale
-required-version = ">=0.12.0"
+required-version = ">=0.11.31"
 
 [tool.setuptools.packages.find]
 include = ["btclib*"]


### PR DESCRIPTION
## Summary
- `[tool.uv]`'s `required-version` floor drops from `>=0.12.0` to
  `>=0.11.31`, restoring Dependabot's uv-ecosystem updates: its updater
  bundles exactly 0.11.31 and does not self-update to satisfy a higher
  floor, so every attempted update (security updates included) has been
  failing with `tool_version_not_supported`.
- Verified the format-drift risk the floor exists to guard against does
  not apply here: 0.11.31's `uv.lock` schema revision is unchanged from
  the rev the `uv-lock` pre-commit hook pins (checked against uv's own
  source, `crates/uv-resolver/src/lock/mod.rs`, at both tags), and
  `uv lock --check --offline` with 0.11.31 against this repo's current
  `uv.lock` reports it up to date without rewriting it.

Closes #485

## Test plan
- [x] `uv run pre-commit run --all-files`
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html`
- [x] `uv run pytest --cov` (100% coverage, 17546 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Lower the uv required-version floor to restore Dependabot’s uv-ecosystem updates while keeping uv.lock format compatibility.

Build:
- Relax `[tool.uv]`'s `required-version` constraint from `>=0.12.0` to `>=0.11.31` to align with Dependabot’s bundled uv version.

Documentation:
- Document the lowered uv `required-version` floor and its rationale in the changelog, including Dependabot behavior and lockfile format considerations.