### PR TITLE
Enforce BIP322's SIGHASH_ALL, the engine reporting what it took for a signature (#514)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -382,15 +382,29 @@ documented at release-notes length in the first place, and are still in
   of an unknown version, each of them successful *because* nothing checks
   it. The BIP's own two vector files are vendored whole and every case
   runs, the three transaction hashes and the 36 error cases included and
-  nothing marked `xfail`. One required rule is not enforced, SIGHASH_ALL,
-  and #514 is what it costs and what closing it would take: which stack
-  elements were consumed as signatures is bookkeeping the interpreter
-  does not report, and picking them out by shape would refuse a control
-  block that happens to be 65 bytes long. The global psbt field BIP322
+  nothing marked `xfail`. The global psbt field BIP322
   adds for the coordination flow,
   `PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = 0x09`, is #516: it belongs to
   the psbt format rather than to a signature encoding, and an unknown
   global field already round-trips.
+- **Every required rule of BIP322 is enforced, SIGHASH_ALL included**
+  (#514). It is the one that is not a flag: a rule about which stack
+  elements the interpreter consumed as signatures, which nothing outside
+  the interpreter can work out -- the control block of a single-leaf
+  taproot tree is 65 bytes, exactly the shape of a BIP340 signature with
+  an explicit hash type, and a data push in a script-path witness can be
+  anything at all -- so a verifier picking them out by shape refuses
+  proofs that are valid. `verify_input` and `verify_transaction` take a
+  `hash_types` list and report into it what they checked, `None` and no
+  bookkeeping being the default; `bip322` reads it and refuses anything
+  but SIGHASH_ALL, or the SIGHASH_DEFAULT taproot spells as an absent
+  hash type. What that closes is the proof of funds, where the rule is
+  not a formality: ANYONECANPAY commits to no other input, so a
+  signature lifted out of the transaction that really spent a utxo
+  satisfies that same utxo's input inside a proof of control over it.
+  The first input of a `to_sign` was never open that far -- whatever its
+  hash type, it commits to the outpoint it spends, which is the txid the
+  message and the challenge script both enter.
 
 ### Transactions, blocks and PSBT
 

--- a/btclib/bip322.py
+++ b/btclib/bip322.py
@@ -65,13 +65,14 @@ consensus rules, then LOW_S, STRICTENC, NULLFAIL, MINIMALDATA,
 CLEANSTACK, MINIMALIF and CONST_SCRIPTCODE for the required ones, and the
 ``DISCOURAGE_`` family for the upgradeable ones -- the backticks because a
 name ending in an underscore is a link reference to docutils, which
-sphinx runs with `-W`. One rule of the list is not enforced:
-"all signatures MUST use SIGHASH_ALL", because which stack elements were
-consumed as signatures is bookkeeping the interpreter does not report,
-and picking them out of the witness by shape would refuse a control block
-that happens to be 65 bytes long. `sign` here uses SIGHASH_ALL, and
-SIGHASH_DEFAULT where taproot has it; issue 514 is what it costs and what
-closing it would take.
+sphinx runs with `-W`. The one rule of the list that is not a flag is
+"all signatures MUST use SIGHASH_ALL", which no set of flags can express:
+it is a rule about the stack elements the interpreter consumed as
+signatures, and which elements those were is not readable from the
+witness -- the control block of a single-leaf taproot tree is 65 bytes,
+exactly the shape of a BIP340 signature with an explicit hash type. So
+the engine reports them, through `verify_input`'s `hash_types`, and the
+rule is enforced over what it reports.
 
 One field of the BIP is not here either:
 `PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = 0x09`, which a creator puts the
@@ -368,6 +369,32 @@ def _assert_upgradeable(tx: Tx) -> None:
         raise InconclusiveError(err_msg)
 
 
+def _assert_hash_types(hash_types: list[int]) -> None:
+    """Refuse a signature that does not commit to the whole of `to_sign`.
+
+    BIP322's sixth required rule: "all signatures MUST use the
+    SIGHASH_ALL flag, unless the output type supports SIGHASH_DEFAULT,
+    which then MAY be used alternatively" -- so the two are one set
+    here, taproot being where the second is a spelling of the first and
+    the encodings refusing it elsewhere anyway.
+
+    What the rule buys is not the same at every input. The first
+    commits to the outpoint it spends whatever its hash type, and that
+    outpoint is `to_spend`'s txid, which the message and the challenge
+    script both enter; so the binding to the message survives a lax
+    hash type there, and what it loses is a commitment to an output
+    that is the constant OP_RETURN of 0. A further input of a proof of
+    funds has no such floor: ANYONECANPAY does not commit to the other
+    inputs, so a signature lifted out of the transaction that really
+    spent that utxo would satisfy it here -- a proof of control over
+    coins the prover never controlled.
+    """
+    for hash_type in hash_types:
+        if hash_type not in (ALL, DEFAULT):
+            err_msg = f"hash type {hash_type:#04x}: BIP322 requires SIGHASH_ALL"
+            raise BTClibValueError(err_msg)
+
+
 def _assert_scripts(prevouts: list[TxOut], tx: Tx) -> None:
     """Run the engine, telling an invalid signature from an inconclusive one.
 
@@ -377,12 +404,25 @@ def _assert_scripts(prevouts: list[TxOut], tx: Tx) -> None:
     that satisfies the required rules and not the upgradeable ones is
     inconclusive, and one that fails the required rules is invalid --
     which is the exception the second run raises by itself.
+
+    Each run reports its own hash types, and only a run that reached the
+    end of every script reports them all -- so the second run has a list
+    of its own rather than adding to what the first got as far as. The
+    rule is checked on either path because a required rule broken is
+    *invalid* whatever the upgradeable ones say, which is the order
+    BIP322 puts the two sets in.
     """
+    hash_types: list[int] = []
     try:
-        verify_transaction(prevouts, tx, REQUIRED_RULES | UPGRADEABLE_RULES)
+        verify_transaction(
+            prevouts, tx, REQUIRED_RULES | UPGRADEABLE_RULES, hash_types=hash_types
+        )
     except (ValueError, BTClibRuntimeError) as e:
-        verify_transaction(prevouts, tx, REQUIRED_RULES)
+        required_only: list[int] = []
+        verify_transaction(prevouts, tx, REQUIRED_RULES, hash_types=required_only)
+        _assert_hash_types(required_only)
         raise InconclusiveError(f"upgradeable rule: {e}") from e
+    _assert_hash_types(hash_types)
 
 
 def assert_as_valid(

--- a/btclib/script/engine/__init__.py
+++ b/btclib/script/engine/__init__.py
@@ -183,6 +183,7 @@ def _verify_taproot(
     i: int,
     script_flags: ScriptFlag,
     precomputed: PrecomputedTxData | None,
+    hash_types: list[int] | None,
 ) -> None:
     """Verify a p2tr spend: the v1 arm of Core's VerifyWitnessProgram.
 
@@ -197,7 +198,9 @@ def _verify_taproot(
     if len(stack) == 0:
         raise BTClibValueError("empty taproot witness stack")
     if len(stack) == 1:
-        tapscript.verify_key_path(script, stack, prevouts, tx, i, annex, precomputed)
+        tapscript.verify_key_path(
+            script, stack, prevouts, tx, i, annex, precomputed, hash_types
+        )
         return
     script_bytes, stack, leaf_version = taproot_unwrap_script(script, stack)
     if leaf_version != 0xC0:
@@ -209,7 +212,16 @@ def _verify_taproot(
             raise BTClibValueError(f"upgradable taproot leaf version {leaf_version:#x}")
         return
     tapscript.verify_script_path_vc0(
-        script_bytes, stack, prevouts, tx, i, annex, budget, script_flags, precomputed
+        script_bytes,
+        stack,
+        prevouts,
+        tx,
+        i,
+        annex,
+        budget,
+        script_flags,
+        precomputed,
+        hash_types,
     )
 
 
@@ -222,6 +234,7 @@ def _verify_witness_v0(
     i: int,
     script_flags: ScriptFlag,
     precomputed: PrecomputedTxData | None,
+    hash_types: list[int] | None,
 ) -> None:
     """Verify a v0 spend: the v0 arm of Core's VerifyWitnessProgram.
 
@@ -259,7 +272,16 @@ def _verify_witness_v0(
         raise BTClibValueError(f"invalid segwit v0 script type: {script_type}")
 
     verify_script_legacy(
-        script, stack, prevouts[i].value, tx, i, script_flags, True, True, precomputed
+        script,
+        stack,
+        prevouts[i].value,
+        tx,
+        i,
+        script_flags,
+        True,
+        True,
+        precomputed,
+        hash_types,
     )
     # final above popped the one element the script must leave, so any
     # residue is Core's stack.size() != 1
@@ -278,6 +300,7 @@ def _verify_witness_program(
     i: int,
     script_flags: ScriptFlag,
     precomputed: PrecomputedTxData | None,
+    hash_types: list[int] | None,
 ) -> None:
     """Dispatch a witness program: Core's VerifyWitnessProgram.
 
@@ -310,6 +333,7 @@ def _verify_witness_program(
             i,
             script_flags,
             precomputed,
+            hash_types,
         )
         return
 
@@ -326,6 +350,7 @@ def _verify_witness_program(
                 i,
                 script_flags,
                 precomputed,
+                hash_types,
             )
         return
 
@@ -351,6 +376,7 @@ def verify_input(
     i: int,
     flags: ScriptFlags | None = None,
     precomputed: PrecomputedTxData | None = None,
+    hash_types: list[int] | None = None,
 ) -> None:
     """Verify one input of a transaction against the output it spends.
 
@@ -365,6 +391,18 @@ def verify_input(
     single input has nothing to share it with, so it defaults to None and
     each sig_hash computes what it needs (issue #164).
 
+    `hash_types` is the list the interpreter reports into: the hash type
+    of every stack element it consumed as a signature, in the order it
+    met them, appended to whatever the caller passed. Which elements
+    those were is what an outside caller cannot work out on its own --
+    the control block of a single-leaf taproot tree is 65 bytes, exactly
+    the shape of a BIP340 signature with an explicit hash type, and a
+    data push in a script-path witness can be anything at all -- so a
+    rule about the hash types themselves has to be enforced from here or
+    guessed at. `None`, the default, collects nothing: consensus has no
+    such rule, and BIP322's "all signatures MUST use SIGHASH_ALL" is the
+    caller that has one (issue #514).
+
     The split is Core's: this function is VerifyScript -- the two legacy
     runs on one stack, the p2sh unwrap, the malleation checks, the
     CLEANSTACK check -- and the witness arms live behind
@@ -377,13 +415,29 @@ def verify_input(
 
     stack: list[bytes] = []
     verify_script_legacy(
-        script_sig, stack, prevouts[i].value, tx, i, script_flags, False, False
+        script_sig,
+        stack,
+        prevouts[i].value,
+        tx,
+        i,
+        script_flags,
+        False,
+        False,
+        hash_types=hash_types,
     )
     p2sh_script = stack[-1] if stack else b"\x00"
 
     script = prevouts[i].script_pub_key.script
     verify_script_legacy(
-        script, stack, prevouts[i].value, tx, i, script_flags, False, True
+        script,
+        stack,
+        prevouts[i].value,
+        tx,
+        i,
+        script_flags,
+        False,
+        True,
+        hash_types=hash_types,
     )
 
     script_type, payload = type_and_payload(script)
@@ -394,7 +448,15 @@ def verify_input(
         validate_push_only(script_sig)  # BIP16 makes SIGPUSHONLY consensus here
         script = p2sh_script
         verify_script_legacy(
-            script, stack, prevouts[i].value, tx, i, script_flags, False, True
+            script,
+            stack,
+            prevouts[i].value,
+            tx,
+            i,
+            script_flags,
+            False,
+            True,
+            hash_types=hash_types,
         )
         script_type, payload = type_and_payload(script)
 
@@ -423,6 +485,7 @@ def verify_input(
             i,
             script_flags,
             precomputed,
+            hash_types,
         )
         # Core's stack.resize(1) after VerifyWitnessProgram: a witness
         # spend leaves nothing for CLEANSTACK to see, and v0's own
@@ -450,11 +513,14 @@ def verify_transaction(
     tx: Tx,
     flags: ScriptFlags | None = None,
     check_amounts: bool = True,
+    hash_types: list[int] | None = None,
 ) -> None:
     """Verify every input of a transaction against the outputs it spends.
 
     `flags` is what verify_input takes, converted once here rather than
-    once per input.
+    once per input; `hash_types` is what verify_input reports into, one
+    list for the whole transaction, so the inputs' signatures arrive in
+    it in input order.
     """
     script_flags = to_script_flags(flags)
     if len(prevouts) != len(tx.vin):
@@ -473,4 +539,4 @@ def verify_transaction(
     # quadratic the day the two disagreed
     precomputed = PrecomputedTxData(tx, prevouts)
     for i in range(len(prevouts)):
-        verify_input(prevouts, tx, i, script_flags, precomputed)
+        verify_input(prevouts, tx, i, script_flags, precomputed, hash_types)

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -222,6 +222,7 @@ def op_checksig(
     flags: ScriptFlag,
     segwit: bool,
     precomputed: PrecomputedTxData | None = None,
+    hash_types: list[int] | None = None,
 ) -> bool:
     """Verify one ECDSA signature over the script code it commits to.
 
@@ -237,6 +238,10 @@ def op_checksig(
     is BIP143's for a segwit v0 input and the legacy per-input
     serialization for the rest; tapscript signatures never reach here,
     tapscript.py verifying BIP340 on its own.
+
+    `hash_types` is `verify_input`'s collector, appended to here
+    because this is where the last byte of a stack element is known to
+    be a hash type at all.
     """
     if not signature:
         return False
@@ -254,6 +259,14 @@ def op_checksig(
         if ScriptFlag.STRICTENC in flags:
             raise BTClibValueError(f"invalid public key: {pub_key.hex()}")
         return False
+
+    if hash_types is not None:
+        # after the two encoding gates and before the verification: what
+        # is reported is what the interpreter took for a signature, and
+        # whether it verifies is a separate answer -- OP_CHECKMULTISIG
+        # tries one signature against several keys, so a report made
+        # only on success would leave out the very element under check
+        hash_types.append(signature[-1])
 
     script_code = calculate_script_code(
         script_bytes,
@@ -477,6 +490,7 @@ def _run_ops(  # noqa: C901, PLR0912
     precomputed: PrecomputedTxData | None,
     op_code_stops: list[int],
     script_index_ref: list[int],
+    hash_types: list[int] | None,
 ) -> None:
     """Run verify_script's opcode dispatch loop.
 
@@ -535,6 +549,7 @@ def _run_ops(  # noqa: C901, PLR0912
                 flags,
                 segwit,
                 precomputed,
+                hash_types,
             )
             check_nullfail(flags, result, [signature], "OP_CHECKSIG")
             stack.append(_from_num(int(result)))
@@ -572,6 +587,7 @@ def _run_ops(  # noqa: C901, PLR0912
                     flags,
                     segwit,
                     precomputed,
+                    hash_types,
                 )
 
             if signature_index == signature_num:
@@ -620,6 +636,7 @@ def verify_script(
     segwit: bool,
     final: bool = False,
     precomputed: PrecomputedTxData | None = None,
+    hash_types: list[int] | None = None,
 ) -> None:
     """Execute the script over the caller's stack, as Core's EvalScript.
 
@@ -630,6 +647,10 @@ def verify_script(
     the index of the failing command and the stack depth. With `final`
     the script must end on a non-empty stack with a true top element,
     which is the caller saying no script runs after this one.
+
+    `hash_types` is `verify_input`'s collector, threaded through to
+    `op_checksig`; chaining scripts over one stack is chaining them
+    over one collector too.
     """
     if len(script_bytes) > MAX_SCRIPT_SIZE:
         err_msg = f"script longer than {MAX_SCRIPT_SIZE} bytes: {len(script_bytes)}"
@@ -674,6 +695,7 @@ def verify_script(
             precomputed,
             op_code_stops,
             script_index_ref,
+            hash_types,
         )
     except BTClibValueError as e:
         raise ScriptError(str(e), script_index_ref[0], len(stack)) from e

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -93,6 +93,7 @@ def verify_key_path(
     i: int,
     annex: bytes,
     precomputed: PrecomputedTxData | None = None,
+    hash_types: list[int] | None = None,
 ) -> None:
     """Verify a taproot key-path spend, per BIP341.
 
@@ -100,8 +101,13 @@ def verify_key_path(
     itself over the taproot sig_hash with no script committed to; a
     signature that does not verify is the only refusal, get_hashtype's
     aside.
+
+    `hash_types` is `verify_input`'s collector; the one element of the
+    stack is the one signature to report.
     """
     sighash_type = get_hashtype(stack[0])
+    if hash_types is not None:
+        hash_types.append(sighash_type)
     signature = stack[0][:64]
     pub_key = type_and_payload(script_pub_key)[1]
     msg_hash = sig_hash.taproot(
@@ -123,6 +129,7 @@ def op_checksig(
     budget: int,
     flags: ScriptFlag,
     precomputed: PrecomputedTxData | None = None,
+    hash_types: list[int] | None = None,
 ) -> int:
     """Verify one BIP340 signature in a script path: BIP342's OP_CHECKSIG.
 
@@ -136,6 +143,10 @@ def op_checksig(
     room, refused only under DISCOURAGE_UPGRADABLE_PUBKEYTYPE. The
     message hash commits to the tapleaf and to the last executed
     OP_CODESEPARATOR through the BIP341 extension.
+
+    `hash_types` is `verify_input`'s collector, appended to where the
+    hash type is read: an empty signature is not one, and neither is
+    anything popped beside a public key BIP342 left upgradable.
     """
     pub_key = stack.pop()
     signature = stack.pop()
@@ -148,6 +159,8 @@ def op_checksig(
     if len(pub_key) == 32:
         if signature:
             sighash_type = get_hashtype(signature)
+            if hash_types is not None:
+                hash_types.append(sighash_type)
             preimage = b"\xc0"
             preimage += var_bytes.serialize(script_bytes)
             tapleaf_hash = tagged_hash(b"TapLeaf", preimage)
@@ -244,6 +257,7 @@ def _run_ops(  # noqa: C901, PLR0912
     flags: ScriptFlag,
     precomputed: PrecomputedTxData | None,
     script_index_ref: list[int],
+    hash_types: list[int] | None,
 ) -> None:
     """Run verify_script_path_vc0's opcode dispatch loop.
 
@@ -301,6 +315,7 @@ def _run_ops(  # noqa: C901, PLR0912
                 sigops_budget,
                 flags,
                 precomputed,
+                hash_types,
             )
 
         elif op == "OP_CHECKLOCKTIMEVERIFY":
@@ -342,6 +357,7 @@ def verify_script_path_vc0(
     sigops_budget: int,
     flags: ScriptFlag,
     precomputed: PrecomputedTxData | None = None,
+    hash_types: list[int] | None = None,
 ) -> None:
     """Execute a leaf-version-0xc0 tapscript, per BIP342.
 
@@ -352,6 +368,9 @@ def verify_script_path_vc0(
     CHECKMULTISIGs gone in favour of OP_CHECKSIGADD. Refusals leave as
     ScriptError, as they do from the legacy loop, and the script must
     end with exactly one true element on the stack.
+
+    `hash_types` is `verify_input`'s collector, threaded to
+    `op_checksig` as the legacy loop threads it to its own.
     """
     if any(len(x) > MAX_SCRIPT_ELEMENT_SIZE for x in stack):
         err_msg = f"witness stack element longer than {MAX_SCRIPT_ELEMENT_SIZE} bytes"
@@ -385,6 +404,7 @@ def verify_script_path_vc0(
             flags,
             precomputed,
             script_index_ref,
+            hash_types,
         )
     except BTClibValueError as e:
         raise ScriptError(str(e), script_index_ref[0], len(stack)) from e

--- a/tests/bip322_test.py
+++ b/tests/bip322_test.py
@@ -624,7 +624,13 @@ def _sign_with(msg: bytes, script_type: str, hash_type: int) -> tuple[str, bip32
 @pytest.mark.parametrize(
     "hash_type",
     [NONE, SINGLE, ANYONECANPAY | ALL, ANYONECANPAY | NONE, ANYONECANPAY | SINGLE],
-    ids=["none", "single", "anyonecanpay-all", "anyonecanpay-none", "anyonecanpay-sin"],
+    ids=[
+        "none",
+        "single",
+        "anyonecanpay-all",
+        "anyonecanpay-none",
+        "anyonecanpay-single",
+    ],
 )
 def test_a_hash_type_that_is_not_sighash_all_is_refused(
     script_type: str, hash_type: int

--- a/tests/bip322_test.py
+++ b/tests/bip322_test.py
@@ -25,7 +25,7 @@ import pytest
 from btclib import bip322
 from btclib.b32 import p2tr, p2wpkh, p2wsh
 from btclib.b58 import p2pkh, p2wpkh_p2sh, wif_from_prv_key
-from btclib.ecc import bms, dsa
+from btclib.ecc import bms, dsa, ssa
 from btclib.exceptions import (
     BTClibRuntimeError,
     BTClibValueError,
@@ -35,8 +35,17 @@ from btclib.hashes import hash160
 from btclib.psbt import Psbt
 from btclib.script import ScriptPubKey, address, serialize
 from btclib.script.engine import ALL_FLAGS, ScriptFlag
-from btclib.script.sig_hash import ALL, segwit_v0
-from btclib.script.taproot import output_pubkey
+from btclib.script.sig_hash import (
+    ALL,
+    ANYONECANPAY,
+    DEFAULT,
+    NONE,
+    SINGLE,
+    from_tx,
+    segwit_v0,
+)
+from btclib.script.sig_hash import taproot as taproot_sig_hash
+from btclib.script.taproot import output_prvkey, output_pubkey
 from btclib.script.witness import Witness
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
 from btclib.to_pub_key import pub_keyinfo_from_key
@@ -578,3 +587,163 @@ def test_proof_of_funds_reuses_an_earlier_non_witness_utxo() -> None:
         psbt.inputs[1].output_index = out_of_range
         with pytest.raises(BTClibValueError, match="no utxo for input 1"):
             bip322._psbt_prevouts(psbt)
+
+
+def _sign_with(msg: bytes, script_type: str, hash_type: int) -> tuple[str, bip322.Sig]:
+    """Sign as `bip322.sign` does, with the hash type the caller names.
+
+    `sign` writes SIGHASH_ALL, and SIGHASH_DEFAULT where taproot has it,
+    so nothing in this library produces the signatures below: the rule
+    they are here for is the verifier's, and a rule about what a
+    verifier refuses needs something refusable to exist.
+    """
+    addr = _address(WIF, script_type)
+    spend = bip322.to_spend(msg, ScriptPubKey.from_address(addr).script)
+    tx = bip322.to_sign(spend)
+    q = prv_keyinfo_from_prv_key(WIF)[0]
+
+    if script_type == "p2tr":
+        msg_hash = taproot_sig_hash(tx, 0, spend.vout, hash_type, 0, b"", b"")
+        signature = ssa.sign_(msg_hash, output_prvkey(q)).serialize()
+        if hash_type != DEFAULT:
+            # BIP341's 65th byte, and the explicit zero it refuses is
+            # what makes DEFAULT the absence of one rather than a value
+            signature += hash_type.to_bytes(1, "big")
+        return addr, bip322.Sig(Witness([signature]))
+
+    msg_hash = from_tx(spend.vout, tx, 0, hash_type)
+    signature = dsa.sign_(msg_hash, q).serialize() + hash_type.to_bytes(1, "big")
+    pub_key = pub_keyinfo_from_key(WIF, compressed=True)[0]
+    if script_type == "p2pkh":
+        tx.vin[0].script_sig = serialize([signature, pub_key])
+        return addr, bip322.Sig(tx)
+    return addr, bip322.Sig(Witness([signature, pub_key]))
+
+
+@pytest.mark.parametrize("script_type", ["p2pkh", "p2wpkh", "p2tr"])
+@pytest.mark.parametrize(
+    "hash_type",
+    [NONE, SINGLE, ANYONECANPAY | ALL, ANYONECANPAY | NONE, ANYONECANPAY | SINGLE],
+    ids=["none", "single", "anyonecanpay-all", "anyonecanpay-none", "anyonecanpay-sin"],
+)
+def test_a_hash_type_that_is_not_sighash_all_is_refused(
+    script_type: str, hash_type: int
+) -> None:
+    """BIP322's sixth required rule, over the three shapes that carry one.
+
+    Each of these signatures verifies -- it was made for the hash type
+    it declares -- so the refusal is the rule and not a check that
+    happened to fail, and the message says which type it was. The three
+    script types are the two places a hash type is read: the last byte
+    of an ECDSA signature, wherever the input carries it, and the 65th
+    of a BIP340 one.
+    """
+    msg = b"whatever the type says"
+    addr, sig = _sign_with(msg, script_type, hash_type)
+    with pytest.raises(BTClibValueError, match="BIP322 requires SIGHASH_ALL"):
+        bip322.assert_as_valid(msg, addr, sig)
+    assert not bip322.verify(msg, addr, sig)
+
+
+def test_sighash_all_and_taproot_s_default_are_the_two_accepted() -> None:
+    """The exemption the rule carries, and what it exempts.
+
+    "unless the output type supports SIGHASH_DEFAULT, which then MAY be
+    used alternatively": so the accepted set is two values and not one,
+    and taproot is where both spellings exist -- the 64-byte signature
+    BIP341 reads as SIGHASH_ALL, and the 65-byte one that says 0x01 out
+    loud. Either is a valid signature here, and the pair is what a rule
+    narrowed to one of them would break.
+    """
+    msg = b"the two spellings"
+    for hash_type in (DEFAULT, ALL):
+        addr, sig = _sign_with(msg, "p2tr", hash_type)
+        assert bip322.verify(msg, addr, sig)
+    for script_type in ("p2pkh", "p2wpkh"):
+        addr, sig = _sign_with(msg, script_type, ALL)
+        assert bip322.verify(msg, addr, sig)
+
+
+@pytest.mark.parametrize(
+    "hash_type", [ALL, ANYONECANPAY | ALL], ids=["all", "anyonecanpay-all"]
+)
+def test_proof_of_funds_refuses_anyonecanpay_on_a_further_input(
+    hash_type: int,
+) -> None:
+    """Where the rule stops being a formality, and the reason it is one.
+
+    The first input of a `to_sign` commits to the outpoint it spends
+    whatever its hash type, and that outpoint is `to_spend`'s txid,
+    which the message and the challenge script both enter; so the
+    binding to the message survives there, and what a lax type drops is
+    a commitment to an output that is always the OP_RETURN of nothing.
+
+    A further input of a proof of funds has no such floor.
+    ANYONECANPAY does not commit to the other inputs, so this very
+    signature -- one byte from the one above it, which verifies -- would
+    also satisfy the input inside the transaction that really spent that
+    output: a proof of control over coins the prover need never have
+    controlled.
+    """
+    msg, addr = b"and these are mine too", _address(WIF, "p2wpkh")
+    spend = bip322.to_spend(msg, ScriptPubKey.from_address(addr).script)
+    funded = TxOut(1000, ScriptPubKey.from_address(addr))
+    extra = TxIn(OutPoint(b"\x01" * 32, 0), b"", 0)
+    tx = bip322.to_sign(spend, extra_inputs=[extra])
+    prevouts = [spend.vout[0], funded]
+
+    psbt = Psbt.from_tx(tx)
+    pub_key = pub_keyinfo_from_key(WIF, compressed=True)[0]
+    q = prv_keyinfo_from_prv_key(WIF)[0]
+    for i, one_type in enumerate((ALL, hash_type)):
+        signature = dsa.sign_(from_tx(prevouts, tx, i, one_type), q).serialize()
+        psbt.inputs[i].witness_utxo = prevouts[i]
+        psbt.inputs[i].final_script_witness = Witness(
+            [signature + one_type.to_bytes(1, "big"), pub_key]
+        )
+
+    sig = bip322.Sig(psbt)
+    if hash_type == ALL:
+        bip322.assert_as_valid(msg, addr, sig)
+        return
+    with pytest.raises(BTClibValueError, match="BIP322 requires SIGHASH_ALL"):
+        bip322.assert_as_valid(msg, addr, sig)
+    assert not bip322.verify(msg, addr, sig)
+
+
+@pytest.mark.parametrize("hash_type", [ALL, NONE], ids=["all", "none"])
+def test_a_broken_required_rule_answers_before_an_upgradeable_one(
+    hash_type: int,
+) -> None:
+    """Invalid beats inconclusive, which is the order BIP322 asks in.
+
+    The script here breaks one rule of each set: an OP_NOP reserved for
+    a soft fork, which is upgradeable, and -- when the parametrization
+    says so -- a hash type that is not SIGHASH_ALL, which is required.
+    With both broken the answer is `BTClibValueError`: a signature that
+    today's rules cannot judge is one thing, and one they judge and
+    refuse is another.
+
+    The NOP is what puts the hash type on the second run's report,
+    because the first run never reaches the end of the script: it is
+    the case for the second run collecting at all.
+    """
+    keys = pub_keyinfo_from_key(WIF, compressed=True)[0]
+    witness_script = serialize([keys, "OP_CHECKSIGVERIFY", "OP_NOP4", "OP_1"])
+    msg, addr = b"two rules at once", p2wsh(witness_script)
+
+    spend = bip322.to_spend(msg, ScriptPubKey.from_address(addr).script)
+    tx = bip322.to_sign(spend)
+    msg_hash = segwit_v0(witness_script, tx, 0, hash_type, 0)
+    q = prv_keyinfo_from_prv_key(WIF)[0]
+    signature = dsa.sign_(msg_hash, q).serialize() + hash_type.to_bytes(1, "big")
+    sig = bip322.Sig(Witness([signature, witness_script]))
+
+    if hash_type == ALL:
+        # the same spend with nothing else wrong with it: inconclusive,
+        # and the assertion that the NOP is what the other case adds to
+        with pytest.raises(InconclusiveError, match="upgradeable rule"):
+            bip322.assert_as_valid(msg, addr, sig)
+        return
+    with pytest.raises(BTClibValueError, match="BIP322 requires SIGHASH_ALL"):
+        bip322.assert_as_valid(msg, addr, sig)

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -14,6 +14,7 @@ from typing import Any, NamedTuple
 import pytest
 
 from btclib.alias import TaprootScriptTree
+from btclib.ecc import ssa
 from btclib.ecc.dsa import Sig, sign_
 from btclib.exceptions import BTClibValueError, ScriptError
 from btclib.hashes import hash160, sha256
@@ -24,6 +25,7 @@ from btclib.script.engine import (
     ScriptFlag,
     validate_push_only,
     verify_input,
+    verify_transaction,
 )
 from btclib.script.engine.script import (
     DISABLED_OP_CODES,
@@ -35,7 +37,12 @@ from btclib.script.engine.script import (
 from btclib.script.engine.script_op_codes import read_push_data
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
 from btclib.script.script import OP_CODE_NAME_FROM_INT, parse, serialize
-from btclib.script.taproot import input_script_sig, output_pubkey
+from btclib.script.taproot import (
+    input_script_sig,
+    leaf_hash,
+    output_prvkey,
+    output_pubkey,
+)
 from btclib.script.taproot import parse as parse_tapscript
 from btclib.script.taproot import serialize as serialize_tapscript
 from btclib.script.witness import Witness
@@ -1120,3 +1127,86 @@ def test_find_and_delete_takes_one_pass() -> None:
     assert find_and_delete(script, target) == (target, 1)
     # the empty target: Core returns before it can delete forever
     assert find_and_delete(script, b"") == (script, 0)
+
+
+def test_hash_types_report_every_signature_the_interpreter_checked() -> None:
+    """What `verify_input` reports back: three inputs, four hash types.
+
+    A signature and not an input is what makes an entry -- the 2-of-2
+    below carries two of them, with a hash type each -- and the list is
+    one for the whole transaction, in input order, appended to rather
+    than replaced.
+
+    No consensus rule reads it, and the caller that does is one with a
+    rule about the hash types themselves: BIP322's "all signatures MUST
+    use SIGHASH_ALL" (issue #514). Why such a caller cannot pick the
+    signatures out of the witness itself is the third input here -- its
+    control block is 65 bytes, exactly the shape of the BIP340
+    signature two elements below it.
+    """
+    keys = [
+        0x4242424242424242424242424242424242424242424242424242424242424242,
+        0x1111111111111111111111111111111111111111111111111111111111111111,
+    ]
+    sec_keys = [pub_keyinfo_from_prv_key(key)[0] for key in keys]
+
+    witness_script = serialize(["OP_2", *sec_keys, "OP_2", "OP_CHECKMULTISIG"])
+    script_tree: TaprootScriptTree = [(0xC0, [sec_keys[0][1:].hex(), "OP_CHECKSIG"])]
+    tap_script, control = input_script_sig(None, script_tree, 0)
+    leaf_script = serialize_tapscript(tap_script)
+    prevouts = [
+        TxOut(1000, ScriptPubKey(b"\x00\x20" + sha256(witness_script))),
+        TxOut(1000, ScriptPubKey.p2tr(keys[0])),
+        TxOut(
+            1000, ScriptPubKey(serialize(["OP_1", output_pubkey(None, script_tree)[0]]))
+        ),
+    ]
+    vin = [TxIn(OutPoint(b"\x01" * 32, i), b"", 1) for i in range(len(prevouts))]
+    tx = Tx(2, 0, vin, [TxOut(1000, ScriptPubKey(""))], check_validity=False)
+
+    # the 2-of-2, signed in script order and with a hash type each: the
+    # signature is what carries the type, so two signatures of one input
+    # can disagree about it and the report has to say so
+    multisig_types = [sig_hash.SINGLE, sig_hash.ANYONECANPAY | sig_hash.ALL]
+    signatures = [
+        sign_(
+            sig_hash.segwit_v0(witness_script, tx, 0, hash_type, prevouts[0].value), key
+        ).serialize()
+        + hash_type.to_bytes(1, "big")
+        for key, hash_type in zip(keys, multisig_types, strict=True)
+    ]
+    tx.vin[0].script_witness = Witness([b"", *signatures, witness_script])
+
+    # the key path, with the type spelled out: 65 bytes, and BIP341
+    # refuses the 65th being a zero, which is the DEFAULT below
+    msg_hash = sig_hash.taproot(tx, 1, prevouts, sig_hash.NONE, 0, b"", b"")
+    key_path_sig = ssa.sign_(msg_hash, output_prvkey(keys[0])).serialize()
+    tx.vin[1].script_witness = Witness(
+        [key_path_sig + sig_hash.NONE.to_bytes(1, "big")]
+    )
+
+    # and the script path, SIGHASH_DEFAULT: 64 bytes, no type byte at
+    # all, and the report says 0 for it -- the meaning BIP341 gives the
+    # absence rather than a byte read off the stack
+    ext = leaf_hash(0xC0, leaf_script) + b"\x00" + (0xFFFFFFFF).to_bytes(4, "little")
+    msg_hash = sig_hash.taproot(tx, 2, prevouts, sig_hash.DEFAULT, 1, b"", ext)
+    tx.vin[2].script_witness = Witness(
+        [ssa.sign_(msg_hash, keys[0]).serialize(), leaf_script, control]
+    )
+
+    hash_types: list[int] = []
+    verify_transaction(prevouts, tx, ALL_FLAGS, hash_types=hash_types)
+    # the two of the multisig come back the other way round, and that is
+    # the order the interpreter meets them in rather than a detail of
+    # this list: OP_CHECKMULTISIG pops its keys and its signatures off
+    # the stack, so it walks both from the last of the script towards
+    # the first. Order within an input is worth nothing to a caller for
+    # exactly this reason -- what the report answers is which types were
+    # used, and by how many signatures
+    assert hash_types == [*reversed(multisig_types), sig_hash.NONE, sig_hash.DEFAULT]
+
+    # appended to, not replaced: the caller owns the list, and verifying
+    # a second input into it is verifying two inputs into one report
+    verify_input(prevouts, tx, 1, ALL_FLAGS, hash_types=hash_types)
+    assert hash_types[-1] == sig_hash.NONE
+    assert len(hash_types) == 5


### PR DESCRIPTION
Closes #514.

BIP322 lists six required rules and `btclib.bip322` enforced five, all
five being engine flags. The sixth is not a flag and cannot be one:
*all signatures MUST use the SIGHASH_ALL flag, unless the output type
supports SIGHASH_DEFAULT, which then MAY be used alternatively* is a
rule about the stack elements the interpreter **consumed as
signatures**, and which elements those were is not readable from the
witness — the control block of a single-leaf taproot tree is 33 + 32 =
65 bytes, exactly the shape of a BIP340 signature with an explicit hash
type. A verifier guessing by shape refuses proofs that are valid, which
is why option 2 of the issue is not taken here.

This is the issue's option 1: the interpreter reports.

## The engine

`verify_input` and `verify_transaction` take a `hash_types: list[int] |
None = None` and append the hash type of every signature they check, in
the order they meet them. It is threaded to the three places a hash type
is read and no further: the legacy and segwit v0 `op_checksig`
(`engine/script.py`), the taproot key path, and tapscript's own
`op_checksig`. `None` is the default and collects nothing — consensus
has no such rule, so no existing caller pays for one.

The append sits after the two encoding gates and before the
verification: what is reported is what the interpreter *took* for a
signature, whether or not it verifies. OP_CHECKMULTISIG tries one
signature against several keys, so a report made only on success would
leave out the very element under check.

## bip322

`_assert_scripts` passes a list to the run it makes and `_assert_hash_types`
refuses anything but `ALL` or `DEFAULT`. Two details worth a look in
review:

- the report is read from **whichever run succeeded**, each run getting
  its own list: a run that stopped partway reports the signatures it
  reached rather than the ones the witness holds;
- the rule is checked on the inconclusive path too, before
  `InconclusiveError` is raised, because a broken required rule is
  *invalid* whatever the upgradeable ones say — the order BIP322 puts
  the two sets in.

## What it closes

For the first input of a `to_sign` the gap was narrow: whatever hash
type a signature carries, it commits to the outpoint being spent, which
is `to_spend`'s txid, which the message and the challenge script both
enter. For a **proof of funds** it was not narrow. ANYONECANPAY commits
to no other input, so a signature lifted out of the transaction that
really spent a utxo satisfies that same utxo's input inside a proof of
control over it — coins the prover never controlled. That is the test
`test_proof_of_funds_refuses_anyonecanpay_on_a_further_input`, one byte
away from the same proof that verifies.

## Tests

- `tests/script_engine/script_test.py`: three inputs, four signatures,
  four hash types — a 2-of-2 (two entries for one input), a taproot key
  path, a tapscript script path — pinning the content of the report, its
  order, and that it is appended to rather than replaced. The
  OP_CHECKMULTISIG entries come back in pop order, which is what the
  test says and why order within an input is worth nothing to a caller.
- `tests/bip322_test.py`: five non-ALL hash types × p2pkh, p2wpkh, p2tr,
  each signature made *for* the type it declares so the refusal is the
  rule and not a check that failed; both accepted spellings (the 64-byte
  DEFAULT and the explicit 0x01); the proof of funds above; and a script
  breaking one rule of each set, where invalid beats inconclusive.

Suite green with `--cov` at 100%, `pre-commit run --all-files` and the
sphinx `-W` build both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce BIP322’s SIGHASH_ALL / SIGHASH_DEFAULT hash-type rule by having the script engine report hash types for all checked signatures and validating them in bip322.

New Features:
- Add optional hash-type collection to script verification (`verify_input` and `verify_transaction`) so callers can inspect the hash types of all signatures processed.

Bug Fixes:
- Ensure BIP322 proofs are rejected when any signature uses a hash type other than SIGHASH_ALL or, for taproot outputs, SIGHASH_DEFAULT, closing the proof-of-funds ANYONECANPAY loophole.

Enhancements:
- Extend legacy and taproot script engines to thread a hash-type collector through signature opcodes, including multisig and tapscript key/script paths.
- Improve bip322’s validation flow so broken required rules (including hash type violations) are reported as invalid ahead of upgradeable rule inconclusiveness.
- Document the now-complete enforcement of BIP322 required rules, including the SIGHASH_ALL constraint, in the changelog.

Tests:
- Add script engine tests to verify that hash types for all checked signatures are collected in transaction input order, including multisig and taproot cases.
- Add bip322 tests covering refusal of non-ALL hash types across p2pkh, p2wpkh, and taproot, acceptance of SIGHASH_ALL and SIGHASH_DEFAULT, the ANYONECANPAY proof-of-funds scenario, and the precedence of required over upgradeable rule failures.