### PR TITLE
Mutate the code added since #327 was written, and record what it found

### DIFF
--- a/.github/mutation/bip322.toml
+++ b/.github/mutation/bip322.toml
@@ -15,10 +15,13 @@ timeout = 300
 
 excluded-modules = []
 
-# 508 of the 977 mutants sampled in 1200 s: 405 killed, 103 survived. 44
-# are the deferred-annotation class fetch.toml documents, 5 the keyword-
-# only marker, 4 an `is` CPython's small-int cache makes indistinguishable
-# from `==`.
+# all 552 mutants, complete in under ten minutes: 456 killed, 96 survived,
+# 17.39%. 67 of the 96 are the deferred-annotation class fetch.toml
+# documents, 6 the keyword-only marker, 4 an `is` CPython's small-int cache
+# makes indistinguishable from `==`. The other 120 mutants of a `|` here
+# die, which is the point of the first finding below: this is the one scope
+# in this directory whose `|` is arithmetic in the places that matter, so
+# no operator filter belongs in it.
 #
 # One real gap closed, and the most consequential this session found:
 # REQUIRED_RULES and UPGRADEABLE_RULES are each a `|` chain over distinct-

--- a/.github/mutation/descriptors.toml
+++ b/.github/mutation/descriptors.toml
@@ -1,0 +1,87 @@
+# Output descriptors and miniscript, mutated: the checksum, BIP380's key
+# expressions, BIP379's language and the witness that satisfies one. The
+# largest surface added to btclib since #219 was opened, and the one whose
+# answers a caller cannot check by eye -- a miniscript satisfaction is a
+# choice of branch, a set of type properties and a witness whose size
+# decides a fee, none of which a wrong bound announces. Every line of the
+# three modules runs under tests/descriptors; this asks whether the suite
+# would notice if one of them were wrong.
+
+[cosmic-ray]
+# the package, `__init__.py` included: it is re-exports and a docstring, so
+# it contributes a handful of mutants rather than a scope of its own, and
+# naming the directory is what keeps a fourth module added tomorrow from
+# being left out in silence
+module-path = "btclib/descriptors"
+
+# tests/descriptors alone, which is what covers all three modules to 100%
+# -- measured, `--cov=btclib/descriptors` over this command reports every
+# file complete -- in under four seconds. custody_wallet_test.py is in that
+# directory and is the wallet-shaped judgement of a descriptor, so the
+# scope does not need tests/wallet to reach what a wallet asks a descriptor
+# for; wallet.toml mutates the other side of that call.
+#
+# -n0 and -p no:randomly for the reasons sig_hash.toml gives: xdist's
+# worker per core is startup paid once per mutant, and with -x a shuffled
+# collection order makes both the killing test and the runtime
+# irreproducible. No --cov, same file
+test-command = "python -m pytest -x -q -n0 -p no:randomly tests/descriptors"
+
+# seconds of wall clock, wide for the reason sig_hash.toml measures -- a
+# timeout is answered KILLED, so a tight one turns a slow mutant on a
+# loaded machine into a kill nobody earned. This scope has somewhere for
+# one to hide, unlike the parsers: satisfaction and type inference walk a
+# fragment tree, and `miniscript.py` carries the ops, stack and script-size
+# bounds that stop a `thresh` or a nested `andor` from expanding without
+# end, so a mutant that widens one of those is what the slack is for
+timeout = 300
+
+excluded-modules = []
+
+# No operator filter here, and that is a decision rather than an omission:
+# parsers.toml excludes `ReplaceBinaryOperator_BitOr_.*` because every `|`
+# in its scope is an unevaluated annotation under `from __future__ import
+# annotations`, and here most of them are arithmetic. `miniscript.py`
+# computes a fragment's type properties as a set algebra over one-letter
+# properties -- `_if(_has(x, "B"), _t("W")) | (x & _t("ghijkudfems"))` and
+# some seventy lines like it -- so a `|` turned into `^` or `&` there is
+# exactly the question this profile exists to ask. The claim is a grep,
+# a line number here rotting on the next insertion above it:
+#
+#   grep -c ' | ' btclib/descriptors/*.py
+#
+# The annotation half survives instead, and is the class fetch.toml
+# documents at length: unevaluated, unkillable, and not a hole. What the
+# first session says about the trade is that a third of the `|` mutants it
+# ran were *killed*, which no annotation's ever is.
+#
+# 10831 mutants, and the first session judged 383 of them: 291 killed, 92
+# survived. Sampled at a thirtieth, then, and the reason to keep sampling
+# rather than to shrink the scope is the engine's: the verdicts in a slice
+# are stable, so one that changes is a test that stopped checking what it
+# used to.
+#
+# Every non-annotation survivor is in `miniscript.py` -- `descriptors.py`
+# and `key_expression.py` gave none in the 101 of theirs that ran -- and
+# they group into four:
+#
+# - the type-property algebra, which is what this scope was written to
+#   ask about: `_andor_properties`' `&` turned `|` and `|` turned `-`
+#   survive, so the properties a fragment computes are not pinned by any
+#   test that would notice a wrong set.
+# - the sizes: `_TX_BODY_LEEWAY_WEIGHT`'s summands rearrange freely, the
+#   stack-limit term beside it takes `^` for `+`, and `_decomposed`'s
+#   `1 + 2 ** (op_code - 76)` -- the push-prefix width -- survives three
+#   ways. A wrong size here is a wrong fee estimate rather than an
+#   invalid spend, which is why nothing louder catches it.
+# - the fragment dispatch, weakened from `==` to `>=` in seven places:
+#   equivalent wherever the fragment compared is the alphabetical
+#   extreme of the closed set it comes from, which is the class bms.toml
+#   states, and worth a look one by one rather than in bulk.
+# - `satisfy`'s `index: int = 0` default and `_thresh_ops`' and
+#   `_thresh_witness`' `reached[1]`/`reached[-1]`: an undefended default
+#   and two indexes into a list a `thresh` walk builds.
+
+# one mutant at a time, in this working tree: see sig_hash.toml
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/hwi.toml
+++ b/.github/mutation/hwi.toml
@@ -1,0 +1,74 @@
+# The HWI adapter, mutated: the subprocess btclib runs, the json it reads
+# back, and the bounds it holds that output to. Everything this module
+# does is with somebody else's answer -- a hardware wallet's, through a
+# tool btclib does not ship -- so its questions are #327's: a size limit
+# weakened, a status left unchecked, a malformed entry taken for a device
+# instead of refused (#534), a fingerprint compared the wrong way. The
+# adapter is also where a wrong answer is hardest to see by eye, the
+# device being the thing nobody can step through.
+
+[cosmic-ray]
+module-path = "btclib/hwi.py"
+
+# its own file, which covers the module completely, and its own profile
+# because of what that costs: every case starts a fake `hwi` executable,
+# so the command is 4.7 s of wall clock against the fifth of a second
+# signer.toml's three modules take. That is the engine's shape at a
+# smaller scale -- the budget samples this scope rather than finishing it
+# -- and it is why the two are not one command.
+#
+# tests/integration/hwi_device_test.py is not here and cannot be: it wants
+# a device or an emulator (issue #529), and it skips itself everywhere
+# else, so in a mutation session it would judge nothing while looking like
+# it had
+test-command = "python -m pytest -x -q -n0 -p no:randomly tests/hwi_test.py"
+
+# seconds of wall clock, and the one profile where the width is not only
+# about a loop: a mutant that widens a read bound leaves btclib reading
+# a pipe the fake tool has stopped writing to, which the subprocess
+# timeout in the module answers -- unless that timeout is what the mutant
+# widened. See sig_hash.toml for why a cut-short mutant is answered
+# KILLED and why that makes slack the safe direction
+timeout = 300
+
+excluded-modules = []
+
+# the exclusion wallet.toml explains, measured the same way here: `grep -n
+# ' | ' btclib/hwi.py` is annotations only, and the unfiltered session
+# executed 39 BitOr mutants without killing one. Worth the line in a scope
+# this expensive -- at 9 s a mutant on a loaded machine, an unkillable
+# survivor is 9 s spent on a verdict nobody can act on
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
+# 333 mutants, 66 of them the `|` above, and 144 of the 267 left ran in the
+# 1800 s of the first session -- 9.8 s a mutant, which is this scope's
+# subprocess cost doubled by four other profiles sharing the machine: 122
+# killed, 22 survived, 15.28%.
+#
+# The gaps:
+#
+# - `_read(out, max_output + 1)`, mutated to `+ 2`, to `| 1` and to
+#   `<< 1`. The `+ 1` is the module's own comment -- one byte past the
+#   limit is all that has to be read to know the limit was passed -- and
+#   nothing holds it to that, so the bound issue #526 added is enforced
+#   at whatever offset the code happens to say.
+# - `is_usable`'s `fingerprint is not None and not self.error` with `or`
+#   for `and`: no device in the fixtures answers a fingerprint *and* an
+#   error, which is exactly the entry #534 was about.
+# - `_POLL_INTERVAL = 0.05` turned negative: it reaches
+#   `process.wait(timeout=min(_POLL_INTERVAL, left))`, where a negative
+#   timeout is a busy loop rather than the pause the constant names.
+# - `HwiDevice.needs_pin_sent`'s `False` default turned True, and
+#   `enumerate_devices`' `argv.insert(1, "--emulators")` moved: where a
+#   flag goes in the command line is not asserted.
+# - the error messages: `argv[0]` in three of them mutated to `argv[1]`
+#   or `argv[-1]` and unnoticed -- the same shape fetch.toml closed by
+#   asserting the message text rather than the exception type.
+#
+# `_select`'s `assert usable[0].fingerprint is not None` mutated to `[-1]`
+# is equivalent where the suite calls it with one usable device.
+
+# one mutant at a time, in this working tree: see sig_hash.toml
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/hwi.toml
+++ b/.github/mutation/hwi.toml
@@ -46,25 +46,40 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 # subprocess cost doubled by four other profiles sharing the machine: 122
 # killed, 22 survived, 15.28%.
 #
-# The gaps:
+# The gaps, and what closed each -- measured one mutant at a time, alive
+# before its test and dead after:
 #
-# - `_read(out, max_output + 1)`, mutated to `+ 2`, to `| 1` and to
-#   `<< 1`. The `+ 1` is the module's own comment -- one byte past the
-#   limit is all that has to be read to know the limit was passed -- and
-#   nothing holds it to that, so the bound issue #526 added is enforced
-#   at whatever offset the code happens to say.
-# - `is_usable`'s `fingerprint is not None and not self.error` with `or`
-#   for `and`: no device in the fixtures answers a fingerprint *and* an
-#   error, which is exactly the entry #534 was about.
-# - `_POLL_INTERVAL = 0.05` turned negative: it reaches
+# - `is_usable`'s `fingerprint is not None and not self.error` became
+#   `or` and nothing noticed: no fixture answered a fingerprint *and* an
+#   error, which is the entry #534 was about and the one device
+#   `_select` must not pick. A device carrying both is now asserted
+#   unusable, and the two flags a device does not carry asserted off.
+# - the four refusals name `argv[0]`, and `argv[1]` or `argv[-1]` read
+#   the same to a test matching on the tail of the message: what the
+#   assertions now anchor is the element the message opens with -- for
+#   the not-found one against the colon after it, the OSError carried
+#   behind it naming the same path.
+# - `argv.insert(-1, "--emulators")` moved without a word, and where it
+#   goes is not style: a global flag after the subcommand is an
+#   unrecognized argument to that subcommand. The flag is now asserted
+#   to sit immediately before `enumerate`.
+#
+# Three survive with a reason rather than a test owed:
+#
+# - `_read(out, max_output + 1)` mutated to `+ 2`, `| 1` or `<< 1` is
+#   equivalent: the cap only has to exceed the limit for the comparison
+#   below it to see that the limit was passed, so any larger cap gives
+#   the same verdict and only the byte count read differs. What matters
+#   is the limit itself, and `> max_output` is what the flood tests pin.
+# - `_POLL_INTERVAL = 0.05` turned negative reaches
 #   `process.wait(timeout=min(_POLL_INTERVAL, left))`, where a negative
