### PR TITLE
Correct hwi's note on wallet policies, which miniscript falsified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ documented at release-notes length in the first place, and are still in
 
 ### Descriptors and miniscript
 
+- **`btclib.hwi`'s note on wallet policies is no longer wrong about
+  miniscript.** It said "btclib reads no miniscript (issue #187)" and drew
+  the conclusion that a script outside BIP388's fixed set is not
+  expressible here whatever the transport -- both true when it was written
+  and neither true now. What stands between a caller and a registered
+  Ledger policy is the template rewriting of #499, not the language and not
+  the transport. Found by grepping the tree for claims the miniscript work
+  had falsified, which is the only thing that finds a docstring gone stale:
+  no test asserts prose.
 - **A ``tr()`` leaf may be a miniscript**, which is the second of the two
   positions BIP379 allows one in and the last one this library was short
   of: `DescriptorTree` holds a `Miniscript` beside the ``pk()`` and the

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -58,17 +58,16 @@ band, with HWI's Python API or Ledger's own tooling, and then this
 module signs for it: the psbt path needs no policy, only the
 registration does.
 
-Whether btclib could grow it rather than route around it is decided by
-two facts, and neither is about the transport. A policy is a descriptor
-*template* -- `wsh(sortedmulti(2,@0/**,@1/**))` -- with the keys lifted
-out into a vector beside it, which is a rewriting of what `descriptors`
-already builds. But the fragments a template may hold are BIP388's fixed
-set, plus miniscript inside `wsh()` in Ledger's app, and btclib reads no
-miniscript (issue #187). So a script outside that fixed set is not
-expressible here whatever the transport: a locking script with an
-`OP_IF` branch and a `CHECKSEQUENCEVERIFY` in it is a miniscript
-question before it is an HWI one, and an in-process adapter would not
-unblock the caller who asked.
+Whether btclib could grow it rather than route around it is one fact,
+and it is not about the transport. A policy is a descriptor *template* --
+`wsh(sortedmulti(2,@0/**,@1/**))` -- with the keys lifted out into a
+vector beside it, which is a rewriting of what `descriptors` already
+builds: the fragments a template may hold are BIP388's fixed set plus
+miniscript inside `wsh()` in Ledger's app, and both halves of that are
+read here now (issue #187). So the locking script with an `OP_IF` branch
+and a `CHECKSEQUENCEVERIFY` in it that asked the question is expressible,
+and what stands between a caller and a registered policy is the template
+rewriting rather than the language or the transport.
 
 Staying aligned with a project this does not import is two things, and
 neither is a copy of it. `tests/hwi_test.py` writes out the surface used


### PR DESCRIPTION
`btclib/hwi.py` said, of BIP388 wallet policies:

> the fragments a template may hold are BIP388's fixed set, plus
> miniscript inside `wsh()` in Ledger's app, and **btclib reads no
> miniscript (issue #187)**. So a script outside that fixed set is not
> expressible here whatever the transport […] an in-process adapter would
> not unblock the caller who asked.

Both sentences were true when written. Neither is now:
https://github.com/btclib-org/btclib/pull/503 reads a miniscript inside
`wsh()`, https://github.com/btclib-org/btclib/pull/504 satisfies one, and
https://github.com/btclib-org/btclib/pull/506 reads one as a `tr()` leaf.
The locking script with an `OP_IF` branch and a `CHECKSEQUENCEVERIFY` in it
that asked the question is expressible; what stands between a caller and a
registered Ledger policy is the template rewriting of
https://github.com/btclib-org/btclib/issues/499, not the language and not
the transport.

Found by grepping the tree for claims the miniscript work had falsified,
which is the only thing that finds a docstring gone stale: no test asserts
prose. It was the only one — `descriptors`, `miniscript`, the package
`__init__`, the README and `CHANGELOG.md` were each updated in the PR that
changed what they describe.

## Gates

- `uv run pre-commit run --all-files`: exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`: build succeeded
- `uv run pytest`: 17956 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify documentation around wallet policy miniscript support in btclib's HWI module and record the correction in the changelog.

Documentation:
- Update btclib.hwi's wallet policy note to reflect current miniscript support and correct the previous statement that miniscript was not read.
- Add a changelog entry describing the correction to the HWI wallet policy documentation and the current constraints around Ledger policy registration.