### PR TITLE
Hold the signer contract to its own arithmetic, and both sides of it

### DIFF
--- a/.github/mutation/psbt.toml
+++ b/.github/mutation/psbt.toml
@@ -106,7 +106,8 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 #   the only source of such a signature here is a BIP373 MuSig2
 #   aggregation, whose partial signatures commit to SIGHASH_DEFAULT. A
 #   script-path signer taking an explicit sighash type is what would kill
-#   it, and is the test to write rather than an equivalence to accept.
+#   it, and is the test to write rather than an equivalence to accept:
+#   issue #560.
 #
 # The remaining classes are the ones documented elsewhere here: a
 # `check_validity` default, an `is` over interned ints, and a comparison

--- a/.github/mutation/signer.toml
+++ b/.github/mutation/signer.toml
@@ -52,30 +52,48 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 # and it finished while four others shared the machine: 236 killed, 66
 # survived, 21.85%.
 #
-# 46 of the 66 are in `psbt_signer_contract.py`, which is worth stating
+# 46 of the 66 were in `psbt_signer_contract.py`, which is worth stating
 # plainly because it is the file whose whole job is refusing a signer that
 # does not conform. Its checks do fire: tests/psbt_signer_contract_test.py
-# builds a signer to break each one, and that is what kills 121 of its
-# 167 mutants. What survives is the arithmetic inside them --
-# `len(answered_in.partial_sigs) - len(psbt_in.partial_sigs)` with `|`,
-# `^`, `+`, `<<` or `>>` for the `-`, the same across the taproot
-# signature counts, and `_check_fingerprint`'s and `_check_xpub`'s `!=`
-# weakened to `>` -- so a check could be laxer than it reads and every
-# fixture in that file would still pass it. A signer conforming to a
-# weakened contract is the failure this scope exists to ask about.
+# builds a signer to break each one, and that is what killed 121 of its
+# 167 mutants. What survived was the arithmetic inside them, so a check
+# could have been laxer than it reads with every fixture in that file
+# still passing it -- and a signer conforming to a weakened contract is
+# the failure this scope exists to ask about.
 #
-# The rest:
+# What closed it, measured one mutant at a time:
 #
-# - `unsignable_psbt`'s own numbers, which are the fixture it builds: the
-#   9000-satoshi output, the version, the outpoint index, the flipped
-#   fingerprint byte. Equivalent, and worth saying so once: what makes
-#   that psbt unsignable is the key it pays to, not the amount, so these
-#   are the one class here that no test should chase.
-# - `PsbtSigner.display_address`'s `index: int = 0` default, mutated in
-#   both directions across the class and its two implementations -- the
-#   same undefended-default class wallet.toml measures.
-# - `merge_devices`' `break` turned into `continue`, and `_at`'s
-#   `indexes[:len(path)] == path` weakened to `>=`.
+# - `_check_signable`'s `len(answered_in.partial_sigs) -
+#   len(psbt_in.partial_sigs)`, where `|`, `+`, `<<` and `>>` all agree
+#   with the `-` as long as the psbt arrives with no signatures in it:
+#   `1 - 0` is `1 | 0` is `1 + 0`. A 3-of-3 the reference signer holds one
+#   key of, two of the three signed before it is called, is what tells
+#   them apart -- the sum is then 3 against 2, and an idle signer over the
+#   same psbt gives 2 against 2, which is the case `|` reads as one
+#   signature added. `^` is left, and is equivalent: `a ^ b` is zero
+#   exactly when `a == b`, which for the reachable `a >= b` is the same
+#   answer `a - b > 0` gives.
+# - `_check_fingerprint`'s width, tested long and never short, and its
+#   drift check and `_check_xpub`'s, each tested with a second answer
+#   sorting above the first only: a signer drifting downwards closes both.
+# - `display_address`'s comparison, tested with a lie sorting above the
+#   truth; one on each side of it now, and the `index: int = 0` default of
+#   the function and of `SoftwareSigner`'s own method -- the
+#   undefended-default class wallet.toml measures.
+# - `_at`'s `indexes[:len(path)] == path` weakened to `>=`, and
+#   `_prv_key`'s `origin.master_fingerprint != self._fingerprint` to `>`:
+#   a path and a fingerprint sorting *above* what the signer holds close
+#   the direction the fixtures were missing.
+#
+# Two classes are left, and both are equivalent by construction:
+#
+# - `unsignable_psbt`'s own numbers -- the 9000-satoshi output, the
+#   version, the outpoint index, the flipped fingerprint byte -- which are
+#   the fixture it builds: what makes that psbt unsignable is the key it
+#   pays to, so no test should chase them.
+# - the `AddressDisplay` protocol's declared `index: int = 0`, which is a
+#   Protocol member and never called: the implementations' own defaults
+#   are the ones a caller reaches, and those are asserted above.
 
 # one mutant at a time, in this working tree: see sig_hash.toml
 [cosmic-ray.distributor]

