### PR TITLE
satisfaction_sizer sizes the branch a spend will build, not the largest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,26 @@ documented at release-notes length in the first place, and are still in
   `from btclib.descriptors import parse, KeyExpression, PrvKeys` reaches
   the same objects -- and `miniscript` is published beside them as the
   subgroup a caller reaches by name.
+- **`satisfaction_sizer` estimates the branch a spend will build, beside
+  `miniscript_sizer`'s largest it could** (#547). A quorum with a
+  timelocked recovery quorum behind the same address is a wallet that
+  knows which of the two a transaction takes before anything is
+  estimated -- the recovery spend is a separate operation, with its own
+  inputs and its own signatures -- and `miniscript_sizer` cannot use
+  that: `max_witness_stack` assumes every branch open and every signature
+  present, so a recovery spend pays for whichever branch is larger even
+  when it never opens it.
+
+  `Miniscript.satisfy` already answers the narrower question: given
+  which keys will sign, it picks the branch those satisfy and reports
+  that witness. `satisfaction_sizer(keys)` is that answer as a
+  `SolutionSizer`, a filler signature of `psbt_size.SIG_SIZE` bytes per
+  key standing in for one that does not exist yet -- `satisfy` never
+  checks a signature against anything, so the byte content is
+  irrelevant and only the length is. The sequence read is the input
+  being sized, so an `older()` branch is measured against what that
+  spend actually carries; `locktime` is not, being the transaction's and
+  not this call's to know, so an `after()` branch is answered as unmet.
 
 ### Curves, signatures and keys
 

--- a/btclib/descriptors/__init__.py
+++ b/btclib/descriptors/__init__.py
@@ -52,6 +52,7 @@ from btclib.descriptors.descriptors import (
     multipath_descriptors,
     normalized,
     parse,
+    satisfaction_sizer,
     strip_checksum,
 )
 from btclib.descriptors.key_expression import KeyExpression, PrvKeys
@@ -89,5 +90,6 @@ __all__ = [
     "multipath_descriptors",
     "normalized",
     "parse",
+    "satisfaction_sizer",
     "strip_checksum",
 ]

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -138,7 +138,7 @@ from __future__ import annotations
 import operator
 import re
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, fields, replace
 from typing import Any, cast
@@ -187,6 +187,7 @@ from btclib.network import NETWORKS, network_from_xkeyversion
 from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
+from btclib.psbt.psbt_size import SIG_SIZE, SolutionSizer
 from btclib.script.script import op_int, serialize
 from btclib.script.script import parse as _parse_script
 from btclib.script.script_pub_key import ScriptPubKey, _script_from
@@ -223,6 +224,7 @@ __all__ = [
     "multipath_descriptors",
     "normalized",
     "parse",
+    "satisfaction_sizer",
     "strip_checksum",
 ]
 
@@ -2383,6 +2385,75 @@ def miniscript_sizer(psbt_in: PsbtIn, tx_in: TxIn) -> list[int] | None:
     if stack is None:
         return None
     return [*stack, len(psbt_in.witness_script)]