-#   timeout is a busy loop rather than the pause the constant names.
-# - `HwiDevice.needs_pin_sent`'s `False` default turned True, and
-#   `enumerate_devices`' `argv.insert(1, "--emulators")` moved: where a
-#   flag goes in the command line is not asserted.
-# - the error messages: `argv[0]` in three of them mutated to `argv[1]`
-#   or `argv[-1]` and unnoticed -- the same shape fetch.toml closed by
-#   asserting the message text rather than the exception type.
+#   timeout returns at once rather than waiting: the deadline still ends
+#   the loop, so what the mutant buys is a busy wait and not a wrong
+#   answer -- unobservable to a test that is not timing the process.
+# - `sign_psbt`'s `" was" if returned == sent` weakened to `>=` picks the
+#   wording by comparing two base64 strings for order, and which way a
+#   signed psbt sorts against the one it was built from is nothing a test
+#   should pin.
 #
 # `_select`'s `assert usable[0].fingerprint is not None` mutated to `[-1]`
 # is equivalent where the suite calls it with one usable device.

--- a/.github/mutation/musig2.toml
+++ b/.github/mutation/musig2.toml
@@ -1,0 +1,78 @@
+# MuSig2, mutated: BIP327's key aggregation, nonce aggregation and partial
+# signatures, and the BIP373 psbt fields a signing session is carried in.
+# The one signature scheme in btclib where a wrong answer is not a wrong
+# signature but a lost key -- nonce reuse across sessions, a tweak applied
+# twice, a partial signature verified against the wrong aggregate nonce --
+# and where the reference vectors are the whole of what says otherwise.
+# signatures.toml asks issue #219's question of ssa and dsa; this asks it
+# of the protocol built on them.
+
+[cosmic-ray]
+# both halves, judged by the same two test files: `ecc/musig2.py` is the
+# scheme and `psbt/musig2.py` the BIP373 role, which is why psbt.toml
+# names its five other modules one by one and leaves this one here
+module-path = [
+  "btclib/ecc/musig2.py",
+  "btclib/psbt/musig2.py",
+]
+
+# both modules' own files, complete over the two -- measured with `--cov`
+# over this command -- for a seventh of a second, which makes this profile
+# and wallet.toml the two that finish soonest here
+test-command = """python -m pytest -x -q -n0 -p no:randomly \
+  tests/ecc/musig2_test.py tests/psbt/musig2_test.py"""
+
+# seconds of wall clock, wide for the reason sig_hash.toml measures --
+# a timeout is answered KILLED, so slack is the safe direction. As in
+# parsers.toml, what the width is not guarding is a loop in this scope:
+# the key and nonce aggregation walk the lists they are given with
+# comprehensions, and a tweak chain is as long as the caller's, so there
+# is no bound here for a mutant to uncap
+timeout = 300
+
+excluded-modules = []
+
+# the exclusion wallet.toml explains: every `|` in the two modules is in an
+# annotation --
+#
+#   grep -n ' | ' btclib/ecc/musig2.py btclib/psbt/musig2.py
+#
+# -- and the unfiltered session that decided it executed 10 BitOr mutants
+# and killed none of them. The arithmetic this scope does have is `^`,
+# which is `_xor_bytes` over the nonce seed, and no filter touches it
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
+# 1409 mutants, 132 of them the `|` above, and 159 of the 1277 left ran in
+# the 900 s of the first session: 149 killed, 10 survived, 6.29% -- the
+# lowest rate of any profile measured here, which is what a reference
+# implementation's own vector file buys.
+#
+# 5.3 s a mutant against a test command of a seventh of a second, and two
+# mutants are where two thirds of that session went: `sign`'s two `%
+# secp256k1.n` reductions turned into `** secp256k1.n`, which is a 256-bit
+# exponent and never returns. Both spent the whole 300 s timeout and both
+# were answered KILLED, which sig_hash.toml explains and numeric.toml met
+# first in its KDF -- so the cost is real, the verdict is sound, and the
+# arithmetic is the reason this profile is sampled rather than finished
+# despite a test command nothing else here beats.
+#
+# The 10, and none of them is a hole in the protocol:
+#
+# - `partial_sig_verify`'s `len(pub_nonces) != len(pub_keys)` as `is not`,
+#   and `sign`'s `Q[1] % 2 == 0` as `<= 0` -- the interned-int and the
+#   `% 2` classes, both equivalent by construction.
+# - `apply_tweak`'s `(g * gacc) % n` as `+ n`: the value is reduced again
+#   before use, so it is equivalent here and fragile rather than wrong.
+# - `key_agg`'s `Q[0] == 0` sits under `# pragma: no cover` -- BIP327's
+#   placeholder for an aggregate key at infinity, which no vector
+#   reaches -- so its mutants are unkillable by construction, the way an
+#   annotation's are.
+# - `_require_same_length`'s `!=` as `>`, and the BIP373 field key
+#   comparisons in `psbt/musig2.py` as `>=`, `<=` and `is not`: a
+#   participant list and a key are compared one way only, which is the
+#   shape fetch.toml's `chain != expected_chain` had.
+
+# one mutant at a time, in this working tree: see sig_hash.toml
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/psbt.toml
+++ b/.github/mutation/psbt.toml
@@ -70,31 +70,45 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 # command, four other profiles sharing the machine: 780 killed, 107
 # survived, 12.06%. Sampled, and the sample is a third of the scope.
 #
-# The gaps, in the order they are worth acting on:
+# The gaps, and the six of them closed by the tests beside this commit --
+# each measured surviving before its test and dying after, one mutant at a
+# time:
 #
-# - every lock-time bound, at both ends and in three places:
-#   `0 <= fallback_lock_time <= 0xFFFFFFFF` weakened to `-1 <=` and to
-#   `< 0xFFFFFFFF`, `LOCK_TIME_THRESHOLD <= required_time_lock_time <=
-#   0xFFFFFFFF` to 0x100000000, and `0 < required_height_lock_time <
-#   LOCK_TIME_THRESHOLD` to `1 <`. The values these accept or refuse are
-#   what BIP370 says a psbt may carry, and the suite asks about the
-#   middle of the range.
-# - `0 <= tx_modifiable <= 0xFF` weakened to `0 != tx_modifiable`, which
-#   accepts a negative flag byte.
-# - `_assert_new_taproot_sigs_verify`'s `sig[:64]` widened to `sig[:65]`:
-#   what is verified is the 64 bytes of a Schnorr signature, and a
-#   65-byte one carries a sighash byte that must not be hashed with it.
-# - `parse_taproot_bip32`'s `len_ * LEAF_HASH_SIZE + FINGERPRINT_SIZE >
-#   available` with `^` for `+`, the bound that stops a leaf-hash count
-#   from being read past the end of the value.
-# - `assert_signatures_only`'s `zip(..., strict=True)` turned to False, in
-#   the walk that compares a returned psbt's outputs against the request:
-#   a returned psbt with fewer outputs would be compared as far as it goes
-#   and accepted.
-# - `combine`'s `other_id != tx_id` weakened to `>`, tested with an id
-#   sorting one way only -- the same shape fetch.toml closed for `tx.id`.
+# - every lock-time bound had a side nothing asked for. BIP370's three
+#   fields are now asserted at the value each admits as well as the one
+#   it refuses: `fallback_lock_time` at 0 and 0xFFFFFFFF and refusing -1,
+#   `required_time_lock_time` at 0xFFFFFFFF and refusing the second after
+#   it, `required_height_lock_time` at 1 and refusing 0 -- which is the
+#   one value BIP65 gives a meaning of its own, nLockTime's "no lock time
+#   at all".
+# - `0 <= tx_modifiable <= 0xFF` weakened to `0 != tx_modifiable`
+#   accepted a negative flag byte: no flag set is now asserted valid,
+#   being a psbt nobody may modify rather than an invalid one.
+# - `combine`'s `other_id != tx_id` weakened to `>` was tested with the
+#   ids in one arrangement only; the same disagreement combined the other
+#   way round closes it -- the shape fetch.toml closed for `tx.id`.
 #
-# The equivalence classes are the ones already documented elsewhere here: a
+# Three are left open, and each has a reason rather than a test owed:
+#
+# - `parse_taproot_bip32`'s `len_ * LEAF_HASH_SIZE + FINGERPRINT_SIZE`
+#   with `^` for `+` is equivalent by arithmetic: `32 * len_` is a
+#   multiple of 32, so bit 2 is clear and `^ 4` is `+ 4` for every count.
+# - `assert_signatures_only`'s `zip(..., strict=True)` turned False needs
+#   a returned psbt with a different number of outputs, and the whole
+#   transaction is compared before the walk is reached: measured, a
+#   dropped output and a dropped input each answer "the transaction being
+#   signed was changed" first.
+# - `_assert_new_taproot_sigs_verify`'s `sig[:64]` widened to `sig[:65]`
+#   is equivalent for a 64-byte signature -- slicing past the end is not
+#   an error -- and differs only for the 65-byte shape, where the last
+#   byte is a sighash type that must not be verified as part of the
+#   signature. This tree cannot produce one for a taproot script path:
+#   the only source of such a signature here is a BIP373 MuSig2
+#   aggregation, whose partial signatures commit to SIGHASH_DEFAULT. A
+#   script-path signer taking an explicit sighash type is what would kill
+#   it, and is the test to write rather than an equivalence to accept.
+#
+# The remaining classes are the ones documented elsewhere here: a
 # `check_validity` default, an `is` over interned ints, and a comparison
 # against a value at the extreme of its closed set.
 