--- a/.github/mutation/wallet.toml
+++ b/.github/mutation/wallet.toml
@@ -99,6 +99,7 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 # `pub_keyinfo_from_key(xkey)[0]` weakened to `[-1]` -- the network beside
 # the key -- survives because nothing builds a `ScriptWallet` with
 # `order="account"`, the one ordering that sorts participants by it.
+# Issue #561.
 
 # one mutant at a time, in this working tree: see sig_hash.toml
 [cosmic-ray.distributor]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -980,12 +980,21 @@ documented at release-notes length in the first place, and are still in
     produce one, the only source being a MuSig2 aggregation over
     SIGHASH_DEFAULT.
     - `signer.toml` (302 of 302, the one profile that finished): 46 of
-    its 66 survivors are inside `psbt_signer_contract.py`, the file whose
+    its 66 survivors were inside `psbt_signer_contract.py`, the file whose
     job is refusing a signer that does not conform. Its checks do fire —
     each has a signer built to break it — but the arithmetic inside them
-    does not, so a check could be laxer than it reads and every fixture
-    would still pass. Not closed here: the arithmetic is the next round's
-    work, and `signer.toml` lists it.
+    did not, so a check could have been laxer than it reads with every
+    fixture still passing. `_check_signable` sums
+    `len(answered_in.partial_sigs) - len(psbt_in.partial_sigs)`, and `|`,
+    `+`, `<<` and `>>` all agree with that `-` as long as the psbt arrives
+    with no signature in it: a 3-of-3 the reference signer holds one key
+    of, two of the three signed before it is called, is what tells them
+    apart. The rest of that file's survivors, and the signer boundary's
+    own, were comparisons exercised in one direction: a fingerprint width
+    tested long and never short, two drift checks whose second answer
+    always sorted above the first, a displayed address lied about upwards
+    only, and a path prefix and an origin fingerprint never tried above
+    what the signer holds.
     - `wallet.toml` (293 of 419): the `branch=0, index=0` defaults were
     undefended in all four modules — nothing called `address`,
     `script_pub_key`, `redeem_script`, `witness_script`, `satisfy` or

--- a/tests/psbt_signer_contract_test.py
+++ b/tests/psbt_signer_contract_test.py
@@ -30,7 +30,7 @@ from btclib.psbt_signer_contract import (
     check_psbt_signer,
     unsignable_psbt,
 )
-from btclib.script import sig_hash
+from btclib.script import serialize, sig_hash
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.to_pub_key import pub_keyinfo_from_key
 from btclib.tx.out_point import OutPoint
@@ -122,6 +122,15 @@ def test_a_fingerprint_of_the_wrong_width_is_refused() -> None:
     with pytest.raises(BTClibValueError, match="is 5 bytes, not 4"):
         check_psbt_signer(_TooLong())
 
+    # and short of it, which a width checked as a ceiling would accept: a
+    # three-byte fingerprint is what a key origin would then be written to
+    class _TooShort(_Wrapper):
+        def master_fingerprint(self) -> bytes:
+            return b"\x00" * 3
+
+    with pytest.raises(BTClibValueError, match="is 3 bytes, not 4"):
+        check_psbt_signer(_TooShort())
+
 
 def test_a_fingerprint_that_changes_is_refused() -> None:
     """A signer answers for one master, so the answer is one answer."""
@@ -137,6 +146,21 @@ def test_a_fingerprint_that_changes_is_refused() -> None:
 
     with pytest.raises(BTClibValueError, match="two different values"):
         check_psbt_signer(_Drifting())
