### PR TITLE
KeyGroup(verify=True) writes OP_CHECKMULTISIGVERIFY for a required quorum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -600,6 +600,16 @@ documented at release-notes length in the first place, and are still in
   does not ask. A `combo()` is refused: four scripts at one index are
   four addresses at one position, which would make `address(branch,
   index)` a lie, and `Descriptor.script_pub_keys` is what answers for one.
+- **`KeyGroup` can write `OP_CHECKMULTISIGVERIFY`** (#546). A group wrote
+  `OP_CHECKMULTISIG` and nothing else, so the quorum a required branch
+  needs -- `and_v(v:multi(...), older(n))` compiles to the VERIFY form,
+  which is what a BIP67 sort on the *derived* keys places outside every
+  descriptor's reach -- had no way into a template except a caller
+  reaching past `ScriptWallet` for `script.serialize` directly.
+  `KeyGroup(threshold, keys, verify=True)` writes that one opcode in
+  place of the other and changes nothing else about the group, mirroring
+  the `verify` parameter `descriptors.miniscript` already carries for the
+  same opcode.
 
 ### Packaging, linting and CI
 

--- a/btclib/wallet/script_wallet.py
+++ b/btclib/wallet/script_wallet.py
@@ -38,11 +38,13 @@ index)` and `position_of(script_pub_key)`::
 The template is a `script.serialize` command list with `KeyGroup` objects
 among the commands, and a group writes what OP_CHECKMULTISIG reads:
 `k <key>... n OP_CHECKMULTISIG`, the keys being the ones derived at the
-position. So the template is Python objects and not text: **there is no
-text format here, and no parser**. Inventing a second, worse descriptor
-language is how this feature goes wrong, and a wallet that cannot be
-written down cannot be mistaken for one that can be handed to Bitcoin
-Core.
+position -- or, with `verify=True`, `OP_CHECKMULTISIGVERIFY` in place of
+that last opcode, which is the form a required quorum takes rather than
+one left on the stack. So the template is Python objects and not text:
+**there is no text format here, and no parser**. Inventing a second,
+worse descriptor language is how this feature goes wrong, and a wallet
+that cannot be written down cannot be mistaken for one that can be
+handed to Bitcoin Core.
 
 **Not liftable, in either direction.** No `from_script`, and no
 `to_descriptor`. A wallet that a descriptor states should be one --
@@ -173,9 +175,16 @@ class KeyGroup:
     in, unless the wallet holding the group says otherwise: ordering is
     the wallet's parameter, not the group's, because the wallets deployed
     with a per-index order apply it to every quorum of the script.
+
+    `verify=True` writes `OP_CHECKMULTISIGVERIFY` in place of the last
+    opcode and nothing else about the group -- the same choice miniscript
+    makes with its `v:` wrapper, and the form `and_v(v:multi(...), ...)`
+    compiles to.
     """
 
-    def __init__(self, threshold: int, keys: Sequence[BIP32Key]) -> None:
+    def __init__(
+        self, threshold: int, keys: Sequence[BIP32Key], verify: bool = False
+    ) -> None:
         self.keys = tuple(
             key if isinstance(key, BIP32KeyData) else BIP32KeyData.b58decode(key)
             for key in keys
@@ -189,10 +198,12 @@ class KeyGroup:
             err_msg = f"invalid threshold in {threshold}-of-{n}"
             raise BTClibValueError(err_msg)
         self.threshold = threshold
+        self.verify = verify
 
     def __repr__(self) -> str:
         """Return the quorum, and no key: one of them may be an xprv."""
-        return f"KeyGroup({self.threshold}, {len(self.keys)} keys)"
+        verify = ", verify=True" if self.verify else ""
+        return f"KeyGroup({self.threshold}, {len(self.keys)} keys{verify})"
 
 
 class ScriptWallet(RangedWallet):
@@ -294,7 +305,12 @@ class ScriptWallet(RangedWallet):
         )[0]
 
     def _quorum(
-        self, threshold: int, keys: tuple[BIP32KeyData, ...], branch: int, index: int
+        self,
+        threshold: int,
+        keys: tuple[BIP32KeyData, ...],
+        verify: bool,
+        branch: int,
+        index: int,
     ) -> ScriptList:
         """Return what a group writes into the script at one position."""
         derived = [self._derived_sec(key, branch, index) for key in keys]
@@ -302,7 +318,8 @@ class ScriptWallet(RangedWallet):
             # `key=None` is the plain byte order sorted() would use
             # anyway, so one call spells both readings
             derived.sort(key=self.sort_key)
-        return [op_int(threshold), *derived, op_int(len(derived)), "OP_CHECKMULTISIG"]
+        opcode = "OP_CHECKMULTISIGVERIFY" if verify else "OP_CHECKMULTISIG"
+        return [op_int(threshold), *derived, op_int(len(derived)), opcode]
 
     def _script(self, branch: int, index: int) -> bytes:
         """Return the script the template writes at one position."""
@@ -310,7 +327,11 @@ class ScriptWallet(RangedWallet):
         for position, command in enumerate(self.template):
             if isinstance(command, KeyGroup):
                 commands += self._quorum(
-                    command.threshold, self._ordered_keys[position], branch, index
+                    command.threshold,
+                    self._ordered_keys[position],
+                    command.verify,
+                    branch,
+                    index,
                 )
             else:
                 commands.append(command)

--- a/tests/wallet/script_wallet_test.py
+++ b/tests/wallet/script_wallet_test.py
@@ -43,13 +43,19 @@ def _derived(xpub: str, branch: int, index: int) -> bytes:
 
 
 def _quorum(
-    threshold: int, xpubs: list[str], branch: int, index: int, sort: bool = False
+    threshold: int,
+    xpubs: list[str],
+    branch: int,
+    index: int,
+    sort: bool = False,
+    verify: bool = False,
 ) -> list[Command]:
-    """Return `k <key>... n OP_CHECKMULTISIG`, by hand."""
+    """Return `k <key>... n OP_CHECKMULTISIG[VERIFY]`, by hand."""
     keys = [_derived(xpub, branch, index) for xpub in xpubs]
     if sort:
         keys.sort()
-    return [op_int(threshold), *keys, op_int(len(keys)), "OP_CHECKMULTISIG"]
+    opcode = "OP_CHECKMULTISIGVERIFY" if verify else "OP_CHECKMULTISIG"
+    return [op_int(threshold), *keys, op_int(len(keys)), opcode]
 
 
 def test_a_template_is_the_commands_with_the_groups_among_them() -> None:
@@ -220,6 +226,37 @@ def test_a_quorum_is_bounded_by_what_op_int_spells() -> None:
         == KeyGroup(1, _XPUBS[:1]).keys
     )
     assert repr(KeyGroup(2, _XPUBS)) == "KeyGroup(2, 3 keys)"
+
+
+def test_verify_writes_checkmultisigverify_and_nothing_else() -> None:
+    """The required-quorum form miniscript's `v:` wrapper compiles to.
+
+    One opcode differs from the group's usual script, and `repr` says so.
+    """
+    assert repr(KeyGroup(2, _XPUBS, verify=True)) == "KeyGroup(2, 3 keys, verify=True)"
+
+    template: list[Command | KeyGroup] = [
+        KeyGroup(2, _XPUBS, verify=True),
+        *_TIMELOCK,
+        KeyGroup(1, _XPUBS[:1]),
+    ]
+    wallet = ScriptWallet(template, "p2wsh", "derived")
+    for branch, index in ((0, 0), (1, 7)):
+        by_hand = script.serialize(
+            [
+                *_quorum(2, _XPUBS, branch, index, sort=True, verify=True),
+                *_TIMELOCK,
+                *_quorum(1, _XPUBS[:1], branch, index),
+            ]
+        )
+        assert wallet.witness_script(branch, index) == by_hand
+
+    # verify=False is the default, and the only difference from the plain
+    # group is the last opcode
+    plain = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "derived")
+    verified = ScriptWallet([KeyGroup(2, _XPUBS, verify=True)], "p2wsh", "derived")
+    assert plain.witness_script(0, 0)[:-1] == verified.witness_script(0, 0)[:-1]
+    assert plain.witness_script(0, 0)[-1] != verified.witness_script(0, 0)[-1]
 
 
 def test_a_script_too_long_for_the_output_it_would_pay() -> None:


### PR DESCRIPTION
## Summary

- `KeyGroup` gains a `verify: bool = False` parameter. `ScriptWallet._quorum`
  now writes `OP_CHECKMULTISIGVERIFY` in place of `OP_CHECKMULTISIG` when the
  group asks for it, and nothing else about the group changes.
- This is the form `and_v(v:multi(...), older(n))` compiles to -- the
  "quorum and then a timelock" branch of the multisig-with-recovery family
  #538 pins -- and, combined with a BIP67 sort on the *derived* keys
  (`order="derived"`), a shape no descriptor states, which is `ScriptWallet`'s
  reason to exist.
- Mirrors the `verify` parameter `descriptors.miniscript._multi_fragment_script`
  already carries for the same opcode (and the same pattern for
  `OP_CHECKSIG`/`OP_CHECKSIGVERIFY`, `OP_EQUAL`/`OP_EQUALVERIFY`), rather than
  introducing a new convention.

Closes #546

## Test plan

- [x] `uv run pytest -q --cov` — 100% coverage, full suite green
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `sphinx-build -W --keep-going` — builds clean
- [x] New test `test_verify_writes_checkmultisigverify_and_nothing_else`
      asserts the VERIFY form against a hand-built script, and that the
      only byte that differs from the plain form is the last opcode

## Summary by Sourcery

Allow ScriptWallet key groups to optionally use OP_CHECKMULTISIGVERIFY for required-quorum branches while preserving existing behavior by default.

New Features:
- Add a verify flag to KeyGroup and ScriptWallet quorum generation to emit OP_CHECKMULTISIGVERIFY instead of OP_CHECKMULTISIG when requested.

Enhancements:
- Extend KeyGroup string representation to surface the verify setting for clearer diagnostics and template readability.

Documentation:
- Update ScriptWallet documentation and changelog to describe the new KeyGroup verify option and its miniscript/descriptor context.

Tests:
- Add coverage to ensure verify-enabled key groups produce the expected OP_CHECKMULTISIGVERIFY scripts and differ only in the final opcode from plain groups.