### PR TITLE
Write the refusal of an in-process HWI adapter into the module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ documented at release-notes length in the first place, and are still in
 
 ### Descriptors and miniscript
 
+- **The in-process HWI adapter is refused, in `btclib.hwi` and not only in
+  a closed issue** (#469). The reason is a Python range: HWI declares
+  `^3.9,<3.13`, this library supports 3.10 to 3.14 and pypy, so an optional
+  extra importing `hwilib` cannot be installed on the two newest
+  interpreters here -- a second and narrower support matrix wearing the word
+  "optional", where a subprocess keeps the executable in an environment of
+  its own. Of the three things it was to buy, one is void since #187 (Ledger
+  policy registration was blocked by miniscript, not by the transport), one
+  is small (a signing session is dominated by a human pressing a button, and
+  `signtx` signs every input of a psbt in one call), and one needs no
+  transport change (HWI's numeric codes have not moved since 2019, and
+  `SignerError` already carries them). What a caller holding an open
+  `hwilib` device writes instead is a `PsbtSigner` of their own, which is a
+  shape `psbt_signer_contract` already names.
 - **Two CHANGELOG references to #499 named the wrong thing.** #499 is the
   merged pull request whose note on BIP388 wallet policies said what a
   Ledger cannot be shown; the *template rewriting* that note describes has

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -21,6 +21,16 @@ by the caller and absent until a device is actually being used, so the
 import costs `json` and `subprocess` and the tests run with no HWI at
 all.
 
+An optional extra importing `hwilib` beside this was weighed and refused
+(#469), and the reason is that Python range: HWI declares `^3.9,<3.13`,
+where this library supports 3.10 to 3.14 and pypy, so an extra nobody can
+install on the two newest interpreters is a second and narrower support
+matrix rather than an option. A subprocess has no such problem, the
+executable living in an environment of its own. What a caller who does hold
+an open `hwilib` device writes instead is a `psbt_signer.PsbtSigner` of
+their own: that contract names an in-process driver as one of its shapes,
+and it is met in the caller's environment rather than in this one.
+
 `enumerate_devices` is the one call that names no device; everything else
 is `HwiSigner`, which is selected by fingerprint and passes `--fingerprint`
 to every command it runs. That is issue #381's own rule, and the reason


### PR DESCRIPTION
https://github.com/btclib-org/btclib/issues/469 is closed as not planned.
This puts the decision where a reader looks: `btclib.hwi` said the
alternative was "listed and did not take", which reads as a thing nobody got
to rather than a thing weighed and refused.

## The reason, which is not a preference

HWI declares `python = "^3.9,<3.13"`, still in 3.2.0 of 2026-02-10, where
this library supports 3.10 to 3.14 and pypy. **An optional extra nobody can
install on the two newest interpreters btclib supports is a second and
narrower support matrix wearing the word "optional".** A subprocess has no
such problem: the `hwi` executable lives in an environment of its own, on
3.12, while btclib runs on 3.14.

## The three things it was to buy

| argument | state |
|---|---|
| what the command line does not expose | **void.** It named Ledger wallet policy registration, which was blocked by btclib reading no miniscript — https://github.com/btclib-org/btclib/issues/187, closed today. https://github.com/btclib-org/btclib/pull/507 corrected the docstring that still said otherwise; what is left is the BIP388 template rewriting, which is transport-independent. |
| no process per command | **small.** A signing session is dominated by a human pressing a button and by USB round trips; `signtx` signs every input of a psbt in one call, so the cost is per session, not per command. |
| typed failures | **needs no transport change.** HWI's numeric codes are the part of its interface that has not moved since 2019, and `SignerError` already carries them; finer classes are a mapping table. |

## What the decision costs, named

The consumer that issue found — one that imports `hwilib` directly and
carries a driver of its own in a fork — is left doing exactly that. It is
also the case already served: `psbt_signer.PsbtSigner` is a protocol, and
`psbt_signer_contract` names "an in-process driver" as one of its shapes. A
caller holding an open `hwilib` device writes one in their environment, on
their interpreter range, with their own `ecdsa`, `pyaes` and `mnemonic` in
it. Shipping it here would add a dependency to solve a problem the contract
already solves.

What would reopen it is upstream's to change: HWI widening its Python range.

## Gates

- `uv run pre-commit run --all-files`: exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`: build succeeded
- `uv run pytest`: 18093 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the decision to refuse an in-process HWI adapter and direct users to rely on subprocess-based HWI or custom PsbtSigner implementations instead.

Enhancements:
- Clarify in btclib.hwi that an in-process HWI adapter importing hwilib was considered and explicitly rejected due to incompatible Python support ranges and existing PsbtSigner contracts.

Documentation:
- Add a detailed CHANGELOG entry explaining the rationale for refusing an in-process HWI adapter, including Python compatibility, transport considerations, and guidance for callers using hwilib directly.