+
+    # drifting the other way, which is the same disagreement: what the
+    # check asks is whether the two answers are one answer, and an
+    # ordering would ask which of them is larger
+    class _Receding(_Wrapper):
+        def __init__(self) -> None:
+            super().__init__()
+            self._asked = 4
+
+        def master_fingerprint(self) -> bytes:
+            self._asked -= 1
+            return bytes([self._asked, 0, 0, 0])
+
+    with pytest.raises(BTClibValueError, match="two different values"):
+        check_psbt_signer(_Receding())
 
 
 def test_an_xpub_that_is_not_an_extended_key_is_refused() -> None:
@@ -175,6 +199,20 @@ def test_an_xpub_that_changes_is_refused() -> None:
 
     with pytest.raises(BTClibValueError, match="two different keys"):
         check_psbt_signer(_Drifting(), der_path=_ACCOUNT)
+
+    # and the two keys the other way round: whichever of the two base58
+    # strings sorts first, they are two keys for one path
+    class _Receding(_Wrapper):
+        def __init__(self) -> None:
+            super().__init__()
+            self._asked = 4
+
+        def xpub(self, der_path: DerPath) -> str:
+            self._asked -= 1
+            return self._signer.xpub(f"m/84h/0h/{self._asked}h")
+
+    with pytest.raises(BTClibValueError, match="two different keys"):
+        check_psbt_signer(_Receding(), der_path=_ACCOUNT)
 
 
 def test_signing_an_input_of_another_master_is_refused() -> None:
@@ -264,3 +302,76 @@ def test_capabilities_that_change_are_refused() -> None:
 
     with pytest.raises(BTClibValueError, match="capabilities answered two"):
         check_psbt_signer(_Drifting())
+
+
+# two more seeds, so a quorum can hold a signature that is not the
+# reference signer's: BIP39's own second and third test vectors
+_OTHER_MNEMONICS = (
+    "legal winner thank year wave sausage worth useful legal winner thank yellow",
+    "letter advice cage absurd amount doctor acoustic avoid letter advice cage above",
+)
+
+
+def _partly_signed_quorum() -> Psbt:
+    """Return a 3-of-3 the reference signer holds one key of, two signed.
+
+    What `_signable` cannot be and what the count in `_check_signable`
+    needs: a psbt whose input already carries signatures. With none there
+    the sum it computes is `1 - 0`, and every arithmetic operator agrees
+    on that -- so the check reads as though it were counting when nothing
+    says it is.
+    """
+    root = bip39.mxprv_from_mnemonic(_MNEMONIC, "", "mainnet")
+    roots = [
+        root,
+        *(bip39.mxprv_from_mnemonic(m, "", "mainnet") for m in _OTHER_MNEMONICS),
+    ]
+    keys = [pub_keyinfo_from_key(derive(r, f"{_ACCOUNT}/0/0"))[0] for r in roots]
+    witness_script = serialize(["OP_3", *keys, "OP_3", "OP_CHECKMULTISIG"])
+    script_pub_key = ScriptPubKey.p2wsh(witness_script)
+
+    tx_in = TxIn(OutPoint(b"\xcc" * 32, 0))
+    tx_out = TxOut(9_000, script_pub_key)
+    psbt = Psbt.from_tx(Tx(version=2, lock_time=0, vin=[tx_in], vout=[tx_out]))
+    psbt_in = psbt.inputs[0]
+    psbt_in.witness_utxo = TxOut(10_000, script_pub_key)
+    psbt_in.witness_script = witness_script
+    for key, one in zip(keys, roots, strict=True):
+        psbt_in.hd_key_paths[key] = BIP32KeyOrigin(
+            SoftwareSigner(one).master_fingerprint(), f"{_ACCOUNT}/0/0"
+        )
+
+    # the other two sign first, which is what leaves the reference signer
+    # one signature to add rather than the only one
+    for one in roots[1:]:
+        psbt = SoftwareSigner(one).sign_psbt(psbt)
+    assert len(psbt.inputs[0].partial_sigs) == 2
+    return psbt
+
+
+def test_a_quorum_the_signer_adds_one_signature_to_is_accepted() -> None:
+    """The check counts, and counting is what a psbt with signatures asks.
+
+    Two of the three are there before the signer is called, so what
+    `_check_signable` compares is 3 against 2 rather than 1 against
+    nothing -- and a sum that is right for the second is not necessarily
+    right for the first.
+    """
+    check_psbt_signer(_signer(), der_path=_ACCOUNT, signable=_partly_signed_quorum())
+
+
+def test_a_signer_that_adds_nothing_to_a_signed_quorum_is_refused() -> None:
+    """Handing back a psbt untouched is abstaining, whatever is in it.
+
+    The same `_Idle` signer as above, over a psbt that already holds two
+    signatures: the answer has as many as the request, so nothing was
+    added, and the count has to say so rather than answering with what is
+    there.
+    """
+
+    class _Idle(_Wrapper):
+        def sign_psbt(self, psbt: Psbt) -> Psbt:
+            return deepcopy(psbt)
+
+    with pytest.raises(BTClibValueError, match="added no signature"):
+        check_psbt_signer(_Idle(), signable=_partly_signed_quorum())

