### PR TITLE
Point at the constant-time boundary from where the choice is made

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -459,6 +459,15 @@ documented at release-notes length in the first place, and are still in
   choice are in CONTRIBUTING.md, the repository and the channel are badges
   below, and the table that grouped them is gone -- the alternative text
   says what a badge means, which is what the table's left column did.
+- **The README and `btclib.ecc` now say where constant time ends** (#525).
+  SECURITY.md documented it and still does, in full; what was missing was a
+  pointer from where the choice is made. A reader picking a signing api met
+  the capabilities and not the conditions on them -- that a Python object
+  holding a secret is not zeroized, that the constant-time properties are
+  libsecp256k1's and hold on the C side of the call, and that another
+  curve, another hash function or a caller's own nonce takes the Python
+  path. Both places link the detailed text rather than restating it, so
+  there is one canonical answer and two ways to reach it.
 
 ## v2026.8.7
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,39 @@ Included features are:
 
 ---
 
+## Secrets, and where constant time ends
+
+btclib is used to teach and to prototype as much as to build, and the two
+uses want different things of it. What follows is the boundary between
+them, before a private key is handed to any of the above.
+
+A Python object carrying secret material cannot be reliably zeroized: it
+stays in the process memory until garbage collection, and the interpreter
+may have copied it meanwhile. The constant-time properties are
+libsecp256k1's, and they hold on the C side of the call — not before it,
+and not after.
+
+Not every operation crosses that call. `dsa.sign` and `ssa.sign` reach the
+bindings for secp256k1 with sha256 and no nonce of the caller's; another
+curve, another hash function, or a nonce you supply runs the Python
+arithmetic instead, which the suite validates against the bindings but
+which is not constant-time. So a caller whose threat model includes timing
+should stay on the delegated paths, or keep the key out of the process
+altogether: `btclib.hwi` drives a hardware wallet through HWI, behind the
+same `PsbtSigner` contract a software signer answers.
+
+<!-- The link is to the file and not to its section: the documentation
+build renders this README with myst, which mints no heading ids, so a
+fragment naming one is an unresolved reference and fails sphinx-build -W.
+The section is named in the prose instead, which costs the reader one
+scroll and the build nothing. -->
+[SECURITY](./SECURITY.md)'s "Limitations, not vulnerabilities" states each
+condition exactly — which arguments delegate, which do not, and what the
+Python path does hide — and is the canonical text; this section is the
+pointer to it.
+
+---
+
 ## Module layout
 
 Three pairs of modules are one idea split in two, and each split runs one

--- a/btclib/ecc/__init__.py
+++ b/btclib/ecc/__init__.py
@@ -41,6 +41,15 @@ yet an attribute falls back to importing package.name as a submodule,
 which is what happens here. tests/imports_test.py imports every module of
 the library with nothing else in sys.modules, which is the order that
 would find it if it did not.
+
+**Secrets.** This is the package a private key is handed to, and what
+holds around it is conditional. A signature of secp256k1 with sha256 and
+a nonce btclib derives is one libsecp256k1 call; another curve, another
+hash function or a nonce of the caller's runs the Python arithmetic,
+which the suite validates against the bindings but which is not
+constant-time. Nor is a Python object holding a secret zeroized, on
+either path. SECURITY.md's limitations section states each condition,
+argument by argument, and README.md carries the short form.
 """
 
 from btclib.ecc import (


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/525.

`SECURITY.md` already documents which calls reach libsecp256k1 and what
the Python path does not promise, and it stays the canonical text. What
was missing was a pointer from the two places a reader actually decides
from: `README.md` and the `btclib.ecc` package docstring.

- **README.md** gains a `## Secrets, and where constant time ends`
  section, placed after the feature list and before `## Module layout`,
  i.e. before the reader picks a module. Three facts: a Python object
  holding a secret is not zeroized, the constant-time properties are
  libsecp256k1's and hold on the C side of the call, and another curve,
  another hash function or a caller's own nonce takes the Python path —
  with `btclib.hwi` named as the way to keep the key out of the process.
- **`btclib/ecc/__init__.py`** says the same to whoever arrives by import
  rather than by the website.

Neither restates `SECURITY.md`; both link it. The README link carries no
anchor on purpose, and an HTML comment says why: the documentation build
renders the file with myst, which mints no heading ids, so a fragment is
an unresolved reference and fails `sphinx-build -W`. That was the first
version of this branch, and it failed the gate.

Gates run locally, all green: `uv run pre-commit run --all-files`,
`uv run pytest --cov`, and the sphinx `-W` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify where constant-time guarantees apply and direct readers to the canonical security documentation from the main entry points.

Documentation:
- Add a README section explaining the boundary of constant-time behavior, secret handling limitations, and when operations fall back to Python implementations, with a pointer to SECURITY.md.
- Extend the btclib.ecc package docstring to describe secret-handling conditions, constant-time scope, and reference SECURITY.md and README.md as the detailed sources.