### PR TITLE
Write down which boundary a class can be asked about (#517)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -744,6 +744,21 @@ documented at release-notes length in the first place, and are still in
   the curve nearly every caller wants and says the catalogue holds more,
   which is what a reader arriving at the package needs. Counting is what
   a release does, when it wants the number.
+- **The parse contract says which boundary a class can be asked about**
+  (#517). `check_validity` gates one flag at three of them -- the object,
+  the json and the octets -- and only the first two ask "is this object
+  well formed"; the third asks "do these octets decode into something
+  that is not", which for a class whose invariants are exactly the widths
+  of its fields nothing can. That was true and written nowhere: a
+  contributor met it when a case broke in their hands, the knowledge
+  living in two exclusion sets inside `tests/check_validity_test.py`.
+  `btclib/utils.py` now states it beside the structural rule it belongs
+  to -- a class whose invariants its encoding already enforces is one in
+  good order rather than one missing a check -- and names the two that
+  are in that position, `OutPoint` and the `TxIn` whose only invalidable
+  child is one. Which is also why those two lose their fixtures in that
+  test file: what each demonstrated was a *type* error standing in for a
+  value error, and the fact is worth more written down than acted out.
 
 ### Tests
 

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -25,6 +25,29 @@ A fixed-size object read whole -- a 78-byte bip32 key, a 65-byte bms
 signature, an 80-byte block header -- reports its own decoded length
 instead of naming a field, the buffer being the object and not a part of
 one; that check is unconditional for the same reason.
+
+What `check_validity` does gate is the semantic half, and *where* it can
+be asked is not the same at the three boundaries the flag appears at.
+The object (`serialize`) and the json (`to_dict`/`from_dict`) ask "is
+this object well formed"; the octets (`parse`) ask "do these octets
+decode into something that is not" -- and for a class whose invariants
+are exactly the widths of its fields, nothing can. The decoding enforces
+them by construction, so at that boundary the flag is unreachable by
+design rather than unchecked, and the class is one in good order rather
+than one missing a check. `OutPoint` is such a class: 32 octets of
+tx_id and four of vout, every value of which is a valid outpoint since
+Bitcoin Core was found to accept the shapes it used to refuse. A class
+whose only invalidable child is one -- `TxIn`, whose own fields are of
+the same kind -- inherits the property.
+
+The two are not the same question asked twice, which is why an object
+can be asked one and not the other: an invalidity of *type* rather than
+of value survives the json and not the octets, a bool being an int that
+reads back as the number one, while an amount above MoneyRange survives
+the octets and not the json, the conversion to BTC asking what
+`assert_valid` would ask. `tests/check_validity_test.py` is where the
+cases live, one per class and boundary, and this is the rule they are
+read under.
 """
 
 from __future__ import annotations

--- a/tests/check_validity_test.py
+++ b/tests/check_validity_test.py
@@ -16,6 +16,12 @@ check. Nothing held any of those defaults to it -- the mutation profile of
 issue #327 reported one survivor per default and per `if check_validity:`
 in `btclib/tx/` -- and the tests at the end of this module are what does,
 over the wire-format classes that profile measures.
+
+Which of the three boundaries a class can be asked about is not this
+file's to decide, and the exclusion sets below are not where that rule
+is written: it is in `btclib/utils.py`, beside the parse contract, and a
+class missing from one of these lists is a class whose invariants its
+encoding already enforces rather than one nobody got round to.
 """
 
 from __future__ import annotations
@@ -165,14 +171,14 @@ def test_a_parameter_before_the_flag_stays_positional() -> None:
 
 # an outpoint whose vout is a bool, which `is_integer` refuses: a bool is
 # an int, so it passes every range check, and naming the type is the
-# whole of what assert_valid has to say about it.
-# It used to be the half-coinbase outpoint -- the all-zero tx_id with a
-# real vout -- which is a valid OutPoint since issue 513, Bitcoin Core
-# accepting it. What is left to be invalid about the two fields is a
-# tx_id of the wrong length and a vout outside four bytes or beside the
-# type, and only the last of the three survives a conversion: the other
-# two are what serialize and to_dict cannot write, rather than what
-# assert_valid refuses about what they wrote
+# whole of what assert_valid has to say about it. What it stands in for
+# is nothing: an `OutPoint` has no invalidity of *value* left to be
+# asked about, 32 octets of tx_id and four of vout being an outpoint
+# whatever they hold, and a `TxIn` has no child that has one. The rule
+# that makes that a type in good order rather than a class missing a
+# check is written down in `btclib/utils.py`, beside the parse contract
+# it belongs to; here it is why neither class has a case of its own, and
+# why the transaction below has to reach for a bool to have one
 _BOOL_VOUT = OutPoint(b"\x01" * 32, True, check_validity=False)
 _GOOD_OUT_POINT = OutPoint(b"\x01" * 32, 0)
 
@@ -197,9 +203,7 @@ _GOOD_OUT_POINT = OutPoint(b"\x01" * 32, 0)
 # MoneyRange all serialize, so what refuses them is the flag and not the
 # arithmetic underneath
 _INVALID: list[tuple[str, Any]] = [
-    ("outpoint", _BOOL_VOUT),
     ("tx_in-itself", TxIn(_GOOD_OUT_POINT, b"", True, check_validity=False)),
-    ("tx_in-nested", TxIn(_BOOL_VOUT, check_validity=False)),
     ("tx_out", TxOut(_MAX_SATOSHI + 1, "", check_validity=False)),
     ("tx-itself", Tx(1, 0, [], [TxOut(1, "")], check_validity=False)),
     # two nested transactions and not one, because the two boundaries
@@ -234,12 +238,12 @@ _INVALID: list[tuple[str, Any]] = [
 # all, the input count being where the segwit marker lives, so its `\x00`
 # opens a witness section rather than an empty list.
 #
-# That takes the outpoint and everything holding one out of the octets
-# test, and `tx-nested-out` is what keeps a nested case in it: an amount
-# above MoneyRange survives the round trip, eight little-endian bytes
-# carrying it, and `Tx.assert_valid` reaches it through
-# `tx_out.assert_valid()` before the total it would also refuse
-_NO_OCTETS = {"outpoint", "tx_in-itself", "tx_in-nested", "tx-itself", "tx-nested-in"}
+# That takes everything holding a bool out of the octets test, and
+# `tx-nested-out` is what keeps a nested case in it: an amount above
+# MoneyRange survives the round trip, eight little-endian bytes carrying
+# it, and `Tx.assert_valid` reaches it through `tx_out.assert_valid()`
+# before the total it would also refuse
+_NO_OCTETS = {"tx_in-itself", "tx-itself", "tx-nested-in"}
 
 # and what a dict cannot be asked. TxOut's only validity question is the
 # amount, and `to_dict` puts that amount through `btc_from_sats`, which is


### PR DESCRIPTION
Closes #517.

Both decisions the issue puts, taken the way its own opinion leans. The
first is a deletion and the maintainer's call, so it is easy to reverse:
it is one hunk of `tests/check_validity_test.py`.

## 2. Where the rule gets written down

`btclib/utils.py`, beside the structural half it already draws. One
paragraph: which of the three boundaries a class can be asked about
depends on whether its invariants outlive its encoding, a class whose do
not is not missing a check, and the two that are in that position are
named — `OutPoint` and the `TxIn` whose only invalidable child is one.

A second paragraph states the asymmetry the two exclusion sets encode,
because it is the part that reads as an oversight until it is written
down: an invalidity of *type* survives the json and not the octets (a
bool is an int that reads back as one), an amount above MoneyRange
survives the octets and not the json (the conversion to BTC asks what
`assert_valid` would).

`tests/check_validity_test.py`'s module docstring now points there,
which is the defect the issue actually names: the rule was discoverable
only by breaking a test.

## 1. The bool-vout fixture

Dropped for `outpoint` and `tx_in-nested`, exactly the two the issue
names, and the prose above says the fact instead. Coverage is unchanged
at 100% — nothing those two held is held by them alone.

**Where I would like a second opinion:** the same `_BOOL_VOUT` is still
used by `tx-nested-in`, which is what holds "`Tx.to_dict` validates a
nested input", and `tx_in-itself` reaches for a bool `sequence` for the
same kind of reason. So the fixture does not disappear, and the prose is
careful to say what is true — an `OutPoint` has no invalidity of *value*
left, and the transaction below has to reach for a bool to have a case
at all. If you would rather the file stopped using bools entirely, that
is a larger change than this issue: `TxIn`'s own remaining invalidity is
a bool `sequence` too, so the two nested transaction cases would have to
be rebuilt on `TxOut` alone, and the "`Tx.to_dict` validates its inputs"
case would go with them.

The other direction — keeping all three cases and writing only the rule
— is the first two hunks of this diff without the third.

Suite green with `--cov` at 100% (18363 tests, four fewer),
`pre-commit run --all-files` and the sphinx `-W` build both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document the validity-checking boundaries for transaction-related classes and align tests and changelog with the clarified parse contract.

Enhancements:
- Clarify in the utils module when `check_validity` applies at object, JSON, and octet boundaries, explicitly naming classes whose invariants are enforced by encoding.

Documentation:
- Add documentation of the parse contract and boundary rules for `check_validity` to `btclib/utils.py` and the project changelog.

Tests:
- Update validity-checking tests to remove now-redundant fixtures for `OutPoint` and certain `TxIn` cases, and adjust exclusion sets to reflect the documented boundary rules.