### PR TITLE
Give each regtest test an account, and stop them sharing an address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -555,6 +555,15 @@ documented at release-notes length in the first place, and are still in
 
 ### Tests
 
+- **The two regtest tests get an account each**, where they shared one and
+  so shared its first address. The node is the session's, and a wallet the
+  second test to run creates still saw what the first had paid: the import
+  asks for `now`, which does not mean "scan nothing" -- Core rescans from
+  that timestamp less its two-hour window, and a regtest chain minted
+  seconds ago lies inside it whole. Order-dependent, so it passed
+  whenever xdist put the two on different workers and pytest-randomly is
+  what eventually did not; the first scheduled run of the `integration`
+  workflow (#524) is what found it, which is what that workflow is for.
 - **`tests/fuzz_test.py` reaches the entry points it was missing** (#523):
   the base64 wrappers `Psbt.b64decode`, `bip322.Sig.b64decode` and
   `ecies.Envelope.b64decode`, the binary `ecies.Envelope.parse`, and the

--- a/tests/integration/regtest_test.py
+++ b/tests/integration/regtest_test.py
@@ -45,7 +45,16 @@ pytestmark = pytest.mark.integration
 # has it for every test chain. The seed is this file's own: a key that
 # signs for coins mined in a directory pytest deletes
 ROOT = rootxprv_from_seed("0f" * 16, NETWORKS["regtest"].bip32_prv)
-ACCOUNT = "m/84h/1h/0h"
+# an account per test, and a test added here wants one of its own too.
+# The node is the session's, so two tests sharing an account derive the
+# same first address, and the wallet the second one creates sees what the
+# first paid to it: `account_import_requests` asks for `now`, which does
+# not mean "scan nothing" -- Core rescans from that timestamp less its
+# two-hour window, and a regtest chain minted seconds ago lies inside it
+# whole. Different accounts are different addresses, and `listunspent`
+# then answers for the test that asked
+RELAY_ACCOUNT = "m/84h/1h/0h"
+DECODE_ACCOUNT = "m/84h/1h/1h"
 
 
 def test_core_imports_what_btclib_exports_and_relays_what_it_signs(
@@ -55,7 +64,7 @@ def test_core_imports_what_btclib_exports_and_relays_what_it_signs(
     """The pure half of issue #381, end to end, with a node as the judge."""
     miner, watcher = wallets
     signer = SoftwareSigner(ROOT)
-    receive, change = export_account(signer, ACCOUNT)
+    receive, change = export_account(signer, RELAY_ACCOUNT)
 
     # Core imports the pair, and answers one result per request
     requests = account_import_requests(receive, change, key_range=(0, 20))
@@ -110,7 +119,7 @@ def test_the_change_output_is_what_the_node_calls_change(
     """
     miner, watcher = wallets
     signer = SoftwareSigner(ROOT)
-    receive, change = export_account(signer, ACCOUNT)
+    receive, change = export_account(signer, DECODE_ACCOUNT)
     watcher.call(
         "importdescriptors",
         [account_import_requests(receive, change, key_range=(0, 5))],
@@ -124,7 +133,7 @@ def test_the_change_output_is_what_the_node_calls_change(
 
     ((origin,),) = [output["bip32_derivs"] for output in decoded["outputs"] if output]
     assert origin["master_fingerprint"] == signer.master_fingerprint().hex()
-    assert origin["path"] == "m/84h/1h/0h/1/0"
+    assert origin["path"] == f"{DECODE_ACCOUNT}/1/0"
     assert decoded["outputs"][0] == {}
 
     # and the amount is what btclib put there, read back by Core


### PR DESCRIPTION
The `integration` workflow of
https://github.com/btclib-org/btclib/issues/524 found this on its first
run, which is what that workflow is for.

## The defect

`tests/integration/regtest_test.py` derived both tests' addresses from one
account, and the node is session-scoped. So the watch-only wallet the
*second* test to run creates still sees what the first paid:
`account_import_requests` asks for `timestamp: "now"`, which does not mean
"scan nothing" — Core rescans from that timestamp less `TIMESTAMP_WINDOW`,
two hours, and a regtest chain minted seconds ago lies inside it whole.

`listunspent` then answers with two utxos where the test asserts one:

```
E  AssertionError: assert ['2de9e1fd20e...44ec53092168'] == ['2de9e1fd20e...0504e6c8403a']
E    Left contains one more item: '32e9f278b905fd0495eef29de9b6ac46a5606bdd454d7a3bc2a244ec53092168'
```

Order-dependent, so it passes whenever xdist puts the two tests on
different workers — which is every run on a machine with cores to spare,
including the local runs that were used to check the workflow before it
merged. pytest-randomly is what eventually orders them the other way, and
a two-core runner is what puts them in the same worker. Reproduced
locally with `-n0 -p no:randomly` and the two tests named in the failing
order.

## The fix

An account each — `RELAY_ACCOUNT` and `DECODE_ACCOUNT` — so the addresses
differ and a wallet sees only its own payments. The comment beside them
says why, and that a test added there wants an account of its own too.
The path assertion of the second test now reads from its constant rather
than repeating the string.

Verified in both orders on a shared node, plus the usual gates:
`pre-commit run --all-files` and `pytest --cov` at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Assign separate accounts to each regtest integration test to prevent shared addresses from causing order-dependent failures when importing watch-only wallets on a session-scoped node.

Documentation:
- Document the regtest integration test fix and its order-dependent failure mode in the changelog under the tests section.

Tests:
- Update regtest integration tests to derive addresses from distinct accounts and adjust path assertions accordingly to ensure isolation between tests and stable results regardless of execution order.