### PR TITLE
Turn a malformed hwi enumerate entry into a SignerError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ documented at release-notes length in the first place, and are still in
 
 ### Descriptors and miniscript
 
+- **A malformed `hwi enumerate` entry is a `SignerError`** (#522).
+  `enumerate` is the one command whose answer is a list of objects rather
+  than one object with a known field in it, and the list was the only
+  thing checked: an entry that was a string reached `.get` and left as an
+  `AttributeError`, and two more fields left through classes this module
+  does not name. The audit that closing it started found them: a
+  fingerprint that is not four octets of hex escaped as the `ValueError`
+  `bytes.fromhex` raises, and a `code` that is not a number arrived
+  intact, in a field annotated `int | None` and read by callers as one of
+  HWI's error codes -- -14 being the button that says no.
+
+  Each of the three is now a `SignerError` naming what was wrong, which
+  is the module's own contract: a caller catches one class. Where the
+  line falls is the other half of it. `type`, `model`, `path` and `error`
+  go on being coerced with `str`, and the two flags with `bool`, because
+  those accept every object there is and a model name that arrived as a
+  number describes the device it describes; a fingerprint and a code are
+  the fields a caller acts on, and neither has a reading that is merely
+  odd. A code that is `True` is refused with the rest, `utils.is_integer`
+  being where this library already says that a boolean is not a number.
 - **`btclib.hwi` bounds what the backend writes, not what it parses**
   (#519). `max_output` was checked after `subprocess.run` had read both
   streams to EOF, so what it limited was the answer handed to the json

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -97,7 +97,7 @@ import os
 import subprocess
 import tempfile
 import time
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import IO, Any
 
@@ -108,7 +108,7 @@ from btclib.exceptions import BTClibValueError, SignerError, SignerNotFoundError
 from btclib.network import NETWORKS
 from btclib.psbt.psbt import Psbt
 from btclib.psbt_signer import SignerCapabilities
-from btclib.utils import bytes_from_octets
+from btclib.utils import bytes_from_octets, is_integer
 
 __all__ = [
     "DEFAULT_MAX_OUTPUT",
@@ -308,18 +308,66 @@ def _run(
     return answer
 
 
-def _device(entry: dict[str, Any]) -> HwiDevice:
-    """Return one enumerate entry as an `HwiDevice`, fingerprint decoded."""
+def _fingerprint(entry: Mapping[str, Any]) -> bytes | None:
+    """Return the four octets of an entry's fingerprint, or None for none.
+
+    None is a device that cannot be asked for one yet, which `HwiDevice`
+    documents; anything that is not four octets of hex is a device
+    described by a backend that is not speaking HWI's protocol, and is
+    the caller's `SignerError` rather than the `ValueError` `bytes.fromhex`
+    raises from underneath the library.
+    """
     fingerprint = entry.get("fingerprint")
+    if fingerprint is None:
+        return None
+    try:
+        return bytes_from_octets(fingerprint, 4)
+    except (TypeError, ValueError) as e:
+        err_msg = f"hwi enumerate answered an invalid fingerprint {fingerprint!r}: {e}"
+        raise SignerError(err_msg) from e
+
+
+def _code(entry: Mapping[str, Any]) -> int | None:
+    """Return an entry's error code, refusing one that is not a number.
+
+    `HwiDevice.code` is what a caller branches on -- -14 is the button
+    that says no -- so a code is a number or there is none. `is_integer`
+    and not `isinstance`, `True` being an `int` in this language and not
+    an error code in any other.
+    """
+    code = entry.get("code")
+    if code is None or is_integer(code):
+        return code
+    raise SignerError(f"hwi enumerate answered a code that is not a number: {code!r}")
+
+
+def _device(entry: Any) -> HwiDevice:
+    """Return one enumerate entry as an `HwiDevice`, its fields narrowed.
+
+    `enumerate` is the one command whose answer is a list of objects
+    rather than one object with a known field in it, so this is where a
+    json nobody validated is read. What the entry can be wrong about is a
+    `SignerError` like everything else the exchange can be wrong about: a
+    caller catches one class, and an `AttributeError` from a string that
+    stood where an object should have is not that class.
+
+    The strings and the two flags are coerced rather than refused, which
+    is the line drawn here: `str` and `bool` accept every object there
+    is, and a model name that arrived as a number describes the device it
+    describes. A fingerprint and a code are the two fields a caller acts
+    on, and neither has a reading that is merely odd.
+    """
+    if not isinstance(entry, Mapping):
+        raise SignerError(f"hwi enumerate did not answer a device: {entry!r}")
     return HwiDevice(
         type=str(entry.get("type", "")),
         model=str(entry.get("model", "")),
         path=str(entry.get("path", "")),
-        fingerprint=None if fingerprint is None else bytes_from_octets(fingerprint, 4),
+        fingerprint=_fingerprint(entry),
         needs_pin_sent=bool(entry.get("needs_pin_sent")),
         needs_passphrase_sent=bool(entry.get("needs_passphrase_sent")),
         error=str(entry.get("error", "")),
-        code=entry.get("code"),
+        code=_code(entry),
     )
 
 

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -512,6 +512,63 @@ def test_an_answer_of_the_wrong_shape_is_a_failure(tmp_path: Path) -> None:
         enumerate_devices(executable=listed)
 
 
+@pytest.mark.parametrize(
+    "entry, message",
+    [
+        pytest.param("not a mapping", "did not answer a device", id="not-an-object"),
+        pytest.param(["neither"], "did not answer a device", id="a-list"),
+        pytest.param(
+            {"fingerprint": "not hex"}, "invalid fingerprint", id="fingerprint-not-hex"
+        ),
+        pytest.param(
+            {"fingerprint": "0011"}, "invalid fingerprint", id="fingerprint-too-short"
+        ),
+        pytest.param(
+            {"fingerprint": 5}, "invalid fingerprint", id="fingerprint-a-number"
+        ),
+        pytest.param({"code": "oops"}, "code that is not a number", id="code-a-string"),
+        pytest.param({"code": True}, "code that is not a number", id="code-a-bool"),
+    ],
+)
+def test_a_malformed_enumerate_entry_is_a_signer_error(
+    tmp_path: Path, entry: object, message: str
+) -> None:
+    """A list of the right shape holding the wrong thing is still a failure.
+
+    `enumerate` is the one command whose answer is a list of objects, so
+    it is where a backend that is not speaking HWI's protocol reaches the
+    fields a caller acts on. Every one of these used to leave through a
+    class this module does not name: an `AttributeError` from `.get` on a
+    string, a `ValueError` from `bytes.fromhex` -- and a `code` that is
+    not a number used to arrive intact, in a field annotated `int | None`
+    and read as an HWI error code.
+    """
+    listed = stand_in(tmp_path, {"enumerate": [entry]})
+    with pytest.raises(SignerError, match=message):
+        enumerate_devices(executable=listed)
+
+
+def test_an_enumerate_entry_is_read_for_what_it_says(tmp_path: Path) -> None:
+    """And the fields that are prose are coerced rather than refused.
+
+    `str` and `bool` accept every object there is, and a model name that
+    arrived as a number describes the device it describes; the two fields
+    a caller acts on are the two that are refused above. A device with no
+    fingerprint is not one of those failures either -- it is a locked
+    Trezor, which `HwiDevice` documents and `_select` names in its
+    refusal.
+    """
+    entry = {"type": 5, "model": None, "error": ["locked"], "needs_pin_sent": "yes"}
+    (device,) = enumerate_devices(executable=stand_in(tmp_path, {"enumerate": [entry]}))
+    assert device.type == "5"
+    assert device.model == "None"
+    assert device.error == "['locked']"
+    assert device.needs_pin_sent
+    assert device.fingerprint is None
+    assert device.code is None
+    assert not device.is_usable
+
+
 def test_a_closed_signer_runs_nothing(hwi: list[str]) -> None:
     """A subprocess per command holds nothing open, so closing is a decision.
 


### PR DESCRIPTION
Closes #522.

`enumerate` is the one command whose answer is a list of objects rather
than one object with a known field in it, and the list was the only
thing checked: an entry that was a string reached `.get` and left as an
`AttributeError`, which is what the issue reports.

Auditing the rest of the entry found two more fields leaving through
classes this module does not name:

| entry | before |
| --- | --- |
| `"not a mapping"` | `AttributeError` |
| `{"fingerprint": "not hex"}` | `ValueError` from `bytes.fromhex` |
| `{"fingerprint": 5}` | `TypeError: object of type 'int' has no len()` |
| `{"code": "oops"}` | accepted: `HwiDevice.code == "oops"`, annotated `int \| None` |

All of them are a `SignerError` naming what was wrong now, which is the
module's own contract: a caller catches one class.

Where the line falls is the other half of it. `type`, `model`, `path`
and `error` go on being coerced with `str`, and the two flags with
`bool`, because those accept every object there is and a model name
that arrived as a number describes the device it describes; a
fingerprint and a code are the two fields a caller acts on -- -14 is
the button that says no -- and neither has a reading that is merely
odd. A code of `True` is refused with the rest: `utils.is_integer` is
where this library already says that a boolean is not a number.

Tests: the seven malformed entries above through a stand-in that prints
them, and one well-formed-but-odd entry pinning the coercion, the
absent fingerprint of a locked device included.

Gates run on this tree: `uv run pre-commit run --all-files`, `uv run
pytest --cov` (18210 passed, 5 integration tests skipped as documented,
100% coverage), and the sphinx `-W` docs build; the suite again after
rebasing onto current `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Validate `hwi enumerate` entries so malformed responses consistently surface as `SignerError` instead of leaking lower-level exceptions or invalid error codes.

New Features:
- Introduce explicit fingerprint and error code parsing helpers for HWI enumerate entries, treating invalid values as signer-level errors.

Bug Fixes:
- Ensure non-mapping enumerate entries, invalid fingerprints, and non-numeric error codes all raise `SignerError` rather than AttributeError, ValueError, or being accepted as valid codes.

Enhancements:
- Coerce descriptive fields from enumerate responses (`type`, `model`, `path`, `error`, and boolean flags) to their expected types while keeping fingerprint and code strictly validated.
- Refine `btclib.hwi` error handling contract so callers can rely on `SignerError` as the single class for malformed backend responses.

Documentation:
- Document the new `SignerError` behavior for malformed `hwi enumerate` entries in the changelog.

Tests:
- Add parameterized tests covering malformed enumerate entries and verifying they raise `SignerError` with informative messages.
- Add a test confirming that odd but well-formed enumerate entries are coerced for descriptive fields while missing fingerprints are treated as non-usable, locked devices.