### PR TITLE
Extend mutation testing to nine more scopes beyond #327's own four

### DIFF
--- a/.github/mutation/bip32.toml
+++ b/.github/mutation/bip32.toml
@@ -1,0 +1,44 @@
+# Extended keys, mutated: serialization, the derivation path codec beneath
+# it, and the key-origin encoding PSBT carries. A wrong depth, a wrong
+# fingerprint or a hardened-index bit read the wrong way round is exactly
+# the class of boundary #219 and #327 ask mutation testing to check for --
+# every line runs under the existing vectors, and this asks whether the
+# suite would notice one of them being wrong.
+
+[cosmic-ray]
+module-path = [
+  "btclib/bip32/bip32.py",
+  "btclib/bip32/key_origin.py",
+  "btclib/bip32/der_path.py",
+]
+
+test-command = "python -m pytest -x -q -n0 -p no:randomly tests/bip32"
+
+timeout = 300
+
+excluded-modules = []
+
+# 1356 mutants, complete: 1123 killed, 233 survived. 66 are the deferred-
+# annotation class fetch.toml documents, 19 the keyword-only `*` to `/`
+# marker sig_hash.toml's docstring already names, 6 an `is` CPython's
+# small-int cache makes indistinguishable from `==`.
+#
+# Of the 142 real ones, three were genuine gaps, closed:
+#
+# - `is_root` was not exercised by any caller, so every operator on its
+#   three-way `and` survived together -- depth, index and parent
+#   fingerprint each compared, none of the three tested. A valid object
+#   can only vary the depth term (`_assert_valid_depth_and_index` ties
+#   depth zero to index zero and to a zero fingerprint), so the other two
+#   needed `check_validity=False` to isolate at all.
+# - `str_from_der_path`'s fingerprint length check was tested short
+#   (`!= 8` weakened to `< 8` still refuses six octets) and never long.
+#
+# The rest are the same shape scattered one or two at a time across forty
+# other methods -- a boundary compared or an argument's default never
+# exercised at the value that would tell one operator from another --
+# each needing its own look the way `is_root` did. Sampled as data here
+# rather than chased method by method.
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/bip32.toml
+++ b/.github/mutation/bip32.toml
@@ -39,6 +39,150 @@ excluded-modules = []
 # exercised at the value that would tell one operator from another --
 # each needing its own look the way `is_root` did. Sampled as data here
 # rather than chased method by method.
+#
+# A second pass worked through that data, file by file.
+#
+# `der_path.py`: three more real gaps. `steps[0].lower() == "m"` weakened
+# to `>=` would strip any step sorting at or after "m" instead of "m"
+# alone; the depth-255 boundary a der_path string can carry (`> 255`
+# weakened to `> 256`); and the per-element type check inside
+# `indexes_from_der_path`'s iterable branch, replaced with a loop over
+# nothing, uncaught because every existing iterable vector is already
+# all integers.
+#
+# `key_origin.py`: `BIP32KeyOrigin`'s own `check_validity` default was
+# untested on all four of `to_dict`/`from_dict`/`serialize`/`parse`, the
+# same class `block.toml` and `signatures.toml` already name -- with the
+# added wrinkle that `parse` reads its four fingerprint octets
+# structurally regardless of check_validity, so the over-long-fingerprint
+# vector that catches the other three needed a too-deep der_path instead
+# to reach `assert_valid`'s own check for `parse`, and `from_description`
+# needed a too-*short* description, `data[:8]` on four hex characters
+# giving a fingerprint only `assert_valid` -- not the slice -- refuses.
+# `decode_hd_key_paths`'s `{...} if map_ else {}` negated returned `{}`
+# for a populated map, silently dropping every entry; nothing had passed
+# it one, only `None` and `{}`. `assert_valid_hd_key_paths`'s pub_key
+# length set, `{78, 33, 65}`, had all six of its numeric neighbors
+# survive with no vector at any of the three lengths' plus-or-minus-one,
+# and its per-entry loop, replaced with one over nothing, survived
+# because every existing map has one entry or is invalid in that one.
+# `BIP32KeyOrigin`'s `@dataclass(frozen=True)` was untested directly.
+#
+# `bip32.py`, real gaps beyond `is_root`'s three field-comparison
+# survivors closed in the first pass, `is_root` also needing its two
+# `Eq_LtE` mutations (`self.depth == 0`/`self.index == 0` weakened to
+# `<= 0`) closed with a negative case, no existing vector using a
+# negative depth or index:
+#
+# - `is_hardened`'s `>= _HARDENED_OFFSET` weakened to `==`, and the same
+#   expression inside `__pub_key_path_derivation` and
+#   `_derive_from_account`'s branch and address_index checks: every
+#   existing hardened index in the test vectors (`0h`, `44h`) lands
+#   exactly on the offset, so nothing had ever derived, or refused to
+#   derive, past it. `__prv_key_derivation`'s and
+#   `pub_key_derivation_tweaks`'s own copies of the same expression
+#   were already exercised past the boundary (`463h`, `m/1h`) and did
+#   not survive.
+# - `_assert_valid_depth_and_index`'s two closed ranges, `0 <= depth <=
+#   255` and `0 <= index <= 0xffffffff`, tested short and long on both
+#   sides already but never at the top of either range itself.
+# - `_assert_valid_key`'s chained `0 < q < secp256k1.n`, which cosmic-ray
+#   mutates as two independent comparisons: the left one, `0 < q`
+#   weakened to `0 != q`, is equivalent (q is an unsigned parse, never
+#   negative, so the two agree everywhere); the right one, `q < n`
+#   weakened to `q != n`, is not -- both existing invalid-key vectors
+#   put q at 0 and at n exactly, so `q != n` alone already refuses
+#   either, and only a scalar strictly above n tells `q < n` apart from
+#   it.
+# - four prefix-refusal messages -- the private and public key checks in
+#   `_assert_valid_key`, `_xpub_from_xprv`'s "not a private key", and
+#   `_err_msg` -- all slice one byte, `key[:1].hex()`, widened by
+#   `NumberReplacer` to `key[:2]`. Every existing vector matches the
+#   message with `pytest.raises(match=...)`, which searches rather than
+#   anchors, so a wider slice's hex still contains the narrower one as a
+#   leading substring and the widening was never caught; an exact
+#   `str(excinfo.value) ==` comparison is what tells them apart.
+# - `pub_key_derivation_tweaks`'s `offset.to_bytes(32, ...)` widened to
+#   33: the existing test compares the point the tweaks reconstruct,
+#   which a leading zero byte does not move, so nothing had checked the
+#   tweaks' own length.
+# - `_force_version` was entirely unexercised -- no test anywhere passed
+#   `derive`'s `forced_version` argument -- so its `in`/`not in` checks
+#   negated and its `bytes_from_octets(forced_version, 4)` widened to 5
+#   or narrowed to 3 all survived for want of a single call.
+# - `b58decode`'s `isinstance(address, str)` negated would strip bytes
+#   instead of strings, untested since no vector passes a string with
+#   whitespace to strip in the first place.
+# - `BIP32KeyData`'s own `check_validity` default, untested on all four
+#   of `__init__`/`serialize`/`b58encode`/`parse` the way key_origin.py's
+#   was -- a zero depth with a non-zero parent fingerprint serializes
+#   structurally fine and is refused only by `assert_valid`'s cross-field
+#   check, the one check_validity=False defers at each of the four.
+#   `_BIP32KeyData.__init__`'s own copy of the same guard, `if
+#   check_validity` negated to `if not check_validity`, needed a direct
+#   call: `_derive` only ever builds one from an already-valid key, so
+#   nothing through the public API reaches it invalid.
+# - `_derive`'s `final_depth > 255`, tested long (256) but not at the
+#   boundary itself (255).
+# - `derive_from_account`'s `max_index: int = 0xffff` widened to 65536
+#   or narrowed to 65534: the *public* function's own default, tested at
+#   the boundary. `_derive_from_account`, the private function one layer
+#   down, carries an identical-looking default that is equivalent for a
+#   different reason below.
+#
+# Checked and left equivalent:
+#
+# - `_assert_valid_depth_and_index`'s `parent_fingerprint != b"\x00" * 4`
+#   weakened to `>`, and `index != 0` weakened to `>`: a 4-byte value
+#   can never sort below all-zero and an index can never be negative
+#   (both already checked above this point), so `!=` and the one-sided
+#   comparison agree everywhere reachable -- the same bytes-minimum and
+#   non-negative-bound reasoning `key_origin.py`'s own first pass used.
+# - `is_private`'s `self.key[0] == 0` and `__repr__`'s `self.key[:1] ==
+#   b"\x00"` weakened to `<=`: a byte value and a single all-zero byte
+#   string are each their own minimum, so `==` and `<=` coincide.
+# - four `key[1:]` reads -- in `_assert_valid_key`, `_xpub_from_xprv`,
+#   `_BIP32KeyData.__init__`, and `crack_prv_key` -- widened to `key[0:]`:
+#   each is reached only after its own `key[0] != 0` guard (directly, or
+#   through `is_private`) has already confirmed that first byte is zero,
+#   and a leading zero byte never changes a big-endian integer's value,
+#   so the extra byte in the slice is silent.
+# - `is_root`'s three-way `and` negated to `or` at either junction: the
+#   existing `non_root_depth`/`non_root_index`/`non_root_fingerprint`
+#   cases already isolate each term to false while the other two hold,
+#   which is exactly what an `and`-to-`or` widening needs a witness
+#   against.
+# - `RemoveDecorator` on `is_root`'s own `@property`: turns `.is_root`
+#   into a bound method, always truthy whether or not the key is root,
+#   which the existing `assert not other.is_root` cases already catch
+#   (a truthy bound method fails `not`).
+# - `RemoveDecorator` on `_BIP32KeyData`'s own `@dataclass(repr=False)`:
+#   the class defines its own `__init__`, which a manual `_set_new_
+#   attribute`-style check in `dataclasses` never overwrites either way;
+#   `repr=False` already means "inherit the parent's", identical with or
+#   without the decorator; and the `__eq__` the decorator would add
+#   compares `prv_key_int`/`pub_key_point` beside the six inherited
+#   fields, but both are pure functions of `key` and `is_private`, values
+#   already in that comparison -- two instances equal on the six can
+#   never disagree on the two derived from them, so the wider or the
+#   narrower `__eq__` never differs in what it answers.
+# - `_rootxprv_from_seed`'s `bit_length < 128` and `> 512` widened by one
+#   to 127 and 513: `bit_length = len(seed) * 8` is always a multiple of
+#   8, so 127 and 513 are values no byte-sized seed can ever produce --
+#   every reachable bit_length either both operators accept or both
+#   refuse.
+# - `_derive_from_account`'s own `max_index: int = 0xffff` default: the
+#   public `derive_from_account` above it always passes its own
+#   `max_index` down explicitly, so the private function's default is
+#   never the value actually used -- an unreachable default, the same
+#   class `key_origin.py`'s `_pairs_from_der_path_str` and
+#   `_decode_from_bip32_deriv` are.
+#
+# Not chased further, the same shape as the first pass's own note: the
+# `signed=False` reads and writes across the various `to_bytes`/
+# `int.from_bytes` calls in the derivation functions, and the
+# public-key-prefix set `{2, 3}`'s own numeric neighbors, both sampled
+# rather than exhausted.
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/bip322.toml
+++ b/.github/mutation/bip322.toml
@@ -36,6 +36,61 @@ excluded-modules = []
 # class parsers.toml's follow-up already names; the rest is comparison
 # operators and off-by-ones scattered across the input-validation and
 # signing helpers, sampled as data here.
+#
+# A second pass worked through that data and closed the real gaps in it:
+#
+# - `Sig.b64decode`'s and `_is_bms`'s own `validate=True` each had no
+#   caller telling `base64.b64decode` apart from its lenient twin --
+#   `Sig.b64decode`'s is a real gap, a smuggled newline mid-signature
+#   silently stripped and decoded instead of refused; `_is_bms`'s is
+#   equivalent, below.
+# - `_is_bms`'s `== _BMS_SIZE` weakened to `<=` let a base64 blob
+#   shorter than 65 octets sniff as a legacy signature: `assert_as_valid`
+#   still refuses it, but through `bms.Sig.parse`'s own length check
+#   rather than `Witness.parse`'s, a `BTClibValueError` where the
+#   correct routing raises `BTClibRuntimeError`.
+# - `_assert_shape`'s error message named `tx.vin[0]` in the f-string
+#   alone, never a `to_sign` with a second input whose id is not the
+#   first's -- reachable because `_assert_shape` allows more than one
+#   input (proof of funds), unlike every other index into a `tx.vin` or
+#   `tx.vout` this file also has, see below.
+# - `Sig.b64decode`'s `prefix == FULL`/`SIMPLE` `parse`'s three-way
+#   dispatch had a wrong upper boundary already caught by
+#   `test_b64decode_refuses_what_is_not_base64`; the two remaining
+#   comparisons proved equivalent rather than needing a vector, next.
+#
+# Checked and left equivalent:
+#
+# - the three-way `prefix` dispatch (`smp`/`ful`/`pof`) weakened to `<=`
+#   or `>=`: `ful` sorts first and `smp` last of the three reachable
+#   values, so each bound coincides with `==` over that closed set the
+#   same way ScriptType's alphabetical extremes do below.
+# - `_assert_key_owns`'s `len(pub_key) == 33` weakened to `<=`: a key is
+#   33 bytes compressed or 65 uncompressed, never anything shorter, so
+#   no value this function is ever called with falls between them.
+# - `sign`'s `script_type == "p2sh"` weakened to `<=` or `>=`, reachable
+#   for `p2pkh` and for `p2tr`/`p2wpkh` respectively: the `script_sig` it
+#   guards is overwritten outright for `p2pkh`, never read back for
+#   `p2tr` (returned before reaching it) or for native `p2wpkh` (the
+#   *simple* variant returns the witness alone), so a wrong value there
+#   reaches no output regardless of which address type set it.
+# - `sign`'s `script_type == "p2pkh"` weakened to `<=`: `p2pkh` sorts
+#   first of the four types `_assert_key_owns` recognizes, the same
+#   extremity as `_assert_p2pkh`'s check in `bms.toml`. `== "p2wpkh"`
+#   weakened to `>=` in the final return: `p2tr` and `p2pkh` already
+#   returned earlier, and `p2wpkh` sorts after the one type left,
+#   `p2sh`, making it the extreme of what is left to compare.
+# - `type_and_payload(script_pub_key)[0] != "p2pkh"` weakened to `>`:
+#   `from_address` only ever produces p2pkh, p2sh or a segwit type for
+#   this call, and p2pkh sorts before all four of the others, the same
+#   reasoning `bms.toml` gives for its own p2pkh dispatch.
+# - six of the seven `NumberReplacer` survivors turn `tx.vin[0]` or
+#   `tx.vout[0]` into `tx.vin[-1]`/`tx.vout[-1]`: `_assert_shape` checks
+#   `len(tx.vout) != 1` before either of its own `tx.vout[0]`s, and
+#   every one of `sign`'s own is on the `vin` `to_sign` builds with no
+#   `extra_inputs`, always length 1 -- `[0]` and `[-1]` name the same
+#   element throughout. The `_assert_shape` survivor above is the one
+#   exception, on the very field that is allowed more than one.
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/bip322.toml
+++ b/.github/mutation/bip322.toml
@@ -1,0 +1,41 @@
+# BIP322 generic signed messages, mutated. The newest module in this
+# directory's scope -- it lands the same week as this profile -- and one
+# whose whole point is a signature an address cannot be recovered from,
+# built out of `ecc.bms`, `ecc.dsa`, `ecc.ssa`, `script.engine` and `psbt`
+# already running under their own coverage. Mutation testing on day one
+# rather than after a defect report is what #219's question is for: whether
+# the suite would notice a wrong boundary before somebody else finds one.
+
+[cosmic-ray]
+module-path = "btclib/bip322.py"
+
+test-command = "python -m pytest -x -q -n0 -p no:randomly tests/bip322_test.py"
+
+timeout = 300
+
+excluded-modules = []
+
+# 508 of the 977 mutants sampled in 1200 s: 405 killed, 103 survived. 44
+# are the deferred-annotation class fetch.toml documents, 5 the keyword-
+# only marker, 4 an `is` CPython's small-int cache makes indistinguishable
+# from `==`.
+#
+# One real gap closed, and the most consequential this session found:
+# REQUIRED_RULES and UPGRADEABLE_RULES are each a `|` chain over distinct-
+# bit ScriptFlag members, and nothing called either name to check the
+# result -- an `&` at any position collapses everything accumulated left
+# of it against a single bit, so REQUIRED_RULES could have silently been
+# one flag wide instead of the seven the module lists. A `^` at the first
+# position of UPGRADEABLE_RULES survives the same test and is equivalent
+# there on purpose: two disjoint bits combine the same way under `^` and
+# under `|`, which is not true once a third term brings the accumulator
+# past a single bit -- exactly why the later positions in both chains die.
+#
+# check_validity defaults account for another block (Sig.serialize,
+# b64encode, b64decode, assert_as_valid's `legacy` parameter), the same
+# class parsers.toml's follow-up already names; the rest is comparison
+# operators and off-by-ones scattered across the input-validation and
+# signing helpers, sampled as data here.
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/block.toml
+++ b/.github/mutation/block.toml
@@ -50,6 +50,169 @@ excluded-modules = []
 # merkle_root one fixed above and were not each given their own test;
 # the remainder is comparison operators in the parsing and validation
 # helpers, sampled as data here.
