### PR TITLE
Assert ScriptWallet's key orders over a quorum that has an order to assert (#561)

### DIFF
--- a/.github/mutation/wallet.toml
+++ b/.github/mutation/wallet.toml
@@ -95,11 +95,23 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 #   (bms.toml states the class), and `len(indexes) is not
 #   _ACCOUNT_LEVELS`, where CPython interns both small ints.
 #
-# One is left open and is a gap: `_account_sec`'s
-# `pub_keyinfo_from_key(xkey)[0]` weakened to `[-1]` -- the network beside
-# the key -- survives because nothing builds a `ScriptWallet` with
-# `order="account"`, the one ordering that sorts participants by it.
-# Issue #561.
+# The last one, `_account_sec`'s `pub_keyinfo_from_key(xkey)[0]` weakened
+# to `[-1]` -- the network beside the key, which every participant of a
+# wallet shares, so the sort becomes a no-op -- is closed too (#561), and
+# what it took is worth writing down: not a wallet with `order="account"`,
+# which the suite did build, but a quorum over which that order is
+# *observable*. The three accounts it was built from were declared in the
+# byte order of their own account keys, and over a quorum already sorted
+# every sort writes the script no sort writes. The three
+# `tests/wallet/script_wallet_test.py` uses are declared in an order that
+# is none of the four the module reaches -- the account keys', their
+# case-folded xpubs', the derived keys', and the private keys' -- and each
+# of the four is asserted to be the one the script carries. The three
+# mutants beside it, `_account_order`'s `!= "account"` turned `==` and its
+# `sort_key or _account_sec` turned `and`, and `_quorum`'s `== "derived"`
+# turned `!=`, were dead before this and are dead after: measured, because
+# a fixture that makes one assertion vacuous is the kind of thing that
+# makes its neighbours vacuous too.
 
 # one mutant at a time, in this working tree: see sig_hash.toml
 [cosmic-ray.distributor]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1062,6 +1062,20 @@ documented at release-notes length in the first place, and are still in
   the `Psbt.b64decode` defect above. `bip322.Sig` has no binary entry
   point to add, its three payloads being told apart by the prefix of the
   text form alone.