--- a/.github/mutation/psbt.toml
+++ b/.github/mutation/psbt.toml
@@ -1,0 +1,103 @@
+# The partially signed transaction, mutated: the three maps, the key-value
+# codecs under them and the size estimate a fee rate is applied to. A psbt
+# is a format two programs exchange, so its boundaries are somebody else's
+# input in the sense issue #327 means -- an unknown field kept or dropped,
+# a required one missing, a duplicate key, a map ending where the next one
+# begins -- and the vectors that judge it are BIP174's, BIP370's, BIP371's
+# and BIP373's own. Every line runs under tests/psbt; this asks whether the
+# suite would notice a wrong one.
+
+[cosmic-ray]
+# `musig2.py` is not here: musig2.toml mutates it beside `ecc/musig2.py`,
+# the BIP327 half it implements the BIP373 fields for, and the two are
+# judged by the same two test files. Named one by one for that reason,
+# where descriptors.toml and wallet.toml can name their directory
+module-path = [
+  "btclib/psbt/psbt.py",
+  "btclib/psbt/psbt_in.py",
+  "btclib/psbt/psbt_out.py",
+  "btclib/psbt/psbt_utils.py",
+  "btclib/psbt/psbt_size.py",
+  "btclib/psbt/__init__.py",
+]
+
+# tests/psbt, which covers these six to a single line -- measured with
+# `--cov=btclib.psbt` over this command. The line is `psbt_utils`'
+# refusal of an empty PSBT_IN_TAP_LEAF_SCRIPT value, a record with no room
+# for the leaf version it must end with, and the only thing that reaches
+# it is tests/fuzz_test.py: hypothesis draws that input rather than a
+# vector file holding it. That file is deliberately in no profile here --
+# a `@given` draws fresh bytes on each run, so its verdict is not
+# reproducible, and the value of a weekly report is the comparison with
+# the week before -- so the mutants of that one line are expected
+# survivors.
+#
+# tests/psbt/musig2_test.py is left in: it costs a tenth of a second and
+# it exercises the shared key-value codecs through the BIP373 fields,
+# where musig2.toml is what judges the module those fields are parsed by
+test-command = "python -m pytest -x -q -n0 -p no:randomly tests/psbt"
+
+# seconds of wall clock, wide for the reason sig_hash.toml measures, and
+# with somewhere to hide here: `psbt_utils.deserialize_map` reads
+# key-value records in a `while True` until the 0x00 separator, so a
+# mutated end condition is a read that never stops rather than a wrong
+# answer
+timeout = 300
+
+excluded-modules = []
+
+# the `BitOr` exclusion parsers.toml argues, and the one scope here where
+# it costs something rather than nothing, which is why the price is stated
+# instead of the rule. 913 of the 3524 mutants are `|`, and all but two
+# lines' worth of them are annotations:
+#
+#   grep -n ' | ' btclib/psbt/psbt.py btclib/psbt/psbt_in.py \
+#       btclib/psbt/psbt_out.py btclib/psbt/psbt_utils.py \
+#       btclib/psbt/psbt_size.py btclib/psbt/__init__.py
+#
+# The two are `_tx_modifiable`'s `INPUTS_MODIFIABLE | OUTPUTS_MODIFIABLE`
+# and the mask that combines two flag bytes below it, and the unfiltered
+# session says what skipping them loses: of the BitOr mutants it ran, the
+# only five it killed are on those two lines, and the sixth mutant there
+# -- `|` for `+` over two disjoint bits -- is equivalent. So the exclusion
+# gives up mutants that a `combine` test already answers, and takes 913
+# unkillable survivors out of a list somebody has to read
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
+# 3524 mutants, 913 of them the `|` above, and 887 of the 2611 left ran in
+# the 2400 s of the first session -- 2.0 s a mutant against a 0.9 s test
+# command, four other profiles sharing the machine: 780 killed, 107
+# survived, 12.06%. Sampled, and the sample is a third of the scope.
+#
+# The gaps, in the order they are worth acting on:
+#
+# - every lock-time bound, at both ends and in three places:
+#   `0 <= fallback_lock_time <= 0xFFFFFFFF` weakened to `-1 <=` and to
+#   `< 0xFFFFFFFF`, `LOCK_TIME_THRESHOLD <= required_time_lock_time <=
+#   0xFFFFFFFF` to 0x100000000, and `0 < required_height_lock_time <
+#   LOCK_TIME_THRESHOLD` to `1 <`. The values these accept or refuse are
+#   what BIP370 says a psbt may carry, and the suite asks about the
+#   middle of the range.
+# - `0 <= tx_modifiable <= 0xFF` weakened to `0 != tx_modifiable`, which
+#   accepts a negative flag byte.
+# - `_assert_new_taproot_sigs_verify`'s `sig[:64]` widened to `sig[:65]`:
+#   what is verified is the 64 bytes of a Schnorr signature, and a
+#   65-byte one carries a sighash byte that must not be hashed with it.
+# - `parse_taproot_bip32`'s `len_ * LEAF_HASH_SIZE + FINGERPRINT_SIZE >
+#   available` with `^` for `+`, the bound that stops a leaf-hash count
+#   from being read past the end of the value.
+# - `assert_signatures_only`'s `zip(..., strict=True)` turned to False, in
+#   the walk that compares a returned psbt's outputs against the request:
+#   a returned psbt with fewer outputs would be compared as far as it goes
+#   and accepted.
+# - `combine`'s `other_id != tx_id` weakened to `>`, tested with an id
+#   sorting one way only -- the same shape fetch.toml closed for `tx.id`.
+#
+# The equivalence classes are the ones already documented elsewhere here: a
+# `check_validity` default, an `is` over interned ints, and a comparison
+# against a value at the extreme of its closed set.
+
+# one mutant at a time, in this working tree: see sig_hash.toml
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/script.toml
+++ b/.github/mutation/script.toml
@@ -1,0 +1,128 @@
+# The script encodings, mutated: the command codec, the standard output
+# templates, the taproot tree and control block, the witness stack and the
+# signature-operation count. What the consensus profiles sit on -- the
+# engine executes what `script.parse` produced and `sig_hash` hashes what
+# `script_pub_key` built -- and until now the half of `btclib/script` no
+# profile mutated: sig_hash.toml takes one file of it and engine.toml the
+# subdirectory, leaving these seven. Issue #219's question on the layer
+# below the one it opened.
+
+[cosmic-ray]
+# named one by one rather than as `btclib/script` with the other two
+# scopes excluded, which is what sig_hash.toml explains: the test command
+# is per-configuration, and an engine mutant costs 7.2 s where these cost
+# under two. `limits.py` is here for its arithmetic -- the tapscript
+# script-size bound is derived from the stack and element limits rather
+# than copied
+module-path = [
+  "btclib/script/script.py",
+  "btclib/script/script_pub_key.py",
+  "btclib/script/taproot.py",
+  "btclib/script/witness.py",
+  "btclib/script/sig_ops.py",
+  "btclib/script/op_codes_tapscript.py",
+  "btclib/script/limits.py",
+  "btclib/script/__init__.py",
+]
+
+# tests/script first, where nearly every mutant dies, and four files after
+# it that each reach statements no test in that directory does -- measured
+# with `--cov=btclib.script` over this command, which reports every module
+# here complete but for the seven lines named below:
+#
+# - tests/all_test.py is `btclib/script/__init__.py`'s only caller: the
+#   PEP 562 `__getattr__` and `__dir__` that import `engine` and
+#   `sig_hash` on demand are reached by nothing that imports them by name
+# - tests/tx/tx_out_test.py is what asks a `ScriptPubKey` for its
+#   `addresses`, whose p2ms fallback the templates' own tests never take
+# - tests/wallet/wallet_test.py and tests/psbt/psbt_test.py are the two
+#   callers of `_script_of` and of `assert_valid_control_block`
+#
+# Not tests/script_engine, which sig_hash.toml pairs with tests/script and
+# which is the only thing that reaches `taproot._read_push_data`'s
+# OP_PUSHDATA branch (lines 100-104, 107 and 152 -- an unknown op code
+# past a push in a tapscript). Its vectors cost 7.2 s against this
+# command's 1.7 s, so buying those seven lines would multiply the session
+# by four; the handful of mutants on them are reported as survivors here
+# instead, and engine.toml kills them from its own side.
+#
+# Also not tests/fuzz_test.py, and for a different reason -- see the
+# comment on the operator filter below
+test-command = """python -m pytest -x -q -n0 -p no:randomly \
+  tests/script tests/all_test.py tests/tx/tx_out_test.py \
+  tests/wallet/wallet_test.py tests/psbt/psbt_test.py"""
+
+# seconds of wall clock, wide for the reason sig_hash.toml measures. This
+# scope holds the loops that need it: `script.parse` reads a push length
+# off the stream and then reads that many bytes, and `taproot.parse` walks
+# a tree, so a mutated bound is how one stops ending
+timeout = 300
+
+excluded-modules = []
+
+# The `BitOr` exclusion wallet.toml explains and parsers.toml argues.
+# Expected to be the other way here -- the templates do arithmetic on a
+# witness version and on flags -- and measured to be annotations only:
+#
+#   grep -n ' | ' btclib/script/script.py btclib/script/script_pub_key.py \
+#       btclib/script/taproot.py btclib/script/witness.py \
+#       btclib/script/sig_ops.py btclib/script/op_codes_tapscript.py \
+#       btclib/script/limits.py btclib/script/__init__.py
+#
+# Every hit is an annotation, the arithmetic being `&`, `<<` and `+` and
+# untouched by this, and the unfiltered session that settled it executed
+# 37 BitOr mutants without killing one.
+#
+# No hypothesis, either, which is the other exclusion worth stating once:
+# tests/fuzz_test.py reaches parsers in this scope that no vector file
+# does, and every `@given` in it draws fresh input on each run. A verdict
+# drawn that way is not reproducible, so a mutant killed one week and
+# surviving the next would say nothing about the suite -- and a weekly
+# report whose value is the comparison cannot afford that. The same reason
+# -p no:randomly is in every test command here
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
+# 2561 mutants, 187 of them the `|` above, and 406 of the 2374 left ran in
+# the 2100 s of the first session -- 4.7 s a mutant with four other
+# profiles of this directory on the same ten-core machine, against a 1.7 s
+# test command: 309 killed, 97 survived, 23.89%. Sampled, then, and the
+# sample already answers the question the profile was written to ask.
+#
+# `op_codes_tapscript.py` is the finding: 50 of the 51 mutants of it that
+# ran survived, and the 236 it holds are almost all numeric literals in
+# `OP_CODE_NAMES` and `OP_SUCCESS`. Nothing in the suite asserts either
+# table -- a code number may be changed, duplicated or dropped and every
+# test still passes -- and the two tables are exactly the kind of thing a
+# reader checks by eye and never re-checks. What would kill nearly all of
+# them is cheap: `OP_CODE_NAMES` has to be the inverse of `OP_CODES` for
+# every entry it names, and `OP_SUCCESS` has to be BIP342's set, which is
+# a range expression rather than a list to be transcribed.
+#
+# The rest, in the order they are worth acting on:
+#
+# - `nulldata`'s 80-byte bound, in both directions and unpinned in both:
+#   `assert_nulldata`'s `length < 80` weakened to 79 and the builder's
+#   `len(data) > 80` to 79 each survive, so the standardness limit this
+#   library publishes is not what its tests hold it to.
+# - `assert_segwit`'s `0x51 <= script_pub_key[0] <= 0x60` weakened to
+#   `80 <=`, which accepts 0x50 -- OP_RESERVED, not a witness version.
+# - `p2ms`'s arithmetic: `length < 37` at 36, `script_pub_key[0] - 80`
+#   turned into `^ 80` and `% 80`, `m <= n <= 16` into `!= 17`, and the
+#   builder's own `0 < n <= 16` into `< 16`, which never tests 16 keys.
+# - `taproot.parse`'s `len(data) > MAX_SCRIPT_ELEMENT_SIZE` weakened to
+#   `==` and `>=`: the 520-byte element limit is exercised on one side.
+# - `read_op_code`'s `stop + size > len(script)` as `-` and `%`, and
+#   `_serialize_int_command`'s `-1 <= command <= 16` as `~1`.
+#
+# `taproot._read_push_data`'s `i > 75` and `2 ** (i - 76)` are in the list
+# too, and they are the seven lines the test command above says it does not
+# reach: engine.toml is what judges them, exactly as predicted here rather
+# than found out afterwards. The equivalence classes are the ones the other
+# profiles document: an `is` where CPython interns both ints, a
+# `check_validity` default, a `@dataclass(eq=True)` flag, and comparisons
+# against a marker byte at the extreme of the closed set it comes from.
+
+# one mutant at a time, in this working tree: see sig_hash.toml
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/script.toml
+++ b/.github/mutation/script.toml
@@ -89,31 +89,42 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 # test command: 309 killed, 97 survived, 23.89%. Sampled, then, and the
 # sample already answers the question the profile was written to ask.
 #
-# `op_codes_tapscript.py` is the finding: 50 of the 51 mutants of it that
-# ran survived, and the 236 it holds are almost all numeric literals in
-# `OP_CODE_NAMES` and `OP_SUCCESS`. Nothing in the suite asserts either
-# table -- a code number may be changed, duplicated or dropped and every
-# test still passes -- and the two tables are exactly the kind of thing a
-# reader checks by eye and never re-checks. What would kill nearly all of
-# them is cheap: `OP_CODE_NAMES` has to be the inverse of `OP_CODES` for
-# every entry it names, and `OP_SUCCESS` has to be BIP342's set, which is
-# a range expression rather than a list to be transcribed.
+# `op_codes_tapscript.py` was the finding, and is now the answer: 50 of the
+# 51 mutants of it that ran survived, because nothing asserted either of
+# the two BIP342 tables -- a code number could be changed, duplicated or
+# dropped with every test still passing. Two tests hold the tables to each
+# other instead of to a transcription of the BIP's own numbers, and all 236
+# mutants of that module die now: `OP_CODE_NAMES` is the inverse of
+# `OP_CODES` in both directions, and `OP_SUCCESS` is what the two leave
+# over -- every byte below 0xFF that is neither a push nor a named code,
+# which is what BIP342's list *is*.
 #
-# The rest, in the order they are worth acting on:
+# The bounds beside it, each measured surviving before its test and dying
+# after, one mutant at a time, which is what a claim like this is worth:
 #
-# - `nulldata`'s 80-byte bound, in both directions and unpinned in both:
-#   `assert_nulldata`'s `length < 80` weakened to 79 and the builder's
-#   `len(data) > 80` to 79 each survive, so the standardness limit this
-#   library publishes is not what its tests hold it to.
-# - `assert_segwit`'s `0x51 <= script_pub_key[0] <= 0x60` weakened to
-#   `80 <=`, which accepts 0x50 -- OP_RESERVED, not a witness version.
-# - `p2ms`'s arithmetic: `length < 37` at 36, `script_pub_key[0] - 80`
-#   turned into `^ 80` and `% 80`, `m <= n <= 16` into `!= 17`, and the
-#   builder's own `0 < n <= 16` into `< 16`, which never tests 16 keys.
-# - `taproot.parse`'s `len(data) > MAX_SCRIPT_ELEMENT_SIZE` weakened to
-#   `==` and `>=`: the 520-byte element limit is exercised on one side.
-# - `read_op_code`'s `stop + size > len(script)` as `-` and `%`, and
-#   `_serialize_int_command`'s `-1 <= command <= 16` as `~1`.
+# - `nulldata`'s 80-byte cap: the builder's `len(data) > 80` had no test
+#   building the 80 it allows, only the 81 it refuses.
+# - `assert_segwit`'s `0x51 <= script_pub_key[0]`, weakened to `80 <=`,
+#   accepted 0x50 -- OP_RESERVED, which BIP141 leaves out of the witness
+#   versions -- and its exact-length check had never been given a script
+#   shorter than its own marker announces, nor its message read.
+# - `p2ms`'s arithmetic: 16-of-16 is the case that tells `- 80` from the
+#   `^ 80` agreeing with it up to 15, and 16 keys is what the builder's
+#   own `0 < n < 17` had never been asked for. The two markers that
+#   decode to no quorum -- 0xB1 and 0x62 -- name their number in the
+#   refusal now, which is what tells that subtraction from a modulo.
+# - `taproot.parse`'s `len(data) > MAX_SCRIPT_ELEMENT_SIZE`, exercised at
+#   519, 520 and 521 rather than above the limit alone.
+# - `check_output_pubkey`'s `control[0] & 1 == Q[1] % 2`: the parity bit
+#   is flipped now on a proof that is otherwise correct, for an output
+#   key of each parity and on both the bindings and the Python path.
+#
+# `assert_nulldata`'s `length < 78` weakened to 79 is equivalent, and the
+# reason is three lines above it: `length == 78` is refused before that
+# branch is reached, and 78 is the only length at which the two differ.
+#
+# Left open: `read_op_code`'s `stop + size > len(script)` as `-` and `%`,
+# and `_serialize_int_command`'s `-1 <= command <= 16` as `~1`.
 #
 # `taproot._read_push_data`'s `i > 75` and `2 ** (i - 76)` are in the list
 # too, and they are the seven lines the test command above says it does not