+
+
+def satisfaction_sizer(keys: Iterable[Octets]) -> SolutionSizer:
+    """Return a `SolutionSizer` for the satisfaction these keys will build.
+
+    `miniscript_sizer` answers "how large could this get", every branch
+    open and every signature assumed -- right where a caller does not yet
+    know which branch a spend will take, and an overpay where it does. A
+    quorum with a timelocked recovery quorum behind the same address is
+    exactly that second caller: which of the two a transaction takes is
+    decided before anything is estimated, the recovery spend being a
+    separate operation with its own inputs and its own signatures.
+
+    `Miniscript.satisfy` already answers the narrower question -- given
+    which keys will sign, which branch and how large -- so this is that
+    answer as a `SolutionSizer`, beside `miniscript_sizer` and not a mode
+    of it::
+
+        witness = estimated_input_sizes(
+            psbt_in, tx_in, sizer=satisfaction_sizer(recovery_keys)
+        )
+
+    `satisfy` never checks a signature against anything, so a filler one
+    of `psbt_size.SIG_SIZE` bytes for each key does exactly what a real
+    one would for sizing, and none of them has to exist yet, any more
+    than the ones `miniscript_sizer` assumes do. The preimages are the
+    psbt input's own, and the sequence is the input being sized, so an
+    ``older()`` branch is measured against what this spend actually
+    carries. An ``after()`` branch is not, `locktime` being the
+    transaction's and not this call's to read -- it is answered as unmet,
+    and a script whose only open branch needs one refuses rather than
+    guesses.
+
+    None for that refusal and the two `miniscript_sizer` already answers
+    with it: no witness script, or one that is no miniscript. A caller
+    then falls back exactly as it would for any other sizer answering
+    "not mine".
+    """
+    signer_keys = tuple(bytes_from_octets(key) for key in keys)
+
+    def sizer(psbt_in: PsbtIn, tx_in: TxIn) -> list[int] | None:
+        if not psbt_in.witness_script:
+            return None
+        known = (*psbt_in.partial_sigs, *psbt_in.hd_key_paths, *signer_keys)
+        try:
+            node = _miniscript_from_script(
+                psbt_in.witness_script,
+                miniscript.P2WSH,
+                {hash160(key): key for key in known},
+            )
+        # not a miniscript, which is the answer "not mine" and not an error
+        except BTClibValueError:
+            return None
+        signatures = dict.fromkeys(signer_keys, bytes(SIG_SIZE))
+        spend = SpendContext(
+            sha256_preimages=psbt_in.sha256_preimages,
+            hash256_preimages=psbt_in.hash256_preimages,
+            ripemd160_preimages=psbt_in.ripemd160_preimages,
+            hash160_preimages=psbt_in.hash160_preimages,
+            sequence=tx_in.sequence,
+        )
+        try:
+            stack = node.satisfy(cast("Mapping[Octets, Octets]", signatures), spend)
+        # these keys build no satisfaction, or only a malleable one
+        except BTClibValueError:
+            return None
+        return [*(len(element) for element in stack), len(psbt_in.witness_script)]
+
+    return sizer
 
 
 def miniscript_solver(psbt: Psbt, vin_i: int) -> tuple[bytes, Witness] | None:

--- a/tests/descriptors/miniscript_test.py
+++ b/tests/descriptors/miniscript_test.py
@@ -49,6 +49,7 @@ from btclib.descriptors import (
     WshDescriptor,
     miniscript_sizer,
     miniscript_solver,
+    satisfaction_sizer,
 )
 from btclib.descriptors import parse as parse_descriptor
 from btclib.descriptors.key_expression import KeyExpression
@@ -1405,3 +1406,56 @@ def test_the_sizer_answers_for_what_is_its_business_and_no_more() -> None:
     unspendable = parse("or_b(0,a:0)")
     psbt_in.witness_script = unspendable.script()
     assert miniscript_sizer(psbt_in, tx_in) is None
+
+
+# a primary quorum larger than its timelocked recovery quorum, which is
+# issue #547's own shape: which branch a spend takes is decided before
+# anything is estimated, and `max_witness_stack` cannot use that
+_PRIMARY = f"multi(3,{KEYS[0]},{KEYS[1]},{KEYS[2]},{KEYS[3]},{KEYS[4]})"
+_RECOVERY = f"and_v(v:older(36),multi(2,{KEYS[5]},{KEYS[6]}))"
+
+
+def test_the_satisfaction_sizer_answers_for_the_branch_these_keys_build() -> None:
+    """Size the branch a caller knows it will build, not the largest one.
+
+    `max_witness_stack` reports the larger of the two branches -- the
+    primary quorum here -- and a recovery spend pays for it too, though it
+    never opens that branch. `satisfaction_sizer` given the keys that will
+    actually sign reports what that spend builds instead, the same psbt
+    input and the same `TxIn` both times: only the signers change.
+    """
+    node = parse(f"or_i({_RECOVERY},{_PRIMARY})")
+    psbt_in, tx_in = psbt_input(node)
+    assert node.max_witness_stack == (0, 72, 72, 72, 0)
+
+    primary = estimated_input_sizes(psbt_in, tx_in, sizer=satisfaction_sizer(KEYS[0:3]))
+    assert primary == (0, [0, 72, 72, 72, 0, len(node.script())])
+    # the primary quorum is the larger branch, so this is what
+    # `miniscript_sizer` would have answered too: no savings to find
+    assert primary == estimated_input_sizes(psbt_in, tx_in, sizer=miniscript_sizer)
+
+    recovery = estimated_input_sizes(
+        psbt_in, tx_in, sizer=satisfaction_sizer(KEYS[5:7])
+    )
+    assert recovery == (0, [0, 72, 72, 1, len(node.script())])
+    # the bytes issue #547 measures: paid on every recovery spend by a
+    # sizer that does not know which branch it is, and not on this one
+    assert sum(recovery[1][:-1]) < sum(primary[1][:-1])
+
+
+def test_the_satisfaction_sizer_answers_for_what_is_its_business_and_no_more() -> None:
+    """Refuse for the two reasons `miniscript_sizer` does, and a third.
+
+    No witness script and no miniscript are the two they share; building
+    no satisfaction at all from the given keys is this sizer's own.
+    """
+    node = parse(f"and_v(v:pk({KEY}),older(36))")
+    psbt_in, tx_in = psbt_input(node)
+    assert satisfaction_sizer([KEY])(psbt_in, tx_in) is not None
+    psbt_in.witness_script = b""
+    assert satisfaction_sizer([KEY])(psbt_in, tx_in) is None
+    psbt_in.witness_script = serialize(["OP_DROP", "OP_1"])
+    assert satisfaction_sizer([KEY])(psbt_in, tx_in) is None
+    # a key that will not sign this quorum builds no satisfaction either
+    psbt_in.witness_script = node.script()
+    assert satisfaction_sizer([KEYS[0]])(psbt_in, tx_in) is None


