### PR TITLE
Register PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE, and both ends of the flow it exists for (#516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -382,11 +382,8 @@ documented at release-notes length in the first place, and are still in
   of an unknown version, each of them successful *because* nothing checks
   it. The BIP's own two vector files are vendored whole and every case
   runs, the three transaction hashes and the 36 error cases included and
-  nothing marked `xfail`. The global psbt field BIP322
-  adds for the coordination flow,
-  `PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = 0x09`, is #516: it belongs to
-  the psbt format rather than to a signature encoding, and an unknown
-  global field already round-trips.
+  nothing marked `xfail`. The psbt coordination flow is
+  `to_sign_psbt` and `signed_message`, the entry below.
 - **Every required rule of BIP322 is enforced, SIGHASH_ALL included**
   (#514). It is the one that is not a flag: a rule about which stack
   elements the interpreter consumed as signatures, which nothing outside
@@ -407,6 +404,36 @@ documented at release-notes length in the first place, and are still in
   message and the challenge script both enter.
 
 ### Transactions, blocks and PSBT
+
+- **`PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = 0x09` is a field**, and
+  `btclib.bip322` has the two ends of the flow it exists for (#516).
+  BIP322 adds the global to BIP174's registry so that a psbt says what
+  is being signed: the transaction it carries spends a virtual output of
+  0 to an OP_RETURN of 0 and says nothing about any message, and a
+  signing device reading it can only offer "spending 0 satoshi" where
+  what the user is being asked is "sign this message for this address".
+  `Psbt.signed_message` holds it -- through `parse` and `serialize`,
+  `to_dict` and `from_dict`, and `combine`, which takes it from either
+  side by the rule that keeps the empty message a message. Allowed in
+  versions 0 and 2 both, which is why it is neither in the BIP370 table
+  nor version-gated: no other field of the eight is in both. It arrived
+  as an unknown global before this and round-tripped as one, so what
+  changes for a psbt from another wallet is that the message is now
+  readable rather than kept.
+
+  `bip322.to_sign_psbt` is the Creator half -- the message, the psbt of
+  `to_sign`, and the whole of `to_spend` as the utxo of its first input,
+  which is what a signer of any challenge type can read -- and
+  `bip322.signed_message` is the Signer's question: the message this
+  psbt signs, or `None` where it signs none. The field alone is not that
+  answer, and this is the half a library can be held to: a message the
+  transaction does not commit to is what a device showing "signing
+  message m" would be lying about, so the field is one of five
+  conditions and the other four are the psbt being a `to_sign` of that
+  very message and that very challenge script.
+  `bip322.assert_signed_message` is the same question with the reason,
+  for a caller that has to tell "no message" from "a message this psbt
+  does not bear out".
 
 - **A `BitcoinCoreFetcher` asks the node which chain it serves** (#521).
   `assert_network` has always been able to catch the one silent failure

--- a/btclib/bip322.py
+++ b/btclib/bip322.py
@@ -74,13 +74,15 @@ exactly the shape of a BIP340 signature with an explicit hash type. So
 the engine reports them, through `verify_input`'s `hash_types`, and the
 rule is enforced over what it reports.
 
-One field of the BIP is not here either:
-`PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = 0x09`, which a creator puts the
-message in so that a signing device shows "signing message m for address
-A" rather than "spending 0 satoshi". It belongs to the psbt format
-rather than to a signature encoding, and `btclib.psbt` keeps an unknown
-global field as it arrives, so such a psbt round-trips through this
-library today. Issue 516 is registering it.
+The fourth flow of the BIP is not a signature encoding at all: a
+multisig signature is coordinated as a psbt, and the psbt says what is
+being signed through `PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = 0x09`, the
+global field BIP322 adds to BIP174's registry. `Psbt.signed_message`
+holds it; here `to_sign_psbt` is the Creator that writes one and
+`signed_message` the question a Signer puts to what it received --
+"is this a BIP322 psbt, and for which message" -- so that a device shows
+"signing message m for address A" rather than "spending 0 satoshi",
+which is the promise the field exists to let it keep.
 
 https://github.com/bitcoin/bips/blob/master/bip-0322.mediawiki
 """
@@ -120,9 +122,12 @@ __all__ = [
     "UPGRADEABLE_RULES",
     "Sig",
     "assert_as_valid",
+    "assert_signed_message",
     "message_hash",
     "sign",
+    "signed_message",
     "to_sign",
+    "to_sign_psbt",
     "to_spend",
     "verify",
 ]
@@ -241,6 +246,34 @@ def to_sign(
     return Tx(version, lock_time, vin, [TxOut(0, _OP_RETURN)])
 
 
+def to_sign_psbt(msg: Octets, addr: String) -> Psbt:
+    """Return the psbt a Creator hands the signers of this challenge.
+
+    BIP322's fourth flow: a signature that several keys make together is
+    coordinated as a psbt, so what a Signer receives is the unsigned
+    `to_sign` rather than a witness stack to fill in. Two fields make it
+    one -- the message, in the global
+    `PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE`, and the output being spent,
+    without which no signature can be made -- and `signed_message` is
+    the question this answers on the other side.
+
+    The whole of `to_spend` goes in as the non-witness utxo rather than
+    its one output as a witness utxo: it is the answer for a challenge
+    script of any type, where a witness utxo is the answer for the
+    segwit ones alone, and the transaction is virtual but it is a
+    transaction. Nothing is signed here, and nothing is finalized: what
+    comes back is what a Signer signs, `psbt.sign` and `psbt.finalize`
+    being the roles that follow, and `Sig` of the finalized psbt the
+    proof-of-funds encoding.
+    """
+    script_pub_key = ScriptPubKey.from_address(addr).script
+    spend = to_spend(msg, script_pub_key)
+    psbt = Psbt.from_tx(to_sign(spend))
+    psbt.inputs[0].non_witness_utxo = spend
+    psbt.signed_message = bytes_from_octets(msg)
+    return psbt
+
+
 @dataclass(frozen=True)
 class Sig:
     """A BIP322 signature: what the variant carries, and nothing beside it.
@@ -337,6 +370,21 @@ def _psbt_prevouts(psbt: Psbt) -> list[TxOut]:
     return outs
 
 
+def _assert_op_return_output(tx: Tx) -> None:
+    """Refuse a `to_sign` whose output is not the one BIP322 fixes.
+
+    Exactly one, paying nothing, to an OP_RETURN: the output every
+    `to_sign` has, whatever the message and whatever the challenge. Its
+    own function because a verifier and a Signer ask it of two different
+    things -- a transaction that carries a signature, and a psbt that is
+    about to -- and one rule read in two places is one rule.
+    """
+    if len(tx.vout) != 1:
+        raise BTClibValueError(f"{len(tx.vout)} outputs in to_sign instead of one")
+    if tx.vout[0].value or tx.vout[0].script_pub_key.script != _OP_RETURN:
+        raise BTClibValueError("the output of to_sign is not the OP_RETURN of 0")
+
+
 def _assert_shape(tx: Tx, spend: Tx, prevouts: list[TxOut]) -> None:
     """Refuse a `to_sign` that is not one, the signature apart.
 
@@ -356,10 +404,7 @@ def _assert_shape(tx: Tx, spend: Tx, prevouts: list[TxOut]) -> None:
     if len(prevouts) != len(tx.vin):
         err_msg = f"{len(prevouts)} utxos for {len(tx.vin)} inputs"
         raise BTClibValueError(err_msg)
-    if len(tx.vout) != 1:
-        raise BTClibValueError(f"{len(tx.vout)} outputs in to_sign instead of one")
-    if tx.vout[0].value or tx.vout[0].script_pub_key.script != _OP_RETURN:
-        raise BTClibValueError("the output of to_sign is not the OP_RETURN of 0")
+    _assert_op_return_output(tx)
 
 
 def _assert_upgradeable(tx: Tx) -> None:
@@ -492,6 +537,76 @@ def verify(
         return False
 
     return True
+
+
+def _challenge_script(psbt: Psbt) -> bytes:
+    """Return the script_pub_key the psbt's first input spends.
+
+    Either utxo field answers it, and a psbt carries whichever its
+    Updater had. The non-witness one is indexed without a bounds check
+    because `assert_valid` is what the caller ran first: an outpoint
+    naming an output that transaction does not have is what it refuses.
+    """
+    psbt_in = psbt.inputs[0]
+    if psbt_in.witness_utxo is not None:
+        return psbt_in.witness_utxo.script_pub_key.script
+    if psbt_in.non_witness_utxo is None:
+        raise BTClibValueError("no utxo for the first input")
+    return psbt_in.non_witness_utxo.vout[
+        psbt_in.output_index or 0
+    ].script_pub_key.script
+
+
+def assert_signed_message(psbt: Psbt) -> bytes:
+    """Return the message this psbt is the BIP322 challenge of, or refuse.
+
+    The Signer's own question, and it is not "does the psbt carry a
+    message": a message that the transaction does not commit to is what
+    a device showing "signing message m" would be lying about. So the
+    field is one of five conditions and the other four are the psbt
+    being a `to_sign` -- an input to spend, its outpoint being output 0
+    of the `to_spend` this very message and this very challenge script
+    rebuild, and the one output that pays nothing to an OP_RETURN.
+
+    The challenge script comes from the psbt itself, which is what
+    leaves the caller nothing to be told: `assert_as_valid` is handed an
+    address and checks a signature against it, where a Signer has not
+    been told an address and is working out what it would be signing.
+    """
+    psbt.assert_valid()
+    msg = psbt.signed_message
+    if msg is None:
+        raise BTClibValueError("no signed message in the psbt")
+    if not psbt.inputs:
+        raise BTClibValueError("no input in to_sign")
+
+    tx = psbt.tx
+    spend = to_spend(msg, _challenge_script(psbt))
+    if tx.vin[0].prev_out != OutPoint(spend.id, 0):
+        err_msg = "the first input does not spend to_spend: "
+        err_msg += f"{tx.vin[0].prev_out.tx_id.hex()} instead of {spend.id.hex()}"
+        raise BTClibValueError(err_msg)
+    _assert_op_return_output(tx)
+    return msg
+
+
+def signed_message(psbt: Psbt) -> bytes | None:
+    """Return the message the psbt signs, or None if it signs no message.
+
+    `assert_signed_message` collapsed to what a signing device does with
+    it: a message to show in place of the spend, or nothing and the
+    spend as usual. None is both "no such field" and "a field the
+    transaction does not bear out", the second being the one worth an
+    exception, so a caller that has to tell them apart asks the other
+    one and reads what it says.
+    """
+    # as `verify` catches them, and for its reasons: a psbt that is not
+    # a BIP322 one is an answer rather than an error, and a TypeError is
+    # the caller handing this something that is not a psbt
+    try:
+        return assert_signed_message(psbt)
+    except (ValueError, BTClibRuntimeError):
+        return None
 
 
 def _is_bms(sig: String) -> bool:

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -54,6 +54,7 @@ from btclib.psbt.psbt_utils import (
     assert_not_a_v2_field,
     assert_valid_unknown,
     decode_dict_bytes_bytes,
+    deserialize_bytes,
     deserialize_count,
     deserialize_map,
     deserialize_sized_int,
@@ -92,6 +93,7 @@ __all__ = [
     "INPUTS_MODIFIABLE",
     "OUTPUTS_MODIFIABLE",
     "PSBT_GLOBAL_FALLBACK_LOCKTIME",
+    "PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE",
     "PSBT_GLOBAL_INPUT_COUNT",
     "PSBT_GLOBAL_OUTPUT_COUNT",
     "PSBT_GLOBAL_TX_MODIFIABLE",
@@ -132,6 +134,15 @@ PSBT_GLOBAL_FALLBACK_LOCKTIME = b"\x03"
 PSBT_GLOBAL_INPUT_COUNT = b"\x04"
 PSBT_GLOBAL_OUTPUT_COUNT = b"\x05"
 PSBT_GLOBAL_TX_MODIFIABLE = b"\x06"
+# BIP322's addition to BIP174's registry, and the only global field of
+# the eight that is not about the transaction being built: the message a
+# BIP322 signature is *for*, which the transaction says nothing about --
+# it spends a virtual output of 0 to an OP_RETURN of 0. A signer that
+# reads it shows "signing message m for address A" rather than "spending
+# 0 satoshi", which is the whole reason the field exists. Allowed in
+# versions 0 and 2 both, so it is neither in _V2_GLOBAL_FIELDS below nor
+# in the parser table beside it
+PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = b"\x09"
 PSBT_GLOBAL_VERSION = b"\xfb"
 # 0xfc is reserved for proprietary use, and needs no constant of its own:
 # explicit support for proprietary (and por) is unnecessary,
@@ -308,7 +319,11 @@ _V2_GLOBAL_PARSERS: dict[bytes, tuple[str, str, Callable[[bytes, bytes, str], in
 def _parse_global_map(
     global_map: Mapping[bytes, bytes], version: int
 ) -> tuple[
-    Tx | None, dict[str, int | None], dict[Octets, BIP32KeyOrigin], dict[Octets, Octets]
+    Tx | None,
+    dict[str, int | None],
+    dict[Octets, BIP32KeyOrigin],
+    dict[Octets, Octets],
+    bytes | None,
 ]:
     """Return what the global map holds: the transaction, if any, and the rest.
 
@@ -319,6 +334,11 @@ def _parse_global_map(
     indistinguishable from a *parsed* one with no inputs, and a count of
     0 from a psbt with no maps, so a check on the value would refuse the
     two zero-input psbts BIP174 lists as valid (issue 170).
+
+    The signed message is the same distinction and the one field where
+    it is the caller's to see: `None` is a psbt that carries no message
+    and `b""` one that carries the empty one, which BIP322 signs like
+    any other -- its own vectors do.
     """
     tx: Tx | None = None
     globals_: dict[str, int | None] = {
@@ -326,6 +346,7 @@ def _parse_global_map(
     }
     hd_key_paths: dict[Octets, BIP32KeyOrigin] = {}
     unknown: dict[Octets, Octets] = {}
+    signed_message: bytes | None = None
 
     for k, v in global_map.items():
         type_ = k[:1]
@@ -333,6 +354,11 @@ def _parse_global_map(
         if type_ in _V2_GLOBAL_PARSERS:
             field, what, deserialize = _V2_GLOBAL_PARSERS[type_]
             globals_[field] = deserialize(k, v, what)
+        elif type_ == PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE:
+            # keydata "none", so a key longer than its type byte is a
+            # second field of one type rather than this one, which
+            # deserialize_bytes refuses for every field written that way
+            signed_message = deserialize_bytes(k, v, "global signed message")
         elif type_ == PSBT_GLOBAL_UNSIGNED_TX:
             if version != PSBT_V0:
                 err_msg = "PSBT_GLOBAL_UNSIGNED_TX is not allowed in a v2 psbt"
@@ -347,7 +373,7 @@ def _parse_global_map(
         else:  # unknown
             unknown[k] = v
 
-    return tx, globals_, hd_key_paths, unknown
+    return tx, globals_, hd_key_paths, unknown, signed_message
 
 
 def _settle_globals(
@@ -639,6 +665,7 @@ class Psbt:
     unknown: dict[bytes, bytes]
     fallback_lock_time: int | None
     tx_modifiable: int | None
+    signed_message: bytes | None
 
     @property
     def lock_time(self) -> int:
@@ -797,6 +824,7 @@ class Psbt:
         unknown: Mapping[Octets, Octets] | None = None,
         fallback_lock_time: int | None = None,
         tx_modifiable: int | None = None,
+        signed_message: Octets | None = None,
         *,
         check_validity: bool = True,
     ) -> None:
@@ -808,6 +836,11 @@ class Psbt:
         self.unknown = dict(sorted(decode_dict_bytes_bytes(unknown).items()))
         self.fallback_lock_time = fallback_lock_time
         self.tx_modifiable = tx_modifiable
+        # `is None` and not truthiness: the empty message is a message,
+        # and the absence of the field is what says there is none
+        self.signed_message = (
+            None if signed_message is None else bytes_from_octets(signed_message)
+        )
 
         if check_validity:
             self.assert_valid()
@@ -925,6 +958,12 @@ class Psbt:
             "unknown": dict(sorted(encode_dict_bytes_bytes(self.unknown).items())),
             "fallback_lock_time": self.fallback_lock_time,
             "tx_modifiable": self.tx_modifiable,
+            # hex like every other octet string here, and `None` where
+            # the field is absent: the empty string is the message of
+            # zero octets, which is a message
+            "signed_message": (
+                None if self.signed_message is None else self.signed_message.hex()
+            ),
             # what the fields above make, for whoever is reading rather
             # than round-tripping: from_dict ignores it, as it must --
             # two ways in would let a dict say two different things.
@@ -964,6 +1003,7 @@ class Psbt:
             dict_["unknown"],
             dict_["fallback_lock_time"],
             dict_["tx_modifiable"],
+            dict_["signed_message"],
             check_validity=check_validity,
         )
 
@@ -1027,6 +1067,15 @@ class Psbt:
             # skipped over
             _assert_valid_version(self.version)
 
+        # written by both versions, BIP322 allowing it in either, and
+        # written here rather than in the two branches above for that
+        # reason. `is not None`: the empty message is a message, and a
+        # psbt that carries the field with nothing in it is a psbt whose
+        # signer must be shown the empty message rather than a spend
+        if self.signed_message is not None:
+            psbt_bin.append(
+                serialize_bytes(PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE, self.signed_message)
+            )
         if self.version:
             temp = self.version.to_bytes(4, byteorder="little", signed=False)
             psbt_bin.append(serialize_bytes(PSBT_GLOBAL_VERSION, temp))
@@ -1072,7 +1121,9 @@ class Psbt:
         # a map has no order to put the version first in
         version = _global_version(global_map)
         _assert_valid_version(version)
-        tx, globals_, hd_key_paths, unknown = _parse_global_map(global_map, version)
+        tx, globals_, hd_key_paths, unknown, signed_message = _parse_global_map(
+            global_map, version
+        )
         _settle_globals(tx, globals_, version)
         input_count = cast(int, globals_["input_count"])
         output_count = cast(int, globals_["output_count"])
@@ -1103,6 +1154,7 @@ class Psbt:
             unknown,
             globals_["fallback_lock_time"],
             globals_["tx_modifiable"],
+            signed_message,
             check_validity=check_validity,
         )
 
@@ -1274,12 +1326,13 @@ def _combine_field(
 def _combine_optional_field(
     psbt_map: PsbtIn | PsbtOut | Psbt, out: PsbtIn | PsbtOut | Psbt, key: str
 ) -> None:
-    """Add one optional integer field of psbt_map to out.
+    """Add one optional field of psbt_map to out, whatever it holds.
 
     _combine_field's rule -- take it when out has none, keep out's when
     it has one -- read with `is not None` rather than with truthiness,
     which for these fields answers the wrong question: 0 is a sequence
-    BIP125 gives a meaning to, and an amount of 0 is an amount.
+    BIP125 gives a meaning to, an amount of 0 is an amount, and the
+    empty signed message is a message.
     """
     item = getattr(psbt_map, key)
     if item is None:
@@ -1460,6 +1513,11 @@ def combine(psbts: Sequence[Psbt]) -> Psbt:
         # for combine([a, b]) and another for combine([b, a]), the copy
         # merged into being the one that happened to come first
         _combine_optional_field(psbt, final_psbt, "fallback_lock_time")
+        # the optional rule and not the truthy one, for the reason that
+        # function gives: the empty message is a message, and taking it
+        # only when it is non-empty would answer one thing for
+        # combine([a, b]) and another for combine([b, a])
+        _combine_optional_field(psbt, final_psbt, "signed_message")
 
     return final_psbt
 
@@ -2696,6 +2754,13 @@ def join(
     every psbt in the sequence, so without the copy the joined psbt's
     inputs *are* theirs, and an Updater filling one in afterwards fills
     in a psbt somebody else is still holding.
+
+    A signed message is not carried over, and that is not an omission:
+    it says which challenge *this* transaction answers, and joining
+    builds a transaction that is not it -- BIP322 binds the message to
+    the first input's outpoint, which the join can move. A caller
+    building a proof of funds this way sets the field on the result,
+    where what it names is a transaction that exists.
     """
     _ensure_consistency(psbts)
     psbts = deepcopy(list(psbts))

--- a/tests/bip322_test.py
+++ b/tests/bip322_test.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import base64
 import dataclasses
+from copy import deepcopy
 from typing import Any
 
 import pytest
@@ -32,7 +33,7 @@ from btclib.exceptions import (
     InconclusiveError,
 )
 from btclib.hashes import hash160
-from btclib.psbt import Psbt
+from btclib.psbt import Psbt, finalize
 from btclib.script import ScriptPubKey, address, serialize
 from btclib.script.engine import ALL_FLAGS, ScriptFlag
 from btclib.script.sig_hash import (
@@ -753,3 +754,146 @@ def test_a_broken_required_rule_answers_before_an_upgradeable_one(
         return
     with pytest.raises(BTClibValueError, match="BIP322 requires SIGHASH_ALL"):
         bip322.assert_as_valid(msg, addr, sig)
+
+
+@pytest.mark.parametrize("script_type", ["p2pkh", "p2wpkh", "p2sh-p2wpkh", "p2tr"])
+@pytest.mark.parametrize("msg", [b"", b"Hello World", "öäüéàè 测试文本 😄".encode()])
+def test_a_created_psbt_says_which_message_it_signs(
+    script_type: str, msg: bytes
+) -> None:
+    """What the Creator writes, the Signer reads: the round trip of #516.
+
+    Through the wire form, which is the point of registering the field:
+    a psbt that says what is being signed is only useful if it still
+    says it after the trip to the device. The empty message goes through
+    the same as the others -- absent and empty are two answers, and the
+    field is what tells them apart.
+    """
+    addr = _address(WIF, script_type)
+    psbt = bip322.to_sign_psbt(msg, addr)
+
+    assert psbt.signed_message == msg
+    assert bip322.signed_message(psbt) == msg
+    assert bip322.assert_signed_message(psbt) == msg
+
+    parsed = Psbt.b64decode(psbt.b64encode())
+    assert parsed == psbt
+    assert bip322.signed_message(parsed) == msg
+
+    # and it is a `to_sign` of that very challenge, which is what makes
+    # the message worth showing: the psbt signs the address it names
+    spend = bip322.to_spend(msg, ScriptPubKey.from_address(addr).script)
+    assert psbt.tx.vin[0].prev_out == OutPoint(spend.id, 0)
+    assert psbt.inputs[0].non_witness_utxo == spend
+
+
+def test_a_psbt_that_signs_no_message() -> None:
+    """The three answers a Signer gets, and the two that are the same one.
+
+    No field is `None` and no exception: an ordinary psbt spending
+    ordinary coins, which a device shows as the spend it is. A field the
+    transaction does not bear out is `None` too, and *that* is the one
+    worth an exception -- a device showing "signing message m" for a
+    transaction that does not commit to m would be lying about it.
+    """
+    msg, addr = b"the challenge", _address(WIF, "p2wpkh")
+    psbt = bip322.to_sign_psbt(msg, addr)
+
+    plain = Psbt.from_tx(psbt.tx)
+    assert plain.signed_message is None
+    assert bip322.signed_message(plain) is None
+    with pytest.raises(BTClibValueError, match="no signed message in the psbt"):
+        bip322.assert_signed_message(plain)
+
+    # the field alone is not the answer: this psbt spends the output of
+    # a `to_spend` built from another message, so the message it claims
+    # is one the transaction does not commit to
+    lying = bip322.to_sign_psbt(msg, addr)
+    lying.signed_message = b"another message entirely"
+    assert bip322.signed_message(lying) is None
+    with pytest.raises(BTClibValueError, match="does not spend to_spend"):
+        bip322.assert_signed_message(lying)
+
+
+def test_a_signed_message_psbt_is_a_to_sign_in_every_field() -> None:
+    """Each of the five conditions, refused one at a time.
+
+    The message is checked against what the psbt itself says the
+    challenge is -- the script of the output its first input spends --
+    so a psbt with no utxo for that input is a psbt with nothing to
+    check the message against, and not one that passes.
+    """
+    msg, addr = b"five conditions", _address(WIF, "p2wpkh")
+
+    no_utxo = bip322.to_sign_psbt(msg, addr)
+    no_utxo.inputs[0].non_witness_utxo = None
+    with pytest.raises(BTClibValueError, match="no utxo for the first input"):
+        bip322.assert_signed_message(no_utxo)
+
+    # the witness utxo answers it as well, which is the field a psbt of
+    # a segwit challenge may carry instead
+    witness_utxo = bip322.to_sign_psbt(msg, addr)
+    spend = witness_utxo.inputs[0].non_witness_utxo
+    assert spend is not None
+    witness_utxo.inputs[0].non_witness_utxo = None
+    witness_utxo.inputs[0].witness_utxo = spend.vout[0]
+    assert bip322.assert_signed_message(witness_utxo) == msg
+
+    # the outpoint is output 0 of to_spend, and the index is half of
+    # that condition: `to_spend` has one output, so any other index is a
+    # challenge that does not exist. Moved on the witness utxo, the
+    # non-witness one having a vout for `assert_valid` to bound it by --
+    # which is the same refusal one question earlier
+    wrong_vout = deepcopy(witness_utxo)
+    wrong_vout.inputs[0].output_index = 1
+    with pytest.raises(BTClibValueError, match="does not spend to_spend"):
+        bip322.assert_signed_message(wrong_vout)
+
+    # and the output every to_sign has: exactly one, paying nothing to
+    # an OP_RETURN
+    for amount, script in ((0, b"\x6a\x51"), (1, b"\x6a")):
+        wrong_output = bip322.to_sign_psbt(msg, addr)
+        wrong_output.outputs[0].amount = amount
+        wrong_output.outputs[0].script_pub_key = script
+        with pytest.raises(BTClibValueError, match="not the OP_RETURN"):
+            bip322.assert_signed_message(wrong_output)
+
+    two_outputs = bip322.to_sign_psbt(msg, addr)
+    two_outputs.outputs.append(deepcopy(two_outputs.outputs[0]))
+    with pytest.raises(BTClibValueError, match="outputs in to_sign"):
+        bip322.assert_signed_message(two_outputs)
+
+    no_input = bip322.to_sign_psbt(msg, addr)
+    no_input.inputs.clear()
+    with pytest.raises(BTClibValueError, match="no input in to_sign"):
+        bip322.assert_signed_message(no_input)
+
+
+def test_a_created_psbt_is_signed_and_finalized_into_a_proof() -> None:
+    """The flow the field is there for, end to end.
+
+    A 2-of-2 p2wsh: the Creator writes the psbt and the message in it,
+    the Signer reads the message rather than the spend, `psbt.sign` and
+    `psbt.finalize` play their roles, and what comes out is the proof of
+    funds `assert_as_valid` accepts. Which is the whole point of the
+    coordination flow -- the psbt is how the two signatures meet, and
+    the field is how the second signer knows what it is signing.
+    """
+    keys = [pub_keyinfo_from_key(wif, compressed=True)[0] for wif in (WIF, OTHER_WIF)]
+    witness_script = serialize(["OP_2", *keys, "OP_2", "OP_CHECKMULTISIG"])
+    addr = p2wsh(witness_script)
+    msg = b"two keys, one psbt"
+
+    psbt = bip322.to_sign_psbt(msg, addr)
+    assert bip322.signed_message(psbt) == msg
+
+    spend = bip322.to_spend(msg, ScriptPubKey.from_address(addr).script)
+    psbt.inputs[0].witness_utxo = spend.vout[0]
+    psbt.inputs[0].witness_script = witness_script
+    msg_hash = segwit_v0(witness_script, psbt.tx, 0, ALL, 0)
+    for key, wif in zip(keys, (WIF, OTHER_WIF), strict=True):
+        psbt.inputs[0].partial_sigs[key] = dsa_sign(msg_hash, wif)
+
+    sig = bip322.Sig(finalize(psbt))
+    assert sig.variant == bip322.PROOF_OF_FUNDS
+    assert bip322.verify(msg, addr, sig.b64encode())

--- a/tests/psbt/_generated_files/psbt.json
+++ b/tests/psbt/_generated_files/psbt.json
@@ -234,6 +234,7 @@
     "unknown": {},
     "fallback_lock_time": 0,
     "tx_modifiable": null,
+    "signed_message": null,
     "tx": {
         "txid": "82efd652d7ab1197f01a5f4d9a30cb4c68bb79ab6fec58dfa1bf112291d1617b",
         "hash": "82efd652d7ab1197f01a5f4d9a30cb4c68bb79ab6fec58dfa1bf112291d1617b",

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -1375,6 +1375,103 @@ def test_global_unknown() -> None:
     assert Psbt.b64decode(psbt.b64encode()) == psbt
 
 
+def _one_input_psbt() -> Psbt:
+    """Return the smallest psbt these tests need: one input, one output."""
+    tx_in = TxIn(OutPoint(bytes(range(32)), 1), b"", 0xFFFFFFFF)
+    tx_out = TxOut(2500000, "a914f987c321394968be164053d352fc49763b2be55c87")
+    return Psbt.from_tx(Tx(1, 0, [tx_in], [tx_out]))
+
+
+@pytest.mark.parametrize("message", [b"hello world", b"", "öäü \U0001f604".encode()])
+def test_the_signed_message_round_trips_in_both_versions(message: bytes) -> None:
+    """BIP322's global field, a field now rather than an unknown key.
+
+    "Versions allowing inclusion: 0, 2" is what keeps it out of the
+    BIP370 table beside it, and is what the two halves below are: the
+    same message in a version 0 psbt and in the version 2 psbt of the
+    same transaction, each written and read back as itself. Nothing is
+    left under `unknown`, which is where it went before it was a field
+    and is what says the registration took.
+
+    The empty message is the case a truthiness test loses: BIP322 signs
+    it like any other -- its own vectors do -- so what says a psbt
+    carries no message is the absence of the field, not an empty value.
+    """
+    psbt = _one_input_psbt()
+    assert psbt.signed_message is None
+
+    for one in (psbt, psbt.to_v2()):
+        one.signed_message = message
+        parsed = Psbt.parse(one.serialize())
+        assert parsed.signed_message == message
+        assert not parsed.unknown
+        assert parsed == one
+        assert Psbt.from_dict(one.to_dict()) == one
+
+
+def test_the_signed_message_key_is_its_type_byte_alone() -> None:
+    """<keydata> is "none", so a longer key is not this field.
+
+    The rule every field written that way is held to, and the reason it
+    is a rule: a key of two octets is a second field of one type, which
+    is one psbt with two messages in it.
+    """
+    psbt = _one_input_psbt()
+    psbt.signed_message = b"hi"
+    raw = psbt.serialize()
+
+    # 0x01 0x09, the key length and the global type, then the message as
+    # a var_bytes; the replacement is the same field with a zero octet
+    # of keydata after the type
+    assert raw.count(bytes.fromhex("0109026869")) == 1
+    keyed = raw.replace(bytes.fromhex("0109026869"), bytes.fromhex("020900026869"))
+    with pytest.raises(BTClibValueError, match="invalid global signed message key"):
+        Psbt.parse(keyed)
+
+
+def test_combining_takes_a_signed_message_from_either_side() -> None:
+    """The Combiner's rule for a field that is one key-value pair.
+
+    Taken where the psbt combined into has none, kept where it has one,
+    and the empty message is a message in both directions: a truthy test
+    would drop it, so combine([a, b]) and combine([b, a]) would answer
+    differently for the same pair.
+    """
+    for message in (b"a message", b""):
+        plain, carrying = _one_input_psbt(), _one_input_psbt()
+        carrying.signed_message = message
+        assert combine([deepcopy(plain), deepcopy(carrying)]).signed_message == message
+        assert combine([deepcopy(carrying), deepcopy(plain)]).signed_message == message
+
+    kept, other = _one_input_psbt(), _one_input_psbt()
+    kept.signed_message = b"the first"
+    other.signed_message = b"the second"
+    assert combine([kept, other]).signed_message == b"the first"
+
+    assert combine([_one_input_psbt(), _one_input_psbt()]).signed_message is None
+
+
+def test_joining_does_not_carry_a_signed_message_over() -> None:
+    """A message names a transaction, and joining builds another one.
+
+    BIP322 binds the message to the first input's outpoint, and a join
+    can put a different input first; carrying the field over would name
+    a challenge the joined transaction does not answer.
+    """
+    first = _one_input_psbt()
+    first.signed_message = b"mine"
+    second = Psbt.from_tx(
+        Tx(
+            1,
+            0,
+            [TxIn(OutPoint(bytes(reversed(range(32))), 0), b"", 0xFFFFFFFF)],
+            [TxOut(1000, "a914f987c321394968be164053d352fc49763b2be55c87")],
+        )
+    )
+    joined = join([first, second], False, False, False, False)
+    assert joined.signed_message is None
+
+
 def test_output_unknown() -> None:
     """Round-trip a psbt carrying an unknown output key."""
     psbt_str = "cHNidP8BAJoCAAAAAljoeiG1ba8MI76OcHBFbDNvfLqlyHV5JPVFiHuyq911AAAAAAD/////g40EJ9DsZQpoqka7CwmK6kQiwHGyyng1Kgd5WdB86h0BAAAAAP////8CcKrwCAAAAAAWABTYXCtx0AYLCcmIauuBXlCZHdoSTQDh9QUAAAAAFgAUAK6pouXw+HaliN9VRuh0LR2HAI8AAAAAAAEAuwIAAAABqtc5MQGL0l+ErkALaISL4J23BurCrBgpi6vucatlb4sAAAAASEcwRAIgWPb8fGoz4bMVSNSByCbAFb0wE1qtQs1neQ2rZtKtJDsCIEoc7SYExnNbY5PltBaR3XiwDwxZQvufdRhW+qk4FX26Af7///8CgPD6AgAAAAAXqRQPuUY0IWlrgsgzryQceMF9295JNIfQ8gonAQAAABepFCnKdPigj4GZlCgYXJe12FLkBj9hh2UAAAAiAgKVg785rgpgl0etGZrd1jT6YQhVnWxc05tMIYPxq5bgf0cwRAIgdAGK1BgAl7hzMjwAFXILNoTMgSOJEEjn282bVa1nnJkCIHPTabdA4+tT3O+jOCPIBwUUylWn3ZVE8VfBZ5EyYRGMASICAtq2H/SaFNtqfQKwzR+7ePxLGDErW05U2uTbovv+9TbXSDBFAiEA9hA4swjcHahlo0hSdG8BV3KTQgjG0kRUOTzZm98iF3cCIAVuZ1pnWm0KArhbFOXikHTYolqbV2C+ooFvZhkQoAbqAQEDBAEAAAABBEdSIQKVg785rgpgl0etGZrd1jT6YQhVnWxc05tMIYPxq5bgfyEC2rYf9JoU22p9ArDNH7t4/EsYMStbTlTa5Nui+/71NtdSriIGApWDvzmuCmCXR60Zmt3WNPphCFWdbFzTm0whg/GrluB/ENkMak8AAACAAAAAgAAAAIAiBgLath/0mhTban0CsM0fu3j8SxgxK1tOVNrk26L7/vU21xDZDGpPAAAAgAAAAIABAACAAAEBIADC6wsAAAAAF6kUt/X69A49QKWkWbHbNTXyty+pIeiHIgIDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtxHMEQCIGLrelVhB6fHP0WsSrWh3d9vcHX7EnWWmn84Pv/3hLyyAiAMBdu3Rw2/LwhVfdNWxzJcHtMJE+mWzThAlF2xIijaXwEiAgI63ZBPPW3PWd25BrDe4jUpt/+57VDl6GFRkmhgIh8Oc0cwRAIgZfRbpZmLWaJ//hp77QFq8fH5DVSzqo90UKpfVqJRA70CIH9yRwOtHtuWaAsoS1bU/8uI9/t1nqu+CKow8puFE4PSAQEDBAEAAAABBCIAIIwjUxc3Q7WV37Sge3K6jkLjeX2nTof+fZ10l+OyAokDAQVHUiEDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtwhAjrdkE89bc9Z3bkGsN7iNSm3/7ntUOXoYVGSaGAiHw5zUq4iBgI63ZBPPW3PWd25BrDe4jUpt/+57VDl6GFRkmhgIh8OcxDZDGpPAAAAgAAAAIADAACAIgYDCJ3BDHrG21T5EymvYXMz2ziM6tDCMfcjN50bmQMLAtwQ2QxqTwAAAIAAAACAAgAAgAAiAgOppMN/WZbTqiXbrGtXCvBlA5RJKUJGCzVHU+2e7KWHcRDZDGpPAAAAgAAAAIAEAACAACICAn9jmXV9Lv9VoTatAsaEsYOLZVbl8bazQoKpS2tQBRCWENkMak8AAACAAAAAgAUAAIAA"


### PR DESCRIPTION
Closes #516.

BIP322 v1.0.0 adds one global to BIP174's registry and #515 implemented
everything around it. This is the field, and the two functions it is
useless without.

## `btclib.psbt`

`PSBT_GLOBAL_GENERIC_SIGNED_MESSAGE = 0x09` and `Psbt.signed_message:
bytes | None`, through every place a global is spelled: `__init__`,
`to_dict`/`from_dict`, `serialize`, `_parse_global_map`, `parse`,
`combine`, and the golden `tests/psbt/_generated_files/psbt.json`.

Three details worth review:

- **it is in neither version table.** "Versions allowing inclusion: 0,
  2" is unique to it — every field in `_V2_GLOBAL_PARSERS` is version 2
  only — so it is parsed by a branch of its own and written outside the
  two version arms of `serialize`.
- **`None` and `b""` are two answers.** The empty message is a message
  BIP322 signs like any other (its own vectors do), so what says a psbt
  carries none is the absence of the field. That is why `combine` uses
  `_combine_optional_field` and not `_combine_field`: the truthy rule
  would drop the empty message, and `combine([a, b])` and `combine([b,
  a])` would then disagree.
- **`join` does not carry it over**, and says so: the message names the
  transaction it is a challenge for — BIP322 binds it to the first
  input's outpoint — and a join builds another one.

`assert_valid` gained nothing, and that is deliberate: the field is
octets of any length, `__init__` converts them, and every rule that
could be checked about it is a rule about the *transaction* — which is
`btclib.bip322`'s to ask, the layering running that way. Say if you
would rather have a stub there.

## `btclib.bip322`

- `to_sign_psbt(msg, addr)` — the Creator: the psbt of `to_sign`, the
  message in the global field, and the whole of `to_spend` as the first
  input's `non_witness_utxo`. The whole transaction rather than its one
  output as a `witness_utxo` because it is the answer for a challenge
  script of any type, where a witness utxo is the answer for the segwit
  ones alone.
- `signed_message(psbt)` — the Signer's question: the message this psbt
  signs, or `None`. The field alone is not that answer, and this is the
  half a library can be held to — a message the transaction does not
  commit to is what a device showing "signing message m" would be lying
  about. So it is one of five conditions, the other four being the psbt
  being a `to_sign` of that very message and that very challenge script,
  read off the psbt's own first input.
- `assert_signed_message(psbt)` — the same with the reason, for a caller
  that has to tell "no field" from "a field this psbt does not bear
  out". The pair is `assert_as_valid`/`verify` again.

`_assert_op_return_output` is the one condition a verifier already
asked; it is now one function asked by both.

**The naming is the decision I would most like reviewed**:
`bip322.signed_message` reads as the question and sits next to
`Psbt.signed_message`, which is the raw field it validates. If that
proximity is more confusing than useful, `message_of` / `assert_message_of`
is a one-line rename.

## Tests

`tests/psbt/psbt_test.py`: the round trip in both psbt versions, three
messages including the empty one, with nothing left under `unknown`;
the key being its type byte alone; the Combiner from either side and the
conflict kept; `join` dropping it. `tests/bip322_test.py`: the Creator
read back by the Signer through the base64 form, for the four
single-key challenge types and three messages; a psbt that signs no
message and one that claims a message it does not commit to; each of
the five conditions refused on its own; and the flow end to end — 2-of-2
p2wsh created, signed, finalized, verified as a proof of funds.

Suite green with `--cov` at 100%, `pre-commit run --all-files` and the
sphinx `-W` build both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Register the BIP322 PSBT global generic signed message field and wire it through PSBT and BIP322, enabling creation and validation of message-signing PSBTs and testing the full coordination flow.

New Features:
- Expose Psbt.signed_message to represent the BIP322 generic signed message global field across PSBT parsing, serialization, and dict conversion.
- Add bip322.to_sign_psbt to construct a PSBT-based BIP322 signing challenge carrying the message and its corresponding to_spend transaction.
- Add bip322.signed_message and bip322.assert_signed_message to derive or assert the message a PSBT signs based on its structure and BIP322 rules.

Enhancements:
- Ensure PSBT combine and join respect the semantics of the signed_message field, including correct handling of empty messages and omitting it on joined transactions.
- Refactor BIP322 validation helpers (e.g., OP_RETURN output and challenge script extraction) to support PSBT-based message-signing verification.
- Update CHANGELOG with documentation of the new PSBT signed message field and the BIP322 coordination flow APIs.

Tests:
- Extend psbt tests to cover signed_message round-trips in v0 and v2 PSBTs, key encoding validation, combiner behavior, and join semantics.
- Add bip322 tests that exercise creator/signer round-trip, handling of PSBTs with no or inconsistent signed messages, per-condition failures, and an end-to-end 2-of-2 p2wsh proof-of-funds flow.