### PR TITLE
Take six pinned hook revisions and cosmic-ray to their newest release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -188,7 +188,7 @@ repos:
   # here: the skip list needs a paragraph of justification, and a hook
   # invocation is the wrong place for one
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.1
+    rev: v2.4.3
     hooks:
       - id: codespell
         name: codespell (prose and comments)
@@ -211,7 +211,13 @@ repos:
   # README's `bitcon` included. pyproject.toml ([tool.typos]) has the whole
   # of the reasoning and the configuration, as for codespell
   - repo: https://github.com/crate-ci/typos
-    rev: v1.48.0
+    # a release tag, not the `v1` beside it: that one is a major-version
+    # alias upstream moves onto each release, so `pre-commit autoupdate`
+    # picks it as the newest tag and the pin stops being one -- the hook
+    # would then follow every future 1.x, which is the whole of what a rev
+    # is here to prevent. A dictionary that grows under a fixing hook is
+    # not a detail: this one rewrites what it reads
+    rev: v1.49.0
     hooks:
       - id: typos
         name: typos (identifiers and hyphenated words, in place fixes)
@@ -290,7 +296,7 @@ repos:
   # reads as yaml and nothing reads as a build definition, on a service
   # whose failure mode is a docs build that stops happening
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.35.0
+    rev: 0.38.0
     hooks:
       - id: check-dependabot
       - id: check-readthedocs
@@ -333,7 +339,7 @@ repos:
   # and 4 in test.yml, all of them unnamed jobs) and is worth
   # running by hand rather than on every commit
   - repo: https://github.com/zizmorcore/zizmor-pre-commit
-    rev: v1.28.0
+    rev: v1.29.0
     hooks:
       - id: zizmor
         # offline is what it does by default, said out loud: it warns about
@@ -355,7 +361,7 @@ repos:
   # docformatter, flake8, isort, pydocstringformatter, pydocstyle, pylint,
   # pyupgrade, and yesqa
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.16.0
+    rev: v0.16.2
     hooks:
       - id: ruff-check
         name: ruff check (in place fixes)
@@ -394,7 +400,7 @@ repos:
         pass_filenames: false
         require_serial: true
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.12.0
+    rev: 0.12.3
     hooks:
       # keep uv.lock in sync with pyproject.toml
       - id: uv-lock
@@ -414,6 +420,11 @@ repos:
         args: [--no-build-isolation]
         additional_dependencies: [setuptools]
   - repo: https://github.com/regebro/pyroma
+    # the newest *stable* tag: 5.1b1 and 5.1b2 sit above it, and
+    # `pre-commit autoupdate` offers a prerelease as readily as a release,
+    # having no notion of one -- it did so here and in pull request #315
+    # before it. What a beta of the packaging checker would gate is the
+    # release workflow, on a judgement its own author has not settled yet
     rev: "5.0.1"
     hooks:
       - id: pyroma

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,32 @@ documented at release-notes length in the first place, and are still in
   instead of only saying "no loadable shared libsecp256k1 found"; that
   reaches a caller here on a platform with no wheel of its own. Nothing
   else about the release touches this package's own code.
+- **Six pinned hook revisions move, and two `pre-commit autoupdate`
+  offered do not.** `codespell` (v2.4.3), `typos` (v1.49.0),
+  `check-jsonschema` (0.38.0), `zizmor` (v1.29.0), `ruff` (v0.16.2) and
+  the `uv-pre-commit` that owns the `uv-lock` hook (0.12.3) are what the
+  gate runs now: no new finding, and no fixing hook rewrote a file, which
+  for `typos` and `ruff` is the question worth asking rather than an
+  aside. The two refused are the failure modes autoupdate has no notion
+  of. It took `typos` to `v1`, which is not a release but the
+  major-version alias upstream moves onto each one -- a rev that follows
+  every future 1.x is not a pin, and a growing dictionary under
+  `--write-changes` is what would follow it in. And it took `pyroma` to
+  `5.1b1`, a prerelease, with `5.1b2` above it; the pin stays at 5.0.1,
+  the newest release. Both revs now carry the reason beside them, this
+  being the second time the beta was offered -- pull request #315 was the
+  first.
+- **`uv.lock` is at every dependency's newest release again**:
+  `cosmic-ray` (8.7.0), and it alone, everything else still being where
+  the upgrade a day earlier left it. It is reached through the `mutation`
+  group only, so it was never in a wheel, and nothing a pull request runs
+  reaches it either -- `mutation.yml` is weekly and dispatched, so the
+  minor-version jump was checked by hand instead of waiting for a
+  scheduled run to report it. Against 8.4.6 on this tree, `cosmic-ray
+  init` enumerates the same mutants for the same scope, and `baseline`,
+  `cr-filter-operators`, `exec` and `.github/scripts/mutation_counts.py`
+  read and write the session the way that script's docstring says they
+  do.
 
 ### Documentation and the website
 

