### PR TITLE
Let index_of take a ScriptPubKey or an address, and refuse the rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,47 @@ documented at release-notes length in the first place, and are still in
 
 ### Descriptors and miniscript
 
+- **`Descriptor.index_of` takes the `ScriptPubKey` beside it, and an
+  address** (#540). `script_pub_key(i)` returns a `ScriptPubKey`, so
+  handing that object back to the method next to it is what the API reads
+  like -- and it answered `None`, which does not mean "wrong type" here:
+  it means *this output is not this wallet's*, the answer a caller acts
+  on to say that an address is somebody else's or that a change output is
+  not its change. The mechanism was `bytes_from_octets` with no
+  `out_size`, which returns anything that is not a `str` untouched: the
+  object travelled through to a comparison against `bytes` that is False
+  at every index, and the loop fell off the end. An address fared better
+  by being loud, but the noise was `bytes.fromhex`'s `ValueError` rather
+  than anything this library promises.
+
+  Four spellings of one output are now accepted and all four answer the
+  same index: the `ScriptPubKey`, its script as bytes, that script as a
+  hex-string, and the address it renders as -- "which index is this
+  address" being the question a human has, and `ScriptPubKey.from_address`
+  being one call away. What is compared is the script in every case, an
+  address being read for the script it encodes; the network its prefix
+  carries is not part of the answer, the same key paying to the same
+  script on every chain. Which spelling a string is is not guesswork: it
+  is the hex of a script where `bytes.fromhex` reads it and an address
+  where it does not, and although base58 and bech32 do hold hex digits,
+  an address of hex digits only, of even length and with a valid checksum
+  is not a string anybody has.
+
+  What is refused is refused through the exception contract:
+  `BTClibTypeError` naming the type for anything that is none of the
+  four, and `BTClibValueError` for a string that names no output. The
+  empty string is one of those, and is the case this cost the most
+  thought: it is what `address` answers where a script has none, so
+  `index_of(descriptor.address(i))` on a `pk()` would otherwise be read
+  as the empty script and answer that the wallet's own output is not the
+  wallet's. Empty `bytes` still go through and still answer `None`: no
+  descriptor derives an empty script, and a caller who wrote `b""` meant
+  it.
+
+  `bytes_from_octets` itself is untouched. Whether the library's front
+  door for "anything convertible" should keep trusting every non-`str` it
+  is handed is the wider question the issue raises, and it is one about
+  every caller that compares rather than parses.
 - **A malformed `hwi enumerate` entry is a `SignerError`** (#522).
   `enumerate` is the one command whose answer is a list of objects rather
   than one object with a known field in it, and the list was the only

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -181,7 +181,7 @@ from btclib.descriptors.miniscript import (
 )
 from btclib.descriptors.miniscript import from_script as _miniscript_from_script
 from btclib.descriptors.miniscript import parse as _parse_miniscript
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import NETWORKS, network_from_xkeyversion
 from btclib.psbt.psbt import Psbt
@@ -688,6 +688,58 @@ def _musig2_participants(
     }
 
 
+def _script_from(script_pub_key: Octets | ScriptPubKey) -> bytes:
+    """Return the script bytes of whatever names one output.
+
+    The spellings `index_of` takes, and which of them is which is not
+    guesswork: a `ScriptPubKey` and `bytes` are what they are, and a
+    string is the hex of a script where `bytes.fromhex` reads it and an
+    address where it does not. The two alphabets do overlap -- base58 and
+    bech32 both hold hex digits -- but an address of hex digits only,
+    of even length, and carrying a valid checksum is not a string anybody
+    has.
+
+    The empty string is the one refused outright, and for the reason the
+    whole function exists: it is what `address` answers where a script
+    has none, so `index_of(descriptor.address(i))` on a ``pk()`` would
+    otherwise read as the empty script, match nothing, and say that the
+    wallet's own output is not the wallet's. Empty `bytes` are the empty
+    script and go through: no descriptor derives one, and the caller who
+    wrote them meant them.
+
+    `bytes_from_octets` alone cannot do this: it returns anything that is
+    not a `str` untouched, so the `ScriptPubKey` the method beside
+    `index_of` returns would travel through to a comparison against
+    `bytes` that is False at every index, and the caller would read the
+    None it falls off the end with as "not this wallet's".
+    """
+    if isinstance(script_pub_key, ScriptPubKey):
+        return script_pub_key.script
+    if isinstance(script_pub_key, bytes):
+        return script_pub_key
+    # unreachable to mypy, the annotation having no fourth case, and the
+    # whole point to a caller who is not running it: `Octets` is honoured
+    # inside btclib and nowhere else
+    if not isinstance(script_pub_key, str):
+        err_msg = f"invalid script_pub_key type: {type(script_pub_key).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
+    if not script_pub_key:
+        err_msg = "empty script_pub_key: a script with no address renders as ''"
+        raise BTClibValueError(err_msg)
+    try:
+        return bytes.fromhex(script_pub_key)
+    except ValueError:
+        pass
+    try:
+        return ScriptPubKey.from_address(script_pub_key).script
+    # ValueError rather than BTClibValueError, which is one: the address
+    # codecs raise their own, and a string that reaches them is decoded
+    # before it is checked, so it may fail on a plain one from underneath
+    except ValueError as e:
+        err_msg = f"neither a script nor an address: '{script_pub_key}'"
+        raise BTClibValueError(err_msg) from e
+
+
 @dataclass(frozen=True, kw_only=True)
 class Descriptor(ABC):
     """A parsed output descriptor: the scripts it describes, on demand.
@@ -875,7 +927,7 @@ class Descriptor(ABC):
 
     def index_of(
         self,
-        script_pub_key: Octets,
+        script_pub_key: Octets | ScriptPubKey,
         last_index: int = 999,
         prv_keys: PrvKeys | None = None,
     ) -> int | None:
@@ -888,12 +940,30 @@ class Descriptor(ABC):
         marked as change on a fingerprint is an output a wallet may hand
         to somebody else believing it keeps it.
 
+        The output is named however the caller holds it: the
+        `ScriptPubKey` that `script_pub_key` returns, that script as
+        bytes or as a hex-string, or the address it renders as -- "which
+        index is this address" being the question a human has, and
+        `ScriptPubKey.from_address` being what answers it. What is
+        compared is the script in every case: an address is read for the
+        script it encodes, and the network its prefix carries is not part
+        of the answer, the same key paying to the same script on every
+        chain.
+
+        Anything else is a `BTClibTypeError`, and a string that names no
+        output -- neither hex nor an address, the `""` that a script with
+        no address renders as among them -- a `BTClibValueError`, because
+        None is not "you passed the wrong thing" here: it is *this output
+        is not this wallet's*, which is the answer a caller acts on to
+        say that an address is somebody else's or that an output is not
+        its own change (issue #540).
+
         `last_index` bounds the search, both ends included, and is the
         caller's: how far ahead of its own gap limit a wallet is willing
         to look is a policy this module has no view on. A descriptor that
         is not ranged has one script and answers 0 or None.
         """
-        script = bytes_from_octets(script_pub_key)
+        script = _script_from(script_pub_key)
         last = last_index if self.is_ranged else 0
         for index in range(last + 1):
             if any(

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -68,7 +68,7 @@ from btclib.descriptors import (
 )
 from btclib.descriptors.descriptors import __descsum_expand
 from btclib.ecc import dsa, ssa
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160, tagged_hash
 from btclib.psbt.musig2 import nonce_gen, partial_sign, partial_sigs_agg
 from btclib.psbt.psbt import (
@@ -2193,6 +2193,54 @@ def test_index_of_answers_with_the_whole_script() -> None:
     combo = parse(f"combo({KEY_A})")
     for script_pub_key in combo.script_pub_keys():
         assert combo.index_of(script_pub_key.script) == 0
+
+
+def test_index_of_takes_the_output_however_the_caller_holds_it() -> None:
+    """The ScriptPubKey, its bytes, its hex and its address, all one index.
+
+    The object `script_pub_key` returns is the natural thing to hand back
+    to the method beside it, and the address is the question a human
+    actually has.
+    """
+    descriptor = parse(f"wpkh([d34db33f/84h/0h/0h]{XPUB}/1/*)")
+    script_pub_key = descriptor.script_pub_key(7)
+    assert descriptor.index_of(script_pub_key) == 7
+    assert descriptor.index_of(script_pub_key.script) == 7
+    assert descriptor.index_of(script_pub_key.script.hex()) == 7
+    assert descriptor.index_of(script_pub_key.address) == 7
+
+    # somebody else's address is somebody else's, which is what None says
+    other = parse(f"wpkh({KEY_B})")
+    assert descriptor.index_of(other.address()) is None
+    assert descriptor.index_of(other.script_pub_key()) is None
+
+    # a script with no address is named by its bytes and by nothing else:
+    # the "" that `address` answers for one names no output, and reading
+    # it as the empty script would deny the wallet its own p2pk
+    p2pk = parse(f"pk({KEY_A})")
+    assert p2pk.index_of(p2pk.script_pub_key()) == 0
+    assert p2pk.address() == ""
+    with pytest.raises(BTClibValueError, match="empty script_pub_key: "):
+        p2pk.index_of(p2pk.address())
+    # empty bytes are the empty script, which no descriptor derives
+    assert p2pk.index_of(b"") is None
+
+
+def test_index_of_refuses_what_it_could_only_answer_none_for() -> None:
+    """None means "not this wallet's", so a wrong type may not say it.
+
+    A value that is neither a script nor an address compares False
+    against every candidate, and the caller reads the None that falls out
+    of the loop as an answer about the output.
+    """
+    descriptor = parse(f"wpkh([d34db33f/84h/0h/0h]{XPUB}/1/*)")
+    for wrong in (7, None, [descriptor.script_pub_key().script]):
+        with pytest.raises(BTClibTypeError, match="invalid script_pub_key type: "):
+            descriptor.index_of(wrong)  # type: ignore[arg-type]
+    # a string is the hex of a script or an address, and this one is
+    # neither, so the complaint is btclib's rather than bytes.fromhex's
+    with pytest.raises(BTClibValueError, match="neither a script nor an address: "):
+        descriptor.index_of("not an address")
 
 
 def taproot_merkle_root_of(tree: list[tuple[int, int, bytes]]) -> bytes:


### PR DESCRIPTION
`Descriptor.script_pub_key(i)` returns a `ScriptPubKey`, so handing that
object back to the method beside it is what the API reads like -- and
`index_of` answered `None`, which does not mean "wrong type" here: it
means *this output is not this wallet's*, the answer a caller acts on to
say that an address is somebody else's or that a change output is not
its change. The mechanism was `bytes_from_octets` with no `out_size`,
which returns anything that is not a `str` untouched: the object
travelled through to a comparison against `bytes` that is False at every
index, and the loop fell off the end. An address fared better by being
loud, but the noise was `bytes.fromhex`'s `ValueError` rather than
anything this library promises.

Four spellings of one output are accepted now and all four answer the
same index: the `ScriptPubKey`, its script as bytes, that script as a
hex-string, and the address it renders as -- "which index is this
address" being the question a human has, and the issue's "worth deciding
separately". What is compared is the script in every case, an address
being read for the script it encodes; the network its prefix carries is
not part of the answer, the same key paying to the same script on every
chain. Which spelling a string is is not guesswork: it is hex where
`bytes.fromhex` reads it and an address where it does not, and although
base58 and bech32 do hold hex digits, an address of hex digits only, of
even length and with a valid checksum is not a string anybody has.

What is refused is refused through the exception contract:
`BTClibTypeError` naming the type for anything that is none of the four,
and `BTClibValueError` for a string that names no output. The empty
string is one of those, and is the case this cost the most thought: it
is what `address` answers where a script has none, so
`index_of(descriptor.address(i))` on a `pk()` would otherwise be read as
the empty script and answer that the wallet's own output is not the
wallet's. Empty `bytes` still go through and still answer `None`: no
descriptor derives an empty script, and a caller who wrote `b""` meant
it.

`bytes_from_octets` itself is untouched. Whether the library's front
door for "anything convertible" should keep trusting every non-`str` it
is handed is the wider question the issue raises, and it is one about
every caller that compares rather than parses.

Gates run on this tree: `uv run pre-commit run --all-files`, `uv run
pytest --cov` (18235 passed, 5 integration tests skipped as documented,
100% coverage), and the sphinx `-W` docs build.

Closes #540

## Summary by Sourcery

Allow descriptor index lookup by script or address while distinguishing invalid inputs from non-wallet outputs.

New Features:
- Support passing ScriptPubKey objects and addresses, in addition to script bytes and hex strings, to Descriptor.index_of for output index resolution.

Bug Fixes:
- Ensure Descriptor.index_of no longer silently returns None for unsupported types or malformed strings, but raises explicit BTClibTypeError or BTClibValueError instead.

Enhancements:
- Introduce a helper to consistently derive script bytes from ScriptPubKey, bytes, hex strings, or addresses for descriptor comparisons.
- Clarify Descriptor.index_of behavior and error semantics in the changelog and docstring, emphasizing that None means the output is not from the wallet.

Tests:
- Add tests verifying Descriptor.index_of accepts multiple output representations and that invalid types or strings raise the expected BTClib exceptions.