### PR TITLE
Read and spend a miniscript as a tr() leaf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,32 @@ documented at release-notes length in the first place, and are still in
 
 ### Descriptors and miniscript
 
+- **A ``tr()`` leaf may be a miniscript**, which is the second of the two
+  positions BIP379 allows one in and the last one this library was short
+  of: `DescriptorTree` holds a `Miniscript` beside the ``pk()`` and the
+  ``multi_a()`` leaves it held before, `_parse_tree` reads the tapscript
+  dialect wherever a leaf is not one of those, and a script path spend
+  satisfies it -- the witness being the satisfaction, the leaf script and
+  the control block, the same order every other leaf is spent in.
+
+  The dialect is what the position picks: 32-byte keys, ``multi_a()`` where
+  ``wsh()`` has ``multi()``, a ``d:`` wrapper that is "u" because MINIMALIF
+  is consensus under taproot and only policy under P2WSH, and resource
+  limits of its own. All of it was implemented and tested against Core's
+  tapscript column when the language landed; what this adds is the
+  descriptor plumbing that reaches it, and the sanity every leaf is now
+  held to -- a tree is several scripts, and one that can be spent without
+  a signature is one no wallet should be handed whatever the others are.
+
+  A leaf that the signatures at hand do not open is still an answer and not
+  an error, which is what walking a tree means: a miniscript leaf whose
+  branches want a preimage or a lock time the spend does not carry is
+  simply not the leaf being spent, and the walk goes on to the next.
+
+  What a taproot *psbt* input needs is not this: its leaf script,
+  signatures and control block live in BIP371 fields of their own rather
+  than in a witness script, so `miniscript_solver` does not answer for one.
+  That is a solver of its own shape and the next thing here.
 - **`psbt.finalize` spends a miniscript input**, through
   `descriptors.miniscript_solver`: the `InputSolver` the finalizer already
   takes, which reads an input's witness script back into the expression it