### PR DESCRIPTION
## Summary

- New `satisfaction_sizer(keys) -> SolutionSizer` in `btclib.descriptors`,
  beside `miniscript_sizer` rather than a mode of it -- the issue's own
  framing, "a SolutionSizer for the satisfaction a spend will build,
  beside the one for the largest it could".
- `miniscript_sizer` assumes every branch open and every signature present
  (`Miniscript.max_witness_stack`), which overpays for a caller who
  already knows which branch a spend takes -- a quorum with a timelocked
  recovery quorum behind the same address, per #538, being exactly that
  caller.
- `satisfaction_sizer` uses `Miniscript.satisfy` with a filler signature
  (`psbt_size.SIG_SIZE` bytes, never checked against anything) for each
  given key, so it picks the same branch and size a real spend with those
  signers would build. The sequence read is the input being sized, so an
  `older()` branch is measured correctly; `locktime` is not reachable
  from a `SolutionSizer`'s `(psbt_in, tx_in)` shape, so an `after()`
  branch is answered as unmet rather than guessed.

Closes #547

## Design decision

The issue sketches two spellings -- `satisfaction_sizer(keys)` or
`miniscript_sizer(..., signers=keys)` -- and I discussed both with the
maintainer on the issue before implementing. Went with the separate
factory: the issue's own title and code sketch both treat the two sizers
as peers ("beside", not "a mode of"), and the shared logic
(`_miniscript_from_script`, the `known` keys mapping) is already a
private helper reused by `miniscript_sizer` and `miniscript_solver`, so a
third public function costs little duplication.

## Test plan

- [x] `uv run pytest -q --cov` -- 100% coverage, full suite green
- [x] `uv run pre-commit run --all-files` -- all hooks pass
- [x] `sphinx-build -W --keep-going` -- builds clean
- [x] New tests in `tests/descriptors/miniscript_test.py`:
      `test_the_satisfaction_sizer_answers_for_the_branch_these_keys_build`
      sizes a primary-quorum/timelocked-recovery-quorum expression (the
      #547 shape) both ways and asserts the recovery branch sizes smaller
      than what `miniscript_sizer` would answer;
      `test_the_satisfaction_sizer_answers_for_what_is_its_business_and_no_more`
      covers the three refusals (no witness script, not a miniscript,
      these keys build no satisfaction)

## Summary by Sourcery

Add a satisfaction-based miniscript solution sizer that estimates the actual branch a spend will use, and integrate it into the descriptors API, tests, and changelog.

New Features:
- Introduce satisfaction_sizer factory returning a SolutionSizer that sizes the miniscript branch satisfied by given signing keys.

Enhancements:
- Export satisfaction_sizer from the descriptors package and document its behavior in the changelog.

Tests:
- Add miniscript tests covering satisfaction_sizer sizing the intended branch and its refusal conditions.