+#
+# A second pass worked through that data. Real gaps closed, by file:
+#
+# `proof_of_work.py`
+# - `block_work`'s `target + 1` weakened to `| 1` or `^ 1` agrees with
+#   `+` on every even target, 2 (the earlier vector) included; only an
+#   odd one -- 1, giving 2, 1 and 0 respectively -- tells the three apart.
+# - `block_work`'s own `int.from_bytes(..., signed=False)` read of the
+#   target: a target past 2^255 is misread negative, and nothing here
+#   wraps it back the way `next_bits`'s multiply-mod-2^256 does for the
+#   equivalent read there (below) -- `2**256 // (target + 1)` on a
+#   negative target is simply wrong.
+# - `next_bits`'s own read of `pow_limit_bits`, the same signedness bug
+#   one call further down: `min(target, pow_limit)` has no modulus after
+#   it to undo a misread, and a synthetic `pow_limit_bits` past 2^255
+#   turns the `min` negative, `to_bytes(..., signed=False)` then raising
+#   `OverflowError` where the correct read returns the smaller, positive
+#   `target` unclamped.
+# - `next_bits`'s `% 2**256` weakened to `% 2**255`: provably reachable,
+#   unlike the read above -- the two moduli agree whenever the product
+#   stays under 2^255, which most vectors do, but a target and timespan
+#   chosen so the product's own bit 255 is set (bits `1e080000`, an
+#   unchanged two-week period) came back wrong under the narrower ring.
+# - `bits_from_target`'s `exponent <= 3` weakened to `<= 4` sends
+#   exponent 4 through the left-shift branch by a *negative* amount --
+#   `ValueError`, not a quiet wrong answer, and exponent 4 is the first
+#   value the widened boundary newly admits.
+# - `DIFFICULTY_ADJUSTMENT_INTERVAL`'s `//` weakened to `/`: the float it
+#   produces still equals 2016, floating point being exact at this size,
+#   but is no longer the `int` `retarget_first_height`'s subtraction wants.
+#
+# `block_header.py`
+# - `assert_valid`'s version range, `0 < self.version <= 0x7FFFFFFF`: the
+#   lower bound was pinned at zero, `0 != self.version` still refusing
+#   only that one value and letting every negative one through; the
+#   upper bound had no vector at 0x7FFFFFFF itself, so `< 0x7FFFFFFF` and
+#   the literal `2147483646` each passed by refusing a version every
+#   other vector in the suite already carries.
+# - `assert_valid`'s `0 <= self.nonce`: pinned at zero the same way,
+#   `-1 <=` unrefused by any existing vector, all of them non-negative.
+# - `check_validity` defaults on `__init__`, `to_dict`, `from_dict`,
+#   `serialize` and `parse`, and the `if check_validity:` guards in
+#   `to_dict` and `serialize` themselves (`AddNot`) -- the same class
+#   `parsers.toml`'s follow-up names, closed here the way `bms.toml` and
+#   `bip322.toml` closed theirs: a negative version is invalid on its
+#   own and needs `signed=True` to survive the round trip below, so one
+#   fixture exercises the checked-vs-bypassed default at every one of
+#   the five entry points at once.
+# - `hash`'s own `serialize(check_validity=False)` weakened to `True`:
+#   `True` there would refuse to hash the very header being mined,
+#   before its proof-of-work exists to check.
+# - `serialize`'s `self.version.to_bytes(..., signed=True)` and `parse`'s
+#   `int.from_bytes(header_bin[:4], ..., signed=True)`: the same negative
+#   version above needs both to survive a `check_validity=False` round
+#   trip without an `OverflowError` on the way out or a wrong 4-byte
+#   unsigned reading on the way back.
+# - `parse`'s own `t = int.from_bytes(rest[:4], ..., signed=False)` for
+#   the *timestamp*: unrelated to the version bug above, and unguarded
+#   by any round trip through `assert_valid` -- a real, valid instant
+#   past 2038 (`assert_valid` allows up to 2106) has its top bit set and
+#   comes back over a century early, silently, under `signed=True`.
+# - `_EPOCH`'s `datetime.fromtimestamp(0, ...)`, and `__init__`'s
+#   `version: int = 1` and `nonce: int = 0` defaults: nothing had ever
+#   asked what a bare `BlockHeader(check_validity=False)` carries in the
+#   three fields it does not name.
+#
+# `block.py`
+# - `assert_valid_length`'s transaction-count check, `count *
+#   WITNESS_SCALE_FACTOR > MAX_BLOCK_WEIGHT` weakened to `count <<
+#   WITNESS_SCALE_FACTOR`: the existing vector at `limit + 1` triggers
+#   both, so a count between the count check's own boundary and the
+#   *stripped-size* check's -- 250,001, a quarter-million real (if
+#   reused) coinbases -- raises on a different message under each,
+#   proving the widened check moved.
+# - The same check's `stripped_size` half, and `assert_valid_weight`'s
+#   `weight > MAX_BLOCK_WEIGHT`, each weakened to `>=`: all three had a
+#   vector one past the cap and none sitting on it, so each rule's own
+#   boundary value was untested territory of its own.
+# - `vsize`'s `ceil(self.weight / 4)` weakened to `// 4`: every existing
+#   weight vector happens to be a multiple of four, where the two agree;
+#   one more witness byte moves the weight off that multiple.
+# - `height`'s `self.header.version == 1` weakened to `<= 1`: version 0
+#   is not version 1, and nothing had asked a coinbase with a BIP34
+#   commitment and a version below 1 whether it still decoded.
+# - `assert_valid_merkle_root`'s `!=` and `assert_valid_witness_commitment`'s
+#   `!=`, each weakened to one direction (`<` and `>` respectively): the
+#   existing wrong-value vectors each happen to sort the direction the
+#   weakened operator still catches; block 170 with its last transaction
+#   popped, and a witness nonce of `21 * 32`, each sort the other way.
+# - `bip34_commitment`'s `-1 <= height`: four different mutations on the
+#   same term (`!=`, `<`, `~1` i.e. -2, and the literal `-0`), and no
+#   test had ever called the function directly. Height -1 and -2 are the
+#   two boundary values `op_int`'s own op-code range needs told apart --
+#   `-2` is refused by `op_int` outright, not silently miscoded.
+# - `witness_commitment`'s `len(script) >= _COMMITMENT_LENGTH` weakened
+#   to `==` or `<=`: every commitment output on hand happens to be
+#   exactly the minimum length; nothing followed the prefix with extra
+#   bytes the way an unrelated later push in the same script could.
+# - `assert_valid`'s `self.transactions[0].assert_valid()` weakened to
+#   `[-1]`: on the one-transaction block 1 the two names are the same
+#   object, so a second, non-coinbase transaction -- block 200,000's --
+#   is what tells a coinbase validated from one that merely resembles it
+#   because the loop below already checked it once as `transactions[1:]`.
+# - `check_validity` defaults on `to_dict`, `from_dict` and `serialize`,
+#   the `to_dict` guard (`AddNot`), and the six internal calls that
+#   hardcode `check_validity=False` when a sub-object is converted
+#   without being judged -- the header and each transaction inside
+#   `to_dict`/`from_dict`, and the transactions inside the merkle-root
+#   and witness-commitment hash loops. One fixture (a valid coinbase
+#   beside a transaction with no outputs, refused on its own) exercises
+#   the whole set: every conversion has to survive it, and `True`
+#   anywhere in the chain raises on the second transaction's own account
+#   instead of leaving that to whichever `assert_valid` a caller made.
+#
+# Checked and left equivalent, the patterns already established
+# elsewhere in this session applied to this module's own call sites:
+#
+# - bit-disjoint offsets, `4 + _HF_LEN`/`4 + 2 * _HF_LEN` in
+#   `BlockHeader.parse` and `len(_COMMITMENT_PREFIX) + 32` in `block.py`:
+#   4, 6, 32 and 64 share no set bit with each other, so `|` and `^`
+#   against `+` agree everywhere these constants are used.
+# - the exponent-3 boundary, on both sides: `target_from_bits`'s
+#   `exponent < 3` weakened to `<= 3` and `bits_from_target`'s
+#   `exponent <= 3` weakened to `< 3` each move exponent 3 to the other
+#   branch, and both branches shift by zero there -- `3 - 3` either way
+#   -- so the branch taken is not observable. The same identity, `3 - e
+#   == 3 ^ e` for e in 0..3, is what makes `ReplaceBinaryOperator_Sub_BitXor`
+#   equivalent at both of the two lines it appears on.
+# - masking cancels an extra byte or a sign, three ways: `_value_from_bits`'s
+#   and `is_negative_bits`'s `bits[1:]` weakened to `bits[0:]` is undone
+#   by `_SIGNIFICAND_MASK`/`_SIGNIFICAND_SIGN_BIT` immediately after,
+#   both masks landing below the extra byte's own bit positions;
+#   `bool(significand & _SIGNIFICAND_SIGN_BIT)` weakened to `//` agrees
+#   with `&` because `significand` is always under 2^24 at both call
+#   sites (the second by construction, the shift just above it sized to
+#   guarantee it); and `assert_valid_pow`'s zero-check, `int.from_bytes`
+#   read `signed=False` weakened to `True`, is a truthiness test that a
+#   sign flip cannot change -- zero is zero, negative-nonzero is still
+#   truthy nonzero.
+# - a coinbase has exactly one input, `Tx.is_coinbase` requiring it, and
+#   `_assert_coinbase` having already asked before any of `height`,
+#   `assert_valid_witness_commitment` or `assert_valid_coinbase_height`
+#   reads `self.transactions[0].vin[0]`: `[-1]` there names the same
+#   object. The witness stack index right after it is the same
+#   argument once more, guarded by the `len(witness_stack) != 1` check
+#   on the line above instead.
+# - `next_bits`'s own two remaining `signed=False` reads: the one for
+#   `target` is undone the same way the modulus above is real for --
+#   `(target * timespan) % 2**256` cancels a misread by exactly 2^256,
+#   which subtracting or not on the way in does not survive -- and the
+#   final `target.to_bytes(..., signed=False)` never reaches a value
+#   past 2^236 to begin with, `// POW_TARGET_TIMESPAN` on a sub-2^256
+#   numerator bounding it three orders of magnitude below the sign bit
+#   the mutation would need.
+# - `BlockHeader.parse`'s `len(header_bin) != _REQUIRED_LENGTH` against
+#   `<`: `stream.read(_REQUIRED_LENGTH)` never returns more, the same
+#   bounded-read reasoning `bms.toml`'s `Sig.parse` gives; its final
+#   `rest[8:12]` against `rest[8:13]`, `rest` itself exactly 12 bytes by
+#   that point, Python's own slice-past-the-end silently clipping to it.
+# - `BlockHeader.assert_valid_pow`'s `self.hash > target` against `>=` is
+#   the file's own pre-existing answer, unchanged: a hash equal to the
+#   target is the last one that solves the block, and constructing one
+#   is asking a 256-bit hash for one exact value.
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/block.toml
+++ b/.github/mutation/block.toml
@@ -1,0 +1,55 @@
+# The block header and the block around it, mutated. Not a hypothetical
+# scope: issue #134 is merkle_root accepting the CVE-2012-2459 duplicate-
+# transaction mutation, and issue #163 is Block.assert_valid not checking
+# the BIP-141 witness commitment -- both found in code that already ran
+# under 100% statement coverage, which is #219's question stated twice
+# already in this one directory before mutation testing existed to ask it
+# on purpose. proof_of_work.py is beside them for the same target/nBits
+# boundary the header's own difficulty check depends on.
+
+[cosmic-ray]
+module-path = [
+  "btclib/block/block.py",
+  "btclib/block/block_header.py",
+  "btclib/block/proof_of_work.py",
+]
+
+test-command = "python -m pytest -x -q -n0 -p no:randomly tests/block"
+
+timeout = 300
+
+excluded-modules = []
+
+# 1481 mutants, complete: 1314 killed, 167 survived. 55 are the deferred-
+# annotation class fetch.toml documents, 9 the keyword-only marker, 4 an
+# `is` CPython's small-int cache makes indistinguishable from `==`.
+#
+# Two real gaps closed:
+#
+# - `block_work`'s `2**256 // (target + 1)` against `target - 1`: every
+#   existing vector's target sits within a whisker of 2^224, where the
+#   two floor-divide 2^256 to the same integer -- a target as small as 2
+#   is what separates them, `- 1` on that one being the difference
+#   between a quarter of 2^256 and all of it.
+# - `hash_rate`'s `difficulty <= 0` and `timespan <= 0`, each tested at
+#   zero only: a negative difficulty told `<= 0` from `== 0`, and
+#   timespan 1 told `<= 0` from the `<= 1` that would have refused the
+#   smallest positive one.
+#
+# One survivor is already the file's own answer, not this session's:
+# `BlockHeader.assert_valid`'s `self.hash > target` weakened to `>=` is
+# the proof-of-work check reading Core's own comparison, and the comment
+# beside it says why no vector can move it -- a hash equal to the target
+# is the last one that solves the block, and constructing one is asking
+# a 256-bit hash for one exact value.
+#
+# check_validity defaults account for a large block of the rest (Block
+# and BlockHeader each carry several), the same class parsers.toml's
+# follow-up already names; length checks scattered across
+# BlockHeader/Block's field validation are the same shape as the
+# merkle_root one fixed above and were not each given their own test;
+# the remainder is comparison operators in the parsing and validation
+# helpers, sampled as data here.
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/bms.toml
+++ b/.github/mutation/bms.toml
@@ -40,11 +40,51 @@ excluded-modules = []
 #   another here -- what a caller can assert is that the result lands in
 #   range, which every operator that survived still does most draws.
 #
-# check_validity defaults account for another block (`serialize`,
-# `b64encode`, `b64decode` each carry one), the same class parsers.toml's
-# highest-yield follow-up already names. The remainder is comparison
-# operators scattered across the address-type dispatch in `assert_as_valid`
-# and its helpers, each needing its own vector; sampled as data here.
+# A second pass worked through the address-type dispatch and the
+# check_validity/lower_s defaults this file's first pass sampled rather
+# than chased, closing the rest of the real gaps:
+#
+# - `_assert_p2pkh`/`_assert_p2wpkh`/`_assert_p2wpkh_p2sh`'s recovery-
+#   flag ranges were each pinned by a single vector -- 39 for p2pkh, 35
+#   for p2wpkh -- which only ever moves one side of a range that has
+#   two boundaries apiece. Swept 27..42 against all three directly
+#   (bypassing `assert_as_valid`'s own recovery, which does not find a
+#   point for every `rf`/signature pair and is a fact about elliptic-
+#   curve recovery rather than about the range check) with a wrong key
+#   and a real address: every valid `rf` fails on the address, every
+#   invalid one on the flag itself, so a boundary moved either way shows.
+# - `Sig.assert_valid`'s own `self.rf > 42` was tested at 26 below the
+#   range and never at 42, the upper boundary itself.
+# - the four hash/signature comparisons (`!=` weakened to `<` or `>`)
+#   guarding p2wpkh, p2wpkh-p2sh and the base64 canonical check were each
+#   tested with a mismatch that happens to sort the wrong way for `<`/`>`
+#   to also catch; sorting the other way is what a real forged key or a
+#   non-canonical encoding is not guaranteed to do.
+# - `_assert_p2wpkh`'s `wit_ver != 0` weakened to `< 0` survived because
+#   wit_ver is never negative; a *non-zero* version paired with a
+#   20-byte program -- valid for no other witness type -- is what a
+#   version-0-only length check cannot rule out on its own.
+# - check_validity defaults on `serialize`, `b64encode` and `parse` had
+#   no test building an invalid `Sig` and calling any of the three at
+#   their default; `assert_as_valid`'s and `verify`'s `lower_s` default
+#   had no test relying on it instead of passing the keyword.
+#
+# Checked and left equivalent: `script_type == "p2pkh"` against `<=`,
+# `p2sh` being the only other value and always sorting after `p2pkh`;
+# `Sig.parse`'s `len(sig_bin) != 65` against `<`, `stream.read(65)`
+# never returning more than 65 bytes to begin with; `_assert_p2wpkh`'s
+# `len(h160) != 20` against `>`, wit_ver 0 restricted upstream to
+# exactly 20 or 32 bytes, both already caught by `> 20`; the base64
+# decode's own `validate=True` against `False`, undone by the re-encode
+# comparison the line right after it already makes; and
+# `_libsecp256k1_applicable`'s branch negated, both paths already held
+# to the same answer by `test_the_python_path_answers_the_same`.
+#
+# One survivor left open: `compressed = sig.rf > 30` needs `rf == 30`
+# exactly to move, which needs key_id 3 -- the recovery id secp256k1
+# assigns when a nonce's x-coordinate lands past the group order,
+# probability on the order of (p-n)/p, roughly 2^-128. Not constructible
+# without a synthetic (r, s) built to force it, which was not attempted.
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/bms.toml
+++ b/.github/mutation/bms.toml
@@ -1,0 +1,50 @@
+# Bitcoin message signing, mutated: the legacy and segwit signature formats
+# `bms.py` builds on `ecc.dsa` and the address decoders. A wrong recovery
+# id or a normalization dropped silently is a signature that verifies
+# against the wrong key rather than failing, which coverage cannot
+# distinguish from the correct line running -- the same question #219 and
+# #327 ask of the consensus and wire-format code, here on the message-
+# signing boundary.
+
+[cosmic-ray]
+module-path = "btclib/ecc/bms.py"
+
+test-command = "python -m pytest -x -q -n0 -p no:randomly tests/ecc/bms_test.py"
+
+timeout = 300
+
+excluded-modules = []
+
+# 496 of the 977 mutants sampled in 1200 s: 360 killed, 136 survived. 66
+# are the deferred-annotation class fetch.toml documents, 5 the keyword-
+# only marker, 2 an `is` CPython's small-int cache makes indistinguishable
+# from `==`.
+#
+# One real gap closed: `Sig` is `@dataclass(frozen=True, init=False)`, and
+# nothing after construction ever assigned to a field to find out whether
+# the frozen half of that still held -- `frozen=False` survived next to
+# it. `__init__` itself goes through `object.__setattr__` on purpose (the
+# comment on `dsa.Sig.__init__` gives the reason), so the property being
+# pinned is what every other assignment is refused, not what the
+# constructor does.
+#
+# Two shapes account for most of the rest, checked rather than assumed:
+#
+# - `r = int.from_bytes(sig_bin[1 : 1 + n_size], ...)`: `n_size` is
+#   secp256k1's 32, whose bit 0 is unset, so `+`, `|` and `^` against the
+#   literal `1` agree -- the operator family this survives for is
+#   equivalent for the one curve this module signs on.
+# - `prv_key = 1 + secrets.randbelow(ec.n - 1)` in `gen_keys`: mutating
+#   the arithmetic changes a formula whose output is random on every call
+#   regardless, so no fixed vector distinguishes one operator from
+#   another here -- what a caller can assert is that the result lands in
+#   range, which every operator that survived still does most draws.
+#
+# check_validity defaults account for another block (`serialize`,
+# `b64encode`, `b64decode` each carry one), the same class parsers.toml's
+# highest-yield follow-up already names. The remainder is comparison
+# operators scattered across the address-type dispatch in `assert_as_valid`
+# and its helpers, each needing its own vector; sampled as data here.
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/codecs.toml
+++ b/.github/mutation/codecs.toml
@@ -30,20 +30,47 @@ excluded-modules = []
 # are the deferred-annotation class fetch.toml documents, 2 an `is`
 # CPython's small-int cache makes indistinguishable from `==`.
 #
-# One real gap, closed: `bech32._decode`'s `UnicodeDecodeError` catch for
-# a byte string outside ascii had no caller supplying one -- every bytes
-# input in the suite was `str.encode("ascii")` on an already-valid bech32
-# string, which cannot raise it.
+# A second pass on this same 490-mutant sample closed every other real
+# candidate:
 #
-# Most of the rest -- a dozen or so -- are `b32.convertbits`'s `max_acc`
-# mask, computed with `+`, `-`, `<<` and `-1` all replaced in turn.
-# Checked by hand rather than left assumed: applying the widest of them
-# (`+` to `*`, a mask thousands of times too large) against the full
-# bech32/b32 suite still passes every vector, because `from_bits` and
-# `to_bits` are always 5 and 8 here and `acc` never approaches even the
-# correct mask's boundary -- a defensive bound BIP173's own 5-to-8 and
-# 8-to-5 regrouping never binds. Left as found rather than given a test
-# that would only assert the mask's arithmetic, not a behaviour.
+# - `bech32._decode`'s `UnicodeDecodeError` catch for a byte string
+#   outside ascii had no caller supplying one -- every bytes input in the
+#   suite was `str.encode("ascii")` on an already-valid bech32 string,
+#   which cannot raise it.
+# - the HRP character range `47 < ord(x) < 123` was tested at \\x20,
+#   \\x7f and \\x80, all far outside it, and never at the boundary itself
+#   -- "/" (47) and "{" (123).
+# - the checksum alphabet check `bech[-6:]` weakened to `bech[-5:]` was
+#   tested with the invalid byte at the very last position, where both
+#   slices agree; six characters from the end, where they do not, was not.
+# - `base58.decode`'s `len(result) == out_size` weakened to `>=` was
+#   tested with an `out_size` larger than the decoded length -- which
+#   both comparisons refuse -- and never smaller, where `>=` wrongly
+#   accepts.
+# - `b32.witness_from_address`'s `isinstance(b32addr, str)` weakened to
+#   `not isinstance` was never told an address padded with the
+#   whitespace only the `str` branch strips.
+# - `power_of_2_base_conversion`'s `value < 0 or (value >> from_bits)`
+#   weakened to `and` was tested with a negative value only, whose
+#   right shift is always -1 (truthy) in Python's infinite two's
+#   complement, satisfying `and` on its own; a value merely too large
+#   and not negative is what the `or` is actually for.
+# - `b32.p2tr` hardcodes witness version 1, and nothing checked which
+#   version the address it built decoded back as.
+#
+# Checked by hand and left as equivalent, not assumed: `bech32._polymod`'s
+# `chk << 5 ^ value` against `|` never overlaps a bit, the shift clearing
+# exactly the low five bits `value` (five bits itself) then occupies.
+# `b32.convertbits`'s `max_acc` mask, computed with `+`, `-`, `<<` and
+# `-1` all replaced in turn, keeps every vector passing even at the
+# widest of them (`+` to `*`, a mask thousands of times too large)
+# because `from_bits`/`to_bits` are always 5 and 8 here and `acc` never
+# approaches even the correct bound -- a defensive mask BIP173's own
+# regrouping does not bind. `bech32._decode`'s second case-check,
+# `bech.upper() != bech` weakened to `<`, is provably the same
+# comparison here: upper-casing never increases a character's code
+# point, so the first position where the two strings differ is always
+# the position where the upper-cased one sorts lower.
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/codecs.toml
+++ b/.github/mutation/codecs.toml
@@ -1,0 +1,49 @@
+# The checksummed codecs, mutated: base58 and bech32 with the bitcoin
+# semantics on top of them, b58 and b32. A checksum is exactly the boundary
+# mutation testing is for -- a single flipped bit has to be refused, and
+# 100% statement coverage says only that the refusal's line ran on the
+# vectors already in hand, not that every wrong checksum is caught. Beyond
+# this session's own four candidates (issue #327 sized ssa.py, utils.py,
+# fetch and the numeric validators), no profile had measured this pair of
+# pairs yet; #219's question applies here as much as to the consensus code.
+
+[cosmic-ray]
+module-path = [
+  "btclib/base58.py",
+  "btclib/bech32.py",
+  "btclib/b58.py",
+  "btclib/b32.py",
+]
+
+# each module's own test file, in the order the pair builds on the codec:
+# base58/bech32 are checksums with no bitcoin in them, b58/b32 the address
+# semantics on top -- both are named because a b58/b32 mutant can be one
+# base58/bech32 does not reach and the reverse
+test-command = """python -m pytest -x -q -n0 -p no:randomly \
+  tests/base58_test.py tests/bech32_test.py tests/b58_test.py tests/b32_test.py"""
+
+timeout = 300
+
+excluded-modules = []
+
+# 490 of the 1083 mutants sampled in 1800 s: 411 killed, 79 survived. 51
+# are the deferred-annotation class fetch.toml documents, 2 an `is`
+# CPython's small-int cache makes indistinguishable from `==`.
+#
+# One real gap, closed: `bech32._decode`'s `UnicodeDecodeError` catch for
+# a byte string outside ascii had no caller supplying one -- every bytes
+# input in the suite was `str.encode("ascii")` on an already-valid bech32
+# string, which cannot raise it.
+#
+# Most of the rest -- a dozen or so -- are `b32.convertbits`'s `max_acc`
+# mask, computed with `+`, `-`, `<<` and `-1` all replaced in turn.
+# Checked by hand rather than left assumed: applying the widest of them
+# (`+` to `*`, a mask thousands of times too large) against the full
+# bech32/b32 suite still passes every vector, because `from_bits` and
+# `to_bits` are always 5 and 8 here and `acc` never approaches even the
+# correct mask's boundary -- a defensive bound BIP173's own 5-to-8 and
+# 8-to-5 regrouping never binds. Left as found rather than given a test
+# that would only assert the mask's arithmetic, not a behaviour.
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/fetch.toml
+++ b/.github/mutation/fetch.toml
@@ -21,5 +21,35 @@ timeout = 300
 
 excluded-modules = []
 
+# 183 mutants, complete: 129 killed, 54 survived, 33 the deferred-
+# annotation class documented in this session's other profiles. Of the
+# 17 real candidates, seven are fixed by the tests in this commit and the
+# one before it:
+#
+# - `tx.id.hex() != tx_id` weakened to `>` was tested with a requested id
+#   sorting below the actual one only; one sorting above closes the
+#   other half.
+# - `out_point.vout >= len(tx.vout)` weakened to `==` or to `is` was
+#   tested at the exact boundary only; a vout far past it and outside
+#   CPython's interned range closes both.
+# - `Fetcher`'s three abstract methods were only ever exercised together.
+# - `chain != expected_chain` weakened to `>` was tested in the direction
+#   where the actual chain sorts after the expected one only.
+# - `_signet_magic` was never called by a test asserting its output.
+# - `RpcError`/`HttpError`'s translation checked the code, status and
+#   data carried across, never the message itself -- one assertion on
+#   the message text kills the mutant in both `fetcher.py`'s shared
+#   translation and, being the same line, every caller of it.
+# - `esplora.py`'s `status != 200` weakened to `> 200` was tested above
+#   200 only; 100 is what tells them apart.
+#
+# Two are left open. `network == "mainnet"` weakened to `<=` is
+# equivalent for every name `NETWORKS` currently holds -- mainnet sorts
+# first alphabetically among mainnet/regtest/signet/testnet/testnet4 --
+# but the equivalence is fragile: a network named before "mainnet" would
+# break it silently. `check_validity=True` surviving where `tx_for_network`
+# builds a relabelled `Tx` is the same deferred class parsers.toml's
+# follow-up already names.
+
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/fetch.toml
+++ b/.github/mutation/fetch.toml
@@ -1,0 +1,25 @@
+# The fetch boundary, mutated: the transport, the two backends built on it,
+# and the fetcher module both call into. Issue #327 proposed this scope
+# directly -- a response-size limit weakened, a status check turned into
+# an acceptance, a tx-id verification skipped -- as the same class of gap
+# #219 found in the consensus code, on a boundary that is network input
+# rather than a parsed byte string. The test transport seam already keeps
+# these runs offline and deterministic, which is what makes a mutation
+# session over this scope no slower than any other local one.
+
+[cosmic-ray]
+module-path = [
+  "btclib/fetch/transport.py",
+  "btclib/fetch/esplora.py",
+  "btclib/fetch/bitcoin_core.py",
+  "btclib/fetch/fetcher.py",
+]
+
+test-command = "python -m pytest -x -q -n0 -p no:randomly tests/fetch"
+
+timeout = 300
+
+excluded-modules = []
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/mnemonic.toml
+++ b/.github/mutation/mnemonic.toml
@@ -35,14 +35,41 @@ excluded-modules = []
 # len(indexes)` essentially never lands on, so it is equivalent for
 # every base this ships rather than for the one test vector above.
 #
