### PR TITLE
One vocabulary for three wallets, and a ScriptWallet for the rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -508,6 +508,99 @@ documented at release-notes length in the first place, and are still in
   the expression with the keys lifted into a vector, and #469 is where it
   was asked for.
 
+### Wallets
+
+- **`btclib.wallet` is one vocabulary over three sources of addresses**
+  (#542). `btclib.keystore` was the only wallet the library had, and it
+  answered one question -- the address of a `branch/index` below a BIP44
+  account -- while `Descriptor` answered the same question its own way and
+  a script no descriptor states had nobody to ask. The three now live in
+  one package, under one set of words: `Wallet` is the ledger of what has
+  been handed out, and `RangedWallet` the half addressed by a position,
+  so `script_pub_key(branch, index)`, `address(branch, index)`,
+  `next_address(branch)`, `redeem_script`, `witness_script`,
+  `position_of`, `address_info`, `addresses`, `len()`, `in` and
+  `is_watch_only` mean the same thing whichever wallet a caller holds.
+  `KeyStore` is `KeyWallet` and `BIP32KeyStore` is `BIP32KeyWallet`,
+  renamed because the family they now belong to is named after what it
+  does; HISTORY.md's breaking-changes list has the spellings.
+
+  What each of the two new answers costs is what makes the shape worth
+  it. `position_of` is the one that is not a convenience: it is "is this
+  output mine", the whole script computed at every position of every
+  branch and compared -- never a key origin whose four-byte fingerprint
+  matches, which is what would send change to somebody else -- and it
+  takes the output however the caller holds it, a `ScriptPubKey`, the
+  script as bytes or hex, or the address, exactly as
+  `Descriptor.index_of` does since #541. The two answer the same question
+  at different scopes, so the reader that turns any of those spellings
+  into script bytes is now `script.script_pub_key`'s and is imported by
+  both rather than copied. `redeem_script` and `witness_script` are the
+  two pre-images BIP174 asks an Updater for, `b""` where the output
+  commits to a key rather than to a script -- the empty answer that
+  `ScriptPubKey.address` already gives for a script with no address.
+
+  What a branch *is* stays each wallet's own, and is the one thing not
+  hidden: a key wallet and a script wallet derive it, bounded by
+  `bip32.derive_from_account`, so 0 is the receiving chain and 1 the
+  change one; a descriptor wallet has the derivation inside each
+  descriptor and reads the branch as the label of which one. The
+  non-goals are `keystore`'s, unchanged and now stated once for all three:
+  no utxos, no balances, no transaction building, no persistence, no
+  encryption at rest.
+- **`ScriptWallet` is a wallet for the scripts no descriptor states**
+  (#542). Multisig wallets predating output descriptors are still holding
+  coins, and their scripts miss BIP380-390 by a detail: a `<n> OP_CSV
+  OP_DROP` where miniscript writes `OP_CSV OP_VERIFY`, or a BIP67 sort
+  applied to the *derived* keys of a quorum, which `sortedmulti()`
+  follows and which BIP379 has no fragment for inside a combinator. Both
+  refusals are right and neither is relaxed -- #538 pins a production
+  wallet with one of each -- and "right to refuse" is not "nothing to
+  answer". A `ScriptWallet` is a script **template**, the `KeyGroup`
+  quorums it writes into it, and an **order** for the keys of each: a
+  template is a `script.serialize` command list with the groups among the
+  commands, and a group expands to `k <key>... n OP_CHECKMULTISIG` with
+  each key derived at the position. The addresses it computes are pinned
+  against the mainnet ones that deployed wallet holds coins at, through
+  the class and by hand both.
+
+  The order is a parameter because deployed wallets disagree, and the
+  disagreement is what no ranged descriptor can state: `"derived"` sorts
+  the keys at every index, which is the order `sortedmulti()` follows and
+  not a property of the wallet at all; `"account"` sorts the account keys
+  once and derives afterwards, which `multi()` states; `"none"` keeps them
+  as declared. `sort_key` changes what the sort compares and not when it
+  runs, for the wallet that orders its xpubs case-insensitively -- neither
+  a byte order nor a BIP, and deployed. `alias.KeyOrder` and
+  `alias.EmbeddedScriptType` are the two vocabularies, Literals for the
+  reason every other closed vocabulary here is one.
+
+  What it deliberately is not is most of the design. No text format and
+  no parser: the template is Python objects, because inventing a second,
+  worse descriptor language is how this goes wrong, and a wallet that
+  cannot be written down cannot be mistaken for one that can be handed to
+  Bitcoin Core. Not liftable either way -- no `from_script`, no
+  `to_descriptor` -- a wallet a descriptor states should *be* one. And not
+  a signer: miniscript knows what satisfies a fragment and a template does
+  not, so the satisfaction and the psbt Updaters stay outside, where a
+  caller holding such a script already owns the spend.
+- **`DescriptorWallet` is a descriptor per chain, and the wallet questions
+  over the pair** (#542). `Descriptor` has an index and no chains, so a
+  wallet is two of them, and this is that pairing: the descriptors in a
+  mapping or in chain order, `from_descriptor` for BIP389's `<0;1>`
+  multipath spelling -- one line of text for the whole wallet, expanded
+  positionally -- or `from_account`, which is
+  `descriptors.account_descriptors` with an account xpub and a master
+  fingerprint. Named `from_descriptor` and not `parse` for the reason
+  `ScriptPubKey.from_address` is: a `parse` classmethod in btclib reads
+  octets out of a stream. `position_of` is `Descriptor.index_of` per
+  chain rather than a second comparison, `satisfy` and the two psbt
+  Updaters take a position where the descriptor takes an index, and
+  `descriptor(branch)` hands back the `Descriptor` for everything this
+  does not ask. A `combo()` is refused: four scripts at one index are
+  four addresses at one position, which would make `address(branch,
+  index)` a lie, and `Descriptor.script_pub_keys` is what answers for one.
+
 ### Packaging, linting and CI
 
 - **The regtest integration tests now run unattended** (#524), in an

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -32,6 +32,21 @@ full year, short month, short day (YYYY-M-D)
   network, verify_network=False)` is the previous behaviour, for a
   caller that has checked by other means or is talking to something that
   does not answer that call.
+- **`btclib.keystore` is `btclib.wallet`, and its two classes are named
+  after the family they now belong to.** The module is a package holding
+  three kinds of wallet behind one vocabulary, so `from btclib.keystore
+  import BIP32KeyStore, KeyStore, AddressInfo` becomes `from btclib.wallet
+  import BIP32KeyWallet, KeyWallet, AddressInfo`. The methods a caller
+  already used are unchanged in name and in answer -- `address`,
+  `next_address`, `addresses`, `address_info`, `prv_key`, `sign`, `add`,
+  `is_watch_only`, `in`, `len()` -- and what is added is the surface the
+  other two wallets share: `script_pub_key`, `redeem_script`,
+  `witness_script`, `position_of` and `branches`. `AddressInfo` carries
+  two fields more, `branch` and `index`, so a caller comparing a whole
+  record has to pass them; the three it had are in the same order.
+  Two error messages read "wallet" where they read "keystore": an address
+  the wallet never handed out, and the refusal to sign without a private
+  key.
 - **`btclib.descriptors` is a package, and its three checksum tables moved
   with the module into it.** `INPUT_CHARSET`, `CHECKSUM_CHARSET` and
   `GENERATOR` are `btclib.descriptors.descriptors.INPUT_CHARSET` and its

--- a/README.md
+++ b/README.md
@@ -147,9 +147,15 @@ Included features are:
 - fee rates carrying their unit (sat/kvB and sat/vB), the fee a virtual
   size owes at one, and the dust threshold of any output type, computed as
   Bitcoin Core computes it rather than tabulated
-- keystore: the addresses an extended key or a set of individual keys has
-  handed out, the derivation path of each, and the private key that signs
-  for one — what `sign(address, msg)` needs
+- wallets, three sources of addresses behind one vocabulary: an extended
+  key at a BIP44 account or a set of individual keys, which also answer
+  the private key that signs for an address — what `sign(address, msg)`
+  needs — an output descriptor per chain, and a script template with
+  multisig quorums in it, for the pre-descriptor wallets no descriptor
+  states. Each answers `address(branch, index)`,
+  `script_pub_key(branch, index)` and `position_of(script_pub_key)`, the
+  last being "is this output mine", compared whole and never on a key
+  origin's fingerprint
 - an external signer behind one contract, with Bitcoin Core's
   [HWI](https://github.com/bitcoin-core/HWI) behind it for a hardware
   wallet
@@ -228,9 +234,11 @@ is the contract an external signer answers; `hwi` is that contract over
 Bitcoin Core's HWI.
 
 Nothing in the library imports `bip21`, `bip322`, `slip132`, `fee`,
-`keystore`, `hwi` or `fetch`: they are the top of the stack, and `fetch`
-is the only one that goes out to the network. `keystore` remembers which
-addresses `bip44` has handed out and signs for one with `ecc.bms`.
+`wallet`, `hwi` or `fetch`: they are the top of the stack, and `fetch`
+is the only one that goes out to the network. `wallet` remembers which
+addresses it has handed out — over `bip44`, over `descriptors` or over a
+script template of its own — and its key wallets sign for one with
+`ecc.bms`.
 `bip322` is the other message signing, and it is at the top rather than
 beside `ecc.bms` because it needs everything below it: a script, a
 transaction, a psbt and the engine that runs them.

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -94,7 +94,6 @@ __all__ = [
     "fetch",
     "hashes",
     "hwi",
-    "keystore",
     "mnemonic",
     "network",
     "number_theory",
@@ -110,6 +109,7 @@ __all__ = [
     "utils",
     "var_bytes",
     "var_int",
+    "wallet",
 ]
 
 

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -32,12 +32,14 @@ __all__ = [
     "BinaryData",
     "CipherF",
     "Command",
+    "EmbeddedScriptType",
     "H160_Net",
     "HashDigestF",
     "HashF",
     "HashObject",
     "Integer",
     "JacPoint",
+    "KeyOrder",
     "MnemonicLang",
     "NetworkField",
     "NetworkName",
@@ -281,6 +283,29 @@ ValidSigHashType = Literal[0, 1, 2, 3, 129, 130, 131]
 # it is a mypy fact and not a runtime one, so the json is still checked
 # where it is used
 BIP44ScriptType = Literal["p2pkh", "p2wpkh-p2sh", "p2wpkh", "p2tr"]
+
+# The three ways a script becomes an output, which is what a
+# wallet.ScriptWallet takes: the script is hashed into a p2sh, into a
+# p2wsh, or into a p2wsh that a p2sh wraps. Not ScriptType either, and
+# for BIP44ScriptType's reason -- `p2sh-p2wsh` is a nesting of one script
+# in another and not something type_and_payload answers -- while the
+# overlap with those four is only apparent: these three say what happens
+# to a *script*, where those four say what happens to a key.
+#
+# A parameter type: the vocabulary is closed by what a hash of a script
+# can be paid to, so a fourth entry would need a new output type rather
+# than a new line here
+EmbeddedScriptType = Literal["p2sh", "p2wsh", "p2sh-p2wsh"]
+
+# When a wallet.ScriptWallet orders the keys of a quorum, which is the
+# one thing about a pre-descriptor multisig wallet that cannot be read off
+# its script: "derived" sorts them at every index, which is BIP67 on the
+# derived keys and what sortedmulti() follows; "account" sorts the account
+# keys once and derives afterwards, which multi() states; "none" keeps
+# them as declared. The three are a strategy and not a constant because
+# deployed wallets disagree, and the sort_key beside them is what a wallet
+# ordering by something that is not a byte order needs
+KeyOrder = Literal["none", "account", "derived"]
 
 
 # What a HashF returns: as much of the hashlib object as this library uses,

--- a/btclib/bip44.py
+++ b/btclib/bip44.py
@@ -22,7 +22,7 @@ import `bip32`, so it cannot live inside the package whose keys it
 derives addresses from either.
 
 What imports this module is what the mapping and the checks are for, and
-in one direction only: `keystore` takes the encoders and the purpose
+in one direction only: `wallet` takes the encoders and the purpose
 lookup rather than keeping a second copy of either, and `descriptors`
 takes the path checks and the same lookup for the account descriptor pair
 it builds. Neither is imported back -- a descriptor is what a wallet
@@ -110,7 +110,7 @@ def _p2tr(key: Key, network: str) -> str:
 # other -- a fifth encoding is a key mypy does not know.
 #
 # The key is a Key and not the str this module always passes, because
-# all four encoders take one and `keystore` reaches for this same table
+# all four encoders take one and `wallet` reaches for this same table
 # with a key that has not been through b58: narrowing it here would make
 # the table this module's rather than the library's, for no check gained
 _ADDRESS_FROM_SCRIPT_TYPE: dict[BIP44ScriptType, Callable[[Key, str], str]] = {

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -181,7 +181,7 @@ from btclib.descriptors.miniscript import (
 )
 from btclib.descriptors.miniscript import from_script as _miniscript_from_script
 from btclib.descriptors.miniscript import parse as _parse_miniscript
-from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import NETWORKS, network_from_xkeyversion
 from btclib.psbt.psbt import Psbt
@@ -189,7 +189,7 @@ from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
 from btclib.script.script import op_int, serialize
 from btclib.script.script import parse as _parse_script
-from btclib.script.script_pub_key import ScriptPubKey
+from btclib.script.script_pub_key import ScriptPubKey, _script_from
 from btclib.script.taproot import input_script_sig, leaf_hash, tree_helper
 from btclib.script.witness import Witness
 from btclib.to_pub_key import fingerprint
@@ -686,58 +686,6 @@ def _musig2_participants(
         for key in keys
         if key.is_aggregate
     }
-
-
-def _script_from(script_pub_key: Octets | ScriptPubKey) -> bytes:
-    """Return the script bytes of whatever names one output.
-
-    The spellings `index_of` takes, and which of them is which is not
-    guesswork: a `ScriptPubKey` and `bytes` are what they are, and a
-    string is the hex of a script where `bytes.fromhex` reads it and an
-    address where it does not. The two alphabets do overlap -- base58 and
-    bech32 both hold hex digits -- but an address of hex digits only,
-    of even length, and carrying a valid checksum is not a string anybody
-    has.
-
-    The empty string is the one refused outright, and for the reason the
-    whole function exists: it is what `address` answers where a script
-    has none, so `index_of(descriptor.address(i))` on a ``pk()`` would
-    otherwise read as the empty script, match nothing, and say that the
-    wallet's own output is not the wallet's. Empty `bytes` are the empty
-    script and go through: no descriptor derives one, and the caller who
-    wrote them meant them.
-
-    `bytes_from_octets` alone cannot do this: it returns anything that is
-    not a `str` untouched, so the `ScriptPubKey` the method beside
-    `index_of` returns would travel through to a comparison against
-    `bytes` that is False at every index, and the caller would read the
-    None it falls off the end with as "not this wallet's".
-    """
-    if isinstance(script_pub_key, ScriptPubKey):
-        return script_pub_key.script
-    if isinstance(script_pub_key, bytes):
-        return script_pub_key
-    # unreachable to mypy, the annotation having no fourth case, and the
-    # whole point to a caller who is not running it: `Octets` is honoured
-    # inside btclib and nowhere else
-    if not isinstance(script_pub_key, str):
-        err_msg = f"invalid script_pub_key type: {type(script_pub_key).__name__}"  # type: ignore[unreachable]
-        raise BTClibTypeError(err_msg)
-    if not script_pub_key:
-        err_msg = "empty script_pub_key: a script with no address renders as ''"
-        raise BTClibValueError(err_msg)
-    try:
-        return bytes.fromhex(script_pub_key)
-    except ValueError:
-        pass
-    try:
-        return ScriptPubKey.from_address(script_pub_key).script
-    # ValueError rather than BTClibValueError, which is one: the address
-    # codecs raise their own, and a string that reaches them is decoded
-    # before it is checked, so it may fail on a plain one from underneath
-    except ValueError as e:
-        err_msg = f"neither a script nor an address: '{script_pub_key}'"
-        raise BTClibValueError(err_msg) from e
 
 
 @dataclass(frozen=True, kw_only=True)

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from btclib import b32, b58, var_bytes
 from btclib.alias import Octets, ScriptList, ScriptType, String, TaprootScriptTree
 from btclib.curves import point_from_octets
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160, sha256
 from btclib.network import NETWORKS, network_type_from_network
 from btclib.script.script import Script, op_int, serialize
@@ -793,3 +793,61 @@ class ScriptPubKey(Script):
         pub_key = output_pubkey(internal_key, script_path)[0]
         script = serialize(["OP_1", pub_key])
         return cls(script, network, check_validity=check_validity)
+
+
+def _script_from(script_pub_key: Octets | ScriptPubKey) -> bytes:
+    """Return the script bytes of whatever names one output.
+
+    The spellings a caller may hold an output as, and which of them is
+    which is not guesswork: a `ScriptPubKey` and `bytes` are what they
+    are, and a string is the hex of a script where `bytes.fromhex` reads
+    it and an address where it does not. The two alphabets do overlap --
+    base58 and bech32 both hold hex digits -- but an address of hex digits
+    only, of even length, and carrying a valid checksum is not a string
+    anybody has.
+
+    Private, and imported by the two questions that ask "is this output
+    mine": `Descriptor.index_of` and `wallet.RangedWallet.position_of`.
+    Here rather than in either, because it is about this module's own
+    class and this module's own `from_address`, and because a second copy
+    of the rule is a second answer to give.
+
+    The empty string is the one refused outright, and for the reason the
+    whole function exists: it is what `address` answers where a script has
+    none, so `index_of(descriptor.address(i))` on a ``pk()`` would
+    otherwise read as the empty script, match nothing, and say that the
+    wallet's own output is not the wallet's. Empty `bytes` are the empty
+    script and go through: no descriptor derives one, and the caller who
+    wrote them meant them.
+
+    `bytes_from_octets` alone cannot do this: it returns anything that is
+    not a `str` untouched, so the `ScriptPubKey` that a wallet and a
+    descriptor both answer with would travel through to a comparison
+    against `bytes` that is False at every index, and the caller would
+    read the None it falls off the end with as "not this wallet's".
+    """
+    if isinstance(script_pub_key, ScriptPubKey):
+        return script_pub_key.script
+    if isinstance(script_pub_key, bytes):
+        return script_pub_key
+    # unreachable to mypy, the annotation having no fourth case, and the
+    # whole point to a caller who is not running it: `Octets` is honoured
+    # inside btclib and nowhere else
+    if not isinstance(script_pub_key, str):
+        err_msg = f"invalid script_pub_key type: {type(script_pub_key).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
+    if not script_pub_key:
+        err_msg = "empty script_pub_key: a script with no address renders as ''"
+        raise BTClibValueError(err_msg)
+    try:
+        return bytes.fromhex(script_pub_key)
+    except ValueError:
+        pass
+    try:
+        return ScriptPubKey.from_address(script_pub_key).script
+    # ValueError rather than BTClibValueError, which is one: the address
+    # codecs raise their own, and a string that reaches them is decoded
+    # before it is checked, so it may fail on a plain one from underneath
+    except ValueError as e:
+        err_msg = f"neither a script nor an address: '{script_pub_key}'"
+        raise BTClibValueError(err_msg) from e

--- a/btclib/wallet/__init__.py
+++ b/btclib/wallet/__init__.py
@@ -1,0 +1,50 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Wallets: the addresses one is holding, and what each was computed from.
+
+Three sources of addresses, one vocabulary over them, and the vocabulary
+is the point: whatever a wallet computes its outputs from, it is asked
+`address(branch, index)`, `script_pub_key(branch, index)`,
+`next_address(branch)` and `position_of(script_pub_key)`, and it remembers
+what it has handed out.
+
+Four modules make it up, and each imports the ones before it and none
+after:
+
+- `wallet` is that vocabulary and holds no source of its own: `Wallet` is
+  the ledger, and `RangedWallet` the half addressed by a branch and an
+  index;
+- `key_wallet` is the wallets whose output hashes one key -- `KeyWallet`
+  for individual keys and `BIP32KeyWallet` for a BIP44 account -- and
+  they are the two that can `sign(address, msg)`, a single key being a
+  single thing to look up;
+- `descriptor_wallet` is `DescriptorWallet`, one `Descriptor` per chain,
+  which covers every script BIP380 to BIP390 can state, reads the whole
+  pair off BIP389's ``<0;1>`` spelling, and delegates the spend to it;
+- `script_wallet` is `ScriptWallet`, a script template with `KeyGroup`
+  quorums in it, for the wallets no descriptor states -- and it imports
+  `descriptor_wallet` not at all, having no descriptor in it and no
+  business gaining one.
+
+The flat surface is this package's: the classes above are read off
+`btclib.wallet`, the four modules being where they are written rather
+than how they are reached.
+"""
+
+from btclib.wallet.descriptor_wallet import DescriptorWallet
+from btclib.wallet.key_wallet import BIP32KeyWallet, KeyWallet
+from btclib.wallet.script_wallet import KeyGroup, ScriptWallet
+from btclib.wallet.wallet import AddressInfo, RangedWallet, Wallet
+
+__all__ = [
+    "AddressInfo",
+    "BIP32KeyWallet",
+    "DescriptorWallet",
+    "KeyGroup",
+    "KeyWallet",
+    "RangedWallet",
+    "ScriptWallet",
+    "Wallet",
+]

--- a/btclib/wallet/descriptor_wallet.py
+++ b/btclib/wallet/descriptor_wallet.py
@@ -1,0 +1,313 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""A wallet of output descriptors: one per chain, the rest is theirs.
+
+`Descriptor` answers everything about the scripts it describes and knows
+nothing about chains: it has one index, so a wallet is two of them --
+BIP44 puts receiving addresses under `/0` and change under `/1`, and a
+wallet holding one and not the other cannot recognize its own change,
+which is a lost output rather than a missing feature. This module is that
+pairing, and the `btclib.wallet` vocabulary over it.
+
+So the branch here is a *label* and not a derivation step: which of the
+descriptors, the path inside each having derived it already. The three
+ways in put the labels there:
+
+- the descriptors themselves, in a mapping from branch or in chain order;
+- `from_descriptor`, which reads BIP389's ``<0;1>`` multipath spelling --
+  one line of text for the pair, expanded positionally, so element 0 is
+  branch 0. Named as `ScriptPubKey.from_address` is, and not `parse`: a
+  `parse` classmethod in btclib reads octets out of a stream, and this
+  reads a line of text;
+- `from_account`, which is `descriptors.account_descriptors`: an account
+  xpub and its master fingerprint in, the receive and change descriptors
+  out.
+
+What this adds to a descriptor is the branch, the ledger of what has been
+handed out, and `position_of`; what it delegates is everything else, and
+`descriptor(branch)` hands back the `Descriptor` for the questions this
+does not ask -- `str()`, `key_expressions`, `satisfy` for a shape the
+wallet-level one refuses. `satisfy` and the two psbt Updaters are here
+because their argument is a position, and a caller holding a psbt has one
+rather than an index.
+
+A ``combo()`` is refused: it is four scripts at one index, so it is four
+addresses at one position, and a wallet position that means four
+addresses would make `address(branch, index)` a lie. `descriptors.parse`
+reads one, and a caller wanting it uses `Descriptor.script_pub_keys`
+directly.
+
+A parsed descriptor holds no private key -- `descriptors.parse` neuters an
+xprv to its xpub -- so a wallet is watch-only unless it is handed the
+`prv_keys` mapping that module takes: the hardened steps an xpub cannot
+walk, keyed as it keys them. That mapping is also the whole of what
+`is_watch_only` reads, there being nothing else here that could sign.
+
+BIP380: https://github.com/bitcoin/bips/blob/master/bip-0380.mediawiki
+BIP389: https://github.com/bitcoin/bips/blob/master/bip-0389.mediawiki
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from btclib.alias import BIP44ScriptType, Octets
+from btclib.bip32.bip32 import BIP32Key
+from btclib.bip32.der_path import DerPath
+from btclib.descriptors.descriptors import (
+    ComboDescriptor,
+    Descriptor,
+    ShDescriptor,
+    WshDescriptor,
+    account_descriptors,
+    multipath_descriptors,
+)
+from btclib.descriptors.descriptors import parse as _parse_descriptor
+from btclib.descriptors.key_expression import PrvKeys
+from btclib.descriptors.miniscript import SpendContext
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.psbt.psbt import Psbt
+from btclib.script.script_pub_key import ScriptPubKey
+from btclib.script.witness import Witness
+from btclib.wallet.wallet import _LAST_INDEX, RangedWallet
+
+__all__ = [
+    "DescriptorWallet",
+]
+
+
+class DescriptorWallet(RangedWallet):
+    """One descriptor per chain, and the wallet questions over the pair."""
+
+    def __init__(
+        self,
+        descriptors: Descriptor | Mapping[int, Descriptor] | Sequence[Descriptor],
+        prv_keys: PrvKeys | None = None,
+    ) -> None:
+        # a string is the mistake worth naming: `Sequence` admits one, so
+        # a descriptor's text would become one branch per character
+        # rather than an error. `Octets` is honoured inside btclib and
+        # nowhere else, which is why the annotation has no case for it
+        if isinstance(descriptors, str):
+            err_msg = "a descriptor string is not a Descriptor:"
+            err_msg += " DescriptorWallet.from_descriptor reads one"
+            raise BTClibTypeError(err_msg)
+        if isinstance(descriptors, Descriptor):
+            by_branch = {0: descriptors}
+        elif isinstance(descriptors, Mapping):
+            by_branch = dict(descriptors)
+        else:
+            # a sequence is the chains in order, which is what
+            # `account_descriptors` returns and how BIP389 expands
+            by_branch = dict(enumerate(descriptors))
+        if not by_branch:
+            err_msg = "no descriptor: a wallet has at least one chain"
+            raise BTClibValueError(err_msg)
+
+        for branch, descriptor in by_branch.items():
+            if branch < 0:
+                raise BTClibValueError(f"invalid branch: {branch}")
+            if isinstance(descriptor, ComboDescriptor):
+                err_msg = f"combo() at branch {branch}: four scripts at one"
+                err_msg += " index are four addresses at one position, so a"
+                err_msg += " wallet cannot hold one -- Descriptor"
+                err_msg += ".script_pub_keys is what answers for it"
+                raise BTClibValueError(err_msg)
+
+        networks = {descriptor.network for descriptor in by_branch.values()}
+        if len(networks) != 1:
+            err_msg = f"descriptors of different networks: {sorted(networks)}"
+            raise BTClibValueError(err_msg)
+
+        super().__init__(networks.pop())
+        # sorted, so that `branches` is ascending and `position_of`
+        # searches the receiving chain before the change one
+        self._descriptors = dict(sorted(by_branch.items()))
+        self.prv_keys = prv_keys
+        # computed here rather than answered lazily: it is one derivation,
+        # it is the same at every index -- a descriptor function is what
+        # decides it -- and doing it at construction is what refuses a
+        # descriptor this wallet cannot derive at all before a caller
+        # asks it for an address
+        self.script_type = self.script_pub_key(self.branches[0]).type
+
+    @classmethod
+    def from_descriptor(
+        cls,
+        descriptor: str,
+        network: str = "mainnet",
+        prv_keys: dict[str, str] | None = None,
+    ) -> DescriptorWallet:
+        """Return the wallet of a descriptor, checksum verified.
+
+        BIP389's ``<0;1>`` is what makes one line of text a whole wallet,
+        and it is expanded positionally: as many branches as the
+        multipath steps have elements, branch 0 taking the first element
+        of every step. A descriptor with no such step is one chain, and
+        a wallet of one branch -- which is what a caller watching a
+        single chain has, and not an error.
+        """
+        return cls(
+            [
+                _parse_descriptor(single, network, prv_keys)
+                for single in multipath_descriptors(descriptor)
+            ],
+            prv_keys,
+        )
+
+    @classmethod
+    def from_account(
+        cls,
+        xkey: BIP32Key,
+        der_path: DerPath,
+        master_fingerprint: Octets | None = None,
+        script_type: BIP44ScriptType | None = None,
+        prv_keys: PrvKeys | None = None,
+    ) -> DescriptorWallet:
+        """Return the wallet of a BIP44 account, both of its chains.
+
+        `descriptors.account_descriptors` is the whole of it, and every
+        argument is that function's: the account path selects the
+        encoding through its purpose, the master fingerprint is what the
+        key origin needs, and the network is the extended key's own.
+
+        `BIP32KeyWallet` is the same account without the descriptors, and
+        the two answer the same addresses. What this one adds is what a
+        descriptor carries: the text to hand to Bitcoin Core, the key
+        origins a hardware signer wants, and the psbt Updaters.
+        """
+        return cls(
+            list(account_descriptors(xkey, der_path, master_fingerprint, script_type)),
+            prv_keys,
+        )
+
+    @property
+    def branches(self) -> tuple[int, ...]:
+        """The chains, which are the branches the descriptors came under."""
+        return tuple(self._descriptors)
+
+    @property
+    def is_watch_only(self) -> bool:
+        """Whether the wallet was handed no private key.
+
+        A parsed descriptor never holds one, `descriptors.parse` keeping
+        the xpub of an xprv, so the `prv_keys` mapping is the only key
+        material a wallet of descriptors can have.
+        """
+        return not self.prv_keys
+
+    @property
+    def is_ranged(self) -> bool:
+        """Whether any chain describes a range of scripts.
+
+        A wallet of descriptors with no wildcard is one address per
+        chain, index 0 and nothing else; `Descriptor.is_ranged` is the
+        same question of one chain.
+        """
+        return any(descriptor.is_ranged for descriptor in self._descriptors.values())
+
+    def descriptor(self, branch: int = 0) -> Descriptor:
+        """Return the descriptor of a chain."""
+        self._assert_position(branch, 0)
+        return self._descriptors[branch]
+
+    def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
+        return self._descriptors[branch].script_pub_key(index, self.prv_keys)
+
+    def redeem_script(self, branch: int = 0, index: int = 0) -> bytes:
+        """Return the script a ``sh()`` at this position embeds.
+
+        Which is the redeem script of every shape ``sh()`` wraps: the
+        script of a ``sh(multi())``, and the p2wpkh or p2wsh program of
+        the two wrapped segwit forms, that program being what a p2sh
+        input pushes either way.
+        """
+        self._assert_position(branch, index)
+        descriptor = self._descriptors[branch]
+        if not isinstance(descriptor, ShDescriptor):
+            return b""
+        return descriptor.inner.redeem_script(index, self.prv_keys)
+
+    def witness_script(self, branch: int = 0, index: int = 0) -> bytes:
+        """Return the script a ``wsh()`` at this position embeds.
+
+        Native or wrapped in a ``sh()``, which is the same witness script
+        in the same psbt field: the wrapping shows up in the redeem
+        script and nowhere else.
+        """
+        self._assert_position(branch, index)
+        descriptor = self._descriptors[branch]
+        if isinstance(descriptor, ShDescriptor):
+            descriptor = descriptor.inner
+        if not isinstance(descriptor, WshDescriptor):
+            return b""
+        return descriptor.inner.redeem_script(index, self.prv_keys)
+
+    def position_of(
+        self, script_pub_key: Octets | ScriptPubKey, last_index: int = _LAST_INDEX
+    ) -> tuple[int, int] | None:
+        """Return the position paying to this output, None where none is.
+
+        `Descriptor.index_of` per chain, in `branches` order, rather than
+        a comparison written a second time here: it is the same whole-
+        script comparison, it refuses the same spellings that name no
+        output, and it is what bounds the search of a chain that is not
+        ranged to the one script it has.
+        """
+        for branch, descriptor in self._descriptors.items():
+            index = descriptor.index_of(script_pub_key, last_index, self.prv_keys)
+            if index is not None:
+                return branch, index
+        return None
+
+    def satisfy(
+        self,
+        signatures: Mapping[Octets, Octets],
+        branch: int = 0,
+        index: int = 0,
+        spend: SpendContext | None = None,
+    ) -> tuple[bytes, Witness]:
+        """Return the script_sig and witness spending this position.
+
+        `Descriptor.satisfy` with the position resolved, and every word
+        of its contract: the signatures are handed in and assembled
+        rather than verified, a satisfaction short of what the script
+        pops is an error rather than a shorter answer, and `spend` is
+        what a miniscript branch reads beside the signatures.
+        """
+        self._assert_position(branch, index)
+        return self._descriptors[branch].satisfy(
+            signatures, index, self.prv_keys, spend
+        )
+
+    def update_psbt_input(
+        self, psbt: Psbt, vin_i: int, branch: int = 0, index: int = 0
+    ) -> Psbt:
+        """Return the psbt with an input told what this position is.
+
+        `Descriptor.update_psbt_input`, which is BIP174's Updater: the
+        scripts and the key origins of the position, for signers to fill
+        in and `psbt.finalize` to assemble.
+        """
+        self._assert_position(branch, index)
+        return self._descriptors[branch].update_psbt_input(
+            psbt, vin_i, index, self.prv_keys
+        )
+
+    def update_psbt_output(
+        self, psbt: Psbt, vout_i: int, branch: int = 0, index: int = 0
+    ) -> Psbt:
+        """Return the psbt with an output told what this position is.
+
+        `Descriptor.update_psbt_output`, which refuses unless the output
+        being paid is the very script this position derives: marking an
+        output as the wallet's own is a claim about where money goes, and
+        the whole script is the only evidence for it. `position_of` is
+        the same claim asked as a question.
+        """
+        self._assert_position(branch, index)
+        return self._descriptors[branch].update_psbt_output(
+            psbt, vout_i, index, self.prv_keys
+        )

--- a/btclib/wallet/key_wallet.py
+++ b/btclib/wallet/key_wallet.py
@@ -2,47 +2,40 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Keystore: the addresses handed out, and the key that signs for each.
+"""The wallets whose output is the hash of one key, and who signs for it.
 
 `btclib.ecc.bms` says it in its own docstring -- "at signing time, a
 wallet infrastructure is required to access the private key corresponding
 to a given address" -- and then has none to reach for. This module is
 that infrastructure, and no more of it than the sentence asks for: a
-`KeyStore` holds a key source, hands out addresses, remembers the
-derivation path of each, and answers which private key signs for one.
+wallet holds a key source, hands out addresses, remembers what each was
+derived from, and answers which private key signs for one.
 `sign(address, msg)` is what the three together buy, a message signature
 addressed by *address*, which `bms.sign` cannot offer because it has no
 way to find the key.
 
-Two key sources, one class each. `BIP32KeyStore` takes an extended key
-and the BIP44 account path it sits on, and derives addresses down the two
-unhardened levels below it; `KeyStore` takes individual keys, one address
-each, and is also the base the derivation is added to. Either one is
-watch-only when it holds no private key -- an xpub, or public keys -- and
-that is a first-class state rather than a broken one: watching is most of
-what a keystore does, and `sign` on one raises rather than returning
-something a caller might mistake for a signature.
+Two key sources, one class each. `BIP32KeyWallet` takes an extended key
+and the BIP44 account path it sits on, and derives the addresses of the
+two unhardened levels below it; `KeyWallet` takes individual keys, one
+address each, and is also the base the derivation is added to. Either one
+is watch-only when it holds no private key -- an xpub, or public keys --
+and `sign` on one raises rather than returning something a caller might
+mistake for a signature.
 
-**What this module is not.** No utxo tracking, no balances, no
-transaction building, no persistence to disk, no encryption at rest. Each
-of those is a decision this module cannot take on its own: the first three
-need a view of the chain, which btclib does not have and does not fetch,
-and the last two need a file format and a key-derivation function that
-would outlive any release choosing them. Without them a keystore is a
-pure function of its key source -- the same source gives the same
-addresses in the same order, every time -- which is what makes it
-testable and what keeps its whole state in memory, where the caller can
-see it. A spender is the larger reading of "wallet" and belongs above
-this, not inside it.
+Both are the one-key half of `btclib.wallet`: the address is a hash of a
+single public key, which is what makes a private key for it a single
+thing to look up. `BIP44ScriptType` is therefore the whole of what they
+encode -- a p2wsh address is the hash of a *script*, and `ScriptWallet`
+is where a script goes.
 
 Which encoding an account path means is `bip44`'s question and is
 answered there, not here: this module imports that mapping and those four
 encoders rather than keeping a second copy, so a purpose added to
-`bip44`'s data file is a purpose a keystore hands out. What it does not
+`bip44`'s data file is a purpose a wallet hands out. What it does not
 borrow is `bip44.address_from_der_path`, which walks the whole five-level
-path from the extended key it is given; a keystore has already derived
-down to the account at construction, and `bip32.derive_from_account` --
-which imposes the branch and index bounds -- is the two levels left.
+path from the extended key it is given; a wallet has already derived down
+to the account at construction, and `bip32.derive_from_account` -- which
+imposes the branch and index bounds -- is the two levels left.
 
 https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 """
@@ -51,9 +44,8 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Iterable
-from dataclasses import dataclass
 
-from btclib import b32, b58
+from btclib import b58
 from btclib.alias import BIP44ScriptType, Octets, String
 from btclib.bip32.bip32 import (
     BIP32Key,
@@ -70,18 +62,19 @@ from btclib.bip32.der_path import (
 from btclib.bip44 import _ADDRESS_FROM_SCRIPT_TYPE, _script_type_from_purpose
 from btclib.ecc import bms
 from btclib.exceptions import BTClibValueError
-from btclib.network import NETWORKS, network_from_xkeyversion
+from btclib.network import network_from_xkeyversion
+from btclib.script.script_pub_key import ScriptPubKey
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
 from btclib.to_pub_key import Key, pub_keyinfo_from_key, pub_keyinfo_from_pub_key
+from btclib.wallet.wallet import AddressInfo, RangedWallet, Wallet
 
 __all__ = [
-    "AddressInfo",
-    "BIP32KeyStore",
-    "KeyStore",
+    "BIP32KeyWallet",
+    "KeyWallet",
 ]
 
 # purpose, coin type, account: the three hardened levels of a BIP44 path
-# above the two a keystore walks itself
+# above the two a wallet walks itself
 _ACCOUNT_LEVELS = 3
 
 # native segwit, which is what a wallet created today uses and what
@@ -108,19 +101,6 @@ def _checked_script_type(script_type: str) -> BIP44ScriptType:
     return script_type
 
 
-def _address_str(address: String) -> str:
-    """Return an address spelled the way a keystore records it.
-
-    Bech32 is case insensitive and BIP173 blesses the upper case spelling
-    for QR codes, so an address read off one has to find the lower case
-    one the keystore handed out. Base58 is not case insensitive -- `1Lq`
-    and `1lq` are different payloads -- so it is left exactly as it came.
-    """
-    addr = address.decode("ascii") if isinstance(address, bytes) else address
-    addr = addr.strip()
-    return addr.lower() if b32.has_segwit_prefix(addr) else addr
-
-
 def _wif_if_private(key: Key, network: str) -> str:
     """Return the WIF of a private key, or "" for a public one.
 
@@ -131,7 +111,7 @@ def _wif_if_private(key: Key, network: str) -> str:
 
     The rest -- octets, a WIF or an extended key -- are told apart in the
     order `to_pub_key.pub_keyinfo_from_key` tells them apart, public
-    first: a public key is a complete answer here, the keystore watching
+    first: a public key is a complete answer here, the wallet watching
     that address and unable to sign for it, while anything that is not
     one has to be a private key, and the error raised for a malformed one
     is the diagnosis the caller needs rather than a silent demotion to
@@ -150,39 +130,22 @@ def _wif_if_private(key: Key, network: str) -> str:
     return b58.wif_from_prv_key(q, net, compressed)
 
 
-@dataclass(frozen=True)
-class AddressInfo:
-    """What a keystore remembers about one address it has handed out.
-
-    No key material, deliberately: this is the record a caller prints,
-    logs and compares, and the private key is one call away behind
-    `KeyStore.prv_key`, which reads as the request it is. Frozen for the
-    same reason `addresses` hands back a tuple -- what comes out of a
-    keystore is a copy of what it knows, not a handle on it.
-
-    `der_path` is the whole path from the master key, so that it can be
-    handed to `bip32.derive` or written into a PSBT key origin as it
-    stands; it is empty for a key that came into the keystore on its own,
-    which has no path.
-    """
-
-    address: str
-    script_type: BIP44ScriptType
-    der_path: str
-
-
-class KeyStore:
+class KeyWallet(Wallet):
     """Individual keys, the address of each, and who signs for it.
 
     The addresses are handed out by `add`, one per key, all of them in
-    the script type the keystore was built with; `BIP32KeyStore` below is
+    the script type the wallet was built with; `BIP32KeyWallet` below is
     the same thing with an extended key underneath and derivation on top.
 
     A public key is as welcome as a private one and makes that address
     watch-only. `sign` then raises, naming the address: the alternative
-    would be a keystore that answers a signing request with something
+    would be a wallet that answers a signing request with something
     falsy, and every caller that forgets to check has published an
     unsigned message.
+
+    Not a `RangedWallet`: a key handed over is one address and there is
+    no position it came from, so `address(branch, index)` would have
+    nothing to compute. `BIP32KeyWallet` is where the positions are.
     """
 
     def __init__(
@@ -191,88 +154,45 @@ class KeyStore:
         script_type: BIP44ScriptType = _DEFAULT_SCRIPT_TYPE,
         network: str = "mainnet",
     ) -> None:
-        if network not in NETWORKS:
-            raise BTClibValueError(f"unknown network: {network}")
-        self.network = network
+        super().__init__(network)
         self.script_type = _checked_script_type(script_type)
 
-        # insertion ordered, which is the order the addresses were handed
-        # out in: `addresses` is that order and nothing else records it
-        self._handed_out: dict[str, AddressInfo] = {}
         # address -> WIF, and only for the keys that came in on their own.
-        # A BIP32KeyStore re-derives instead of caching, so what is held
+        # A BIP32KeyWallet re-derives instead of caching, so what is held
         # here is exactly the key material the caller handed over
         self._prv_keys: dict[str, str] = {}
 
         for key in keys:
             self.add(key)
 
-    def __len__(self) -> int:
-        return len(self._handed_out)
-
-    def __contains__(self, address: String) -> bool:
-        """Whether the keystore has handed this address out.
-
-        The question `address_info` raises on, asked without the
-        exception: a caller deciding what to do about an unknown address
-        is not handling an error, and should not have to write one.
-        """
-        return _address_str(address) in self._handed_out
-
-    @property
-    def addresses(self) -> tuple[str, ...]:
-        """Every address handed out, in the order it was handed out."""
-        return tuple(self._handed_out)
-
     @property
     def is_watch_only(self) -> bool:
-        """Whether the keystore holds no private key at all."""
+        """Whether the wallet holds no private key at all."""
         return not self._prv_keys
 
     def add(self, key: Key, script_type: BIP44ScriptType | None = None) -> str:
-        """Take one key into the keystore, and return its address."""
-        script_type = (
-            self.script_type
-            if script_type is None
-            else _checked_script_type(script_type)
+        """Take one key into the wallet, and return its address."""
+        # one call for both paths, and it is what narrows the str
+        # `Wallet.script_type` carries back to the Literal the table below
+        # is keyed by: what every wallet answers is a script type, and
+        # which four of them exist is this module's own vocabulary
+        checked = _checked_script_type(
+            self.script_type if script_type is None else script_type
         )
         pub_key, _ = pub_keyinfo_from_key(key, self.network)
         # segwit has no uncompressed form, so the three segwit encodings
         # would silently answer an uncompressed key with the address of
         # its compressed twin -- an address bms cannot then sign for,
         # because the recovery flag it would need says compressed
-        if script_type != "p2pkh" and len(pub_key) != 33:
-            err_msg = f"uncompressed key cannot be {script_type}:"
+        if checked != "p2pkh" and len(pub_key) != 33:
+            err_msg = f"uncompressed key cannot be {checked}:"
             err_msg += " segwit has no uncompressed form"
             raise BTClibValueError(err_msg)
 
-        address = _ADDRESS_FROM_SCRIPT_TYPE[script_type](key, self.network)
+        address = _ADDRESS_FROM_SCRIPT_TYPE[checked](key, self.network)
         if wif := _wif_if_private(key, self.network):
             self._prv_keys[address] = wif
-        self._handed_out[address] = AddressInfo(address, script_type, "")
-        return address
-
-    def address_info(self, address: String) -> AddressInfo:
-        """Return what the keystore remembers about an address.
-
-        A miss raises rather than answering None. A keystore that has not
-        handed an address out has no opinion about it -- not "no key",
-        which is what a watch-only address has -- and the two are worth
-        different answers; and every other lookup in btclib raises, so a
-        None here would be the one place a caller has to remember not to
-        use the result. `address in keystore` is the question that wants
-        a boolean.
-
-        A miss is also not evidence that the keystore cannot reach the
-        address: a `BIP32KeyStore` derives on demand, so an address of
-        its own chain that it has not been asked for yet is a miss.
-        `address(branch, index)` is what puts one in.
-        """
-        addr = _address_str(address)
-        if addr not in self._handed_out:
-            err_msg = f"address not in the keystore: {addr}"
-            raise BTClibValueError(err_msg)
-        return self._handed_out[addr]
+        return self._record(AddressInfo(address, checked, ""))
 
     def prv_key(self, address: String) -> str:
         """Return the WIF of the private key signing for an address."""
@@ -312,7 +232,7 @@ class KeyStore:
         return bms.sign(msg, self.prv_key(info.address), info.address)
 
 
-class BIP32KeyStore(KeyStore):
+class BIP32KeyWallet(KeyWallet, RangedWallet):
     """An extended key at a BIP44 account, and the addresses below it.
 
     `xkey` is the master key, the account key, or any key between the
@@ -325,7 +245,11 @@ class BIP32KeyStore(KeyStore):
     Addresses come from the two unhardened levels BIP44 puts under an
     account, `branch/index` with branch 0 receiving and 1 change, which
     is also what public derivation can walk -- so an account *xpub* is a
-    complete watch-only keystore.
+    complete watch-only wallet.
+
+    Both bases carry their weight: `RangedWallet` is the positions, and
+    `KeyWallet` the signing and the loose keys, which an extended key
+    does not stop a caller from adding.
     """
 
     def __init__(
@@ -362,12 +286,6 @@ class BIP32KeyStore(KeyStore):
 
         self.der_path = str_from_der_path(indexes)
         self._xkey = self._account_xkey(xkey, indexes)
-        # branch -> the index `next_address` will hand out next, which is
-        # one past the highest handed out so far and not a count of them:
-        # `address(0, 7)` on a fresh keystore leaves the next at 8, so
-        # that a keystore restored by replaying the paths it issued does
-        # not reissue one
-        self._next_index: dict[int, int] = {}
 
     @staticmethod
     def _account_xkey(xkey: BIP32KeyData, indexes: list[int]) -> BIP32KeyData:
@@ -395,53 +313,86 @@ class BIP32KeyStore(KeyStore):
         return BIP32KeyData.b58decode(derive(xkey, indexes[xkey.depth :]))
 
     @property
+    def branches(self) -> tuple[int, ...]:
+        """The receiving and change chains, which is what BIP44 defines.
+
+        The two `bip32.derive_from_account` walks and the only two: a
+        third would be a chain no BIP44 wallet looks at, so an address of
+        it is an address nobody else recovers.
+        """
+        return (0, 1)
+
+    @property
     def is_watch_only(self) -> bool:
-        """Whether the keystore holds no private key at all.
+        """Whether the wallet holds no private key at all.
 
         An xpub account is the watch-only case; a private key handed to
         `add` alongside it is not derived from the account and does not
-        make the account signable, but it does make the keystore hold key
+        make the account signable, but it does make the wallet hold key
         material, which is what this answers.
         """
         return not self._xkey.is_private and super().is_watch_only
 
-    def address(self, branch: int, index: int) -> str:
-        """Hand out the address at branch/index, and remember the path.
+    def _derived_key(self, branch: int, index: int) -> str:
+        """Return the extended key of a position, bounds imposed.
 
-        Idempotent: asking twice derives twice and records once, the
-        keystore being a function of its key source rather than a
-        generator with a position. `bip32.derive_from_account` is what
-        imposes the bounds -- branch 0 or 1, index at most 65535 -- and
-        the message on a violation is its own.
+        `bip32.derive_from_account` is what imposes them -- branch 0 or 1,
+        index at most 65535 -- and the message on a violation is its own.
         """
-        key = derive_from_account(self._xkey, branch, index)
-        address = _ADDRESS_FROM_SCRIPT_TYPE[self.script_type](key, self.network)
-        der_path = f"{self.der_path}/{branch}/{index}"
-        self._handed_out[address] = AddressInfo(address, self.script_type, der_path)
-        self._next_index[branch] = max(self._next_index.get(branch, 0), index + 1)
-        return address
+        return derive_from_account(self._xkey, branch, index)
 
-    def next_address(self, branch: int = 0) -> str:
-        """Hand out the next unused address of a branch."""
-        return self.address(branch, self._next_index.get(branch, 0))
+    def _address(self, branch: int, index: int) -> str:
+        # checked again for the narrowing and not for the check, which the
+        # constructor already made: see `add` above
+        return _ADDRESS_FROM_SCRIPT_TYPE[_checked_script_type(self.script_type)](
+            self._derived_key(branch, index), self.network
+        )
+
+    def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
+        """Return the output of a position, read back from its address.
+
+        The address and not a second table: `bip44`'s is the library's one
+        mapping from a key and a network to an address, `p2wpkh-p2sh` is
+        a nesting rather than an output script type, and
+        `ScriptPubKey.from_address` reads any of the four back into the
+        very script that pays it. What it costs is one base58 or bech32
+        round trip on a string this wallet has just written.
+        """
+        return ScriptPubKey.from_address(self._address(branch, index))
+
+    def _der_path(self, branch: int, index: int) -> str:
+        return f"{self.der_path}/{branch}/{index}"
+
+    def redeem_script(self, branch: int = 0, index: int = 0) -> bytes:
+        """Return the p2wpkh script a `p2wpkh-p2sh` output commits to.
+
+        The one script type here that has one: the other three pay to a
+        key hash or to a key, so what a spend of them pushes is the key
+        itself and there is no pre-image for a psbt to carry -- which is
+        the base class's answer, and is deferred to rather than repeated.
+        """
+        if self.script_type != "p2wpkh-p2sh":
+            return super().redeem_script(branch, index)
+        self._assert_position(branch, index)
+        return ScriptPubKey.p2wpkh(self._derived_key(branch, index)).script
 
     def prv_key(self, address: String) -> str:
         """Return the WIF of the private key signing for an address."""
         info = self.address_info(address)
         # a key added on its own, which the base class holds and this
-        # keystore cannot derive: it has no path, and the account key is
+        # wallet cannot derive: it has no path, and the account key is
         # not its parent
         if info.address in self._prv_keys:
             return self._prv_keys[info.address]
 
         if not self._xkey.is_private:
-            err_msg = "watch-only keystore, no private key for"
+            err_msg = "watch-only wallet, no private key for"
             err_msg += f" {info.address} at {info.der_path}"
             raise BTClibValueError(err_msg)
 
         # re-derived rather than cached: the path is the record, and one
         # source of truth cannot disagree with itself. It also keeps the
-        # keystore holding one private key, the account one, however many
+        # wallet holding one private key, the account one, however many
         # addresses it has handed out
         branch, index = indexes_from_der_path(info.der_path)[-2:]
-        return b58.wif_from_prv_key(derive_from_account(self._xkey, branch, index))
+        return b58.wif_from_prv_key(self._derived_key(branch, index))

--- a/btclib/wallet/script_wallet.py
+++ b/btclib/wallet/script_wallet.py
@@ -1,0 +1,344 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""A wallet whose output is a script no descriptor states: template, groups.
+
+`DescriptorWallet` covers every wallet whose script is sayable in BIP380
+to BIP390, and refuses the ones that are not -- correctly, and with
+nothing to offer instead. This module is the something else. Multisig
+wallets predating output descriptors are still holding coins, and their
+scripts miss the language by a detail: a `<n> OP_CSV OP_DROP` where
+miniscript writes `OP_CSV OP_VERIFY`, or a BIP67 sort applied to the
+*derived* keys of a quorum, which `sortedmulti()` follows exactly and
+which BIP379 has no fragment for inside a combinator. Both refusals are
+right, and "right to refuse" is not "nothing to answer".
+
+A `ScriptWallet` is three things and no more: a script **template**, the
+key **groups** the template writes into it, and an **order** for the keys
+of each group. That is enough to compute the script at a position, which
+is enough for the two questions a wallet is for -- `address(branch,
+index)` and `position_of(script_pub_key)`::
+
+    wallet = ScriptWallet(
+        [
+            "OP_IF",
+            KeyGroup(2, [xpub_a, xpub_b, xpub_c]),
+            "OP_ELSE",
+            encode_num(144).hex(),
+            "OP_CHECKSEQUENCEVERIFY",
+            "OP_DROP",
+            KeyGroup(1, [xpub_recovery]),
+            "OP_ENDIF",
+        ],
+        script_type="p2wsh",
+        order="derived",
+    )
+
+The template is a `script.serialize` command list with `KeyGroup` objects
+among the commands, and a group writes what OP_CHECKMULTISIG reads:
+`k <key>... n OP_CHECKMULTISIG`, the keys being the ones derived at the
+position. So the template is Python objects and not text: **there is no
+text format here, and no parser**. Inventing a second, worse descriptor
+language is how this feature goes wrong, and a wallet that cannot be
+written down cannot be mistaken for one that can be handed to Bitcoin
+Core.
+
+**Not liftable, in either direction.** No `from_script`, and no
+`to_descriptor`. A wallet that a descriptor states should be one --
+`DescriptorWallet.from_descriptor` is where it goes -- and this class is for the
+ones no descriptor states; offering a conversion would re-open the
+ambiguity that refusing the script closes.
+
+**Not a signer.** `DescriptorWallet.satisfy` can assemble a spend because
+miniscript knows what satisfies a fragment; a template does not, so
+neither the satisfaction nor the psbt Updaters are here. What is here is
+`redeem_script` and `witness_script`, which are the pre-images -- a caller
+holding a script no language describes already owns the spend, and those
+two are what a psbt needs from the wallet.
+
+**The order is a parameter because deployed wallets disagree about it**,
+and the disagreement is not expressible in a ranged descriptor:
+
+- `"derived"` sorts the keys of each group at every index, which is BIP67
+  on the derived keys and the order `sortedmulti()` follows -- and which
+  no ranged descriptor can state, the order not being a property of the
+  wallet but of the position;
+- `"account"` sorts the account keys once, before deriving, so the order
+  is fixed and `multi()` states it;
+- `"none"` leaves the keys in the order the group declares them.
+
+`sort_key` changes what the sort compares, not when it runs: without one
+it is byte order, which is BIP67, on the derived public key or on the
+account key's public key. A wallet that sorted its xpubs
+case-insensitively -- neither a byte order nor a BIP, and deployed -- is
+`order="account"` with a `sort_key` of its own.
+
+https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from btclib.alias import Command, EmbeddedScriptType, KeyOrder, ScriptList
+from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, derive_from_account
+from btclib.exceptions import BTClibValueError
+from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE, MAX_SCRIPT_SIZE
+from btclib.script.script import op_int, serialize
+from btclib.script.script_pub_key import ScriptPubKey
+from btclib.to_pub_key import pub_keyinfo_from_key
+from btclib.wallet.wallet import RangedWallet
+
+__all__ = [
+    "KeyGroup",
+    "ScriptWallet",
+]
+
+# what OP_CHECKMULTISIG can be written for: `op_int` spells 0 to 16, so a
+# seventeenth key would need the threshold and the count as data pushes,
+# which is a script no wallet of this shape has. Core's
+# MAX_PUBKEYS_PER_MULTISIG is 20 and is the looser bound of the two
+_MAX_KEYS = 16
+
+# the three orders as a runtime list, for the caller who runs no type
+# checker: `KeyOrder` is a mypy fact and not a runtime one, which is the
+# same limit `bip44`'s script-type table is checked against
+_KEY_ORDERS: tuple[KeyOrder, ...] = ("none", "account", "derived")
+
+# how a script becomes an output, and what that costs the script: a p2sh
+# redeem script is pushed into the script_sig, so the push limit bounds
+# it, while a p2wsh witness script is bounded by the script size limit
+# instead -- Bitcoin Core reads the last witness element with
+# MAX_SCRIPT_SIZE and every other one with MAX_SCRIPT_ELEMENT_SIZE
+_MAX_SCRIPT_FROM_SCRIPT_TYPE: dict[EmbeddedScriptType, int] = {
+    "p2sh": MAX_SCRIPT_ELEMENT_SIZE,
+    "p2wsh": MAX_SCRIPT_SIZE,
+    "p2sh-p2wsh": MAX_SCRIPT_SIZE,
+}
+
+
+def _p2sh_p2wsh(script: bytes, network: str) -> ScriptPubKey:
+    """Return the p2sh output wrapping the p2wsh program of a script.
+
+    A function here and not in the table below, for `bip44._p2tr`'s
+    reason: the other two entries are `ScriptPubKey` classmethods taking
+    exactly these arguments, and this one is a nesting of one in the
+    other.
+    """
+    return ScriptPubKey.p2sh(ScriptPubKey.p2wsh(script, network).script, network)
+
+
+# the script and the network in, the output out
+_SCRIPT_PUB_KEY_FROM_SCRIPT_TYPE: dict[
+    EmbeddedScriptType, Callable[[bytes, str], ScriptPubKey]
+] = {
+    "p2sh": ScriptPubKey.p2sh,
+    "p2wsh": ScriptPubKey.p2wsh,
+    "p2sh-p2wsh": _p2sh_p2wsh,
+}
+
+
+def _account_sec(xkey: BIP32KeyData) -> bytes:
+    """Return the public key of an account key, private or not.
+
+    What `order="account"` compares by default, and the reason it is not
+    `BIP32KeyData.key`: that field is the private key prefixed with a
+    zero byte for an xprv, so sorting by it would order two participants
+    by material one of them does not have -- and the same wallet built
+    from xpubs would order them the other way.
+    """
+    return pub_keyinfo_from_key(xkey)[0]
+
+
+class KeyGroup:
+    """A quorum of extended keys, as a template writes it into a script.
+
+    `threshold` of as many keys as are given, which OP_CHECKMULTISIG
+    needs stated twice: what a group expands to at a position is
+    `k <key>... n OP_CHECKMULTISIG`, with each key derived down the two
+    unhardened levels `bip32.derive_from_account` walks -- so every key
+    here is an *account* key, exactly as `BIP32KeyWallet` takes one.
+
+    An xprv is as welcome as an xpub and is what makes a wallet not
+    watch-only; what goes in the script is the public key either way.
+
+    The order the keys are given in is the order the script carries them
+    in, unless the wallet holding the group says otherwise: ordering is
+    the wallet's parameter, not the group's, because the wallets deployed
+    with a per-index order apply it to every quorum of the script.
+    """
+
+    def __init__(self, threshold: int, keys: Sequence[BIP32Key]) -> None:
+        self.keys = tuple(
+            key if isinstance(key, BIP32KeyData) else BIP32KeyData.b58decode(key)
+            for key in keys
+        )
+        n = len(self.keys)
+        if not 0 < n <= _MAX_KEYS:
+            err_msg = f"invalid n in {threshold}-of-{n}:"
+            err_msg += f" 1 to {_MAX_KEYS} keys, which is what op_int spells"
+            raise BTClibValueError(err_msg)
+        if not 0 < threshold <= n:
+            err_msg = f"invalid threshold in {threshold}-of-{n}"
+            raise BTClibValueError(err_msg)
+        self.threshold = threshold
+
+    def __repr__(self) -> str:
+        """Return the quorum, and no key: one of them may be an xprv."""
+        return f"KeyGroup({self.threshold}, {len(self.keys)} keys)"
+
+
+class ScriptWallet(RangedWallet):
+    """A script template, its key groups, and the addresses they compute."""
+
+    def __init__(
+        self,
+        template: Sequence[Command | KeyGroup],
+        script_type: EmbeddedScriptType = "p2wsh",
+        order: KeyOrder = "none",
+        sort_key: Callable[[Any], Any] | None = None,
+        network: str = "mainnet",
+    ) -> None:
+        super().__init__(network)
+        if script_type not in _SCRIPT_PUB_KEY_FROM_SCRIPT_TYPE:
+            known = ", ".join(sorted(_SCRIPT_PUB_KEY_FROM_SCRIPT_TYPE))
+            err_msg = f"unknown script type: {script_type} not in ({known})"
+            raise BTClibValueError(err_msg)
+        if order not in _KEY_ORDERS:
+            known = ", ".join(_KEY_ORDERS)
+            err_msg = f"unknown key order: {order} not in ({known})"
+            raise BTClibValueError(err_msg)
+        if order == "none" and sort_key is not None:
+            err_msg = 'sort_key with order "none": there is nothing to sort by,'
+            err_msg += ' and the keys stay as declared -- "account" and'
+            err_msg += ' "derived" are what a sort_key orders'
+            raise BTClibValueError(err_msg)
+
+        self.script_type = script_type
+        # the table entry resolved once, which is also what keeps the
+        # lookup typed: `Wallet.script_type` is the str every wallet
+        # answers, and a str is not a key of a table keyed by the three
+        self._output = _SCRIPT_PUB_KEY_FROM_SCRIPT_TYPE[script_type]
+        self.order = order
+        self.sort_key = sort_key
+        self.template = tuple(template)
+        # the account order applied once, here, which is the whole of what
+        # "account" means: what is left for a position is the derivation
+        # and, for "derived", a sort of what came out of it
+        self._ordered_keys = {
+            position: self._account_order(command.keys)
+            for position, command in enumerate(self.template)
+            if isinstance(command, KeyGroup)
+        }
+        if not self._ordered_keys:
+            err_msg = "no KeyGroup in the template: a script with no key to"
+            err_msg += " derive is one script, and script.serialize writes it"
+            raise BTClibValueError(err_msg)
+
+        # built once at construction, which is what refuses a template no
+        # position of this wallet could be computed from -- a command
+        # `serialize` cannot write, a key of another network, an account
+        # key that is not hardened. The size it checks is the size at
+        # every index: a derived public key is 33 bytes wherever it came
+        # from, so a script that fits here fits everywhere
+        script = self._script(0, 0)
+        max_size = _MAX_SCRIPT_FROM_SCRIPT_TYPE[script_type]
+        if len(script) > max_size:
+            err_msg = f"invalid script length: {len(script)} bytes is past the"
+            err_msg += f" {max_size} a {script_type} script may have"
+            raise BTClibValueError(err_msg)
+
+    @property
+    def branches(self) -> tuple[int, ...]:
+        """The receiving and change chains, which is what BIP44 defines.
+
+        The two `bip32.derive_from_account` walks, and the same two
+        `BIP32KeyWallet` has: every key of every group is an account key,
+        so what a branch means here is the step below one.
+        """
+        return (0, 1)
+
+    @property
+    def is_watch_only(self) -> bool:
+        """Whether no key of any group is a private one."""
+        return not any(
+            key.is_private for keys in self._ordered_keys.values() for key in keys
+        )
+
+    def _account_order(
+        self, keys: tuple[BIP32KeyData, ...]
+    ) -> tuple[BIP32KeyData, ...]:
+        """Return the account keys of a group in the order they derive in."""
+        if self.order != "account":
+            return keys
+        return tuple(sorted(keys, key=self.sort_key or _account_sec))
+
+    def _derived_sec(self, key: BIP32KeyData, branch: int, index: int) -> bytes:
+        """Return the public key a group key derives to at a position.
+
+        The public one whatever the key is: an xprv derives to an xprv,
+        whose `BIP32KeyData.key` is the private key behind a zero byte, and
+        that is not what goes into a script. `bip32.derive_from_account` is
+        what imposes the bounds -- branch 0 or 1, index at most 65535 --
+        and the network check is `to_pub_key`'s.
+        """
+        return pub_keyinfo_from_key(
+            derive_from_account(key, branch, index), self.network
+        )[0]
+
+    def _quorum(
+        self, threshold: int, keys: tuple[BIP32KeyData, ...], branch: int, index: int
+    ) -> ScriptList:
+        """Return what a group writes into the script at one position."""
+        derived = [self._derived_sec(key, branch, index) for key in keys]
+        if self.order == "derived":
+            # `key=None` is the plain byte order sorted() would use
+            # anyway, so one call spells both readings
+            derived.sort(key=self.sort_key)
+        return [op_int(threshold), *derived, op_int(len(derived)), "OP_CHECKMULTISIG"]
+
+    def _script(self, branch: int, index: int) -> bytes:
+        """Return the script the template writes at one position."""
+        commands: ScriptList = []
+        for position, command in enumerate(self.template):
+            if isinstance(command, KeyGroup):
+                commands += self._quorum(
+                    command.threshold, self._ordered_keys[position], branch, index
+                )
+            else:
+                commands.append(command)
+        return serialize(commands)
+
+    def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
+        return self._output(self._script(branch, index), self.network)
+
+    def redeem_script(self, branch: int = 0, index: int = 0) -> bytes:
+        """Return the script a p2sh output at this position commits to.
+
+        The template's own script where the output is a plain p2sh, and
+        the p2wsh program where a p2sh wraps one: what a p2sh input
+        pushes is the pre-image of the hash in the output, which for
+        `p2sh-p2wsh` is the witness program and not the script that
+        program commits to.
+        """
+        self._assert_position(branch, index)
+        if self.script_type == "p2wsh":
+            return b""
+        script = self._script(branch, index)
+        if self.script_type == "p2sh":
+            return script
+        return ScriptPubKey.p2wsh(script, self.network).script
+
+    def witness_script(self, branch: int = 0, index: int = 0) -> bytes:
+        """Return the script a p2wsh output at this position commits to.
+
+        The template's own script, wrapped in a p2sh or not, and `b""` for
+        a plain p2sh, where the template script is the redeem script
+        instead.
+        """
+        self._assert_position(branch, index)
+        if self.script_type == "p2sh":
+            return b""
+        return self._script(branch, index)

--- a/btclib/wallet/wallet.py
+++ b/btclib/wallet/wallet.py
@@ -1,0 +1,367 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""What a wallet is asked, in the words every wallet here answers to.
+
+Three classes in this package say "these are my addresses", and they say
+it from three different sources -- an extended key, an output descriptor,
+a script template. The questions put to them are one set, and this module
+is that set: it holds no key, no descriptor and no script of its own.
+
+`Wallet` is the ledger half -- the addresses handed out, what is
+remembered about each, and whether any private key is held -- and
+`KeyWallet`, which takes individual keys and has no position to compute
+them from, is a wallet on that much alone.
+
+`RangedWallet` is the half addressed by *position*, which is the branch
+and index BIP44 puts below an account, and it is where one vocabulary is
+worth an abstraction:
+
+- `script_pub_key(branch, index)` is what the wallet pays to there, and
+  `address(branch, index)` the same output as text; `next_address(branch)`
+  walks a branch, and `addresses` is what has been handed out;
+- `redeem_script` and `witness_script` are the two pre-images BIP174 asks
+  an Updater for, empty where the output commits to a key rather than to
+  a script;
+- `position_of(script_pub_key)` runs the comparison the other way, which
+  is the question a caller gets wrong: an output is this wallet's when
+  the whole script derived at a position is the script being paid, and
+  never because a key origin's four-byte fingerprint matches.
+  `Descriptor.index_of` asks it of one descriptor and answers the index
+  alone; a wallet has branches, so the answer here is the pair.
+
+What a branch *is* differs, and the difference is the one thing not
+hidden: a key wallet and a script wallet derive it, `branch/index` below
+the account, so 0 is the receiving chain and 1 the change one, both bound
+by `bip32.derive_from_account`; a descriptor wallet has the derivation
+inside each descriptor already and reads the branch as the label of which
+one. The chains are the same two chains either way, named rather than
+derived.
+
+**What no wallet here does.** No utxos, no balances, no transaction
+building, no persistence to disk, no encryption at rest. Each of those is
+a decision this package cannot take on its own: the first three need a
+view of the chain, which btclib does not have and does not fetch, and the
+last two need a file format and a key-derivation function that would
+outlive any release choosing them. Without them a wallet is a pure
+function of its source -- the same source gives the same addresses in the
+same order, every time -- which is what makes it testable and what keeps
+its whole state in memory, where the caller can see it. A spender is the
+larger reading of "wallet" and belongs above this, not inside it.
+
+https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from btclib import b32
+from btclib.alias import Octets, String
+from btclib.exceptions import BTClibValueError
+from btclib.network import NETWORKS
+from btclib.script.script_pub_key import ScriptPubKey, _script_from
+
+__all__ = [
+    "AddressInfo",
+    "RangedWallet",
+    "Wallet",
+]
+
+# how far ahead of what it has handed out a wallet looks for an output of
+# its own, where the caller expresses no policy of its own. The same
+# default `Descriptor.index_of` takes, and for the same reason: a gap
+# limit is the caller's business and this is only a number to start from
+_LAST_INDEX = 999
+
+
+def _address_str(address: String) -> str:
+    """Return an address spelled the way a wallet records it.
+
+    Bech32 is case insensitive and BIP173 blesses the upper case spelling
+    for QR codes, so an address read off one has to find the lower case
+    one the wallet handed out. Base58 is not case insensitive -- `1Lq`
+    and `1lq` are different payloads -- so it is left exactly as it came.
+    """
+    addr = address.decode("ascii") if isinstance(address, bytes) else address
+    addr = addr.strip()
+    return addr.lower() if b32.has_segwit_prefix(addr) else addr
+
+
+@dataclass(frozen=True)
+class AddressInfo:
+    """What a wallet remembers about one address it has handed out.
+
+    No key material, deliberately: this is the record a caller prints,
+    logs and compares, and the private key is one call away behind
+    `KeyWallet.prv_key`, which reads as the request it is. Frozen for the
+    same reason `addresses` hands back a tuple -- what comes out of a
+    wallet is a copy of what it knows, not a handle on it.
+
+    `script_type` is the wallet's own spelling: `bip44`'s four for a key
+    wallet, which is where `p2wpkh-p2sh` is a script type at all, and how
+    the script becomes an output for the other two.
+
+    `der_path` is the whole path from the master key, so that it can be
+    handed to `bip32.derive` or written into a psbt key origin as it
+    stands. It is empty wherever there is not one path to write: a key
+    that came into a `KeyWallet` on its own has none, and a script naming
+    several keys has one per key, which a psbt key origin records and a
+    single field cannot.
+
+    `branch` and `index` are the position the address was computed from,
+    and `None` for an address that was not computed from one.
+    """
+
+    address: str
+    script_type: str
+    der_path: str
+    branch: int | None = None
+    index: int | None = None
+
+
+class Wallet(ABC):
+    """The addresses a wallet has handed out, and what it knows of each.
+
+    A ledger and nothing else: what puts an address in it is each
+    wallet's own business -- `KeyWallet.add` takes a key, and
+    `RangedWallet.address` computes a position -- and what it answers is
+    the same either way.
+    """
+
+    # every wallet sets it in __init__, and the spelling is its own:
+    # `bip44`'s four for a key wallet, the three ways a script becomes an
+    # output for a script wallet, and the shape of the script itself for
+    # a descriptor one. Annotated and not a property, so that a subclass
+    # assigns it as the plain attribute it is
+    script_type: str
+
+    def __init__(self, network: str = "mainnet") -> None:
+        if network not in NETWORKS:
+            raise BTClibValueError(f"unknown network: {network}")
+        self.network = network
+        # insertion ordered, which is the order the addresses were handed
+        # out in: `addresses` is that order and nothing else records it
+        self._handed_out: dict[str, AddressInfo] = {}
+
+    def __len__(self) -> int:
+        return len(self._handed_out)
+
+    def __contains__(self, address: String) -> bool:
+        """Whether the wallet has handed this address out.
+
+        The question `address_info` raises on, asked without the
+        exception: a caller deciding what to do about an unknown address
+        is not handling an error, and should not have to write one.
+        """
+        return _address_str(address) in self._handed_out
+
+    @property
+    def addresses(self) -> tuple[str, ...]:
+        """Every address handed out, in the order it was handed out."""
+        return tuple(self._handed_out)
+
+    @property
+    @abstractmethod
+    def is_watch_only(self) -> bool:
+        """Whether the wallet holds no private key at all.
+
+        A first-class state rather than a broken one: watching is most of
+        what a wallet does, and every wallet here is asked, so that no
+        caller has to know which kind of source it was built from.
+        """
+
+    def address_info(self, address: String) -> AddressInfo:
+        """Return what the wallet remembers about an address.
+
+        A miss raises rather than answering None. A wallet that has not
+        handed an address out has no opinion about it -- not "no key",
+        which is what a watch-only address has -- and the two are worth
+        different answers; and every other lookup in btclib raises, so a
+        None here would be the one place a caller has to remember not to
+        use the result. `address in wallet` is the question that wants a
+        boolean.
+
+        A miss is also not evidence that the wallet cannot reach the
+        address: a `RangedWallet` computes on demand, so an address of
+        its own chains that it has not been asked for yet is a miss.
+        `address(branch, index)` is what puts one in, and
+        `position_of(address)` answers whether it is reachable at all.
+        """
+        addr = _address_str(address)
+        if addr not in self._handed_out:
+            err_msg = f"address not in the wallet: {addr}"
+            raise BTClibValueError(err_msg)
+        return self._handed_out[addr]
+
+    def _record(self, info: AddressInfo) -> str:
+        """Take one address into the ledger, and return it."""
+        self._handed_out[info.address] = info
+        return info.address
+
+
+class RangedWallet(Wallet, ABC):
+    """A wallet whose outputs are computed from a branch and an index.
+
+    Three methods are the subclass's to answer -- `branches`, the
+    `_script_pub_key` at a position, and `is_watch_only` -- and the rest
+    of the surface is written once, here, in terms of those.
+
+    Idempotent, all of it: asking for the same position twice computes it
+    twice and records it once, a wallet being a function of its source
+    rather than a generator with a position of its own. What it does
+    remember is how far it has been asked, which is what `next_address`
+    reads.
+    """
+
+    def __init__(self, network: str = "mainnet") -> None:
+        super().__init__(network)
+        # branch -> the index `next_address` will hand out next, which is
+        # one past the highest asked for so far and not a count of them:
+        # `address(0, 7)` on a fresh wallet leaves the next at 8, so that
+        # a wallet restored by replaying the positions it issued does not
+        # reissue one
+        self._next_index: dict[int, int] = {}
+
+    @property
+    @abstractmethod
+    def branches(self) -> tuple[int, ...]:
+        """The chains this wallet has outputs on, in ascending order.
+
+        BIP44's two, `(0, 1)`, wherever the branch is a derivation step;
+        whatever the descriptors were given under, where it is a label.
+        `position_of` searches these and `address` refuses anything else,
+        so this is also the wallet's answer to "which chains are there".
+        """
+
+    @abstractmethod
+    def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
+        """Return the output at a position, the position being checked."""
+
+    def _address(self, branch: int, index: int) -> str:
+        """Return the address of the output at a position.
+
+        The script's own address, which is the answer wherever the script
+        is what the wallet computes. A key wallet overrides it: `bip44`'s
+        table is the library's one mapping from a key and a network to an
+        address, and going through a script to reach the same string
+        would be a second one.
+        """
+        return self._script_pub_key(branch, index).address
+
+    def _der_path(self, branch: int, index: int) -> str:
+        """Return the whole derivation path of the position, or "".
+
+        Empty here, which is the honest answer for a wallet whose output
+        names more than one key: `AddressInfo.der_path` is one path and
+        there are several. A key wallet has exactly one and overrides it.
+        """
+        return ""
+
+    def _assert_position(self, branch: int, index: int) -> None:
+        """Refuse a position this wallet has no output at.
+
+        The branch against `branches`, which is the one bound every
+        subclass shares; the index only for the sign, its upper bound
+        being the subclass's own -- 65535 from
+        `bip32.derive_from_account` where the branch is derived, and
+        BIP32's own limit where a descriptor derives it.
+        """
+        if branch not in self.branches:
+            branches = ", ".join(str(b) for b in self.branches)
+            err_msg = f"invalid branch: {branch} not in ({branches})"
+            raise BTClibValueError(err_msg)
+        if index < 0:
+            raise BTClibValueError(f"invalid index: {index}")
+
+    def script_pub_key(self, branch: int = 0, index: int = 0) -> ScriptPubKey:
+        """Return the output this wallet pays to at a position."""
+        self._assert_position(branch, index)
+        return self._script_pub_key(branch, index)
+
+    def redeem_script(self, branch: int = 0, index: int = 0) -> bytes:
+        """Return the script a p2sh output at this position commits to.
+
+        BIP174's PSBT_IN_REDEEM_SCRIPT, and `b""` where the output is not
+        a p2sh -- the empty answer being what "there is no such script"
+        looks like everywhere else here, as `ScriptPubKey.address` is ""
+        for a script with no address.
+        """
+        self._assert_position(branch, index)
+        return b""
+
+    def witness_script(self, branch: int = 0, index: int = 0) -> bytes:
+        """Return the script a p2wsh output at this position commits to.
+
+        BIP174's PSBT_IN_WITNESS_SCRIPT, and `b""` where the output is
+        not a p2wsh, wrapped in a p2sh or not.
+        """
+        self._assert_position(branch, index)
+        return b""
+
+    def address(self, branch: int = 0, index: int = 0) -> str:
+        """Hand out the address at a position, and remember it.
+
+        A script with no address raises rather than recording the ""
+        that names it: a wallet handing out the empty string has handed
+        out nothing, and `script_pub_key` is what such a wallet answers
+        with.
+        """
+        self._assert_position(branch, index)
+        address = self._address(branch, index)
+        if not address:
+            err_msg = f"no address for the script at {branch}/{index}:"
+            err_msg += " script_pub_key is what this output has"
+            raise BTClibValueError(err_msg)
+        self._next_index[branch] = max(self._next_index.get(branch, 0), index + 1)
+        return self._record(
+            AddressInfo(
+                address,
+                self.script_type,
+                self._der_path(branch, index),
+                branch,
+                index,
+            )
+        )
+
+    def next_address(self, branch: int = 0) -> str:
+        """Hand out the next address of a branch not yet asked for."""
+        return self.address(branch, self._next_index.get(branch, 0))
+
+    def position_of(
+        self, script_pub_key: Octets | ScriptPubKey, last_index: int = _LAST_INDEX
+    ) -> tuple[int, int] | None:
+        """Return the position paying to this output, None where none is.
+
+        What makes an output *this wallet's*, and the only thing that
+        does: the script is computed at each position and compared whole.
+        A key origin whose fingerprint matches is not an answer -- four
+        bytes of a hash160 collide, and a psbt is written by whoever
+        sends it, so an output marked as change on a fingerprint is an
+        output a wallet may hand to somebody else believing it keeps it.
+
+        The output is named however the caller holds it: the
+        `ScriptPubKey` that `script_pub_key` returns, that script as
+        bytes or as a hex-string, or the address it renders as -- "which
+        position is this address" being the question a human has.
+        Anything else raises, and so does a string that names no output,
+        because None is not "you passed the wrong thing" here: it is
+        *this output is not this wallet's*, which is the answer a caller
+        acts on.
+
+        `last_index` bounds the search of every branch, both ends
+        included, and is the caller's: how far ahead of its own gap limit
+        a wallet is willing to look is a policy this package has no view
+        on. The branches are searched in `branches` order, one whole
+        branch before the next, and the first match wins -- two positions
+        paying to one script is a wallet whose source repeats itself, not
+        something this has to choose between.
+        """
+        script = _script_from(script_pub_key)
+        for branch in self.branches:
+            for index in range(last_index + 1):
+                if self._script_pub_key(branch, index).script == script:
+                    return branch, index
+        return None

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -17,6 +17,7 @@ Subpackages
    btclib.psbt
    btclib.script
    btclib.tx
+   btclib.wallet
 
 Submodules
 ----------
@@ -116,13 +117,6 @@ btclib.hwi module
 -----------------
 
 .. automodule:: btclib.hwi
-   :members:
-   :show-inheritance:
-
-btclib.keystore module
-----------------------
-
-.. automodule:: btclib.keystore
    :members:
    :show-inheritance:
 

--- a/docs/source/btclib.wallet.rst
+++ b/docs/source/btclib.wallet.rst
@@ -1,0 +1,40 @@
+btclib.wallet package
+=====================
+
+Submodules
+----------
+
+btclib.wallet.descriptor\_wallet module
+---------------------------------------
+
+.. automodule:: btclib.wallet.descriptor_wallet
+   :members:
+   :show-inheritance:
+
+btclib.wallet.key\_wallet module
+--------------------------------
+
+.. automodule:: btclib.wallet.key_wallet
+   :members:
+   :show-inheritance:
+
+btclib.wallet.script\_wallet module
+-----------------------------------
+
+.. automodule:: btclib.wallet.script_wallet
+   :members:
+   :show-inheritance:
+
+btclib.wallet.wallet module
+---------------------------
+
+.. automodule:: btclib.wallet.wallet
+   :members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: btclib.wallet
+   :members:
+   :show-inheritance:

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -190,6 +190,15 @@ CHILD_MODULES = {
         "groups": [],
         "unpublished": ["out_point", "tx", "tx_in", "tx_out"],
     },
+    "btclib.wallet": {
+        "groups": [],
+        "unpublished": [
+            "descriptor_wallet",
+            "key_wallet",
+            "script_wallet",
+            "wallet",
+        ],
+    },
 }
 
 
@@ -642,7 +651,9 @@ def test_every_child_module_is_a_group_or_deliberately_not() -> None:
     rather than a silent pair of empty lists.
     """
     packages = [module for module in library_modules() if hasattr(module, "__path__")]
-    assert len(packages) == len(CHILD_MODULES) + 1, "btclib plus the ten packages"
+    assert len(packages) == len(CHILD_MODULES) + 1, (
+        "btclib itself plus every package CHILD_MODULES records"
+    )
     for package in packages:
         if package.__name__ == "btclib":  # the directory is its assertion
             continue

--- a/tests/descriptors/custody_wallet_test.py
+++ b/tests/descriptors/custody_wallet_test.py
@@ -44,6 +44,15 @@ as well, message included, because a later release that started *accepting*
 either spelling would change what a descriptor means, not just what it
 parses.
 
+Those same four calls are what a `wallet.ScriptWallet` is made of, and the
+last test below is the one that matters most to it: the plain shape
+written as a template with two `KeyGroup` quorums in it, answering the
+very addresses transcribed here. The addresses are the authority in both
+directions -- by hand and through the class -- so a `ScriptWallet` that
+ordered a quorum differently, or wrote the timelock as miniscript would,
+would be caught by the deployment rather than by a unit test agreeing with
+itself.
+
 Every address below is a mainnet address that has held value. They are
 transcribed from the wallets' own committed address lists, and the two
 timelocks -- 5184 blocks, 576 blocks -- are the deployed ones.
@@ -64,6 +73,7 @@ from btclib.descriptors import (
 from btclib.exceptions import BTClibValueError
 from btclib.script import Command, op_int, script
 from btclib.utils import encode_num
+from btclib.wallet import KeyGroup, ScriptWallet
 
 # The ranged shape, twice: the descriptor of each (wallet, branch), and
 # the first eleven addresses it derives. The two deployments share the
@@ -427,3 +437,56 @@ def test_sorted_multi_is_not_a_fragment() -> None:
     # while the same expression on its own is a descriptor, and a ranged
     # one: what is missing is the combinator around it, not the sort
     assert parse(add_checksum(f"wsh(sortedmulti(1,{key}))")).is_ranged
+
+
+def _plain_script_wallet(wallet: str) -> ScriptWallet:
+    """Return the plain shape as a `ScriptWallet`: template and quorums.
+
+    The same commands `_plain_witness_script` writes by hand, with the two
+    quorums as `KeyGroup` objects instead of expanded calls -- and the
+    per-index sort as the wallet's `order`, which is the parameter that
+    exists because this deployment needs it.
+    """
+    if wallet == "vault":
+        template: list[Command | KeyGroup] = [
+            "OP_IF",
+            KeyGroup(3, _PRIMARY),
+            "OP_ELSE",
+            *_older(_VAULT_RECOVERY_BLOCKS),
+            KeyGroup(2, _RECOVERY),
+            "OP_ENDIF",
+        ]
+    else:
+        template = [
+            "OP_IF",
+            *_older(_TRANSIT_PRIMARY_BLOCKS),
+            KeyGroup(2, _CUSTODIAN),
+            "OP_ELSE",
+            KeyGroup(2, _RECOVERY),
+            "OP_ENDIF",
+        ]
+    return ScriptWallet(template, "p2wsh", "derived")
+
+
+@pytest.mark.parametrize("wallet", ["vault", "transit"])
+@pytest.mark.parametrize("branch", [0, 1])
+def test_the_plain_shape_is_a_script_wallet(wallet: str, branch: int) -> None:
+    """The deployed addresses, from a template rather than from four calls.
+
+    Which is what `btclib.wallet.ScriptWallet` is for: the script no
+    descriptor states, and the two questions a wallet is asked about it --
+    the address at a position, and whether an output is its own.
+    """
+    addresses = _PLAIN[wallet][branch]
+    script_wallet = _plain_script_wallet(wallet)
+    assert [
+        script_wallet.address(branch, i) for i in range(len(addresses))
+    ] == addresses
+    # the same witness script, byte for byte, as the four calls write
+    for index in (0, 7):
+        assert script_wallet.witness_script(branch, index) == _plain_witness_script(
+            wallet, branch, index
+        )
+    # and the other half of what a wallet answers: this output is mine,
+    # the whole script compared at each position of each branch
+    assert script_wallet.position_of(addresses[7], 10) == (branch, 7)

--- a/tests/wallet/__init__.py
+++ b/tests/wallet/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Non-regression tests for btclib.wallet."""

--- a/tests/wallet/descriptor_wallet_test.py
+++ b/tests/wallet/descriptor_wallet_test.py
@@ -1,0 +1,307 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.wallet.descriptor_wallet` module.
+
+What a `DescriptorWallet` adds to a `Descriptor` is the branch, the ledger
+and `position_of`; what it delegates is the rest. So these tests are about
+the pairing -- the three ways the chains get their labels, and the
+refusals a chain cannot be built from -- and about the delegation being
+the descriptor's own answer at the position asked for, rather than a
+second implementation of it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from btclib.bip32 import bip32
+from btclib.descriptors import add_checksum, parse
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.psbt.psbt import Psbt
+from btclib.script.script_pub_key import ScriptPubKey
+from btclib.tx.out_point import OutPoint
+from btclib.tx.tx import Tx
+from btclib.tx.tx_in import TxIn
+from btclib.tx.tx_out import TxOut
+from btclib.wallet import BIP32KeyWallet, DescriptorWallet
+
+# the "abandon abandon ... about" seed and its BIP84 account, which is the
+# account every other wallet test uses too
+_ROOT = "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
+_ACCOUNT = "m/84h/0h/0h"
+_FINGERPRINT = "73c5da0a"
+
+# SLIP132's account xpub for purpose 44, which most of the tests below
+# only need to be *an* account xpub, and the BIP84 one beside it, for the
+# two that check a descriptor wallet against the key wallet of the very
+# same account
+_XPUB = "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj"
+_ACCOUNT_XPUB = "xpub6CatWdiZiodmUeTDp8LT5or8nmbKNcuyvz7WyksVFkKB4RHwCD3XyuvPEbvqAQY3rAPshWcMLoP2fMFMKHPJ4ZeZXYVUhLv1VMrjPC7PW6V"
+_XPUB_OTHER = "xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL"
+
+# a p2wsh address of nobody's wallet here: BIP173's own vector
+_ELSEWHERE = "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"
+
+
+def _descriptor(expression: str) -> str:
+    """Return the expression with the checksum `parse` verifies."""
+    return add_checksum(expression)
+
+
+def test_the_chains_can_be_given_three_ways() -> None:
+    """A mapping, a sequence, and one descriptor on its own.
+
+    The sequence is the chains in order, which is what
+    `descriptors.account_descriptors` returns and how BIP389 expands; the
+    mapping is for a caller whose labels are not 0 and 1, and one
+    descriptor alone is the wallet of a single chain -- what a caller
+    watching only receiving addresses has, and not an error.
+    """
+    receive, change = (parse(_descriptor(f"wpkh({_XPUB}/{i}/*)")) for i in (0, 1))
+
+    ordered = DescriptorWallet([receive, change])
+    assert ordered.branches == (0, 1)
+
+    labelled = DescriptorWallet({7: receive, 3: change})
+    # sorted, so that `branches` is ascending whatever order they came in
+    assert labelled.branches == (3, 7)
+    assert labelled.descriptor(7) is receive
+
+    alone = DescriptorWallet(receive)
+    assert alone.branches == (0,)
+    assert alone.address(0, 4) == ordered.address(0, 4)
+
+
+def test_the_multipath_spelling_is_one_line_for_the_whole_wallet() -> None:
+    """BIP389's ``<0;1>``, expanded positionally: element 0 is branch 0."""
+    wallet = DescriptorWallet.from_descriptor(
+        _descriptor(f"wpkh([{_FINGERPRINT}/84h/0h/0h]{_ACCOUNT_XPUB}/<0;1>/*)")
+    )
+    assert wallet.branches == (0, 1)
+    assert wallet.is_ranged
+    assert wallet.address(1, 0) == BIP32KeyWallet(_ROOT, _ACCOUNT).address(1, 0)
+
+    # and a descriptor with no multipath step is a wallet of one chain
+    single = DescriptorWallet.from_descriptor(_descriptor(f"wpkh({_XPUB}/0/*)"))
+    assert single.branches == (0,)
+
+
+def test_an_account_xpub_is_the_wallet_its_purpose_says() -> None:
+    """`from_account` is `descriptors.account_descriptors`, as a wallet.
+
+    Every argument is that function's, and the addresses are the ones the
+    same account answers as a `BIP32KeyWallet`: the purpose selects the
+    encoding in both.
+    """
+    keys = BIP32KeyWallet(_ROOT, "m/49h/0h/0h")
+    wallet = DescriptorWallet.from_account(_ROOT, "m/49h/0h/0h", _FINGERPRINT)
+    assert wallet.script_type == "p2sh"
+    assert wallet.address(0, 0) == keys.address(0, 0)
+    # the script type override is account_descriptors' own, and reaches it
+    overridden = DescriptorWallet.from_account(
+        _ROOT, "m/49h/0h/0h", _FINGERPRINT, "p2wpkh"
+    )
+    assert overridden.script_type == "p2wpkh"
+    assert overridden.address(0, 0) == BIP32KeyWallet(
+        _ROOT, "m/49h/0h/0h", "p2wpkh"
+    ).address(0, 0)
+
+
+def test_a_descriptor_string_is_not_a_descriptor() -> None:
+    """The mistake a `Sequence` would otherwise read character by character."""
+    err_msg = "a descriptor string is not a Descriptor"
+    with pytest.raises(BTClibTypeError, match=err_msg):
+        DescriptorWallet(f"wpkh({_XPUB}/0/*)")  # type: ignore[arg-type]
+
+
+def test_a_wallet_has_at_least_one_chain() -> None:
+    """No descriptor is not a wallet with nothing in it; it is nothing."""
+    with pytest.raises(BTClibValueError, match="no descriptor"):
+        DescriptorWallet([])
+    with pytest.raises(BTClibValueError, match="no descriptor"):
+        DescriptorWallet({})
+
+
+def test_a_branch_is_a_label_and_labels_are_not_negative() -> None:
+    """The one thing a chain label has to be, `position_of` walking them."""
+    with pytest.raises(BTClibValueError, match="invalid branch: -1"):
+        DescriptorWallet({-1: parse(_descriptor(f"wpkh({_XPUB}/0/*)"))})
+
+
+def test_the_chains_must_be_of_one_network() -> None:
+    """A wallet is on a chain, and a network is what a chain is."""
+    mainnet = parse(_descriptor(f"wpkh({_XPUB}/0/*)"))
+    testnet = parse(_descriptor(f"wpkh({_XPUB}/1/*)"), "testnet")
+    err_msg = r"descriptors of different networks: \['mainnet', 'testnet'\]"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        DescriptorWallet([mainnet, testnet])
+
+
+def test_a_combo_is_four_addresses_at_one_position() -> None:
+    """Which is not a wallet position, so the wallet refuses it.
+
+    `Descriptor.script_pub_keys` is what answers for a ``combo()``, and
+    the message says so: a position that meant four addresses would make
+    `address(branch, index)` a lie.
+    """
+    combo = parse(_descriptor(f"combo({_XPUB}/0/*)"))
+    with pytest.raises(BTClibValueError, match="combo\\(\\) at branch 0"):
+        DescriptorWallet([combo])
+
+
+def test_a_script_with_no_address_is_not_handed_out() -> None:
+    """A ``pk()`` is a script and not an address, and says which it is.
+
+    The wallet is built all the same -- `script_pub_key` and
+    `position_of` answer for it -- and it is `address` that refuses,
+    rather than handing out the "" a script with no address renders as.
+    """
+    wallet = DescriptorWallet(parse(_descriptor(f"pk({_XPUB}/0/*)")))
+    assert wallet.script_type == "p2pk"
+    assert wallet.script_pub_key(0, 3).script
+    assert wallet.position_of(wallet.script_pub_key(0, 3), 4) == (0, 3)
+    with pytest.raises(BTClibValueError, match="no address for the script at 0/3"):
+        wallet.address(0, 3)
+
+
+def test_a_wallet_that_is_not_ranged_has_one_position_per_chain() -> None:
+    """`is_ranged` is the descriptors', and so is the bound it imposes."""
+    address = _ELSEWHERE
+    wallet = DescriptorWallet(parse(_descriptor(f"addr({address})")))
+    assert not wallet.is_ranged
+    assert wallet.address() == address
+    assert wallet.position_of(address, 999) == (0, 0)
+    err_msg = "not a ranged descriptor: no script at index 1"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        wallet.address(0, 1)
+
+
+def test_the_two_pre_images_are_the_wrapped_descriptors_own() -> None:
+    """BIP174's redeem script and witness script, per position.
+
+    Four shapes: a ``sh()`` has the first, a ``wsh()`` the second, a
+    ``sh(wsh())`` both -- the wrapping showing up in the redeem script and
+    nowhere else -- and a bare ``wpkh()`` neither.
+    """
+    multi = f"multi(1,{_XPUB}/0/*,{_XPUB_OTHER}/0/*)"
+    sh = DescriptorWallet(parse(_descriptor(f"sh({multi})")))
+    wsh = DescriptorWallet(parse(_descriptor(f"wsh({multi})")))
+    sh_wsh = DescriptorWallet(parse(_descriptor(f"sh(wsh({multi}))")))
+    wpkh = DescriptorWallet(parse(_descriptor(f"wpkh({_XPUB}/0/*)")))
+
+    quorum = parse(_descriptor(multi)).redeem_script(3)
+    assert sh.redeem_script(0, 3) == quorum
+    assert not sh.witness_script(0, 3)
+
+    assert wsh.witness_script(0, 3) == quorum
+    assert not wsh.redeem_script(0, 3)
+
+    assert sh_wsh.witness_script(0, 3) == quorum
+    assert sh_wsh.redeem_script(0, 3) == ScriptPubKey.p2wsh(quorum).script
+
+    assert not wpkh.redeem_script(0, 3)
+    assert not wpkh.witness_script(0, 3)
+    # a sh(wpkh()) has the p2wpkh program as its redeem script, which is
+    # what the wrapped form pushes
+    sh_wpkh = DescriptorWallet(parse(_descriptor(f"sh(wpkh({_XPUB}/0/*))")))
+    assert (
+        sh_wpkh.redeem_script(0, 3)
+        == ScriptPubKey.p2wpkh(
+            parse(_descriptor(f"wpkh({_XPUB}/0/*)"))
+            .key_expressions[0]
+            .sec(3, "mainnet")
+        ).script
+    )
+    assert not sh_wpkh.witness_script(0, 3)
+
+
+def test_position_of_is_index_of_per_chain() -> None:
+    """The same whole-script comparison, asked of each chain in turn."""
+    wallet = DescriptorWallet.from_account(_ROOT, _ACCOUNT, _FINGERPRINT)
+    assert wallet.position_of(wallet.script_pub_key(1, 6), 9) == (1, 6)
+    assert wallet.position_of(wallet.script_pub_key(1, 6), 5) is None
+    assert wallet.position_of(_ELSEWHERE, 5) is None
+    # the refusals are index_of's, which is what makes them one rule
+    with pytest.raises(BTClibValueError, match="empty script_pub_key"):
+        wallet.position_of("")
+
+
+def test_the_hardened_steps_are_walked_with_the_private_keys() -> None:
+    """`prv_keys` is what a descriptor takes and what makes a wallet sign.
+
+    A parsed descriptor holds no private key -- `descriptors.parse` keeps
+    the xpub of an xprv -- so that mapping is the only key material a
+    wallet of descriptors can have, and `is_watch_only` reads it.
+    """
+    xprv = bip32.derive(_ROOT, _ACCOUNT)
+    xpub = bip32.xpub_from_xprv(xprv)
+    expression = f"wpkh([{_FINGERPRINT}/84h/0h/0h]{xpub}/0h/*)"
+
+    # and the refusal is at construction, not at the first address: the
+    # first thing a wallet does is derive one script, so a wallet that
+    # could compute none of its own scripts is never built
+    err_msg = "invalid hardened derivation from public key"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        DescriptorWallet.from_descriptor(_descriptor(expression))
+
+    signing = DescriptorWallet.from_descriptor(
+        _descriptor(expression), prv_keys={xpub: xprv}
+    )
+    assert not signing.is_watch_only
+    assert signing.address(0, 0)
+
+
+def test_satisfy_is_the_descriptors_own_at_the_position() -> None:
+    """The spend of one position, assembled from the signatures handed in."""
+    wallet = DescriptorWallet.from_account(_ROOT, _ACCOUNT, _FINGERPRINT)
+    descriptor = wallet.descriptor(1)
+    sec = descriptor.key_expressions[0].sec(2, "mainnet")
+    signature = bytes.fromhex("3045") + b"\x01" * 69
+
+    assert wallet.satisfy({sec: signature}, 1, 2) == descriptor.satisfy(
+        {sec: signature}, 2
+    )
+    # and a position the wallet has no output at is refused before the
+    # signatures are looked up under a key derived from it
+    with pytest.raises(BTClibValueError, match="invalid branch: 2"):
+        wallet.satisfy({sec: signature}, 2, 2)
+
+
+def _psbt_spending(script_pub_key: ScriptPubKey) -> Psbt:
+    """Return a psbt whose one input spends an output of that script."""
+    prev_tx = Tx(
+        vin=[TxIn(OutPoint(b"\x02" * 32, 0))], vout=[TxOut(1000, script_pub_key)]
+    )
+    psbt = Psbt.from_tx(
+        Tx(vin=[TxIn(OutPoint(prev_tx.id, 0))], vout=[TxOut(900, script_pub_key)])
+    )
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    return psbt
+
+
+def test_the_updaters_take_a_position_where_a_descriptor_takes_an_index() -> None:
+    """Which is the whole of what the wallet adds to BIP174's Updater.
+
+    A caller holding a psbt has a position -- the change output is
+    `branch 1`, at whatever index the wallet handed out -- and the fields
+    written are the descriptor's own.
+    """
+    wallet = DescriptorWallet.from_account(_ROOT, "m/49h/0h/0h", _FINGERPRINT)
+    change = wallet.script_pub_key(1, 2)
+    psbt = _psbt_spending(change)
+
+    updated = wallet.update_psbt_input(psbt, 0, 1, 2)
+    assert updated.inputs[0].redeem_script == wallet.redeem_script(1, 2)
+    assert updated.inputs[0].hd_key_paths
+
+    paid = wallet.update_psbt_output(psbt, 0, 1, 2)
+    assert paid.outputs[0].redeem_script == wallet.redeem_script(1, 2)
+    # the output half refuses unless the output being paid is the very
+    # script the position derives, which is `position_of` as a claim
+    with pytest.raises(BTClibValueError, match="which is not the script"):
+        wallet.update_psbt_output(psbt, 0, 1, 3)
+    for method in (wallet.update_psbt_input, wallet.update_psbt_output):
+        with pytest.raises(BTClibValueError, match="invalid branch: 2"):
+            method(psbt, 0, 2, 2)

--- a/tests/wallet/key_wallet_test.py
+++ b/tests/wallet/key_wallet_test.py
@@ -2,17 +2,18 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Tests for the `btclib.keystore` module."""
+"""Tests for the `btclib.wallet.key_wallet` module."""
 
 from __future__ import annotations
 
 import pytest
 
+from btclib import b58
 from btclib.alias import BIP44ScriptType
 from btclib.bip32 import bip32
 from btclib.ecc import bms
 from btclib.exceptions import BTClibValueError
-from btclib.keystore import AddressInfo, BIP32KeyStore, KeyStore
+from btclib.wallet import AddressInfo, BIP32KeyWallet, KeyWallet
 
 # the "abandon abandon ... about" seed, whose master key BIP84 and BIP86
 # both publish as their rootpriv and whose addresses SLIP132, BIP49,
@@ -30,7 +31,7 @@ _ACCOUNT_84_ZPRV = "zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvB
 # `bip32.derive` down m/84h/0h/0h from the master gives
 _ACCOUNT_84_XPRV = "xprv9ybY78BftS5UGANki6oSifuQEjkpyAC8ZmBvBNTshQnCBcxnefjHS7buPMkkqhcRzmoGZ5bokx7GuyDAiktd5HemohAU4wV1ZPMDRmLpBMm"
 
-_MSG = b"Hello, keystore"
+_MSG = b"Hello, wallet"
 
 # the classic uncompressed WIF of the private key 0x01...01 is not
 # wanted here: this is a random key, compressed and uncompressed
@@ -92,23 +93,23 @@ def test_published_vectors(
     Three per purpose: the first two of the receiving branch and the
     first of the change branch, which is the whole of what BIP84 and
     BIP86 print. Asserted from the master key and again from the account
-    xpub, the two ends a keystore can be built from.
+    xpub, the two ends a wallet can be built from.
     """
     der_path = f"m/{purpose}h/0h/0h"
-    keystore = BIP32KeyStore(_ROOT, der_path)
-    assert keystore.script_type == script_type
-    assert keystore.network == "mainnet"
-    assert keystore.der_path == der_path
-    assert not keystore.is_watch_only
+    wallet = BIP32KeyWallet(_ROOT, der_path)
+    assert wallet.script_type == script_type
+    assert wallet.network == "mainnet"
+    assert wallet.der_path == der_path
+    assert not wallet.is_watch_only
 
-    assert keystore.next_address() == addresses[0]
-    assert keystore.next_address() == addresses[1]
-    assert keystore.next_address(1) == addresses[2]
-    assert keystore.addresses == addresses
-    assert len(keystore) == 3
+    assert wallet.next_address() == addresses[0]
+    assert wallet.next_address() == addresses[1]
+    assert wallet.next_address(1) == addresses[2]
+    assert wallet.addresses == addresses
+    assert len(wallet) == 3
 
     account_xpub = bip32.xpub_from_xprv(bip32.derive(_ROOT, der_path))
-    watching = BIP32KeyStore(account_xpub, der_path)
+    watching = BIP32KeyWallet(account_xpub, der_path)
     assert watching.is_watch_only
     assert [watching.address(0, 0), watching.address(0, 1), watching.address(1, 0)] == [
         *addresses
@@ -117,10 +118,10 @@ def test_published_vectors(
 
 def test_bip49_testnet_vector() -> None:
     """BIP49's own vector, which is the only testnet one published."""
-    keystore = BIP32KeyStore(_TROOT, "m/49h/1h/0h")
-    assert keystore.network == "testnet"
-    assert keystore.script_type == "p2wpkh-p2sh"
-    assert keystore.next_address() == "2Mww8dCYPUpKHofjgcXcBCEGmniw9CoaiD2"
+    wallet = BIP32KeyWallet(_TROOT, "m/49h/1h/0h")
+    assert wallet.network == "testnet"
+    assert wallet.script_type == "p2wpkh-p2sh"
+    assert wallet.next_address() == "2Mww8dCYPUpKHofjgcXcBCEGmniw9CoaiD2"
 
 
 def test_the_path_says_the_script_type_and_the_version_bytes_do_not() -> None:
@@ -131,8 +132,8 @@ def test_the_path_says_the_script_type_and_the_version_bytes_do_not() -> None:
     same account answer one path with two different addresses depending
     on how the key was spelled, and only one of them would be watched.
     """
-    from_zprv = BIP32KeyStore(_ACCOUNT_84_ZPRV, "m/84h/0h/0h")
-    from_xprv = BIP32KeyStore(_ACCOUNT_84_XPRV, "m/84h/0h/0h")
+    from_zprv = BIP32KeyWallet(_ACCOUNT_84_ZPRV, "m/84h/0h/0h")
+    from_xprv = BIP32KeyWallet(_ACCOUNT_84_XPRV, "m/84h/0h/0h")
     assert from_zprv.address(0, 0) == from_xprv.address(0, 0)
     assert from_zprv.address(0, 0) == "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
 
@@ -147,25 +148,25 @@ def test_a_key_anywhere_on_the_account_path() -> None:
         _ACCOUNT_44_XPRV,
         _ACCOUNT_44_XPUB,
     ):
-        assert BIP32KeyStore(xkey, "m/44h/0h/0h").next_address() == address
+        assert BIP32KeyWallet(xkey, "m/44h/0h/0h").next_address() == address
 
 
 def test_a_bip32keydata_is_taken_as_it_is() -> None:
     """Verify a decoded BIP32KeyData works as the account key."""
     xkey = bip32.BIP32KeyData.b58decode(_ACCOUNT_44_XPRV)
-    keystore = BIP32KeyStore(xkey, "m/44h/0h/0h")
-    assert keystore.next_address() == "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"
+    wallet = BIP32KeyWallet(xkey, "m/44h/0h/0h")
+    assert wallet.next_address() == "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"
 
 
 def test_the_key_index_must_be_the_path_element_at_its_depth() -> None:
     """Refuse a key at the wrong index, or past the account depth."""
     # the account 0 xpub against the path of account 1
     with pytest.raises(BTClibValueError, match="is not the account path's"):
-        BIP32KeyStore(_ACCOUNT_44_XPUB, "m/44h/0h/1h")
+        BIP32KeyWallet(_ACCOUNT_44_XPUB, "m/44h/0h/1h")
     # a key already below the account level
     too_deep = bip32.derive(_ACCOUNT_44_XPUB, "m/0/0")
     with pytest.raises(BTClibValueError, match="invalid key depth: 5 is past the"):
-        BIP32KeyStore(too_deep, "m/44h/0h/0h")
+        BIP32KeyWallet(too_deep, "m/44h/0h/0h")
 
 
 @pytest.mark.parametrize(
@@ -181,34 +182,34 @@ def test_the_key_index_must_be_the_path_element_at_its_depth() -> None:
 def test_invalid_account_path(der_path: str, err_msg: str) -> None:
     """Refuse an account path of wrong depth or missing hardening."""
     with pytest.raises(BTClibValueError, match=err_msg):
-        BIP32KeyStore(_ROOT, der_path)
+        BIP32KeyWallet(_ROOT, der_path)
 
 
 def test_an_unknown_purpose_is_refused_and_script_type_is_the_override() -> None:
     """Refuse purpose 45 bare, and let the script type override win."""
     with pytest.raises(BTClibValueError, match="unknown BIP44 purpose: 45"):
-        BIP32KeyStore(_ROOT, "m/45h/0h/0h")
-    keystore = BIP32KeyStore(_ROOT, "m/45h/0h/0h", "p2wpkh")
-    assert keystore.script_type == "p2wpkh"
-    assert keystore.next_address().startswith("bc1q")
+        BIP32KeyWallet(_ROOT, "m/45h/0h/0h")
+    wallet = BIP32KeyWallet(_ROOT, "m/45h/0h/0h", "p2wpkh")
+    assert wallet.script_type == "p2wpkh"
+    assert wallet.next_address().startswith("bc1q")
     # and the override wins over a purpose the table does name
-    assert BIP32KeyStore(_ROOT, "m/84h/0h/0h", "p2pkh").next_address().startswith("1")
+    assert BIP32KeyWallet(_ROOT, "m/84h/0h/0h", "p2pkh").next_address().startswith("1")
 
 
 def test_an_unknown_script_type_is_refused() -> None:
     """Refuse p2wsh at every entry point that takes a script type."""
     with pytest.raises(BTClibValueError, match="unknown script type: p2wsh"):
-        BIP32KeyStore(_ROOT, "m/84h/0h/0h", "p2wsh")  # type: ignore[arg-type]
+        BIP32KeyWallet(_ROOT, "m/84h/0h/0h", "p2wsh")  # type: ignore[arg-type]
     with pytest.raises(BTClibValueError, match="unknown script type: p2wsh"):
-        KeyStore(script_type="p2wsh")  # type: ignore[arg-type]
+        KeyWallet(script_type="p2wsh")  # type: ignore[arg-type]
     with pytest.raises(BTClibValueError, match="unknown script type: p2wsh"):
-        KeyStore().add(_PUB_KEY, "p2wsh")  # type: ignore[arg-type]
+        KeyWallet().add(_PUB_KEY, "p2wsh")  # type: ignore[arg-type]
 
 
 def test_an_unknown_network_is_refused() -> None:
     """Refuse a network name btclib does not register."""
     with pytest.raises(BTClibValueError, match="unknown network: regtest2"):
-        KeyStore(network="regtest2")
+        KeyWallet(network="regtest2")
 
 
 @pytest.mark.parametrize("purpose", [44, 49, 84])
@@ -216,14 +217,14 @@ def test_sign_by_address_verifies_with_bms(purpose: int) -> None:
     """The whole point: a signature asked for by address, not by key.
 
     `bms.verify` is the authority -- it is the code a counterparty runs
-    -- and the address it is given is the one the keystore handed out.
+    -- and the address it is given is the one the wallet handed out.
     """
-    keystore = BIP32KeyStore(_ROOT, f"m/{purpose}h/0h/0h")
-    address = keystore.next_address()
-    sig = keystore.sign(address, _MSG)
+    wallet = BIP32KeyWallet(_ROOT, f"m/{purpose}h/0h/0h")
+    address = wallet.next_address()
+    sig = wallet.sign(address, _MSG)
     assert bms.verify(_MSG, address, sig)
     # and the signature is bms's own, reachable the long way round
-    assert sig == bms.sign(_MSG, keystore.prv_key(address), address)
+    assert sig == bms.sign(_MSG, wallet.prv_key(address), address)
 
 
 def test_the_recovery_flag_names_the_address_type() -> None:
@@ -235,87 +236,87 @@ def test_the_recovery_flag_names_the_address_type() -> None:
     """
     flags = {}
     for purpose in (44, 49, 84):
-        keystore = BIP32KeyStore(_ROOT, f"m/{purpose}h/0h/0h")
-        address = keystore.next_address()
-        flags[purpose] = keystore.sign(address, _MSG).rf
+        wallet = BIP32KeyWallet(_ROOT, f"m/{purpose}h/0h/0h")
+        address = wallet.next_address()
+        flags[purpose] = wallet.sign(address, _MSG).rf
     assert 30 < flags[44] < 35
     assert 34 < flags[49] < 39
     assert flags[84] > 38
 
 
 def test_bms_cannot_sign_for_a_taproot_address() -> None:
-    """The one script type the keystore hands out and cannot sign for."""
-    keystore = BIP32KeyStore(_ROOT, "m/86h/0h/0h")
-    address = keystore.next_address()
+    """The one script type the wallet hands out and cannot sign for."""
+    wallet = BIP32KeyWallet(_ROOT, "m/86h/0h/0h")
+    address = wallet.next_address()
     with pytest.raises(BTClibValueError, match="BMS cannot sign for a p2tr address"):
-        keystore.sign(address, _MSG)
+        wallet.sign(address, _MSG)
     # the key is there all the same: it is the scheme that is missing
-    assert keystore.prv_key(address)
+    assert wallet.prv_key(address)
 
 
-def test_a_watch_only_keystore_fails_to_sign_and_says_why() -> None:
+def test_a_watch_only_wallet_fails_to_sign_and_says_why() -> None:
     """Refuse to sign without a private key, naming the reason."""
-    keystore = BIP32KeyStore(_ACCOUNT_44_XPUB, "m/44h/0h/0h")
-    assert keystore.is_watch_only
-    address = keystore.next_address()
-    err_msg = "watch-only keystore, no private key for"
+    wallet = BIP32KeyWallet(_ACCOUNT_44_XPUB, "m/44h/0h/0h")
+    assert wallet.is_watch_only
+    address = wallet.next_address()
+    err_msg = "watch-only wallet, no private key for"
     with pytest.raises(BTClibValueError, match=err_msg):
-        keystore.prv_key(address)
+        wallet.prv_key(address)
     with pytest.raises(BTClibValueError, match=err_msg):
-        keystore.sign(address, _MSG)
+        wallet.sign(address, _MSG)
 
 
 def test_a_lookup_miss_raises() -> None:
-    """Refuse an address the keystore never handed out."""
-    keystore = BIP32KeyStore(_ROOT, "m/84h/0h/0h")
+    """Refuse an address the wallet never handed out."""
+    wallet = BIP32KeyWallet(_ROOT, "m/84h/0h/0h")
     # an address of its own chain, not handed out yet: a miss all the
-    # same, the map being what the keystore has issued rather than what
+    # same, the map being what the wallet has issued rather than what
     # it could issue
-    unissued = BIP32KeyStore(_ROOT, "m/84h/0h/0h").address(0, 7)
+    unissued = BIP32KeyWallet(_ROOT, "m/84h/0h/0h").address(0, 7)
     for address in (unissued, "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"):
-        assert address not in keystore
-        with pytest.raises(BTClibValueError, match="address not in the keystore"):
-            keystore.address_info(address)
-        with pytest.raises(BTClibValueError, match="address not in the keystore"):
-            keystore.sign(address, _MSG)
-    assert keystore.next_address() in keystore
+        assert address not in wallet
+        with pytest.raises(BTClibValueError, match="address not in the wallet"):
+            wallet.address_info(address)
+        with pytest.raises(BTClibValueError, match="address not in the wallet"):
+            wallet.sign(address, _MSG)
+    assert wallet.next_address() in wallet
 
 
 def test_the_record_is_the_path_and_no_key_material() -> None:
     """Verify AddressInfo is frozen and no repr leaks key material."""
-    keystore = BIP32KeyStore(_ROOT, "m/84h/0h/0h")
-    address = keystore.address(1, 5)
-    info = keystore.address_info(address)
-    assert info == AddressInfo(address, "p2wpkh", "m/84h/0h/0h/1/5")
-    assert address not in repr(keystore)
-    assert keystore.prv_key(address) not in repr(info)
-    # frozen: what comes out of a keystore is a copy of what it knows
+    wallet = BIP32KeyWallet(_ROOT, "m/84h/0h/0h")
+    address = wallet.address(1, 5)
+    info = wallet.address_info(address)
+    assert info == AddressInfo(address, "p2wpkh", "m/84h/0h/0h/1/5", 1, 5)
+    assert address not in repr(wallet)
+    assert wallet.prv_key(address) not in repr(info)
+    # frozen: what comes out of a wallet is a copy of what it knows
     with pytest.raises(AttributeError):
         info.address = "whatever"  # type: ignore[misc]
 
 
 def test_handing_out_is_idempotent_and_ordered() -> None:
     """Verify an address is issued once, next_address one past the top."""
-    keystore = BIP32KeyStore(_ROOT, "m/84h/0h/0h")
-    first = keystore.address(0, 0)
-    assert keystore.address(0, 0) == first
-    assert len(keystore) == 1
+    wallet = BIP32KeyWallet(_ROOT, "m/84h/0h/0h")
+    first = wallet.address(0, 0)
+    assert wallet.address(0, 0) == first
+    assert len(wallet) == 1
     # next_address is one past the highest handed out, not a count
-    keystore.address(0, 7)
-    assert keystore.next_address() == keystore.address(0, 8)
-    assert len(keystore) == 3
+    wallet.address(0, 7)
+    assert wallet.next_address() == wallet.address(0, 8)
+    assert len(wallet) == 3
     # the branches count separately
-    assert keystore.next_address(1) == keystore.address(1, 0)
-    assert keystore.addresses[0] == first
+    assert wallet.next_address(1) == wallet.address(1, 0)
+    assert wallet.addresses[0] == first
 
 
 def test_the_derivation_bounds_are_bip32s_own() -> None:
     """Refuse a branch outside (0, 1) and an address index out of range."""
-    keystore = BIP32KeyStore(_ROOT, "m/84h/0h/0h")
+    wallet = BIP32KeyWallet(_ROOT, "m/84h/0h/0h")
     with pytest.raises(BTClibValueError, match="not in \\(0, 1\\)"):
-        keystore.address(2, 0)
+        wallet.address(2, 0)
     with pytest.raises(BTClibValueError, match="invalid address index"):
-        keystore.address(0, 0x10000)
+        wallet.address(0, 0x10000)
 
 
 @pytest.mark.parametrize(
@@ -328,86 +329,122 @@ def test_the_derivation_bounds_are_bip32s_own() -> None:
 )
 def test_individual_keys(script_type: BIP44ScriptType, address: str) -> None:
     """Verify one WIF gives one address per script type, and it signs."""
-    keystore = KeyStore([_WIF_COMPRESSED], script_type)
-    assert keystore.addresses == (address,)
-    assert not keystore.is_watch_only
-    assert keystore.prv_key(address) == _WIF_COMPRESSED
-    assert keystore.address_info(address) == AddressInfo(address, script_type, "")
-    assert bms.verify(_MSG, address, keystore.sign(address, _MSG))
+    wallet = KeyWallet([_WIF_COMPRESSED], script_type)
+    assert wallet.addresses == (address,)
+    assert not wallet.is_watch_only
+    assert wallet.prv_key(address) == _WIF_COMPRESSED
+    assert wallet.address_info(address) == AddressInfo(address, script_type, "")
+    assert bms.verify(_MSG, address, wallet.sign(address, _MSG))
 
 
 def test_a_key_that_says_what_it_is_by_its_type() -> None:
     """An int is a scalar, a point is a pair: neither needs the guess."""
     q = 0xCA978112CA1BBDCAFAC231B39A23DC4DA786EFF8147C4E72B9807785AFEE48BB
     address = "14dD6ygPi5WXdwwBTt1FBZK3aD8uDem1FY"
-    keystore = KeyStore([q], "p2pkh")
-    assert keystore.addresses == (address,)
-    assert keystore.prv_key(address) == _WIF_COMPRESSED
+    wallet = KeyWallet([q], "p2pkh")
+    assert wallet.addresses == (address,)
+    assert wallet.prv_key(address) == _WIF_COMPRESSED
 
     point = (
         0x30D54FD0DD420A6E5F8D3624F5F3482CAE350F79D5F0753BF5BEEF9C2D91AF3C,
         0x04717159CE0828A7F686C2C7510B7AA7D4C685EBC2051642CCBEBC7099E2F679,
     )
-    watching = KeyStore([point], "p2wpkh")
+    watching = KeyWallet([point], "p2wpkh")
     assert watching.is_watch_only
     assert watching.addresses == ("bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu",)
 
 
 def test_a_public_key_makes_a_watch_only_entry() -> None:
     """Verify an entry built from a public key alone cannot sign."""
-    keystore = KeyStore([_PUB_KEY])
-    address = keystore.addresses[0]
-    assert keystore.is_watch_only
+    wallet = KeyWallet([_PUB_KEY])
+    address = wallet.addresses[0]
+    assert wallet.is_watch_only
     assert address == "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu"
     with pytest.raises(BTClibValueError, match="watch-only address, no private key"):
-        keystore.prv_key(address)
+        wallet.prv_key(address)
     with pytest.raises(BTClibValueError, match="watch-only address, no private key"):
-        keystore.sign(address, _MSG)
+        wallet.sign(address, _MSG)
 
 
 def test_an_uncompressed_key_can_only_be_p2pkh() -> None:
     """Segwit has no uncompressed form, so the address would be a lie."""
-    address = KeyStore([_WIF_UNCOMPRESSED], "p2pkh").addresses[0]
+    address = KeyWallet([_WIF_UNCOMPRESSED], "p2pkh").addresses[0]
     assert address == "1GAehh7TsJAHuUAeKZcXf5CnwuGuGgyX2S"
     for script_type in ("p2wpkh-p2sh", "p2wpkh", "p2tr"):
         with pytest.raises(BTClibValueError, match="uncompressed key cannot be"):
-            KeyStore([_WIF_UNCOMPRESSED], script_type)
+            KeyWallet([_WIF_UNCOMPRESSED], script_type)
 
 
 def test_add_takes_a_script_type_of_its_own() -> None:
     """Verify each added key can carry its own script type."""
-    keystore = KeyStore(script_type="p2pkh")
-    assert not keystore.addresses
-    assert keystore.is_watch_only
-    p2pkh = keystore.add(_WIF_COMPRESSED)
-    p2wpkh = keystore.add(_WIF_COMPRESSED, "p2wpkh")
-    assert keystore.addresses == (p2pkh, p2wpkh)
-    assert keystore.address_info(p2wpkh).script_type == "p2wpkh"
-    assert not keystore.is_watch_only
+    wallet = KeyWallet(script_type="p2pkh")
+    assert not wallet.addresses
+    assert wallet.is_watch_only
+    p2pkh = wallet.add(_WIF_COMPRESSED)
+    p2wpkh = wallet.add(_WIF_COMPRESSED, "p2wpkh")
+    assert wallet.addresses == (p2pkh, p2wpkh)
+    assert wallet.address_info(p2wpkh).script_type == "p2wpkh"
+    assert not wallet.is_watch_only
 
 
-def test_a_key_added_to_a_bip32_keystore_is_not_derived() -> None:
+def test_a_key_added_to_a_bip32_wallet_is_not_derived() -> None:
     """Verify an added key signs while the derived ones stay watch-only."""
-    keystore = BIP32KeyStore(_ACCOUNT_44_XPUB, "m/44h/0h/0h")
-    derived = keystore.next_address()
-    added = keystore.add(_WIF_COMPRESSED, "p2pkh")
-    # the account is still watch-only, but the keystore now holds a key
-    assert not keystore.is_watch_only
-    assert keystore.prv_key(added) == _WIF_COMPRESSED
-    assert bms.verify(_MSG, added, keystore.sign(added, _MSG))
-    with pytest.raises(BTClibValueError, match="watch-only keystore"):
-        keystore.prv_key(derived)
-    assert not keystore.address_info(added).der_path
+    wallet = BIP32KeyWallet(_ACCOUNT_44_XPUB, "m/44h/0h/0h")
+    derived = wallet.next_address()
+    added = wallet.add(_WIF_COMPRESSED, "p2pkh")
+    # the account is still watch-only, but the wallet now holds a key
+    assert not wallet.is_watch_only
+    assert wallet.prv_key(added) == _WIF_COMPRESSED
+    assert bms.verify(_MSG, added, wallet.sign(added, _MSG))
+    with pytest.raises(BTClibValueError, match="watch-only wallet"):
+        wallet.prv_key(derived)
+    assert not wallet.address_info(added).der_path
 
 
 def test_an_address_is_found_however_it_is_spelled() -> None:
     """Verify bech32 lookups ignore case and spaces; base58 must not."""
-    keystore = BIP32KeyStore(_ROOT, "m/84h/0h/0h")
-    address = keystore.next_address()
+    wallet = BIP32KeyWallet(_ROOT, "m/84h/0h/0h")
+    address = wallet.next_address()
     for spelling in (address.upper(), f"  {address}  ", address.encode("ascii")):
-        assert spelling in keystore
-        assert keystore.address_info(spelling).address == address
+        assert spelling in wallet
+        assert wallet.address_info(spelling).address == address
     # base58 is not case insensitive and is left exactly as it came
-    b58_keystore = BIP32KeyStore(_ROOT, "m/44h/0h/0h")
-    b58_address = b58_keystore.next_address()
-    assert b58_address.upper() not in b58_keystore
+    b58_wallet = BIP32KeyWallet(_ROOT, "m/44h/0h/0h")
+    b58_address = b58_wallet.next_address()
+    assert b58_address.upper() not in b58_wallet
+
+
+def test_the_wrapped_segwit_spelling_is_the_one_with_a_pre_image() -> None:
+    """`p2wpkh-p2sh` has a redeem script; the other three have neither.
+
+    Which is what a psbt needs from the wallet: the p2wpkh program is the
+    pre-image of the hash in the p2sh output, and a wallet paying to a key
+    hash directly has no script to carry -- `b""`, and not an error, being
+    what "there is no such script" answers.
+    """
+    wrapped = BIP32KeyWallet(_ROOT, "m/49h/0h/0h")
+    address = wrapped.address(0, 0)
+    redeem_script = wrapped.redeem_script(0, 0)
+    assert b58.p2sh(redeem_script) == address
+    assert not wrapped.witness_script(0, 0)
+
+    for purpose in (44, 84, 86):
+        wallet = BIP32KeyWallet(_ROOT, f"m/{purpose}h/0h/0h")
+        assert not wallet.redeem_script(0, 0)
+        assert not wallet.witness_script(0, 0)
+
+
+def test_the_output_is_the_script_the_address_pays() -> None:
+    """`script_pub_key` reads the address back into the script it encodes.
+
+    Which is what `position_of` compares, and what makes the four
+    encodings one answer: the address is the library's own mapping from a
+    key, and the script is that address decoded rather than a second
+    table.
+    """
+    for purpose in (44, 49, 84, 86):
+        wallet = BIP32KeyWallet(_ROOT, f"m/{purpose}h/0h/0h")
+        script_pub_key = wallet.script_pub_key(1, 3)
+        assert script_pub_key.address == wallet.address(1, 3)
+        assert script_pub_key.network == "mainnet"
+        assert wallet.position_of(script_pub_key, 4) == (1, 3)

--- a/tests/wallet/script_wallet_test.py
+++ b/tests/wallet/script_wallet_test.py
@@ -1,0 +1,267 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.wallet.script_wallet` module.
+
+The script a template writes is asserted against the same script built by
+hand -- `derive_from_account`, a sort, `op_int`, `script.serialize` --
+because those four calls are what a caller had to write before this class
+existed, and what it must keep answering. The deployed wallet that made
+the case for it is pinned in `tests/descriptors/custody_wallet_test.py`,
+against the mainnet addresses it holds coins at.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from btclib.alias import Command
+from btclib.bip32 import bip32
+from btclib.bip32.bip32 import BIP32KeyData, derive_from_account
+from btclib.exceptions import BTClibValueError
+from btclib.script import script
+from btclib.script.script import op_int
+from btclib.script.script_pub_key import ScriptPubKey
+from btclib.wallet import KeyGroup, ScriptWallet
+
+# the "abandon abandon ... about" seed, and three account keys of it that
+# no wallet elsewhere in the suite uses as a quorum
+_ROOT = "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
+_ACCOUNTS = [f"m/48h/0h/{i}h" for i in range(3)]
+_XPRVS = [bip32.derive(_ROOT, account) for account in _ACCOUNTS]
+_XPUBS = [bip32.xpub_from_xprv(xprv) for xprv in _XPRVS]
+
+# the timelock of the example in the module docstring, spelled the way the
+# wallets that need this class spell it: a push, OP_CSV, OP_DROP
+_TIMELOCK: list[Command] = ["9000", "OP_CHECKSEQUENCEVERIFY", "OP_DROP"]
+
+
+def _derived(xpub: str, branch: int, index: int) -> bytes:
+    """Return the public key of a position, the four-primitive way."""
+    return BIP32KeyData.b58decode(derive_from_account(xpub, branch, index)).key
+
+
+def _quorum(
+    threshold: int, xpubs: list[str], branch: int, index: int, sort: bool = False
+) -> list[Command]:
+    """Return `k <key>... n OP_CHECKMULTISIG`, by hand."""
+    keys = [_derived(xpub, branch, index) for xpub in xpubs]
+    if sort:
+        keys.sort()
+    return [op_int(threshold), *keys, op_int(len(keys)), "OP_CHECKMULTISIG"]
+
+
+def test_a_template_is_the_commands_with_the_groups_among_them() -> None:
+    """The script is what `script.serialize` would write, group expanded.
+
+    Which is the claim the class exists for: the four calls a caller wrote
+    by hand are still what comes out, and the template is only where they
+    are written down.
+    """
+    template: list[Command | KeyGroup] = [
+        "OP_IF",
+        KeyGroup(2, _XPUBS),
+        "OP_ELSE",
+        *_TIMELOCK,
+        KeyGroup(1, _XPUBS[:1]),
+        "OP_ENDIF",
+    ]
+    wallet = ScriptWallet(template, "p2wsh")
+    assert wallet.template == tuple(template)
+
+    for branch, index in ((0, 0), (1, 7)):
+        by_hand = script.serialize(
+            [
+                "OP_IF",
+                *_quorum(2, _XPUBS, branch, index),
+                "OP_ELSE",
+                *_TIMELOCK,
+                *_quorum(1, _XPUBS[:1], branch, index),
+                "OP_ENDIF",
+            ]
+        )
+        assert wallet.witness_script(branch, index) == by_hand
+        assert wallet.script_pub_key(branch, index) == ScriptPubKey.p2wsh(by_hand)
+        assert wallet.address(branch, index) == ScriptPubKey.p2wsh(by_hand).address
+
+
+@pytest.mark.parametrize("branch", [0, 1])
+@pytest.mark.parametrize("index", [0, 1, 13])
+def test_the_derived_order_is_remade_at_every_position(branch: int, index: int) -> None:
+    """BIP67 on the derived keys, which no ranged descriptor can state.
+
+    The order is a property of the position and not of the wallet, so the
+    script has to be built at the position to know it -- and the keys of
+    two indices of one quorum can come out the other way round.
+    """
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "derived")
+    assert wallet.witness_script(branch, index) == script.serialize(
+        _quorum(2, _XPUBS, branch, index, sort=True)
+    )
+
+
+def test_the_account_order_is_applied_once_and_derived_afterwards() -> None:
+    """Which is the order a fixed ``multi()`` states, and it is not the same.
+
+    The two BIP67 readings answer different scripts at the same position:
+    sorting the account keys and sorting what they derive to are the same
+    operation on different bytes, and a wallet has to say which it means.
+    """
+    by_account = sorted(_XPUBS, key=lambda xpub: BIP32KeyData.b58decode(xpub).key)
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "account")
+    for index in (0, 4):
+        assert wallet.witness_script(0, index) == script.serialize(
+            _quorum(2, by_account, 0, index)
+        )
+
+    derived = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "derived")
+    assert derived.witness_script(0, 0) != wallet.witness_script(0, 0)
+    # and declaration order is a third answer, which is the default
+    declared = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh")
+    assert declared.witness_script(0, 0) == script.serialize(_quorum(2, _XPUBS, 0, 0))
+
+
+def test_a_sort_key_orders_by_something_that_is_not_a_byte_order() -> None:
+    """The deployed case: account xpubs sorted case-insensitively.
+
+    Neither a byte order nor a BIP, and a wallet holding coins does it, so
+    the sort is a strategy with a key function rather than a constant.
+    """
+    by_lower_case = sorted(_XPUBS, key=str.lower)
+    wallet = ScriptWallet(
+        [KeyGroup(2, _XPUBS)],
+        "p2wsh",
+        "account",
+        sort_key=lambda xkey: xkey.b58encode().lower(),
+    )
+    assert wallet.witness_script(0, 0) == script.serialize(
+        _quorum(2, by_lower_case, 0, 0)
+    )
+
+    # and the same key function on the derived keys, which sorts what the
+    # script carries rather than what it came from
+    on_derived = ScriptWallet(
+        [KeyGroup(2, _XPUBS)], "p2wsh", "derived", sort_key=bytes.hex
+    )
+    assert on_derived.witness_script(0, 0) == script.serialize(
+        _quorum(2, _XPUBS, 0, 0, sort=True)
+    )
+
+
+def test_a_sort_key_with_no_sort_is_refused() -> None:
+    """Two arguments that contradict each other, rather than one ignored."""
+    with pytest.raises(BTClibValueError, match='sort_key with order "none"'):
+        ScriptWallet([KeyGroup(1, _XPUBS[:1])], "p2wsh", sort_key=bytes.hex)
+
+
+@pytest.mark.parametrize(
+    "script_type, address_prefix",
+    [("p2wsh", "bc1q"), ("p2sh", "3"), ("p2sh-p2wsh", "3")],
+)
+def test_the_three_ways_a_script_becomes_an_output(
+    script_type: str, address_prefix: str
+) -> None:
+    """And the two pre-images each of them commits to.
+
+    A p2sh pushes the script itself, a p2wsh commits to it in the witness,
+    and the wrapped form has both -- the redeem script being the witness
+    program, which is what the input pushes, and not the script that
+    program commits to.
+    """
+    group = KeyGroup(2, _XPUBS)
+    wallet = ScriptWallet([group], script_type)  # type: ignore[arg-type]
+    template_script = script.serialize(_quorum(2, _XPUBS, 0, 0))
+    assert wallet.address(0, 0).startswith(address_prefix)
+
+    if script_type == "p2sh":
+        assert wallet.redeem_script(0, 0) == template_script
+        assert not wallet.witness_script(0, 0)
+    elif script_type == "p2wsh":
+        assert not wallet.redeem_script(0, 0)
+        assert wallet.witness_script(0, 0) == template_script
+        assert wallet.script_pub_key(0, 0) == ScriptPubKey.p2wsh(template_script)
+    else:
+        assert wallet.witness_script(0, 0) == template_script
+        assert wallet.redeem_script(0, 0) == ScriptPubKey.p2wsh(template_script).script
+        assert wallet.script_pub_key(0, 0) == ScriptPubKey.p2sh(
+            ScriptPubKey.p2wsh(template_script).script
+        )
+
+
+def test_an_unknown_script_type_or_order_is_refused() -> None:
+    """The two vocabularies, checked for the caller who runs no mypy."""
+    group = KeyGroup(1, _XPUBS[:1])
+    with pytest.raises(BTClibValueError, match="unknown script type: p2pkh"):
+        ScriptWallet([group], "p2pkh")  # type: ignore[arg-type]
+    with pytest.raises(BTClibValueError, match="unknown key order: sorted"):
+        ScriptWallet([group], "p2wsh", "sorted")  # type: ignore[arg-type]
+
+
+def test_a_template_with_no_key_group_is_not_a_wallet() -> None:
+    """One script is not a range of them, and `script.serialize` writes it."""
+    with pytest.raises(BTClibValueError, match="no KeyGroup in the template"):
+        ScriptWallet(["OP_1"], "p2wsh")
+
+
+def test_a_quorum_is_bounded_by_what_op_int_spells() -> None:
+    """1 to 16 keys, and a threshold no larger than the count."""
+    with pytest.raises(BTClibValueError, match="invalid n in 1-of-0"):
+        KeyGroup(1, [])
+    with pytest.raises(BTClibValueError, match="invalid n in 1-of-17"):
+        KeyGroup(1, _XPUBS[:1] * 17)
+    with pytest.raises(BTClibValueError, match="invalid threshold in 4-of-3"):
+        KeyGroup(4, _XPUBS)
+    with pytest.raises(BTClibValueError, match="invalid threshold in 0-of-3"):
+        KeyGroup(0, _XPUBS)
+    # a group takes any spelling of an extended key, decoded or not
+    assert (
+        KeyGroup(1, [BIP32KeyData.b58decode(_XPUBS[0])]).keys
+        == KeyGroup(1, _XPUBS[:1]).keys
+    )
+    assert repr(KeyGroup(2, _XPUBS)) == "KeyGroup(2, 3 keys)"
+
+
+def test_a_script_too_long_for_the_output_it_would_pay() -> None:
+    """A p2sh redeem script is pushed, so the push limit bounds it.
+
+    Refused at construction rather than at the address, and the size is
+    the size at every index: a derived public key is 33 bytes wherever it
+    came from, so a script that fits at one position fits at all of them.
+    """
+    sixteen = KeyGroup(16, _XPUBS[:1] * 16)
+    assert ScriptWallet([sixteen], "p2wsh").address(0, 0)
+    with pytest.raises(BTClibValueError, match="invalid script length: 5[0-9][0-9]"):
+        ScriptWallet([sixteen], "p2sh")
+
+
+def test_a_key_of_another_network_cannot_be_in_the_quorum() -> None:
+    """The template is built at construction, which is where this shows."""
+    with pytest.raises(BTClibValueError, match="not a private or public key"):
+        ScriptWallet([KeyGroup(1, _XPUBS[:1])], "p2wsh", network="testnet")
+
+
+def test_an_xprv_in_a_quorum_is_what_makes_a_wallet_not_watch_only() -> None:
+    """And what goes into the script is the public key either way."""
+    watching = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "derived")
+    assert watching.is_watch_only
+
+    signing = ScriptWallet([KeyGroup(2, _XPRVS)], "p2wsh", "derived")
+    assert not signing.is_watch_only
+    # the private spelling is never what the script carries: the two
+    # wallets are the same wallet, and the same addresses
+    assert signing.address(0, 0) == watching.address(0, 0)
+    # nor does the account order read the private key: sorting by
+    # BIP32KeyData.key would order the xprvs by material the xpubs do not
+    # have, and answer two different scripts for one wallet
+    assert ScriptWallet([KeyGroup(2, _XPRVS)], "p2wsh", "account").address(
+        0, 0
+    ) == ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "account").address(0, 0)
+
+
+def test_the_derivation_bounds_are_bip32s_own() -> None:
+    """The two branches BIP44 defines, and an index that fits in a level."""
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "derived")
+    assert wallet.branches == (0, 1)
+    with pytest.raises(BTClibValueError, match="invalid address index"):
+        wallet.address(0, 0x10000)

--- a/tests/wallet/wallet_test.py
+++ b/tests/wallet/wallet_test.py
@@ -1,0 +1,243 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the vocabulary every `btclib.wallet` class answers to.
+
+One account, three wallets over it, and one set of assertions run against
+all three: the ledger of what has been handed out, `next_address` walking
+a branch, `position_of` taking every spelling of an output, and the bounds
+of a position. What each computes an address *from* is its own module's
+test; this one is about the words being the same words, which is what a
+caller who does not know which kind of wallet it has depends on.
+
+The three are the same account wherever they can be -- the key wallet and
+the descriptor wallet derive the very same BIP84 addresses, which is
+asserted below -- and the script wallet is a 2-of-3 p2wsh of the same
+seed's keys, there being no key-hash wallet for it to agree with.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from btclib.bip32 import bip32
+from btclib.exceptions import BTClibTypeError, BTClibValueError
+from btclib.script.script_pub_key import ScriptPubKey
+from btclib.wallet import (
+    BIP32KeyWallet,
+    DescriptorWallet,
+    KeyGroup,
+    RangedWallet,
+    ScriptWallet,
+)
+
+# the "abandon abandon ... about" seed, whose master key BIP84 publishes
+# as its rootpriv
+_ROOT = "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
+_ACCOUNT = "m/84h/0h/0h"
+_FINGERPRINT = "73c5da0a"
+
+# an address of nobody's wallet here: BIP173's own p2wsh vector
+_ELSEWHERE = "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3"
+
+
+def _multisig_xpubs() -> list[str]:
+    """Three account xpubs of the seed, for the script wallet's quorum."""
+    return [
+        bip32.xpub_from_xprv(bip32.derive(_ROOT, f"m/48h/0h/{i}h")) for i in range(3)
+    ]
+
+
+def key_wallet() -> BIP32KeyWallet:
+    """Return the BIP84 account, as an extended key."""
+    return BIP32KeyWallet(_ROOT, _ACCOUNT)
+
+
+def descriptor_wallet() -> DescriptorWallet:
+    """Return the same account, as the ``wpkh()`` pair of its chains."""
+    return DescriptorWallet.from_account(_ROOT, _ACCOUNT, _FINGERPRINT)
+
+
+def script_wallet() -> ScriptWallet:
+    """Return a 2-of-3 p2wsh of the seed, which no descriptor states."""
+    return ScriptWallet([KeyGroup(2, _multisig_xpubs())], order="derived")
+
+
+WALLETS: list[Callable[[], RangedWallet]] = [
+    key_wallet,
+    descriptor_wallet,
+    script_wallet,
+]
+
+BUILDERS = pytest.mark.parametrize("build", WALLETS, ids=lambda build: build.__name__)
+
+
+@BUILDERS
+def test_the_ledger_holds_what_was_handed_out(
+    build: Callable[[], RangedWallet],
+) -> None:
+    """A wallet remembers the positions it was asked for, and only those.
+
+    Idempotent, and in the order it was asked: a wallet is a function of
+    its source rather than a generator with a position, so the same
+    position twice is one entry.
+    """
+    wallet = build()
+    assert not len(wallet)
+    assert not wallet.addresses
+
+    first = wallet.address(0, 0)
+    assert wallet.address(0, 0) == first
+    assert len(wallet) == 1
+    assert first in wallet
+    assert wallet.addresses == (first,)
+
+    change = wallet.address(1, 2)
+    assert list(wallet.addresses) == [first, change]
+    info = wallet.address_info(change)
+    assert (info.address, info.branch, info.index) == (change, 1, 2)
+    assert info.script_type == wallet.script_type
+
+    # an address of the wallet's own chains, not asked for yet, is a miss:
+    # the ledger is what has been issued and not what could be
+    unissued = build().address(0, 9)
+    assert unissued not in wallet
+    for address in (unissued, _ELSEWHERE):
+        with pytest.raises(BTClibValueError, match="address not in the wallet"):
+            wallet.address_info(address)
+
+
+@BUILDERS
+def test_next_address_is_one_past_the_top_of_a_branch(
+    build: Callable[[], RangedWallet],
+) -> None:
+    """And each branch counts on its own, as BIP44's two chains do."""
+    wallet = build()
+    assert wallet.next_address() == wallet.address(0, 0)
+    assert wallet.next_address() == wallet.address(0, 1)
+    assert wallet.next_address(1) == wallet.address(1, 0)
+
+    wallet.address(0, 7)
+    assert wallet.next_address() == wallet.address(0, 8)
+    assert wallet.next_address(1) == wallet.address(1, 1)
+
+
+@BUILDERS
+def test_position_of_takes_every_spelling_of_an_output(
+    build: Callable[[], RangedWallet],
+) -> None:
+    """The output as a ScriptPubKey, as bytes, as hex, or as its address.
+
+    One question -- "is this output mine" -- and the answer is the whole
+    script compared at each position, which is why the address is read
+    for the script it encodes rather than matched as text.
+    """
+    wallet = build()
+    script_pub_key = wallet.script_pub_key(1, 3)
+    for named in (
+        script_pub_key,
+        script_pub_key.script,
+        script_pub_key.script.hex(),
+        script_pub_key.address,
+    ):
+        assert wallet.position_of(named, 4) == (1, 3)
+
+    # bounded by last_index, both ends included, and the bound is the
+    # caller's gap limit rather than a policy of the wallet's
+    assert wallet.position_of(script_pub_key, 2) is None
+    # and somebody else's output is not this wallet's, which is the answer
+    # a caller acts on
+    assert wallet.position_of(ScriptPubKey.from_address(_ELSEWHERE), 2) is None
+    # asking does not hand anything out: position_of records nothing
+    assert not len(wallet)
+
+
+@BUILDERS
+def test_position_of_refuses_what_names_no_output(
+    build: Callable[[], RangedWallet],
+) -> None:
+    """None means "not this wallet's", so a bad argument cannot mean it."""
+    wallet = build()
+    with pytest.raises(BTClibTypeError, match="invalid script_pub_key type"):
+        wallet.position_of(None)  # type: ignore[arg-type]
+    with pytest.raises(BTClibValueError, match="empty script_pub_key"):
+        wallet.position_of("")
+    with pytest.raises(BTClibValueError, match="neither a script nor an address"):
+        wallet.position_of("not an address")
+
+
+@BUILDERS
+def test_a_position_outside_the_wallet_is_refused(
+    build: Callable[[], RangedWallet],
+) -> None:
+    """The branch against `branches`, and the index for its sign.
+
+    Every method that takes a position asks, `redeem_script` and
+    `witness_script` included: a pre-image of a position the wallet has
+    no output at is not `b""`, it is a mistake.
+    """
+    wallet = build()
+    assert wallet.branches == (0, 1)
+    for method in (
+        wallet.address,
+        wallet.script_pub_key,
+        wallet.redeem_script,
+        wallet.witness_script,
+    ):
+        with pytest.raises(
+            BTClibValueError, match=r"invalid branch: 2 not in \(0, 1\)"
+        ):
+            method(2, 0)
+        with pytest.raises(BTClibValueError, match="invalid index: -1"):
+            method(0, -1)
+
+
+@BUILDERS
+def test_every_wallet_answers_whether_it_can_sign(
+    build: Callable[[], RangedWallet],
+) -> None:
+    """`is_watch_only` is asked of all three, whatever the source is."""
+    assert isinstance(build().is_watch_only, bool)
+
+
+def test_the_key_wallet_and_the_descriptor_wallet_are_one_account() -> None:
+    """Two ways to hold a BIP84 account, and one set of addresses.
+
+    Which is what makes the vocabulary worth having: a caller that
+    switched from one to the other would be watching the same chain.
+    """
+    keys = key_wallet()
+    descriptors = descriptor_wallet()
+    assert keys.script_type == descriptors.script_type == "p2wpkh"
+    for branch in (0, 1):
+        for index in (0, 1, 5):
+            assert keys.address(branch, index) == descriptors.address(branch, index)
+            assert keys.script_pub_key(branch, index) == descriptors.script_pub_key(
+                branch, index
+            )
+
+
+def test_only_a_key_wallet_records_one_derivation_path() -> None:
+    """`der_path` is one path, and two of the three have no single one.
+
+    A quorum has a path per key, which a psbt key origin records and an
+    `AddressInfo` field cannot; a descriptor holds its paths inside the
+    key expressions. Both answer "" rather than one of the paths.
+    """
+    keys = key_wallet()
+    assert keys.address_info(keys.address(1, 4)).der_path == "m/84h/0h/0h/1/4"
+    for build in (descriptor_wallet, script_wallet):
+        wallet = build()
+        assert not wallet.address_info(wallet.address(1, 4)).der_path
+
+
+def test_an_address_of_a_bech32_spelling_is_found_however_it_is_written() -> None:
+    """Which is `Wallet.__contains__` and the lookup under it."""
+    wallet = script_wallet()
+    address = wallet.address(0, 0)
+    for spelling in (address.upper(), f"  {address}  ", address.encode("ascii")):
+        assert spelling in wallet
+        assert wallet.address_info(spelling).address == address


### PR DESCRIPTION
Closes #542.

`btclib.keystore` was the only wallet the library had, and it answered one
question: the address of a `branch/index` below a BIP44 account.
`Descriptor` answered the same question its own way — an index, and no
chains — and a script no descriptor states had nobody to ask at all.

## One vocabulary

The three now live in `btclib.wallet`, under one set of words. `Wallet` is
the ledger of what has been handed out, `RangedWallet` the half addressed
by a position, so `script_pub_key(branch, index)`, `address(branch,
index)`, `next_address(branch)`, `redeem_script`, `witness_script`,
`position_of`, `address_info`, `addresses`, `len()`, `in` and
`is_watch_only` mean the same thing whichever wallet a caller holds.

| source | class |
| --- | --- |
| individual keys | `KeyWallet` (was `KeyStore`) |
| an extended key at a BIP44 account | `BIP32KeyWallet` (was `BIP32KeyStore`) |
| an output descriptor per chain | `DescriptorWallet` |
| a script template with key groups | `ScriptWallet` |

Renamed after the family they belong to, which is not backward compatible
and is stated as such: HISTORY.md's breaking-changes list carries the
before-and-after spellings, `AddressInfo`'s two new fields (`branch`,
`index`) included.

`position_of` is the half that is not a convenience: "is this output
mine", the whole script computed at every position of every branch and
compared — never a key origin whose four-byte fingerprint matches. It
takes the output in every spelling `Descriptor.index_of` takes since #541,
so the reader that turns any of them into script bytes moved to
`script.script_pub_key` and is imported by both rather than copied.

What a branch *is* stays each wallet's own, and is the one thing not
hidden: a key wallet and a script wallet derive it; a descriptor wallet
reads it as the label of which descriptor.

## `ScriptWallet`, which is what the issue asked for

A script **template**, the `KeyGroup` quorums it writes into it, and an
**order** for the keys of each — enough to compute the script at a
position, and nothing past that. The order is a parameter because deployed
wallets disagree and the disagreement is what no ranged descriptor states:
`"derived"` sorts at every index (the order `sortedmulti()` follows),
`"account"` sorts the account keys once (`multi()` states it), `"none"`
keeps them as declared, and `sort_key` is for the wallet that orders its
xpubs case-insensitively.

No text format and no parser, not liftable in either direction, and not a
signer — the issue's non-goals, kept.

The evidence it works is not a unit test agreeing with itself: the
production custody wallet of #538 is now pinned a third way, and
`ScriptWallet` answers the same mainnet addresses it holds coins at as the
four calls by hand.

## Gates

- `uv run pytest --cov`: 18305 passed, 100.00% coverage
- `uv run pre-commit run --all-files`: every hook passed
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a unified wallet package with shared vocabulary, migrating key-based keystore functionality into btclib.wallet and adding descriptor- and script-based wallets.

New Features:
- Add btclib.wallet package defining common Wallet and RangedWallet abstractions with shared address and script interfaces.
- Introduce ScriptWallet and KeyGroup to support multisig and template-based scripts that are not expressible as standard output descriptors.
- Introduce DescriptorWallet to manage one descriptor per chain, including PSBT update and satisfaction helpers over descriptor-based wallets.

Enhancements:
- Rename KeyStore to KeyWallet and BIP32KeyStore to BIP32KeyWallet and integrate them with the new wallet abstractions while preserving existing behaviors.
- Extend AddressInfo with branch and index metadata and centralize address normalization and script extraction logic for use across wallets and descriptors.
- Unify script_pub_key comparison and position lookup via shared helpers so outputs can be matched to wallet positions regardless of representation.

Build:
- Register btclib.wallet as a child module in test metadata to keep package structure assertions up to date.

Documentation:
- Update README, btclib.rst, and add btclib.wallet.rst to document the new wallet package, its abstractions, and supported wallet types.
- Document breaking changes and migration notes for keystore-to-wallet renames and AddressInfo structure updates in HISTORY.md.

Tests:
- Add comprehensive test suites for Wallet/RangedWallet core behavior and for DescriptorWallet and ScriptWallet, including custody wallet regression tests.
- Migrate keystore tests to wallet/key_wallet_test.py and extend them to cover new wallet interfaces such as redeem_script, witness_script, and script_pub_key.