### PR TITLE
Ask the node which chain it serves before the first fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,25 @@ documented at release-notes length in the first place, and are still in
 
 ### Transactions, blocks and PSBT
 
+- **A `BitcoinCoreFetcher` asks the node which chain it serves** (#521).
+  `assert_network` has always been able to catch the one silent failure
+  of this class -- a testnet node under a `mainnet` label renders mainnet
+  addresses for outputs that are not there -- and nothing required a
+  caller to call it. `verify_network` does, and it is on by default: the
+  question is asked once, before the first fetch, and the answer is kept.
+  `verify_network=False` is the opt-out, and is what this class did
+  before.
+
+  Before the first fetch rather than in the constructor, which is the
+  other shape the issue offered: the round trip is worth paying where an
+  answer is about to be trusted and wasted where a fetcher is built and
+  never used, and a node that is merely down should not be a failure to
+  *construct* anything. What is remembered is an answer and not an
+  attempt: a chain that disagrees is a fact about a configuration, so it
+  is raised again for every later fetch without asking twice, while a
+  node that could not be reached is asked again by the fetch after it. A
+  fetcher that refused once and then served an address on the next call
+  would be the silent failure with one more step in it.
 - **`OutPoint` no longer refuses half a coinbase marker** (#513). The
   rule was `(tx_id == 0) ^ (vout == 0xFFFFFFFF)`, i.e. both sentinels or
   neither; Bitcoin Core's is the conjunction — `COutPoint::IsNull` is

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,6 +25,13 @@ full year, short month, short day (YYYY-M-D)
   `is_xonly` for its truth, so `1` was an x-only tweak and `"false"` was
   one too; both raise `BTClibTypeError` now. A caller passing `True` or
   `False`, which the annotation always asked for, is unaffected.
+- **a `BitcoinCoreFetcher` asks the node which chain it serves, before
+  the first fetch.** One `getblockchaininfo` per fetcher, and a node on
+  another chain than the label is a `BTClibValueError` instead of
+  addresses for coins that are not there. `BitcoinCoreFetcher(client,
+  network, verify_network=False)` is the previous behaviour, for a
+  caller that has checked by other means or is talking to something that
+  does not answer that call.
 - **`btclib.descriptors` is a package, and its three checksum tables moved
   with the module into it.** `INPUT_CHARSET`, `CHECKSUM_CHARSET` and
   `GENERATOR` are `btclib.descriptors.descriptors.INPUT_CHARSET` and its

--- a/btclib/fetch/bitcoin_core.py
+++ b/btclib/fetch/bitcoin_core.py
@@ -84,13 +84,57 @@ class BitcoinCoreFetcher(Fetcher):
 
     `network` is btclib's chain label and belongs here, not to the connection:
     it is what the outputs of a fetched transaction are labelled with. The
-    client knows a URL and no chain, and no fetch asks the node which one it
-    serves; `assert_network` is that question, asked when a caller asks it.
+    client knows a URL and no chain, so the label is a claim until the node
+    is asked, and `assert_network` is the question.
+
+    `verify_network` is who asks it. On by default and before the first
+    fetch rather than in this constructor: the answer costs a round trip
+    that is worth paying where it is checked and wasted where a fetcher is
+    built and never used, and a node that is merely down should not be a
+    failure to *construct* anything. The answer is then kept -- a node
+    does not change chain under a client that goes on pointing at it --
+    and a caller that would rather not ask says `verify_network=False`,
+    which is what this class did before the option existed.
     """
 
-    def __init__(self, client: BitcoinCoreRpcClient, network: str = "mainnet") -> None:
+    def __init__(
+        self,
+        client: BitcoinCoreRpcClient,
+        network: str = "mainnet",
+        *,
+        verify_network: bool = True,
+    ) -> None:
         super().__init__(network)
         self.client = client
+        self.verify_network = verify_network
+        self._agreed = False
+        self._disagreement = ""
+
+    def _verify_once(self) -> None:
+        """Compare the node's chain with this fetcher's label, once.
+
+        Called by the three fetches and not by `_call`, which is what
+        `assert_network` itself goes through: a check in there would ask
+        the node about the node, from inside the question.
+
+        A disagreement is remembered and raised again for every later
+        fetch, because it is a settled fact about a configuration rather
+        than a request that failed -- and a fetcher that asked once,
+        refused once and then served an address would be the silent
+        failure this exists to stop. A `FetchError` is not an answer and
+        is remembered as nothing: the node was unreachable or spoke
+        nonsense, which the next fetch may well find otherwise.
+        """
+        if not self.verify_network or self._agreed:
+            return
+        if self._disagreement:
+            raise BTClibValueError(self._disagreement)
+        try:
+            self.assert_network()
+        except BTClibValueError as e:
+            self._disagreement = str(e)
+            raise
+        self._agreed = True
 
     def _call(
         self,
@@ -124,18 +168,21 @@ class BitcoinCoreFetcher(Fetcher):
         its mempool, one of its wallet's, and -- only with `-txindex` -- any
         other. Without the index the error is RPC code -5.
         """
+        self._verify_once()
         hex_ = tx_id_hex(tx_id)
         raw = self._call("getrawtransaction", [hex_])
         return tx_from_raw(raw, hex_, self.network)
 
     def get_block_count(self) -> int:
         """Return the height of the node's best chain tip."""
+        self._verify_once()
         with fetch_errors("getblockcount"):
             reply = self._call("getblockcount", max_body_size=_MAX_SMALL_REPLY)
             return int(reply)
 
     def get_best_block_id(self) -> bytes:
         """Return the hash of the node's best chain tip, display order."""
+        self._verify_once()
         with fetch_errors("getbestblockhash"):
             reply = self._call("getbestblockhash", max_body_size=_MAX_SMALL_REPLY)
             return bytes_from_octets(reply, 32)
@@ -143,12 +190,13 @@ class BitcoinCoreFetcher(Fetcher):
     def assert_network(self) -> None:
         """Raise unless the node serves the chain this fetcher labels with.
 
-        Explicit, and asked by a caller rather than by every fetch: it
-        costs an rpc round trip that a caller with one node and one chain
-        has no use for, and the answer cannot change under a client that
-        goes on pointing at the same node.
+        One round trip, asked once and not per fetch: the answer cannot
+        change under a client that goes on pointing at the same node.
+        `verify_network` is what asks it before the first fetch, and this
+        stays public for a caller that wants the question answered at a
+        moment of its own -- at startup, or after a client was repointed.
 
-        Worth one call, though, because the failure it catches is silent.
+        Worth the call, because the failure it catches is silent.
         A client built for a testnet node -- an explicit url, no port
         default in the way -- under a fetcher labelled `mainnet` renders a
         mainnet address for every output it fetches, for coins that are

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -102,10 +102,21 @@ def client(
 def fetcher(
     *answers: tuple[int, bytes] | Exception, **kwargs: object
 ) -> BitcoinCoreFetcher:
-    """Return a BitcoinCoreFetcher over a recorded client."""
+    """Return a BitcoinCoreFetcher over a recorded client.
+
+    `verify_network=False` unless a test says otherwise: the scripted
+    replies are consumed in order, so a fetcher that asked the node which
+    chain it serves would eat the reply the test wrote for the call it is
+    about. The tests that *are* about the question say so and script the
+    `getblockchaininfo` reply first.
+    """
     network = kwargs.pop("network", "mainnet")
     assert isinstance(network, str)
-    return BitcoinCoreFetcher(client(*answers, **kwargs), network)
+    verify_network = kwargs.pop("verify_network", False)
+    assert isinstance(verify_network, bool)
+    return BitcoinCoreFetcher(
+        client(*answers, **kwargs), network, verify_network=verify_network
+    )
 
 
 def recording(endpoint: BitcoinCoreRpcClient) -> Recorded:
@@ -122,6 +133,18 @@ def sent(endpoint: BitcoinCoreRpcClient) -> dict[str, object]:
     return body
 
 
+def asked(endpoint: BitcoinCoreRpcClient) -> list[str]:
+    """Return the method of every call a client made, in order."""
+    methods = []
+    for request in recording(endpoint).requests:
+        data = request.data
+        assert isinstance(data, bytes)
+        body = json.loads(data)
+        assert isinstance(body, dict)
+        methods.append(str(body["method"]))
+    return methods
+
+
 def test_get_tx_parses_the_serialization_the_node_sent() -> None:
     """Verbosity 0, so the id is recomputed rather than taken on trust."""
     tx = fetcher((200, recorded_body("getrawtransaction.json"))).get_tx(TX_ID)
@@ -133,7 +156,7 @@ def test_get_tx_parses_the_serialization_the_node_sent() -> None:
 def test_get_tx_asks_for_the_id_it_was_given() -> None:
     """Verify get_tx sends getrawtransaction with the hex id it was given."""
     endpoint = client((200, recorded_body("getrawtransaction.json")))
-    BitcoinCoreFetcher(endpoint).get_tx(bytes.fromhex(TX_ID))
+    BitcoinCoreFetcher(endpoint, verify_network=False).get_tx(bytes.fromhex(TX_ID))
     body = sent(endpoint)
     assert body["method"] == "getrawtransaction"
     assert body["params"] == [TX_ID]
@@ -142,7 +165,7 @@ def test_get_tx_asks_for_the_id_it_was_given() -> None:
 def test_get_tx_labels_the_outputs_for_the_fetchers_network() -> None:
     """The network is the fetcher's: the client knows a url and no chain."""
     endpoint = client((200, recorded_body("getrawtransaction.json")))
-    tx = BitcoinCoreFetcher(endpoint, "testnet").get_tx(TX_ID)
+    tx = BitcoinCoreFetcher(endpoint, "testnet", verify_network=False).get_tx(TX_ID)
     assert [out.script_pub_key.network for out in tx.vout] == ["testnet"] * 2
 
 
@@ -306,6 +329,75 @@ def test_assert_network_refuses_a_malformed_reply(result: object, message: str) 
     body = json.dumps({"jsonrpc": "2.0", "result": result, "id": "x"}).encode()
     with pytest.raises(FetchError, match=message):
         fetcher((200, body), network="mainnet").assert_network()
+
+
+def test_the_first_fetch_asks_the_node_which_chain_it_serves() -> None:
+    """Which is what `verify_network` buys, and it is on by default."""
+    endpoint = client(
+        blockchaininfo(chain="main"), (200, recorded_body("getrawtransaction.json"))
+    )
+    assert BitcoinCoreFetcher(endpoint).get_tx(TX_ID).id.hex() == TX_ID
+    assert asked(endpoint) == ["getblockchaininfo", "getrawtransaction"]
+
+
+def test_the_chain_is_asked_for_once_and_not_per_fetch() -> None:
+    """A node does not change chain under a client pointing at it."""
+    endpoint = client(
+        blockchaininfo(chain="main"),
+        (200, recorded_body("getblockcount.json")),
+        (200, recorded_body("getbestblockhash.json")),
+    )
+    core = BitcoinCoreFetcher(endpoint)
+    assert core.get_block_count() == TIP_HEIGHT
+    assert core.get_best_block_id().hex() == TIP_ID
+    assert asked(endpoint) == ["getblockchaininfo", "getblockcount", "getbestblockhash"]
+
+
+def test_a_node_on_another_chain_answers_no_fetch_at_all() -> None:
+    """The failure the option exists for, and it does not wear off.
+
+    A fetcher that asked once, was refused once and then served an
+    address on the next call would be the silent failure with an extra
+    step, so the disagreement is remembered -- and remembered rather than
+    re-asked, which is what the second call proves by adding no request.
+    """
+    endpoint = client(blockchaininfo(chain="test"))
+    core = BitcoinCoreFetcher(endpoint, "mainnet")
+    for _ in range(2):
+        with pytest.raises(BTClibValueError, match="node is on test"):
+            core.get_tx(TX_ID)
+    assert asked(endpoint) == ["getblockchaininfo"]
+
+
+def test_a_node_that_could_not_be_asked_is_asked_again() -> None:
+    """A node that did not answer said nothing about which chain it is on.
+
+    The distinction the remembering rests on: a chain that disagrees is a
+    fact about a configuration, where a socket that did not connect is a
+    request to make again.
+    """
+    endpoint = client(
+        rpc.FetchError("no answer from http://127.0.0.1:8332: refused"),
+        blockchaininfo(chain="main"),
+        (200, recorded_body("getrawtransaction.json")),
+    )
+    core = BitcoinCoreFetcher(endpoint)
+    with pytest.raises(FetchError, match="refused"):
+        core.get_tx(TX_ID)
+    assert core.get_tx(TX_ID).id.hex() == TX_ID
+    assert asked(endpoint) == [
+        "getblockchaininfo",
+        "getblockchaininfo",
+        "getrawtransaction",
+    ]
+
+
+def test_verify_network_false_asks_the_node_nothing() -> None:
+    """The opt-out is one round trip, and is what this class did before."""
+    endpoint = client((200, recorded_body("getrawtransaction.json")))
+    core = BitcoinCoreFetcher(endpoint, verify_network=False)
+    assert core.get_tx(TX_ID).id.hex() == TX_ID
+    assert asked(endpoint) == ["getrawtransaction"]
 
 
 def test_get_tx_out_reads_one_output_of_the_previous_transaction() -> None:


### PR DESCRIPTION
Closes #521.

`assert_network` has always been able to catch the one silent failure of
`BitcoinCoreFetcher` -- a testnet node under a `mainnet` label renders
mainnet addresses for outputs that are not there -- and nothing required
a caller to call it. `verify_network` does, and it is on by default: the
question is asked once, before the first fetch, and the answer is kept.
`verify_network=False` is the opt-out, and is what this class did
before.

Before the first fetch rather than in the constructor, which is the
other shape the issue offered: the round trip is worth paying where an
answer is about to be trusted and wasted where a fetcher is built and
never used, and a node that is merely down should not be a failure to
*construct* anything.

What is remembered is an answer and not an attempt. A chain that
disagrees is a fact about a configuration, so it is raised again for
every later fetch without asking twice; a node that could not be reached
said nothing about which chain it is on, so the fetch after it asks
again. A fetcher that refused once and then served an address on the
next call would be the silent failure with one more step in it.

The check hangs off the three fetches rather than off `_call`, which is
what `assert_network` itself goes through: a check in there would ask
the node about the node, from inside the question. `assert_network`
stays public, for a caller that wants the answer at a moment of its own.

Tests: the `getblockchaininfo` that precedes the first fetch and is not
repeated before the second, the disagreement that stops every fetch and
is asked once, the unreachable node that is asked again, and the
opt-out that asks nothing. The existing tests script replies in order,
so their helper passes `verify_network=False` -- the node is not what
they are about.

Gates run on this tree: `uv run pre-commit run --all-files`, `uv run
pytest --cov` (18187 passed, 5 integration tests skipped as documented,
100% coverage), and the sphinx `-W` docs build; the suite again after
rebasing onto e5d53cb5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add optional network verification to BitcoinCoreFetcher that checks the node’s chain via getblockchaininfo before the first fetch and remembers mismatches.

New Features:
- Introduce a verify_network option on BitcoinCoreFetcher that automatically asserts the node’s chain once before the first fetch and caches the result.

Enhancements:
- Document the new BitcoinCoreFetcher network verification behaviour in CHANGELOG and HISTORY, including the default-on semantics and verify_network=False opt-out.

Tests:
- Extend BitcoinCoreFetcher tests to cover first-fetch chain verification, single-check behaviour, handling of unreachable nodes, remembered chain mismatches, and the verify_network=False opt-out path.