-# The other 24 are `collect_rolls`' manual dice-entry path -- the `else`
-# branch `input()` reads from when `automate` is false. Roughly a third
-# are cosmetic (the `roll #{i + 1}` prompt text, arithmetic-mutated eight
-# ways, changes what a human is shown and nothing a test reads); the rest
-# are `valid_dice_sides` entries and the roll bounds `0 < roll <= base`,
-# real but each needing a scripted `sys.stdin` session
-# (`test_collect_rolls` already has the fixture) to reach past `automate`.
-# Left as a sampled first pass rather than chased number by number here.
+# The other 24 were `collect_rolls`' manual dice-entry path and
+# `bin_str_entropy_from_int`'s prefix detection, both worked through in a
+# second pass on this same 150-mutant sample (the session itself is still
+# only 150 of 739, not re-run):
+#
+# - `bin_str_entropy_from_int`'s `== "0b"` weakened to `<=` reads a plain
+#   decimal starting with "0" and a digit below "b" as binary instead
+#   ("010" is 10 in decimal, 2 read as binary); `== "0x"` weakened to
+#   `>=` needed a string that is neither prefixed nor a valid plain
+#   decimal to distinguish -- "ab" sorts above "0x" and parses as hex
+#   where `int("ab")` raises.
+# - `collect_rolls`' roll-prompt text (`roll #{i + 1}`, arithmetic-
+#   mutated eight ways, and the dice-sides list truncated by `[:-1]`
+#   mutated to `[:-0]`) is printed and discarded by `input()`, so nothing
+#   read it until `capsys` did.
+# - the roll bounds `0 < roll <= base`: `!= 0` still refuses a negative
+#   roll only by coincidence of the D120 vectors' own numbers, and every
+#   manual roll already in the suite equals `base` exactly, so `== base`
+#   in place of `<= base` went unnoticed. `bin_str_entropy_from_rolls`'
+#   own `dice_sides < 2` was tested at 1, never at 2, the boundary itself.
+# - `valid_dice_sides` entries 8, 30 and 48 were never offered to the
+#   `while dice_sides not in valid_dice_sides` loop by any existing vector.
+#
+# Two are left open, checked rather than assumed. `automate`'s
+# `1 + secrets.randbelow(dice_sides)` shifted to `2 + ...` still produces
+# a diverse roll sequence -- the reroll loop discards whatever lands
+# outside `[1, base]` regardless of the offset -- so a "not all equal"
+# assertion (which does kill the `**` mutant collapsing every roll to 1)
+# does not kill this one; only a distribution test would, and the loop's
+# own correctness does not depend on it. `bip39.lang_from_mnemonic`'s
+# `language_length(lang) == _BIP39_WORDLIST_LENGTH` weakened to `<=`
+# needs a sentence built entirely from the 553 words `en` and `slip39`
+# share, and even then only distinguishes if entropy_from_mnemonic's
+# checksum happens to validate under both -- constructible in principle,
+# not attempted here.
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/mnemonic.toml
+++ b/.github/mutation/mnemonic.toml
@@ -1,0 +1,48 @@
+# BIP39 mnemonics, mutated: the checksum over the entropy, and the entropy
+# boundaries beneath it. A wordlist index off by one bit or a checksum
+# comparison that accepts the wrong nibble is a recovery phrase that does
+# not reproduce the wallet it was written down for -- silent on any vector
+# already in the suite, which is the same coverage-versus-boundary gap
+# #219 and #327 ask about elsewhere, on a boundary where the failure mode
+# is a wallet nobody can recover rather than a rejected transaction.
+
+[cosmic-ray]
+module-path = [
+  "btclib/mnemonic/bip39.py",
+  "btclib/mnemonic/entropy.py",
+]
+
+test-command = """python -m pytest -x -q -n0 -p no:randomly \
+  tests/mnemonic/bip39_test.py tests/mnemonic/entropy_test.py"""
+
+timeout = 300
+
+excluded-modules = []
+
+# 150 of the 739 mutants sampled in 600 s: 111 killed, 39 survived. 11 of
+# the 39 are the deferred-annotation class fetch.toml documents, and one
+# is `is` for `==` on two small ints CPython interns.
+#
+# Of the 27 real ones, two were genuine gaps in
+# `bin_str_entropy_from_wordlist_indexes`, now closed:
+# `entropy * base + index` weakened to `|` or `^`, and its `bit_length()`
+# padding weakened by a bitshift -- both equivalent for a power-of-two
+# base (2048, every wordlist this ships), so a base that is not one
+# (1626, the Electrum Portuguese wordlist the function's own comment
+# already names) is what a test needed to tell `+` from `|`/`^` at all.
+# The `-1` beside that shift survived the same test and is left open: it
+# only changes `bit_length()` at a power-of-two boundary `base **
+# len(indexes)` essentially never lands on, so it is equivalent for
+# every base this ships rather than for the one test vector above.
+#
+# The other 24 are `collect_rolls`' manual dice-entry path -- the `else`
+# branch `input()` reads from when `automate` is false. Roughly a third
+# are cosmetic (the `roll #{i + 1}` prompt text, arithmetic-mutated eight
+# ways, changes what a human is shown and nothing a test reads); the rest
+# are `valid_dice_sides` entries and the roll bounds `0 < roll <= base`,
+# real but each needing a scripted `sys.stdin` session
+# (`test_collect_rolls` already has the fixture) to reach past `automate`.
+# Left as a sampled first pass rather than chased number by number here.
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/numeric.toml
+++ b/.github/mutation/numeric.toml
@@ -1,0 +1,52 @@
+# The numeric and monetary validators, mutated: satoshi amounts, fee rates,
+# and the X9.63 KDF's output length. Issue #327 proposed this scope beside
+# the wire-format and fetch profiles, listing the same defect class each
+# time -- negative, zero, maximum and maximum-plus-one, a bool passing
+# where a bool is not a number, and the rounding direction of a fee.
+# tests/integer_policy_test.py is beside each module's own file because it
+# is where the bool-is-not-a-number refusal (#326) is asserted for
+# `amount.py` and `fee.py` by name.
+
+[cosmic-ray]
+module-path = [
+  "btclib/amount.py",
+  "btclib/fee.py",
+  "btclib/ecc/dh.py",
+]
+
+test-command = """python -m pytest -x -q -n0 -p no:randomly \
+  tests/amount_test.py tests/fee_test.py tests/ecc/dh_test.py \
+  tests/integer_policy_test.py"""
+
+# wide for the reason sig_hash.toml gives, and this profile is why that
+# reason is not hypothetical: `ansi_x9_63_kdf`'s `size > max_size` guard,
+# mutated away, does not fail fast -- it goes on hashing towards the size
+# it was asked for, so the one or two mutants of that guard each pay close
+# to the full 300 s here rather than the sub-second a killed mutant costs
+# everywhere else. Measured over a 90-mutant sample of the 507 (see
+# below): two of them alone accounted for most of the wall clock a full
+# session would need
+timeout = 300
+
+excluded-modules = []
+
+# 90 of the 507 mutants sampled before the two slow ones above absorbed the
+# budget: 83 killed, 7 survived. Five of the seven are the `bytes | None`
+# annotation on `ansi_x9_63_kdf`'s `shared_info` parameter, mutated five
+# different ways -- equivalent under Python 3.14's deferred annotation
+# evaluation (PEP 649), the class fetch.toml documents at length. The other
+# two are real and left open rather than chased:
+#
+# - `range(1, ceil(size / hf_size) + 1)` widened to compute twice as many
+#   blocks: `K_temp` is truncated to `size` afterwards, so the extra
+#   blocks are wasted work and not a wrong answer -- equivalent by that
+#   truncation, not by an annotation.
+# - `hf_size * (2**32 - 1)` weakened to `hf_size | (2**32 - 1)`, which is
+#   `0xFFFFFFFF` for every hash function in `HashF`: a real bound lowered
+#   from roughly `hf_size` times as large. Killing it needs a `size`
+#   between the two bounds, and for every hash function this ships with
+#   that is gigabytes of KDF output -- the boundary the test above pays
+#   close to 300 s to exercise once already having found it.
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/signatures.toml
+++ b/.github/mutation/signatures.toml
@@ -23,15 +23,20 @@ module-path = [
   "btclib/ecc/dsa.py",
 ]
 
-# anti_exfil_test.py and commit_nonce_test.py are ssa's sign-to-contract
+# anti_exfil_test.py and commit_nonce_test.py are the sign-to-contract
 # and anti-exfiltration paths, which sig_hash.toml's docstring notes
 # `ssa.sign` itself never takes -- they are what still calls
 # `ssa.sign_custom` and are the only tests that do. parse_contract_test.py
 # is the parse/serialize boundary convention shared with every other
