### PR TITLE
Name the right thing where two entries said #499

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ documented at release-notes length in the first place, and are still in
 
 ### Descriptors and miniscript
 
+- **Two CHANGELOG references to #499 named the wrong thing.** #499 is the
+  merged pull request whose note on BIP388 wallet policies said what a
+  Ledger cannot be shown; the *template rewriting* that note describes has
+  no issue of its own, and #469 -- the in-process HWI adapter -- is where a
+  caller asked for what it would unblock. Both entries now say so.
+
+  Caught by reading the numbers back rather than by any check: a `#N` in
+  prose is never verified, and a merged pull request and an open issue read
+  exactly the same.
 - **A miniscript input is sized before it is signed**, through
   `descriptors.miniscript_sizer`: the `SolutionSizer` that
   `psbt_size.estimated_input_sizes` takes, answering with the witness a
@@ -61,10 +70,10 @@ documented at release-notes length in the first place, and are still in
   the conclusion that a script outside BIP388's fixed set is not
   expressible here whatever the transport -- both true when it was written
   and neither true now. What stands between a caller and a registered
-  Ledger policy is the template rewriting of #499, not the language and not
-  the transport. Found by grepping the tree for claims the miniscript work
-  had falsified, which is the only thing that finds a docstring gone stale:
-  no test asserts prose.
+  Ledger policy is the template rewriting, which #469 asked for and no
+  issue holds yet, not the language and not the transport. Found by
+  grepping the tree for claims the miniscript work had falsified, which is
+  the only thing that finds a docstring gone stale: no test asserts prose.
 - **A ``tr()`` leaf may be a miniscript**, which is the second of the two
   positions BIP379 allows one in and the last one this library was short
   of: `DescriptorTree` holds a `Miniscript` beside the ``pk()`` and the
@@ -302,8 +311,9 @@ documented at release-notes length in the first place, and are still in
   band. Whether btclib could grow it is not a transport question: a
   policy is a descriptor template with the keys lifted out, and the
   fragments one may hold are BIP388's fixed set plus miniscript inside
-  `wsh()`, which btclib now reads -- what is left for #499 is the
-  template, which is the expression with the keys lifted into a vector.
+  `wsh()`, which btclib now reads -- what is left is the template, which is
+  the expression with the keys lifted into a vector, and #469 is where it
+  was asked for.
 
 ### Packaging, linting and CI
 


### PR DESCRIPTION
A factual error of mine, in two CHANGELOG entries.

`#499` is the **merged pull request**
https://github.com/btclib-org/btclib/pull/499, whose note on BIP388 wallet
policies said what a Ledger cannot be shown. The *template rewriting* that
note describes has no issue of its own, and
https://github.com/btclib-org/btclib/issues/469 — the in-process HWI adapter
— is where a caller asked for what it would unblock. Both entries called
#499 the place that work is recorded, which reads as open work under a
number that is closed.

Caught by reading the numbers back rather than by any check: nothing
verifies a `#N` in prose, and a merged pull request and an open issue look
exactly the same in it. The same correction goes on
https://github.com/btclib-org/btclib/issues/187, where I repeated it in a
comment.

## Gates

- `uv run pre-commit run --all-files`: exit 0
- `uv run pytest`: 18093 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Correct misattributed references to work on BIP388 wallet policy templates in documentation, ensuring they point to the appropriate issue rather than the merged pull request.

Documentation:
- Add a changelog entry explaining that two previous references to #499 mistakenly named the merged pull request instead of the corresponding issue.
- Update existing changelog notes to attribute the template rewriting work to issue #469 and clarify that no dedicated issue currently tracks the template work.