### PR TITLE
Let a caller check a signer, choose between signers, and be told which

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,49 @@ documented at release-notes length in the first place, and are still in
   side appends the other's element. A sizer answering None is the refusal
   that was there before it was asked.
 
+- **`psbt_signer_contract` checks an implementation of the signer
+  contract, from outside btclib.** A protocol is a promise the type
+  checker reads and nothing runs, so an adapter answering a five-byte
+  fingerprint, an xpub derived from the wrong path, or a signature on
+  an input whose key origin names another master, type-checks and is
+  wrong at the first spend. btclib's own adapters were checked by
+  btclib's tests, which is no help to whoever writes the next one:
+  `check_psbt_signer` is that question asked from outside, and it takes
+  any `PsbtSigner` -- a command line adapter, an in-process driver, a
+  signing service. It is a function and not a test suite, so it belongs
+  to no test framework, and it checks what a type cannot say rather
+  than repeating what one already does. The psbt it needs for the "not
+  my key" check is built from the signer's own fingerprint, so no
+  caller has to supply material for it; a path the signer holds and a
+  psbt it can sign are the two things only the caller has, and both
+  are optional.
+- **`select_device` and `merge_devices` share the one thing a caller
+  does before it has a signer.** Selecting by fingerprint is the same
+  rule for every transport, and a caller with more than one way of
+  reaching a signer has to decide which of them answers for a
+  fingerprint two of them offer -- which is the caller's decision, so
+  it is the order of the arguments. A device that cannot be asked for
+  a fingerprint yet is kept by the merge and refused by the selection
+  with what it said, a locked device being one to unlock rather than
+  one to look for. `SignerDevice` is the protocol both read;
+  `hwi.HwiDevice` satisfies it.
+- **`SignerNotFoundError` says the backend is not installed**, a
+  `SignerError` subclass so that code catching that keeps catching
+  this. `btclib.hwi` turned every `OSError` into one `SignerError`, so
+  a missing executable and a permission the udev rules do not grant
+  arrived as one class with one `code` of None: a caller offering
+  signers of several kinds had to match on the text of a message, or
+  look for the executable itself and ask a second question that can
+  disagree with the first.
+- **What `btclib.hwi` cannot register, and why, is written down.** A
+  Ledger will not sign a multisig it has not been shown, BIP388 wallet
+  policies are how it is shown, and `hwilib/_cli.py` does not expose
+  registration -- so this module cannot, and a caller registers out of
+  band. Whether btclib could grow it is not a transport question: a
+  policy is a descriptor template with the keys lifted out, but the
+  fragments one may hold are BIP388's fixed set plus miniscript inside
+  `wsh()`, and btclib reads no miniscript (#187).
+
 ### Packaging, linting and CI
 
 - **RELEASING.md says what `griffe check` actually reports**: breakage

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -98,6 +98,7 @@ __all__ = [
     "number_theory",
     "psbt",
     "psbt_signer",
+    "psbt_signer_contract",
     "script",
     "slip132",
     "to_prv_key",

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -52,6 +52,7 @@ __all__ = [
     "RpcError",
     "ScriptError",
     "SignerError",
+    "SignerNotFoundError",
 ]
 
 
@@ -177,6 +178,29 @@ class SignerError(BTClibRuntimeError):
         if self.code is None:
             return str(self.args[0])
         return f"{self.args[0]} (signer error code {self.code})"
+
+
+class SignerNotFoundError(SignerError):
+    """The backend an adapter runs is not installed.
+
+    A `SignerError` still, so a caller catching that keeps catching this,
+    and separate because it is the one failure that is not about a
+    device: nothing is unplugged, locked or busy, and no retry will
+    change it. A caller that offers signers of several kinds tells "there
+    is no hardware here" from "the hardware could not be reached" on this
+    class, and the two are not the same thing to report before a signing
+    operation.
+
+    Without it the distinction is not recoverable. `btclib.hwi` turns
+    every `OSError` into a `SignerError` -- a missing executable and a
+    permission the udev rules do not grant arrive as one class with one
+    `code` of None -- so a caller had to either match on the text of a
+    message or look for the executable itself, and looking for it is
+    asking a second question that can disagree with the first.
+
+    `code` is None, as for every failure of the exchange rather than of a
+    device.
+    """
 
 
 class ScriptError(BTClibValueError):

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -39,7 +39,36 @@ is parsed rather than what is buffered.
 
 Failures come back as `exceptions.SignerError`, carrying HWI's own error
 code where there is one: -14 is the user pressing the button that says
-no, -3 is a cable, -9 is a model that will never do it.
+no, -3 is a cable, -9 is a model that will never do it. The one failure
+that is not about a device -- the executable is not installed -- is the
+`SignerNotFoundError` subclass, so that a caller which also offers
+signers of other kinds can tell "no hardware here" from "the hardware
+could not be reached" without matching on the text of a message.
+
+## Wallet policies, and the multisig this cannot register
+
+A Ledger will not display or sign a multisig it has not been shown
+first. BIP388 wallet policies are how it is shown, and registration is a
+one-time exchange ending in an HMAC the host keeps and replays on every
+later call. `hwilib`'s ledger driver does that; `hwilib/_cli.py` does
+not expose it, so this module cannot -- issue #381 delegates policy
+registration to HWI on purpose, and the command line is where the
+delegation stops. A caller with a Ledger multisig registers it out of
+band, with HWI's Python API or Ledger's own tooling, and then this
+module signs for it: the psbt path needs no policy, only the
+registration does.
+
+Whether btclib could grow it rather than route around it is decided by
+two facts, and neither is about the transport. A policy is a descriptor
+*template* -- `wsh(sortedmulti(2,@0/**,@1/**))` -- with the keys lifted
+out into a vector beside it, which is a rewriting of what `descriptors`
+already builds. But the fragments a template may hold are BIP388's fixed
+set, plus miniscript inside `wsh()` in Ledger's app, and btclib reads no
+miniscript (issue #187). So a script outside that fixed set is not
+expressible here whatever the transport: a locking script with an
+`OP_IF` branch and a `CHECKSEQUENCEVERIFY` in it is a miniscript
+question before it is an HWI one, and an in-process adapter would not
+unblock the caller who asked.
 
 Staying aligned with a project this does not import is two things, and
 neither is a copy of it. `tests/hwi_test.py` writes out the surface used
@@ -61,7 +90,7 @@ from typing import Any
 from btclib.alias import Octets
 from btclib.bip32.der_path import DerPath, str_from_der_path
 from btclib.descriptors import Descriptor, add_checksum, at_index
-from btclib.exceptions import BTClibValueError, SignerError
+from btclib.exceptions import BTClibValueError, SignerError, SignerNotFoundError
 from btclib.network import NETWORKS
 from btclib.psbt.psbt import Psbt
 from btclib.psbt_signer import SignerCapabilities
@@ -165,6 +194,11 @@ def _run(
         )
     except subprocess.TimeoutExpired as e:
         raise SignerError(f"{argv[0]} timed out after {timeout} s") from e
+    except FileNotFoundError as e:
+        # the one failure that is not about a device: the command line is
+        # not installed, which a caller offering signers of several kinds
+        # reports differently from one it could not reach
+        raise SignerNotFoundError(f"cannot run {argv[0]}: {e}") from e
     except OSError as e:
         raise SignerError(f"cannot run {argv[0]}: {e}") from e
 

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -54,7 +54,7 @@ from btclib.bip32.der_path import DerPath, indexes_from_der_path, str_from_der_p
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.descriptors import Descriptor, account_descriptors
 from btclib.ecc import bms, dsa, ssa
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibValueError, SignerError
 from btclib.psbt.psbt import Psbt, assert_signatures_only, combine, sign
 from btclib.script.taproot import output_prvkey_from_merkle_root
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
@@ -62,18 +62,21 @@ from btclib.to_pub_key import fingerprint, pub_keyinfo_from_key
 from btclib.utils import bytes_from_octets
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Mapping, Sequence
 
 __all__ = [
     "AddressDisplay",
     "MessageSigner",
     "PsbtSigner",
     "SignerCapabilities",
+    "SignerDevice",
     "SoftwareSigner",
     "assert_public",
     "display_address",
     "export_account",
+    "merge_devices",
     "request_signatures",
+    "select_device",
     "sign_message",
 ]
 
@@ -174,6 +177,92 @@ class MessageSigner(Protocol):
     def sign_message(self, message: Octets, der_path: DerPath) -> str:
         """Return the compact signature of a message, by the key at a path."""
         ...
+
+
+@runtime_checkable
+class SignerDevice(Protocol):
+    """What a caller knows of a device before it has a signer for it.
+
+    Selecting which device answers is the one thing a caller does with no
+    signer in hand, and it is the same rule for every transport: the
+    fingerprint identifies the master key, so it identifies the device
+    that holds it, whatever answered for it. `hwi.HwiDevice` satisfies
+    this; so does a caller's own record of a signer that is not a device
+    at all.
+
+    `fingerprint` is None for a device that cannot be asked for one yet
+    -- a locked Trezor, a Ledger with no app open -- and `error` says
+    why. Such a device is listed on purpose: what a caller does about a
+    locked device is unlock it, and a list that left it out would say it
+    is not there.
+    """
+
+    @property
+    def fingerprint(self) -> bytes | None:
+        """Return the master fingerprint, or None if it cannot be asked."""
+        ...
+
+    @property
+    def error(self) -> str:
+        """Return why the device could not be asked, empty if it could."""
+        ...
+
+
+def _fingerprint(fingerprint: Octets) -> bytes:
+    """Return the four bytes of a fingerprint, however it was spelled."""
+    return bytes_from_octets(fingerprint, 4)
+
+
+def merge_devices(
+    *sources: Sequence[SignerDevice],
+) -> list[SignerDevice]:
+    """Return one list of devices from several, the earlier source winning.
+
+    A caller with more than one way of reaching a signer -- a command
+    line, an in-process driver, keys of its own -- has one question to
+    answer that none of the adapters can: which of them answers for a
+    fingerprint two of them offer. Order is that answer, and it is the
+    caller's to state, so the sources are positional and the first one
+    that names a fingerprint keeps it.
+
+    Devices that cannot be asked for a fingerprint yet are all kept:
+    there is no fingerprint to be a duplicate of, and dropping them would
+    say a locked device is not plugged in.
+    """
+    merged: list[SignerDevice] = []
+    seen: set[bytes] = set()
+    for source in sources:
+        for device in source:
+            if device.fingerprint is None:
+                merged.append(device)
+                continue
+            if device.fingerprint in seen:
+                continue
+            seen.add(device.fingerprint)
+            merged.append(device)
+    return merged
+
+
+def select_device(devices: Sequence[SignerDevice], fingerprint: Octets) -> SignerDevice:
+    """Return the one device answering for a fingerprint, or raise.
+
+    Two failures and they are different news, so they are different
+    messages: no device answers for it, or one does and it said why it
+    cannot be asked -- which is a device to unlock rather than a device
+    to look for.
+
+    More than one is not among them: `merge_devices` is where a caller
+    states which source wins, and a single source answering one
+    fingerprint twice is two cables to one device, so the first is taken.
+    """
+    wanted = _fingerprint(fingerprint)
+    for device in devices:
+        if device.fingerprint == wanted:
+            if device.error:
+                err_msg = f"device {wanted.hex()} cannot be used: {device.error}"
+                raise SignerError(err_msg)
+            return device
+    raise SignerError(f"no device with fingerprint {wanted.hex()}")
 
 
 def assert_public(descriptor: Descriptor) -> None:

--- a/btclib/psbt_signer_contract.py
+++ b/btclib/psbt_signer_contract.py
@@ -1,0 +1,247 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Check an implementation of `psbt_signer`'s contract, from outside it.
+
+`psbt_signer` says what a signer answers; this says whether one does. A
+protocol is a promise the type checker reads and nothing runs, so an
+adapter that returns a five-byte fingerprint, or a psbt it edited, or an
+xpub it derived from the wrong path, type-checks and is wrong at the
+first spend.
+
+btclib's own adapters are checked by btclib's tests, which is no help to
+the caller writing the next one: an implementer outside this repository
+had no way to ask the library whether their signer answers what callers
+of it will assume. `check_psbt_signer` is that question, and it takes any
+`PsbtSigner` -- a command line adapter, an in-process driver, a signing
+service, a signer that is not a device at all.
+
+It is a function and not a test suite so that it belongs to no test
+framework: call it from pytest, from unittest, from a script run against
+the hardware on a bench. It raises on the first breach, with what was
+expected and what came back, because the first breach is the one to fix
+and a list of consequences of it is not more information.
+
+What it checks is what a type cannot say. A method returning the wrong
+type is what the implementer's own type checker reports, and repeating
+that here would be a second, weaker copy of it; a fingerprint of the
+wrong width, an xpub that is not one, a key answered privately, a
+signature added to somebody else's input -- none of those are type
+errors, and all of them type-check.
+
+**What it does not check is whether the signatures are right.** That is
+`request_signatures`, which holds an answer to the psbt that was sent and
+verifies every signature that arrived -- the check that matters most is
+the one a caller runs on every spend, not one a conformance pass runs
+once. What this adds is the shape of the answers around it: the things
+`request_signatures` assumes and does not restate.
+
+Two of the checks need material only the caller has, and both are
+optional. A signer holds keys at paths this module cannot guess, so
+`der_path` is asked for rather than defaulted -- a wrong guess would
+report a conforming signer as broken. And a psbt the signer can actually
+sign is the only way to see it sign, so `signable` is what turns a shape
+check into an end-to-end one.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NoReturn
+
+from btclib.bip32.bip32 import BIP32KeyData
+from btclib.bip32.key_origin import BIP32KeyOrigin
+from btclib.exceptions import BTClibValueError
+from btclib.psbt import Psbt
+from btclib.psbt_signer import (
+    AddressDisplay,
+    MessageSigner,
+    PsbtSigner,
+    request_signatures,
+)
+from btclib.script.script_pub_key import ScriptPubKey
+from btclib.tx.out_point import OutPoint
+from btclib.tx.tx import Tx
+from btclib.tx.tx_in import TxIn
+from btclib.tx.tx_out import TxOut
+
+if TYPE_CHECKING:
+    from btclib.bip32.der_path import DerPath
+
+__all__ = [
+    "check_optional_protocols",
+    "check_psbt_signer",
+    "unsignable_psbt",
+]
+
+# a fingerprint is four bytes, BIP32's own, and every psbt key origin is
+# written against that width
+_FINGERPRINT_SIZE = 4
+
+# the generator point of secp256k1, used as the key of the input no
+# signer is meant to sign: a point on the curve is needed -- an output
+# script is not built from arbitrary bytes -- and this one is the public
+# key of a private key nobody chose and everybody knows, which is the
+# property wanted of a key that must not be signed with
+_SOMEBODY_ELSES_KEY = bytes.fromhex(
+    "0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+)
+
+
+def _fail(what: str) -> NoReturn:
+    """Raise the one refusal this module makes, so it reads as one."""
+    raise BTClibValueError(f"the signer breaks the contract: {what}")
+
+
+def unsignable_psbt(fingerprint: bytes) -> Psbt:
+    """Return a psbt of one input no signer of this fingerprint can sign.
+
+    A p2wpkh whose key origin names somebody else's master, which is the
+    shape of the psbt a caller sends to every signer it has and expects
+    most of them to hand straight back. Built from the signer's own
+    fingerprint with a bit flipped, so it is somebody else's for *this*
+    signer whoever it is, and no caller has to supply a key to find out
+    what the signer does with a psbt that is not its business.
+    """
+    other = bytes([fingerprint[0] ^ 0xFF, *fingerprint[1:]])
+    script_pub_key = ScriptPubKey.p2wpkh(_SOMEBODY_ELSES_KEY)
+
+    tx_in = TxIn(OutPoint(b"\xaa" * 32, 0))
+    tx_out = TxOut(9_000, script_pub_key)
+    psbt = Psbt.from_tx(Tx(version=2, lock_time=0, vin=[tx_in], vout=[tx_out]))
+    # the fields are set on the input the psbt already holds rather than
+    # on one built beside it: BIP370 keeps the outpoint on the input, so
+    # an input replaced wholesale is an input naming nothing
+    psbt_in = psbt.inputs[0]
+    psbt_in.witness_utxo = TxOut(10_000, script_pub_key)
+    psbt_in.hd_key_paths[_SOMEBODY_ELSES_KEY] = BIP32KeyOrigin(other, "m/84h/0h/0h/0/0")
+    return psbt
+
+
+def _check_fingerprint(signer: PsbtSigner) -> bytes:
+    """Check the master fingerprint and return it, the rest needing it."""
+    fingerprint = signer.master_fingerprint()
+    if len(fingerprint) != _FINGERPRINT_SIZE:
+        _fail(f"master_fingerprint is {len(fingerprint)} bytes, not 4")
+    if signer.master_fingerprint() != fingerprint:
+        _fail("master_fingerprint answered two different values")
+    return fingerprint
+
+
+def _check_capabilities(signer: PsbtSigner) -> None:
+    """Check that what the signer says it can sign does not change.
+
+    A caller reads this once and sends taproot inputs, or does not, for
+    the rest of the session: a signer that answers differently the
+    second time has already been acted on.
+    """
+    if signer.capabilities() != signer.capabilities():
+        _fail("capabilities answered two different values")
+
+
+def _check_xpub(signer: PsbtSigner, der_path: DerPath) -> None:
+    """Check the key at a path: public, parseable, and the same twice."""
+    xpub = signer.xpub(der_path)
+    try:
+        key = BIP32KeyData.b58decode(xpub)
+    except ValueError as e:
+        _fail(f"xpub is not an extended key: {e}")
+    if key.is_private:
+        # the one answer that is not merely wrong: a signer that hands
+        # out a key that signs has published the thing it exists to keep
+        _fail("xpub answered a private key")
+    if signer.xpub(der_path) != xpub:
+        _fail("xpub answered two different keys for one path")
+
+
+def _check_unsignable(signer: PsbtSigner, fingerprint: bytes) -> None:
+    """Check what the signer does with a psbt that is not its business.
+
+    Hand it back, having added nothing. Not an error: a caller sends one
+    request to every signer it has, and a signer that raises rather than
+    abstaining makes "this device holds no key here" indistinguishable
+    from "this device failed", which is the distinction the caller needs
+    in order to go on to the next one.
+    """
+    psbt = unsignable_psbt(fingerprint)
+    answered = request_signatures(signer, psbt)
+    added = [
+        pub_key
+        for psbt_in, answered_in in zip(psbt.inputs, answered.inputs, strict=True)
+        for pub_key in answered_in.partial_sigs
+        if pub_key not in psbt_in.partial_sigs
+    ]
+    if added:
+        _fail("sign_psbt signed an input whose key origin names another master")
+
+
+def _check_signable(signer: PsbtSigner, signable: Psbt) -> None:
+    """Check that the signer signs what it was said to be able to sign."""
+    answered = request_signatures(signer, signable)
+    added = sum(
+        len(answered_in.partial_sigs) - len(psbt_in.partial_sigs)
+        for psbt_in, answered_in in zip(signable.inputs, answered.inputs, strict=True)
+    )
+    added += sum(
+        len(answered_in.taproot_script_spend_signatures)
+        - len(psbt_in.taproot_script_spend_signatures)
+        + (answered_in.taproot_key_spend_signature is not None)
+        - (psbt_in.taproot_key_spend_signature is not None)
+        for psbt_in, answered_in in zip(signable.inputs, answered.inputs, strict=True)
+    )
+    if added <= 0:
+        _fail("sign_psbt added no signature to a psbt it was said to sign")
+
+
+def check_psbt_signer(
+    signer: object,
+    *,
+    der_path: DerPath | None = None,
+    signable: object = None,
+) -> None:
+    """Check a signer against the contract, raising at the first breach.
+
+    `der_path` is a path the signer holds a key at; without one the xpub
+    checks are skipped, since a path guessed here would report a
+    conforming signer as broken. `signable` is a psbt the signer can
+    sign; without one the checks are of shape alone, and nothing sees it
+    sign.
+
+    Both it and the signer are typed `object` rather than what they have
+    to be. A function whose subject is what a type cannot promise is one
+    that has to be callable with what a type would have refused, and it
+    says what arrived instead of the caller's type checker saying it
+    first: an adapter written without one is exactly the caller this
+    exists for.
+
+    Closing is checked last and twice, `close` being documented as
+    idempotent -- a caller closes a signer it is not sure about -- so the
+    signer is spent when this returns.
+    """
+    if not isinstance(signer, PsbtSigner):
+        _fail("it does not implement PsbtSigner")
+
+    fingerprint = _check_fingerprint(signer)
+    _check_capabilities(signer)
+    if der_path is not None:
+        _check_xpub(signer, der_path)
+    _check_unsignable(signer, fingerprint)
+    if signable is not None:
+        if not isinstance(signable, Psbt):
+            _fail(f"signable is {type(signable).__name__}, not a Psbt")
+        _check_signable(signer, signable)
+
+    signer.close()
+    signer.close()
+
+
+def check_optional_protocols(signer: object) -> tuple[bool, bool]:
+    """Return which optional protocols the signer offers, as a caller asks.
+
+    `isinstance` against the two runtime-checkable protocols, which is
+    the whole of it: what `display_address` and `sign_message` answer is
+    checked by the functions of `psbt_signer` that call them, against the
+    descriptor and the address the caller says the answer must match, and
+    a conformance pass has neither.
+    """
+    return isinstance(signer, AddressDisplay), isinstance(signer, MessageSigner)

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -146,6 +146,13 @@ btclib.psbt\_signer module
    :members:
    :show-inheritance:
 
+btclib.psbt\_signer\_contract module
+------------------------------------
+
+.. automodule:: btclib.psbt_signer_contract
+   :members:
+   :show-inheritance:
+
 btclib.slip132 module
 ---------------------
 

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -41,7 +41,7 @@ import pytest
 
 from btclib.bip32.bip32 import derive, xpub_from_xprv
 from btclib.descriptors import Descriptor, at_index, parse
-from btclib.exceptions import BTClibValueError, SignerError
+from btclib.exceptions import BTClibValueError, SignerError, SignerNotFoundError
 from btclib.hwi import (
     _HWI_CHAIN,
     DEFAULT_MAX_OUTPUT,
@@ -427,8 +427,21 @@ def test_what_the_subprocess_can_do_wrong(tmp_path: Path) -> None:
     past the limit, a command that prints nothing, and the error object
     HWI itself returns — the last being the one that carries a number.
     """
+    # not installed is its own subclass: a caller offering signers of
+    # other kinds tells it from a device it could not reach, and a
+    # SignerError still, so code catching that keeps catching this
+    with pytest.raises(SignerNotFoundError, match="cannot run"):
+        enumerate_devices(executable=str(tmp_path / "nowhere"))
     with pytest.raises(SignerError, match="cannot run"):
         enumerate_devices(executable=str(tmp_path / "nowhere"))
+
+    # an OSError that is not a missing executable is not that subclass:
+    # a directory is there, and running it is a different failure
+    unrunnable = tmp_path / "a_directory"
+    unrunnable.mkdir()
+    with pytest.raises(SignerError, match="cannot run") as raised:
+        enumerate_devices(executable=str(unrunnable))
+    assert not isinstance(raised.value, SignerNotFoundError)
 
     not_json = tmp_path / "not_json.py"
     not_json.write_text("print('hello')\n", encoding="ascii")

--- a/tests/psbt_signer_contract_test.py
+++ b/tests/psbt_signer_contract_test.py
@@ -1,0 +1,266 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The conformance checks, against signers built to break each one.
+
+`SoftwareSigner` passing is one half of the evidence and the weaker
+half: a checker that never refuses passes everything. So each check has
+a signer here that breaks exactly it and nothing else, wrapping the
+conforming one, which is what says the check is the thing that fired.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+import pytest
+
+from btclib.bip32.bip32 import derive
+from btclib.bip32.key_origin import BIP32KeyOrigin
+from btclib.ecc import dsa
+from btclib.exceptions import BTClibValueError
+from btclib.mnemonic import bip39
+from btclib.psbt.psbt import Psbt
+from btclib.psbt_signer import PsbtSigner, SignerCapabilities, SoftwareSigner
+from btclib.psbt_signer_contract import (
+    _SOMEBODY_ELSES_KEY,
+    check_optional_protocols,
+    check_psbt_signer,
+    unsignable_psbt,
+)
+from btclib.script import sig_hash
+from btclib.script.script_pub_key import ScriptPubKey
+from btclib.to_pub_key import pub_keyinfo_from_key
+from btclib.tx.out_point import OutPoint
+from btclib.tx.tx import Tx
+from btclib.tx.tx_in import TxIn
+from btclib.tx.tx_out import TxOut
+
+if TYPE_CHECKING:
+    from btclib.bip32.der_path import DerPath
+
+_MNEMONIC = (
+    "abandon abandon abandon abandon abandon abandon "
+    "abandon abandon abandon abandon abandon about"
+)
+_ACCOUNT = "m/84h/0h/0h"
+
+
+def _signer() -> SoftwareSigner:
+    """Return the reference signer every check is expected to pass."""
+    return SoftwareSigner(bip39.mxprv_from_mnemonic(_MNEMONIC, "", "mainnet"))
+
+
+class _Wrapper:
+    """A signer that forwards everything, so a subclass breaks one thing."""
+
+    def __init__(self) -> None:
+        self._signer = _signer()
+
+    def master_fingerprint(self) -> bytes:
+        return self._signer.master_fingerprint()
+
+    def xpub(self, der_path: DerPath) -> str:
+        return self._signer.xpub(der_path)
+
+    def sign_psbt(self, psbt: Psbt) -> Psbt:
+        return self._signer.sign_psbt(psbt)
+
+    def capabilities(self) -> SignerCapabilities:
+        return self._signer.capabilities()
+
+    def close(self) -> None:
+        self._signer.close()
+
+
+def _signable() -> Psbt:
+    """Return a psbt the reference signer holds the key of one input of."""
+    signer = _signer()
+    xprv = derive(
+        bip39.mxprv_from_mnemonic(_MNEMONIC, "", "mainnet"), f"{_ACCOUNT}/0/0"
+    )
+    pub_key = pub_keyinfo_from_key(xprv)[0]
+    script_pub_key = ScriptPubKey.p2wpkh(pub_key)
+
+    tx_in = TxIn(OutPoint(b"\xbb" * 32, 0))
+    tx_out = TxOut(9_000, script_pub_key)
+    psbt = Psbt.from_tx(Tx(version=2, lock_time=0, vin=[tx_in], vout=[tx_out]))
+    psbt_in = psbt.inputs[0]
+    psbt_in.witness_utxo = TxOut(10_000, script_pub_key)
+    psbt_in.hd_key_paths[pub_key] = BIP32KeyOrigin(
+        signer.master_fingerprint(), f"{_ACCOUNT}/0/0"
+    )
+    return psbt
+
+
+def test_the_reference_signer_conforms() -> None:
+    """What the checks are calibrated against."""
+    check_psbt_signer(_signer(), der_path=_ACCOUNT, signable=_signable())
+
+
+def test_the_optional_protocols_are_reported() -> None:
+    """SoftwareSigner offers both; a signer of the four methods, neither."""
+    assert check_optional_protocols(_signer()) == (True, True)
+    assert check_optional_protocols(_Wrapper()) == (False, False)
+
+
+def test_something_that_is_not_a_signer_is_refused() -> None:
+    """The one check a caller cannot make with a type annotation."""
+    with pytest.raises(BTClibValueError, match="does not implement PsbtSigner"):
+        check_psbt_signer(object())
+
+
+def test_a_fingerprint_of_the_wrong_width_is_refused() -> None:
+    """Four bytes is BIP32's own, and every key origin is written to it."""
+
+    class _TooLong(_Wrapper):
+        def master_fingerprint(self) -> bytes:
+            return b"\x00" * 5
+
+    with pytest.raises(BTClibValueError, match="is 5 bytes, not 4"):
+        check_psbt_signer(_TooLong())
+
+
+def test_a_fingerprint_that_changes_is_refused() -> None:
+    """A signer answers for one master, so the answer is one answer."""
+
+    class _Drifting(_Wrapper):
+        def __init__(self) -> None:
+            super().__init__()
+            self._asked = 0
+
+        def master_fingerprint(self) -> bytes:
+            self._asked += 1
+            return bytes([self._asked, 0, 0, 0])
+
+    with pytest.raises(BTClibValueError, match="two different values"):
+        check_psbt_signer(_Drifting())
+
+
+def test_an_xpub_that_is_not_an_extended_key_is_refused() -> None:
+    """A string is a string: that it spells a key is not a type."""
+
+    class _Nonsense(_Wrapper):
+        def xpub(self, der_path: DerPath) -> str:
+            return "not a key at all"
+
+    with pytest.raises(BTClibValueError, match="not an extended key"):
+        check_psbt_signer(_Nonsense(), der_path=_ACCOUNT)
+
+
+def test_an_xpub_that_is_private_is_refused() -> None:
+    """The one answer that is not merely wrong."""
+
+    class _Leaking(_Wrapper):
+        def xpub(self, der_path: DerPath) -> str:
+            return derive(bip39.mxprv_from_mnemonic(_MNEMONIC, "", "mainnet"), der_path)
+
+    with pytest.raises(BTClibValueError, match="answered a private key"):
+        check_psbt_signer(_Leaking(), der_path=_ACCOUNT)
+
+
+def test_an_xpub_that_changes_is_refused() -> None:
+    """One path is one key, or the descriptors built from it are fiction."""
+
+    class _Drifting(_Wrapper):
+        def __init__(self) -> None:
+            super().__init__()
+            self._asked = 0
+
+        def xpub(self, der_path: DerPath) -> str:
+            self._asked += 1
+            return self._signer.xpub(f"m/84h/0h/{self._asked}h")
+
+    with pytest.raises(BTClibValueError, match="two different keys"):
+        check_psbt_signer(_Drifting(), der_path=_ACCOUNT)
+
+
+def test_signing_an_input_of_another_master_is_refused() -> None:
+    """The check that needs a signature to be real, so it makes one.
+
+    The key of the unsignable input is the generator point, whose
+    private key is 1 and is therefore available to a test: a rogue
+    signer can produce a signature that verifies, which is what it takes
+    to reach the check rather than being stopped by
+    `request_signatures`.
+    """
+
+    class _Rogue(_Wrapper):
+        def sign_psbt(self, psbt: Psbt) -> Psbt:
+            answer = deepcopy(psbt)
+            psbt_in = answer.inputs[0]
+            assert psbt_in.witness_utxo is not None
+            msg_hash = sig_hash.from_tx(
+                [psbt_in.witness_utxo], answer.tx, 0, sig_hash.ALL
+            )
+            signature = dsa.sign_(msg_hash, 1).serialize() + b"\x01"
+            psbt_in.partial_sigs[_SOMEBODY_ELSES_KEY] = signature
+            return answer
+
+    with pytest.raises(BTClibValueError, match="names another master"):
+        check_psbt_signer(_Rogue())
+
+
+def test_a_signer_that_signs_nothing_it_was_said_to_sign_is_refused() -> None:
+    """The end-to-end half: the caller says it can, so it has to."""
+
+    class _Idle(_Wrapper):
+        def sign_psbt(self, psbt: Psbt) -> Psbt:
+            return deepcopy(psbt)
+
+    with pytest.raises(BTClibValueError, match="added no signature"):
+        check_psbt_signer(_Idle(), signable=_signable())
+
+
+def test_the_unsignable_psbt_names_another_master() -> None:
+    """What the psbt is for, said against the psbt itself."""
+    fingerprint = _signer().master_fingerprint()
+    psbt = unsignable_psbt(fingerprint)
+    ((_, origin),) = psbt.inputs[0].hd_key_paths.items()
+    assert origin.master_fingerprint != fingerprint
+    assert origin.master_fingerprint[1:] == fingerprint[1:]
+
+
+def test_a_conforming_signer_is_closed_twice() -> None:
+    """`close` is documented idempotent, so the checks close twice."""
+    closed = 0
+
+    class _Counting(_Wrapper):
+        def close(self) -> None:
+            nonlocal closed
+            closed += 1
+            super().close()
+
+    # the forwarding wrapper answers every question here, which is what
+    # says the checks pass for a signer that is not SoftwareSigner itself
+    check_psbt_signer(_Counting(), der_path=_ACCOUNT)
+    assert closed == 2
+
+
+def test_the_wrapper_is_a_signer() -> None:
+    """The stand-in every broken signer builds on has to be one itself."""
+    assert isinstance(_Wrapper(), PsbtSigner)
+
+
+def test_something_that_is_not_a_psbt_is_refused() -> None:
+    """`signable` is checked rather than assumed, being typed `object`."""
+    with pytest.raises(BTClibValueError, match="is str, not a Psbt"):
+        check_psbt_signer(_signer(), signable="not a psbt")
+
+
+def test_capabilities_that_change_are_refused() -> None:
+    """A caller acts on the first answer for the rest of the session."""
+
+    class _Drifting(_Wrapper):
+        def __init__(self) -> None:
+            super().__init__()
+            self._asked = 0
+
+        def capabilities(self) -> SignerCapabilities:
+            self._asked += 1
+            return SignerCapabilities(taproot=self._asked % 2 == 0)
+
+    with pytest.raises(BTClibValueError, match="capabilities answered two"):
+        check_psbt_signer(_Drifting())

--- a/tests/psbt_signer_test.py
+++ b/tests/psbt_signer_test.py
@@ -31,7 +31,8 @@ from btclib.descriptors import (
     parse,
 )
 from btclib.ecc import bms, dsa
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibValueError, SignerError
+from btclib.hwi import HwiDevice
 from btclib.psbt.psbt import Psbt, sign
 from btclib.psbt_signer import (
     AddressDisplay,
@@ -41,7 +42,9 @@ from btclib.psbt_signer import (
     assert_public,
     display_address,
     export_account,
+    merge_devices,
     request_signatures,
+    select_device,
     sign_message,
 )
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
@@ -383,3 +386,54 @@ def test_a_signed_message_is_verified_against_the_address_asked_for() -> None:
     elsewhere = _MessageSigner("m/84h/0h/0h/0/1")
     with pytest.raises(BTClibValueError):
         sign_message(elsewhere, b"hello", der_path, address)
+
+
+def test_a_device_is_selected_by_fingerprint() -> None:
+    """The one thing a caller does before it has a signer at all."""
+    wanted = HwiDevice(type="ledger", model="nanos", path="a", fingerprint=b"\x01" * 4)
+    other = HwiDevice(type="trezor", model="one", path="b", fingerprint=b"\x02" * 4)
+
+    assert select_device([other, wanted], b"\x01" * 4) is wanted
+    assert select_device([other, wanted], "01010101") is wanted
+
+    with pytest.raises(SignerError, match="no device with fingerprint 03030303"):
+        select_device([other, wanted], b"\x03" * 4)
+
+
+def test_a_device_that_said_why_it_cannot_be_asked_is_not_selected() -> None:
+    """Different news from "not there": this one is a device to unlock."""
+    locked = HwiDevice(
+        type="trezor",
+        model="one",
+        path="a",
+        fingerprint=b"\x01" * 4,
+        error="device is locked",
+    )
+    with pytest.raises(SignerError, match="cannot be used: device is locked"):
+        select_device([locked], b"\x01" * 4)
+
+
+def test_devices_of_several_sources_are_merged_in_the_caller_s_order() -> None:
+    """Which source wins is the caller's to state, so order states it."""
+    hardware = HwiDevice(
+        type="ledger", model="nanos", path="a", fingerprint=b"\x01" * 4
+    )
+    software = HwiDevice(
+        type="software", model="emulated", path="b", fingerprint=b"\x01" * 4
+    )
+    only_software = HwiDevice(
+        type="software", model="emulated", path="c", fingerprint=b"\x02" * 4
+    )
+
+    merged = merge_devices([hardware], [software, only_software])
+    assert merged == [hardware, only_software]
+    assert merge_devices([software], [hardware]) == [software]
+    assert merge_devices() == []
+
+
+def test_a_device_with_no_fingerprint_yet_is_kept_by_the_merge() -> None:
+    """There is no fingerprint to be a duplicate of, and it is plugged in."""
+    locked = HwiDevice(type="trezor", model="one", path="a", error="locked")
+    also_locked = HwiDevice(type="trezor", model="one", path="b", error="locked")
+
+    assert merge_devices([locked], [also_locked]) == [locked, also_locked]


### PR DESCRIPTION
Closes the code half of #469.

That issue asks whether the second HWI adapter should be the in-process
one. The [answer from the downstream it names](https://github.com/btclib-org/btclib/issues/469#issuecomment-5225451768)
is no, for the reason the issue itself calls decisive: HWI's interpreter
range put that consumer on the subprocess boundary and keeps it there.
This is what the same consumer *did* need and had to write for itself.

## A conformance check that ships — `btclib.psbt_signer_contract`

A protocol is a promise the type checker reads and nothing runs. A
signer that answers a five-byte fingerprint, an xpub derived from the
wrong path, or a signature on an input whose key origin names another
master, type-checks and is wrong at the first spend.

btclib's own adapters are checked by btclib's tests, which is no help to
whoever writes the next one — the tests are not shipped
(`include = ["btclib*"]`). `check_psbt_signer` asks the question from
outside, over any `PsbtSigner`: a command line adapter, an in-process
driver, a signing service, a signer that is not a device.

- **a function, not a test suite**, so it belongs to no test framework:
  call it from pytest, from unittest, from a script run against the
  hardware on a bench;
- **it checks what a type cannot say.** A method returning the wrong
  type is what the implementer's own type checker reports, and
  repeating that here would be a second, weaker copy of it. A
  fingerprint of the wrong width, an xpub that is not one, a key
  answered privately, capabilities that change between two calls, a
  signature added to somebody else's input — none of those are type
  errors;
- **it supplies its own material** for the "this is not my key" check:
  the psbt is built from the signer's own fingerprint with a bit
  flipped, so it is somebody else's whoever the signer is. The two
  things only a caller has — a path the signer holds a key at, a psbt
  it can sign — are optional, and a path guessed here would report a
  conforming signer as broken;
- **`signer` and `signable` are typed `object`.** A function whose
  subject is what a type cannot promise has to be callable with what a
  type would have refused — an adapter written without a type checker
  is exactly the caller it exists for.

Each check has a test with a signer built to break exactly it and
nothing else, wrapping the conforming one: a checker that never refuses
passes everything, so `SoftwareSigner` passing is the weaker half of the
evidence. The rogue-signature test produces a signature that really
verifies — the key of the unsignable input is the generator point, whose
private key is 1 — because otherwise `request_signatures` stops it
before the check under test is reached.

## Selection, shared across transports — issue point 4

Selecting a device by fingerprint is the same rule for any transport,
and it is the one thing a caller does before it has a signer at all.

`select_device` and `merge_devices` read a `SignerDevice` protocol that
`HwiDevice` already satisfies, and so does a caller's own record of a
signer that is not a device. Which source wins when two offer one
fingerprint is the caller's decision, so it is the order of the
arguments. A device that cannot be asked for a fingerprint yet is kept
by the merge — there is nothing for it to be a duplicate of, and
dropping it would say a locked device is not plugged in — and refused by
the selection with what it said, being a device to unlock rather than
one to look for.

## `SignerNotFoundError`

`_run` turned every `OSError` into one `SignerError` with one `code` of
`None`, so "the executable is not installed" and "the device could not
be reached" were the same class. A caller offering signers of several
kinds had to match on the text of a message — or look for the executable
itself, which is asking a second question that can disagree with the
first.

A subclass, so `except SignerError` keeps catching it.

## BIP388, written down

A Ledger will not display or sign a multisig it has not been shown;
wallet policies are how it is shown; `hwilib/_cli.py` does not expose
registration, so this module cannot, and a caller registers out of band.

Whether btclib could grow it is **not a transport question**, which is
the part worth settling before #469 is decided on this ground: a policy
is a descriptor template with the keys lifted into a vector, which is a
rewriting of what `descriptors` already builds — but the fragments a
template may hold are BIP388's fixed set, plus miniscript inside `wsh()`
in Ledger's app, and btclib reads no miniscript (#187). A locking script
with an `OP_IF` branch and a `CHECKSEQUENCEVERIFY` in it is a miniscript
question first, and an in-process adapter would not unblock the caller
who asked.

## Verification

- `pytest --cov`: 100.00%, `fail_under` met;
- `pre-commit run --all-files`: clean;
- the sphinx `-W --keep-going` build: clean.

One note on that last one: `Psbt` as a **parameter** annotation of a
public function in a new module renders as a cross-reference with two
targets (`btclib.psbt.Psbt` and `btclib.psbt.psbt.Psbt`) and fails `-W`.
Typing the parameter `object`, which this module wanted anyway, avoids
it; a return annotation does not trigger it. Worth knowing before the
next module hits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add external conformance checking for PSBT signer implementations, introduce shared device selection utilities, and distinguish missing signer backends from other hardware interface failures.

New Features:
- Provide psbt_signer_contract module with check_psbt_signer and related helpers to validate PsbtSigner implementations from outside btclib.
- Expose SignerDevice protocol and merge_devices/select_device helpers to unify device discovery and selection across transports.

Enhancements:
- Add SignerNotFoundError as a dedicated subclass of SignerError to represent missing signer backends and update HWI subprocess handling to use it.
- Document Ledger wallet policy and BIP388 limitations in the HWI module and changelog.

Documentation:
- Update changelog and HWI documentation to describe the new signer contract checks, device selection helpers, and Ledger/BIP388 support limitations.

Tests:
- Add comprehensive tests for psbt_signer_contract to cover each conformance check and wrapper behavior.
- Add tests for device merging/selection semantics and for SignerNotFoundError behavior in HWI subprocess execution.