### PR TITLE
Fuzz the entry points the file was missing, and fix what that found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,6 +332,17 @@ documented at release-notes length in the first place, and are still in
   node that could not be reached is asked again by the fetch after it. A
   fetcher that refused once and then served an address on the next call
   would be the silent failure with one more step in it.
+- **`Psbt.b64decode` refuses unreadable base64 with `BTClibValueError`**
+  (#523), where it let `binascii.Error` out for a string base64 cannot
+  group and a bare `ValueError` for one that is not ascii. The audience of
+  that method is a caller handing it what somebody pasted, and that caller
+  catches the library's exception; `bms.Sig.b64decode` and
+  `ecies.Envelope.b64decode` already answered with it. Both escapes derive
+  from `ValueError`, as `BTClibValueError` does, so an `except ValueError`
+  written against either behaviour still catches. Found by
+  `tests/fuzz_test.py` on the day the method was added to it, and the
+  three inputs that found it are a test of their own in
+  `tests/psbt/psbt_test.py`.
 - **`OutPoint` no longer refuses half a coinbase marker** (#513). The
   rule was `(tx_id == 0) ^ (vout == 0xFFFFFFFF)`, i.e. both sentinels or
   neither; Bitcoin Core's is the conjunction — `COutPoint::IsNull` is
@@ -541,6 +552,19 @@ documented at release-notes length in the first place, and are still in
   curve, another hash function or a caller's own nonce takes the Python
   path. Both places link the detailed text rather than restating it, so
   there is one canonical answer and two ways to reach it.
+
+### Tests
+
+- **`tests/fuzz_test.py` reaches the entry points it was missing** (#523):
+  the base64 wrappers `Psbt.b64decode`, `bip322.Sig.b64decode` and
+  `ecies.Envelope.b64decode`, the binary `ecies.Envelope.parse`, and the
+  two text languages `descriptors.parse` and `miniscript.parse`. A
+  wrapper is a parser of its own -- what it adds is the decoding, a str
+  that is not ascii and padding that is not canonical, which the binary
+  entry point beneath it never sees -- and adding the first of them found
+  the `Psbt.b64decode` defect above. `bip322.Sig` has no binary entry
+  point to add, its three payloads being told apart by the prefix of the
+  text form alone.
 
 ## v2026.8.7
 

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -1119,7 +1119,16 @@ class Psbt:
         if isinstance(psbt_str, str):
             psbt_str = psbt_str.strip()
 
-        psbt_decoded = base64.b64decode(psbt_str)
+        # base64 answers a string it cannot read with binascii.Error, and
+        # a str carrying a non-ascii character with a plain ValueError.
+        # Neither is BTClibValueError, so a caller catching that to reject
+        # a pasted psbt -- which is the whole audience of this method --
+        # gets an exception it never asked about. `bms.Sig.b64decode` and
+        # `ecies.Envelope.b64decode` both answer with the library's own
+        try:
+            psbt_decoded = base64.b64decode(psbt_str)
+        except ValueError as e:  # binascii.Error and UnicodeEncodeError
+            raise BTClibValueError(f"invalid base64 encoding: {e}") from e
 
         return cls.parse(psbt_decoded, check_validity=check_validity)
 

--- a/tests/fuzz_test.py
+++ b/tests/fuzz_test.py
@@ -28,13 +28,14 @@ import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from btclib import b32, b58, base58, bech32, descriptors, var_bytes, var_int
+from btclib import b32, b58, base58, bech32, bip322, descriptors, var_bytes, var_int
 from btclib.bip32.bip32 import BIP32KeyData
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.block.block import Block
 from btclib.block.block_header import BlockHeader
 from btclib.curves.sec_point import point_from_octets
-from btclib.ecc import bms, dsa, ssa
+from btclib.descriptors import miniscript
+from btclib.ecc import bms, dsa, ecies, ssa
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.psbt import psbt_utils
 from btclib.psbt.psbt import Psbt
@@ -88,13 +89,23 @@ BINARY_PARSERS: dict[str, Callable[[bytes], Any]] = {
     "dsa.Sig.parse": dsa.Sig.parse,
     "ssa.Sig.parse": ssa.Sig.parse,
     "bms.Sig.parse": bms.Sig.parse,
+    # no bip322.Sig.parse: that class has none, its three payloads being
+    # three unrelated serializations told apart by the prefix of the text
+    # form alone, so the text entry point below is where it is read
+    "ecies.Envelope.parse": ecies.Envelope.parse,
     "point_from_octets": point_from_octets,
     "base58.decode": base58.decode,
     "bech32.decode": bech32.decode,
 }
 
 # The same contract, for what a user pastes rather than what a peer
-# sends: an address, a WIF, an extended key, a descriptor
+# sends: an address, a WIF, an extended key, a descriptor.
+#
+# The base64 wrappers are here rather than above, and each is a parser of
+# its own: `b64decode` decodes and then hands the bytes to `parse`, so
+# what it adds is the decoding -- a str that is not ascii, padding that
+# is not canonical, a length no multiple of four -- and that is a layer
+# the binary entry point never sees
 TEXT_PARSERS: dict[str, Callable[[str], Any]] = {
     "base58.decode": base58.decode,
     "bech32.decode": bech32.decode,
@@ -102,7 +113,12 @@ TEXT_PARSERS: dict[str, Callable[[str], Any]] = {
     "b58.h160_from_address": b58.h160_from_address,
     "BIP32KeyData.b58decode": BIP32KeyData.b58decode,
     "bms.Sig.b64decode": bms.Sig.b64decode,
+    "bip322.Sig.b64decode": bip322.Sig.b64decode,
+    "Psbt.b64decode": Psbt.b64decode,
+    "ecies.Envelope.b64decode": ecies.Envelope.b64decode,
     "descriptors.checksum": descriptors.checksum,
+    "descriptors.parse": descriptors.parse,
+    "miniscript.parse": miniscript.parse,
 }
 
 

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -3987,3 +3987,23 @@ def test_a_solver_does_not_take_over_checking_the_signatures() -> None:
     assert solved.inputs[0].final_script_witness.stack[-1] == (
         signed.inputs[0].witness_script
     )
+
+
+@pytest.mark.parametrize(
+    "psbt_str",
+    [
+        pytest.param("0", id="one character, no group"),
+        pytest.param("\x80", id="not ascii"),
+        pytest.param("cHNidP8", id="a truncated group"),
+    ],
+)
+def test_b64decode_refuses_a_string_base64_cannot_read(psbt_str: str) -> None:
+    """A psbt that is not base64 is refused with the library's exception.
+
+    Found by tests/fuzz_test.py, and kept here as the input that found it:
+    `base64.b64decode` raises binascii.Error for the first and the third
+    and a plain ValueError for the second, and a caller catching
+    BTClibValueError to reject what somebody pasted caught neither.
+    """
+    with pytest.raises(BTClibValueError, match="invalid base64 encoding"):
+        Psbt.b64decode(psbt_str)


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/523.

`tests/fuzz_test.py` already ran Hypothesis over every binary and text
parser of the public surface, over near-miss mutations of valid
serializations, and over the consumers that read an object which parsed
cleanly. Three kinds of entry point the issue named were outside it:

- the base64 wrappers `Psbt.b64decode`, `bip322.Sig.b64decode` and
  `ecies.Envelope.b64decode`;
- the binary `ecies.Envelope.parse`;
- the two text languages of the descriptor package, `descriptors.parse`
  and `miniscript.parse`.

A wrapper is a parser of its own: what it adds is the decoding — a str
that is not ascii, padding that is not canonical, a length no multiple of
four — which the binary entry point beneath it never sees.

**And adding the first of them found a defect.** `Psbt.b64decode` let
`binascii.Error` out for a string base64 cannot group and a bare
`ValueError` for one that is not ascii, where `bms.Sig.b64decode` and
`ecies.Envelope.b64decode` both answer with `BTClibValueError` — and the
audience of that method is a caller handing it what somebody pasted.
Fixed, and the three inputs that found it are
`test_b64decode_refuses_a_string_base64_cannot_read` in
`tests/psbt/psbt_test.py`. Both escapes derive from `ValueError`, as
`BTClibValueError` does, so an `except ValueError` written against either
behaviour still catches: no source break, and no HISTORY.md entry.

`bip322.Sig` has no binary entry point to add — its three payloads are
told apart by the prefix of the text form alone, which its class
docstring states.

**One asymmetry left, deliberately not touched here.** `bms.Sig` and
`ecies.Envelope` require the *canonical* base64 encoding (`validate=True`
plus a re-encode comparison), so an unbounded number of strings cannot
map to one object; `Psbt.b64decode` still uses the lenient decode, which
discards anything outside the alphabet. Tightening it would refuse a
multi-line psbt that decodes today, which is a behaviour change beyond
this issue — worth deciding on its own.

The coverage-guided half of the issue is split off as
https://github.com/btclib-org/btclib/issues/530: Atheris 3.1.0 publishes
`manylinux_2_17_x86_64` wheels for cp312–cp314 and nothing else — no
macOS wheel since 2023, no aarch64, and no sdist — so the "documented
local command" the issue asked for would be `docker run` on the machines
this repository is developed on.

Gates run locally, all green: `uv run pre-commit run --all-files`,
`uv run pytest --cov`, the sphinx `-W` build, and the suite again after
the rebase onto `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve PSBT base64 decoding error handling and expand fuzz coverage for previously untested entry points.

Bug Fixes:
- Ensure Psbt.b64decode consistently raises BTClibValueError for invalid or unreadable base64 input instead of leaking binascii.Error or ValueError.

Enhancements:
- Extend fuzz testing to cover base64 wrapper entry points, ECIES binary parsing, and descriptor/miniscript text parsers.

Documentation:
- Update CHANGELOG to document the Psbt.b64decode error handling change and the expanded fuzz test coverage.

Tests:
- Add targeted regression tests for Psbt.b64decode to verify invalid base64 inputs are rejected with BTClibValueError.