+- **`ScriptWallet`'s key orders are asserted over a quorum that has an
+  order to assert** (#561), which is the one gap `wallet.toml` left open.
+  `_account_sec` reads the key of the `(key, network)` pair
+  `pub_keyinfo_from_key` answers, and reading the network instead --
+  which every participant of a wallet shares, so the sort becomes a
+  no-op -- was unnoticed. Not because nothing built a wallet with
+  `order="account"`: because the three accounts it was built from were
+  declared in the byte order of their own account keys, and over a quorum
+  already sorted every sort writes the script no sort writes. The three
+  accounts are declared in an order that is none of the four the module
+  reaches now -- the account keys', their case-folded xpubs', the derived
+  keys' at a position, and the private keys' -- and each of the four is
+  asserted to be the one the script carries, the last of them being what
+  says an xprv quorum and its xpub quorum are one wallet.
 
 ## v2026.8.7
 

--- a/tests/wallet/script_wallet_test.py
+++ b/tests/wallet/script_wallet_test.py
@@ -25,10 +25,17 @@ from btclib.script.script import op_int
 from btclib.script.script_pub_key import ScriptPubKey
 from btclib.wallet import KeyGroup, ScriptWallet
 
-# the "abandon abandon ... about" seed, and three account keys of it that
-# no wallet elsewhere in the suite uses as a quorum
+# the "abandon abandon ... about" seed, and three account keys of it in an
+# order that none of the sorts below answers: the account keys sort one
+# way, their case-folded xpubs another, and what they derive to a third,
+# so the script written at a position says which of the three wrote it.
+# The first three accounts of the same seed -- which is the quorum
+# `tests/wallet/wallet_test.py` builds -- would say nothing: they are
+# already in the byte order of both their account keys and their xpubs, so
+# a wallet that sorted by anything at all, the network beside the key
+# included, would write the script a wallet that sorted by nothing writes
 _ROOT = "xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu"
-_ACCOUNTS = [f"m/48h/0h/{i}h" for i in range(3)]
+_ACCOUNTS = ["m/48h/0h/1h", "m/48h/0h/0h", "m/48h/0h/5h"]
 _XPRVS = [bip32.derive(_ROOT, account) for account in _ACCOUNTS]
 _XPUBS = [bip32.xpub_from_xprv(xprv) for xprv in _XPRVS]
 
@@ -115,6 +122,11 @@ def test_the_account_order_is_applied_once_and_derived_afterwards() -> None:
     operation on different bytes, and a wallet has to say which it means.
     """
     by_account = sorted(_XPUBS, key=lambda xpub: BIP32KeyData.b58decode(xpub).key)
+    # the sort is a reorder over this quorum, which is what makes the
+    # equality below an assertion about the order rather than about the
+    # keys: over a quorum already in account order every sort writes the
+    # same script, and so does no sort at all
+    assert by_account != _XPUBS
     wallet = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "account")
     for index in (0, 4):
         assert wallet.witness_script(0, index) == script.serialize(
@@ -126,6 +138,8 @@ def test_the_account_order_is_applied_once_and_derived_afterwards() -> None:
     # and declaration order is a third answer, which is the default
     declared = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh")
     assert declared.witness_script(0, 0) == script.serialize(_quorum(2, _XPUBS, 0, 0))
+    assert declared.witness_script(0, 0) != wallet.witness_script(0, 0)
+    assert declared.witness_script(0, 0) != derived.witness_script(0, 0)
 
 
 def test_a_sort_key_orders_by_something_that_is_not_a_byte_order() -> None:
@@ -135,6 +149,14 @@ def test_a_sort_key_orders_by_something_that_is_not_a_byte_order() -> None:
     the sort is a strategy with a key function rather than a constant.
     """
     by_lower_case = sorted(_XPUBS, key=str.lower)
+    # a third order, and that is the whole of what makes the assertion
+    # below about the key function: it is not the declaration order, so a
+    # sort ran, and it is not the account keys' byte order either, so the
+    # sort that ran is this one and not the default
+    assert by_lower_case != _XPUBS
+    assert by_lower_case != sorted(
+        _XPUBS, key=lambda xpub: BIP32KeyData.b58decode(xpub).key
+    )
     wallet = ScriptWallet(
         [KeyGroup(2, _XPUBS)],
         "p2wsh",
@@ -294,7 +316,12 @@ def test_an_xprv_in_a_quorum_is_what_makes_a_wallet_not_watch_only() -> None:
     assert signing.address(0, 0) == watching.address(0, 0)
     # nor does the account order read the private key: sorting by
     # BIP32KeyData.key would order the xprvs by material the xpubs do not
-    # have, and answer two different scripts for one wallet
+    # have, and answer two different scripts for one wallet -- these three
+    # accounts sort one way by their private keys and the other by their
+    # public ones, which is what leaves the equality below something to say
+    assert sorted(range(3), key=lambda i: BIP32KeyData.b58decode(_XPRVS[i]).key) != (
+        sorted(range(3), key=lambda i: BIP32KeyData.b58decode(_XPUBS[i]).key)
+    )
     assert ScriptWallet([KeyGroup(2, _XPRVS)], "p2wsh", "account").address(
         0, 0
     ) == ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "account").address(0, 0)


### PR DESCRIPTION
Closes [ISS561](https://github.com/btclib-org/btclib/issues/561).

`_account_sec` reads the key of the `(key, network)` pair
`pub_keyinfo_from_key` answers, and `[0]` weakened to `[-1]` — the
network, which every participant of a wallet shares, so the sort becomes
a no-op — survived the suite.

The issue supposed the reason was that nothing builds a `ScriptWallet`
with `order="account"`, which is what a mutation session sees from the
outside. The suite does build one. What it did not build was a quorum
over which that order is *observable*: the three accounts were
`m/48h/0h/{0,1,2}h`, already in the byte order of both their account keys
and their xpubs, so every sort of them writes the script no sort writes —
and the case-folded `sort_key` test beside it was measuring nothing
either, the case-folded order of those three being the same order again.

The three accounts are declared in an order that is none of the four the
module reaches now — the account keys', their case-folded xpubs', the
derived keys' at a position, and the private keys' — and each of the four
is asserted to be the one the script carries.

Measured, one mutant at a time, on this tree:

| mutant | before | after |
| --- | --- | --- |
| `_account_sec`'s `[0]` → `[-1]` | alive | dead |
| `_account_order`'s `!= "account"` → `==` | dead | dead |
| `_account_order`'s `sort_key or _account_sec` → `and` | dead | dead |
| `_quorum`'s `== "derived"` → `!=` | dead | dead |

The three neighbours are measured rather than assumed: a fixture that
makes one assertion vacuous is what makes its neighbours vacuous too.

`.github/mutation/wallet.toml` records the closure, and says what it took
rather than only that it is closed.

Gates: `uv run pre-commit run --all-files`, the sphinx `-W` build, and
`uv run pytest --cov` — 18426 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure ScriptWallet key ordering behavior is exercised over a quorum where ordering differences are observable and document the closure of the related mutation-testing gap.

Documentation:
- Document closure of the ScriptWallet key-ordering mutation gap and explain how observable quorums validate the account-order logic in the changelog.

Tests:
- Adjust ScriptWallet quorum test fixtures and assertions so that different key ordering strategies (declaration, account, case-folded xpub, derived, and private) produce distinguishable scripts and are explicitly asserted.
- Add test assertions that distinguish watch-only and signing wallets by verifying that private-key and public-key based orderings yield different key orders while preserving address equivalence.

Chores:
- Update wallet mutation-testing configuration notes to record how the previously surviving _account_sec mutant is now killed and how its neighboring mutants are validated.