### PR TITLE
Do not count the catalogue in the btclib.curves docstring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -736,6 +736,14 @@ documented at release-notes length in the first place, and are still in
   curve, another hash function or a caller's own nonce takes the Python
   path. Both places link the detailed text rather than restating it, so
   there is one canonical answer and two ways to reach it.
+- **The `btclib.curves` docstring no longer counts the catalogue**, where
+  secp256k1 was "among 26 others". The number is spread over the four
+  catalogue files under `curves/_data`, so a reader cannot check it where
+  it is written, and a curve added to any of them makes it wrong without
+  failing anything. The sentence loses nothing by dropping it: it names
+  the curve nearly every caller wants and says the catalogue holds more,
+  which is what a reader arriving at the package needs. Counting is what
+  a release does, when it wants the number.
 
 ### Tests
 

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -6,7 +6,7 @@
 
 **The arithmetic.** btclib.curves holds the elliptic curve itself: the field
 and group operations of `curve_group`, the `Curve` built on them, the
-catalogued curves (secp256k1 among 26 others), and the SEC encoding of a
+catalogued curves (secp256k1 among them), and the SEC encoding of a
 point. Nothing here knows what a signature is.
 
 What is built *on* a curve lives in btclib.ecc -- dsa, ssa, bms, borromean,


### PR DESCRIPTION
The `btclib.curves` package docstring introduced secp256k1 as one "among
26 others". The number is spread over the four catalogue files under
`curves/_data`, so a reader cannot check it where it is written, and a
curve added to any of them makes it wrong without failing anything —
`tests/release_notes_test.py` and `tests/vendored_data_test.py` guard
CHANGELOG.md, HISTORY.md and `tests/_data/README.md`, and nothing guards
a docstring.

The sentence needs the count for nothing: it names the curve nearly every
caller wants and says the catalogue holds more, which is what a reader
arriving at the package needs. Counting is what a release does, when it
wants the number.

Noticed while closing #191 and #192.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove the hard-coded catalogue curve count from the btclib.curves docstring and document this behavioral clarification in the changelog.

Enhancements:
- Stop claiming a specific count of catalogue curves in the btclib.curves package docstring to avoid needing updates when the catalogue changes.

Documentation:
- Update CHANGELOG.md to note that the btclib.curves docstring no longer reports a fixed number of catalogue curves.