--- a/tests/psbt_signer_test.py
+++ b/tests/psbt_signer_test.py
@@ -310,10 +310,20 @@ def test_a_displayed_address_is_compared_with_the_descriptor_s() -> None:
     receive = export_account(signer, ACCOUNT)[0]
 
     assert display_address(signer, receive, 3) == receive.address(3)
+    # and the index defaults to the first address of the chain, which is
+    # what a caller asking for "the" address of a descriptor means
+    assert display_address(signer, receive) == receive.address(0)
 
-    lying = _Display("bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu")
-    with pytest.raises(BTClibValueError, match="the signer displayed"):
-        display_address(lying, receive, 3)
+    # a lie on each side of the truth in byte order: what the check asks
+    # is whether the two strings are the same string, where an ordering
+    # would accept every address that sorts the right way
+    truth = receive.address(3)
+    below = "bc1q" + "0" * (len(truth) - 4)
+    above = "bc1q" + "z" * (len(truth) - 4)
+    assert below < truth < above
+    for lie in (below, above):
+        with pytest.raises(BTClibValueError, match="the signer displayed"):
+            display_address(_Display(lie), receive, 3)
 
 
 def test_a_descriptor_that_holds_a_private_key_is_not_sent() -> None:

--- a/tests/software_signer_test.py
+++ b/tests/software_signer_test.py
@@ -161,8 +161,12 @@ def test_the_signer_answers_for_its_own_keys_only() -> None:
     assert signer.sign_ecdsa(pub_key, origin, msg_hash) is not None
     assert signer.sign_ecdsa(pub_key, None, msg_hash) is None
 
-    stranger = BIP32KeyOrigin("deadbeef", origin.der_path)
-    assert signer.sign_ecdsa(pub_key, stranger, msg_hash) is None
+    # one stranger on each side of this signer's own fingerprint in byte
+    # order -- 73c5da0a -- the question being whose master it is and not
+    # which of the two sorts first
+    for stranger_fingerprint in ("deadbeef", "0badcafe"):
+        stranger = BIP32KeyOrigin(stranger_fingerprint, origin.der_path)
+        assert signer.sign_ecdsa(pub_key, stranger, msg_hash) is None
 
     # a hardened step under an xpub, which no derivation can take
     watch_only = SoftwareSigner(xpub_from_xprv(derive(XPRV_ROOT, "m/84h/0h/0h")))
@@ -208,6 +212,10 @@ def test_a_watch_only_signer_shows_and_derives_but_does_not_sign() -> None:
     holder = SoftwareSigner(XPRV_ROOT)
     receive, change = export_account(holder, "m/84h/0h/0h")
     assert display_address(signer, receive, 2) == receive.address(2)
+    # and the method's own default, which the function above always passes
+    # explicitly: the first address of the chain is what "the" address of a
+    # descriptor means
+    assert signer.display_address(receive) == receive.address(0)
 
     psbt = spending(receive, change)[0]
     with pytest.raises(BTClibValueError, match="watch-only signer"):
@@ -326,9 +334,13 @@ def test_the_longest_account_prefixing_an_origin_answers() -> None:
     assert signer.xpub("m/84h/0h/0h/0/7") == xpub_from_xprv(
         derive(XPRV_ROOT, "m/84h/0h/0h/0/7")
     )
-    # a path no account of it prefixes is a key it does not hold
-    with pytest.raises(BTClibValueError, match="no key held for the path"):
-        signer.xpub("m/44h/0h/0h")
+    # a path no account of it prefixes is a key it does not hold, and that
+    # is a prefix and not an ordering: the second of these sorts above
+    # both accounts where the first sorts below them, and neither is a
+    # path either account can walk to
+    for elsewhere in ("m/44h/0h/0h", "m/99h/0h/0h"):
+        with pytest.raises(BTClibValueError, match="no key held for the path"):
+            signer.xpub(elsewhere)
 
 
 def test_a_signer_of_accounts_has_no_single_key() -> None:


