### PR TITLE
Anchor CPY001's notice-rgx to the start of the file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -692,9 +692,10 @@ parametrize-names-type = "csv"
 # would have passed the single-line version and does not pass this one.
 # Escaped literally rather than searched loosely, so the dated holder
 # variants ed6e8014 found and reverted (2017-2021, 2017-2022,
-# 2020-2022) would not have matched either. What it still does not do
-# is diff a file against COPYRIGHT byte for byte the way the retired
-# hook's --enforce-all did: nothing here anchors the match to the very
-# start of the file, so text prepended above the notice would go
-# unnoticed
-notice-rgx = "Copyright \\(c\\) The btclib developers\\n# Distributed under the MIT software license, see the accompanying\\n# LICENSE file or https://opensource\\.org/license/mit for the full text\\."
+# 2020-2022) would not have matched either.
+# Anchored with ^ for the same reason: unanchored, CPY001 is a search
+# over the first 4096 bytes and not a check that the notice opens the
+# file, so an import or a docstring placed above it would still pass.
+# No file here opens with a shebang, so nothing legitimate sits between
+# byte zero and the notice for the anchor to exclude
+notice-rgx = "^# Copyright \\(c\\) The btclib developers\\n# Distributed under the MIT software license, see the accompanying\\n# LICENSE file or https://opensource\\.org/license/mit for the full text\\."


### PR DESCRIPTION
Follow-up to #501, merged before this was caught in review.

## What

`notice-rgx` gains a leading `^`.

## Why

Unanchored, `CPY001` is a search over a file's first 4096 bytes, not a check that the notice opens the file. That's a real behavior change from the retired `leoll2/copyright_notice_precommit` hook, not just a theoretical one:

```python
import os
import sys

# Copyright (c) The btclib developers
...
```

passed `CPY001` before this fix, exactly the case #501 set out to keep catching. No source file here opens with a shebang, so nothing legitimate sits between byte zero and the notice for the anchor to exclude.

## Verification

- Regex tested in isolation: a file with the notice on line 1 passes; the same notice pushed below two imports now correctly fails (it passed before this fix).
- `uv run ruff check --select CPY001 --no-cache btclib tests .github/scripts` — clean across every source file.
- `uv run --locked --only-group lint pre-commit run --all-files` — clean.