-# profile that carries it.
+# profile that carries it. der_test.py is dsa.py's own DER codec --
+# `_serialize_scalar`/`_deserialize_scalar`/`_parse_der_value` -- missing
+# from the first pass's command entirely, so every mutant of that codec
+# this session found was a mutant its own dedicated test file already
+# killed, uncredited for want of being asked
 test-command = """python -m pytest -x -q -n0 -p no:randomly \
-  tests/ecc/ssa_test.py tests/ecc/dsa_test.py tests/ecc/anti_exfil_test.py \
-  tests/ecc/commit_nonce_test.py tests/parse_contract_test.py"""
+  tests/ecc/ssa_test.py tests/ecc/dsa_test.py tests/ecc/der_test.py \
+  tests/ecc/anti_exfil_test.py tests/ecc/commit_nonce_test.py \
+  tests/parse_contract_test.py"""
 
 timeout = 300
 
@@ -65,6 +70,151 @@ excluded-modules = []
 # the remainder is comparison operators and DER sign-byte handling
 # scattered across the parse/serialize/recover paths, sampled as data
 # here rather than chased to completion.
+#
+# A second pass worked through that data. The most consequential real
+# gap this session found, in either module, is in `ssa._assert_as_valid_`:
+# `if ec.y_aff_from_jac(KJ) % 2:` -- "Fail if y_K is odd" -- weakened to
+# `% 1` is always zero, so the check never fires. Every existing vector
+# missed it because a wrong `s` almost always moves K by whole multiples
+# of the generator, which moves its x-coordinate too, so 'Fail if x_K !=
+# r' catches the forgery first regardless of the y check. The one input
+# that isolates the y check is the odd-y twin of the correct K, `-(k*G)`,
+# which shares K's x-coordinate and fails only on parity; solving
+# `s'*G - e*Q = -(k*G)` for `s'` gives `n - k + e*q`, computable directly
+# without ever building the point. A verifier with this check disabled
+# accepts a signature BIP340 does not, on every message it would
+# otherwise accept the honest one for.
+#
+# The rest, by file:
+#
+# `ssa.py`
+# - `assert_batch_as_valid_`'s `batch_size == 1` weakened to `< 1`: the
+#   shortcut it guards validates a lone `Sig` on its own account
+#   (`assert_as_valid_`, which runs `sig.assert_valid()`), where the
+#   general multi_mult sum below it does not; `< 1` never being true
+#   once `batch_size == 0` has already raised two lines above, the
+#   widened guard sends every batch of one through the sum instead,
+#   silently dropping that check.
+# - the same function's `len(msgs) != batch_size` weakened to `>`: every
+#   existing mismatch vector adds an extra message, which both operators
+#   catch; a batch with fewer messages than pub_keys is the direction
+#   `>` cannot see.
+# - `Sig.serialize`'s own `check_validity` default, the same class as
+#   `BlockHeader`'s and `Block`'s in `block.toml`: nothing had asked an
+#   invalid `Sig` (built with `check_validity=False`) to serialize at
+#   the default and expected a refusal.
+# - `Sig.assert_valid`'s `0 <= self.s`: pinned at zero, the same
+#   boundary `dsa.Sig`'s tests already had and `ssa.Sig`'s did not,
+#   `ssa.Sig` alone allowing zero itself.
+#
+# `dsa.py`
+# - the DER codec's own tests, `tests/ecc/der_test.py`, were missing
+#   from the first pass's `test-command` entirely -- a configuration
+#   gap and not a coverage one: `_deserialize_scalar`'s `scalar_bytes[0]
+#   >= 0x80` weakened to `> 0x80` or to `len(scalar_bytes) > 1` weakened
+#   to `== 1` (the exact one-byte-scalar IndexError the surrounding
+#   comment warns about) were already refused by vectors that file
+#   carries, uncredited for want of being asked. `>= 0x80` weakened to
+#   `== 0x80` was not: every existing vector uses the byte `0x80` itself,
+#   never one above it, so one more vector closes it.
+# - `recover_pub_key_`'s dispatch guard, `0 <= key_id <= 3`: six
+#   different mutations on the same guard, and no vector had ever asked
+#   a `key_id` outside it. Both sides of the range answer in the
+#   bindings' own words once out of it -- "the recovery id must be 0,
+#   1, 2, or 3" -- which four boundary values (-1, 2, 3, 4) against one
+#   fixed signature were enough to tell the widened or narrowed guard's
+#   own answer ("public key recovery failed", "signature verification
+#   failed") apart from the bindings' refusal, one case per mutation.
+# - `Sig.assert_valid`'s `0 < self.r` and `0 < self.s`: pinned at zero
+#   the same way `ssa.Sig`'s test already was, `-1 <` accepting the one
+#   value below the range dsa.Sig -- unlike ssa.Sig -- excludes.
+# - `lower_s`'s default, `True`, on `assert_as_valid`, `verify` and
+#   `anti_exfil_host_verify`: three functions, the same class as the
+#   guard above, and no test had asked any of the three to refuse a
+#   malleated (high-s) signature *without* passing the keyword. The
+#   malleated twin already built for `verify(..., lower_s=False)`
+#   answers the question at the default too; libsecp256k1's own verify
+#   is what refuses it there, lower_s deciding only whether the
+#   signature is normalized in front of that call, so the message is
+#   "signature verification failed" and not `_assert_as_valid_`'s "not
+#   a low s", which the Python path alone raises.
+#
+# Checked and left equivalent, most of it the patterns already
+# established elsewhere in this session applied to this pair's own call
+# sites:
+#
+# - `gen_keys`' `q = 1 + secrets.randbelow(ec.n - 1)`, in both modules,
+#   and `assert_batch_as_valid_`'s `rand = 1 if i == 0 else 1 +
+#   secrets.randbelow(ec.n - 1)`: a result random on every call, the
+#   equivalence this file's own first pass already named -- extending to
+#   `1 ** secrets.randbelow(...)`, which is not a differently-random
+#   value but always exactly 1. An ordinary signature batch cannot tell
+#   a fixed blinding coefficient from a random one either: every term of
+#   the sum is a true equation on its own, so any coefficients satisfy
+#   it, honest or fixed. Telling them apart needs a forged entry
+#   engineered to cancel under the *specific* coefficients used, a
+#   rogue-coefficient construction against Fiat-Shamir's own hash of the
+#   nonce point rather than a fixed test vector, and was not attempted.
+# - message-formatting thresholds, `self.r`/`self.s > 0xFFFFFFFF`
+#   deciding hex or decimal display in an already-invalid value's error
+#   message: this file's first pass already named the class, and the
+#   mutations sampled from it here -- the threshold negated, widened to
+#   `>=`, narrowed to `==`, or shifted by the one integer `4294967296`
+#   is off `0xFFFFFFFF` by -- are exactly it, changing which of two
+#   strings names a value already being refused rather than the refusal.
+# - `ssa._recover_pub_key_`'s `QJ[2] == 0` (Jacobian Z, "is this
+#   infinity") against `QJ[1]` (Y): every curve this file's own exhaustive
+#   `test_low_cardinality` runs was checked by hand for a point with
+#   y = 0, and none has one, so a real point's Y is never the value this
+#   would-be infinity check tests for; `INFJ = (7, 0, 0)` is what every
+#   infinity this function can return actually is, Y included, so the
+#   two checks agree on it too.
+# - `assert_batch_as_valid_`'s `Qs[0]`/`ec = sigs[0].ec` weakened to
+#   `[-1]`: the first is inside the `batch_size == 1` shortcut, where a
+#   batch of one makes index 0 and -1 the same object; the second reads
+#   `ec` only after the very next line has confirmed every signature
+#   shares one curve, which -- if it holds -- already makes `sigs[0].ec`
+#   and `sigs[-1].ec` equal, and if it does not, raises before `ec` is
+#   used for anything the choice of index could still change.
+# - `_recover_pub_keys_`'s own range, `range(2 * (ec.cofactor + 1))`
+#   weakened to `range(2 * (ec.cofactor << 1))`: equal for cofactor 1
+#   (secp256k1's own), and checked by hand rather than assumed for the
+#   two cofactor-2 low-cardinality curves the exhaustive test also
+#   carries -- every `key_id` the widened range adds was tried against
+#   every `(r, s, c)` those tiny curves have, and none ever recovers a
+#   candidate, widened or not: `j` above `cofactor` is already reaching
+#   past what `x_K = r + j*ec.n` can still land under `ec.p`.
+# - `_sign_recoverable_`'s `s > ec.n // 2` weakened to `s > ec.n / 2`:
+#   `ec.n` is prime, hence odd, so `(n - 1) / 2` (what `//` gives) and
+#   `n / 2` (what `/` gives) round to the same integer boundary for
+#   every integer `s` -- the smallest one satisfying either is
+#   `(n + 1) / 2`, and this holds regardless of which of the two call
+#   sites carrying the expression is asked.
+# - `_sign_recoverable_`'s own `s = ec.n - s` (the lower-s negation)
+#   against `s = ec.n % s`: for `s` in `(n/2, n)`, the range the branch
+#   above it already restricts `s` to, `n // s` is always 1, so `n % s
+#   == n - s` exactly -- not an approximation, the two expressions
+#   computing the identical integer over the whole reachable domain.
+# - the four `signed=False` reads/writes weakened to `signed=True` this
+#   pass closed none of and checked instead: `_serialize_scalar`'s own
+#   `to_bytes`, whose `scalar_size` already reserves the pad byte a sign
+#   bit would otherwise need, so no value it ever writes has that bit
+#   set to begin with; and `_libsecp256k1_recover_sec_`'s and
+#   `sign_recoverable_`'s reads of a lower-s `s`, bounded by `ec.n // 2`
+#   whose bit length is 255 and not 256, one bit short of ever setting
+#   the sign bit a 32-byte signed read would test.
+# - `@overload`-decorated stubs, in `RemoveDecorator`'s two mutations:
+#   `typing.overload` has no runtime body a caller ever reaches: mypy
+#   reads the decorator, and removing it changes nothing python -m
+#   pytest can see.
+#
+# One survivor is left open, not chased: `Sig.assert_valid`'s congruence
+# loop, `r < self.ec.p` weakened to `r <= self.ec.p`, moves the boundary
+# by testing one extra candidate the loop's own increment, `r += ec.n`,
+# would need to land on `ec.p` exactly to reach -- `r == ec.p - ec.n`,
+# a single fixed ~128-bit value out of the ~256-bit range `r` is drawn
+# from in practice, the same order of coincidence `bms.toml`'s key_id 3
+# is and not attempted for the same reason.
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/signatures.toml
+++ b/.github/mutation/signatures.toml
@@ -1,0 +1,70 @@
+# Schnorr and ECDSA signing and verification, mutated. Issue #327 sized
+# ssa.py at 977 mutants while measuring the wire-format profile and left it
+# for its own session, "signing arithmetic" being a different triage from a
+# wire format; dsa.py is beside it here rather than in a profile of its own
+# because the two share both shape and test fixtures, and issue #323 -- one
+# of the five defects that opened #327 -- is `ssa.Sig.parse` accepting a
+# 63-byte or trailing-data encoding, the same class of parse boundary
+# `dsa.Sig.parse`'s DER carries.
+#
+# CLAUDE.md's own warning about this pair applies to what a survivor here
+# can mean: `curves.curve.mult`/`double_mult`/`multi_mult` call the
+# libsecp256k1 bindings for secp256k1, so a mutant of the Python arithmetic
+# in `curves/curve_group.py` is invisible to a test running the default
+# curve -- it is not in this module-path and is not what this profile is
+# asking about. What this profile mutates is `dsa.py`/`ssa.py` themselves:
+# nonce derivation, the DER and BIP340 codecs, low-s and lower-x
+# normalization, and the recovery/anti-exfil paths that stay in Python
+# regardless of curve.
+
+[cosmic-ray]
+module-path = [
+  "btclib/ecc/ssa.py",
+  "btclib/ecc/dsa.py",
+]
+
+# anti_exfil_test.py and commit_nonce_test.py are ssa's sign-to-contract
+# and anti-exfiltration paths, which sig_hash.toml's docstring notes
+# `ssa.sign` itself never takes -- they are what still calls
+# `ssa.sign_custom` and are the only tests that do. parse_contract_test.py
+# is the parse/serialize boundary convention shared with every other
+# profile that carries it.
+test-command = """python -m pytest -x -q -n0 -p no:randomly \
+  tests/ecc/ssa_test.py tests/ecc/dsa_test.py tests/ecc/anti_exfil_test.py \
+  tests/ecc/commit_nonce_test.py tests/parse_contract_test.py"""
+
+timeout = 300
+
+excluded-modules = []
+
+# 812 of the 2475 mutants sampled in 5400 s -- the largest scope in this
+# session and the one furthest from finishing, both modules together
+# being nearly as large as sig_hash.py and engine.toml combined. 507
+# killed, 305 survived: 228 the deferred-annotation class fetch.toml
+# documents (both modules carry many typed signatures), 5 the keyword-
+# only marker, 1 an `is` CPython's small-int cache makes indistinguishable
+# from `==`.
+#
+# Two real gaps closed, both a scalar's upper bound: `ssa.Sig`'s
+# `0 <= self.s < self.ec.n` and `dsa.Sig`'s two equivalents were tested
+# invalid against `ec.p` -- a different, larger prime -- and never
+# against `ec.n` itself. For `ssa.Sig` that survived: `< n` weakened to
+# `<= n` still refuses `ec.p`, which sits far enough above `n` that
+# either comparison rejects it. `dsa.Sig`'s pair did not survive the same
+# widening -- `ec.p` there already lands close enough to `ec.n` to catch
+# a boundary shifted by one -- so a test at the exact boundary was added
+# for both anyway, to say why in the suite and not only in this file.
+#
+# `gen_keys`' random-scalar formulas, in both modules and in the batch-
+# verification helper, are the same equivalence bms.toml found: a result
+# random on every call is not what a fixed vector can hold an operator to.
+# Message-formatting thresholds (`self.r > 0xFFFFFFFF` deciding hex or
+# decimal display) account for several more, cosmetic rather than a
+# validity boundary. check_validity and `lower_s` defaults account for
+# another block, the same class parsers.toml's follow-up already names;
+# the remainder is comparison operators and DER sign-byte handling
+# scattered across the parse/serialize/recover paths, sampled as data
+# here rather than chased to completion.
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/utils.toml
+++ b/.github/mutation/utils.toml
@@ -1,0 +1,67 @@
+# The shared codec helpers, mutated. Nearly every other profile in this
+# directory calls into `btclib/utils.py`: `decode_num`/`encode_num` are the
+# script-number codec the engine and `Tx.height` both read, `int_from_bits`
+# is the RFC 6979 bit-string-to-int helper `borromean`, `ssa` and the other
+# deterministic-nonce modules share, and `read_exactly`/`assert_no_trailing`
+# are the exact-read boundary `tx`, `psbt` and `bip32` share. Issue #327
+# measured this file at 325 mutants while sizing the wire-format profile and
+# left it for a session of its own; #219's question is the same one here --
+# 100% statement coverage, and whether the suite would notice a wrong bound.
+
+[cosmic-ray]
+module-path = "btclib/utils.py"
+
+# tests/utils_test.py exercises decode_num/encode_num, read_exactly,
+# assert_no_trailing, hex_string and int_from_bits directly -- it
+# round-trips every sign, zero and length boundary rather than relying on
+# a caller to reach them -- but does not import is_integer or
+# int_from_json_number, so those two need a caller's test to be reached
+# at all. tests/integer_policy_test.py is is_integer's own file, already
+# named in parsers.toml for the same reason; tests/bip32 and tests/block
+# are int_from_json_number's only two callers, through `from_dict`.
+# tests/ecc/ssa_test.py is beside them for int_from_bits' own boundary --
+# every real caller hashes into exactly `ec.nlen` bits, so this file's
+# `blen < nlen` case is the only one that exercises the other direction.
+# Not tests/script_engine: encode_num/decode_num's boundaries are already
+# the round trip above, and the engine's mutants cost 7.2 s each for
+# coverage this file's own suite already gives for a tenth of a second.
+test-command = """python -m pytest -x -q -n0 -p no:randomly \
+  tests/utils_test.py tests/integer_policy_test.py tests/ecc/ssa_test.py \
+  tests/bip32 tests/block"""
+
+# seconds of wall clock: see sig_hash.toml for why a per-mutant timeout is
+# answered KILLED rather than left pending, and why the width is paid only
+# by a mutant that loops forever
+timeout = 300
+
+excluded-modules = []
+
+# 57 of the 388 mutants sampled in 1800 s -- the same shape numeric.toml
+# measured: `int_from_bits`' own bound absorbed most of the budget once
+# widened into a negative shift, `i >> n` for a negative `n` raising
+# rather than looping, so the cost here is the traceback's, paid once per
+# such mutant rather than accumulating. 50 killed, 7 survived, one an
+# `is` CPython's small-int cache makes indistinguishable from `==`.
+#
+# Three real gaps, closed:
+#
+# - `hex_string`'s `int_ < 0` was tested negative and positive, never at
+#   zero, so `<= 0` survived.
+# - Its index loop's `range(len(a_str), 0, -8)` was tested at a length
+#   the stop bound never reaches (18, the vector's own), so `-1` for `0`
+#   survived: at a length that is an exact multiple of 8 (16), it lets 0
+#   itself join the indexes and prints an empty leading group.
+# - `int_from_bits`' `n = (blen - nlen) if blen >= nlen else 0` was
+#   tested at `blen == nlen` (every real caller hashes into exactly the
+#   curve's `nlen` bits) and never at `blen < nlen`, where `!=` computes
+#   a negative shift instead of returning the input unchanged.
+#
+# Two survivors checked and left as equivalent: `encode_num`'s
+# `abs(i) | ((i < 0) << ...)` against `+` never overlaps a bit, `n_bytes`
+# being sized to hold the sign bit above `abs(i)`'s own; `decode_num`'s
+# `int.from_bytes(..., signed=False)` against `signed=True` is undone by
+# the mask correction three lines below, checked against the existing
+# suite's int64 boundary vectors rather than assumed.
+
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -120,6 +120,58 @@ jobs:
             ceiling: 45
             sessions: |
               parsers.toml 30m
+          # extended keys and the checksummed codecs beneath them: bip32.toml
+          # finishes at 1356 mutants in about twenty minutes, codecs.toml is
+          # sampled at 490 of 1083 in the 30 minutes it is given -- both
+          # measured on a machine already running the rest of this matrix,
+          # so a dedicated runner has room to spare rather than needing it
+          - profile: extended keys and the checksummed codecs
+            slug: keys
+            ceiling: 95
+            sessions: |
+              bip32.toml 45m
+              codecs.toml 30m
+          # the message-signing formats: bms.toml and bip322.toml each
+          # finish their own count -- 977 mutants apiece -- in about two
+          # minutes, small enough that the budget below is headroom rather
+          # than a measurement
+          - profile: message signing and BIP322
+            slug: signing
+            ceiling: 35
+            sessions: |
+              bms.toml 10m
+              bip322.toml 10m
+          # the block header and the proof-of-work arithmetic under it:
+          # 1481 mutants, complete in under an hour on the machine that
+          # measured it
+          - profile: the block chain
+            slug: block
+            ceiling: 95
+            sessions: |
+              block.toml 75m
+          # the shared codec helpers and the numeric/network boundaries
+          # built on them: utils.toml is the slow one of the four -- a
+          # weakened size bound turns into a near-timeout mutant the way
+          # numeric.toml's own does -- so it carries the largest budget
+          # here for the same reason, sampled rather than expected to
+          # finish
+          - profile: shared helpers, numeric bounds and fetch
+            slug: shared
+            ceiling: 95
+            sessions: |
+              utils.toml 30m
+              numeric.toml 15m
+              fetch.toml 15m
+              mnemonic.toml 15m
+          # Schnorr and ECDSA signing: 2475 mutants between the two
+          # modules, nearly as large as the consensus job's own two
+          # sessions and, like the engine's, sampled rather than expected
+          # to finish -- 812 of them in the 90 minutes measured here
+          - profile: signature signing and verification
+            slug: signatures
+            ceiling: 100
+            sessions: |
+              signatures.toml 90m
     steps:
       # every action is pinned to a commit SHA, the tag in the comment: a
       # tag, let alone a branch, is a name its owner can move

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -751,6 +751,70 @@ documented at release-notes length in the first place, and are still in
   miniscript fragment: sortedmulti()`, because a release that started
   accepting either would be changing what a descriptor means rather than
   what it parses.
+- **Mutation testing reaches nine more scopes beyond issue #327's own
+  four** (ssa.py was #327's fifth candidate and is not among them; see
+  below): extended keys, the checksummed codecs, bitcoin message
+  signing, BIP322, the block header and its proof-of-work arithmetic,
+  and the shared codec helpers, beside the fetch boundary and the
+  numeric validators #327 already named. Ten `.github/mutation/*.toml`
+  profiles in total, each measured on this tree rather than estimated,
+  wired into `mutation.yml` as three new jobs beside the two #327 added.
+  The real gaps each one found and closed:
+    - `bip32.toml` (1356 mutants, complete): `BIP32KeyData.is_root` had no
+    caller at all, so every operator on its three-way `and` survived
+    together; `str_from_der_path`'s fingerprint length check was tested
+    short and never long.
+    - `codecs.toml` (490 of 1083 sampled): `bech32._decode`'s own comment
+    already said a `UnicodeDecodeError` let out "would fly past every
+    caller written to catch `BTClibValueError`", and nothing supplied
+    the bytes that would raise it.
+    - `bms.toml` (496 of 977 sampled): `Sig` is
+    `@dataclass(frozen=True, init=False)`, and nothing after
+    construction assigned to a field to find out whether the frozen
+    half still held.
+    - `bip322.toml` (508 of 977 sampled), the most consequential single
+    finding: `REQUIRED_RULES` and `UPGRADEABLE_RULES` are each a `|`
+    chain over distinct-bit `ScriptFlag` members, and nothing called
+    either name to check the result — an `&` at any position collapses
+    everything accumulated left of it against a single bit, so
+    `REQUIRED_RULES` could have silently been one flag wide instead of
+    the seven it names.
+    - `block.toml` (1481 mutants, complete): `block_work`'s
+    `target + 1` against `target - 1` agree for every existing vector,
+    whose target sits within a whisker of 2^224; a target as small as 2
+    is what tells them apart. `hash_rate`'s two bounds were each tested
+    at zero only, missing a negative difficulty and a timespan of 1.
+    (One survivor needed no fix: `BlockHeader.assert_valid`'s
+    `self.hash > target` weakened to `>=` is Core's own proof-of-work
+    comparison, and the comment already beside it says why no vector
+    can move it.)
+    - `utils.toml` (57 of 388 sampled): `hex_string`'s negative check was
+    never tried at zero, its index loop's stop bound was never tried at
+    a length landing exactly on it, and `int_from_bits`' truncation
+    guard was never tried below the length it guards.
+    - `numeric.toml`, `fetch.toml`, `mnemonic.toml` (sampled): six more
+    real gaps closed across the KDF's output-length cap, `fetch`'s
+    tx-id and chain-mismatch comparisons and its three abstract methods
+    tested only together, and the BIP39 entropy codec's non-power-of-two
+    base.
+
+  A wide class recurs across all ten and is documented, not fixed, in
+  each profile's own file: Python 3.14 evaluates annotations lazily by
+  default (PEP 649), so an operator confined to a type annotation is
+  equivalent on this interpreter regardless of
+  `from __future__ import annotations` — a broader class than the one
+  `sig_hash.toml`/`parsers.toml` documented for pre-3.14 semantics, and
+  the majority of every profile's raw survivor count. `check_validity`
+  defaults account for most of the rest, the same class `parsers.toml`'s
+  own follow-up already names.
+
+  `btclib/ecc/ssa.py` and `dsa.py`, #327's fifth candidate, are mutated
+  together as `signatures.toml` (812 of 2475 sampled, the largest and
+  least complete scope this round). Two real gaps closed, both a
+  scalar's upper bound tested against the wrong "invalid" value:
+  `ssa.Sig`'s `0 <= self.s < self.ec.n` and `dsa.Sig`'s two equivalents
+  were exercised invalid with `ec.p` — a different, larger prime — and
+  never with `ec.n` itself
 - **The two regtest tests get an account each**, where they shared one and
   so shared its first address. The node is the session's, and a wallet the
   second test to run creates still saw what the first had paid: the import

--- a/tests/b32_test.py
+++ b/tests/b32_test.py
@@ -104,6 +104,15 @@ def test_valid_address() -> None:
         script_pub_key: ScriptList = [op_int(wit_ver), wit_prg]
         assert serialize(script_pub_key).hex() == hexscript
 
+    # a str is stripped, a bytes object is not asked to be: `isinstance`
+    # weakened to `not isinstance` would strip nothing off a str address
+    # and leave the surrounding whitespace to fail as an invalid
+    # character further in, rather than being trimmed here
+    padded = f"  {valid_bc_addresses[0][0]}  "
+    assert b32.witness_from_address(padded) == b32.witness_from_address(
+        valid_bc_addresses[0][0]
+    )
+
 
 def test_invalid_address() -> None:
     """Test whether invalid addresses fail to decode."""
@@ -229,6 +238,15 @@ def test_address_witness() -> None:
     with pytest.raises(BTClibValueError, match="invalid value: "):
         b32.power_of_2_base_conversion(wit_prg_ints, 8, 5)
 
+    # too large, not negative: a negative value's `>> from_bits` is always
+    # -1 in Python (infinite two's complement), truthy on its own, so
+    # `or` weakened to `and` still raises above -- 256 does not have that
+    # shortcut, and needs the first half of the `or` to be false and the
+    # second true
+    wit_prg_ints[0] = 256
+    with pytest.raises(BTClibValueError, match="invalid value: "):
+        b32.power_of_2_base_conversion(wit_prg_ints, 8, 5)
+
     addr = "tb1qq5zs2pg9q5zs2pg9q5zs2pg9q5zs2pg9q5mpvsef"
     err_msg = "invalid size: "
     with pytest.raises(BTClibValueError, match=err_msg):
@@ -317,8 +335,12 @@ def test_p2tr() -> None:
     key = 1
     pub_key = output_pubkey(key)[0]
     addr = b32.p2tr(pub_key)
-    _, wit_prg, _ = b32.witness_from_address(addr)
+    wit_ver, wit_prg, _ = b32.witness_from_address(addr)
 
+    # the witness version, not only the program: p2tr is taproot's own
+    # version 1, and nothing above checked which version the address
+    # round-trips as
+    assert wit_ver == 1
     assert wit_prg == pub_key
 
 

--- a/tests/base58_test.py
+++ b/tests/base58_test.py
@@ -85,6 +85,13 @@ def test_exceptions() -> None:
     with pytest.raises(BTClibValueError, match="invalid decoded size: "):
         decode(encoded, wrong_length)
 
+    # a requested size smaller than what decoded, not larger: the vector
+    # above asks for more than the 11 decoded bytes, which `== out_size`
+    # weakened to `>= out_size` also refuses (11 is not >= 19); asking
+    # for fewer is what tells them apart, 11 being >= 5
+    with pytest.raises(BTClibValueError, match="invalid decoded size: "):
+        decode(encoded, 5)
+
     invalid_checksum = encoded[:-4] + b"1111"
     with pytest.raises(BTClibValueError, match="invalid checksum: "):
         decode(invalid_checksum, 4)

--- a/tests/bech32_test.py
+++ b/tests/bech32_test.py
@@ -84,12 +84,27 @@ def test_bech32() -> None:
         ["\x20" + " 1nwldj5", r"HRP character out of range: *"],
         ["\x7f" + "1axkwrx", r"HRP character out of range: *"],
         ["\x80" + "1eym55h", r"HRP character out of range: *"],
+        # the boundary itself, not \x20/\x7f/\x80 (all far outside it):
+        # `47 < ord(x) < 123` weakened at either end to `<=` still
+        # refuses those three and would accept "/" (47) or "{" (123)
+        ["/1nwldj5", r"HRP character out of range: *"],
+        ["{1axkwrx", r"HRP character out of range: *"],
+        # mixed case where lowering it does not sort below the original:
+        # `bech.lower() != bech` weakened to `< bech` is false here (the
+        # raised "u" sorts above the "U" it replaces), and the `and`
+        # after it only raises if the upper-casing check also does
+        ["a12UEL5L", r"mixed case: *"],
         ["pzry9x0s0muk", r"no separator character: *"],
         ["1pzry9x0s0muk", r"empty HRP: *"],
         ["x1b4n0q5v", r"invalid data character: *"],
         ["li1dgmt3", r"too short checksum: *"],
         # Invalid character in checksum
         ["de1lg7wt\xff", r"invalid character in checksum: *"],
+        # the same, at the far end of the checksum rather than the near
+        # one: `bech[-6:]` weakened to `bech[-5:]` still catches the
+        # vector above (its invalid byte is the very last character) and
+        # misses this one, six characters from the end and not five
+        ["de1\xffqpzry", r"invalid character in checksum: *"],
         # checksum calculated with uppercase form of HRP
         ["A1G7SGD8", r"invalid checksum: *"],
         ["10a06t8", r"empty HRP: *"],

--- a/tests/bech32_test.py
+++ b/tests/bech32_test.py
@@ -71,6 +71,15 @@ def test_bech32() -> None:
         with pytest.raises(BTClibValueError):  # assorted error messages
             decode(test, _BECH32_1_CONST)
 
+    # a byte outside ascii is not a str decode() ever receives from the
+    # loop above, which only ever encodes an already-valid bech32 string:
+    # nothing else exercises the UnicodeDecodeError catch this raises
+    # instead of letting fly past a caller written to catch BTClibValueError
+    with pytest.raises(BTClibValueError, match="non-ascii character in bech32 string"):
+        decode(
+            b"\xff1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqc8247j"
+        )
+
     invalid_checksum = [
         ["\x20" + " 1nwldj5", r"HRP character out of range: *"],
         ["\x7f" + "1axkwrx", r"HRP character out of range: *"],

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -634,6 +634,51 @@ def test_the_coercion_still_happens_in_init() -> None:
     assert BIP32KeyData.b58decode(coerced.b58encode()) == coerced
 
 
+def test_is_root_is_all_three_fields_and_not_just_one() -> None:
+    """No caller of `is_root` exercises it, so pin the property itself.
+
+    `_assert_valid_depth_and_index` ties depth zero to index zero and to
+    a zero parent fingerprint, so a *valid* object never isolates the
+    index or the fingerprint term: it is depth alone a valid non-root key
+    can vary. The other two need `check_validity=False`, the same
+    combination `_assert_valid_depth_and_index` itself would refuse.
+    """
+    root = BIP32KeyData.b58decode(XKEY)
+    assert root.is_root
+
+    non_root_depth = BIP32KeyData(
+        version=root.version,
+        depth=1,
+        parent_fingerprint=root.parent_fingerprint,
+        index=0,
+        chain_code=root.chain_code,
+        key=root.key,
+    )
+    assert not non_root_depth.is_root
+
+    non_root_index = BIP32KeyData(
+        version=root.version,
+        depth=0,
+        parent_fingerprint=root.parent_fingerprint,
+        index=1,
+        chain_code=root.chain_code,
+        key=root.key,
+        check_validity=False,
+    )
+    assert not non_root_index.is_root
+
+    non_root_fingerprint = BIP32KeyData(
+        version=root.version,
+        depth=0,
+        parent_fingerprint=b"\x01\x02\x03\x04",
+        index=0,
+        chain_code=root.chain_code,
+        key=root.key,
+        check_validity=False,
+    )
+    assert not non_root_fingerprint.is_root
+
+
 def test_the_tweaks_of_a_public_derivation_are_the_derivation() -> None:
     """The scalars a path adds up to, against the key the path derives.
 

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -22,7 +22,7 @@ from btclib.bip32 import (
     rootxprv_from_seed,
     xpub_from_xprv,
 )
-from btclib.bip32.bip32 import _derive
+from btclib.bip32.bip32 import _BIP32KeyData, _derive
 from btclib.bip32.der_path import _indexes_from_der_path_str
 from btclib.curves import (
     bytes_from_point,
@@ -60,6 +60,13 @@ def test_exceptions() -> None:
 
     with pytest.raises(BTClibValueError, match="too few bits for seed: "):
         rootxprv_from_seed(seed[:-2])
+
+    # both boundaries themselves, not only past them: seeds come in whole
+    # bytes, so bit_length is always a multiple of 8, and every value a
+    # `< 128`/`> 512` neighbor would treat differently from `< 127`/`>
+    # 513` is one no byte-sized seed can ever reach
+    assert rootxprv_from_seed("00" * 16)
+    assert rootxprv_from_seed("00" * 64)
 
 
 def test_assert_valid2() -> None:
@@ -282,6 +289,11 @@ def test_derive_exceptions() -> None:
         with pytest.raises(OverflowError, match="int too big to convert"):
             derive(xprv, index)
 
+    # the boundary itself, not only one past it: `> 255` weakened to
+    # `>= 255` or to `> 254` would refuse the 255 the vector above stops
+    # one short of
+    assert derive(XKEY, "m" + 255 * "/0")
+
     xprv = _derive(xprv, "1")
     err_msg = "final depth greater than 255: "
     with pytest.raises(BTClibValueError, match=err_msg):
@@ -348,6 +360,22 @@ def test_derive_from_account() -> None:
     err_msg = "invalid address index: 65536"
     with pytest.raises(BTClibValueError, match=err_msg):
         derive_from_account(mxpub, 0, 0xFFFF + 1)
+
+    # max_index's own default, not one passed in: `0xffff` widened to
+    # 65536 or narrowed to 65534 would move the boundary this vector
+    # relies on being exactly 65535
+    assert derive_from_account(mxpub, 0, 0xFFFF)
+
+    # strictly above the offset, not only at it: `>= _HARDENED_OFFSET`
+    # weakened to `==` would refuse only the exact boundary above, the
+    # one 0x80000000 case already covers
+    err_msg = "invalid private derivation at branch level"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        derive_from_account(mxpub, 0x80000000 + 1, 0, True)
+
+    err_msg = "invalid private derivation at address index level"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        derive_from_account(mxpub, 0, 0x80000000 + 1, max_index=0xFFFFFFFF)
 
     der_path = "m / 44 h / 0"
     mxpub = xpub_from_xprv(derive(rmxprv, der_path))
@@ -677,6 +705,254 @@ def test_is_root_is_all_three_fields_and_not_just_one() -> None:
         check_validity=False,
     )
     assert not non_root_fingerprint.is_root