### PR DESCRIPTION
Follow-up to [PR 558](https://github.com/btclib-org/btclib/pull/558),
which added the seven profiles and closed the script, psbt, hwi and wallet
gaps its first sessions found. This is the scope that was left:
`signer.toml`, whose survivors were the most consequential of the round —
46 of its 66 inside `psbt_signer_contract.py`, the file whose whole job is
refusing a signer that does not conform.

## The arithmetic

`_check_signable` sums

```python
len(answered_in.partial_sigs) - len(psbt_in.partial_sigs)
```

and `|`, `+`, `<<` and `>>` all agree with that `-` as long as the psbt
arrives with no signature in it: `1 - 0` is `1 | 0` is `1 + 0`. The checks
do fire — `tests/psbt_signer_contract_test.py` builds a signer to break
each one — but nothing said the counting was counting.

A 3-of-3 the reference signer holds one key of, two of the three signed
before it is called, is what tells them apart: the conforming signer makes
the sum 3 against 2, and an idle signer over the same psbt makes it 2
against 2 — which is the case `|` reads as a signature added. Both are
asserted. `^` stays alive and is equivalent: `a ^ b` is zero exactly when
`a == b`, which for the reachable `a >= b` is what `a - b > 0` answers.

A signer that *strips* another participant's signature is refused already,
by `request_signatures`' own comparison, before the count is reached —
which is why the idle signer is the case that reaches it.

## The comparisons

Five, all the shape `fetch.toml` closed for its own: exercised in one
direction, so weakening `!=` to an ordering changed nothing.

| check | tested | added |
|---|---|---|
| `_check_fingerprint` width | 5 bytes | 3 bytes |
| `_check_fingerprint` drift | second answer above the first | one below |
| `_check_xpub` drift | second key above the first | one below |
| `display_address` | a lie above the truth | one on each side |
| `_at` path prefix | a path below the accounts held | one above |
| `_prv_key` origin fingerprint | `deadbeef`, above | `0badcafe`, below |

`display_address`'s `index` default is asserted too, for the function and
for `SoftwareSigner`'s own method — the undefended-default class
`wallet.toml` measures.

## What is left alive, with a reason

The `^` above; `unsignable_psbt`'s own fixture numbers, which are the psbt
it builds rather than anything under test; and the `AddressDisplay`
protocol's declared default, a Protocol member that is never called.
`signer.toml` records all three.

## Verification

Every mutant measured alive before its test and dead after, one at a time,
with `__pycache__` cleared between the two — a `.pyc` compiled from the
mutant and read back after the restore gives a false kill, which happened
once and is why the check clears it. `pre-commit run --all-files`,
`pytest --cov` (18428 passed, 100%) and the sphinx `-W` build pass.

Still open across the other profiles, and the next round's work:
`descriptors.toml`'s miniscript type-property algebra, and `musig2.toml`'s
ten survivors, most of which are equivalences. Two of this round's gaps
became issues rather than tests:
[ISS560](https://github.com/btclib-org/btclib/issues/560) and
[ISS561](https://github.com/btclib-org/btclib/issues/561).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Strengthen signer contract validation around signature counting and comparison edge cases, and document the mutation-testing closures and remaining gaps for signer, psbt, and wallet profiles.

Bug Fixes:
- Ensure signers adding no signatures to a partially signed quorum are refused while signers adding a single signature to an existing quorum are accepted.

Enhancements:
- Extend signer contract tests to cover fingerprint length below the required width, bidirectional fingerprint and xpub drift, and additional path-prefix cases.
- Broaden display-address tests to assert default index behaviour and reject incorrect addresses that differ on either side of the true value.
- Tighten SoftwareSigner tests so origins with fingerprints both above and below the signer’s own are treated as strangers, and non-account-prefixed derivation paths above and below held accounts are rejected.

Documentation:
- Update CHANGELOG and mutation profile comments (signer.toml, psbt.toml, wallet.toml) to explain the arithmetic and comparison mutants now killed and to reference remaining work via issues #560 and #561.

Tests:
- Add a 3-of-3 quorum fixture with pre-existing signatures to exercise `_check_signable`’s signature-counting logic and idle-signer behaviour.
- Expand psbt signer, software signer, and display-address tests to fully cover comparison directions and default-index handling in signer contract and wallet logic.