### PR TITLE
Say where the per-index order stops being expressible

### DIFF
--- a/btclib/wallet/script_wallet.py
+++ b/btclib/wallet/script_wallet.py
@@ -58,14 +58,19 @@ holding a script no language describes already owns the spend, and those
 two are what a psbt needs from the wallet.
 
 **The order is a parameter because deployed wallets disagree about it**,
-and the disagreement is not expressible in a ranged descriptor:
+and one of the three is why this class exists at all:
 
 - `"derived"` sorts the keys of each group at every index, which is BIP67
-  on the derived keys and the order `sortedmulti()` follows -- and which
-  no ranged descriptor can state, the order not being a property of the
-  wallet but of the position;
+  on the derived keys, so the order is a property of the position and not
+  of the wallet. `sortedmulti()` follows exactly that order and states it
+  for a quorum that is the whole script; what states it for a quorum
+  *inside* a combinator is nothing, BIP379 having no `sortedmulti`
+  fragment and its `multi()` being the declared-order one. A timelocked
+  branch is therefore where the order stops being expressible, which is
+  the wallet #538 pins and the reason for this parameter;
 - `"account"` sorts the account keys once, before deriving, so the order
-  is fixed and `multi()` states it;
+  is fixed and `multi()` states it by listing the keys in it. What this
+  saves a caller is the sort, not an inexpressible wallet;
 - `"none"` leaves the keys in the order the group declares them.
 
 `sort_key` changes what the sort compares, not when it runs: without one


### PR DESCRIPTION
Follow-up to #543, which is already on `dev`: one clause of
`btclib/wallet/script_wallet.py`'s module docstring is imprecise, and the
imprecision is on the very claim that justifies the class.

It called the BIP67 sort of the *derived* keys an order "no ranged
descriptor can state". Taken literally that is false:
`wsh(sortedmulti(2,xpub/0/*,...))` states exactly that order, sorts at
every index, and is ranged — btclib's own `MultiDescriptor._pub_keys`
sorts the derived keys when `sort` is set.

The gap is one level in, and the suite already pins it:
`tests/descriptors/custody_wallet_test.py::test_sorted_multi_is_not_a_fragment`
refuses `wsh(or_i(sortedmulti(1,…),1))` with "unknown miniscript fragment"
while `wsh(sortedmulti(1,…))` parses. BIP379 has no `sortedmulti`
fragment and the `multi()` it does have is the declared-order one, so a
quorum *inside a combinator* — the timelocked branch of the wallet #538
pins — is where the order becomes unwriteable. That is the reason `order`
is a parameter, and it is what the docstring now says.

The `"account"` bullet gains the same honesty: a fixed order is always
expressible as a `multi()` listing the keys in that order, so what the
mode saves a caller is the sort itself, not a wallet no language covers.
Prose only, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Refine explanations of the `derived` and `account` key order modes to correctly describe when their ordering can and cannot be expressed in miniscript descriptors.