--- a/.github/mutation/signer.toml
+++ b/.github/mutation/signer.toml
@@ -1,0 +1,82 @@
+# The signer boundary, mutated: the role that walks a psbt asking a key
+# manager for signatures, the contract that says what an implementation of
+# one owes its caller, and the union type a caller hands either a
+# transaction or a psbt through. What is asked here is not a hash or an
+# encoding but a decision -- which input this signer can sign, whether the
+# answer it got back belongs to the request, whether what came back is
+# signatures and nothing else -- and a wrong decision is a signature over
+# somebody else's transaction. Issue #219's question, on the boundary
+# between btclib and whatever holds the keys.
+
+[cosmic-ray]
+# `hwi.py` is an implementation of that contract rather than the contract,
+# and it is in hwi.toml for a measured reason: its tests spawn a
+# subprocess per case, which costs 4.7 s against this command's 0.2 s, so
+# sharing one command would make every mutant here pay for a fake
+# `hwi.py` being started twenty times
+module-path = [
+  "btclib/psbt_signer.py",
+  "btclib/psbt_signer_contract.py",
+  "btclib/tx_or_psbt.py",
+]
+
+# the three modules' own files plus tests/software_signer_test.py, which
+# is the in-process key manager the contract test drives: measured with
+# `--cov` over the three, this command reports every one complete, in a
+# fifth of a second -- the cheapest command of any profile here
+test-command = """python -m pytest -x -q -n0 -p no:randomly \
+  tests/psbt_signer_test.py tests/psbt_signer_contract_test.py \
+  tests/software_signer_test.py tests/tx_or_psbt_test.py"""
+
+# seconds of wall clock, wide for the reason sig_hash.toml measures: what
+# it guards here is `sign`'s walk over the inputs a manager answered for,
+# where a mutated index or bound is a walk that does not end
+timeout = 300
+
+excluded-modules = []
+
+# the same exclusion wallet.toml explains and parsers.toml argues, for the
+# same measured reason: the only `|` in these three modules are in
+# annotations --
+#
+#   grep -n ' | ' btclib/psbt_signer.py btclib/psbt_signer_contract.py \
+#       btclib/tx_or_psbt.py
+#
+# -- and the first session here, run unfiltered, executed 110 BitOr
+# mutants of which not one was killed
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
+# 412 mutants, 110 of them the `|` above, and the 302 left ran to
+# completion in 565 s -- the only profile of this session that finished,
+# and it finished while four others shared the machine: 236 killed, 66
+# survived, 21.85%.
+#
+# 46 of the 66 are in `psbt_signer_contract.py`, which is worth stating
+# plainly because it is the file whose whole job is refusing a signer that
+# does not conform. Its checks do fire: tests/psbt_signer_contract_test.py
+# builds a signer to break each one, and that is what kills 121 of its
+# 167 mutants. What survives is the arithmetic inside them --
+# `len(answered_in.partial_sigs) - len(psbt_in.partial_sigs)` with `|`,
+# `^`, `+`, `<<` or `>>` for the `-`, the same across the taproot
+# signature counts, and `_check_fingerprint`'s and `_check_xpub`'s `!=`
+# weakened to `>` -- so a check could be laxer than it reads and every
+# fixture in that file would still pass it. A signer conforming to a
+# weakened contract is the failure this scope exists to ask about.
+#
+# The rest:
+#
+# - `unsignable_psbt`'s own numbers, which are the fixture it builds: the
+#   9000-satoshi output, the version, the outpoint index, the flipped
+#   fingerprint byte. Equivalent, and worth saying so once: what makes
+#   that psbt unsignable is the key it pays to, not the amount, so these
+#   are the one class here that no test should chase.
+# - `PsbtSigner.display_address`'s `index: int = 0` default, mutated in
+#   both directions across the class and its two implementations -- the
+#   same undefended-default class wallet.toml measures.
+# - `merge_devices`' `break` turned into `continue`, and `_at`'s
+#   `indexes[:len(path)] == path` weakened to `>=`.
+
+# one mutant at a time, in this working tree: see sig_hash.toml
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/utils.toml
+++ b/.github/mutation/utils.toml
@@ -36,12 +36,12 @@ timeout = 300
 
 excluded-modules = []
 
-# 57 of the 388 mutants sampled in 1800 s -- the same shape numeric.toml
-# measured: `int_from_bits`' own bound absorbed most of the budget once
-# widened into a negative shift, `i >> n` for a negative `n` raising
-# rather than looping, so the cost here is the traceback's, paid once per
-# such mutant rather than accumulating. 50 killed, 7 survived, one an
-# `is` CPython's small-int cache makes indistinguishable from `==`.
+# all 388 mutants, complete in 1200 s: 377 killed, 11 survived, 2.84% --
+# the lowest rate of any profile here, which is what a file of its own
+# round-trip tests earns. The shape numeric.toml met is here too and is
+# what makes the wall clock what it is: `int_from_bits`' bound widened
+# into a negative shift raises rather than loops, so the cost is a
+# traceback's, paid once per such mutant rather than accumulating.
 #
 # Three real gaps, closed:
 #
@@ -56,12 +56,20 @@ excluded-modules = []
 #   curve's `nlen` bits) and never at `blen < nlen`, where `!=` computes
 #   a negative shift instead of returning the input unchanged.
 #
-# Two survivors checked and left as equivalent: `encode_num`'s
-# `abs(i) | ((i < 0) << ...)` against `+` never overlaps a bit, `n_bytes`
-# being sized to hold the sign bit above `abs(i)`'s own; `decode_num`'s
-# `int.from_bytes(..., signed=False)` against `signed=True` is undone by
-# the mask correction three lines below, checked against the existing
-# suite's int64 boundary vectors rather than assumed.
+# Of the 11 left, ten are equivalent and the arithmetic says why rather
+# than a test being owed one: `encode_num`'s `abs(i) | ((i < 0) << ...)`
+# against `+` and `^` never overlaps a bit, `n_bytes` being sized to hold
+# the sign bit above `abs(i)`'s own; `decode_num`'s `signed=False` against
+# True is undone by the mask correction three lines below, and that mask's
+# own `2 ** (length * 8) - 1 >> 1` against `- 2` shifts the difference
+# away; `read_exactly`'s `!=` against `<` cannot differ where `read(size)`
+# returns no more than it was asked for; `hex_string`'s `% 2 != 0` against
+# `> 0` and `int_from_bits`' `>=` against `>` compare values that have two
+# and one reachable answers; and the two `is` mutants are CPython's
+# small-int cache. The eleventh is `encode_num`'s `i.bit_length() + 1`
+# against `| 1`, which differ for an odd bit length and reach the same
+# `n_bytes` for every value the suite carries -- open, and not chased,
+# `n_bytes` being what the round trip already pins from both ends.
 
 [cosmic-ray.distributor]
 name = "local"

--- a/.github/mutation/wallet.toml
+++ b/.github/mutation/wallet.toml
@@ -1,0 +1,87 @@
+# The wallets, mutated: the ledger of what has been handed out, the two
+# key-derived sources, the descriptor-backed one and the script template
+# beside it. What a wallet answers is an address somebody is about to be
+# paid at, and the failure this asks about is the one a test suite is
+# built to miss -- a gap index quietly reused, a branch swapped, a change
+# address answered where a receive one was asked for. Every line runs
+# under tests/wallet; whether the suite would notice a wrong one is this
+# profile's question (issue #219).
+
+[cosmic-ray]
+# the package, `__init__.py` included, for the reason descriptors.toml
+# gives: it is re-exports, and naming the directory is what keeps a fifth
+# module from being left out in silence
+module-path = "btclib/wallet"
+
+# tests/wallet alone, and it is enough for a reason worth stating: the
+# four modules measure 100% under it -- `--cov=btclib/wallet` over this
+# command reports no missing line -- and the whole command costs half a
+# second, which is what makes this the cheapest profile in the directory
+# to run to completion. The descriptor a `DescriptorWallet` delegates to
+# is mutated by descriptors.toml from the other side of the same call
+test-command = "python -m pytest -x -q -n0 -p no:randomly tests/wallet"
+
+# seconds of wall clock, wide for the reason sig_hash.toml measures. What
+# it guards against here is `position_of`, the one loop in the scope with
+# a bound a mutant can widen: it computes the script at every index of
+# every branch up to `last_index` and compares it whole, so a widened
+# bound is minutes of derivation rather than a wrong answer
+timeout = 300
+
+excluded-modules = []
+
+# every `|` in this scope is an annotation, so its mutants are unevaluated
+# and unkillable: parsers.toml carries the whole argument for excluding
+# them by operator, and what belongs here is the measurement behind the
+# claim. The grep, a line number rotting on the next insertion above it:
+#
+#   grep -n ' | ' btclib/wallet/*.py
+#
+# Every hit is an annotation today, and the first session over this scope
+# -- run before this filter, which is how the decision was made rather
+# than assumed -- executed 131 BitOr mutants and every one of them
+# survived, against a rate of 19.11% over what is left. That is the
+# difference between a survivor list somebody reads and one nobody does,
+# and it is minutes as well: an unkillable mutant is a survivor, and a
+# survivor pays the whole test command where most kills pay a fraction
+[cosmic-ray.filters.operators-filter]
+exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
+
+# 595 mutants, 176 of them the `|` above, and 293 of the 419 left ran in
+# the 900 s of the first session: 237 killed, 56 survived, 19.11%. Measured
+# with four other profiles of this directory on the same ten-core machine,
+# so 2.1 s a mutant is the contended figure and a runner on its own is
+# faster; what it says about the budget in mutation.yml is that this scope
+# finishes there with room, which is what makes its rate comparable week to
+# week.
+#
+# What the 56 are, in the order they are worth acting on:
+#
+# - the branch and index defaults. `redeem_script`, `witness_script`,
+#   `satisfy` and `update_psbt_input` all take `branch: int = 0, index:
+#   int = 0`, and every mutant of every one of those defaults survives in
+#   all four modules: no test calls them without arguments, so the
+#   defaults are undefended. The cheapest kills in the profile.
+# - `Wallet.address`'s `self._next_index.get(branch, 0)`, mutated either
+#   way: nothing pins what the ledger answers for a branch it has not
+#   handed anything out on yet, which is what `next_address` reads.
+# - `position_of`'s `range(last_index + 1)`, weakened to `+ 0` and to
+#   `^ 1`: the search is never asked for the output sitting at exactly
+#   `last_index`, so the inclusive end of its own bound is untested.
+# - `ScriptWallet.__init__`'s `not 0 < threshold <= n` weakened to
+#   `not 0 != threshold <= n`, which accepts a negative threshold: the
+#   suite refuses 0 and refuses `threshold > n`, and asks nothing below
+#   zero.
+# - `RangedWallet.branches`' `@abstractmethod`, removed and unnoticed --
+#   the class fetch.toml names, where three abstract methods were only
+#   ever exercised together.
+#
+# The rest are the two equivalence classes the other profiles here already
+# document: `script_type != "p2wpkh-p2sh"` and friends weakened to an
+# inequality, where the value compared is the alphabetical extreme of the
+# closed set it comes from (bms.toml states it), and `len(indexes) is not
+# _ACCOUNT_LEVELS`, where CPython interns both small ints.
+
+# one mutant at a time, in this working tree: see sig_hash.toml
+[cosmic-ray.distributor]
+name = "local"

