### PR TITLE
File the previous uv.lock upgrade under the cycle it landed in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -774,17 +774,24 @@ documented at release-notes length in the first place, and are still in
   the newest release. Both revs now carry the reason beside them, this
   being the second time the beta was offered -- pull request #315 was the
   first.
+- **`uv.lock` is at every dependency's newest release**: `setuptools`
+  (84.0.0), `virtualenv` (21.7.3) and `platformdirs` (4.11.1), each one
+  patch release past what the upgrade of the previous cycle had frozen
+  two days earlier. All three are reached through the `dev` group only --
+  `setuptools` through `check-manifest` and `pyroma`, `virtualenv` and
+  `platformdirs` through `pre-commit` -- so none was ever in a wheel, and
+  nothing in the lint gate or the suite moved for them.
 - **`uv.lock` is at every dependency's newest release again**:
   `cosmic-ray` (8.7.0), and it alone, everything else still being where
-  the upgrade a day earlier left it. It is reached through the `mutation`
-  group only, so it was never in a wheel, and nothing a pull request runs
-  reaches it either -- `mutation.yml` is weekly and dispatched, so the
-  minor-version jump was checked by hand instead of waiting for a
-  scheduled run to report it. Against 8.4.6 on this tree, `cosmic-ray
-  init` enumerates the same mutants for the same scope, and `baseline`,
-  `cr-filter-operators`, `exec` and `.github/scripts/mutation_counts.py`
-  read and write the session the way that script's docstring says they
-  do.
+  the upgrade above left it a day earlier. It is reached through the
+  `mutation` group only, so it was never in a wheel, and nothing a pull
+  request runs reaches it either -- `mutation.yml` is weekly and
+  dispatched, so the minor-version jump was checked by hand instead of
+  waiting for a scheduled run to report it. Against 8.4.6 on this tree,
+  `cosmic-ray init` enumerates the same mutants for the same scope, and
+  `baseline`, `cr-filter-operators`, `exec` and
+  `.github/scripts/mutation_counts.py` read and write the session the way
+  that script's docstring says they do.
 
 ### Documentation and the website
 
@@ -965,13 +972,6 @@ edit.
 
 ### Repository
 
-- **`uv.lock` is at every dependency's newest release again**: `setuptools`
-  (84.0.0), `virtualenv` (21.7.3) and `platformdirs` (4.11.1), each one
-  patch release past what the previous upgrade had frozen two days
-  earlier. All three are reached through the `dev` group only --
-  `setuptools` through `check-manifest` and `pyroma`, `virtualenv` and
-  `platformdirs` through `pre-commit` -- so none was ever in a wheel, and
-  nothing in the lint gate or the suite moved for them.
 - **`uv.lock` is at every dependency's newest release**, which closed the
   seven advisories the default branch was carrying: six on GitPython,
   reached through `cosmic-ray`, and one on `cryptography`, reached


### PR DESCRIPTION
## Summary

- **https://github.com/btclib-org/btclib/pull/536's bullet moves out of a
  released section.** It went to v2026.8.7's "Repository" group, and
  `8c948314` came after `3de89b11` opened the v2026.9 cycle, so the entry
  belongs there. That group is called "Packaging, linting and CI" in this
  cycle, and the bullet now sits directly above the `cosmic-ray` one that
  https://github.com/btclib-org/btclib/pull/554 added, the two `uv.lock`
  upgrades reading in order.
- **The bullet below it stays where it is**, checked rather than assumed:
  the `v2026.8.7` tag points at `a54a0ef4`, which is the upgrade that
  bullet describes, so that one is filed under its own release.
- **Two cross-references move with it.** "past what the previous upgrade
  had frozen" is now "past what the upgrade of the previous cycle had
  frozen", the previous upgrade being under another release heading; and
  the `cosmic-ray` bullet says "where the upgrade above left it a day
  earlier" rather than naming a day alone, which is only true with the
  two adjacent.

This is what the `merge=union` driver CLAUDE.md describes cannot catch: a
bullet appended to the wrong group merges in silence, there being no
conflict to decide.

## Test plan

- [x] `uv run pre-commit run --all-files`
- [x] `uv run pytest --cov` (18405 passed, 5 integration tests skipped as
      documented, 100% coverage)
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Update CHANGELOG entries so uv.lock upgrades are filed under the correct release headings and their descriptions reflect the new ordering and relationships between upgrades.