+
+    # negative, not only positive: `depth == 0`/`index == 0` weakened to
+    # `<= 0` would call this one root too, index and parent fingerprint
+    # both being the root's own
+    negative_depth = BIP32KeyData(
+        version=root.version,
+        depth=-1,
+        parent_fingerprint=root.parent_fingerprint,
+        index=0,
+        chain_code=root.chain_code,
+        key=root.key,
+        check_validity=False,
+    )
+    assert not negative_depth.is_root
+
+    negative_index = BIP32KeyData(
+        version=root.version,
+        depth=0,
+        parent_fingerprint=root.parent_fingerprint,
+        index=-1,
+        chain_code=root.chain_code,
+        key=root.key,
+        check_validity=False,
+    )
+    assert not negative_index.is_root
+
+
+def test_is_hardened_is_not_narrowed_to_the_boundary_alone() -> None:
+    """An index strictly above the offset is hardened too, not just it.
+
+    `self.index >= _HARDENED_OFFSET` weakened to `==` would call every
+    non-root path in the test vectors hardened all the same, since every
+    one of them lands exactly on the offset (`0h`, `44h`); nothing there
+    ever derives past it.
+    """
+    root = BIP32KeyData.b58decode(XKEY)
+    above_offset = BIP32KeyData(
+        version=root.version,
+        depth=1,
+        parent_fingerprint=b"\x01\x02\x03\x04",
+        index=0x80000000 + 1,
+        chain_code=root.chain_code,
+        key=root.key,
+        check_validity=False,
+    )
+    assert above_offset.is_hardened
+
+
+def test_hardened_public_derivation_is_refused_above_the_offset_too() -> None:
+    """A hardened index above the offset is refused, not just the exact one.
+
+    `any(index >= _HARDENED_OFFSET ...)` weakened to `==` in
+    `__pub_key_path_derivation` would refuse only the exact boundary
+    `derive(xpub, 0x80000000)` already covers, letting an ordinary
+    hardened index above it reach a private-only derivation instead.
+    """
+    xpub = xpub_from_xprv(XKEY)
+    err_msg = "invalid hardened derivation from public key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        derive(xpub, 0x80000000 + 1)
+
+
+def test_assert_valid_depth_and_index_accepts_its_own_boundaries() -> None:
+    """Depth 255 and index 0xffffffff are the top of their ranges, not past it.
+
+    `0 <= x <= bound` weakened on either side, or a bound replaced with a
+    neighbor, would refuse exactly the value every other vector stops one
+    short of.
+    """
+    root = BIP32KeyData.b58decode(XKEY)
+    top = BIP32KeyData(
+        version=root.version,
+        depth=255,
+        parent_fingerprint=b"\x01\x02\x03\x04",
+        index=0xFFFFFFFF,
+        chain_code=root.chain_code,
+        key=root.key,
+    )
+    assert top.depth == 255
+    assert top.index == 0xFFFFFFFF
+
+
+def test_assert_valid_key_refuses_a_scalar_above_n_too() -> None:
+    """`0 < q < n` chained: weakening the right `<` to `!=` misses q > n.
+
+    Both existing invalid-key vectors put q at 0 and at n exactly, so
+    `q != n` alone would already refuse either one; only a scalar
+    strictly above n tells `q < n` apart from it.
+    """
+    xkey_data = BIP32KeyData.b58decode(XKEY)
+    xkey_data.key = b"\x00" + (ec.n + 1).to_bytes(32, byteorder="big", signed=False)
+    with pytest.raises(BTClibValueError, match="invalid private key not in 1..n-1"):
+        xkey_data.assert_valid()
+
+
+def test_invalid_key_prefix_messages_show_exactly_one_byte() -> None:
+    """The hex in each prefix-refusal message is one byte, not a slice past it.
+
+    `key[:1].hex()` widened to `key[:2]` still contains the same text as
+    a leading substring, so only an exact match on the whole message --
+    not `pytest.raises(match=...)`'s search -- tells the two spellings
+    apart.
+    """
+    root = BIP32KeyData.b58decode(XKEY)
+
+    bad_prv = BIP32KeyData.b58decode(XKEY)
+    bad_prv.key = b"\x05" + root.key[1:]
+    with pytest.raises(BTClibValueError) as excinfo:
+        bad_prv.assert_valid()
+    assert str(excinfo.value) == "invalid private key prefix: 0x05"
+
+    xpub = BIP32KeyData.b58decode(xpub_from_xprv(XKEY))
+    bad_pub = BIP32KeyData.b58decode(xpub_from_xprv(XKEY))
+    bad_pub.key = b"\x05" + xpub.key[1:]
+    with pytest.raises(BTClibValueError) as excinfo:
+        bad_pub.assert_valid()
+    assert str(excinfo.value) == "invalid public key prefix not in (0x02, 0x03): 0x05"
+
+    with pytest.raises(BTClibValueError) as excinfo:
+        xpub_from_xprv(bad_pub)
+    assert str(excinfo.value) == "not a private key: prefix 0x05"
+
+    child_xpub_data = BIP32KeyData.b58decode(xpub_from_xprv(XKEY))
+    prefix = f"0x{child_xpub_data.key[:1].hex()}"
+    with pytest.raises(BTClibValueError) as excinfo:
+        crack_prv_key(xpub_from_xprv(XKEY), xpub_from_xprv(XKEY))
+    assert (
+        str(excinfo.value)
+        == f"extended child key is not a private key: prefix {prefix}"
+    )
+
+
+def test_pub_key_derivation_tweaks_are_32_bytes_each() -> None:
+    """`offset.to_bytes(32, ...)` widened to 33 would leak a byte per tweak.
+
+    Every existing assertion on `pub_key_derivation_tweaks` compares the
+    accumulated point, which a leading zero byte would not move: nothing
+    checks the tweaks' own length.
+    """
+    rootxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
+    xpub = BIP32KeyData.b58decode(xpub_from_xprv(rootxprv))
+    tweaks = pub_key_derivation_tweaks(xpub.key, xpub.chain_code, "m/1/2")
+    assert all(len(tweak) == 32 for tweak in tweaks)
+
+
+def test_derive_with_a_forced_version() -> None:
+    """A forced version must be the same kind, private or public, as the key.
+
+    `_force_version` is otherwise unexercised by any test: `version in
+    XPRV_VERSIONS_ALL` negated, `fversion not in allowed_versions`
+    negated, and `bytes_from_octets(forced_version, 4)` widened to 5 or
+    narrowed to 3 all survive without a single call anywhere passing
+    forced_version.
+    """
+    forced_prv = NETWORKS["mainnet"].slip132_p2wpkh_p2sh_prv
+    forced = derive(XKEY, "m/0h", forced_prv)
+    assert BIP32KeyData.b58decode(forced).version == forced_prv
+
+    err_msg = "invalid version forced on the extended key"
+    forced_pub = NETWORKS["mainnet"].slip132_p2wpkh_p2sh_pub
+    with pytest.raises(BTClibValueError, match=err_msg):
+        derive(XKEY, "m/0h", forced_pub)
+
+
+def test_b58decode_strips_a_string_and_not_bytes() -> None:
+    """A string is whitespace-stripped before decoding.
+
+    `isinstance(address, str)` negated would strip bytes instead of
+    strings and leave a padded string for base58.decode to choke on --
+    nothing downstream surfaces the swap without checking the string
+    path directly.
+    """
+    xkey_data = BIP32KeyData.b58decode(f"  {XKEY}  ")
+    assert xkey_data == BIP32KeyData.b58decode(XKEY)
+
+
+def test_check_validity_defaults_to_true() -> None:
+    """`__init__`, serialize, parse and b58encode all default to True.
+
+    A zero depth with a non-zero parent fingerprint serializes fine
+    structurally -- one byte and four, whatever they hold -- and is
+    refused only by assert_valid's cross-field check, the one
+    check_validity=False defers on every one of these four call sites.
+    """
+    root = BIP32KeyData.b58decode(XKEY)
+    invalid = BIP32KeyData(
+        version=root.version,
+        depth=0,
+        parent_fingerprint=b"\x01\x02\x03\x04",
+        index=0,
+        chain_code=root.chain_code,
+        key=root.key,
+        check_validity=False,
+    )
+    err_msg = "zero depth with non-zero parent fingerprint: "
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        BIP32KeyData(
+            version=invalid.version,
+            depth=invalid.depth,
+            parent_fingerprint=invalid.parent_fingerprint,
+            index=invalid.index,
+            chain_code=invalid.chain_code,
+            key=invalid.key,
+        )
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        invalid.serialize()
+    as_bytes = invalid.serialize(check_validity=False)
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        invalid.b58encode()
+    assert invalid.b58encode(check_validity=False)
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        BIP32KeyData.parse(as_bytes)
+    assert BIP32KeyData.parse(as_bytes, check_validity=False) == invalid
+
+
+def test_bip32keydata_init_check_validity_guard_is_not_negated() -> None:
+    """`_BIP32KeyData`'s own check_validity guard, not just its parent's.
+
+    `_derive` always builds one from an already-valid key, so nothing
+    through the public API ever constructs an invalid `_BIP32KeyData`;
+    the private class itself has to be called directly to reach `if
+    check_validity` negated to `if not check_validity`, which would
+    validate exactly backwards.
+    """
+    root = BIP32KeyData.b58decode(XKEY)
+    with pytest.raises(BTClibValueError, match="invalid depth: "):
+        _BIP32KeyData(
+            version=root.version,
+            depth=256,
+            parent_fingerprint=root.parent_fingerprint,
+            index=root.index,
+            chain_code=root.chain_code,
+            key=root.key,
+        )
+    unchecked = _BIP32KeyData(
+        version=root.version,
+        depth=256,
+        parent_fingerprint=root.parent_fingerprint,
+        index=root.index,
+        chain_code=root.chain_code,
+        key=root.key,
+        check_validity=False,
+    )
+    assert unchecked.depth == 256
 
 
 def test_the_tweaks_of_a_public_derivation_are_the_derivation() -> None:

--- a/tests/bip32/der_path_test.py
+++ b/tests/bip32/der_path_test.py
@@ -15,7 +15,7 @@ from btclib.bip32 import (
     str_from_index_int,
 )
 from btclib.bip32.der_path import _HARDENING, _indexes_from_der_path_str
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 
 
 def test_from_der_path_str() -> None:
@@ -176,6 +176,43 @@ def test_hardenings_from_der_path() -> None:
     # BIP380's own valid vector with mixed indicators
     assert hardenings_from_der_path("0'/0h/0'") == ["'", "h", "'"]
     assert indexes_from_der_path("0'/0h/0'") == [0x80000000] * 3
+
+
+def test_only_a_leading_m_is_skipped() -> None:
+    """Any other first step is an index, not a lookalike to drop.
+
+    `steps[0].lower() == "m"` weakened to `>=` would strip any step
+    sorting at or after "m" -- most letters, not `m` alone -- silently
+    dropping it instead of refusing it as the index it is not.
+    """
+    with pytest.raises(BTClibValueError, match="invalid derivation index: zzz"):
+        indexes_from_der_path("zzz/5")
+
+
+def test_a_path_holds_at_most_255_steps() -> None:
+    """The depth byte a header carries is one octet: 0 to 255.
+
+    255 steps parse; 256 do not. `> 255` weakened to `> 256` would
+    accept the step count depth itself cannot hold.
+    """
+    path_255 = "m/" + "/".join(["0"] * 255)
+    assert len(indexes_from_der_path(path_255)) == 255
+
+    path_256 = "m/" + "/".join(["0"] * 256)
+    with pytest.raises(BTClibValueError, match="depth greater than 255: 256"):
+        indexes_from_der_path(path_256)
+
+
+def test_an_iterable_of_indexes_is_checked_element_by_element() -> None:
+    """A non-integer among otherwise good indexes is still refused.
+
+    Every existing DerPath vector that is a plain iterable is all
+    integers, so the loop that checks each one had never been asked
+    about an iterable it was not: replaced with one over an empty list,
+    nothing here would have noticed.
+    """
+    with pytest.raises(BTClibTypeError, match="invalid derivation index type: str"):
+        indexes_from_der_path([0, 1, "2"])  # type: ignore[list-item]
 
     assert hardenings_from_der_path("m/44h/0'/1H/0/10") == ["h", "'", "H", "", ""]
     assert hardenings_from_der_path("m/44h/0'/1h") == ["h", "'", "h"]

--- a/tests/bip32/der_path_test.py
+++ b/tests/bip32/der_path_test.py
@@ -116,6 +116,10 @@ def test_str_from_der_path() -> None:
     err_msg = "invalid master fingerprint length: "
     with pytest.raises(BTClibValueError, match=err_msg):
         str_from_der_path(der_path, "baaaad")
+    # one octet too many, not too few: `!= 8` weakened to `< 8` would
+    # still catch the short one above and miss this one
+    with pytest.raises(BTClibValueError, match=err_msg):
+        str_from_der_path(der_path, "deadbeef00")
 
 
 def test_three_symbols_are_read_and_two_are_written() -> None:

--- a/tests/bip32/key_origin_test.py
+++ b/tests/bip32/key_origin_test.py
@@ -4,12 +4,16 @@
 
 """Tests for the `btclib.bip32.key_origin` module."""
 
+import dataclasses
+
 import pytest
 
+from btclib.alias import Octets
 from btclib.bip32 import (
     BIP32KeyOrigin,
     assert_valid_hd_key_paths,
     decode_from_bip32_derivs,
+    decode_hd_key_paths,
     encode_to_bip32_derivs,
 )
 from btclib.bip32.der_path import _HARDENING
@@ -21,12 +25,25 @@ def test_bip32_key_origin() -> None:
     """Parse descriptions in every hardening spelling; refuse bad ones."""
     with pytest.raises(BTClibValueError, match="invalid master fingerprint length: "):
         BIP32KeyOrigin("badbad", [0])
+    # one octet too many, not too few: `!= 4` weakened to `< 4` would
+    # still catch the short one above and miss this one
+    with pytest.raises(BTClibValueError, match="invalid master fingerprint length: "):
+        BIP32KeyOrigin("deadbeef00", [0])
 
     with pytest.raises(BTClibValueError, match="invalid der_path size: "):
         BIP32KeyOrigin("deadbeef", [0] * 256)
+    # the boundary itself, not only one past it: `> 255` weakened to
+    # `>= 255` or to `> 254` would refuse the 255 every other vector
+    # already carries a shorter version of
+    assert len(BIP32KeyOrigin("deadbeef", [0] * 255)) == 255
 
     with pytest.raises(BTClibValueError, match="invalid der_path element"):
         BIP32KeyOrigin("deadbeef", [0xFFFFFFFF + 1])
+    with pytest.raises(BTClibValueError, match="invalid der_path element"):
+        BIP32KeyOrigin("deadbeef", [-1])
+    # the upper boundary itself: `<= 0xffffffff` weakened to `<
+    # 0xffffffff` or to `<= 0xfffffffe` would refuse it
+    assert BIP32KeyOrigin("deadbeef", [0xFFFFFFFF]).der_path == [0xFFFFFFFF]
 
     description = master_fingerprint = "deadbeef"
     key_origin = BIP32KeyOrigin.from_description(description)
@@ -65,6 +82,116 @@ def test_bip32_key_origin() -> None:
     assert BIP32KeyOrigin.parse(key_origin.serialize()) == key_origin
     assert BIP32KeyOrigin.from_dict(key_origin.to_dict()) == key_origin
     assert len(key_origin) == 5
+
+
+def test_key_origin_is_frozen() -> None:
+    """`@dataclass(frozen=True)`, refusing an assignment nothing else tries."""
+    key_origin = BIP32KeyOrigin("deadbeef", [0])
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        key_origin.master_fingerprint = b"\x00" * 4  # type: ignore[misc]
+
+
+def test_check_validity_defaults_to_true_on_to_dict_from_dict_and_serialize() -> None:
+    """An over-long fingerprint tells the three defaults apart from `False`.
+
+    `to_dict` and `serialize` read the field back as it is stored, no
+    boundary of their own in the way; an invalid `BIP32KeyOrigin` (built
+    with `check_validity=False`) must still be refused at the default,
+    and `from_dict` must refuse the same dict right back.
+    """
+    key_origin = BIP32KeyOrigin("deadbeef00", [0], check_validity=False)
+    err_msg = "invalid master fingerprint length: "
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        key_origin.to_dict()
+    as_dict = key_origin.to_dict(check_validity=False)
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        BIP32KeyOrigin.from_dict(as_dict)
+    assert BIP32KeyOrigin.from_dict(as_dict, check_validity=False) == key_origin
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        key_origin.serialize()
+    assert key_origin.serialize(check_validity=False)
+
+
+def test_check_validity_defaults_to_true_on_parse() -> None:
+    """`parse` always reads exactly four fingerprint octets, valid or not.
+
+    What check_validity still guards there is everything past them:
+    `assert_valid`'s own `len(self) > 255`, unreachable through a string
+    path (`_pairs_from_der_path_str` refuses the same count first) but
+    not through the raw indexes a serialized path decodes to.
+    """
+    key_origin = BIP32KeyOrigin("deadbeef", [0] * 256, check_validity=False)
+    as_bytes = key_origin.serialize(check_validity=False)
+
+    with pytest.raises(BTClibValueError, match="invalid der_path size: "):
+        BIP32KeyOrigin.parse(as_bytes)
+    assert BIP32KeyOrigin.parse(as_bytes, check_validity=False) == key_origin
+
+
+def test_check_validity_defaults_to_true_on_from_description() -> None:
+    """A description too short for its 8-hex-octet fingerprint slice.
+
+    `data[:8]` takes whatever there is of a shorter string, so a bare
+    four-hex-character fingerprint with no path at all is what reaches
+    `assert_valid`'s length check rather than being caught by the slice.
+    """
+    with pytest.raises(BTClibValueError, match="invalid master fingerprint length: "):
+        BIP32KeyOrigin.from_description("dead")
+    parsed = BIP32KeyOrigin.from_description("dead", check_validity=False)
+    assert parsed.master_fingerprint == bytes.fromhex("dead")
+
+
+def test_decode_hd_key_paths_reads_the_map_it_is_given() -> None:
+    """A populated map decodes to itself; `None` and `{}` to an empty one.
+
+    `{...} if map_ else {}` negated builds the comprehension only when
+    `map_` is falsy -- `None`, crashing on `.items()`, or empty, staying
+    empty -- and returns `{}` for the one case, a populated map, that
+    should not.
+    """
+    key_origin = BIP32KeyOrigin("deadbeef", [0])
+    pub_key = bytes(33)
+    populated: dict[Octets, BIP32KeyOrigin] = {pub_key: key_origin}
+
+    assert decode_hd_key_paths(populated) == populated
+    assert decode_hd_key_paths(None) == {}
+    assert decode_hd_key_paths({}) == {}
+
+
+def test_assert_valid_hd_key_paths_checks_the_pub_key_length() -> None:
+    """78, 65 or 33 octets: an xpub, an uncompressed or a compressed key.
+
+    Each boundary is checked on both sides, `not in {78, 33, 65}`
+    surviving being narrowed to any one of the six neighbors a single
+    `NumberReplacer` reaches.
+    """
+    key_origin = BIP32KeyOrigin("deadbeef", [0])
+    for length in (78, 65, 33):
+        hd_key_paths = {bytes(length): key_origin}
+        assert_valid_hd_key_paths(hd_key_paths)
+    for length in (77, 79, 64, 66, 32, 34):
+        hd_key_paths = {bytes(length): key_origin}
+        with pytest.raises(BTClibValueError, match="invalid public key length: "):
+            assert_valid_hd_key_paths(hd_key_paths)
+
+
+def test_assert_valid_hd_key_paths_checks_every_entry() -> None:
+    """A second, invalid entry is refused, not just the first one checked.
+
+    The per-entry loop survives being replaced with one over an empty
+    list unless an entry past the first is what is wrong with the map:
+    every existing vector either has one entry or is invalid in its
+    first one.
+    """
+    good = BIP32KeyOrigin("deadbeef", [0])
+    good2 = BIP32KeyOrigin("deadbeef", [1])  # a different origin: no duplicate
+    bad_pub_key = bytes(32)  # neither 78, 65 nor 33 octets
+    hd_key_paths = {bytes(33): good, bad_pub_key: good2}
+    with pytest.raises(BTClibValueError, match="invalid public key length: "):
+        assert_valid_hd_key_paths(hd_key_paths)
 
 
 def test_dataclasses_json_dict_key_origin(json_golden: JsonGolden) -> None:

--- a/tests/bip322_test.py
+++ b/tests/bip322_test.py
@@ -16,6 +16,8 @@ would pass all of the first group and none of the second.
 
 from __future__ import annotations
 
+import base64
+import dataclasses
 from typing import Any
 
 import pytest
@@ -326,6 +328,11 @@ def test_legacy_signature_is_accepted_for_p2pkh_alone() -> None:
     assert not bip322.verify(msg, p2pkh(WIF), legacy, legacy=False)
     assert not bip322.verify(b"another", p2pkh(WIF), legacy)
 