--- a/uv.lock
+++ b/uv.lock
@@ -791,7 +791,7 @@ wheels = [
 
 [[package]]
 name = "cosmic-ray"
-version = "8.4.6"
+version = "8.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -809,9 +809,9 @@ dependencies = [
     { name = "toml" },
     { name = "yattag" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/fe/3ae2caf974a5ffe7411dccd4d067f3b3b06f2fe655097be959bf2c9cf571/cosmic_ray-8.4.6.tar.gz", hash = "sha256:2b9a72d2aec3480608a7d665fd6637133a75963472dec42e2de4afb69f0665f9", size = 1642209, upload-time = "2026-04-02T13:36:29.92Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/44/0f033f653a859f82efb8b72edfa3dd3feba30f94b1784c74149908d9bbfd/cosmic_ray-8.7.0.tar.gz", hash = "sha256:f1e8cdbd9b8c9d9145bc2b37247081b423d1e079d929a3da30714b23d40b4a70", size = 1667525, upload-time = "2026-08-09T14:57:55.744Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9b/45/f78505d164e38a1bf00bd2ec8f54f340969c61c4d2486aaa2e18090a1ccf/cosmic_ray-8.4.6-py3-none-any.whl", hash = "sha256:448af7e6aa365bdbb254106b907a677950fc785f7745ab9a659d4735285bb307", size = 59932, upload-time = "2026-04-02T13:36:28.388Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/20/ec3c7d8c592ec75846f75dbcf9f2e031b4035be8ae9660136e642cafc364/cosmic_ray-8.7.0-py3-none-any.whl", hash = "sha256:759510a02cf2b23ba15a00680ecc1fd6c74d3082622e5a7d2d514b5227267659", size = 62310, upload-time = "2026-08-09T14:57:54.376Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **Six hook revisions** in `.pre-commit-config.yaml`: `codespell`
  (v2.4.1 -> v2.4.3), `typos` (v1.48.0 -> v1.49.0), `check-jsonschema`
  (0.35.0 -> 0.38.0), `zizmor` (v1.28.0 -> v1.29.0), `ruff` (v0.16.0 ->
  v0.16.2) and `uv-pre-commit` (0.12.0 -> 0.12.3). No new finding, and no
  fixing hook rewrote a file.
- **Two `pre-commit autoupdate` also offered are refused**, each with the
  reason now beside its rev: `typos` `v1` is the major-version alias
  upstream moves onto every release, not a release -- a rev that follows
  every future 1.x is not a pin, and this hook runs `--write-changes`;
  `pyroma` 5.1b1 is a prerelease, with 5.1b2 above it, and the pin stays
  at 5.0.1. autoupdate has no notion of either, and offered the same beta
  in https://github.com/btclib-org/btclib/pull/315.
- **`cosmic-ray` 8.4.6 -> 8.7.0** in `uv.lock`, the only package a full
  `uv lock --upgrade` moves, everything else still being where
  https://github.com/btclib-org/btclib/pull/536 left it a day earlier. It
  is in the `mutation` group, so it was never in a wheel and no pull
  request gate reaches it -- `mutation.yml` is weekly and dispatched --
  which is why the minor jump was checked by hand, see below.
- **Nothing else was behind**: the eight actions are each pinned to the
  commit their newest release tags, as are actionlint's
  `shellcheck-py` 0.11.0.1 and `pyflakes` 3.4.0, `integration.yml`'s
  Bitcoin Core 31.1, and both runtime dependencies
  (`btclib_libsecp256k1` 0.7.1.3, `bitcoin-core-rpc` 2026.8.8).

## Test plan

- [x] `uv run pre-commit run --all-files`
- [x] `uv run pytest --cov` (18405 passed, 5 integration tests skipped as
      documented, 100% coverage)
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html`
- [x] cosmic-ray 8.7.0 against 8.4.6 on this tree: `cosmic-ray init`
      enumerates the same 552 mutants for `.github/mutation/bip322.toml`,
      and `cosmic-ray baseline`, `cr-filter-operators`, `cosmic-ray exec`
      and `.github/scripts/mutation_counts.py` read and write the session
      the way that script's docstring says they do (64 killed, 14
      survived, 78 executed on a partial run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update tooling pins for pre-commit hooks and mutation testing while keeping dependencies on stable, fully pinned releases.

Build:
- Refresh pinned versions of multiple pre-commit hooks without introducing new findings or file rewrites.
- Document rationale for rejecting non-stable or non-pinned pre-commit autoupdate suggestions for typos and pyroma in config comments.
- Regenerate uv.lock to upgrade cosmic-ray to its latest release while leaving other dependencies unchanged.

Documentation:
- Add changelog entry describing updated pre-commit hooks, cosmic-ray upgrade, and handling of autoupdate edge cases.

Chores:
- Ensure mutation-testing tooling (cosmic-ray) and pre-commit ecosystem are aligned with their latest stable releases and project pinning policy.