### PR TITLE
Carry the draft condition into the workflows that lacked it

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -47,6 +47,11 @@ on:
   # run, so once a pull request touches one of these every later push to
   # that branch runs this too
   pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request
+    # would wait for its next push to be checked at all
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - .github/workflows/integration.yml
       - tests/integration/**
@@ -66,6 +71,15 @@ concurrency:
 jobs:
   regtest:
     name: Regtest against Bitcoin Core
+    # a draft pull request is work in progress and spends no runner
+    # here either, the release pull request excepted: dev -> master is
+    # a draft from one release to the next, and its runs are what
+    # checks a commit merged into dev. The same condition lint.yml and
+    # test.yml carry, and ready_for_review is a trigger type above for
+    # the same reason
+    if: >-
+      ${{ !github.event.pull_request.draft
+      || github.base_ref == 'master' }}
     runs-on: ubuntu-latest
     # the whole flow is seconds -- two tests, a node that answers its
     # first rpc call in well under a second, and a chain of a few blocks

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -40,6 +40,11 @@ on:
   # nothing -- but it does mean a transient failure shows up on pushes that
   # changed no link at all
   pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request
+    # would wait for its next push to be checked at all
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - .github/workflows/links.yml
       - .lycheeignore
@@ -64,6 +69,15 @@ concurrency:
 jobs:
   links:
     name: Check the documentation links
+    # a draft pull request is work in progress and spends no runner
+    # here either, the release pull request excepted: dev -> master is
+    # a draft from one release to the next, and its runs are what
+    # checks a commit merged into dev. The same condition lint.yml and
+    # test.yml carry, and ready_for_review is a trigger type above for
+    # the same reason
+    if: >-
+      ${{ !github.event.pull_request.draft
+      || github.base_ref == 'master' }}
     runs-on: ubuntu-latest
     # a few hundred requests with retries; a job past this is hung on one
     timeout-minutes: 15

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -27,6 +27,11 @@ on:
     - cron: "53 4 1 * *"
   workflow_dispatch:
   pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request
+    # would wait for its next push to be checked at all
+    types: [opened, reopened, synchronize, ready_for_review]
     paths:
       - .github/workflows/vendored-vectors.yml
       - .github/scripts/check_vendored_vectors.py
@@ -43,6 +48,15 @@ concurrency:
 jobs:
   check:
     name: Check vendored vectors against upstream
+    # a draft pull request is work in progress and spends no runner
+    # here either, the release pull request excepted: dev -> master is
+    # a draft from one release to the next, and its runs are what
+    # checks a commit merged into dev. The same condition lint.yml and
+    # test.yml carry, and ready_for_review is a trigger type above for
+    # the same reason
+    if: >-
+      ${{ !github.event.pull_request.draft
+      || github.base_ref == 'master' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
`lint.yml` and `test.yml` withhold their runs from a draft pull
request. The workflows that also trigger on `pull_request` did not, so
a draft still spent runners there. They now carry the same condition,
with the same exemption for the release pull request, and
`ready_for_review` joins their trigger types, the default set not
including it:

```yaml
if: >-
  ${{ !github.event.pull_request.draft
  || github.base_ref == 'master' }}
```

These are the paths-filtered workflows, which is why they were left
out of the first pass: they run only when a pull request touches the
workflow file or what it configures. It is also what makes the
difference worth closing -- the filter is evaluated against the pull
request's whole diff rather than against the push that triggered the
run, so once a branch touches one of those files every later push to
it runs them, draft or not.

Nothing here is a required check, and the exemption keeps them
answering for `dev`: the release pull request is where a commit merged
into `dev` is checked at all.

## Summary by Sourcery

Align path-filtered GitHub workflows with existing draft PR handling to avoid running non-required checks on drafts while still covering the dev→master release pull request.

CI:
- Update integration, links, and vendored-vectors workflows to trigger on the ready_for_review pull request event.
- Apply a shared condition to skip workflow jobs for draft pull requests except for the dev→master release PR.