+    # assert_as_valid's own legacy default, not verify's: verify always
+    # forwards its own `legacy` argument explicitly, so nothing above
+    # reaches assert_as_valid's default unless called directly
+    bip322.assert_as_valid(msg, p2pkh(WIF), legacy)
+
 
 def test_a_simple_signature_is_not_65_octets() -> None:
     """The size that tells a BMS signature from a witness stack.
@@ -356,6 +363,36 @@ def test_sig_round_trip() -> None:
     assert bip322.Sig.b64decode(psbt_sig.b64encode()) == psbt_sig
 
 
+def test_sig_is_frozen_and_check_validity_defaults_to_true() -> None:
+    """The one field is frozen, and serialize/b64encode/b64decode refuse.
+
+    A `Tx` payload built with `check_validity=False` is the same kind of
+    invalid object the other profiles' `Sig`-like classes use to pin this
+    default: nothing before this test assigned to `Sig.payload`, and
+    nothing called any of the three at their default check_validity
+    instead of passing the keyword explicitly.
+    """
+    msg, addr = b"frozen", _address(WIF, "p2pkh")
+    sig = bip322.sign(msg, WIF, addr)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        sig.payload = sig.payload  # type: ignore[misc]
+
+    invalid_tx = Tx(1, 0, [], [], check_validity=False)
+    invalid = bip322.Sig(invalid_tx)
+    with pytest.raises(BTClibValueError):
+        invalid.serialize()
+    invalid.serialize(check_validity=False)
+    with pytest.raises(BTClibValueError):
+        invalid.b64encode()
+    invalid.b64encode(check_validity=False)
+    data = invalid.serialize(check_validity=False)
+    with pytest.raises(BTClibValueError):
+        bip322.Sig.b64decode(bip322.FULL + base64.b64encode(data).decode("ascii"))
+    bip322.Sig.b64decode(
+        bip322.FULL + base64.b64encode(data).decode("ascii"), check_validity=False
+    )
+
+
 def test_b64decode_refuses_what_is_not_base64() -> None:
     """A prefix is stripped, a bad encoding is named, and nothing is guessed."""
     with pytest.raises(BTClibValueError, match="invalid base64 encoding"):
@@ -364,6 +401,34 @@ def test_b64decode_refuses_what_is_not_base64() -> None:
         bip322.Sig.b64decode("full!!!!")
     with pytest.raises(BTClibValueError, match="invalid base64 encoding"):
         bip322.Sig.b64decode("pof☃")
+
+    # a character outside the base64 alphabet embedded in an otherwise
+    # decodable string, not one that breaks decoding outright: `!!!!`
+    # and `☃` above fail regardless of `validate`, where a stray
+    # newline is stripped and silently decoded under `validate=False`
+    # and is what `validate=True` is actually for
+    sig = bip322.sign(b"x", WIF, _address(WIF, "p2pkh"))
+    text = sig.b64encode()
+    smuggled = text[:10] + "\n" + text[10:]
+    with pytest.raises(BTClibValueError, match="invalid base64 encoding"):
+        bip322.Sig.b64decode(smuggled)
+
+
+def test_is_bms_is_the_exact_65_octets_and_nothing_shorter() -> None:
+    """A legacy-looking signature is 65 octets exactly, not merely no more.
+
+    `_is_bms` only sniffs the size to route `assert_as_valid`'s `legacy`
+    branch; whichever way it decides, a real check waits downstream.
+    But the two downstream checks are not the same one: a base64 blob
+    that decodes to fewer than 65 octets is short for `Witness.parse`
+    (BIP322, `_is_bms` correctly says no) in one wrong way, and short
+    for `bms.Sig.parse` (`_is_bms` wrongly saying yes) in another --
+    which is what tells a weakened `<=` apart from `==` here.
+    """
+    addr = _address(WIF, "p2pkh")
+    short = base64.b64encode(b"x" * 40).decode()
+    with pytest.raises(BTClibRuntimeError, match="not enough binary data"):
+        bip322.assert_as_valid(b"hello", addr, short, legacy=True)
 
 
 def _to_sign_of(msg: bytes, addr: str, **kwargs: Any) -> tuple[Tx, Tx]:
@@ -402,6 +467,41 @@ def test_shape_of_to_sign_is_checked() -> None:
     tx.vin.clear()
     with pytest.raises(BTClibValueError, match="no input in to_sign"):
         bip322.assert_as_valid(msg, addr, bip322.Sig(tx))
+
+    # zero outputs, not only two: `len(tx.vout) != 1` weakened to `> 1`
+    # would let a to_sign with none at all through this check, past the
+    # `tx.vout[0]` right after it that a real answer never reaches empty
+    spend, tx = _to_sign_of(msg, addr, witness=signed.payload)
+    tx.vout.clear()
+    with pytest.raises(BTClibValueError, match="outputs in to_sign"):
+        bip322._assert_shape(tx, spend, list(spend.vout))
+
+    # a script that is not the OP_RETURN, sorting below it and above it:
+    # `!= _OP_RETURN` weakened to `<` or to `>` each miss the direction
+    # the vector above does not move in ("\x6a" itself, an equal script
+    # excluded by the `.value` check next to it instead)
+    for wrong_script in (b"\x00", b"\xff"):
+        _, tx = _to_sign_of(msg, addr, witness=signed.payload)
+        tx.vout[0] = TxOut(0, wrong_script)
+        with pytest.raises(BTClibValueError, match="not the OP_RETURN"):
+            bip322.assert_as_valid(msg, addr, bip322.Sig(tx))
+
+    # more utxos than inputs, not only fewer: `!= len(tx.vin)` weakened
+    # to `< len(tx.vin)` would accept the extra one silently
+    spend, tx = _to_sign_of(msg, addr, witness=signed.payload)
+    with pytest.raises(BTClibValueError, match="utxos for"):
+        bip322._assert_shape(tx, spend, list(spend.vout) * 2)
+
+    # the error message names the first input, which a second one on
+    # the same tx tells apart from the last: `tx.vin[0]` weakened to
+    # `tx.vin[-1]` in the f-string alone still raises on the same
+    # condition, and only the wrong hex in the message gives it away
+    spend, tx = _to_sign_of(msg, addr, witness=signed.payload)
+    other_id = bytes(range(32))
+    tx.vin[0].prev_out = OutPoint(other_id, 0)
+    tx.vin.append(TxIn(OutPoint(spend.id, 0), b"", 0))
+    with pytest.raises(BTClibValueError, match=other_id.hex()):
+        bip322._assert_shape(tx, spend, [spend.vout[0], spend.vout[0]])
 
 
 def test_a_version_that_is_not_0_or_2_is_inconclusive() -> None:
@@ -469,3 +569,12 @@ def test_proof_of_funds_reuses_an_earlier_non_witness_utxo() -> None:
     psbt.inputs[1].non_witness_utxo = None
     with pytest.raises(BTClibValueError, match="no utxo for input 1"):
         bip322._psbt_prevouts(psbt)
+
+    # the referenced transaction is there, but its vout is not: `vout <
+    # len(prev_tx.vout)` weakened to `<=` needs the boundary itself,
+    # weakened to `!=` needs one past it -- `<=` still refuses that one
+    psbt.inputs[1].non_witness_utxo = funding
+    for out_of_range in (len(funding.vout), len(funding.vout) + 1):
+        psbt.inputs[1].output_index = out_of_range
+        with pytest.raises(BTClibValueError, match="no utxo for input 1"):
+            bip322._psbt_prevouts(psbt)

--- a/tests/bip322_test.py
+++ b/tests/bip322_test.py
@@ -32,6 +32,7 @@ from btclib.exceptions import (
 from btclib.hashes import hash160
 from btclib.psbt import Psbt
 from btclib.script import ScriptPubKey, address, serialize
+from btclib.script.engine import ALL_FLAGS, ScriptFlag
 from btclib.script.sig_hash import ALL, segwit_v0
 from btclib.script.taproot import output_pubkey
 from btclib.script.witness import Witness
@@ -75,6 +76,42 @@ def _ids(group: str) -> list[str]:
         vector_id(i, case.get("type"), case.get("description"))
         for i, case in enumerate(_cases(group))
     ]
+
+
+def test_required_and_upgradeable_rules_are_every_flag_named() -> None:
+    """The two flag sets, against the OR of what each lists by name.
+
+    Each is built as one long `|` chain over distinct-bit `ScriptFlag`
+    members, seven and five of them respectively: an `&` anywhere in
+    that chain collapses everything already accumulated to the left of
+    it against a single bit, and nothing before this test called either
+    name to notice a REQUIRED_RULES a hundred times smaller than the
+    seven flags it names.
+    """
+    required = ALL_FLAGS
+    for flag in (
+        ScriptFlag.STRICTENC,
+        ScriptFlag.LOW_S,
+        ScriptFlag.NULLFAIL,
+        ScriptFlag.MINIMALDATA,
+        ScriptFlag.CLEANSTACK,
+        ScriptFlag.MINIMALIF,
+        ScriptFlag.CONST_SCRIPTCODE,
+    ):
+        required |= flag
+    assert required == bip322.REQUIRED_RULES
+
+    upgradeable = (
+        ScriptFlag.DISCOURAGE_UPGRADABLE_NOPS
+        | ScriptFlag.DISCOURAGE_UPGRADABLE_WITNESS_PROGRAM
+        | ScriptFlag.DISCOURAGE_UPGRADABLE_PUBKEYTYPE
+        | ScriptFlag.DISCOURAGE_OP_SUCCESS
+        | ScriptFlag.DISCOURAGE_UPGRADABLE_TAPROOT_VERSION
+    )
+    assert upgradeable == bip322.UPGRADEABLE_RULES
+    # the two sets do not overlap: a required rule failing is invalid, an
+    # upgradeable one inconclusive, and a flag in both could not be either
+    assert not bip322.REQUIRED_RULES & bip322.UPGRADEABLE_RULES
 
 
 @pytest.mark.parametrize("case", BASIC["tx_hashes"], ids=_ids("tx_hashes"))

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -116,6 +116,13 @@ def test_exceptions() -> None:
     with pytest.raises(BTClibValueError, match="invalid merkle_root length: "):
         header.assert_valid()
 
+    # too short, not just too long: `!= size` weakened to `> size` would
+    # still refuse 33 octets and miss 31
+    header = BlockHeader.parse(header_bytes)
+    header.merkle_root = b"\xff" * 31
+    with pytest.raises(BTClibValueError, match="invalid merkle_root length: "):
+        header.assert_valid()
+
     header = BlockHeader.parse(header_bytes)
     header.bits = b"\xff" * 5
     with pytest.raises(BTClibValueError, match="invalid bits length: "):

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -19,7 +19,12 @@ from pathlib import Path
 
 import pytest
 
-from btclib.block import Block, BlockHeader
+from btclib.block import (
+    Block,
+    BlockHeader,
+    bip34_commitment,
+    merkle_root_and_mutated_from_transactions,
+)
 from btclib.block.limits import (
     MAX_BLOCK_SIGOPS_COST,
     MAX_BLOCK_WEIGHT,
@@ -27,10 +32,11 @@ from btclib.block.limits import (
 )
 from btclib.block.proof_of_work import REGTEST_POW_LIMIT_BITS
 from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.hashes import hash256, merkle_root_and_mutated_from_hashes
 from btclib.network import NETWORKS
 from btclib.script import ScriptPubKey
 from btclib.script.witness import Witness
-from btclib.tx import TxOut
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests.conftest import JsonGolden
 
 
@@ -104,6 +110,19 @@ def test_exceptions() -> None:
         header.assert_valid()
     header.version = 0x7FFFFFFF + 1
     with pytest.raises(BTClibValueError, match="invalid version: "):
+        header.assert_valid()
+    # the upper boundary itself, not only past it: `<= 0x7fffffff`
+    # weakened to `<` would refuse the one version every other test
+    # vector already carries, and no vector for it means no signal
+    header.version = 0x7FFFFFFF
+    header.assert_valid()
+
+    header = BlockHeader.parse(header_bytes)
+    # a nonce below zero, not only one past the top: `0 <=` loosened to
+    # `-1 <=` would let it through, the negative side `> 0x100000000`
+    # above never reaches
+    header.nonce = -1
+    with pytest.raises(BTClibValueError, match="invalid nonce: "):
         header.assert_valid()
 
     header = BlockHeader.parse(header_bytes)
@@ -197,6 +216,191 @@ def test_block_header_keywords() -> None:
     assert header.serialize() == header_bytes
 
 
+def test_block_header_defaults() -> None:
+    """Every default `__init__` leaves unset, read back off a bare header."""
+    header = BlockHeader(check_validity=False)
+    assert header.version == 1
+    assert header.nonce == 0
+    # the epoch itself, not one second either side of it: aware, because
+    # a naive one would compare differently depending on the machine
+    assert header.time == datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def test_parse_reads_the_timestamp_field_unsigned() -> None:
+    """A post-2038 timestamp is not a pre-1970 one misread as negative.
+
+    The field is four unsigned bytes, valid up to 2106 per `assert_valid`;
+    `signed=True` would turn one past 2038 negative and `fromtimestamp`
+    would still accept the result, silently, rather than raising or even
+    landing in the right century.
+    """
+    time = datetime(2040, 1, 1, tzinfo=timezone.utc)
+    header = BlockHeader(
+        1,
+        bytes(32),
+        bytes(32),
+        time,
+        bytes.fromhex("1d00ffff"),
+        0,
+        check_validity=False,
+    )
+    parsed = BlockHeader.parse(
+        header.serialize(check_validity=False), check_validity=False
+    )
+    assert parsed.time == time
+
+
+def test_check_validity_defaults_to_true_everywhere_it_appears() -> None:
+    """`__init__`, `to_dict`, `serialize`, `from_dict`, `parse`: five guards.
+
+    One field breaks two rules at once and is reused throughout: a
+    negative version fails `assert_valid` (`0 < version`) and needs
+    `signed=True` to survive `serialize` and `parse` without an
+    `OverflowError` or a silently different number coming back --
+    `to_bytes`/`from_bytes` weakened to `signed=False` would raise on
+    the way out and misread on the way back respectively.
+    """
+    header = BlockHeader(
+        -1,
+        bytes(32),
+        bytes(32),
+        datetime(2009, 1, 9, 2, 54, 25, tzinfo=timezone.utc),
+        bytes.fromhex("1d00ffff"),
+        0,
+        check_validity=False,
+    )
+
+    with pytest.raises(BTClibValueError, match="invalid version: -0x1"):
+        BlockHeader(
+            -1,
+            bytes(32),
+            bytes(32),
+            datetime(2009, 1, 9, 2, 54, 25, tzinfo=timezone.utc),
+            bytes.fromhex("1d00ffff"),
+            0,
+        )
+
+    with pytest.raises(BTClibValueError, match="invalid version: -0x1"):
+        header.to_dict()
+    as_dict = header.to_dict(check_validity=False)
+    assert as_dict["version"] == -1
+
+    with pytest.raises(BTClibValueError, match="invalid version: -0x1"):
+        header.serialize()
+    as_bytes = header.serialize(check_validity=False)
+    assert as_bytes[:4] == (-1).to_bytes(4, "little", signed=True)
+
+    with pytest.raises(BTClibValueError, match="invalid version: -0x1"):
+        BlockHeader.from_dict(as_dict)
+    assert BlockHeader.from_dict(as_dict, check_validity=False) == header
+
+    with pytest.raises(BTClibValueError, match="invalid version: -0x1"):
+        BlockHeader.parse(as_bytes)
+    assert BlockHeader.parse(as_bytes, check_validity=False) == header
+
+    # `hash` always serializes with check_validity=False, whatever the
+    # header's own state: True there would refuse the very header being
+    # hashed, which is what mining a not-yet-valid candidate does not do
+    assert header.hash
+
+
+def _coinbase_and_a_transaction_missing_its_outputs() -> tuple[Tx, Tx]:
+    """Return a valid coinbase and a second transaction `assert_valid` refuses.
+
+    Shared by the tests below: each exercises a different place that
+    must serialize or dict-ify the second transaction without judging
+    it, `Block.assert_valid` -- or a real caller's own -- being what
+    judges it instead, once.
+    """
+    coinbase = Tx(
+        1,
+        0,
+        [TxIn(OutPoint(bytes(32), 0xFFFFFFFF), b"\x01\x01", 0xFFFFFFFF, Witness())],
+        [TxOut(0, b"\x6a")],
+        check_validity=False,
+    )
+    missing_outputs = Tx(
+        1,
+        0,
+        [TxIn(OutPoint(bytes(32), 0), b"\x00", 0xFFFFFFFF, Witness())],
+        [],
+        check_validity=False,
+    )
+    return coinbase, missing_outputs
+
+
+def test_block_check_validity_defaults_to_true_everywhere_it_appears() -> None:
+    """`__init__`, `to_dict`, `serialize`, `from_dict`: the same four guards.
+
+    `BlockHeader`'s own test names, plus the header and every transaction
+    dict-ified or read back at their own default in the process.
+    """
+    coinbase, missing_outputs = _coinbase_and_a_transaction_missing_its_outputs()
+    header = BlockHeader(
+        0,  # invalid on its own, so the header dict/from_dict calls below
+        # cannot pass by accident
+        bytes(32),
+        bytes(32),
+        datetime(2009, 1, 9, 2, 54, 25, tzinfo=timezone.utc),
+        bytes.fromhex("1d00ffff"),
+        0,
+        check_validity=False,
+    )
+    block = Block(header, [coinbase, missing_outputs], check_validity=False)
+
+    with pytest.raises(BTClibValueError, match="invalid version: "):
+        Block(header, [coinbase, missing_outputs])
+
+    with pytest.raises(BTClibValueError, match="invalid version: "):
+        block.to_dict()
+    as_dict = block.to_dict(check_validity=False)
+    assert as_dict["header"]["version"] == 0
+    assert as_dict["transactions"][1]["vout"] == []
+
+    with pytest.raises(BTClibValueError, match="invalid version: "):
+        block.serialize()
+    assert block.serialize(check_validity=False)
+
+    with pytest.raises(BTClibValueError, match="invalid version: "):
+        Block.from_dict(as_dict)
+    assert Block.from_dict(as_dict, check_validity=False) == block
+
+
+def test_merkle_root_and_witness_commitment_serialize_without_judging() -> None:
+    """The two internal hash loops over transactions, at their own default.
+
+    `merkle_root_and_mutated_from_transactions` and the witness-tree
+    loop inside `assert_valid_witness_commitment` each serialize every
+    transaction with `check_validity=False`: `True` there would raise
+    on the second transaction's own account, rather than leaving that
+    to whichever `assert_valid` call the caller made once, outside
+    either loop.
+    """
+    coinbase, missing_outputs = _coinbase_and_a_transaction_missing_its_outputs()
+
+    root, mutated = merkle_root_and_mutated_from_transactions(
+        [coinbase, missing_outputs]
+    )
+    assert root
+    assert not mutated
+
+    nonce = bytes(32)
+    hashes = [
+        b"\x00" * 32,
+        hash256(missing_outputs.serialize(True, check_validity=False)),
+    ]
+    witness_root = merkle_root_and_mutated_from_hashes(hashes, hash256)[0]
+    commitment = hash256(witness_root + nonce)
+    coinbase.vin[0].script_witness = Witness([nonce])
+    coinbase.vout[0] = TxOut(
+        0, ScriptPubKey(bytes.fromhex("6a24aa21a9ed") + commitment)
+    )
+
+    header = BlockHeader(check_validity=False)
+    block = Block(header, [coinbase, missing_outputs], check_validity=False)
+    block.assert_valid_witness_commitment()
+
+
 def test_block_170() -> None:
     """Test first block with a transaction."""
     fname = "block_170.bin"
@@ -233,6 +437,13 @@ def test_block_170() -> None:
     assert header == BlockHeader.parse(header.serialize())
     assert header == BlockHeader.from_dict(header.to_dict())
 
+    # a computed root that sorts *above* the claimed one, not only below
+    # it: `!= self.header.merkle_root` weakened to `<` would miss this
+    # direction, which the vector in test_block_200000 does not exercise
+    block.transactions.pop()
+    with pytest.raises(BTClibValueError, match="invalid merkle root: "):
+        block.assert_valid_merkle_root()
+
 
 def test_block_200000() -> None:
     """Verify block 200,000: 388 transactions and a BIP34 height."""
@@ -247,6 +458,11 @@ def test_block_200000() -> None:
     assert block.weight == 990_132
     assert block.sig_op_count == 822
     assert block.height == 200_000
+    # only version 1 skips the BIP34 decode, not version 0 too: `== 1`
+    # weakened to `<= 1` would read this same coinbase as heightless
+    block.header.version = 0
+    assert block.height == 200_000
+    block.header.version = 2
     assert not block.has_segwit_tx()
     assert block == Block.parse(block.serialize())
     assert block == Block.from_dict(block.to_dict())
@@ -352,6 +568,24 @@ def test_block_481824() -> None:
             assert block.vsize == 988_519
 
 
+def test_vsize_rounds_up_a_weight_that_is_not_a_multiple_of_four() -> None:
+    """988,720 above is exact; `/ 4` weakened to `// 4` needs a remainder.
+
+    One more byte of witness moves the weight by one without moving the
+    stripped size at all, which is what a witness byte costs.
+    """
+    fname = "block_481824_complete.bin"
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
+        block_bytes = file_.read()
+
+    block = Block.parse(block_bytes)
+    stack = block.transactions[1].vin[0].script_witness.stack
+    block.transactions[1].vin[0].script_witness = Witness([*stack, b"\x00"])
+    assert block.weight == 3_954_885
+    assert block.vsize == 988_722
+
+
 def test_block_witness_commitment() -> None:
     """A block whose witness data was replaced is rejected (BIP141).
 
@@ -398,6 +632,38 @@ def test_block_witness_commitment() -> None:
     assert block.witness_commitment == b"\x00" * 32
     with pytest.raises(BTClibValueError, match="invalid witness commitment: "):
         block.assert_valid_witness_commitment()
+
+    # a wrong commitment that sorts *below* the claimed one, not only
+    # above it: `!= commitment` weakened to `>` would miss this
+    # direction, both other vectors here happening to sort the other way
+    block = Block.parse(block_bytes)
+    block.transactions[0].vin[0].script_witness = Witness([bytes([21]) * 32])
+    computed = "4f367b1b732e90a5f2892968cbdfa0955d089882ca0c377b368063cc24b71228"
+    assert computed < commitment
+    err_msg = f"invalid witness commitment: {commitment} instead of: {computed}"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        block.assert_valid_witness_commitment()
+
+
+def test_witness_commitment_output_may_carry_more_than_the_commitment() -> None:
+    """`>= _COMMITMENT_LENGTH`, not `==` or `<=`: trailing bytes are legal.
+
+    Nothing in BIP141 bounds the output script from above, and Core's
+    own GetWitnessCommitmentIndex does not either -- the 32 bytes right
+    after the prefix are the commitment regardless of what, if
+    anything, follows them.
+    """
+    commitment = bytes(range(32))
+    extra_script = bytes.fromhex("6a24aa21a9ed") + commitment + b"\xff\xff"
+    tx = Tx(
+        1,
+        0,
+        [TxIn(OutPoint(bytes(32), 0xFFFFFFFF), b"\x00", 0xFFFFFFFF, Witness())],
+        [TxOut(0, ScriptPubKey(extra_script))],
+        check_validity=False,
+    )
+    block = Block(BlockHeader(check_validity=False), [tx], check_validity=False)
+    assert block.witness_commitment == commitment
 
 
 def test_block_witness_nonce() -> None:
@@ -589,6 +855,36 @@ def test_block_without_transactions() -> None:
         Block(header, [])
 
 
+def test_bip34_commitment_op_int_range_is_minus_one_to_sixteen() -> None:
+    """The op-code branch is `-1..16`, not one wider on either side.
+
+    -1 is `OP_1NEGATE` and the boundary itself; -2 is a minimal data
+    push instead and the value `op_int` refuses, which is what tells
+    `<=` weakened to `!=`, to `<`, and `-1` itself replaced by `~1`
+    (also -2) or by `-0` apart: each moves one boundary, and the two
+    values here are the two boundaries.
+    """
+    assert bip34_commitment(-1) == bytes.fromhex("4f")
+    assert bip34_commitment(-2) == bytes.fromhex("0182")
+    assert bip34_commitment(16) == bytes.fromhex("60")
+    assert bip34_commitment(17) == bytes.fromhex("0111")
+
+
+def test_assert_valid_coinbase_height_reads_the_first_transaction() -> None:
+    """`self.transactions[0]`, on a coinbase a second transaction is not.
+
+    Block 200,000 is BIP34 and multi-transaction, so a `vin[0]`
+    weakened to the *last* transaction's reads a script_sig that never
+    started with the height commitment to begin with.
+    """
+    fname = "block_200000.bin"
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
+        block = Block.parse(file_.read())
+
+    block.assert_valid_coinbase_height(200_000)
+
+
 def test_a_block_carries_one_coinbase() -> None:
     """A second coinbase is refused, as Core's bad-cb-multiple.
 
@@ -629,6 +925,25 @@ def test_assert_valid_checks_the_coinbase_transaction() -> None:
         block = Block.parse(file_.read())
 
     block.transactions[0].vin[0].script_sig = b""
+    with pytest.raises(BTClibValueError, match="Invalid coinbase script size"):
+        block.assert_valid()
+
+
+def test_assert_valid_checks_the_first_transaction_and_not_the_last() -> None:
+    """`self.transactions[0]` and not `[-1]`, on a block that tells them apart.
+
+    Block 1 above has one transaction, where the two names the same
+    object: `self.transactions[0].assert_valid()` weakened to `[-1]`
+    needs a second transaction to be told from the loop that already
+    validates every one but the first.
+    """
+    fname = "block_200000.bin"
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
+        block = Block.parse(file_.read())
+
+    assert len(block.transactions) > 1
+    block.transactions[0].vin[0].script_sig = b"\x00" * 101
     with pytest.raises(BTClibValueError, match="Invalid coinbase script size"):
         block.assert_valid()
 
@@ -889,6 +1204,47 @@ def test_a_block_cannot_weigh_more_than_the_cap() -> None:
     assert block.weight == 4_000_850
     with pytest.raises(BTClibValueError, match="invalid witness nonce: "):
         block.assert_valid()
+
+    # the cap itself, not only one past it: `> MAX_BLOCK_WEIGHT` weakened
+    # to `>=` would refuse a block every node on the network accepts
+    block = Block.parse(block_bytes)
+    block.transactions[1].vin[0].script_witness = Witness([b"\x00" * 45_114])
+    assert block.weight == MAX_BLOCK_WEIGHT
+    block.assert_valid_weight()
+
+
+def test_the_length_and_weight_caps_are_reachable_not_only_crossable() -> None:
+    """The count, the stripped size and the weight, each at its own cap.
+
+    Three `>` comparisons weakened to `>=` would each refuse the one
+    value the rule is written to allow, and none of the three vectors
+    above happens to land on it.
+    """
+    fname = "block_1.bin"
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
+        block_bytes = file_.read()
+
+    limit = MAX_BLOCK_WEIGHT // WITNESS_SCALE_FACTOR
+    parsed = Block.parse(block_bytes)
+
+    # the count cap: a million transactions is not too many, whatever
+    # `assert_valid_length` finds wrong with them next
+    at_cap = Block(
+        parsed.header, [parsed.transactions[0]] * limit, check_validity=False
+    )
+    with pytest.raises(BTClibValueError, match="invalid stripped size: "):
+        at_cap.assert_valid_length()
+
+    # the stripped-size cap, this time genuinely unrefused: the 215
+    # bytes of block 1, less its 68-byte scripted output, plus one this
+    # size exactly
+    block = Block.parse(block_bytes)
+    block.transactions[0].vout[0] = TxOut(
+        block.transactions[0].vout[0].value, ScriptPubKey(b"\x00" * 999_848)
+    )
+    assert block.stripped_size == limit
+    block.assert_valid_length()
 
 
 def test_a_block_still_requires_the_work() -> None:

--- a/tests/block/proof_of_work_test.py
+++ b/tests/block/proof_of_work_test.py
@@ -57,6 +57,10 @@ def test_consensus_parameters() -> None:
     assert POW_TARGET_TIMESPAN == 14 * 24 * 60 * 60
     assert POW_TARGET_SPACING == 10 * 60
     assert DIFFICULTY_ADJUSTMENT_INTERVAL == 2016
+    # a `//` weakened to `/` still equals 2016, floating point being exact
+    # at this size, but is no longer the int retarget_first_height's own
+    # subtraction wants
+    assert isinstance(DIFFICULTY_ADJUSTMENT_INTERVAL, int)
 
     # mainnet's limit is the genesis block target, which is what makes
     # the genesis difficulty 1
@@ -242,6 +246,12 @@ def test_bits_from_target_edges() -> None:
     assert bits_from_target("01").hex() == "01010000"
     assert bits_from_target("0102").hex() == "02010200"
 
+    # exponent 4 exactly, the first value of the *other* branch: `<= 3`
+    # weakened to `<= 4` sends it through the left shift above instead,
+    # by a negative amount, which is not a quiet wrong answer but a
+    # `ValueError` of its own
+    assert bits_from_target((0x01000000).to_bytes(32, "big")).hex() == "04010000"
+
     # zero occupies no bytes at all
     assert bits_from_target(b"").hex() == "00000000"
     assert bits_from_target(b"\x00" * 32).hex() == "00000000"
@@ -399,6 +409,28 @@ def test_next_bits_pow_limit_is_per_network() -> None:
     )
 
 
+def test_next_bits_reads_the_pow_limit_unsigned() -> None:
+    """A pow_limit past 2^255 is read as itself, not as its negative twin.
+
+    `min(target, pow_limit)` has nothing downstream to wrap a misread
+    back into range the way the multiplication two lines above does for
+    `target` itself (see `test_next_bits_wraps_as_core_does`): a signed
+    read of `pow_limit_bits` here raises trying to re-encode a negative
+    result instead of leaving the small, unclamped target alone.
+    """
+    first = _time(1262152739)
+    two_weeks = timedelta(seconds=POW_TARGET_TIMESPAN)
+    assert (
+        next_bits(
+            MAINNET_POW_LIMIT_BITS,
+            first,
+            first + two_weeks,
+            pow_limit_bits="2100ffff",
+        )
+        == MAINNET_POW_LIMIT_BITS
+    )
+
+
 def test_next_bits_wraps_as_core_does() -> None:
     """Core multiplies in arith_uint256, and arith_uint256 wraps.
 
