### PR TITLE
Retire the copyright-notice hook for ruff's own CPY001

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,8 +29,7 @@ repos:
   # environment to install. A `files` or `exclude` pattern that stops
   # matching anything is a hook that has quietly stopped running, which is
   # the shape of issue #145 one level up: the rule is still written down
-  # and no longer enforced. One pattern to go stale today, the
-  # `files: \.py$` on copyright-notice -- and nothing else would say so
+  # and no longer enforced
   - repo: meta
     hooks:
       - id: check-hooks-apply
@@ -352,14 +351,9 @@ repos:
         # pre-commit.ci (zizmor issue 582) -- not reproducible from here,
         # and not a reason to drop a flag its author put there
         args: [--offline, --no-progress]
-  - repo: https://github.com/leoll2/copyright_notice_precommit
-    rev: 0.1.1
-    hooks:
-      - id: copyright-notice
-        args: [--notice=COPYRIGHT, --enforce-all]
-        files: \.py$
-  # ruff replaces autoflake, bandit, black, docformatter, flake8, isort,
-  # pydocstringformatter, pydocstyle, pylint, pyupgrade, and yesqa
+  # ruff replaces autoflake, bandit, black, copyright_notice_precommit,
+  # docformatter, flake8, isort, pydocstringformatter, pydocstyle, pylint,
+  # pyupgrade, and yesqa
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.0
     hooks:

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -66,7 +66,8 @@ __author__ = "The btclib developers"
 __author_email__ = "devs@btclib.org"
 # the one place the years are written. The notice at the head of every
 # source file carries none, by design: it comes from the COPYRIGHT file,
-# which the copyright-notice hook enforces, so it never needs editing.
+# which ruff's CPY001 (flake8-copyright) enforces, so it never needs
+# editing.
 # docs/source/conf.py reads this line rather than importing it, read the
 # docs not installing this package into the environment it builds in
 __copyright__ = "Copyright (c) 2017-2026 The btclib developers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,9 @@ repository_nwo = "repository_nwo"
 # bindings predicate. Neither can be written differently
 nd = "nd"
 ands = "ands"
+# ruff's own name for flake8-copyright, in the comment above
+# [tool.ruff.lint.flake8-copyright] explaining why it is selected
+CPY = "CPY"
 
 [tool.typos.type.verbatim]
 # the three files that quote misspellings on purpose: the #161 entry names
@@ -532,6 +535,14 @@ select = [
     "BLE",  # flake8-blind-except
     "C4",   # flake8-comprehensions
     "C90",  # mccabe, at ruff's default with noqa'd exceptions: see below
+    # flake8-copyright, replacing the copyright-notice pre-commit hook:
+    # ed6e8014 found that hook checking only staged files unless given
+    # --enforce-all, so "pre-commit run --all-files" -- what the lint
+    # workflow actually runs -- silently checked nothing until that flag
+    # was added by hand. A rule living inside ruff's own file-selection
+    # logic has no separate flag to forget, checking whatever files it is
+    # given the same way whoever is asking
+    "CPY",
     "D",    # pydocstyle
     "E",    # pycodestyle errors
     "ERA",  # eradicate: code that was commented out instead of deleted
@@ -673,3 +684,17 @@ convention = "pep257"
 # a decision this file made -- every other setting in it carries the
 # measurement or the reason that chose it, and this one had neither
 parametrize-names-type = "csv"
+
+[tool.ruff.lint.flake8-copyright]
+# COPYRIGHT is still the one place the notice text is written down; this
+# is all three of its lines as one regex, not only the holder line --
+# a file keeping the first and dropping the licence/text lines below it
+# would have passed the single-line version and does not pass this one.
+# Escaped literally rather than searched loosely, so the dated holder
+# variants ed6e8014 found and reverted (2017-2021, 2017-2022,
+# 2020-2022) would not have matched either. What it still does not do
+# is diff a file against COPYRIGHT byte for byte the way the retired
+# hook's --enforce-all did: nothing here anchors the match to the very
+# start of the file, so text prepended above the notice would go
+# unnoticed
+notice-rgx = "Copyright \\(c\\) The btclib developers\\n# Distributed under the MIT software license, see the accompanying\\n# LICENSE file or https://opensource\\.org/license/mit for the full text\\."


### PR DESCRIPTION
Closes #500.

## What

Replaces the dedicated `leoll2/copyright_notice_precommit` hook with ruff's own `CPY001` (flake8-copyright), selectable by its own code without turning `preview` on project-wide — verified locally before opening this:

```toml
[tool.ruff.lint]
select = ["CPY", ...]

[tool.ruff.lint.flake8-copyright]
notice-rgx = "Copyright \\(c\\) The btclib developers\\n# Distributed under the MIT software license, see the accompanying\\n# LICENSE file or https://opensource\\.org/license/mit for the full text\\."
```

The regex covers all three lines of `COPYRIGHT`, not only the holder line: a file that kept the first line and dropped the licence/text lines below it would fail this check, same as it would have failed `--enforce-all`'s byte-for-byte diff against `COPYRIGHT`.

## Why

- One less repo pinned in `.pre-commit-config.yaml`, one less hook environment for pre-commit(.ci) to install — ruff already runs, and the project's own comment already frames it as replacing a list of single-purpose tools (autoflake, bandit, black, docformatter, flake8, isort, pydocstringformatter, pydocstyle, pylint, pyupgrade, yesqa); this is one more.
- Closes the exact failure mode `ed6e8014` found and patched by hand: the retired hook only checked staged files unless given `--enforce-all`, so `pre-commit run --all-files` — what the lint workflow actually runs — silently checked nothing until that flag was added. A rule living inside ruff's own file-selection logic checks whatever files it's given the same way regardless of who's asking, so there's no separate flag to forget in the first place.

## What's honestly different

- Nothing anchors the match to byte zero of the file, so text prepended above the notice would go unnoticed where `--enforce-all`'s diff would have caught it.
- No autofix: a file missing the notice still needs a human to add it. The retired hook didn't insert one either — `--enforce-all` only ever meant "check", never "fix" — so nothing is lost here specifically.

## Verification

- `uv run ruff check --select CPY001 --no-cache btclib tests .github/scripts` — clean across all 221+ source files, confirming the full three-line regex matches everywhere the old hook did, not only on the holder line.
- Regex tested in isolation first against a file with the full notice, one with only the holder line, and one with none: the middle case now fails, which it would not have under a holder-line-only pattern.
- `uv run --locked --only-group lint pre-commit run --all-files` — clean (one `typos` false positive on the literal string `CPY` in a new comment, fixed via `[tool.typos.default.extend-words]`, the same mechanism already used for `nd`/`ands`).
- `uv run --locked --no-default-groups --group test pytest` — 17567 passed, 5 skipped (integration, opt-in), unaffected by this change as expected.
- `btclib/__init__.py`'s comment pointing at "the copyright-notice hook" updated to name `CPY001` instead, so it still describes what actually enforces the notice.