--- a/.github/mutation/wallet.toml
+++ b/.github/mutation/wallet.toml
@@ -55,32 +55,50 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 # finishes there with room, which is what makes its rate comparable week to
 # week.
 #
-# What the 56 are, in the order they are worth acting on:
+# What the 56 were, and what the tests beside this commit closed -- each
+# measured alive before its test and dead after, one mutant at a time:
 #
-# - the branch and index defaults. `redeem_script`, `witness_script`,
+# - the branch and index defaults, which is the largest class here.
+#   `address`, `script_pub_key`, `redeem_script`, `witness_script`,
 #   `satisfy` and `update_psbt_input` all take `branch: int = 0, index:
-#   int = 0`, and every mutant of every one of those defaults survives in
-#   all four modules: no test calls them without arguments, so the
-#   defaults are undefended. The cheapest kills in the profile.
-# - `Wallet.address`'s `self._next_index.get(branch, 0)`, mutated either
-#   way: nothing pins what the ledger answers for a branch it has not
-#   handed anything out on yet, which is what `next_address` reads.
-# - `position_of`'s `range(last_index + 1)`, weakened to `+ 0` and to
-#   `^ 1`: the search is never asked for the output sitting at exactly
-#   `last_index`, so the inclusive end of its own bound is untested.
-# - `ScriptWallet.__init__`'s `not 0 < threshold <= n` weakened to
-#   `not 0 != threshold <= n`, which accepts a negative threshold: the
-#   suite refuses 0 and refuses `threshold > n`, and asks nothing below
-#   zero.
-# - `RangedWallet.branches`' `@abstractmethod`, removed and unnoticed --
-#   the class fetch.toml names, where three abstract methods were only
-#   ever exercised together.
+#   int = 0` and nothing called any of them without arguments, so a
+#   default was free to name the change chain -- the address a caller
+#   would then have somebody else pay. Each is now asserted to answer
+#   what the explicit first position answers, with the two neighbouring
+#   positions asserted different so the equality is an assertion.
+# - `position_of`'s `range(last_index + 1)`: the search is now asked for
+#   the output at exactly `last_index`, and for one at the index below
+#   its bound, which is what says the bound is inclusive and is a bound.
+# - `KeyGroup`'s `not 0 < threshold <= n` weakened to `not 0 !=
+#   threshold`, which accepts a negative quorum: 0 and `threshold > n`
+#   were refused and nothing asked below zero.
+# - `RangedWallet.branches`' `@abstractmethod`, removed and unnoticed:
+#   the class fetch.toml names. The subclass in the test implements the
+#   other two abstract members and leaves this one out, so the TypeError
+#   is about the member being asserted.
+# - `_account_xkey`'s `indexes[xkey.depth - 1]` in its message, where
+#   `% 1` and `& 1` name a different element of the same path: the
+#   refusal is now read for the index it names.
 #
-# The rest are the two equivalence classes the other profiles here already
-# document: `script_type != "p2wpkh-p2sh"` and friends weakened to an
-# inequality, where the value compared is the alphabetical extreme of the
-# closed set it comes from (bms.toml states it), and `len(indexes) is not
-# _ACCOUNT_LEVELS`, where CPython interns both small ints.
+# Four survive, and each is equivalent rather than a test owed:
+#
+# - `Wallet.redeem_script`'s and `witness_script`'s own defaults, in the
+#   base class: both answer `b""` for every position they accept, so a
+#   default moved to another valid position answers the same. The
+#   overrides that compute a script are the ones the tests above kill.
+# - `Wallet.address`'s `self._next_index.get(branch, 0)`, mutated to -1
+#   or 1: the value is the other argument of `max(..., index + 1)`, and
+#   `index + 1` is at least 1, so the fallback cannot be what max
+#   returns.
+# - the string comparisons weakened to an inequality, where the value
+#   compared is the alphabetical extreme of the closed set it comes from
+#   (bms.toml states the class), and `len(indexes) is not
+#   _ACCOUNT_LEVELS`, where CPython interns both small ints.
+#
+# One is left open and is a gap: `_account_sec`'s
+# `pub_keyinfo_from_key(xkey)[0]` weakened to `[-1]` -- the network beside
+# the key -- survives because nothing builds a `ScriptWallet` with
+# `order="account"`, the one ordering that sorts participants by it.
 
 # one mutant at a time, in this working tree: see sig_hash.toml
 [cosmic-ray.distributor]

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -172,6 +172,54 @@ jobs:
             ceiling: 100
             sessions: |
               signatures.toml 90m
+          # output descriptors and miniscript, and the largest scope in
+          # this matrix by a factor of three: 10831 mutants, of which the
+          # first session judged 383 in 31 minutes -- 4.9 s each with four
+          # other profiles on the same machine. Sampled, then, the way the
+          # engine is, and for the same reason: no budget this workflow is
+          # worth finishes it, and a sample of the same slice each week is
+          # worth having because a verdict that changes in it is a test
+          # that stopped checking what it used to. Its own job because it
+          # would otherwise spend every other scope's budget
+          - profile: output descriptors and miniscript
+            slug: descriptors
+            ceiling: 100
+            sessions: |
+              descriptors.toml 90m
+          # the psbt format: 3524 mutants, 913 of them skipped by the
+          # operator filter that configuration explains, and 887 of the
+          # 2611 left judged in 40 minutes at 2.0 s each -- contended, so a
+          # runner on its own is faster, and 45 minutes there is most of the
+          # scope rather than a third of it
+          - profile: the psbt format
+            slug: psbt
+            ceiling: 60
+            sessions: |
+              psbt.toml 45m
+          # the script encodings the two consensus profiles sit on: 2561
+          # mutants, 187 filtered, and 406 judged in 35 minutes. Not folded
+          # into the consensus job, which spends 180 of its 200 minutes
+          # already, and not into the psbt one, which would then need 90
+          # minutes of its own
+          - profile: the script encodings
+            slug: script
+            ceiling: 60
+            sessions: |
+              script.toml 45m
+          # the four small scopes, which is what makes them one job: signer
+          # finished its 302 filtered mutants in 9 minutes and wallet its
+          # 293 in 15, musig2 spends most of a session on the two `%`
+          # turned `**` its configuration names, and hwi pays 5 s a mutant
+          # for the subprocess each of its tests starts. Budgets in that
+          # order, and the ceiling is their sum plus the environment
+          - profile: wallets, the signer boundary, musig2 and HWI
+            slug: boundaries
+            ceiling: 90
+            sessions: |
+              signer.toml 10m
+              wallet.toml 20m
+              musig2.toml 20m
+              hwi.toml 30m
     steps:
       # every action is pinned to a commit SHA, the tag in the comment: a
       # tag, let alone a branch, is a name its owner can move

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -883,9 +883,10 @@ documented at release-notes length in the first place, and are still in
   below): extended keys, the checksummed codecs, bitcoin message
   signing, BIP322, the block header and its proof-of-work arithmetic,
   and the shared codec helpers, beside the fetch boundary and the
-  numeric validators #327 already named. Ten `.github/mutation/*.toml`
-  profiles in total, each measured on this tree rather than estimated,
-  wired into `mutation.yml` as three new jobs beside the two #327 added.
+  numeric validators #327 already named. Each new
+  `.github/mutation/*.toml` profile measured on this tree rather than
+  estimated, and wired into `mutation.yml` as three new jobs beside the
+  two #327 added.
   The real gaps each one found and closed:
     - `bip32.toml` (1356 mutants, complete): `BIP32KeyData.is_root` had no
     caller at all, so every operator on its three-way `and` survived
@@ -925,8 +926,8 @@ documented at release-notes length in the first place, and are still in
     tested only together, and the BIP39 entropy codec's non-power-of-two
     base.
 
-  A wide class recurs across all ten and is documented, not fixed, in
-  each profile's own file: Python 3.14 evaluates annotations lazily by
+  A wide class recurs across every one of them and is documented, not
+  fixed, in each profile's own file: Python 3.14 evaluates annotations lazily by
   default (PEP 649), so an operator confined to a type annotation is
   equivalent on this interpreter regardless of
   `from __future__ import annotations` — a broader class than the one
@@ -942,6 +943,76 @@ documented at release-notes length in the first place, and are still in
   `ssa.Sig`'s `0 <= self.s < self.ec.n` and `dsa.Sig`'s two equivalents
   were exercised invalid with `ec.p` — a different, larger prime — and
   never with `ec.n` itself
+- **Mutation testing reaches the code added since #327 was written**:
+  output descriptors and miniscript, the wallets, the psbt format, the
+  script encodings the two consensus profiles sit on, MuSig2 with the
+  BIP373 fields it is carried in, the signer boundary and its conformance
+  checker, and the HWI adapter. Seven `.github/mutation/*.toml` profiles
+  and four new jobs in `mutation.yml`, and none of the budgets is an
+  estimate: a first session over each is what wrote them, and each file
+  records its own counts, what its test command covers and why, and the
+  survivors worth acting on. What the sessions found, in the order the
+  findings are worth acting on:
+    - `script.toml` (406 of 2374 judged): `op_codes_tapscript.py` is
+    unjudged — 50 of the 51 mutants of it that ran survived, and the 236
+    it holds are almost all numbers in the two BIP342 tables, so a code
+    number may be changed, duplicated or dropped and the suite still
+    passes. Beside it, `nulldata`'s 80-byte limit is unpinned in both
+    directions, `assert_segwit` accepts 0x50 as a witness version once
+    weakened, and `taproot.parse`'s 520-byte element bound is exercised
+    on one side only.
+    - `psbt.toml` (887 of 2611): every lock-time bound in BIP370's three
+    fields is tested in the middle of its range and at neither end;
+    `_assert_new_taproot_sigs_verify`'s `sig[:64]` widens to `[:65]`
+    unnoticed, which would hash a sighash byte with the signature; and
+    `assert_signatures_only`'s `strict=True` turns False, so a returned
+    psbt with fewer outputs would be compared as far as it goes.
+    - `signer.toml` (302 of 302, the one profile that finished): 46 of
+    its 66 survivors are inside `psbt_signer_contract.py`, the file whose
+    job is refusing a signer that does not conform. Its checks do fire —
+    each has a signer built to break it — but the arithmetic inside them
+    does not, so a check could be laxer than it reads and every fixture
+    would still pass.
+    - `wallet.toml` (293 of 419): the `branch=0, index=0` defaults are
+    undefended in all four modules, nothing pins what the ledger answers
+    for a branch it has handed nothing out on, `position_of` is never
+    asked for the output at exactly `last_index`, and a negative
+    `ScriptWallet` threshold is accepted once the bound is weakened.
+    - `hwi.toml` (144 of 267): the read bound #526 added is enforced at
+    whatever offset the code says — `max_output + 1` mutates freely — and
+    `is_usable`'s `and` becomes `or` unnoticed, no fixture answering both
+    a fingerprint and an error, which is the entry #534 was about.
+    - `descriptors.toml` (383 of 10831, the largest scope here and
+    sampled): the miniscript type-property algebra survives `|` turned
+    `^` in three places, `satisfy`'s index default is undefended, and
+    `_decomposed`'s push-size arithmetic is unpinned.
+    - `musig2.toml` (159 of 1277): 6.29%, the lowest rate measured here,
+    which is what a reference implementation's own vectors buy. Its two
+    `% secp256k1.n` reductions turned `** secp256k1.n` are also the
+    slowest mutants in this round, spending a 300-second timeout each.
+
+  The operator filter is now a per-scope measurement rather than
+  `parsers.toml`'s precedent applied by hand: an ast walk says where a `|`
+  is arithmetic and where it is an unevaluated annotation, and the first
+  unfiltered session says the same thing from the other side — in the five
+  scopes that exclude it, not one `|` mutant was ever killed. `psbt.toml`
+  excludes it too and names the two expressions that costs, and
+  `descriptors.toml` and `bip322.toml` keep it because in those two the
+  operator is the semantics. `tests/fuzz_test.py` is in no profile, and
+  that is now written down where the decision is: hypothesis draws fresh
+  input on each run, so a verdict from it is not reproducible, and the
+  value of a weekly report is the comparison with the week before.
+
+  Two existing profiles were re-measured over code that changed under
+  them, and both now finish rather than sample: `utils.toml` at 388
+  mutants, 2.84%, ten of its eleven survivors equivalent by arithmetic
+  the file now states; and `bip322.toml` at 552, 17.39%, where the 120
+  mutants of a `|` that #537's test was written for all die.
+
+  `CONTRIBUTING.md` no longer counts the profiles or names the Bitcoin
+  Core rpc client that has moved to a repository of its own: it points at
+  `.github/mutation/`, which is the list, and says what each file in it
+  states.
 - **The two regtest tests get an account each**, where they shared one and
   so shared its first address. The node is the session's, and a wallet the
   second test to run creates still saw what the first had paid: the import

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -952,36 +952,57 @@ documented at release-notes length in the first place, and are still in
   estimate: a first session over each is what wrote them, and each file
   records its own counts, what its test command covers and why, and the
   survivors worth acting on. What the sessions found, in the order the
