### PR TITLE
Exempt the release pull request from the draft condition

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -56,8 +56,14 @@ jobs:
     # these checks on a tree its author is not asking anyone to review
     # yet. A run on the merge result still happens the moment the pull
     # request is marked ready, which is why ready_for_review is a
-    # trigger type above
-    if: ${{ !github.event.pull_request.draft }}
+    # trigger type above.
+    # The exception is by base branch, and it is the release pull
+    # request: dev -> master stays a draft from one release to the
+    # next, and nothing here triggers on a push to dev, so without it
+    # a commit merged into dev would be linted by nothing at all
+    if: >-
+      ${{ !github.event.pull_request.draft
+      || github.base_ref == 'master' }}
     runs-on: ubuntu-latest
     # nothing here takes minutes; a job that does is hung
     timeout-minutes: 20
@@ -144,7 +150,9 @@ jobs:
   # parallel and installs a different dependency group.
   docs:
     name: Build the documentation
-    if: ${{ !github.event.pull_request.draft }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+      || github.base_ref == 'master' }}
     runs-on: ubuntu-latest
     # about ten seconds of sphinx; a job that takes minutes is hung
     timeout-minutes: 20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,8 +71,14 @@ jobs:
     # the whole matrix on a tree its author is not asking anyone to
     # review yet. The gate below carries the same condition, so a draft
     # skips uniformly and the gate does not read that skip as a job that
-    # should have run
-    if: ${{ !github.event.pull_request.draft }}
+    # should have run.
+    # The exception is by base branch, and it is the release pull
+    # request: dev -> master stays a draft from one release to the
+    # next, and nothing here triggers on a push to dev, so without it
+    # a commit merged into dev would be tested by nothing at all
+    if: >-
+      ${{ !github.event.pull_request.draft
+      || github.base_ref == 'master' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -151,7 +157,9 @@ jobs:
   # secret and no third party, and it applies to every run, where a
   # coveralls.io upload happens only on pull requests targeting master
   coverage-py:
-    if: ${{ !github.event.pull_request.draft }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+      || github.base_ref == 'master' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -194,7 +202,9 @@ jobs:
   # bindings it resolves are published: while they were not, the step
   # could only be red, for a reason nobody could fix from a branch
   dist-py:
-    if: ${{ !github.event.pull_request.draft }}
+    if: >-
+      ${{ !github.event.pull_request.draft
+      || github.base_ref == 'master' }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -290,7 +300,9 @@ jobs:
     # satisfied. The gate has to run to be able to fail
     # and the draft condition every job above carries, so a draft
     # skips uniformly rather than tripping the skip check below
-    if: ${{ always() && !github.event.pull_request.draft }}
+    if: >-
+      ${{ always() && (!github.event.pull_request.draft
+      || github.base_ref == 'master') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:


### PR DESCRIPTION
The draft condition spends no runner on work in progress. The release
pull request, `dev -> master`, is a draft for the whole time between
one release and the next, and neither workflow triggers on a push to
`dev` -- the push trigger names `master` alone -- so that pull
request's runs are the only ones that lint and test what has landed
there. The condition withheld them, and `dev` was left checked by
nothing at all.

Every job that carries the condition now carries the exemption too:

```yaml
if: >-
  ${{ !github.event.pull_request.draft
  || github.base_ref == 'master' }}
```

and the gate job carries it inside `always()`, as it already carried
the condition, so a draft still skips uniformly rather than tripping
the skip check.

By base branch rather than by number: the release pull request is
closed at each release and opened again for the next cycle, and a
condition naming a number would have to be edited every time. Nothing
else targets `master`.

## Summary by Sourcery

Ensure CI lint and test workflows run for the dev → master release pull request even while it remains a draft, so changes merged into dev are still validated.

Bug Fixes:
- Restore linting, testing, coverage, and distribution checks for commits merged into dev via the long-lived dev → master release pull request.

Enhancements:
- Update workflow job conditions to exempt pull requests targeting master from the draft-based skip logic, including the gate job to keep skip behavior consistent.

Build:
- Adjust GitHub Actions workflow conditions in test and lint pipelines to include an exception for release pull requests targeting master.

CI:
- Modify CI job `if` conditions to run on draft release pull requests based on base branch (`master`) rather than hard-coded PR numbers.