### PR TITLE
Take a musig2 tweak kind as a bool and not as a truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,6 +241,25 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **A musig2 tweak has a kind, and a kind is a `bool`** (#520).
+  `apply_tweak` read `is_xonly` for its truth, so `"false"` -- true, as
+  every non-empty string is -- applied the x-only tweak to an odd-y
+  aggregate key and answered a different key from the one the signers
+  who passed `False` computed, neither side raising anything.
+  `SessionContext` kept the sequence it was handed, so such a value
+  reached signing through `key_agg_and_tweak` as well. All three refuse
+  anything that is not a `bool` now, with `BTClibTypeError`, `0` and `1`
+  included.
+
+  `utils.is_integer`'s policy mirrored, and the boundary that motivates
+  both is the one boundary: a kind written to json or to a configuration
+  file and read back arrives as whatever it was written as, and there
+  `"false"` is true. What made this one worth refusing rather than
+  coercing is what the flag decides -- which of two aggregate keys the
+  group signs under -- and that it is silent: an even-y aggregate key
+  tweaks the same either way, so the arithmetic notices nothing and the
+  signers who disagree find out when their partial signatures do not add
+  up. The BIP327 vectors are untouched.
 - **BIP322 signed messages, in the new `btclib.bip322`**. `ecc.bms` signs
   with a key and lets the verifier recover it, so it can only speak about
   the addresses that *are* a public key hash; a taproot address is a

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,11 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **the kind of a musig2 tweak is a `bool` and nothing else.**
+  `apply_tweak`, `key_agg_and_tweak` and `SessionContext` used to read
+  `is_xonly` for its truth, so `1` was an x-only tweak and `"false"` was
+  one too; both raise `BTClibTypeError` now. A caller passing `True` or
+  `False`, which the annotation always asked for, is unaffected.
 - **`btclib.descriptors` is a package, and its three checksum tables moved
   with the module into it.** `INPUT_CHARSET`, `CHECKSUM_CHARSET` and
   `GENERATOR` are `btclib.descriptors.descriptors.INPUT_CHARSET` and its

--- a/btclib/ecc/musig2.py
+++ b/btclib/ecc/musig2.py
@@ -83,6 +83,7 @@ from btclib.curves.sec_point import (
 from btclib.ecc import ssa
 from btclib.exceptions import (
     BTClibRuntimeError,
+    BTClibTypeError,
     BTClibValueError,
     InvalidContributionError,
 )
@@ -188,6 +189,28 @@ def _require_same_length(tweaks: Sequence[bytes], is_xonly: Sequence[bool]) -> N
     if len(tweaks) != len(is_xonly):
         err_msg = "The `tweaks` and `is_xonly` arrays must have the same length."
         raise BTClibValueError(err_msg)
+
+
+def _flag(is_xonly: bool) -> bool:
+    """Return the kind of a tweak, which is a `bool` and not a truth.
+
+    `utils.is_integer`'s policy mirrored: there a boolean is refused
+    where a number is meant, here anything but a boolean is refused where
+    a kind is meant, and the boundary that motivates both is the same. A
+    kind written down and read back -- json, a configuration file, a
+    coordinator's message -- arrives as whatever it was written as, and
+    `"false"` is true. What this one decides is which of two aggregate
+    keys the group signs under, so a value read for its truth would put
+    half the signers on the other key rather than raise.
+    """
+    if not isinstance(is_xonly, bool):
+        err_msg = f"invalid is_xonly type: {type(is_xonly).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
+    return is_xonly
+
+
+def _flags(is_xonly: Sequence[bool]) -> tuple[bool, ...]:
+    return tuple(_flag(flag) for flag in is_xonly)
 
 
 def individual_pub_key(prv_key: PrvKey) -> bytes:
@@ -298,12 +321,16 @@ def apply_tweak(
     even-y point, so an odd-y Q is negated first and the negation is
     accumulated in gacc for the signers to apply to their keys. A plain
     tweak is BIP32 derivation on the group key, and takes Q as it is.
+
+    Which of the two is a `bool` and nothing else: the line below reads
+    it beside the parity of Q, so a value read for its truth would tweak
+    an odd-y key the other way and answer another aggregate key.
     """
     tweak = bytes_from_octets(tweak)
     if len(tweak) != _SCALAR_SIZE:
         raise BTClibValueError(_TWEAK_SIZE_ERR)
     Q, gacc, tacc = key_agg_ctx.Q, key_agg_ctx.gacc, key_agg_ctx.tacc
-    g = secp256k1.n - 1 if (is_xonly and Q[1] % 2) else 1
+    g = secp256k1.n - 1 if (_flag(is_xonly) and Q[1] % 2) else 1
     t = int.from_bytes(tweak, "big")
     if t >= secp256k1.n:
         raise BTClibValueError(_TWEAK_RANGE_ERR)
@@ -323,6 +350,7 @@ def key_agg_and_tweak(
 ) -> KeyAggContext:
     """Aggregate the keys, then apply the tweaks in order."""
     tweaks_ = _tweaks(tweaks)
+    is_xonly = _flags(is_xonly)
     _require_same_length(tweaks_, is_xonly)
     key_agg_ctx = key_agg(pub_keys)
     for tweak, xonly in zip(tweaks_, is_xonly, strict=True):
@@ -493,7 +521,7 @@ class SessionContext:
         object.__setattr__(self, "agg_nonce", bytes_from_octets(agg_nonce, _NONCE_SIZE))
         object.__setattr__(self, "pub_keys", _pub_keys(pub_keys))
         object.__setattr__(self, "tweaks", _tweaks(tweaks))
-        object.__setattr__(self, "is_xonly", tuple(is_xonly))
+        object.__setattr__(self, "is_xonly", _flags(is_xonly))
         object.__setattr__(self, "msg", bytes_from_octets(msg))
         _require_same_length(self.tweaks, self.is_xonly)
 

--- a/tests/ecc/musig2_test.py
+++ b/tests/ecc/musig2_test.py
@@ -18,7 +18,11 @@ import pytest
 
 from btclib.curves import bytes_from_point, mult
 from btclib.ecc import musig2, ssa
-from btclib.exceptions import BTClibValueError, InvalidContributionError
+from btclib.exceptions import (
+    BTClibTypeError,
+    BTClibValueError,
+    InvalidContributionError,
+)
 from tests import load, vector_id
 
 # the two exception types BIP327 tells apart: a caller's own bad
@@ -613,6 +617,41 @@ def test_tweaks_and_is_xonly_pair_up() -> None:
         musig2.key_agg_and_tweak([pk_1], [bytes(32)], [])
     with pytest.raises(BTClibValueError, match="must have the same length"):
         musig2.SessionContext(bytes(66), [pk_1], [bytes(32)], [], _MSG)
+
+
+@pytest.mark.parametrize("not_a_flag", ["false", "", 0, 1, None])
+def test_the_kind_of_a_tweak_is_a_bool(not_a_flag: Any) -> None:
+    """Verify a kind that is not a bool is refused wherever one is taken.
+
+    Not read for its truth: `"false"` is true, and what the flag decides
+    is which of two aggregate keys the group signs under, so an odd-y key
+    tweaked by a string would answer a key the signers passing `False`
+    never see. The three doors are the one that reads it and the two that
+    carry a sequence of them.
+    """
+    pk_1 = musig2.individual_pub_key(_SK_1)
+    key_agg_ctx = musig2.key_agg([pk_1])
+    with pytest.raises(BTClibTypeError, match="invalid is_xonly type"):
+        musig2.apply_tweak(key_agg_ctx, bytes(32), not_a_flag)
+    with pytest.raises(BTClibTypeError, match="invalid is_xonly type"):
+        musig2.key_agg_and_tweak([pk_1], [bytes(32)], [not_a_flag])
+    with pytest.raises(BTClibTypeError, match="invalid is_xonly type"):
+        musig2.SessionContext(bytes(66), [pk_1], [bytes(32)], [not_a_flag], _MSG)
+
+
+def test_the_two_kinds_of_tweak_differ_on_an_odd_key() -> None:
+    """Verify the flag is what the refusal above is protecting.
+
+    An aggregate key with an odd y is the case where the two kinds part
+    company: the x-only one negates it first. A key with an even y
+    tweaks the same either way, which is why the refusal cannot be left
+    to the arithmetic to notice.
+    """
+    key_agg_ctx = musig2.key_agg([musig2.individual_pub_key(_SK_1)])
+    assert key_agg_ctx.Q[1] % 2
+    plain = musig2.apply_tweak(key_agg_ctx, bytes(32), False)
+    x_only = musig2.apply_tweak(key_agg_ctx, bytes(32), True)
+    assert plain != x_only
 
 
 def test_tweak_size() -> None:


### PR DESCRIPTION
Closes #520.

`apply_tweak` read `is_xonly` for its truth, so `"false"` -- true, as
every non-empty string is -- applied the x-only tweak to an odd-y
aggregate key and answered a different key from the one the signers who
passed `False` computed, with nothing raised on either side.
`SessionContext` kept the sequence it was handed, so such a value
reached signing through `key_agg_and_tweak` as well. All three refuse
anything that is not a `bool` now, with `BTClibTypeError`, `0` and `1`
included.

This is `utils.is_integer`'s policy mirrored -- there a boolean is
refused where a number is meant -- and the boundary that motivates both
is the one boundary: a kind written to json or to a configuration file
and read back arrives as whatever it was written as. What makes this
one worth refusing rather than coercing is what the flag decides, which
of two aggregate keys the group signs under, and that it is silent: an
even-y aggregate key tweaks the same either way, so the arithmetic
notices nothing and the signers who disagree find out when their
partial signatures fail to add up.

`isinstance(x, bool)` rather than `type(x) is bool`: `int` is not a
subclass of `bool`, it is the other way round, so `0` and `1` are
refused by the shorter spelling too.

Tests: `"false"`, `""`, `0`, `1` and `None` refused at all three doors,
and the odd-y case that shows the two kinds differ. The BIP327 vectors
are untouched. HISTORY.md carries the breaking-changes bullet.

Gates run on this tree: `uv run pre-commit run --all-files`, `uv run
pytest --cov` (18188 passed, 5 integration tests skipped as documented,
100% coverage), and the sphinx `-W` docs build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce that the musig2 tweak kind (`is_xonly`) is strictly a boolean across key aggregation, tweaking, and session creation, and document this as a breaking change.

Bug Fixes:
- Prevent non-boolean `is_xonly` values (e.g., strings, integers, None) from silently altering the aggregate key used for musig2 signing by raising a `BTClibTypeError` instead.

Enhancements:
- Introduce internal helpers to validate single and multiple `is_xonly` flags and align musig2 flag handling with existing `utils.is_integer` type policy.

Documentation:
- Add changelog and history entries describing the stricter musig2 tweak kind requirements and their implications for callers.

Tests:
- Add tests that reject non-boolean `is_xonly` values at all musig2 entry points and verify that x-only and plain tweaks differ on odd-y aggregate keys.