-  findings are worth acting on:
-    - `script.toml` (406 of 2374 judged): `op_codes_tapscript.py` is
+  findings are worth acting on — the first four scopes' real gaps closed
+  by the tests in this release, each measured alive before its test and
+  dead after, one mutant at a time:
+    - `script.toml` (406 of 2374 judged): `op_codes_tapscript.py` was
     unjudged — 50 of the 51 mutants of it that ran survived, and the 236
     it holds are almost all numbers in the two BIP342 tables, so a code
-    number may be changed, duplicated or dropped and the suite still
-    passes. Beside it, `nulldata`'s 80-byte limit is unpinned in both
-    directions, `assert_segwit` accepts 0x50 as a witness version once
-    weakened, and `taproot.parse`'s 520-byte element bound is exercised
-    on one side only.
+    number could be changed, duplicated or dropped with the suite still
+    passing. Two tests hold the tables to each other rather than to a
+    second transcription of BIP342's numbers, and that module is at 236
+    of 236 killed now. Beside it: `nulldata`'s 80-byte cap had no test
+    building the 80 it allows, `assert_segwit` accepted 0x50 — OP_RESERVED
+    — as a witness version once weakened and never saw a script shorter
+    than its own marker announces, `p2ms` had never been asked for the
+    16-of-16 that tells its marker arithmetic apart from bit arithmetic,
+    `taproot.parse`'s 520-byte element bound was exercised on one side,
+    and a control block's parity bit was never flipped on a proof that is
+    otherwise correct.
     - `psbt.toml` (887 of 2611): every lock-time bound in BIP370's three
-    fields is tested in the middle of its range and at neither end;
-    `_assert_new_taproot_sigs_verify`'s `sig[:64]` widens to `[:65]`
-    unnoticed, which would hash a sighash byte with the signature; and
-    `assert_signatures_only`'s `strict=True` turns False, so a returned
-    psbt with fewer outputs would be compared as far as it goes.
+    fields was tested in the middle of its range and at neither end, and
+    each is now asserted at the value it admits as well as the one it
+    refuses — 0 included, which is the one value BIP65 gives a meaning of
+    its own. `combine`'s identity comparison was tested with the ids in
+    one arrangement only. `_assert_new_taproot_sigs_verify`'s `sig[:64]`
+    widening to `[:65]` stays open and is named: it differs only for a
+    65-byte signature, and no taproot script path in this tree can yet
+    produce one, the only source being a MuSig2 aggregation over
+    SIGHASH_DEFAULT.
     - `signer.toml` (302 of 302, the one profile that finished): 46 of
     its 66 survivors are inside `psbt_signer_contract.py`, the file whose
     job is refusing a signer that does not conform. Its checks do fire —
     each has a signer built to break it — but the arithmetic inside them
     does not, so a check could be laxer than it reads and every fixture
-    would still pass.
-    - `wallet.toml` (293 of 419): the `branch=0, index=0` defaults are
-    undefended in all four modules, nothing pins what the ledger answers
-    for a branch it has handed nothing out on, `position_of` is never
-    asked for the output at exactly `last_index`, and a negative
-    `ScriptWallet` threshold is accepted once the bound is weakened.
-    - `hwi.toml` (144 of 267): the read bound #526 added is enforced at
-    whatever offset the code says — `max_output + 1` mutates freely — and
-    `is_usable`'s `and` becomes `or` unnoticed, no fixture answering both
-    a fingerprint and an error, which is the entry #534 was about.
+    would still pass. Not closed here: the arithmetic is the next round's
+    work, and `signer.toml` lists it.
+    - `wallet.toml` (293 of 419): the `branch=0, index=0` defaults were
+    undefended in all four modules — nothing called `address`,
+    `script_pub_key`, `redeem_script`, `witness_script`, `satisfy` or
+    `update_psbt_input` without arguments, so a default could have named
+    the change chain — `position_of` was never asked for the output at
+    exactly `last_index`, a negative `ScriptWallet` quorum was accepted
+    once the bound was weakened, and `branches` could stop being abstract
+    unnoticed. All four are closed; what the ledger answers for an
+    untouched branch turned out to be equivalent, `max()` never returning
+    that fallback.
+    - `hwi.toml` (144 of 267): `is_usable`'s `and` became `or` unnoticed,
+    no fixture answering both a fingerprint and an error — the entry #534
+    was about, and the device `_select` must not pick. The four refusals
+    name `argv[0]` and no assertion said so; `--emulators` could move
+    after the subcommand, where HWI reads it as an unrecognized argument.
+    The `max_output + 1` read cap turned out equivalent: any cap above
+    the limit gives the comparison below it the same verdict.
     - `descriptors.toml` (383 of 10831, the largest scope here and
     sampled): the miniscript type-property algebra survives `|` turned
     `^` in three places, `satisfy`'s index default is undefended, and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -359,13 +359,14 @@ The `mutation` workflow, weekly and on demand, which gates nothing either
 and for a different reason: it asks whether the suite would *notice* a
 wrong line, where coverage only says the line ran, and a surviving mutant
 is a test nobody has written rather than a regression somebody just
