### PR TITLE
Bound what HWI writes, not what btclib parses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,28 @@ documented at release-notes length in the first place, and are still in
 
 ### Descriptors and miniscript
 
+- **`btclib.hwi` bounds what the backend writes, not what it parses**
+  (#519). `max_output` was checked after `subprocess.run` had read both
+  streams to EOF, so what it limited was the answer handed to the json
+  parser, while the memory the exchange cost was whatever the executable
+  managed to write before the timeout -- and stderr was not limited at
+  all, being decoded only when stdout was empty. Both streams are now
+  temporary files whose size is watched between two waits: either one
+  past the limit kills the child and raises `SignerError`, and no more
+  than one byte past the limit is ever read back. The limit on stderr is
+  its own and applies to a backend whose answer was perfectly good, which
+  is what keeps the refusal from depending on when the child was noticed.
+
+  Temporary files rather than pipes read a chunk at a time, which is what
+  the issue proposed: a pipe has to be drained by whoever is also timing
+  the child, and draining it is the buffering the limit exists to
+  prevent, so bounding both streams that way needs a reader thread each
+  -- `selectors` does not read pipes on Windows, and the matrix runs
+  Windows. A file is written by the child alone, so its size is a
+  question `os.fstat` answers between two `Popen.wait` slices, and the
+  module keeps its one thread. What the slice costs is how far past the
+  limit a flood can get before it is stopped, which is bounded by the
+  disk rather than by the memory of this process.
 - **The in-process HWI adapter is refused, in `btclib.hwi` and not only in
   a closed issue** (#469). The reason is a Python range: HWI declares
   `^3.9,<3.13`, this library supports 3.10 to 3.14 and pypy, so an optional

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -18,8 +18,8 @@ btclib to work.** HWI declares `hidapi`, `libusb1`, `cbor2`, `pyserial`,
 narrower than btclib's; a mandatory dependency on that is the thing issue
 #381 rules out. What this module needs at runtime is an executable, named
 by the caller and absent until a device is actually being used, so the
-import costs `json` and `subprocess` and the tests run with no HWI at
-all.
+import costs nothing outside the standard library and the tests run with
+no HWI at all.
 
 An optional extra importing `hwilib` beside this was weighed and refused
 (#469), and the reason is that Python range: HWI declares `^3.9,<3.13`,
@@ -43,9 +43,11 @@ The subprocess is bounded twice. `timeout` is how long a command may run
 default is generous and a caller signing unattended should lower it --
 and `max_output` is how much of its answer is accepted: HWI answers with
 one json object, and a backend that sends megabytes is one whose output
-is not read to the end. The timeout is what stops it in the meantime,
-`subprocess.communicate` reading to EOF, so what the limit bounds is what
-is parsed rather than what is buffered.
+is not read to the end. It bounds stdout and stderr separately, and it
+bounds what is written rather than what is parsed: both streams go to
+temporary files whose size is watched while the child runs, so a backend
+past the limit is killed where it stands rather than read to EOF into
+memory and measured afterwards.
 
 Failures come back as `exceptions.SignerError`, carrying HWI's own error
 code where there is one: -14 is the user pressing the button that says
@@ -91,10 +93,13 @@ a command line that moved. What that already caught: `signtx` answers
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import tempfile
+import time
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import IO, Any
 
 from btclib.alias import Octets
 from btclib.bip32.der_path import DerPath, str_from_der_path
@@ -124,6 +129,12 @@ DEFAULT_TIMEOUT = 120.0
 # any transaction standardness relays, and a backend that sends more is
 # not one whose answer should be parsed to find out
 DEFAULT_MAX_OUTPUT = 1 << 20
+
+# the slice a wait is cut into, and so how far past `max_output` a stream
+# may grow before the child is stopped: short enough that a flood is
+# caught while it is still small, long enough that watching a device wait
+# for a button press is not a busy loop
+_POLL_INTERVAL = 0.05
 
 # what a caller that has not said gets: nothing supported, which is the
 # honest default when the answer is not in any json HWI prints. A module
@@ -180,6 +191,50 @@ def _executable(executable: str | Sequence[str]) -> list[str]:
     return [executable] if isinstance(executable, str) else list(executable)
 
 
+def _watch(
+    process: subprocess.Popen[bytes],
+    streams: tuple[IO[bytes], IO[bytes]],
+    *,
+    timeout: float,
+    max_output: int,
+) -> bool:
+    """Wait for the process, answering whether it ran out of time.
+
+    It returns as soon as the child has exited, as soon as either stream
+    is past the limit, or when the deadline is reached. Killing it is the
+    caller's to do, that being what all three ways out have in common.
+    """
+    deadline = time.monotonic() + timeout
+    while (left := deadline - time.monotonic()) > 0:
+        try:
+            process.wait(timeout=min(_POLL_INTERVAL, left))
+        except subprocess.TimeoutExpired:
+            if any(
+                os.fstat(stream.fileno()).st_size > max_output for stream in streams
+            ):
+                return False
+        else:
+            return False
+    return True
+
+
+def _kill(process: subprocess.Popen[bytes]) -> None:
+    """Kill the child and reap it; a child already reaped is left alone.
+
+    `send_signal` is what does the leaving alone, doing nothing once the
+    return code is in, so this needs no state of its own and can run on
+    the way out of every path.
+    """
+    process.kill()
+    process.wait()
+
+
+def _read(stream: IO[bytes], limit: int) -> bytes:
+    """Return at most `limit` bytes of what the child wrote to a stream."""
+    stream.seek(0)
+    return stream.read(limit)
+
+
 def _run(
     argv: list[str],
     *,
@@ -193,36 +248,58 @@ def _run(
     object HWI itself returns. The last is the one carrying a code, which
     is why the others explicitly carry None -- "no number" is a fact about
     the exchange rather than a device that answered zero.
-    """
-    try:
-        completed = subprocess.run(  # noqa: S603
-            argv,
-            capture_output=True,
-            timeout=timeout,
-            check=False,
-        )
-    except subprocess.TimeoutExpired as e:
-        raise SignerError(f"{argv[0]} timed out after {timeout} s") from e
-    except FileNotFoundError as e:
-        # the one failure that is not about a device: the command line is
-        # not installed, which a caller offering signers of several kinds
-        # reports differently from one it could not reach
-        raise SignerNotFoundError(f"cannot run {argv[0]}: {e}") from e
-    except OSError as e:
-        raise SignerError(f"cannot run {argv[0]}: {e}") from e
 
-    if len(completed.stdout) > max_output:
+    The two streams are temporary files rather than pipes, which is what
+    lets the limit be enforced while the child is still running: a pipe
+    has to be drained by whoever is also timing the child, and draining it
+    is the buffering the limit is there to prevent. A file is written by
+    the child alone, so the size is a question this process can ask
+    between two waits, and one byte past the limit is read back whatever
+    the child did afterwards.
+    """
+    with tempfile.TemporaryFile() as out, tempfile.TemporaryFile() as err:
+        try:
+            process = subprocess.Popen(argv, stdout=out, stderr=err)  # noqa: S603
+        except FileNotFoundError as e:
+            # the one failure that is not about a device: the command line
+            # is not installed, which a caller offering signers of several
+            # kinds reports differently from one it could not reach
+            raise SignerNotFoundError(f"cannot run {argv[0]}: {e}") from e
+        except OSError as e:
+            raise SignerError(f"cannot run {argv[0]}: {e}") from e
+
+        try:
+            timed_out = _watch(
+                process, (out, err), timeout=timeout, max_output=max_output
+            )
+        finally:
+            _kill(process)
+
+        if timed_out:
+            raise SignerError(f"{argv[0]} timed out after {timeout} s")
+        # one byte past the limit is all that has to be read to know the
+        # limit was passed, and all that is read of a child that flooded
+        stdout = _read(out, max_output + 1)
+        stderr = _read(err, max_output + 1)
+
+    if len(stdout) > max_output:
         err_msg = f"{argv[0]} answered more than {max_output} bytes"
         raise SignerError(err_msg)
-    if not completed.stdout.strip():
+    if len(stderr) > max_output:
+        # the same limit and a separate one: stderr is diagnostics, so a
+        # backend flooding it says nothing about the answer, and a backend
+        # flooding it is still one this process will not hold in memory
+        err_msg = f"{argv[0]} wrote more than {max_output} bytes to stderr"
+        raise SignerError(err_msg)
+    if not stdout.strip():
         # a command that printed nothing has failed in its own way, and
         # stderr is where it said so: HWI prints a traceback there when it
         # cannot even build the parser
-        message = completed.stderr.decode("utf-8", "replace").strip()
+        message = stderr.decode("utf-8", "replace").strip()
         raise SignerError(f"{argv[0]} answered nothing: {message or 'no output'}")
 
     try:
-        answer = json.loads(completed.stdout)
+        answer = json.loads(stdout)
     except json.JSONDecodeError as e:
         raise SignerError(f"{argv[0]} did not answer json: {e}") from e
 

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -422,10 +422,11 @@ def test_a_message_signature_is_verified_against_the_address(hwi: list[str]) -> 
 def test_what_the_subprocess_can_do_wrong(tmp_path: Path) -> None:
     """Every failure is a SignerError, with HWI's code where there is one.
 
-    Five ways for a command line to fail and one for the device to: an
+    The ways a command line fails and the one way the device does: an
     executable that is not there, an answer that is not json, an answer
-    past the limit, a command that prints nothing, and the error object
-    HWI itself returns — the last being the one that carries a number.
+    past the limit, diagnostics past the limit, a command that prints
+    nothing, one that never stops, and the error object HWI itself
+    returns — the last being the one that carries a number.
     """
     # not installed is its own subclass: a caller offering signers of
     # other kinds tells it from a device it could not reach, and a
@@ -457,6 +458,34 @@ def test_what_the_subprocess_can_do_wrong(tmp_path: Path) -> None:
     flood.write_text("print('x' * 100)\n", encoding="ascii")
     with pytest.raises(SignerError, match="answered more than 10 bytes"):
         enumerate_devices(executable=[sys.executable, str(flood)], max_output=10)
+
+    # the limit is on the diagnostics too, and it is not conditional on
+    # the answer: this one answered an empty device list, correctly, and
+    # is refused for what it wrote beside it
+    chatty = tmp_path / "chatty.py"
+    chatty.write_text(
+        "import sys\nsys.stderr.write('x' * 100)\nprint('[]')\n", encoding="ascii"
+    )
+    with pytest.raises(SignerError, match="wrote more than 10 bytes to stderr"):
+        enumerate_devices(executable=[sys.executable, str(chatty)], max_output=10)
+
+    # a backend that never stops writing is stopped, and the timeout is
+    # not what stops it: these two would take the generous timeout below
+    # and answer "timed out" if the limit were measured after the fact,
+    # so the message is what says the child was killed while it ran
+    endless = "import sys\nwhile True: sys.{0}.write('x' * 100_000)\n"
+    flooding = tmp_path / "flooding.py"
+    flooding.write_text(endless.format("stdout"), encoding="ascii")
+    with pytest.raises(SignerError, match="answered more than 1000 bytes"):
+        enumerate_devices(
+            executable=[sys.executable, str(flooding)], max_output=1000, timeout=60
+        )
+    noisy = tmp_path / "noisy.py"
+    noisy.write_text(endless.format("stderr"), encoding="ascii")
+    with pytest.raises(SignerError, match="wrote more than 1000 bytes to stderr"):
+        enumerate_devices(
+            executable=[sys.executable, str(noisy)], max_output=1000, timeout=60
+        )
 
     slow = tmp_path / "slow.py"
     slow.write_text("import time; time.sleep(5)\n", encoding="ascii")


### PR DESCRIPTION
Closes #519.

`max_output` was read after `subprocess.run` had already read both
streams to EOF, so it limited the answer handed to the json parser
while the memory the exchange cost was whatever the executable could
write within the timeout; stderr was not limited at all, being decoded
only when stdout was empty.

Both streams are temporary files now, their size watched between two
`Popen.wait` slices: either one past the limit kills the child and
reaps it, and at most one byte past the limit is read back. The stderr
limit is its own and refuses a backend whose answer was perfectly good,
which is what keeps the refusal from depending on when the child was
noticed.

Temporary files rather than pipes read a chunk at a time, which is what
the issue proposed: a pipe has to be drained by whoever is also timing
the child, and draining it is the buffering the limit exists to
prevent, so bounding both streams that way takes a reader thread each
-- `selectors` does not read pipes on Windows, and the matrix runs
Windows. A file is written by the child alone, so its size is a
question `os.fstat` answers between two waits, and the module keeps its
one thread. What a slice costs is how far past the limit a flood can
get before it is stopped, bounded by the disk rather than by the memory
of this process.

Tests: a stand-in flooding stdout and one flooding stderr, both
endless and both run under a generous timeout, so a limit measured
after the fact would answer "timed out" instead of the message
asserted; plus a well-behaved answer with over-long diagnostics beside
it. No API change.

Gates run on this tree: `uv run pre-commit run --all-files`, `uv run
pytest --cov` (18182 passed, 5 integration tests skipped as documented,
100% coverage), and the sphinx `-W` docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bound HWI subprocess stdout and stderr output while the child is running, enforcing size limits and surfacing failures as SignerError without increasing memory usage.

Bug Fixes:
- Ensure HWI subprocess output is limited by max_output based on what the backend writes, preventing unbounded buffering of stdout and stderr.
- Apply independent size limits to stderr diagnostics so overly verbose backends are refused even when their primary output is valid.

Enhancements:
- Introduce helper utilities for watching, killing, and reading subprocess output streams via temporary files to keep resource usage controlled.

Documentation:
- Document the new HWI output bounding behavior and rationale in the changelog, including separate limits for stdout and stderr and use of temporary files.

Tests:
- Expand HWI tests to cover stderr size limiting, endlessly flooding stdout and stderr processes, and timeout vs output-limit interactions.