### PR TITLE
Stop spending the matrix on a draft pull request

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,11 @@ on:
     # ever lint it. Tag pushes are covered by the release workflow
     branches: [master]
   pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request
+    # would wait for its next push to be checked at all
+    types: [opened, reopened, synchronize, ready_for_review]
   # lets the release workflow gate publication on these same checks
   workflow_call:
   # the escape hatch: a run on demand for a branch whose pull request is
@@ -47,6 +52,12 @@ concurrency:
 jobs:
   lint:
     name: Lint and type-check
+    # a draft pull request is work in progress: every push to one runs
+    # these checks on a tree its author is not asking anyone to review
+    # yet. A run on the merge result still happens the moment the pull
+    # request is marked ready, which is why ready_for_review is a
+    # trigger type above
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     # nothing here takes minutes; a job that does is hung
     timeout-minutes: 20
@@ -133,6 +144,7 @@ jobs:
   # parallel and installs a different dependency group.
   docs:
     name: Build the documentation
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     # about ten seconds of sphinx; a job that takes minutes is hung
     timeout-minutes: 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,11 @@ on:
       - Gemfile
       - "*.md"
   pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request
+    # would wait for its next push to be checked at all
+    types: [opened, reopened, synchronize, ready_for_review]
   # allows the release workflow to reuse the whole build/test pipeline
   workflow_call:
   # the escape hatch: the matrix on demand for a branch whose pull
@@ -62,6 +67,12 @@ jobs:
   # for the ones uv has to download, and the wheel is selected for the
   # interpreter rather than for the host, so either one links
   test-py:
+    # a draft pull request is work in progress: every push to one spends
+    # the whole matrix on a tree its author is not asking anyone to
+    # review yet. The gate below carries the same condition, so a draft
+    # skips uniformly and the gate does not read that skip as a job that
+    # should have run
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -140,6 +151,7 @@ jobs:
   # secret and no third party, and it applies to every run, where a
   # coveralls.io upload happens only on pull requests targeting master
   coverage-py:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -182,6 +194,7 @@ jobs:
   # bindings it resolves are published: while they were not, the step
   # could only be red, for a reason nobody could fix from a branch
   dist-py:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -275,7 +288,9 @@ jobs:
     # not success(): a job whose dependencies failed is skipped, and a
     # skipped check reports "skipped", which branch protection counts as
     # satisfied. The gate has to run to be able to fail
-    if: always()
+    # and the draft condition every job above carries, so a draft
+    # skips uniformly rather than tripping the skip check below
+    if: ${{ always() && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
`test.yml` and `lint.yml` ran in full on every push to a draft pull
request -- the whole matrix, on a tree its author is not asking anyone
to review yet. Both now skip while the pull request is a draft.

`ready_for_review` joins the trigger types, because the default set
does not include it: without it, a pull request marked ready would
carry the skipped checks until its next push rather than being checked
at the moment it starts asking for review.

The gate job carries the same condition rather than being left with a
bare `always()`. It fails on a `skipped` dependency deliberately --
"nothing in this workflow is conditional, so a skip means something
upstream did not run" -- so leaving it running while the jobs above it
skip would turn every draft red, which is the opposite of the point.
With the condition on all of them a draft skips uniformly, and branch
protection reads a skipped check as satisfied. On every non-draft run
the gate behaves exactly as it does today.

**The push triggers are untouched.** `branches: [master]` is there for
the reason the comment above it gives -- a push to a branch with an
open pull request would run twice, in two concurrency groups that do
not cancel each other, and the `pull_request` run is the one worth
keeping. Adding `dev` there would reintroduce exactly that, permanently,
because the release pull request from `dev` is always open.

Two things considered and deliberately left out:

- a `concurrency` group on `release.yml`: with `github.ref` it would
  not serialize two different tags anyway, since their refs differ, and
  a constant group on a publishing pipeline is a call for its owner to
  make;
- `actions/attest-build-provenance` on the built artifacts, which the
  OIDC already in place would make cheap, but which belongs in its own
  change to the publish path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust CI workflows so tests and linting are skipped on draft pull requests while still running immediately when a PR is marked ready for review.

New Features:
- Add ready_for_review as a pull_request trigger type in test and lint workflows so checks run when a draft PR is marked ready.

Enhancements:
- Skip test, coverage, distribution, lint, and docs jobs for draft pull requests to avoid spending the full matrix on work-in-progress branches.
- Gate job in the test workflow now follows the same draft-skipping condition to keep draft PRs green while preserving existing behavior for non-draft runs.