@@ -421,6 +453,14 @@ def test_next_bits_wraps_as_core_does() -> None:
     assert target_from_bits("220000ff")[0] == 0xFF
 
     assert next_bits("220000ff", first, first + two_weeks) == bytes(4)
+
+    # the ring is 2^256 and not 2^255: this target's bit 255 is the one
+    # the product's wrap carries into the quotient, which a `% 2**256`
+    # weakened to `% 2**255` drops before the floor division ever sees
+    # it, changing an unchanged two-week period into a wrong one instead
+    assert next_bits(
+        "1e080000", first, first + two_weeks, pow_limit_bits=REGTEST_POW_LIMIT_BITS
+    ) == bytes.fromhex("1e080000")
 
 
 def test_block_work() -> None:
@@ -449,6 +489,17 @@ def test_block_work() -> None:
     # the `- 1` that would only fail loudly at target 1, never silently
     small_target_bits = bits_from_target((2).to_bytes(32, "big"))
     assert block_work(small_target_bits) == 2**256 // 3
+
+    # target 1, odd rather than even: `+ 1` weakened to `| 1` or `^ 1`
+    # agrees with it on every even target, 2 above included, and only an
+    # odd one tells the three apart (2 vs 1 vs 0 for a target of 1)
+    odd_target_bits = bits_from_target((1).to_bytes(32, "big"))
+    assert block_work(odd_target_bits) == 2**256 // 2
+
+    # a target past 2^255, the sign bit of a 32-byte signed read: nothing
+    # downstream masks or wraps this one back, unlike `next_bits`'s own
+    # `int.from_bytes` of a target, see there
+    assert block_work("2100ffff") == 1
 
 
 def test_chain_work() -> None:

--- a/tests/block/proof_of_work_test.py
+++ b/tests/block/proof_of_work_test.py
@@ -443,6 +443,13 @@ def test_block_work() -> None:
         with pytest.raises(BTClibValueError, match="zero proof-of-work target: "):
             block_work(bits_hex)
 
+    # every target above is within a whisker of 2^224, where `target + 1`
+    # and `target - 1` floor-divide 2^256 to the same integer -- a target
+    # this small is what tells the `+ 1` the formula is written on from
+    # the `- 1` that would only fail loudly at target 1, never silently
+    small_target_bits = bits_from_target((2).to_bytes(32, "big"))
+    assert block_work(small_target_bits) == 2**256 // 3
+
 
 def test_chain_work() -> None:
     """Best is most work, not most blocks."""
@@ -504,3 +511,10 @@ def test_hash_rate_exceptions() -> None:
 
     with pytest.raises(BTClibValueError, match="invalid difficulty: "):
         hash_rate(0.0, 600.0)
+    # zero and negative are refused by two different comparisons, and
+    # zero alone does not tell `<= 0` from `== 0`
+    with pytest.raises(BTClibValueError, match="invalid difficulty: "):
+        hash_rate(-1.0, 600.0)
+
+    # 1 is the smallest timespan `<= 0` accepts; `<= 1` would refuse it
+    assert hash_rate(1.0, 1.0) > 0

--- a/tests/ecc/anti_exfil_test.py
+++ b/tests/ecc/anti_exfil_test.py
@@ -151,6 +151,17 @@ def test_the_whole_handshake() -> None:
         secp256k1.add(R, secp256k1.G),
     )
 
+    # lower_s defaults to True here too: the malleated twin shares r, so
+    # the commitment check alone would still open, and only the default
+    # refuses it
+    malleated = dsa.Sig(sig.r, sig.ec.n - sig.s)
+    assert dsa.anti_exfil_host_verify(
+        _HANDSHAKE_MSG_HASH, _PUB_KEY, malleated, _RHO, R, lower_s=False
+    )
+    assert not dsa.anti_exfil_host_verify(
+        _HANDSHAKE_MSG_HASH, _PUB_KEY, malleated, _RHO, R
+    )
+
 
 def test_the_signer_keeps_no_state() -> None:
     """A rho that does not match the commitment fails step 5, and only that.

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import base64
 import contextlib
 import dataclasses
+from collections.abc import Callable
 from hashlib import sha256
 from typing import Any
 
@@ -24,6 +25,7 @@ import pytest
 
 from btclib import b32, b58
 from btclib.alias import Point
+from btclib.b58 import h160_from_address
 from btclib.bip32 import bip32
 from btclib.curves import mult, secp256k1
 from btclib.curves.curve import CURVES
@@ -35,6 +37,31 @@ from btclib.to_prv_key import prv_keyinfo_from_prv_key
 from tests import load, vector_id
 
 ec = secp256k1
+
+
+def test_check_validity_defaults_to_true_everywhere_it_appears() -> None:
+    """serialize, b64encode and parse all refuse an invalid Sig by default.
+
+    Built once with `check_validity=False`, an out-of-range recovery
+    flag is invalid for every one of the checks these three otherwise
+    make on the way to bytes or back: a default flipped to `False`
+    would let it through silently instead.
+    """
+    dsa_sig = dsa.Sig(1, 1, ec, check_validity=False)
+    invalid = bms.Sig(100, dsa_sig, check_validity=False)
+
+    with pytest.raises(BTClibValueError, match="invalid recovery flag: "):
+        invalid.serialize()
+    invalid.serialize(check_validity=False)
+
+    with pytest.raises(BTClibValueError, match="invalid recovery flag: "):
+        invalid.b64encode()
+    invalid.b64encode(check_validity=False)
+
+    data = invalid.serialize(check_validity=False)
+    with pytest.raises(BTClibValueError, match="invalid recovery flag: "):
+        bms.Sig.parse(data)
+    bms.Sig.parse(data, check_validity=False)
 
 
 def test_signature() -> None:
@@ -74,6 +101,12 @@ def test_signature() -> None:
     err_msg = "not a low s"
     with pytest.raises(BTClibValueError, match=err_msg):
         bms.assert_as_valid(msg, addr, bms_sig, lower_s=True)
+    # and the same is true left to the default: assert_as_valid's and
+    # verify's lower_s both default to True, and every other call in
+    # this file passes the keyword explicitly
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bms.assert_as_valid(msg, addr, bms_sig)
+    assert not bms.verify(msg, addr, bms_sig)
 
     # bms_sig taken from (Electrum and) Bitcoin Core
     wif, addr = bms.gen_keys("5KMWWy2d3Mjc8LojNoj8Lcz9B1aWu8bRofUgGwQk959Dw5h2iyw")
@@ -120,9 +153,25 @@ def test_exceptions() -> None:
     with pytest.raises(BTClibValueError, match=err_msg):
         bms.assert_as_valid(msg, b32.p2wsh(32 * b"\x00"), exp_sig)
 
+    # a program's length, not only its version: p2wsh above is version 0
+    # with a 32-byte program, caught by the length half of `wit_ver != 0
+    # or len(h160) != 20` alone -- `!= 0` weakened to `< 0` needs a
+    # *non-zero* version paired with a 20-byte program, which no other
+    # witness type is, to be told apart
+    not_p2wpkh = b32.address_from_witness(5, bytes(20))
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bms.assert_as_valid(msg, not_p2wpkh, exp_sig)
+
     err_msg = "invalid recovery flag: "
     with pytest.raises(BTClibValueError, match=err_msg):
         bms.Sig(26, bms_sig.dsa_sig)
+
+    # the upper boundary, not only the lower one: `self.rf > 42` weakened
+    # to `>= 42` would refuse 42 itself, which the vector above cannot
+    # show since it only ever moves the lower bound
+    bms.Sig(42, bms_sig.dsa_sig)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bms.Sig(43, bms_sig.dsa_sig)
 
     # 84 base64 characters and then a padding one, i.e. a pad following
     # a complete group: guards against b64decode discarding it, as
@@ -199,6 +248,62 @@ def test_exceptions() -> None:
     err_msg = "invalid p2wpkh address recovery flag: "
     with pytest.raises(BTClibValueError, match=err_msg):
         bms.assert_as_valid(msg, b32_p2wpkh, bms_sig)
+
+
+def test_every_recovery_flag_is_ruled_on_by_range_alone() -> None:
+    """Sweep 27..42 against each address type, the range check in isolation.
+
+    A single vector per address type -- 39 for p2pkh, 35 for p2wpkh --
+    only ever pins one side of a range that has two boundaries each
+    (p2pkh's is one-sided, p2wpkh's and p2wpkh-p2sh's are not): `> 34`
+    weakened to `>= 34` refuses 34 itself, and `30 < rf < 35 or rf > 38`
+    weakened to `30 < rf != 35 or rf > 38` accepts 36 and 37, neither of
+    which any existing vector asks about.
+
+    Called directly on the three private helpers rather than through
+    `assert_as_valid`: that entry point recovers a public key from `rf`
+    before any range check runs, and not every `rf` recovers one from a
+    fixed signature, which is a fact about elliptic-curve recovery and
+    not about the range check this test is for. A wrong pub_key and
+    h160 here still tell "recovery flag" from "address" apart -- only
+    the range check can raise the first, and the address one always
+    raises the second once the range holds.
+    """
+    wif = "Kx45GeUBSMPReYQwgXiKhG9FzNXrnCeutJp4yjTd5kKxCitadm3C"
+    dummy_pub_key = b"\x02" + 32 * b"\x00"
+    b58_p2pkh = b58.p2pkh(wif)
+    _, h160_p2pkh, _ = h160_from_address(b58_p2pkh)
+    b32_p2wpkh = b32.p2wpkh(wif)
+    b58_p2wpkh_p2sh = b58.p2wpkh_p2sh(wif)
+    _, h160_p2sh, _ = h160_from_address(b58_p2wpkh_p2sh)
+
+    checks: list[tuple[Callable[[int], None], set[int], str, str]] = [
+        (
+            lambda rf: bms._assert_p2pkh(b58_p2pkh, rf, dummy_pub_key, h160_p2pkh),
+            set(range(27, 35)),
+            "invalid p2pkh address recovery flag: ",
+            "invalid p2pkh address: ",
+        ),
+        (
+            lambda rf: bms._assert_p2wpkh(b32_p2wpkh, rf, dummy_pub_key),
+            {31, 32, 33, 34, 39, 40, 41, 42},
+            "invalid p2wpkh address recovery flag: ",
+            "invalid p2wpkh address: ",
+        ),
+        (
+            lambda rf: bms._assert_p2wpkh_p2sh(
+                b58_p2wpkh_p2sh, rf, dummy_pub_key, h160_p2sh
+            ),
+            set(range(31, 39)),
+            "invalid p2wpkh-p2sh address recovery flag: ",
+            "invalid p2wpkh-p2sh address: ",
+        ),
+    ]
+    for check, valid_range, flag_err, address_err in checks:
+        for rf in range(27, 43):
+            expected = address_err if rf in valid_range else flag_err
+            with pytest.raises(BTClibValueError, match=expected):
+                check(rf)
 
 
 def test_one_prv_key_multiple_addresses() -> None:

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import base64
 import contextlib
+import dataclasses
 from hashlib import sha256
 from typing import Any
 
@@ -50,6 +51,12 @@ def test_signature() -> None:
     assert bms_sig == bms.Sig.b64decode(bms_sig.b64encode().encode("ascii"))
 
     assert bms_sig == bms.sign(msg, wif.encode("ascii"))
+
+    # frozen: `__init__` sets both fields through `object.__setattr__`
+    # for exactly this reason, and nothing after construction reaches
+    # them the same way
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        bms_sig.rf = 27  # type: ignore[misc]
 
     # malleated signature
     dsa_sig = dsa.Sig(bms_sig.dsa_sig.r, bms_sig.dsa_sig.ec.n - bms_sig.dsa_sig.s)

--- a/tests/ecc/der_test.py
+++ b/tests/ecc/der_test.py
@@ -81,6 +81,13 @@ def test_der_deserialize() -> None:
         with pytest.raises(BTClibValueError, match=err_msg):
             Sig.parse(bad_sig_bin)
 
+        # 0x80 itself is not the only negative first byte: `>= 0x80`
+        # weakened to `== 0x80` would miss every byte above it
+        bad_sig_bin = sig_bin[:offset] + b"\xff" + sig_bin[offset + 1 :]
+        err_msg = "invalid negative scalar"
+        with pytest.raises(BTClibValueError, match=err_msg):
+            Sig.parse(bad_sig_bin)
+
         bad_sig_bin = sig_bin[:offset] + b"\x00\x7f" + sig_bin[offset + 2 :]
         err_msg = "invalid 'highest bit set' padding"
         with pytest.raises(BTClibValueError, match=err_msg):

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -107,6 +107,13 @@ def test_signature() -> None:
     # malleability
     malleated_sig = dsa.Sig(sig.r, sig.ec.n - sig.s)
     assert dsa.verify(msg, Q, malleated_sig, lower_s=False)
+    # lower_s defaults to True on both assert_as_valid and verify, refusing
+    # the same high-s twin the line above accepts by asking not to --
+    # libsecp256k1's own verify does the refusing here, lower_s deciding
+    # only whether the signature is normalized in front of it first
+    assert not dsa.verify(msg, Q, malleated_sig)
+    with pytest.raises(BTClibRuntimeError, match="signature verification failed"):
+        dsa.assert_as_valid(msg, Q, malleated_sig)
 
     keys = dsa.recover_pub_keys(msg, sig)
     assert len(keys) == 2
@@ -150,6 +157,14 @@ def test_signature() -> None:
         dsa.Sig(sig.ec.n, sig.s)
     with pytest.raises(BTClibValueError, match="scalar s not in 1..n-1: "):
         dsa.Sig(sig.r, sig.ec.n)
+
+    # the lower boundary too, zero and not one below it: `0 < r`/`0 < s`
+    # weakened to `-1 <` would accept the one value this rule excludes
+    # that ssa.Sig's own 0..n-1 does not
+    with pytest.raises(BTClibValueError, match="scalar r not in 1..n-1: "):
+        dsa.Sig(0, sig.s)
+    with pytest.raises(BTClibValueError, match="scalar s not in 1..n-1: "):
+        dsa.Sig(sig.r, 0)
 
     err_msg = "private key not in 1..n-1"
     with pytest.raises(BTClibValueError, match=err_msg):
@@ -817,6 +832,33 @@ def test_the_key_id_survives_what_the_bindings_decline(
     sig, key_id = dsa.sign_recoverable(msg, q, ec=ec)
     assert dsa.recover_pub_key(key_id, msg, sig) == Q
     assert key_id == _search_key_id(msg, sig, Q)
+
+
+def test_recover_pub_key_dispatches_to_the_bindings_for_0_to_3_only() -> None:
+    """The bindings take a recovery id of 0, 1, 2 or 3, and nothing wider.
+
+    A key_id outside that range has to reach the Python path instead,
+    which answers in its own words rather than the bindings': recovering
+    a candidate that does not verify (public key recovery failed) or
+    finding no candidate at all congruent to r (signature verification
+    failed) -- neither of them the bindings' own "the recovery id must
+    be 0, 1, 2, or 3", which is what a widened or narrowed guard sends a
+    boundary value to instead. Four key_ids, one per boundary the six
+    ways this guard survived moved.
+    """
+    q = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD
+    sig = dsa.sign(b"msg", q)
+    msg_hash = b"\x00" * 32
+
+    cases = {
+        -1: (BTClibRuntimeError, "signature verification failed"),
+        2: (BTClibValueError, "public key recovery failed"),
+        3: (BTClibValueError, "public key recovery failed"),
+        4: (BTClibRuntimeError, "signature verification failed"),
+    }
+    for key_id, (exc, err_msg) in cases.items():
+        with pytest.raises(exc, match=err_msg):
+            dsa.recover_pub_key_(key_id, msg_hash, sig)
 
 
 def test_the_low_s_negation_flips_the_key_id_parity_bit() -> None:

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -144,6 +144,13 @@ def test_signature() -> None:
     with pytest.raises(BTClibValueError, match=err_msg):
         dsa.assert_as_valid(msg, Q, sig_invalid)
 
+    # the boundary itself, not `ec.p` (a different, larger prime): `< n`
+    # weakened to `<= n` would still refuse `ec.p` and miss `n` exactly
+    with pytest.raises(BTClibValueError, match="scalar r not in 1..n-1: "):
+        dsa.Sig(sig.ec.n, sig.s)
+    with pytest.raises(BTClibValueError, match="scalar s not in 1..n-1: "):
+        dsa.Sig(sig.r, sig.ec.n)
+
     err_msg = "private key not in 1..n-1"
     with pytest.raises(BTClibValueError, match=err_msg):
         dsa.sign(msg, 0)

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -85,6 +85,11 @@ def test_signature() -> None:
     with pytest.raises(BTClibValueError, match=err_msg):
         ssa.assert_as_valid(msg, x_Q, sig_invalid)
 
+    # the boundary itself, not `ec.p` (a different, larger prime): `< n`
+    # weakened to `<= n` would still refuse `ec.p` and miss `n` exactly
+    with pytest.raises(BTClibValueError, match="scalar s not in 0..n-1: "):
+        ssa.Sig(sig.r, sig.ec.n)
+
     # a 31-byte message is a legal BIP340 message (since 2023-04), so a
     # truncated message is not a size error -- "invalid size: 31 bytes
     # instead of 32" -- but a *different* message, which this signature

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -90,6 +90,20 @@ def test_signature() -> None:
     with pytest.raises(BTClibValueError, match="scalar s not in 0..n-1: "):
         ssa.Sig(sig.r, sig.ec.n)
 
+    # the lower boundary too: `0 <= s` weakened to `-1 <= s` would accept
+    # a scalar one below the range BIP340's own zero-lower-bound allows
+    with pytest.raises(BTClibValueError, match="scalar s not in 0..n-1: "):
+        ssa.Sig(sig.r, -1)
+
+    # `serialize`'s own default, not the constructor's: an invalid Sig
+    # built with check_validity=False must still be refused when asked
+    # to serialize at the default, and only there does check_validity=False
+    # let it through
+    sig_invalid = ssa.Sig(sig.r, sig.ec.n, sig.ec, check_validity=False)
+    with pytest.raises(BTClibValueError, match="scalar s not in 0..n-1: "):
+        sig_invalid.serialize()
+    assert sig_invalid.serialize(check_validity=False)
+
     # a 31-byte message is a legal BIP340 message (since 2023-04), so a
     # truncated message is not a size error -- "invalid size: 31 bytes
     # instead of 32" -- but a *different* message, which this signature
@@ -302,6 +316,28 @@ def test_low_cardinality() -> None:
                             ssa._assert_as_valid_(e, QJ, r, (s - 1) % ec.n, ec)
 
 
+def test_assert_as_valid_rejects_the_odd_y_twin_of_a_correct_k() -> None:
+    """A K whose x matches r but whose y is odd is refused on its own.
+
+    `(s - 1) % ec.n` above moves K by a whole generator and almost
+    always moves its x-coordinate too, so the exhaustive sweep exercises
+    'Fail if x_K != r' far more than 'Fail if y_K is odd' -- and never
+    the two apart. `-(k*G)` is the one point sharing K's x-coordinate
+    without sharing its y, which the algebra reaches directly: solving
+    s'*G - e*Q = -(k*G) for s' gives n - k + e*q, a scalar this function
+    is handed like any other, without producing the point first.
+    """
+    ec = secp256k1
+    q, x_Q = ssa.gen_keys()
+    QJ = jac_from_aff((x_Q, ec.y_even(x_Q)))
+    k, r = ssa.gen_keys()  # k's point has even y, by gen_keys' own normalization
+    e = 5
+
+    s_prime = (ec.n - k + e * q) % ec.n
+    with pytest.raises(BTClibRuntimeError, match="y_K is odd"):
+        ssa._assert_as_valid_(e, QJ, r, s_prime, ec)
+
+
 def test_a_message_of_any_size_reaches_the_bindings(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -417,6 +453,14 @@ def test_batch_validation() -> None:
     assert not ssa.batch_verify(ms, Qs, sigs)
     ms.pop()  # valid again
 
+    # fewer messages than pub_keys, not only more: `!= batch_size`
+    # weakened to `>` would let this one through
+    short_ms = ms[:-1]
+    err_msg = "mismatch between number of pub_keys "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        ssa.assert_batch_as_valid(short_ms, Qs, sigs)
+    assert not ssa.batch_verify(short_ms, Qs, sigs)
+
     sigs.append(sigs[0])  # add extra sig
     err_msg = "mismatch between number of pub_keys "
     with pytest.raises(BTClibValueError, match=err_msg):
@@ -443,6 +487,24 @@ def test_batch_validation() -> None:
     with pytest.raises(BTClibRuntimeError, match=err_msg):
         ssa.assert_batch_as_valid_(ms, Qs, sigs)
     assert not ssa.batch_verify_(ms, Qs, sigs)
+
+
+def test_a_batch_of_one_takes_the_single_signature_shortcut() -> None:
+    """`batch_size == 1` dispatches to `assert_as_valid_`, not the general sum.
+
+    A malformed `Sig` (built with `check_validity=False`) tells the two
+    apart: the shortcut validates it and names the field, where the
+    general multi_mult equation below has nothing that checks a lone
+    signature's own shape and would just fail the sum instead, `!= 1`
+    weakened to `< 1` routing every batch there since batch_size is
+    never below 1 by the point this check runs.
+    """
+    q, x_Q = ssa.gen_keys()
+    sig = ssa.sign(b"msg", q)
+    bad_sig = ssa.Sig(sig.r, sig.ec.n + 5, sig.ec, check_validity=False)
+    err_msg = "scalar s not in 0..n-1: "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        ssa.assert_batch_as_valid_([b"msg"], [x_Q], [bad_sig])
 
 
 def test_batch_validation_on_the_python_path(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -40,6 +40,7 @@ from btclib.fetch.transport import DEFAULT_MAX_BODY_SIZE
 from btclib.network import NETWORKS, Network
 from btclib.tx import OutPoint
 from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
+from tests.network_test import SIGNET_CHALLENGE
 
 # the rpc credentials every test here passes. Named once rather than
 # written at each call, which is what keeps the string out of a
@@ -215,6 +216,20 @@ def custom_signet(challenge: str) -> Network:
     )
 
 
+def test_signet_magic_is_the_reverse_of_the_digest_and_not_the_digest() -> None:
+    """`_signet_magic` itself, not the independent computation beside it.
+
+    `tests/network_test.py` computes the default signet's magic by its own
+    route and pins it to `0a03cf40` reversed; that is a fact about the
+    constant, not a call into this function, so a mutant of the slice this
+    function ends on -- dropped, or read forwards -- is not what that test
+    would notice. `custom_signet`'s docstring says the derivation is
+    "settled elsewhere", which is only true once this test exists.
+    """
+    assert _signet_magic(SIGNET_CHALLENGE).hex() == "40cf030a"
+    assert _signet_magic(SIGNET_CHALLENGE) == NETWORKS["signet"].magic_bytes
+
+
 def test_every_network_btclib_ships_has_a_chain_name() -> None:
     """The coupling between two vocabularies kept in two repositories.
 
@@ -252,6 +267,20 @@ def test_assert_network_refuses_a_node_on_another_chain() -> None:
         BTClibValueError, match="node is on test, this fetcher on mainnet"
     ):
         fetcher(blockchaininfo(chain="test"), network="mainnet").assert_network()