-caused. Three profiles, a parallel job with its own budget each: the
-consensus code — `btclib/script/engine/` and `btclib/script/sig_hash.py` —
-the wire format, `btclib/tx/` with the `var_int` and `var_bytes`
-codecs under it, and the standalone Bitcoin Core rpc client. The
-configurations under `.github/mutation/` are
-what says so, and are what a local run reads, so there is one statement of
-what is mutated and what judges it:
+caused. One parallel job per profile, each under its own budget, and no
+list of them here: `.github/mutation/` is the list, and every file in it
+states what it mutates, what judges it, and what the last session over it
+measured — the consensus code and the wire format it reads, the key,
+codec, descriptor, wallet, psbt and script layers, the signature schemes,
+and the boundaries where somebody else's bytes arrive. Those
+configurations are also what a local run reads, so there is one statement
+of what is mutated and what judges it:
 
 ```shell
 uv run --locked --no-default-groups --group test --group mutation \

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -33,6 +33,7 @@ split every vendored vector here has.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -749,3 +750,85 @@ def test_the_stand_in_is_a_subprocess_and_not_a_mock(hwi: list[str]) -> None:
     )
     (device,) = json.loads(completed.stdout)
     assert device["fingerprint"] == FINGERPRINT
+
+
+def test_a_device_is_usable_only_with_a_fingerprint_and_no_error() -> None:
+    """Both halves, and HWI can answer both at once.
+
+    A locked device answers an error and no fingerprint, and that is the
+    pair this reads like -- but a device can be enumerated with a
+    fingerprint *and* an error, HWI having asked it two questions, and
+    then the fingerprint is one nothing may be signed against. Which is
+    why the two are an `and`: either half alone would make that device
+    usable, and `_select` would pick it as the one to sign with.
+    """
+    known = bytes.fromhex(FINGERPRINT)
+    usable = HwiDevice(type="trezor", model="1", path="0001:0002", fingerprint=known)
+    assert usable.is_usable
+
+    locked = HwiDevice(type="trezor", model="1", path="0001:0002", error="locked")
+    assert not locked.is_usable
+
+    both = HwiDevice(
+        type="trezor",
+        model="1",
+        path="0001:0002",
+        fingerprint=known,
+        error="Could not open client or get fingerprint",
+    )
+    assert not both.is_usable
+
+    # and the flags a device does not carry are off: HWI omits them for a
+    # device that needs nothing sent, so the default is what most devices
+    # are read with
+    assert not usable.needs_pin_sent
+    assert not usable.needs_passphrase_sent
+
+
+def test_every_refusal_names_the_command_it_ran(tmp_path: Path) -> None:
+    """The message names argv[0], which is the executable and not a flag.
+
+    A caller offering signers of several kinds reads that name to know
+    which one failed, and every one of these messages is built from the
+    same argv -- so naming any other element of it would name a chain
+    flag, a subcommand or the script the interpreter was given.
+    """
+    # anchored on the colon that follows it, the OSError carried after it
+    # naming the same path: what is being asserted is which element of the
+    # argv the message opens with
+    missing = str(tmp_path / "nowhere")
+    with pytest.raises(SignerNotFoundError, match=f"cannot run {re.escape(missing)}:"):
+        enumerate_devices(executable=missing)
+
+    flood = tmp_path / "flood.py"
+    flood.write_text("print('x' * 100)\n", encoding="ascii")
+    with pytest.raises(SignerError, match=re.escape(sys.executable)):
+        enumerate_devices(executable=[sys.executable, str(flood)], max_output=10)
+
+    chatty = tmp_path / "chatty.py"
+    chatty.write_text(
+        "import sys\nsys.stderr.write('x' * 100)\nprint('[]')\n", encoding="ascii"
+    )
+    with pytest.raises(SignerError, match=re.escape(sys.executable)):
+        enumerate_devices(executable=[sys.executable, str(chatty)], max_output=10)
+
+    slow = tmp_path / "slow.py"
+    slow.write_text("import time; time.sleep(5)\n", encoding="ascii")
+    with pytest.raises(SignerError, match=re.escape(sys.executable)):
+        enumerate_devices(executable=[sys.executable, str(slow)], timeout=0.2)
+
+
+def test_the_emulators_flag_is_global_and_goes_before_the_command(
+    tmp_path: Path,
+) -> None:
+    """HWI's parser reads it as a global flag, so it goes ahead of enumerate.
+
+    Where in the argv it is inserted is not a style question: a global
+    flag after the subcommand is an unrecognized argument to that
+    subcommand, and the answer is HWI's usage message rather than a
+    device list.
+    """
+    hwi = stand_in(tmp_path, {"enumerate": []})
+    enumerate_devices(executable=hwi, emulators=True)
+    argv = last_argv(hwi)
+    assert argv[argv.index("--emulators") + 1] == "enumerate"

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -497,7 +497,12 @@ def test_the_identifier_of_a_v2_psbt_ignores_the_sequences() -> None:
     other = deepcopy(psbt)
     other.inputs[0].output_index = 1
     with pytest.raises(BTClibValueError, match="mismatched psbt.tx.id: "):
-        combine([psbt, other])
+        combine([deepcopy(psbt), deepcopy(other)])
+    # and the other way round: what is compared is two identifiers for
+    # equality, where an ordering would refuse one of the two arrangements
+    # of the same disagreement and accept the other
+    with pytest.raises(BTClibValueError, match="mismatched psbt.tx.id: "):
+        combine([deepcopy(other), deepcopy(psbt)])
 
     # and the two versions are not combined into each other: which of
     # them the result would be is the caller's to say, with to_v0/to_v2
@@ -806,6 +811,55 @@ def test_the_values_the_v2_fields_may_hold() -> None:
 
     psbt.fallback_lock_time = 0xFFFFFFFF + 1
     with pytest.raises(BTClibValueError, match="invalid fallback locktime: "):
+        psbt.assert_valid()
+
+
+def test_the_v2_fields_are_valid_at_both_ends_of_their_range() -> None:
+    """The value each bound allows, beside the one the test above refuses.
+
+    A range asserted from one side only is a range whose own number never
+    mattered: every one of these bounds survives being moved by one as
+    long as nothing asks for the value it is supposed to admit. So each
+    is exercised here at the edge it accepts -- and at zero, which is a
+    number three of these fields treat differently from each other.
+    """
+    psbt = _bip370_psbt("1 input, 2 output updated PSBTv2")
+    psbt_in = psbt.inputs[0]
+
+    # a timestamp of 0xFFFFFFFF is the last second nLockTime can express,
+    # and the second after it is a field that does not fit
+    psbt_in.required_time_lock_time = 0xFFFFFFFF
+    psbt_in.assert_valid()
+    psbt_in.required_time_lock_time = 0xFFFFFFFF + 1
+    with pytest.raises(BTClibValueError, match="invalid required time locktime: "):
+        psbt_in.assert_valid()
+    psbt_in.required_time_lock_time = None
+
+    # height 1 is the first block a lock time can require: 0 is
+    # nLockTime's "no lock time at all", so an input requiring it
+    # requires nothing
+    psbt_in.required_height_lock_time = 1
+    psbt_in.assert_valid()
+    psbt_in.required_height_lock_time = 0
+    with pytest.raises(BTClibValueError, match="invalid required height locktime: 0"):
+        psbt_in.assert_valid()
+    psbt_in.required_height_lock_time = None
+
+    # no flag set is a psbt nobody may modify, which is a psbt ready to
+    # be signed rather than an invalid one
+    psbt.tx_modifiable = 0
+    psbt.assert_valid()
+    psbt.tx_modifiable = 0xFF
+    psbt.assert_valid()
+    psbt.tx_modifiable = None
+
+    # and both ends of the fallback lock time, which is the field the
+    # Creator writes when no input requires one
+    for lock_time in (0, 0xFFFFFFFF):
+        psbt.fallback_lock_time = lock_time
+        psbt.assert_valid()
+    psbt.fallback_lock_time = -1
+    with pytest.raises(BTClibValueError, match="invalid fallback locktime: -1"):
         psbt.assert_valid()
 
 

--- a/tests/script/op_codes_taproot_test.py
+++ b/tests/script/op_codes_taproot_test.py
@@ -2,12 +2,28 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Tests for the `btclib.script.op_codes_tapscript` module."""
+"""Tests for the `btclib.script.op_codes_tapscript` module.
+
+Two of these hold the tables to each other rather than to a copy of
+BIP342's own numbers, which is what a table can be held to at all: a
+transcription checked against a transcription answers whichever of the
+two the reader trusted, and the numbers are the one thing here nobody
+re-derives by eye.
+"""
 
 import pytest
 
 from btclib.exceptions import BTClibValueError
-from btclib.script.op_codes_tapscript import _serialize_str_command
+from btclib.script.op_codes_tapscript import (
+    OP_CODE_NAMES,
+    OP_CODES,
+    OP_SUCCESS,
+    _serialize_str_command,
+)
+
+# a push of its own length, 0x01 to 0x4b, which is neither a named op code
+# nor an OP_SUCCESS: the byte is the length and the data follows it
+_DATA_PUSHES = frozenset(range(1, 0x4C))
 
 
 def test_invalid_op_success() -> None:
@@ -20,3 +36,46 @@ def test_invalid_op_success() -> None:
         _serialize_str_command("OP_SUCCESS173")
 
     assert _serialize_str_command("OP_SUCCESS80") == b"\x50"
+
+
+def test_the_two_tables_are_each_other_inverted() -> None:
+    """Every name answers the code that names it back, and all of them do.
+
+    `OP_CODES` maps a name to its byte and `OP_CODE_NAMES` the byte back
+    to a name, so a number wrong in either is a script serialized as one
+    thing and parsed as another. Both directions are asserted because
+    each catches what the other cannot: a changed key in `OP_CODE_NAMES`
+    fails the first, an entry dropped from it the second.
+
+    `OP_CODES` holds the more entries of the two, and the difference is
+    the aliases -- OP_FALSE for OP_0, OP_TRUE for OP_1, OP_NOP2 and
+    OP_NOP3 for the two timelock verifications -- which share a byte with
+    the name that byte answers to.
+    """
+    for code, name in OP_CODE_NAMES.items():
+        assert OP_CODES[name] == bytes([code]), name
+
+    named = {byte for (byte,) in OP_CODES.values()}
+    assert named == set(OP_CODE_NAMES)
+
+
+def test_op_success_is_what_the_tables_leave_over() -> None:
+    """OP_SUCCESSx is every byte that is not a push and not a named code.
+
+    BIP342 lists them -- 80, 98, 126-129, 131-134, 137-138, 141-142,
+    149-153 and 187-254 -- and that list is the complement of what a
+    tapscript may otherwise hold, which is what this asserts instead of
+    the list: the opcodes disabled or undefined before taproot are
+    exactly the ones it makes succeed. Written the other way round it
+    would be BIP342's numbers checked against BIP342's numbers.
+
+    0xFF is the one byte in neither set, and it is why the range above
+    stops at 254: Core reads it as OP_INVALIDOPCODE, a value no script
+    can carry rather than one a tapscript spends.
+    """
+    named = {byte for (byte,) in OP_CODES.values()}
+    assert set(OP_SUCCESS) == set(range(0xFF)) - _DATA_PUSHES - named
+    # a list rather than a set in the module, so it can hold a number
+    # twice and cover for one it lost
+    assert len(OP_SUCCESS) == len(set(OP_SUCCESS))
+    assert 0xFF not in OP_SUCCESS

--- a/tests/script/script_pub_key_test.py
+++ b/tests/script/script_pub_key_test.py
@@ -13,6 +13,7 @@ import pytest
 
 from btclib import b32, b58, var_bytes
 from btclib.alias import ScriptList
+from btclib.curves import bytes_from_point, mult
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
 from btclib.script import (
@@ -1000,3 +1001,128 @@ def test_equality_is_by_network_type() -> None:
 
     # and a non-ScriptPubKey is still NotImplemented, i.e. not equal
     assert decoded != decoded.script
+
+
+def test_the_nulldata_payload_cap_is_reachable_not_only_crossable() -> None:
+    """80 bytes is a payload, 81 is one too many, and 76 changes the marker.
+
+    The builder's own bound, where a caller meets it, and the byte on
+    each side of it: `test_nulldata3` above asks for 81 and never for
+    the 80 that must be built.
+
+    The 76-byte payload is the other boundary in the same function, and
+    it is not the payload's: a push of 76 bytes or more needs
+    OP_PUSHDATA1, so the script grows a byte and the length marker moves
+    from `script_pub_key[1]` to `script_pub_key[2]`. 79 octets of script
+    is the first length that reads the second one.
+    """
+    assert len(ScriptPubKey.nulldata(b"\x00" * 80).script) == 83
+    err_msg = "invalid nulldata payload length: "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        ScriptPubKey.nulldata(b"\x00" * 81)
+
+    script_pub_key = serialize(["OP_RETURN", b"\x00" * 76])
+    assert len(script_pub_key) == 79
+    assert script_pub_key[1] == 0x4C
+    assert_nulldata(script_pub_key)
+
+
+def test_a_segwit_script_pub_key_is_its_two_markers() -> None:
+    """OP_RESERVED is not a witness version, and the length must be exact.
+
+    0x50 sits directly below OP_1 and is the byte a version window with
+    the wrong floor lets through: it is OP_RESERVED, which BIP141 leaves
+    out of the versions a segwit output may carry.
+
+    The length is checked against the marker rather than only bounded by
+    it, so a script one byte short of what its own marker announces is
+    refused, and the refusal names both numbers -- which is what says
+    the expected one is the marker plus its two prefix bytes.
+    """
+    program = b"\x00" * 20
+    err_msg = "invalid witness version: 0x50"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_segwit(b"\x50" + bytes([len(program)]) + program)
+    assert_segwit(b"\x51" + bytes([len(program)]) + program)
+
+    err_msg = "invalid segwit script length: 21, 22 expected"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_segwit(b"\x00\x14" + b"\x00" * 19)
+    err_msg = "invalid segwit script length: 23, 22 expected"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_segwit(b"\x00\x14" + b"\x00" * 21)
+
+
+def test_p2ms_at_the_sixteen_key_maximum() -> None:
+    """16-of-16 is the largest m-of-n an op_int can spell.
+
+    Both markers are OP_16, and 0x60 is the one value in OP_1..OP_16
+    whose distance from OP_RESERVED is not what the low bits of the byte
+    alone would make it -- so a 16-of-16 is what tells the subtraction
+    that reads m and n from those markers apart from the bit arithmetic
+    that agrees with it up to 15.
+    """
+    keys = [bytes_from_point(mult(i)) for i in range(1, 17)]
+    script_pub_key = ScriptPubKey.p2ms(16, keys, lexicographic_sorting=False).script
+    assert script_pub_key[0] == 0x60
+    assert script_pub_key[-2] == 0x60
+    assert is_p2ms(script_pub_key)
+    script_type, payload = type_and_payload(script_pub_key)
+    assert script_type == "p2ms"
+    assert payload == script_pub_key[:-1]
+
+
+def test_p2ms_refuses_what_its_markers_cannot_mean() -> None:
+    """The two markers are read as numbers, and both are named when wrong.
+
+    A 1-of-1 with a compressed key is the shortest p2ms there is at 37
+    octets, so 36 is refused for its length and not for what a shorter
+    script happens to hold. The two after it are markers that decode to
+    a number no quorum can use, and the messages carry that number
+    because it is the only way to see which byte the parser read.
+    """
+    key = bytes_from_point(mult(1))
+    shortest = bytes([0x51, 33, *key, 0x51, 0xAE])
+    assert len(shortest) == 37
+    assert is_p2ms(shortest)
+
+    err_msg = "invalid p2ms length 36"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_p2ms(bytes([0x51, 32, *key[:32], 0x51, 0xAE]))
+
+    # 0xB1 is OP_CHECKLOCKTIMEVERIFY, 177: as a quorum marker it is 97,
+    # which is what the message has to say to tell the subtraction from
+    # a modulo that agrees with it for every marker a wallet writes
+    err_msg = "invalid m-of-n: 1-of-97"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_p2ms(bytes([0x51, 33, *key, 0xB1, 0xAE]))
+
+    # OP_18 does not exist, and 0x62 -- OP_VER -- is where it would be:
+    # 18 keys is past the 16 a p2ms may pay to, so the window has an
+    # upper end and not only an ordering against m
+    err_msg = "invalid m-of-n: 1-of-18"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_p2ms(bytes([0x51, 33, *key, 0x62, 0xAE]))
+
+
+def test_a_leading_op_code_is_compared_for_equality() -> None:
+    """Each template's first byte is the op code it names, not a floor.
+
+    Weakened to an inequality every one of these still refuses the byte
+    below it and accepts the byte above, which for a nulldata is a
+    script that is not an OP_RETURN classified as one. The bytes chosen
+    are one above what each template requires, and the rest of every
+    script here is what that template wants.
+    """
+    err_msg = "missing leading OP_RETURN"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_nulldata(b"\x6b\x01\x00")
+    assert not is_nulldata(b"\x6b\x01\x00")
+
+    err_msg = "missing leading OP_HASH160"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_p2sh(b"\xab\x14" + b"\x00" * 20 + b"\x87")
+
+    err_msg = "invalid redeem script hash length marker: 33 instead of 32"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        assert_p2wsh(b"\x00\x21" + b"\x00" * 32)

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -33,6 +33,7 @@ from btclib.script import (
     taproot,
     type_and_payload,
 )
+from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
 from btclib.script.taproot import parse, serialize, tree_helper
 from btclib.tx import TxOut
 from tests import load, vector_id
@@ -379,3 +380,64 @@ def test_tweak_above_group_order() -> None:
     control = b"\xc0" + bytes(32)
     with pytest.raises(BTClibValueError, match=err_msg):
         check_output_pubkey(q, "51", control, ec)
+
+
+def test_the_element_size_limit_is_reachable_not_only_crossable() -> None:
+    """520 bytes is an element a tapscript may push; 521 is one too many.
+
+    BIP342 keeps the limit script.parse enforces and moves the refusal:
+    an OP_SUCCESS makes a script valid whatever else it holds, so the
+    parse notes the oversized element and raises only if it reaches the
+    end without meeting one. What that leaves to test is the bound
+    itself, from both sides -- a limit tested above only is a limit
+    whose own value never mattered.
+    """
+    for size in (MAX_SCRIPT_ELEMENT_SIZE - 1, MAX_SCRIPT_ELEMENT_SIZE):
+        data = b"\x00" * size
+        script = b"\x4d" + size.to_bytes(2, "little") + data
+        assert parse(script) == [data.hex().upper()]
+
+    size = MAX_SCRIPT_ELEMENT_SIZE + 1
+    script = b"\x4d" + size.to_bytes(2, "little") + b"\x00" * size
+    err_msg = "Invalid pushdata length"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        parse(script)
+
+    # and the same element under an OP_SUCCESS, which is valid: 0x50 is
+    # OP_SUCCESS80, and what follows one is not parsed at all
+    assert parse(b"\x50" + script) == ["OP_SUCCESS80", script]
+
+
+@pytest.mark.parametrize("internal_key", [0xC0FFEE, 0xBADC0DE])
+def test_the_control_block_commits_to_the_output_key_parity(
+    internal_key: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The lowest bit of the first control byte is the output key's parity.
+
+    The rest of that byte is the leaf version, which the leaf hash reads
+    with the parity bit masked off, so flipping it leaves every hash in
+    the proof alone and changes only the claim about which of the two y
+    coordinates the output key has. Both paths compare it --
+    libsecp256k1's `tweak_add_check` takes it as an argument and the
+    Python one against Q's own y -- and a wrong claim has to be a no on
+    each.
+
+    Two internal keys because the output key's parity is what it is:
+    0xC0FFEE tweaks to an even y and 0xBADC0DE to an odd one, so between
+    them the bit is asserted in both directions rather than in whichever
+    one this tree happens to produce.
+    """
+    pub_key = mult(internal_key)
+    script_tree: TaprootScriptTree = [[(0xC0, ["OP_2"])], [(0xC0, ["OP_3"])]]
+    q, parity = output_pubkey(pub_key, script_tree)
+    script, control = input_script_sig(pub_key, script_tree, 0)
+    script_bytes = serialize(script)
+    assert control[0] & 1 == parity
+    flipped = bytes([control[0] ^ 1]) + control[1:]
+
+    assert check_output_pubkey(q, script_bytes, control)
+    assert not check_output_pubkey(q, script_bytes, flipped)
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
+        assert check_output_pubkey(q, script_bytes, control)
+        assert not check_output_pubkey(q, script_bytes, flipped)

--- a/tests/wallet/key_wallet_test.py
+++ b/tests/wallet/key_wallet_test.py
@@ -160,8 +160,12 @@ def test_a_bip32keydata_is_taken_as_it_is() -> None:
 
 def test_the_key_index_must_be_the_path_element_at_its_depth() -> None:
     """Refuse a key at the wrong index, or past the account depth."""
-    # the account 0 xpub against the path of account 1
-    with pytest.raises(BTClibValueError, match="is not the account path's"):
+    # the account 0 xpub against the path of account 1, and the message
+    # names the index the path has at that depth -- which is what says
+    # the comparison read the element the key's own depth points at,
+    # rather than some other element of the same path
+    err_msg = "key index 2147483648 at depth 3 is not the account path's 2147483649"
+    with pytest.raises(BTClibValueError, match=err_msg):
         BIP32KeyWallet(_ACCOUNT_44_XPUB, "m/44h/0h/1h")
     # a key already below the account level
     too_deep = bip32.derive(_ACCOUNT_44_XPUB, "m/0/0")

--- a/tests/wallet/script_wallet_test.py
+++ b/tests/wallet/script_wallet_test.py
@@ -220,6 +220,10 @@ def test_a_quorum_is_bounded_by_what_op_int_spells() -> None:
         KeyGroup(4, _XPUBS)
     with pytest.raises(BTClibValueError, match="invalid threshold in 0-of-3"):
         KeyGroup(0, _XPUBS)
+    # and below zero, which a window asserted at 0 alone lets through: the
+    # floor is a quorum of one and not "not zero"
+    with pytest.raises(BTClibValueError, match="invalid threshold in -1-of-3"):
+        KeyGroup(-1, _XPUBS)
     # a group takes any spelling of an extended key, decoded or not
     assert (
         KeyGroup(1, [BIP32KeyData.b58decode(_XPUBS[0])]).keys

--- a/tests/wallet/wallet_test.py
+++ b/tests/wallet/wallet_test.py
@@ -241,3 +241,83 @@ def test_an_address_of_a_bech32_spelling_is_found_however_it_is_written() -> Non
     for spelling in (address.upper(), f"  {address}  ", address.encode("ascii")):
         assert spelling in wallet
         assert wallet.address_info(spelling).address == address
+
+
+@BUILDERS
+def test_every_position_argument_defaults_to_the_first_receiving_address(
+    build: Callable[[], RangedWallet],
+) -> None:
+    """Branch 0 and index 0, which is what "the" address of a wallet means.
+
+    Each of these takes the pair and nothing called them without it, so
+    the defaults were free to name any position -- the change chain
+    included, which is the address a caller would then have somebody else
+    pay. The neighbours are asserted different afterwards, an equality
+    against a position that answers the same everywhere being no
+    assertion at all.
+    """
+    wallet = build()
+    assert wallet.address() == wallet.address(0, 0)
+    assert wallet.script_pub_key() == wallet.script_pub_key(0, 0)
+    assert wallet.redeem_script() == wallet.redeem_script(0, 0)
+    assert wallet.witness_script() == wallet.witness_script(0, 0)
+
+    assert wallet.script_pub_key(0, 0) != wallet.script_pub_key(0, 1)
+    assert wallet.script_pub_key(0, 0) != wallet.script_pub_key(1, 0)
+
+
+@BUILDERS
+def test_position_of_searches_up_to_last_index_inclusive(
+    build: Callable[[], RangedWallet],
+) -> None:
+    """`last_index` is the last index searched, not the first one left out.
+
+    The output at exactly that index is the case that says which, and
+    the index below it is what says the search is bounded at all: a
+    walk one short of its own bound answers None for an output the
+    wallet holds, which is the answer a caller reads as "somebody
+    else's".
+    """
+    wallet = build()
+    script_pub_key = wallet.script_pub_key(0, 3)
+    assert wallet.position_of(script_pub_key, last_index=3) == (0, 3)
+    assert wallet.position_of(script_pub_key, last_index=2) is None
+
+
+def test_a_wallet_that_names_no_branches_is_not_a_wallet() -> None:
+    """`branches` is abstract, and a subclass leaving it out cannot be built.
+
+    Three abstract members, and a test that builds a subclass implementing
+    all of them says nothing about any one of them: what makes this an
+    assertion is that the class below implements the other two, so the
+    TypeError names the one it left out. `position_of` searches whatever
+    this answers, so a wallet without it would search nothing and answer
+    that every output is somebody else's.
+    """
+
+    class Branchless(RangedWallet):
+        """A wallet with an output at every position and no chains."""
+
+        @property
+        def is_watch_only(self) -> bool:
+            return True
+
+        def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
+            return ScriptPubKey(b"\x51")
+
+    with pytest.raises(TypeError, match="branches"):
+        Branchless()  # type: ignore[abstract]
+
+    # the same class with the chains it was missing, which is what says the
+    # refusal above was about that member and not about the other two
+    class OneBranch(Branchless):
+        """The same wallet, on the receiving chain alone."""
+
+        @property
+        def branches(self) -> tuple[int, ...]:
+            return (0,)
+
+    wallet = OneBranch()
+    assert wallet.is_watch_only
+    assert wallet.script_pub_key(0, 0).script == b"\x51"
+    assert wallet.position_of(b"\x51") == (0, 0)


### PR DESCRIPTION
Seven new `.github/mutation/*.toml` profiles and four new jobs in
`mutation.yml`, over the code that has landed since issue
[#327](https://github.com/btclib-org/btclib/issues/327) named its four
scopes: output descriptors and miniscript, the wallets, the psbt format,
the script encodings the two consensus profiles sit on, MuSig2 with the
BIP373 fields carrying it, the signer boundary with its conformance
checker, and the HWI adapter.

Every budget in the workflow comes from a first session over the scope on
this tree, five sessions sharing a ten-core machine, so the per-mutant
figures recorded are the contended ones and a dedicated runner is faster.
Each configuration states its own counts, what its test command covers
and why, what it leaves out, and the survivors worth acting on.

| profile | mutants | filtered | judged | killed | survived | rate |
|---|---|---|---|---|---|---|
| `descriptors` | 10831 | — | 383 | 291 | 92 | 24.02% |
| `psbt` | 3524 | 2611 | 887 | 780 | 107 | 12.06% |
| `script` | 2561 | 2374 | 406 | 309 | 97 | 23.89% |
| `musig2` | 1409 | 1277 | 159 | 149 | 10 | 6.29% |
| `wallet` | 595 | 419 | 293 | 237 | 56 | 19.11% |
| `signer` | 412 | 302 | 302 | 236 | 66 | 21.85% |
| `hwi` | 333 | 267 | 144 | 122 | 22 | 15.28% |

Two existing profiles were re-run over code that changed under them today
and both now finish rather than sample: `utils.toml` at 388 mutants and
2.84%, and `bip322.toml` at 552 and 17.39% — where the 120 mutants of a
`|` that [#537](https://github.com/btclib-org/btclib/pull/537)'s test was
written for all die.

## What the sessions found

A survivor is a test nobody has written yet, and this workflow gates
nothing, so nothing here is fixed in this pull request. Worst first:

- **`op_codes_tapscript.py` is unjudged**: 50 of the 51 mutants of it that
  ran survived, and the 236 it holds are almost all numbers in BIP342's
  two tables. A code number may be changed, duplicated or dropped and the
  suite still passes. What would kill nearly all of them is cheap:
  `OP_CODE_NAMES` has to be the inverse of `OP_CODES`, and `OP_SUCCESS`
  has to be BIP342's set written as ranges rather than transcribed.
- `nulldata`'s 80-byte limit is unpinned in both directions,
  `assert_segwit` accepts 0x50 as a witness version once weakened, and
  `taproot.parse`'s 520-byte element bound is exercised on one side.
- every lock-time bound in BIP370's three fields is tested in the middle
  of its range and at neither end; `_assert_new_taproot_sigs_verify`'s
  `sig[:64]` widens to `[:65]` unnoticed; `assert_signatures_only`'s
  `strict=True` turns False, so a returned psbt with fewer outputs would
  be compared as far as it goes and accepted.
- 46 of `psbt_signer_contract.py`'s survivors are inside the file whose
  job is refusing a signer that does not conform. The checks do fire —
  each has a signer built to break it — but the arithmetic inside them
  does not, so a check could be laxer than it reads.
- the wallets' `branch=0, index=0` defaults are undefended in all four
  modules, `position_of` is never asked for the output at exactly
  `last_index`, and a negative `ScriptWallet` threshold is accepted once
  the bound is weakened.
- hwi's read bound ([#526](https://github.com/btclib-org/btclib/pull/526))
  is enforced at whatever offset the code says, and `is_usable`'s `and`
  becomes `or` unnoticed, no fixture answering both a fingerprint and an
  error — the entry
  [#534](https://github.com/btclib-org/btclib/pull/534) was about.
- miniscript's type-property algebra survives `|` turned `^`.

## Two decisions worth reviewing

**The operator filter is measured per scope now**, rather than
`parsers.toml`'s precedent applied by hand. An ast walk says where a `|`
is arithmetic and where it is an unevaluated annotation, and the first
unfiltered session says the same from the other side: in the five scopes
that exclude it, not one `|` mutant was ever killed. `psbt.toml` excludes
it too and names the two expressions that costs; `descriptors.toml` and
`bip322.toml` keep it, the operator being the semantics there — a third
of descriptors' `|` mutants die.

**`tests/fuzz_test.py` is in no profile**, and the reason is now written
where the decision is: hypothesis draws fresh input on each run, so a
verdict from it is not reproducible, and the value of a weekly report is
the comparison with the week before. It is also the only thing that
reaches two lines in this diff's scopes, which each configuration says.

## Verification

`pre-commit run --all-files`, `pytest --cov` (18405 passed), and the
sphinx `-W` build with its cross-link grep all pass. Every count was
re-enumerated after the rebase onto
[#554](https://github.com/btclib-org/btclib/pull/554)'s cosmic-ray 8.7.0
— the totals and the filter's skip counts are unchanged from the 8.4.6
sessions that measured them, and all nine baselines pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Extend mutation testing to newly added code scopes and update configuration, workflow, and documentation to reflect measured mutation sessions and operator filtering decisions.

New Features:
- Add mutation profiles for descriptors/miniscript, PSBT, script encodings, wallets, signer boundary, MuSig2, and the HWI adapter, each with defined scope and test commands.
- Introduce a consolidated mutation workflow job covering wallets, signer boundary, MuSig2, and HWI, plus dedicated jobs for descriptors, PSBT, and script encodings.

Enhancements:
- Re-measure existing utils and BIP322 mutation profiles so they now run to completion, documenting survivor equivalence and operator filter rationale.
- Refine mutation operator filtering to be per-scope, excluding BitOr in annotation-only modules while retaining it where it affects semantics.
- Update CONTRIBUTING and CHANGELOG entries to describe the mutation workflow via the `.github/mutation/` profiles rather than maintaining a manual list, and to summarize findings from new mutation sessions.

Documentation:
- Document the purpose, coverage, and notable surviving mutants in each new and updated mutation profile, including rationale for excluding fuzz-based tests and certain operators.

Tests:
- Adjust CI mutation workflow budgets and sessions in `mutation.yml` to accommodate the new profiles and ensure reproducible weekly mutation reports.