--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ Included features are:
   output descriptors: the checksum, the parser, the scripts a descriptor
   names, and the spend
 - [BIP379](https://github.com/bitcoin/bips/blob/master/bip-0379.md)
-  miniscript, read, written and spent: the expression compiled to a script,
-  a script read back into the expression it is, the type system that says
-  an expression is well formed, the bounds a spend of it is analysed by,
-  and the non-malleable witness that satisfies it
+  miniscript, read, written and spent, inside `wsh()` and as a `tr()` leaf:
+  the expression compiled to a script, a script read back into the
+  expression it is, the type system that says an expression is well formed,
+  the bounds a spend of it is analysed by, and the non-malleable witness
+  that satisfies it
 - OutPoint, TxIn, TxOut, and TX data classes
 - legacy, segwit_v0 and taproot transaction hash signatures
 - BlockHeader and Block data classes

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -52,13 +52,15 @@ The grammar read is BIP380 to BIP390:
   participants, inside a ``tr()`` or a ``rawtr()`` and nowhere else, with
   BIP328 derivation of the aggregate key where it has a path of its own
 - the ``<a;b>`` multipath form of BIP389, through `multipath_descriptors`
-- a BIP379 miniscript inside ``wsh()``, read by `miniscript` and held by
-  the `MiniscriptDescriptor` this module adds for it. Which expression is
-  read as which is the order Bitcoin Core reads them in: the functions
-  above are tried first, so the ``pk()``, ``pkh()`` and ``multi()`` that
-  belong to both grammars are the descriptor functions they were before
-  miniscript, and everything else inside a ``wsh()`` is a miniscript.
-  BIP379 allows one inside ``tr()`` too, which is the stage after this one
+- a BIP379 miniscript, in both of the positions that BIP allows: inside
+  ``wsh()``, where it is a `MiniscriptDescriptor`, and as a leaf of a
+  ``tr()`` script tree, where it is a leaf beside the ``pk()`` and the
+  ``multi_a()`` ones. Which expression is read as which is the order
+  Bitcoin Core reads them in: the functions above are tried first, so the
+  ``pk()``, ``pkh()`` and ``multi()`` that belong to both grammars are the
+  descriptor functions they were before miniscript, and what is left is a
+  miniscript -- of the P2WSH dialect inside ``wsh()`` and of the tapscript
+  one inside ``tr()``, which is where ``multi_a()`` replaces ``multi()``
 
 `satisfy` takes a `SpendContext` beside the signatures for the one
 fragment that reads more than they carry: a miniscript satisfaction
@@ -186,6 +188,7 @@ from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
 from btclib.script.script import op_int, serialize
+from btclib.script.script import parse as _parse_script
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.script.taproot import input_script_sig, leaf_hash, tree_helper
 from btclib.script.witness import Witness
@@ -309,12 +312,11 @@ _P2WSH = "wsh()"
 _P2TR = "tr()"
 
 # where a miniscript may be written, and which of BIP379's two contexts
-# that position is: inside wsh() and inside a tr() leaf, and nowhere else.
-# The tree leaves are not here yet -- BIP387's multi_a() is the leaf
-# `_parse_tree` reads, and a tapscript miniscript is the stage after this
-# one -- so the mapping has one entry and is a mapping because the second
-# is what it is for
-_MINISCRIPT_CONTEXTS = {_P2WSH: miniscript.P2WSH}
+# that position is: inside wsh() and inside a tr() leaf, and nowhere else,
+# which is the BIP's own "only valid in wsh() and tr() contexts". The two
+# dialects differ in more than their keys, so the position is what picks
+# between them rather than something a caller passes
+_MINISCRIPT_CONTEXTS = {_P2WSH: miniscript.P2WSH, _P2TR: miniscript.TAPSCRIPT}
 
 # BIP387's own bound on the keys of a multi_a(): the satisfaction puts one
 # stack element per key, and a script whose spend would push more than the
@@ -446,23 +448,27 @@ def _tree_expression(tree: DescriptorTree) -> str:
     """Return a BIP386 TREE as text: a leaf, or two subtrees in braces."""
     if isinstance(tree, tuple):
         return f"{{{_tree_expression(tree[0])},{_tree_expression(tree[1])}}}"
-    if isinstance(tree, MultiA):
+    if isinstance(tree, (MultiA, Miniscript)):
         return str(tree)
     return _expression("pk", str(tree))
 
 
 # a tr() script tree: a leaf, or a branch of two subtrees. A leaf is the
-# KEY expression a `pk()` leaf is, or the `MultiA` of BIP387's two
+# KEY expression a `pk()` leaf is, the `MultiA` of BIP387's two
 # functions; a branch is a tuple, which is what tells a branch from a
 # leaf. The leaves hold KEY expressions and not scripts because a ranged
 # descriptor has no script until an index is given
-DescriptorLeaf = KeyExpression | MultiA
+DescriptorLeaf = KeyExpression | MultiA | Miniscript
 DescriptorTree = DescriptorLeaf | tuple["DescriptorTree", "DescriptorTree"]
 
 
 def _leaf_keys(leaf: DescriptorLeaf) -> tuple[KeyExpression, ...]:
     """Return the KEY expressions of one leaf, in the order it names them."""
-    return leaf.keys if isinstance(leaf, MultiA) else (leaf,)
+    if isinstance(leaf, MultiA):
+        return leaf.keys
+    if isinstance(leaf, Miniscript):
+        return leaf.key_expressions
+    return (leaf,)
 
 
 def _tree_leaves(tree: DescriptorTree) -> tuple[DescriptorLeaf, ...]:
@@ -487,9 +493,16 @@ def _tree_keys(tree: DescriptorTree) -> tuple[KeyExpression, ...]:
 def _leaf_script(
     leaf: DescriptorLeaf, index: int, network: str, prv_keys: PrvKeys | None
 ) -> ScriptList:
-    """Return the tapscript of one leaf: a ``pk()``, or a ``multi_a()``."""
+    """Return the tapscript of one leaf: a key, a ``multi_a()``, a miniscript.
+
+    Read back into commands where the leaf is a miniscript, that being
+    what a `TaprootLeaf` holds: the round trip is exact for these bytes,
+    every push a miniscript writes being the minimal one.
+    """
     if isinstance(leaf, MultiA):
         return leaf._script(index, network, prv_keys)
+    if isinstance(leaf, Miniscript):
+        return _parse_script(leaf.script(index, network, prv_keys))
     return [leaf.sec(index, network, prv_keys)[1:], "OP_CHECKSIG"]
 
 
@@ -521,10 +534,24 @@ def _leaf_stack(
     index: int,
     network: str,
     prv_keys: PrvKeys | None,
+    spend: SpendContext | None = None,
 ) -> list[bytes] | None:
-    """Return what satisfies one leaf, None where the signatures do not."""
+    """Return what satisfies one leaf, None where the signatures do not.
+
+    None rather than a refusal, for a miniscript leaf as for the other
+    two: which leaf the signatures at hand open is the question the caller
+    is walking the tree to answer, so a leaf they do not open is an answer
+    and not an error -- including one whose branches want a preimage or a
+    lock time this spend does not have.
+    """
     if isinstance(leaf, MultiA):
         return leaf._stack(signatures, index, network, prv_keys)
+    if isinstance(leaf, Miniscript):
+        offered = cast("Mapping[Octets, Octets]", signatures)
+        try:
+            return leaf.satisfy(offered, spend, index, network, prv_keys)
+        except BTClibValueError:
+            return None
     signature = _offered_signature(
         signatures, leaf.sec(index, network, prv_keys), x_only=True
     )
@@ -1224,11 +1251,12 @@ class WshDescriptor(Descriptor):
 class MiniscriptDescriptor(Descriptor):
     """A BIP379 miniscript where a SCRIPT expression may be one.
 
-    Which is inside ``wsh()`` and nowhere else here: BIP379 allows one
-    inside ``tr()`` too, and a tapscript miniscript is the stage of issue
-    #187 after this one. What it holds is the `Miniscript`, whose own
-    interface -- the type properties, the resource bounds, the script both
-    ways -- is `btclib.descriptors.miniscript`'s.
+    Which is inside ``wsh()``: a miniscript inside ``tr()`` is a leaf of
+    the script tree and not a SCRIPT expression, so `DescriptorTree` holds
+    that one directly, the way it holds a ``multi_a()``. What this holds is
+    the `Miniscript`, whose own interface -- the type properties, the
+    resource bounds, the script both ways, the satisfaction -- is
+    `btclib.descriptors.miniscript`'s.
 
     A fragment like the others in what it answers: the script at an index,
     the KEY expressions it names, and the psbt fields those keys fill.
@@ -1635,8 +1663,12 @@ class TrDescriptor(Descriptor):
 
         A script path witness is what satisfies the leaf, then the leaf
         script and the control block, which is BIP341's order: one
-        signature for a ``pk()`` leaf, and one element per key for a
-        ``multi_a()`` one. Both the parity bit and the merkle path in that
+        signature for a ``pk()`` leaf, one element per key for a
+        ``multi_a()`` one, and for a miniscript leaf whatever its
+        non-malleable satisfaction is -- which is where `spend` is read, a
+        branch of one wanting a preimage or a lock time.
+
+        Both the parity bit and the merkle path in that
         control block are the descriptor's to compute, holding the whole
         tree as it does, where a psbt has to be handed them: it is the one
         thing satisfaction here knows that finalization there cannot work
@@ -1658,7 +1690,7 @@ class TrDescriptor(Descriptor):
             raise BTClibValueError("no signature for the tr() internal key")
         script_tree = _taproot_script_tree(self.tree, index, self.network, prv_keys)
         for number, leaf in enumerate(_tree_leaves(self.tree)):
-            stack = _leaf_stack(leaf, signatures, index, self.network, prv_keys)
+            stack = _leaf_stack(leaf, signatures, index, self.network, prv_keys, spend)
             if stack is not None:
                 script, control_block = self._leaf(script_tree, index, number, prv_keys)
                 return b"", Witness([*stack, script, control_block])
@@ -1866,6 +1898,22 @@ def _parse_multi_a(name: str, args: list[str], prv_keys: dict[str, str]) -> Mult
     return MultiA(int(args[0]), keys, sort=name == "sortedmulti_a")
 
 
+def _parse_leaf_miniscript(expression: str, prv_keys: dict[str, str]) -> Miniscript:
+    """Return the miniscript of a tr() leaf, sanity checked as a wsh() one is.
+
+    The tapscript dialect: 32-byte keys, ``multi_a()`` where ``wsh()`` has
+    ``multi()``, and a ``d:`` wrapper that is "u" because MINIMALIF is
+    consensus under taproot. What is refused is what a descriptor refuses
+    anywhere -- an expression that is malleable, needs no signature, mixes
+    timelocks, repeats a key, or has a spend past a resource limit -- and
+    the leaf is where it is said, a tree being several scripts of which
+    this one is unspendable or unsafe.
+    """
+    node = _parse_miniscript(expression, miniscript.TAPSCRIPT, prv_keys)
+    _assert_sane(node)
+    return node
+
+
 def _parse_tree(expression: str, prv_keys: dict[str, str]) -> DescriptorTree:
     """Return the script tree of a BIP386 TREE expression."""
     if expression.startswith("{"):
@@ -1879,23 +1927,27 @@ def _parse_tree(expression: str, prv_keys: dict[str, str]) -> DescriptorTree:
             _parse_tree(branches[0], prv_keys),
             _parse_tree(branches[1], prv_keys),
         )
-    name, arguments = _split_function(expression)
-    args = _split_arguments(arguments)
+    name = expression.partition("(")[0]
     if name in _TREE_FUNCTIONS:
-        return _parse_multi_a(name, args, prv_keys)
+        return _parse_multi_a(
+            name, _split_arguments(expression[len(name) + 1 : -1]), prv_keys
+        )
     if name == "musig":
         # allowed inside tr(), and as a key rather than as a leaf: a leaf
         # is a script, and what a musig() aggregates to is one key of one
         err_msg = "musig() is a key expression: pk(musig(...)) is the leaf"
         raise BTClibValueError(err_msg)
-    if name in _PARSERS:
+    if name in _PARSERS and name != "pk":
         # a SCRIPT function where a leaf is expected: a position rule and
         # not something a later release adds, which is what the position
         # table says and Bitcoin Core's own message says too. ``pk()``
         # allows tr() among its positions and falls through to be read
         _assert_position(name, _P2TR, _PARSERS[name][0])
     if name != "pk":
-        raise BTClibValueError(f"unknown descriptor function: {name}()")
+        # a leaf that is no BIP386 leaf is a BIP379 miniscript, which is
+        # the same order the wsh() half reads its two grammars in
+        return _parse_leaf_miniscript(expression, prv_keys)
+    args = _split_arguments(expression[len(name) + 1 : -1])
     return _parse_key(
         _one_argument(args, name),
         prv_keys,

--- a/btclib/descriptors/miniscript.py
+++ b/btclib/descriptors/miniscript.py
@@ -43,7 +43,8 @@ fragments are the same, but ``multi()`` belongs to the first and
 ``d:`` wrapper is "u" only under tapscript -- MINIMALIF being consensus
 for taproot and policy for P2WSH -- and each context bounds its own
 resources. The context is therefore a parameter of everything, and
-`descriptors` passes the one the position gives.
+`descriptors` passes the one the position gives: `P2WSH` inside ``wsh()``,
+`TAPSCRIPT` for a leaf of a ``tr()`` script tree.
 
 Above `key_expression`, whose KEY expressions the fragments hold, and
 below `descriptors`, which reads a miniscript wherever a SCRIPT

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -974,7 +974,9 @@ UNPARSABLE = [
     (f"wsh(rawtr({XONLY}))", "not allowed inside"),
     (f"tr({XONLY},rawtr({XONLY}))", "not allowed inside"),
     (f"tr({XONLY},pkh({KEY}))", "not allowed inside"),
-    (f"tr({XONLY},nope({KEY}))", "unknown descriptor function"),
+    # inside tr() a function that is no BIP386 leaf is read as a
+    # miniscript, so what answers is the language and not the table
+    (f"tr({XONLY},nope({KEY}))", "unknown miniscript fragment"),
     # Core refuses a second key too, as rawtr(): only one key expected
     (f"rawtr({XONLY},{XONLY})", "takes one argument"),
     (f"rawtr({UNCOMPRESSED})", "uncompressed"),

--- a/tests/descriptors/miniscript_test.py
+++ b/tests/descriptors/miniscript_test.py
@@ -44,7 +44,7 @@ import pytest
 
 from btclib.alias import Octets, ScriptList
 from btclib.bip32.key_origin import BIP32KeyOrigin
-from btclib.descriptors import WshDescriptor, miniscript_solver
+from btclib.descriptors import TrDescriptor, WshDescriptor, miniscript_solver
 from btclib.descriptors import parse as parse_descriptor
 from btclib.descriptors.key_expression import KeyExpression
 from btclib.descriptors.miniscript import (
@@ -55,14 +55,15 @@ from btclib.descriptors.miniscript import (
     from_script,
     parse,
 )
-from btclib.ecc import dsa
+from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, hash256, ripemd160, sha256
-from btclib.psbt.psbt import Psbt, finalize
+from btclib.psbt.psbt import Psbt, finalize, taproot_sig_hash
 from btclib.script import sig_hash
 from btclib.script.engine import verify_transaction
 from btclib.script.script import serialize
 from btclib.script.script_pub_key import ScriptPubKey
+from btclib.script.taproot import leaf_hash
 from btclib.script.witness import Witness
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from btclib.tx.out_point import OutPoint
@@ -1127,3 +1128,126 @@ def test_the_solver_reads_a_key_the_input_knows_by_its_hash() -> None:
         bytes.fromhex(KEYS[1]): BIP32KeyOrigin("deadbeef", [0])
     }
     assert miniscript_solver(psbt, 0) is not None
+
+
+# a tr() whose script tree holds a miniscript leaf beside a key one: the
+# recovery branch of a taproot custody, which is the shape BIP379 allows
+# inside tr() and #503 could only read as a wsh()
+TR_MINISCRIPT = f"tr({KEYS[0]},{{pk({KEYS[1]}),and_v(v:pk({KEYS[2]}),older(36))}})"
+
+
+def test_a_tr_leaf_may_be_a_miniscript() -> None:
+    """Read a miniscript where a tr() takes a leaf, and write it back.
+
+    The tapscript dialect: the keys of the leaf are the 32 bytes a
+    tapscript pushes, and the leaf script is the miniscript's own -- which
+    is what the tree commits to, so the output key changes with it.
+    """
+    parsed = parse_descriptor(TR_MINISCRIPT)
+    assert isinstance(parsed, TrDescriptor)
+    assert str(parsed) == TR_MINISCRIPT
+    leaf = parsed.tree[1] if isinstance(parsed.tree, tuple) else None
+    assert isinstance(leaf, Miniscript)
+    assert leaf.context == TAPSCRIPT
+    assert (
+        leaf.script() == parse(f"and_v(v:pk({KEYS[2]}),older(36))", TAPSCRIPT).script()
+    )
+    # the leaf is one of the two the tree commits to, and its keys are the
+    # descriptor's own
+    assert len(parsed.taproot_leaf_scripts()) == 2
+    assert {key.sec().hex() for key in parsed.key_expressions} == set(KEYS[:3])
+
+
+def test_a_tr_miniscript_leaf_is_spent_on_the_script_path() -> None:
+    """Spend the miniscript leaf of a tr(), and have the engine accept it.
+
+    The witness of a script path spend is the satisfaction, the leaf script
+    and the control block; what is new is that the elements before the
+    script come from the miniscript satisfier, and that the branch wants a
+    sequence the transaction has to carry. The signature is a real BIP340
+    one over the sig hash of that very spend, and `verify_transaction`
+    decides.
+    """
+    parsed = parse_descriptor(TR_MINISCRIPT)
+    prevout = TxOut(50_000, parsed.script_pub_key())
+    tx = Tx(
+        version=2,
+        vin=[TxIn(OutPoint(b"\x07" * 32, 0), sequence=36)],
+        vout=[TxOut(49_000, ScriptPubKey.p2wpkh(KEYS[0]))],
+    )
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].witness_utxo = prevout
+    leaf_script = parse(f"and_v(v:pk({KEYS[2]}),older(36))", TAPSCRIPT).script()
+    msg_hash = taproot_sig_hash(psbt, 0, leaf_hash=leaf_hash(0xC0, leaf_script))
+    signature = ssa.sign_(msg_hash, SIGNING_KEYS[KEYS[2]]).serialize()
+    script_sig, witness = parsed.satisfy(
+        {KEYS[2]: signature}, spend=SpendContext(sequence=36)
+    )
+    assert script_sig == b""
+    # the satisfaction, the leaf script, the control block
+    assert witness.stack[0] == signature
+    assert witness.stack[1] == leaf_script
+    tx.vin[0].script_witness = witness
+    verify_transaction([prevout], tx)
+    # and without the sequence the branch is shut, so no leaf is satisfied
+    with pytest.raises(BTClibValueError, match="no signature for the tr"):
+        parsed.satisfy({KEYS[2]: signature})
+
+
+def test_a_tr_miniscript_leaf_is_held_to_the_same_sanity() -> None:
+    """Refuse a leaf a descriptor would not hold, naming the leaf.
+
+    A tree is several scripts, and one that cannot be spent safely is one
+    a wallet should not be handed whatever the others are.
+    """
+    with pytest.raises(BTClibValueError, match="without signature exist"):
+        parse_descriptor(f"tr({KEYS[0]},{{pk({KEYS[1]}),older(36)}})")
+    # multi() belongs to P2WSH: inside tr() the fragment is multi_a()
+    with pytest.raises(BTClibValueError, match="not allowed in a tapscript"):
+        parse_descriptor(f"tr({KEYS[0]},and_v(v:multi(1,{KEYS[1]}),older(36)))")
+    with pytest.raises(BTClibValueError, match="ill-typed"):
+        parse_descriptor(f"tr({KEYS[0]},and_v(1,1))")
+
+
+# a tr() with a miniscript leaf and the regtest address Bitcoin Core v31.1
+# answers for it, from `getdescriptorinfo` and `deriveaddresses`. The
+# address is the output key, which commits to the whole tree, so agreeing
+# on it is agreeing on every leaf script: the tapscript dialect of the
+# fragments, the 32-byte keys, and the order the tree is built in
+CORE_TR_VECTORS = [
+    (
+        f"tr({CUSTODY_KEYS[0]},and_v(v:pk({CUSTODY_KEYS[1]}),older(36)))",
+        "bcrt1pf4p484mdhmu0436mmztpj8594tnpkhytdj0du5w0gvke6a9lr8lqtse22f",
+    ),
+    (
+        f"tr({CUSTODY_KEYS[0]},{{pk({CUSTODY_KEYS[1]}),and_v(v:pk({CUSTODY_KEYS[2]}),older(36))}})",
+        "bcrt1p0lw39vec3wgmyyyfvgr5p09ncydezxrmde5e44gjqsk30rwcqk7stm96l7",
+    ),
+    (
+        f"tr({CUSTODY_KEYS[0]},{{and_v(v:multi_a(2,{CUSTODY_KEYS[1]},{CUSTODY_KEYS[2]}),after(1231488000)),pk({CUSTODY_KEYS[2]})}})",
+        "bcrt1pxjtajh8f9lf3svdd9qhl542uehfdzh8pewen70ns8j5tzfv55peq88cxuw",
+    ),
+    (
+        f"tr({CUSTODY_KEYS[0]},or_d(pk({CUSTODY_KEYS[1]}),and_v(v:pkh({CUSTODY_KEYS[2]}),older(1008))))",
+        "bcrt1prx5z8n0jguw4v7clt4v3wsnksuyxvvaqljwl2qz4gu9lxjuev9wsmfnl08",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "descriptor, address",
+    [
+        pytest.param(descriptor, address, id=vector_id(index, descriptor))
+        for index, (descriptor, address) in enumerate(CORE_TR_VECTORS)
+    ],
+)
+def test_a_tr_miniscript_pays_where_core_says(descriptor: str, address: str) -> None:
+    """Pay to the address Bitcoin Core derives for the same tr() descriptor.
+
+    Four trees: one miniscript leaf, one beside a key leaf, one holding a
+    ``multi_a()`` inside a miniscript, and one whose branch names its key by
+    a hash. Nothing in these is checked by Core's `fixed_tests`, which is
+    about expressions rather than about descriptors, and nothing else says
+    the tapscript dialect is wired to the right side of a ``tr()``.
+    """
+    assert parse_descriptor(descriptor, "regtest").address() == address


### PR DESCRIPTION
Issue #187, the stage after #505: the second of the two positions BIP379
allows a miniscript in, and the last one this library was short of.

```python
parse(f"tr({INTERNAL},{{pk({A}),and_v(v:pk({B}),older(36))}})")
```

## What it does

- `DescriptorTree` holds a `Miniscript` beside the `pk()` and `multi_a()`
  leaves it held before;
- `_parse_tree` reads the tapscript dialect wherever a leaf is neither of
  those — the same order the `wsh()` half reads its two grammars in, so
  `pk()` and `multi_a()` stay the BIP386 and BIP387 leaves they were;
- a script path spend satisfies one: the witness is the satisfaction, the
  leaf script and the control block, which is the order every other leaf is
  spent in;
- every leaf is held to the sanity a descriptor holds a `wsh()` miniscript
  to. A tree is several scripts, and one that can be spent without a
  signature is one no wallet should be handed whatever the others are.

The dialect itself was implemented and tested against Core's tapscript
column when the language landed in #503: 32-byte keys, `multi_a()` where
`wsh()` has `multi()`, a `d:` wrapper that is "u" because MINIMALIF is
consensus under taproot and only policy under P2WSH, and resource limits of
its own. What this adds is the descriptor plumbing that reaches it.

A leaf the signatures at hand do not open stays an answer rather than an
error, which is what walking a tree means: a miniscript leaf whose branches
want a preimage or a lock time the spend does not carry is not the leaf
being spent, and the walk goes on to the next.

## Bitcoin Core is the oracle for the wiring

Four `tr()` descriptors are pinned to the regtest addresses Core v31.1
derives for them — one miniscript leaf, one beside a key leaf, one holding
a `multi_a()` inside a miniscript, and one naming a key by its hash. The
address is the output key, which commits to the whole tree, so agreeing on
it is agreeing on every leaf script.

Core's own `fixed_tests` say nothing about this, being about expressions
rather than descriptors, and nothing else says the tapscript dialect is
wired to the right side of a `tr()`.

The spend is checked the way #504's are: a real BIP340 signature over the
sig hash of that very script path spend, and `verify_transaction` on the
witness.

## Not done here

A taproot *psbt* input: its leaf script, signatures and control block live
in BIP371 fields of their own rather than in a witness script, so
`miniscript_solver` does not answer for one. That is a solver of its own
shape, and what remains of #187 beside it is the BIP388 templates (#499),
`psbt_size`'s sizer, and the compiler.

## Gates

- `uv run pre-commit run --all-files`: exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`: build succeeded
- `uv run pytest --cov`: 17956 passed, 100.00% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Support miniscript leaves in taproot descriptors and ensure their parsing, satisfaction, and safety checks integrate consistently with existing descriptor logic.

New Features:
- Allow BIP379 miniscript expressions as leaves in taproot tr() script trees alongside pk() and multi_a() leaves.

Enhancements:
- Extend descriptor parsing to select the appropriate miniscript context (P2WSH vs tapscript) based on position, and expose miniscript leaves directly in DescriptorTree.
- Treat miniscript leaves as valid script path branches whose non-malleable satisfactions can be used to construct taproot witnesses, including support for spend contexts such as timelocks.
- Apply the same sanity and safety checks to miniscript taproot leaves as to wsh() miniscripts, rejecting unsafe or malformed leaf scripts at descriptor parse time.

Documentation:
- Document miniscript support inside tr() leaves and its semantics in the changelog and README.

Tests:
- Add tests that parse and round-trip tr() descriptors with miniscript leaves, spend these leaves via script path with real BIP340 signatures, and validate behavior when spends lack required conditions.
- Add regression vectors to ensure taproot miniscript descriptors produce the same regtest addresses as Bitcoin Core, confirming correct wiring of the tapscript dialect.