+
+
+def test_assert_network_refuses_a_chain_that_sorts_before_the_label() -> None:
+    """The mismatch the other direction: `main` sorts before every label here.
+
+    The sibling test asks for mainnet and gets `test`, which sorts after
+    it -- a comparison weakened from "not equal" to "sorts after" would
+    still refuse that one. Asking for testnet and getting `main`, which
+    sorts before it, is the half only a real inequality catches.
+    """
+    with pytest.raises(
+        BTClibValueError, match="node is on main, this fetcher on testnet"
+    ):
+        fetcher(blockchaininfo(chain="main"), network="testnet").assert_network()
 
 
 def test_assert_network_tells_two_signets_apart() -> None:
@@ -481,6 +510,9 @@ def test_a_status_from_the_client_arrives_as_btclibs_http_error() -> None:
         fetcher((503, b"")).get_block_count()
     assert exc.value.status == 503
     assert not isinstance(exc.value, rpc.HttpError)
+    # the message translated across, not the status carried beside it
+    # under the same positional index the message also answers to
+    assert "getblockcount" in str(exc.value)
 
 
 def test_an_error_the_client_raises_without_a_status_is_a_fetch_error() -> None:
@@ -514,3 +546,6 @@ def test_an_rpc_error_keeps_its_code_and_its_data_across_the_translation() -> No
     assert exc.value.data == {"tx": 1}
     assert not isinstance(exc.value, rpc.RpcError)
     assert str(exc.value).count("rpc error code") == 1
+    # the message itself, and not the code or the data carried beside it
+    # under the same positional index once `args` holds all three
+    assert "No such mempool transaction" in str(exc.value)

--- a/tests/fetch/esplora_test.py
+++ b/tests/fetch/esplora_test.py
@@ -122,7 +122,7 @@ def test_a_404_carries_what_the_explorer_said() -> None:
         fetcher((404, b"Transaction not found")).get_tx(TX_ID)
 
 
-@pytest.mark.parametrize("status", [404, 429, 503])
+@pytest.mark.parametrize("status", [100, 404, 429, 503])
 def test_the_status_of_a_failure_is_a_field(status: int) -> None:
     """Which is what tells a rate limit from a missing transaction.
 
@@ -130,6 +130,9 @@ def test_the_status_of_a_failure_is_a_field(status: int) -> None:
     from a public deployment is worth another attempt and a 404 is not.
     btclib retries neither -- an explorer's rate limit is the caller's
     budget to spend -- so the status has to reach them as a value.
+
+    100 is below 200, not above it: `!= 200` weakened to `> 200` would
+    still refuse every status above, and only one below tells them apart.
     """
     with pytest.raises(HttpError) as exc:
         fetcher((status, b"no")).get_tx(TX_ID)

--- a/tests/fetch/fetcher_test.py
+++ b/tests/fetch/fetcher_test.py
@@ -128,6 +128,21 @@ def test_tx_from_raw_catches_the_answer_to_another_question() -> None:
         tx_from_raw(RAW, OTHER_ID, "mainnet")
 
 
+def test_tx_from_raw_catches_it_on_either_side_of_the_id_requested() -> None:
+    """A backend's id is refused whether it sorts above or below the ask.
+
+    OTHER_ID above sorts below `TX_ID` (`b...` against `f...`), so that
+    case alone leaves `hex() > tx_id` as good a check as `hex() != tx_id`.
+    A requested id that sorts *above* the one `RAW` actually parses to is
+    the other half, and it is what a byte-for-byte comparison must catch
+    too -- a backend is not asked to sort correctly, only to answer for
+    the id it was given.
+    """
+    above = "f" * 64
+    with pytest.raises(FetchError, match=f"transaction {above}: the answer is"):
+        tx_from_raw(RAW, above, "mainnet")
+
+
 @pytest.mark.parametrize(
     "raw",
     [
@@ -147,6 +162,27 @@ def test_the_interface_is_abstract() -> None:
     """No answers here: a Fetcher is one of the backends, or nothing."""
     with pytest.raises(TypeError, match="abstract"):
         Fetcher()  # type: ignore[abstract]
+
+
+@pytest.mark.parametrize("missing", ["get_tx", "get_block_count", "get_best_block_id"])
+def test_leaving_any_one_of_the_three_abstract_refuses_construction(
+    missing: str,
+) -> None:
+    """Each of the three is `abstractmethod` on its own, not by inheriting one.
+
+    `test_the_interface_is_abstract` covers `Fetcher` itself; a subclass
+    that overrides two of the three and forgets the last one is what a
+    decorator removed from only one of them would let through.
+    """
+    methods = {
+        "get_tx": lambda self, tx_id: Tx.parse(RAW),
+        "get_block_count": lambda self: TIP_HEIGHT,
+        "get_best_block_id": lambda self: bytes.fromhex(TIP_ID),
+    }
+    del methods[missing]
+    incomplete = type("Incomplete", (Fetcher,), methods)
+    with pytest.raises(TypeError, match="abstract"):
+        incomplete("mainnet")
 
 
 def test_an_unknown_network_is_refused_at_construction() -> None:
@@ -195,7 +231,15 @@ def test_get_tx_out_answers_for_an_output_already_spent() -> None:
 
 
 def test_get_tx_out_refuses_a_vout_the_transaction_does_not_have() -> None:
-    """Refuse an out-of-range vout with a FetchError naming it."""
+    """Refuse an out-of-range vout with a FetchError naming it.
+
+    2, one past the transaction's last output, is the boundary the check
+    is written on; 1000 is not, and is what tells a `>=` refusal from one
+    that only catches an exact match -- and, being outside the range
+    CPython interns, from one that only catches identity.
+    """
     fetcher = StubFetcher(Tx.parse(RAW))
     with pytest.raises(FetchError, match="out of range vout: 2"):
         fetcher.get_tx_out(OutPoint(TX_ID, 2))
+    with pytest.raises(FetchError, match="out of range vout: 1000"):
+        fetcher.get_tx_out(OutPoint(TX_ID, 1000))

--- a/tests/mnemonic/entropy_test.py
+++ b/tests/mnemonic/entropy_test.py
@@ -88,6 +88,17 @@ def test_conversions() -> None:
         assert bin_str_entropy_from_entropy(i) == raw
         assert bin_str_entropy_from_entropy(b) == raw
 
+    # a decimal string starting with "0" and a digit below "b": "01" sorts
+    # below "0b", so `== "0b"` weakened to `<=` reads a plain decimal as
+    # binary too -- "010" is 10 in decimal and 2 read as binary
+    assert bin_str_entropy_from_int("010", 4) == "1010"
+    # neither prefixed nor a valid plain decimal: `int("ab")` raises, so
+    # `== "0x"` weakened to `>=` is what a string of only letters tells
+    # apart -- "ab" sorts above "0x" and parses as hex (171) where the
+    # unweakened check falls through to `int("ab")` and raises instead
+    with pytest.raises(ValueError, match="invalid literal for int"):
+        bin_str_entropy_from_int("ab", 8)
+
     max_bits = max(_bits)
 
     raw = "10" + "11111111" * (max_bits // 8)
@@ -211,6 +222,79 @@ def test_collect_rolls(monkeypatch: pytest.MonkeyPatch) -> None:
         min_roll_number = math.ceil(bits / bits_per_roll)
         assert len(dice_rolls) == min_roll_number
 
+        # the automated vector's 43 rolls, not the range check above, is
+        # what tells `1 + secrets.randbelow(dice_sides)` from an operator
+        # collapsing it to a constant (`**` makes every roll 1): the range
+        # check alone cannot see that every roll is the same one value
+        if i == 1:
+            assert len(set(dice_rolls)) > 1
+
+
+def test_collect_rolls_refuses_a_negative_or_a_short_roll(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A negative roll is refused, and a roll under base is not base itself.
+
+    D30's base is 16 (2**4, the highest power of 2 below 30), so 5 is a
+    usable roll and not the boundary -- `0 < roll <= base` weakened to
+    `0 != roll <= base` would accept `-1` (nonzero, and `-1 <= 16`), and
+    weakened to `0 < roll == base` would refuse every usable roll that is
+    not 16 itself, which the D120 vectors above never exercise: every one
+    of their manual rolls is 64, D120's own base.
+    """
+    monkeypatch.setattr("sys.stdin", StringIO("30\n-1\n0\n5\n"))
+    dice_sides, dice_rolls = collect_rolls(4)
+    assert dice_sides == 30
+    assert dice_rolls == [5]
+
+
+@pytest.mark.parametrize("sides", [8, 48])
+def test_collect_rolls_accepts_dice_sides_this_module_lists(
+    sides: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """8 and 48 are two of `valid_dice_sides` no other test asks for.
+
+    A `NumberReplacer` mutant of either entry survives on the D6/D120
+    vectors above alone: nothing else in this suite ever offers 8 or 48
+    for the `while dice_sides not in valid_dice_sides` loop to accept.
+    """
+    monkeypatch.setattr("sys.stdin", StringIO(f"{sides}\n1\n"))
+    dice_sides, dice_rolls = collect_rolls(1)
+    assert dice_sides == sides
+    assert dice_rolls == [1]
+
+
+def test_collect_rolls_prompt_names_the_roll_and_the_total(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The prompt counts from 1, and nothing but a human reads it.
+
+    `i + 1` is arithmetic no assertion in this file reaches through
+    `collect_rolls`' return value -- the prompt is printed and discarded
+    by `input()`, not part of what the function hands back -- so it
+    survived mutated eight different ways until captured here.
+    """
+    monkeypatch.setattr("sys.stdin", StringIO("4\n1\n1\n"))
+    collect_rolls(4)
+    out = capsys.readouterr().out
+    assert "roll #1/2: " in out
+    assert "roll #2/2: " in out
+
+
+def test_collect_rolls_prompt_lists_the_dice_sides(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The dice-sides prompt names every side this module accepts.
+
+    `f'{valid_dice_sides}'[:-1]` drops the tuple's closing paren so the
+    line can add the automation note before it; `[:-0]` is `[:0]`, empty,
+    and nothing but this test reads what `input()` printed and threw away.
+    """
+    monkeypatch.setattr("sys.stdin", StringIO("4\n1\n"))
+    collect_rolls(2)
+    out = capsys.readouterr().out
+    assert "dice sides (4, 6, 8, 12, 20, 24, 30, 48, 60, 120" in out
+
 
 def test_bin_str_entropy_from_rolls() -> None:
     """Check the roll-to-bits conversion, its bounds and its refusals."""
@@ -277,6 +361,10 @@ def test_bin_str_entropy_from_rolls() -> None:
     err_msg = "invalid dice base: "
     with pytest.raises(BTClibValueError, match=err_msg):
         bin_str_entropy_from_rolls(bits, 1, rolls)
+
+    # the boundary itself, not 1: `< 2` weakened to `<= 2` still refuses
+    # 1 and would also refuse 2, the smallest base the function accepts
+    assert bin_str_entropy_from_rolls(4, 2, [1, 2, 1, 2], shuffle=False) == "0101"
 
 
 def test_bin_str_entropy_from_random() -> None:

--- a/tests/mnemonic/entropy_test.py
+++ b/tests/mnemonic/entropy_test.py
@@ -46,6 +46,26 @@ def test_indexes() -> None:
         assert indexes == expected
 
 
+def test_indexes_round_trip_a_base_that_is_not_a_power_of_two() -> None:
+    """2048 is a power of two, where `+`, `|` and `^` all agree; 1626 is not.
+
+    Electrum's Portuguese wordlist is the base the module's own comment
+    names: 13 words hold 139 bits, not the 130 that `bits_per_digit *
+    nwords` would claim, and only a base like this -- not 2048 -- makes
+    `entropy * base + index` differ from the same expression with `|` or
+    `^` for a generic index. The value itself, not the decoder's own
+    leading-zero padding for a base that is not a power of two, is what
+    ties the length to the accumulation.
+    """
+    indexes = list(range(1, 14))
+    value = 0
+    for index in indexes:
+        value = value * 1626 + index
+    entropy = bin_str_entropy_from_wordlist_indexes(indexes, 1626)
+    assert len(entropy) == 139
+    assert int(entropy, 2) == value
+
+
 def test_conversions() -> None:
     """Round-trip entropy across its str, int and bytes forms."""
     test_vectors = [
@@ -290,3 +310,10 @@ def test_bin_str_entropy_from_random() -> None:
     err_msg = "too many bits required: "
     with pytest.raises(BTClibValueError, match=err_msg):
         bin_str_entropy_from_random(1024)
+
+    # the cap itself: sha512's 512-bit digest, one bit over is refused and
+    # the bit at it is not -- 1024 above is well past either side of a
+    # cap computed one digest_size wider than it should be
+    assert len(bin_str_entropy_from_random(512)) == 512
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bin_str_entropy_from_random(513)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -15,6 +15,7 @@ from btclib.utils import (
     decode_num,
     encode_num,
     hex_string,
+    int_from_bits,
     int_from_integer,
     read_exactly,
 )
@@ -120,6 +121,30 @@ def test_hex_string() -> None:
     int_ = -1
     with pytest.raises(BTClibValueError, match="negative integer: "):
         hex_string(int_)
+
+    # zero is not negative: `< 0` weakened to `<= 0` would refuse it
+    assert hex_string(0) == "00"
+
+    # a hex length that is an exact multiple of 8 (here 16, unlike the
+    # 18-digit vector above): the index loop's stop bound at 0 is what
+    # keeps the top group from being an empty one -- read as -1 instead,
+    # 0 itself joins the indexes and a leading space appears before "DE"
+    assert hex_string(0xDEADBEEF00000000) == "DEADBEEF 00000000"
+
+
+def test_int_from_bits() -> None:
+    """Discard bits on the right down to nlen, or none if there are fewer.
+
+    Every caller in this codebase hashes into exactly `ec.nlen` bits, so
+    `blen == nlen` is the only case they exercise; `blen > nlen` is the
+    truncation the docstring is about, and `blen < nlen` -- fewer bits
+    than asked for -- is `n` weakened from `blen - nlen` to a negative
+    shift count away from `i >> n` raising instead of returning `i`
+    unchanged.
+    """
+    assert int_from_bits(b"\xff", 4) == 0b1111
+    assert int_from_bits(b"\xff\x00", 4) == 0b1111
+    assert int_from_bits(b"\xff", 16) == 0xFF
 
 
 def test_encode_num() -> None:


### PR DESCRIPTION
## Summary

Issue #327 sized five candidate profiles beyond the consensus code #219
already covered — ssa.py, utils.py, fetch, the numeric validators, and
(measured but never built) — and left all but the wire-format parsers for
later sessions. This PR builds those, and six more found by surveying the
rest of the codebase for the same gap #219/#327 exist to catch: 100%
statement coverage that doesn't mean a boundary is checked.

Ten new `.github/mutation/*.toml` profiles, each measured on this tree
rather than estimated, wired into `mutation.yml` as five new matrix jobs:

- `fetch.toml`, `numeric.toml`, `mnemonic.toml` — #327's remaining scope
- `bip32.toml`, `codecs.toml` — extended keys and the checksummed codecs
- `bms.toml`, `bip322.toml` — message signing, and BIP322 (days-old code)
- `block.toml` — the block header and its proof-of-work arithmetic
- `utils.toml` — the shared codec helpers nearly everything else calls
- `signatures.toml` — Schnorr and ECDSA signing (ssa.py + dsa.py), #327's
  fifth candidate

## The real gaps each one found and closed

The most consequential: **`bip322.py`'s `REQUIRED_RULES` and
`UPGRADEABLE_RULES`** are each a `|` chain over distinct-bit `ScriptFlag`
members, and nothing had ever called either name to check the result — an
`&` at any position collapses everything accumulated left of it against a
single bit, so `REQUIRED_RULES` could have silently been one flag wide
instead of the seven it names.

Others, one per profile:

- **bip32**: `BIP32KeyData.is_root` had no caller at all, so every
  operator on its three-way `and` survived together.
- **codecs**: `bech32._decode`'s own comment already said an uncaught
  `UnicodeDecodeError` "would fly past every caller written to catch
  `BTClibValueError`" — nothing supplied the bytes that would raise it.
- **bms**: `Sig` is `@dataclass(frozen=True, init=False)`, and nothing
  after construction ever assigned to a field to find out whether the
  frozen half still held.
- **block**: `block_work`'s `target + 1` vs `target - 1` agree on every
  existing vector, whose target sits within a whisker of 2^224; a target
  of 2 is what tells them apart. (One survivor needed no fix:
  `BlockHeader.assert_valid`'s `self.hash > target` weakened to `>=` is
  Core's own proof-of-work comparison, and the comment already beside it
  says why no vector can move it.)
- **utils**: `hex_string`'s negative check was never tried at zero, its
  index loop's stop bound never at a length landing exactly on it, and
  `int_from_bits`' truncation guard never below the length it guards.
- **signatures**: `ssa.Sig`'s and `dsa.Sig`'s scalar upper bounds were
  tested invalid against `ec.p` (a different, larger prime) and never
  against `ec.n` itself.
- **numeric, fetch, mnemonic**: six more across the KDF's output-length
  cap, `fetch`'s tx-id and chain-mismatch comparisons and its three
  abstract methods tested only together, and BIP39's non-power-of-two
  wordlist base.

## A wider, non-obvious finding

Python 3.14 evaluates annotations lazily by default (PEP 649), so an
operator confined to a type annotation is equivalent on this interpreter
*regardless* of `from __future__ import annotations` — a broader class
than the one `sig_hash.toml`/`parsers.toml` documented for pre-3.14
semantics. It accounts for the majority of every new profile's raw
survivor count and is written up in each `.toml`'s own comments rather
than left as an unexplained number.

## What's sampled rather than complete

`bip32.toml` and `block.toml` finish; the rest are sampled like
`engine.toml` already is, and each file says so with the real count:
`signatures.toml` is the largest and least complete (812 of 2475),
`bip32`'s remaining ~140 real candidates are scattered one or two per
method, and `mnemonic`'s manual dice-roll CLI path needs a scripted
stdin session to reach. Nothing here is chased to a false completion.

## Test plan

- [x] `uv run pre-commit run --all-files`
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html`
- [x] `uv run pytest --cov` — 18220 passed, 100% coverage
- [x] Each new profile's real-candidate survivors verified by hand with
      `cosmic-ray apply` before writing the fix that kills them, and the
      test suite re-run to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend mutation testing to additional modules and close gaps found by new mutation profiles across fetch, BIP32/BIP322, codecs, blocks, utils, numeric validators, mnemonic handling, and signature code.

CI:
- Expand mutation-testing workflow with additional profiles and jobs covering extended keys, codecs, message signing, BIP322, blocks, shared helpers, numeric bounds, fetch, mnemonics, and signatures.

Documentation:
- Document new mutation-testing scopes, their coverage, and notable findings in the changelog.

Tests:
- Add targeted tests to cover uncovered boundary conditions in fetch APIs, BIP32 root detection and key-origin encoding, BIP322 script flag sets, bech32 decoding, block header and proof-of-work validation, utils helpers, numeric KDF limits, mnemonic entropy/index handling, and DSA/SSA/BMS signature validation.