### PR TITLE
Satisfy a miniscript, non-malleably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,42 @@ documented at release-notes length in the first place, and are still in
 
 ### Descriptors and miniscript
 
+- **A miniscript is satisfied, non-malleably** (issue #187):
+  `Miniscript.satisfy` returns the witness elements that spend the script,
+  and `Descriptor.satisfy` takes a `SpendContext` beside the signatures for
+  the fragment that reads more than they carry. BIP379's algorithm and not
+  an assembly: several branches of an expression may be open at once, and
+  which witness to build is a choice between them -- the one reported is
+  the one no third party could rewrite, and where every candidate is
+  rewritable there is no answer. A witness that is valid and malleable is
+  worse than none, because it is one a relay can change under the
+  transaction carrying it; a satisfaction with no signature in it is
+  refused for the same reason, the lock times having been checked against
+  an nLockTime and an nSequence that would then be a third party's to
+  change.
+
+  The context is what the signatures cannot carry: the four preimage
+  mappings BIP174 gave psbt fields, and the lock times the transaction
+  being built will carry -- with its version, because BIP68's relative
+  locks are enforced from version 2, so an `older()` in a version-1
+  transaction is a branch nothing opens. `PsbtIn` holds all of it already,
+  which is what makes `psbt.finalize` able to build one without asking its
+  caller; that integration is the stage after this one. Every other
+  fragment ignores the context, having neither a branch to choose nor a
+  preimage to look up, and `satisfy` without one still spends everything it
+  spent before.
+
+  The oracle is btclib's own script engine, which is what Core's
+  satisfaction test uses its interpreter for: every valid P2WSH expression
+  of `fixed_tests` is satisfied against four spends -- an absolute lock
+  time of each kind and a relative one of each -- the signatures are real,
+  over the sig hash of the very transaction the witness goes into, and
+  `verify_transaction` is what says the witness is right. Two properties
+  come out of it: the engine accepts every witness produced, and every sane
+  and satisfiable expression is satisfied by at least one of the four
+  spends, which is BIP379's guarantee. The witness size and the element
+  count of each satisfaction are checked against the bounds the static
+  analysis promised for it.
 - **btclib reads and writes miniscript** (issue #187): `wsh()` no longer
   refuses one, and `btclib.descriptors.miniscript` is BIP379's language on
   its own -- `parse` reads an expression, `Miniscript.script` compiles it,

--- a/README.md
+++ b/README.md
@@ -116,9 +116,10 @@ Included features are:
   output descriptors: the checksum, the parser, the scripts a descriptor
   names, and the spend
 - [BIP379](https://github.com/bitcoin/bips/blob/master/bip-0379.md)
-  miniscript, both ways: the expression compiled to a script, a script read
-  back into the expression it is, the type system that says an expression
-  is well formed, and the bounds a spend of it is analysed by
+  miniscript, read, written and spent: the expression compiled to a script,
+  a script read back into the expression it is, the type system that says
+  an expression is well formed, the bounds a spend of it is analysed by,
+  and the non-malleable witness that satisfies it
 - OutPoint, TxIn, TxOut, and TX data classes
 - legacy, segwit_v0 and taproot transaction hash signatures
 - BlockHeader and Block data classes
@@ -182,7 +183,8 @@ Above them, `bip44` composes `bip32`, `script.taproot` and both address
 encodings into an address from an extended key and a derivation path, and
 `descriptors` reads the BIP380 grammar and hands back the scripts a
 descriptor names -- with `descriptors.miniscript` reading BIP379's
-language, which is a script written as a tree of fragments. `psbt_signer`
+language, which is a script written as a tree of fragments, and
+satisfying one. `psbt_signer`
 is the contract an external signer answers; `hwi` is that contract over
 Bitcoin Core's HWI.
 

--- a/btclib/descriptors/__init__.py
+++ b/btclib/descriptors/__init__.py
@@ -11,7 +11,8 @@ none after:
 - `key_expression` is BIP380's KEY expressions, the public keys a
   descriptor names and how they derive;
 - `miniscript` is BIP379's language, which is the SCRIPT expressions
-  written as a tree of fragments rather than as a function;
+  written as a tree of fragments rather than as a function, and the
+  non-malleable witness that satisfies one;
 - `descriptors` is the rest of BIP380 to BIP390: the checksum, the
   functions, the scripts each describes, and the psbt each fills.
 
@@ -52,7 +53,7 @@ from btclib.descriptors.descriptors import (
     strip_checksum,
 )
 from btclib.descriptors.key_expression import KeyExpression, PrvKeys
-from btclib.descriptors.miniscript import Miniscript
+from btclib.descriptors.miniscript import Miniscript, SpendContext
 
 __all__ = [
     "AddrDescriptor",
@@ -71,6 +72,7 @@ __all__ = [
     "RawDescriptor",
     "RawTrDescriptor",
     "ShDescriptor",
+    "SpendContext",
     "TrDescriptor",
     "WpkhDescriptor",
     "WshDescriptor",

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -60,10 +60,11 @@ The grammar read is BIP380 to BIP390:
   miniscript, and everything else inside a ``wsh()`` is a miniscript.
   BIP379 allows one inside ``tr()`` too, which is the stage after this one
 
-What raises NotImplementedError, rather than being read wrong: the
-satisfaction of a miniscript, which needs more than the signatures
-`satisfy` takes -- the fragment says so, and issue #187 is where the
-interface for it is being decided.
+`satisfy` takes a `SpendContext` beside the signatures for the one
+fragment that reads more than they carry: a miniscript satisfaction
+chooses among branches, and the choice reads hash preimages and the lock
+times the transaction being built will carry. Every other fragment ignores
+it, having neither a branch to choose nor a preimage to look up.
 
 BIP390's rule that a multipath ``musig()`` may not hold multipath
 participants has no counterpart here, and cannot: `parse` refuses a
@@ -159,11 +160,16 @@ from btclib.descriptors.key_expression import (
     PrvKeys,
     _assert_musig_allowed,
     _expression,
+    _offered_signature,
     _parse_key,
     _split_arguments,
     _split_function,
 )
-from btclib.descriptors.miniscript import Miniscript, _assert_sane
+from btclib.descriptors.miniscript import (
+    Miniscript,
+    SpendContext,
+    _assert_sane,
+)
 from btclib.descriptors.miniscript import parse as _parse_miniscript
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160
@@ -527,24 +533,6 @@ def _taproot_script_tree(
     return [(_TAPSCRIPT_LEAF_VERSION, _leaf_script(tree, index, network, prv_keys))]
 
 
-def _offered_signature(
-    signatures: Mapping[bytes, bytes], sec: bytes, *, x_only: bool = False
-) -> bytes | None:
-    """Return the signature offered for a public key, None where none is.
-
-    A taproot key answers to either of its two spellings: the 32 x-only
-    bytes the script holds, and the 33-byte even-y SEC form a
-    KeyExpression keeps it as. Neither is the more correct one, a caller
-    has whichever its signer handed back, and 32 bytes cannot be taken
-    for 33.
-    """
-    if sec in signatures:
-        return signatures[sec]
-    if x_only and sec[1:] in signatures:
-        return signatures[sec[1:]]
-    return None
-
-
 def _required_signature(signatures: Mapping[bytes, bytes], sec: bytes) -> bytes:
     """Return the signature made with a public key, refusing where none is.
 
@@ -768,6 +756,7 @@ class Descriptor(ABC):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> list[bytes]:
         """Return the elements that satisfy this fragment's own script.
 
@@ -787,6 +776,7 @@ class Descriptor(ABC):
         signatures: Mapping[Octets, Octets],
         index: int = 0,
         prv_keys: PrvKeys | None = None,
+        spend: SpendContext | None = None,
     ) -> tuple[bytes, Witness]:
         """Return the script_sig and witness that spend the script at `index`.
 
@@ -806,6 +796,14 @@ class Descriptor(ABC):
         for the second, `psbt.PsbtIn.partial_sigs` is where that state
         belongs, and bytes that do not spend would be a second and
         weaker spelling of it.
+
+        `spend` is what a miniscript satisfaction reads beside the
+        signatures -- hash preimages, and the lock times the transaction
+        being built will carry -- and is ignored by every other fragment,
+        none of which has a branch to choose or a preimage to look up. A
+        `wsh()` holding a miniscript is the one shape that needs it, and
+        it says so: without one it refuses the fragments that would have
+        read it.
         """
         self._assert_index(index)
         return self._satisfy(
@@ -815,6 +813,7 @@ class Descriptor(ABC):
             },
             index,
             prv_keys,
+            spend,
         )
 
     def _satisfy(
@@ -822,6 +821,7 @@ class Descriptor(ABC):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> tuple[bytes, Witness]:
         """Return the satisfaction, the mapping being already in bytes.
 
@@ -832,7 +832,7 @@ class Descriptor(ABC):
         argument without normalizing the same mapping a second time.
         """
         return serialize(
-            cast(ScriptList, self._stack(signatures, index, prv_keys))
+            cast(ScriptList, self._stack(signatures, index, prv_keys, spend))
         ), Witness()
 
     def index_of(
@@ -1030,6 +1030,7 @@ class PkDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> list[bytes]:
         # the key is in the script already, so the signature is the whole
         # of what spending a p2pk output takes
@@ -1060,6 +1061,7 @@ class PkhDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> list[bytes]:
         # what the output commits to is the hash of the key, so the key
         # goes on the stack for the script to hash for itself
@@ -1089,6 +1091,7 @@ class WpkhDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> list[bytes]:
         # the witness of a p2wpkh spend is what the script_sig of a p2pkh
         # one is, BIP143 having moved it and changed nothing else
@@ -1100,12 +1103,13 @@ class WpkhDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> tuple[bytes, Witness]:
         # the empty script_sig of BIP141, which is not the same as an
         # empty push: btclib's own engine refuses a native segwit input
         # whose script_sig is there at all (issue #249). A sh(wpkh())
         # gets its one push from the sh() above
-        return b"", Witness(self._stack(signatures, index, prv_keys))
+        return b"", Witness(self._stack(signatures, index, prv_keys, spend))
 
 
 @dataclass(frozen=True)
@@ -1130,6 +1134,7 @@ class ShDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> tuple[bytes, Witness]:
         """Return the argument's satisfaction, the redeem script pushed last.
 
@@ -1141,7 +1146,7 @@ class ShDescriptor(Descriptor):
         pushes and nothing else, so serializing them together and
         serializing them apart give the same bytes.
         """
-        script_sig, witness = self.inner._satisfy(signatures, index, prv_keys)
+        script_sig, witness = self.inner._satisfy(signatures, index, prv_keys, spend)
         redeem_script = self.inner.redeem_script(index, prv_keys)
         return script_sig + serialize(cast(ScriptList, [redeem_script])), witness
 
@@ -1181,6 +1186,7 @@ class WshDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> tuple[bytes, Witness]:
         """Return the witness of a p2wsh spend: the stack, then the script.
 
@@ -1189,7 +1195,7 @@ class WshDescriptor(Descriptor):
         stack already, so BIP141 puts them in it one by one and the
         witness script last.
         """
-        stack = self.inner._stack(signatures, index, prv_keys)
+        stack = self.inner._stack(signatures, index, prv_keys, spend)
         return b"", Witness([*stack, self.inner.redeem_script(index, prv_keys)])
 
     def _update_map(
@@ -1240,21 +1246,22 @@ class MiniscriptDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> list[bytes]:
-        """Refuse to satisfy, a mapping of signatures not being enough.
+        """Return the witness elements that satisfy the miniscript.
 
-        A miniscript satisfaction chooses among branches, and the choice
-        needs what this mapping cannot carry: the hash preimages a
-        ``sha256()`` wants, the locktimes an ``older()`` or an ``after()``
-        is checked against, and the weight of each branch. The interface
-        for it is the next stage of issue #187; until then the refusal
-        names what the caller would have to hand over.
+        The one fragment that reads the spend context, and the reason
+        `satisfy` takes one: a miniscript satisfaction chooses among
+        branches, and the choice reads the hash preimages a ``sha256()``
+        wants and the lock times an ``older()`` or an ``after()`` is
+        checked against. Non-malleable or refused, which is
+        `Miniscript.satisfy`'s rule and BIP379's.
         """
-        err_msg = (
-            "miniscript satisfaction is not implemented: it needs preimages "
-            "and locktime context beside the signatures (issue #187)"
-        )
-        raise NotImplementedError(err_msg)
+        # cast because `Mapping` is invariant in its key: these bytes are
+        # every bit an `Octets`, and a mapping of them is still not a
+        # mapping of "bytes or hex" as far as the type checker is concerned
+        offered = cast("Mapping[Octets, Octets]", signatures)
+        return self.node.satisfy(offered, spend, index, self.network, prv_keys)
 
 
 @dataclass(frozen=True)
@@ -1302,6 +1309,7 @@ class MultiDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> list[bytes]:
         """Return the dummy element and `threshold` signatures, in key order.
 
@@ -1362,6 +1370,7 @@ class ComboDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> tuple[bytes, Witness]:
         """Refuse: four scripts, and each of them spent differently.
 
@@ -1410,6 +1419,7 @@ class AddrDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> tuple[bytes, Witness]:
         """Refuse: an address names a script and not what spends it.
 
@@ -1454,6 +1464,7 @@ class RawDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> tuple[bytes, Witness]:
         """Refuse: a script and no key expression to satisfy it with.
 
@@ -1601,6 +1612,7 @@ class TrDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> tuple[bytes, Witness]:
         """Return the witness of a key path spend, or of a script path one.
 
@@ -1763,6 +1775,7 @@ class RawTrDescriptor(Descriptor):
         signatures: Mapping[bytes, bytes],
         index: int,
         prv_keys: PrvKeys | None,
+        spend: SpendContext | None,
     ) -> tuple[bytes, Witness]:
         """Return the witness of a BIP341 key path spend: one signature.
 

--- a/btclib/descriptors/key_expression.py
+++ b/btclib/descriptors/key_expression.py
@@ -273,6 +273,24 @@ def _expression(name: str, *args: str) -> str:
     return f"{name}({','.join(args)})"
 
 
+def _offered_signature(
+    signatures: Mapping[bytes, bytes], sec: bytes, *, x_only: bool = False
+) -> bytes | None:
+    """Return the signature offered for a public key, None where none is.
+
+    A taproot key answers to either of its two spellings: the 32 x-only
+    bytes the script holds, and the 33-byte even-y SEC form a
+    KeyExpression keeps it as. Neither is the more correct one, a caller
+    has whichever its signer handed back, and 32 bytes cannot be taken
+    for 33.
+    """
+    if sec in signatures:
+        return signatures[sec]
+    if x_only and sec[1:] in signatures:
+        return signatures[sec[1:]]
+    return None
+
+
 def _split_arguments(arguments: str) -> list[str]:
     """Split a comma-separated argument list, at nesting depth zero.
 

--- a/btclib/descriptors/miniscript.py
+++ b/btclib/descriptors/miniscript.py
@@ -12,15 +12,21 @@ BIP379 defines and `from_script` reads a script back into it; `str` and
 `from_script(node.script())` is `node` again, so a signer handed a witness
 script can say what it means without being told.
 
-What this module does not do is satisfy one. A satisfaction needs more
-than the public-key-to-signature mapping `Descriptor.satisfy` takes --
-hash preimages, the locktimes the spending transaction will carry, and a
-choice among branches of different weight -- so it needs an interface of
-its own, which is the next stage of issue #187. The analysis that stage
-will need is here: every bound BIP379 defines is a property of the
-expression alone, `max_ops`, `max_stack_items`, `max_exec_stack_items` and
-`max_witness_size` compute them, and `is_sane` is the conjunction Bitcoin
-Core requires of a miniscript before it accepts a descriptor holding one.
+`satisfy` is the third thing it does: the witness that spends the script,
+which for a miniscript is a choice and not an assembly -- several branches
+may be open at once, and which one to take is what BIP379's non-malleable
+satisfaction algorithm decides. It reads the signatures a caller has and a
+`SpendContext`: the hash preimages, and the lock times the transaction
+being built will carry, because an ``older()`` or an ``after()`` is a
+branch only the right transaction opens. Non-malleable or refused, which
+is Bitcoin Core's default too: a witness a third party could rewrite is
+worse than none.
+
+The bounds are the same analysis read statically: `max_ops`,
+`max_stack_items`, `max_exec_stack_items` and `max_witness_size` answer
+what a spend may cost before there is a spend, and `is_sane` is the
+conjunction Bitcoin Core requires of a miniscript before it accepts a
+descriptor holding one.
 
 The type system is why a fragment can be trusted to compose. Every
 expression has one of four basic types -- "B" base, "V" verify, "K" key,
@@ -50,13 +56,14 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Mapping, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TypeVar
 
 from btclib.alias import Octets, ScriptList
 from btclib.descriptors.key_expression import (
     KeyExpression,
     PrvKeys,
+    _offered_signature,
     _parse_key,
     _split_arguments,
 )
@@ -76,7 +83,14 @@ from btclib.script.script import (
 from btclib.utils import bytes_from_octets, decode_num, encode_num
 from btclib.var_int import serialize as var_int_serialize
 
-__all__ = ["P2WSH", "TAPSCRIPT", "Miniscript", "from_script", "parse"]
+__all__ = [
+    "P2WSH",
+    "TAPSCRIPT",
+    "Miniscript",
+    "SpendContext",
+    "from_script",
+    "parse",
+]
 
 # the two contexts BIP379 is specified for, P2SH and bare scripts being
 # excluded from it. Spelled as the BIP spells them, these being what an
@@ -1280,6 +1294,68 @@ class Miniscript:
             )
 
         return _tree_eval(self, False, _verify_state, up)
+
+    def satisfy(
+        self,
+        signatures: Mapping[Octets, Octets] | None = None,
+        spend: SpendContext | None = None,
+        index: int = 0,
+        network: str = "mainnet",
+        prv_keys: PrvKeys | None = None,
+    ) -> list[bytes]:
+        """Return the witness elements that satisfy the expression.
+
+        In witness order, the script itself excluded: what a p2wsh spend
+        puts in front of the witness script, or a tapscript spend in front
+        of the script and its control block.
+
+        Non-malleable or refused, which is BIP379's algorithm and Bitcoin
+        Core's default: of the stacks that would satisfy this script, the
+        one reported is the one no third party could rewrite, and where
+        every candidate is rewritable there is no answer -- a witness that
+        is valid and malleable is worse than none, because it is one a
+        relay can change under the transaction that carries it. A
+        satisfaction with no signature in it is refused for the same
+        reason: without one, the nLockTime and the nSequence the timelocks
+        were checked against are a third party's to change too.
+
+        `signatures` maps a public key to the signature made with it, as
+        `Descriptor.satisfy` takes it; `spend` is the rest of what a
+        satisfaction reads. The refusal says which of the two was short,
+        because adding to either changes the answer: a preimage or a
+        higher sequence can turn "none" into a satisfaction, and can also
+        turn a non-malleable one malleable, which is why the two are
+        separate messages.
+        """
+        offered = (
+            {}
+            if signatures is None
+            else {
+                bytes_from_octets(key): bytes_from_octets(signature)
+                for key, signature in signatures.items()
+            }
+        )
+        context = SpendContext() if spend is None else spend
+
+        def up(_state: None, node: Miniscript, subs: list[_Inputs]) -> _Inputs:
+            return _computed_input(
+                node, subs, context, offered, index, network, prv_keys
+            )
+
+        satisfaction = _tree_eval(self, None, lambda *_: None, up).sat
+        if satisfaction.stack is None:
+            err_msg = (
+                f"no satisfaction of {self} with the signatures, preimages "
+                "and lock times given"
+            )
+            raise BTClibValueError(err_msg)
+        if satisfaction.malleable or not satisfaction.has_sig:
+            err_msg = (
+                f"no non-malleable satisfaction of {self}: every witness that "
+                "would satisfy it is one a third party could rewrite"
+            )
+            raise BTClibValueError(err_msg)
+        return list(satisfaction.stack)
 
     def __str__(self) -> str:
         """Return the expression as BIP379 writes it.
@@ -2544,3 +2620,403 @@ def _assert_sane(node: Miniscript) -> None:
         raise BTClibValueError(f"{insane} is not sane: it repeats a public key")
     err_msg = f"{insane} is not sane: satisfying it may exceed the resource limits"
     raise BTClibValueError(err_msg)
+
+
+@dataclass(frozen=True)
+class SpendContext:
+    """What a miniscript satisfaction reads beside the signatures.
+
+    The signatures are `Descriptor.satisfy`'s own parameter and are not
+    here: one source of truth for them, and this is the rest of what a
+    satisfaction may need -- the preimage of a hash fragment, and the
+    lock times the transaction being built will carry, which say whether
+    an ``older()`` or an ``after()`` can be met at all.
+
+    The four preimage mappings are `PsbtIn`'s four, field for field, and
+    keyed the same way: the digest to the bytes that hash to it. A psbt
+    carries them because BIP174 gave them fields, and `psbt.finalize`
+    therefore has a `SpendContext` without asking its caller for one.
+
+    `sequence` is the input's own, `locktime` the transaction's, and
+    `version` matters for the same reason it matters to the interpreter:
+    BIP68's relative locks are enforced from version 2, so an ``older()``
+    in a version-1 transaction is a branch nothing can spend.
+    """
+
+    sha256_preimages: Mapping[Octets, Octets] = field(default_factory=dict)
+    hash256_preimages: Mapping[Octets, Octets] = field(default_factory=dict)
+    ripemd160_preimages: Mapping[Octets, Octets] = field(default_factory=dict)
+    hash160_preimages: Mapping[Octets, Octets] = field(default_factory=dict)
+    locktime: int = 0
+    sequence: int = 0
+    version: int = 2
+
+    def _preimage(self, fragment: str, digest: bytes) -> bytes | None:
+        """Return the preimage of a digest, None where the caller has none."""
+        preimages = {
+            "sha256": self.sha256_preimages,
+            "hash256": self.hash256_preimages,
+            "ripemd160": self.ripemd160_preimages,
+            "hash160": self.hash160_preimages,
+        }[fragment]
+        for candidate, preimage in preimages.items():
+            if bytes_from_octets(candidate) == digest:
+                return bytes_from_octets(preimage, 32)
+        return None
+
+    def _after(self, value: int) -> bool:
+        """Answer whether the transaction's lock time meets an ``after()``.
+
+        BIP65's rule, which is what the interpreter enforces in
+        `script.engine`: the two must be the same kind of lock time --
+        both block heights or both timestamps, either side of the
+        500000000 threshold -- and the transaction's must have reached
+        the fragment's. The final sequence that would let a transaction
+        ignore its own lock time is a refusal there and cannot be one
+        here: `sequence` is what this context carries, and a caller that
+        set it to 0xffffffff has asked for a transaction with no lock
+        time at all.
+        """
+        if (value >= _LOCKTIME_THRESHOLD) != (self.locktime >= _LOCKTIME_THRESHOLD):
+            return False
+        return value <= self.locktime and self.sequence != 0xFFFFFFFF
+
+    def _older(self, value: int) -> bool:
+        """Answer whether the input's sequence meets an ``older()``.
+
+        BIP112's rule, again the interpreter's: from version 2, with the
+        disable bit clear, the same unit on bit 22 -- blocks against
+        512-second intervals -- and a relative lock time at least the
+        fragment's.
+        """
+        if self.version < 2 or self.sequence & (1 << 31):
+            return False
+        if value & _SEQUENCE_LOCKTIME_TYPE_FLAG != (
+            self.sequence & _SEQUENCE_LOCKTIME_TYPE_FLAG
+        ):
+            return False
+        return value & 0x0000FFFF <= self.sequence & 0x0000FFFF
+
+
+@dataclass(frozen=True)
+class _Input:
+    """One witness stack that satisfies or dissatisfies an expression.
+
+    `stack` is None where there is no such stack at all -- Bitcoin Core's
+    Availability::NO, and BIP379's *(none)*. The three flags are what the
+    non-malleable algorithm chooses by: whether the stack carries a
+    signature, whether a third party could rewrite it, and whether it is
+    one of the options BIP379 lists as unnecessary. `size` is the witness
+    bytes it takes, which is what breaks a tie.
+    """
+
+    stack: tuple[bytes, ...] | None
+    has_sig: bool = False
+    malleable: bool = False
+    non_canonical: bool = False
+    size: int = 0
+
+
+def _element(data: bytes) -> _Input:
+    """Return a one-element stack, its length prefix counted."""
+    return _Input((data,), size=len(data) + 1)
+
+
+_NO_WITNESS = _Input(None)
+_NO_PUSHES = _Input(())
+_ZERO_PUSH = _element(b"")
+_ONE_PUSH = _element(b"\x01")
+# the dissatisfaction of a hash fragment: any 32 bytes that are not the
+# preimage, and malleable by construction -- a third party can put other
+# 32 bytes there, which is why BIP379 rules it out of a non-malleable
+# satisfaction rather than merely listing it
+_ZERO32_PUSH = _Input((bytes(32),), malleable=True, size=33)
+
+
+def _both(first: _Input, second: _Input) -> _Input:
+    """Return the stack that is the first followed by the second.
+
+    Which is Bitcoin Core's ``+``: the elements of one and then of the
+    other, and every flag of either. Absent where either is absent -- a
+    satisfaction needing two things has neither if one is missing.
+    """
+    if first.stack is None or second.stack is None:
+        return _NO_WITNESS
+    return _Input(
+        first.stack + second.stack,
+        has_sig=first.has_sig or second.has_sig,
+        malleable=first.malleable or second.malleable,
+        non_canonical=first.non_canonical or second.non_canonical,
+        size=first.size + second.size,
+    )
+
+
+def _better(first: _Input, second: _Input) -> _Input:
+    """Return the one of two stacks a non-malleable satisfaction takes.
+
+    BIP379's algorithm, as Bitcoin Core's ``|`` implements it: a stack
+    without a signature is one an attacker can produce too, so where only
+    one option carries a signature the other is what a malleator would
+    use and is therefore the one to report; where neither does, both are
+    malleable, because either could be swapped for the other; where both
+    do, the non-malleable one wins, and between two of a kind the smaller
+    witness does.
+    """
+    if first.stack is None:
+        return second
+    if second.stack is None:
+        return first
+    if first.has_sig != second.has_sig:
+        return second if first.has_sig else first
+    if not first.has_sig:
+        return replace(first if first.size <= second.size else second, malleable=True)
+    if first.malleable != second.malleable:
+        return second if first.malleable else first
+    return first if first.size <= second.size else second
+
+
+@dataclass(frozen=True)
+class _Inputs:
+    """The best stack for satisfying an expression, and for dissatisfying it."""
+
+    sat: _Input
+    dsat: _Input
+
+
+def _key_input(
+    node: Miniscript,
+    signatures: Mapping[bytes, bytes],
+    index: int,
+    network: str,
+    prv_keys: PrvKeys | None,
+) -> _Inputs:
+    """Return the stacks of a ``pk_k()`` or a ``pk_h()``.
+
+    A ``pk_h()`` puts the key on the stack beside the signature, the
+    script holding its hash alone; both are dissatisfied by the empty
+    push where a signature belongs.
+    """
+    # the 33-byte form for the lookup, whatever the script writes: a
+    # signer hands back a signature under either spelling of a taproot key,
+    # which is what `_offered_signature` answers for
+    sec = node.keys[0].sec(index, network, prv_keys)
+    offered = _offered_signature(signatures, sec, x_only=node.context == TAPSCRIPT)
+    signature = (
+        _NO_WITNESS if offered is None else replace(_element(offered), has_sig=True)
+    )
+    if node.fragment == "pk_k":
+        return _Inputs(signature, _ZERO_PUSH)
+    key = _element(sec[1:] if node.context == TAPSCRIPT else sec)
+    return _Inputs(_both(signature, key), _both(_ZERO_PUSH, key))
+
+
+def _multi_input(
+    node: Miniscript,
+    signatures: Mapping[bytes, bytes],
+    index: int,
+    network: str,
+    prv_keys: PrvKeys | None,
+) -> _Inputs:
+    """Return the stacks of a ``multi()`` or a ``multi_a()``.
+
+    `reached[j]` is the best stack carrying j signatures of the keys read
+    so far, which is the only way to choose: any k of the n keys satisfy,
+    and which k are available is not known until they have been asked
+    for. The two differ in what an unused key costs -- nothing to
+    OP_CHECKMULTISIG, which pops only the signatures it is given, and an
+    empty push to OP_CHECKSIGADD, which counts them all -- and in the
+    order, the first key's signature being on top for one and at the
+    bottom for the other.
+    """
+    multi_a = node.fragment == "multi_a"
+    keys = list(reversed(node.keys)) if multi_a else list(node.keys)
+    # OP_CHECKMULTISIG pops one element more than it was given, which is
+    # the empty push every satisfaction of it starts with
+    reached = [_NO_PUSHES if multi_a else _ZERO_PUSH]
+    for key in keys:
+        sec = key.sec(index, network, prv_keys)
+        offered = _offered_signature(signatures, sec, x_only=node.context == TAPSCRIPT)
+        signature = (
+            _NO_WITNESS if offered is None else replace(_element(offered), has_sig=True)
+        )
+        unused = _ZERO_PUSH if multi_a else _NO_PUSHES
+        following = [_both(reached[0], unused)]
+        following.extend(
+            _better(_both(reached[j], unused), _both(reached[j - 1], signature))
+            for j in range(1, len(reached))
+        )
+        following.append(_both(reached[-1], signature))
+        reached = following
+    if multi_a:
+        # one element per key, so dissatisfying is satisfying none of them
+        return _Inputs(reached[node.threshold], reached[0])
+    # and k+1 empty pushes dissatisfy a multi(), the threshold being how
+    # many signatures OP_CHECKMULTISIG will look for
+    dissatisfaction = _ZERO_PUSH
+    for _ in range(node.threshold):
+        dissatisfaction = _both(dissatisfaction, _ZERO_PUSH)
+    return _Inputs(reached[node.threshold], dissatisfaction)
+
+
+def _leaf_input(
+    node: Miniscript,
+    spend: SpendContext,
+    signatures: Mapping[bytes, bytes],
+    index: int,
+    network: str,
+    prv_keys: PrvKeys | None,
+) -> _Inputs:
+    """Return the stacks of a fragment with no subexpressions."""
+    fragment = node.fragment
+    if fragment == "0":
+        inputs = _Inputs(_NO_WITNESS, _NO_PUSHES)
+    elif fragment == "1":
+        inputs = _Inputs(_NO_PUSHES, _NO_WITNESS)
+    elif fragment in {"pk_k", "pk_h"}:
+        inputs = _key_input(node, signatures, index, network, prv_keys)
+    elif fragment in {"older", "after"}:
+        met = (
+            spend._older(node.threshold)
+            if fragment == "older"
+            else spend._after(node.threshold)
+        )
+        # a lock time is met by the transaction or it is not: nothing goes
+        # on the stack either way, and nothing dissatisfies one
+        inputs = _Inputs(_NO_PUSHES if met else _NO_WITNESS, _NO_WITNESS)
+    elif fragment in _HASH_OP_CODES:
+        preimage = spend._preimage(fragment, node.data)
+        inputs = _Inputs(
+            _NO_WITNESS if preimage is None else _element(preimage), _ZERO32_PUSH
+        )
+    else:
+        inputs = _multi_input(node, signatures, index, network, prv_keys)
+    return inputs
+
+
+def _wrapper_input(node: Miniscript, x: _Inputs) -> _Inputs:
+    """Return the stacks of a wrapped expression, from its argument's."""
+    fragment = node.fragment
+    if fragment in {"a:", "s:", "c:", "n:"}:
+        return x
+    if fragment == "d:":
+        # the element the OP_IF reads is part of the witness
+        return _Inputs(_both(x.sat, _ONE_PUSH), _ZERO_PUSH)
+    if fragment == "v:":
+        return _Inputs(x.sat, _NO_WITNESS)
+    # ``j:`` is dissatisfied by the empty push its OP_SIZE reads; where the
+    # argument can also be dissatisfied without a signature, a third party
+    # has two ways to dissatisfy this and the choice is malleable
+    dissatisfiable = x.dsat.stack is not None and not x.dsat.has_sig
+    return _Inputs(x.sat, replace(_ZERO_PUSH, malleable=dissatisfiable))
+
+
+def _and_input(node: Miniscript, x: _Inputs, y: _Inputs) -> _Inputs:
+    """Return the stacks of and_v() or and_b().
+
+    The arguments are written left to right and consume the stack from the
+    top, so what satisfies the second is under what satisfies the first.
+    """
+    if node.fragment == "and_v":
+        # dissatisfying a "V" is impossible, so this stack is listed for
+        # completeness and never chosen
+        return _Inputs(
+            _both(y.sat, x.sat), replace(_both(y.dsat, x.sat), non_canonical=True)
+        )
+    overcomplete = _better(
+        replace(_both(y.sat, x.dsat), malleable=True, non_canonical=True),
+        replace(_both(y.dsat, x.sat), malleable=True, non_canonical=True),
+    )
+    return _Inputs(_both(y.sat, x.sat), _better(_both(y.dsat, x.dsat), overcomplete))
+
+
+def _or_input(node: Miniscript, x: _Inputs, z: _Inputs) -> _Inputs:
+    """Return the stacks of one of the four disjunctions."""
+    fragment = node.fragment
+    if fragment == "or_b":
+        # satisfying both branches is overcomplete: either half can be
+        # turned back into a dissatisfaction and the OP_BOOLOR still holds
+        both = replace(_both(z.sat, x.sat), malleable=True, non_canonical=True)
+        satisfaction = _better(
+            _better(_both(z.dsat, x.sat), _both(z.sat, x.dsat)), both
+        )
+        return _Inputs(satisfaction, _both(z.dsat, x.dsat))
+    satisfaction = _better(x.sat, _both(z.sat, x.dsat))
+    if fragment == "or_c":
+        return _Inputs(satisfaction, _NO_WITNESS)
+    if fragment == "or_d":
+        return _Inputs(satisfaction, _both(z.dsat, x.dsat))
+    # or_i() carries the branch selector in the witness, which is what its
+    # OP_IF reads: OP_1 for the first branch and the empty push for the
+    # second
+    return _Inputs(
+        _better(_both(x.sat, _ONE_PUSH), _both(z.sat, _ZERO_PUSH)),
+        _better(_both(x.dsat, _ONE_PUSH), _both(z.dsat, _ZERO_PUSH)),
+    )
+
+
+def _andor_input(x: _Inputs, y: _Inputs, z: _Inputs) -> _Inputs:
+    """Return the stacks of andor(X,Y,Z): X and Y, or else Z."""
+    return _Inputs(
+        _better(_both(y.sat, x.sat), _both(z.sat, x.dsat)),
+        _better(
+            replace(_both(y.dsat, x.sat), non_canonical=True),
+            _both(z.dsat, x.dsat),
+        ),
+    )
+
+
+def _thresh_input(node: Miniscript, subs: list[_Inputs]) -> _Inputs:
+    """Return the stacks of a thresh(), over every way to reach its threshold.
+
+    `reached[j]` is the best stack satisfying j of the branches read so
+    far, read from the last one: the branches are written left to right
+    and the last one's stack is at the bottom of the witness. Every count
+    but the threshold dissatisfies, and every count but zero does it with
+    more satisfactions than the OP_EQUAL wants -- overcomplete, so
+    malleable and non-canonical, and never chosen while the all-zero
+    dissatisfaction exists.
+    """
+    reached = [_NO_PUSHES]
+    for sub in reversed(subs):
+        following = [_both(reached[0], sub.dsat)]
+        following.extend(
+            _better(_both(reached[j], sub.dsat), _both(reached[j - 1], sub.sat))
+            for j in range(1, len(reached))
+        )
+        following.append(_both(reached[-1], sub.sat))
+        reached = following
+    dissatisfaction = _NO_WITNESS
+    for count, reaching in enumerate(reached):
+        if count == node.threshold:
+            continue
+        # every count but zero satisfies more branches than the OP_EQUAL
+        # asks for: overcomplete, so malleable, and never chosen while the
+        # all-dissatisfied stack exists
+        stack = (
+            replace(reaching, malleable=True, non_canonical=True) if count else reaching
+        )
+        dissatisfaction = _better(dissatisfaction, stack)
+    return _Inputs(reached[node.threshold], dissatisfaction)
+
+
+def _computed_input(
+    node: Miniscript,
+    subs: list[_Inputs],
+    spend: SpendContext,
+    signatures: Mapping[bytes, bytes],
+    index: int,
+    network: str,
+    prv_keys: PrvKeys | None,
+) -> _Inputs:
+    """Return the best stacks of one fragment, from its subexpressions'."""
+    if not subs:
+        return _leaf_input(node, spend, signatures, index, network, prv_keys)
+    if node.fragment in _WRAPPERS:
+        return _wrapper_input(node, subs[0])
+    if node.fragment in {"and_v", "and_b"}:
+        return _and_input(node, subs[0], subs[1])
+    if node.fragment == "andor":
+        return _andor_input(subs[0], subs[1], subs[2])
+    if node.fragment == "thresh":
+        return _thresh_input(node, subs)
+    return _or_input(node, subs[0], subs[1])

--- a/tests/descriptors/miniscript_test.py
+++ b/tests/descriptors/miniscript_test.py
@@ -50,13 +50,19 @@ from btclib.descriptors.miniscript import (
     P2WSH,
     TAPSCRIPT,
     Miniscript,
+    SpendContext,
     from_script,
     parse,
 )
+from btclib.ecc import dsa
 from btclib.exceptions import BTClibValueError
-from btclib.hashes import hash160
+from btclib.hashes import hash160, hash256, ripemd160, sha256
 from btclib.psbt.psbt import Psbt
+from btclib.script import sig_hash
+from btclib.script.engine import verify_transaction
 from btclib.script.script import serialize
+from btclib.script.script_pub_key import ScriptPubKey
+from btclib.script.witness import Witness
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from btclib.tx.out_point import OutPoint
 from btclib.tx.tx import Tx
@@ -779,16 +785,31 @@ def test_a_wsh_descriptor_holds_a_miniscript(descriptor: str) -> None:
     assert not parsed.is_ranged
 
 
-def test_a_miniscript_descriptor_does_not_satisfy_yet() -> None:
-    """Refuse to spend, and say what a satisfaction would need.
+def test_a_miniscript_descriptor_spends_with_a_context() -> None:
+    """Spend a wsh(<miniscript>), and refuse where the context does not.
 
-    The signatures alone cannot choose a branch: a preimage, a locktime
-    and the weight of each branch are what a miniscript satisfaction
-    reads, and none of them is in the mapping.
+    The witness of a p2wsh spend is the satisfaction and then the witness
+    script, which is what every other `wsh()` puts there too; what is new
+    is that the elements before it come from the miniscript satisfier, and
+    that the lock time the branch needs has to be in the context. Without
+    it the same signatures satisfy nothing, which is the honest answer: the
+    branch is unspendable until the transaction carries the sequence.
     """
-    parsed = parse_descriptor(f"wsh(and_v(v:pk({KEY}),older(36)))")
-    with pytest.raises(NotImplementedError, match="187"):
-        parsed.satisfy({KEY: "00" * 71})
+    descriptor = f"wsh(and_v(v:pk({KEY}),older(36)))"
+    parsed = parse_descriptor(descriptor)
+    assert isinstance(parsed, WshDescriptor)
+    signature = "30" * 71 + "01"
+    script_sig, witness = parsed.satisfy(
+        {KEY: signature}, spend=SpendContext(sequence=36)
+    )
+    assert script_sig == b""
+    assert witness.stack == (bytes.fromhex(signature), parsed.inner.redeem_script())
+    # the sequence of the transaction is what says whether the branch is
+    # open, and 35 is not 36
+    with pytest.raises(BTClibValueError, match="no satisfaction"):
+        parsed.satisfy({KEY: signature}, spend=SpendContext(sequence=35))
+    with pytest.raises(BTClibValueError, match="no satisfaction"):
+        parsed.satisfy({KEY: signature})
 
 
 def test_a_ranged_miniscript_descriptor_fills_a_psbt() -> None:
@@ -839,3 +860,157 @@ def test_a_refused_descriptor_says_what_is_wrong(descriptor: str, message: str) 
     """Refuse each descriptor, naming the expression and the reason."""
     with pytest.raises(BTClibValueError, match=message):
         parse_descriptor(descriptor)
+
+
+# Core's TestData, which is what its vectors are named from: the private
+# keys 1 to 255, and the four digests of each key's own 32 bytes -- every
+# hash fragment in the vectors commits to one of those arrays
+PRV_KEYS = [31 * b"\x00" + bytes([i]) for i in range(1, 256)]
+SHA256_PREIMAGES: dict[Octets, Octets] = {sha256(k): k for k in PRV_KEYS}
+HASH256_PREIMAGES: dict[Octets, Octets] = {hash256(k): k for k in PRV_KEYS}
+RIPEMD160_PREIMAGES: dict[Octets, Octets] = {ripemd160(k): k for k in PRV_KEYS}
+HASH160_PREIMAGES: dict[Octets, Octets] = {hash160(k): k for k in PRV_KEYS}
+SIGNING_KEYS = dict(zip(KEYS, PRV_KEYS, strict=True))
+
+# the four spends a satisfaction is tried against: an absolute lock time
+# of each kind, either side of the 500000000 threshold, and a relative one
+# of each, either side of BIP68's bit 22. A fragment is met by the kind it
+# is written in and by no other, so an expression whose branches want
+# different kinds is satisfiable in one of these and not in another --
+# which is what makes four of them rather than one
+# Each is the largest of its kind, so that a fragment of that kind is met
+# whatever value it names: 499999999 is the last lock time read as a block
+# height, 2147483647 the largest a script number holds, and 65535 the
+# largest relative lock either unit can ask for
+SPENDS = [
+    (499999999, 0x0000FFFF),
+    (499999999, 0x0040FFFF),
+    (2147483647, 0x0000FFFF),
+    (2147483647, 0x0040FFFF),
+]
+
+
+def spendable(node: Miniscript, locktime: int, sequence: int) -> list[bytes] | None:
+    """Satisfy the expression and let the script engine judge the witness.
+
+    Which is the oracle Core's own satisfaction test uses, and the only one
+    worth having: a witness is right when the interpreter accepts it. The
+    signatures are real, over the sig hash of the very transaction the
+    witness goes into, so a CHECKSIG that verifies is a CHECKSIG that
+    verified this spend.
+
+    None where the expression cannot be satisfied with what this spend
+    offers -- a lock time of the wrong kind, most often.
+    """
+    script = node.script()
+    prevout = TxOut(50_000, ScriptPubKey.p2wsh(script))
+    tx = Tx(
+        version=2,
+        lock_time=locktime,
+        vin=[TxIn(OutPoint(b"\x02" * 32, 0), sequence=sequence)],
+        vout=[TxOut(49_000, ScriptPubKey.p2wpkh(KEYS[0]))],
+    )
+    msg_hash = sig_hash.segwit_v0(script, tx, 0, 1, prevout.value)
+    signatures: dict[Octets, Octets] = {
+        sec: dsa.sign_(msg_hash, SIGNING_KEYS[sec.hex()]).serialize() + b"\x01"
+        for sec in {key.sec() for key in node.key_expressions}
+    }
+    spend = SpendContext(
+        sha256_preimages=SHA256_PREIMAGES,
+        hash256_preimages=HASH256_PREIMAGES,
+        ripemd160_preimages=RIPEMD160_PREIMAGES,
+        hash160_preimages=HASH160_PREIMAGES,
+        locktime=locktime,
+        sequence=sequence,
+    )
+    try:
+        stack = node.satisfy(signatures, spend)
+    except BTClibValueError:
+        return None
+    tx.vin[0].script_witness = Witness([*stack, script])
+    verify_transaction([prevout], tx)
+    return stack
+
+
+@pytest.mark.parametrize(
+    "vector",
+    [
+        pytest.param(vector, id=vector_id(index, vector["miniscript"]))
+        for index, vector in enumerate(VECTORS)
+        if vector["valid"] and not vector["p2wsh_invalid"]
+    ],
+)
+def test_a_satisfaction_is_a_witness_the_engine_accepts(
+    vector: dict[str, Any],
+) -> None:
+    """Spend each of Core's valid expressions, and have the engine verify it.
+
+    Two properties at once. Every witness this produces is one
+    `verify_transaction` accepts, which is what makes the satisfaction
+    right rather than plausible; and every *sane* expression is satisfied
+    by at least one of the four spends, which is what makes it complete --
+    BIP379's guarantee is that a sane miniscript has a non-malleable
+    satisfaction whenever its conditions can be met at all.
+    """
+    node = parse(vector["miniscript"])
+    satisfied = [spendable(node, locktime, sequence) for locktime, sequence in SPENDS]
+    if node.is_sane and node.is_satisfiable:
+        assert any(stack is not None for stack in satisfied)
+    # and the bound the analysis promised is one no satisfaction passes
+    for stack in satisfied:
+        if stack is not None:
+            witness = sum(len(element) + 1 for element in stack)
+            assert node.max_witness_size is not None
+            assert node.max_stack_items is not None
+            assert witness <= node.max_witness_size
+            assert len(stack) <= node.max_stack_items
+
+
+def test_what_the_context_does_not_carry_cannot_be_satisfied() -> None:
+    """Refuse where a preimage is missing, or a lock time cannot be met.
+
+    Each of these is a branch that exists in the script and not in the
+    caller's hands, which is the difference a satisfier has to report: the
+    expression is fine, the spend is not.
+    """
+    signature = "30" * 71 + "01"
+    preimage = bytes(32)
+    digest = sha256(preimage)
+    node = parse(f"and_v(v:pk({KEY}),sha256({digest.hex()}))")
+    with pytest.raises(BTClibValueError, match="no satisfaction"):
+        node.satisfy({KEY: signature}, SpendContext())
+    # the preimage is under the signature: the sha256() runs after the
+    # v:pk() and takes its input from further down the stack
+    assert node.satisfy(
+        {KEY: signature}, SpendContext(sha256_preimages={digest: preimage})
+    ) == [preimage, bytes.fromhex(signature)]
+    # a digest the mapping does not hold is the same answer as no mapping
+    with pytest.raises(BTClibValueError, match="no satisfaction"):
+        node.satisfy(
+            {KEY: signature}, SpendContext(sha256_preimages={bytes(32): preimage})
+        )
+    # and BIP68's relative locks are enforced from version 2, so a
+    # version-1 transaction opens no older() branch whatever its sequence
+    timelocked = parse(f"and_v(v:pk({KEY}),older(36))")
+    with pytest.raises(BTClibValueError, match="no satisfaction"):
+        timelocked.satisfy({KEY: signature}, SpendContext(sequence=36, version=1))
+    with pytest.raises(BTClibValueError, match="no satisfaction"):
+        timelocked.satisfy({KEY: signature}, SpendContext(sequence=36 | (1 << 31)))
+
+
+def test_a_tapscript_multi_a_is_satisfied_with_one_element_per_key() -> None:
+    """Satisfy a multi_a(), which counts every key rather than popping some.
+
+    Where OP_CHECKMULTISIG pops the signatures it is given and no more,
+    OP_CHECKSIGADD is run once per key: a key that did not sign leaves the
+    empty push in its place, so the witness has one element per key and the
+    first key's is at the bottom.
+    """
+    signature = "30" * 64 + "01"
+    keys = ",".join(KEYS[:3])
+    node = parse(f"multi_a(1,{keys})", TAPSCRIPT)
+    stack = node.satisfy({KEYS[1]: signature})
+    assert stack == [b"", bytes.fromhex(signature), b""]
+    assert len(stack) == len(node.keys)
+    with pytest.raises(BTClibValueError, match="no satisfaction"):
+        node.satisfy({})


### PR DESCRIPTION
Issue #187, the stage after #503: reading and writing a miniscript is
there, this spends one.
[The decision recorded on the issue](https://github.com/btclib-org/btclib/issues/187#issuecomment-5226923165)
was option (b), one context object beside the signatures.

## What it does

`Miniscript.satisfy(signatures, spend)` returns the witness elements that
spend the script, and `Descriptor.satisfy(signatures, ..., spend=...)`
reaches it through `wsh()`:

```python
descriptor = parse(f"wsh(and_v(v:pk({KEY}),older(36)))")
script_sig, witness = descriptor.satisfy(
    {KEY: signature}, spend=SpendContext(sequence=36)
)
```

This is BIP379's non-malleable satisfaction algorithm, which is a *choice*
and not an assembly: several branches of an expression may be open at once,
and the witness reported is the one no third party could rewrite. Where
every candidate is rewritable there is none — a valid malleable witness is
worse than no witness, being one a relay can change under the transaction
carrying it — and a satisfaction with no signature in it is refused for the
same reason: the lock times were checked against an nLockTime and an
nSequence that would otherwise be a third party's to change. Bitcoin Core
refuses both by default too.

## The context

`SpendContext` carries what the signatures cannot, and nothing they can —
one source of truth for the signatures, which already have a parameter:

| field | what it is |
|---|---|
| `sha256_preimages`, `hash256_preimages`, `ripemd160_preimages`, `hash160_preimages` | `PsbtIn`'s four mappings, field for field |
| `locktime`, `sequence` | what the transaction being built will carry |
| `version` | BIP68's relative locks are enforced from version 2, so an `older()` in a version-1 transaction is a branch nothing opens |

`PsbtIn` already holds the four mappings and the sequence, which is what
will let `psbt.finalize` build a context without asking its caller — that
integration is the stage after this one. Every other fragment ignores the
context, having neither a branch to choose nor a preimage to look up, and
`satisfy` without one spends everything it spent before.

## The oracle is the script engine

Which is what Core's own satisfaction test uses its interpreter for: a
witness is right when the interpreter accepts it, and nothing weaker says
so. Every valid P2WSH expression of `fixed_tests` is satisfied against four
spends — an absolute lock time of each kind, either side of the 500000000
threshold, and a relative one of each, either side of BIP68's bit 22 — with
real signatures over the sig hash of the very transaction the witness goes
into, and `verify_transaction` deciding.

Three properties come out of it:

- the engine accepts **every** witness produced;
- every **sane and satisfiable** expression is satisfied by at least one of
  the four spends, which is BIP379's guarantee;
- each satisfaction is within the witness size and the element count the
  static analysis of #503 promised for that expression.

## Two things the vectors caught that no reading would have

- a satisfaction looks its signature up under the **33-byte** key whatever
  the script writes, so a tapscript `multi_a()` finds the signature a
  signer handed back under either spelling of the key. Written the other
  way it silently found none.
- `_EMPTY` was **two constants under one name** — the empty script's stack
  trace, from #503, and the empty witness — and the later definition won
  for both, breaking every `thresh()` the moment the second was added. The
  witness constants are now `_NO_PUSHES` and its neighbours, and a check
  that no module-level name is defined twice is what found it.

## Gates

- `uv run pre-commit run --all-files`: exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`: build succeeded
- `uv run pytest --cov`: 17943 passed, 100.00% coverage

## What is left of #187

the psbt integration, miniscript inside `tr()`, BIP388 templates (#499),
and the compiler, which stays a wishlist entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement non-malleable miniscript satisfaction and integrate it into descriptor spending, backed by script-engine verified tests and updated documentation.

New Features:
- Add Miniscript.satisfy API that produces the non-malleable witness stack to spend a miniscript expression.
- Introduce SpendContext to supply hash preimages and locktime/sequence/version data required for miniscript satisfaction.
- Allow Descriptor.satisfy to accept a SpendContext and route miniscript-based wsh() spends through the miniscript satisfier.

Enhancements:
- Refactor signature lookup into a shared helper that supports both full SEC and x-only taproot keys.
- Tighten miniscript resource bound enforcement by checking actual witness size and element count against static analysis in tests.

Documentation:
- Document miniscript satisfaction and SpendContext in the changelog, README, and descriptors package overview, emphasizing non-malleable witness construction.

Tests:
- Add comprehensive miniscript satisfaction tests using Core’s fixed vectors and btclib’s script engine as the oracle.
- Add tests covering context-dependent satisfactions (hash preimages, absolute/relative locktimes) and failure cases when context is insufficient.
- Add tests ensuring multi_a() tapscript witnesses use one element per key and behave correctly when no signatures are present.