### PR TITLE
Assert the miniscript properties where the union carries information

### DIFF
--- a/.github/mutation/descriptors.toml
+++ b/.github/mutation/descriptors.toml
@@ -66,21 +66,42 @@ excluded-modules = []
 # they group into four:
 #
 # - the type-property algebra, which is what this scope was written to
-#   ask about: `_andor_properties`' `&` turned `|` and `|` turned `-`
-#   survive, so the properties a fragment computes are not pinned by any
-#   test that would notice a wrong set.
+#   ask about -- and the class is smaller than the survivor list makes it
+#   look. BIP379's composition rules are a chain of terms, and almost
+#   every term selects letters no other term contributes: measured over
+#   the 97 expressions of miniscript_fixed_tests.json and one composite
+#   of each family, 50 of the 54 single-term `|` in those rules change no
+#   fragment's properties when they become a symmetric difference. They
+#   are equivalent by disjointness rather than untested.
+#
+#   The four that are not combine the *operands*: the timelocks of a
+#   conjunction and of a disjunction, `(x | y) & _t("ghij")`, and `or_b`'s
+#   and `or_i`'s non-malleability, `_has(x | y, "s")`. A letter both
+#   branches carry is a letter the composite keeps only if the rule is a
+#   union, and the tests beside this commit assert the exact property set
+#   of the four shortest fragments that show it -- two `older()` branches
+#   for the timelock, two signed branches for the "m". All four mutants
+#   are dead now, and the assertions are on the properties themselves
+#   rather than on something downstream of them.
 # - the sizes: `_TX_BODY_LEEWAY_WEIGHT`'s summands rearrange freely, the
 #   stack-limit term beside it takes `^` for `+`, and `_decomposed`'s
 #   `1 + 2 ** (op_code - 76)` -- the push-prefix width -- survives three
 #   ways. A wrong size here is a wrong fee estimate rather than an
-#   invalid spend, which is why nothing louder catches it.
+#   invalid spend, which is why nothing louder catches it. The prefix
+#   width wants a script whose push needs OP_PUSHDATA, which no standard
+#   fragment writes: every key is 33 bytes and every hash 20 or 32.
 # - the fragment dispatch, weakened from `==` to `>=` in seven places:
 #   equivalent wherever the fragment compared is the alphabetical
 #   extreme of the closed set it comes from, which is the class bms.toml
 #   states, and worth a look one by one rather than in bulk.
-# - `satisfy`'s `index: int = 0` default and `_thresh_ops`' and
-#   `_thresh_witness`' `reached[1]`/`reached[-1]`: an undefended default
-#   and two indexes into a list a `thresh` walk builds.
+# - `satisfy`'s `index: int = 0` default, `_thresh_input`'s `count ==
+#   node.threshold` and `_thresh_ops`' and `_thresh_witness`'
+#   `reached[1]`/`reached[-1]`: an undefended default and three indexes
+#   into what a `thresh` walk builds. The default wants a ranged key --
+#   with plain keys the index changes nothing -- and the `thresh` three
+#   want a satisfaction with more satisfiable branches than the quorum
+#   needs, which is where choosing exactly `threshold` of them is what
+#   makes the witness non-malleable.
 
 # one mutant at a time, in this working tree: see sig_hash.toml
 [cosmic-ray.distributor]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1013,9 +1013,18 @@ documented at release-notes length in the first place, and are still in
     The `max_output + 1` read cap turned out equivalent: any cap above
     the limit gives the comparison below it the same verdict.
     - `descriptors.toml` (383 of 10831, the largest scope here and
-    sampled): the miniscript type-property algebra survives `|` turned
-    `^` in three places, `satisfy`'s index default is undefended, and
-    `_decomposed`'s push-size arithmetic is unpinned.
+    sampled): the miniscript type-property algebra survived `|` turned
+    `^`, and the class turned out to be four mutants rather than the
+    survivor list's many — BIP379's composition rules are a chain of
+    terms, and 50 of the 54 single-term unions in them are disjoint by
+    construction, so a symmetric difference there changes no fragment's
+    properties. The four that combine the *operands* do: the timelocks of
+    a conjunction and of a disjunction, and `or_b`'s and `or_i`'s
+    non-malleability, which asks for a signature on either branch. The
+    exact property set of the four shortest fragments that show it is
+    asserted now. `satisfy`'s index default and `_decomposed`'s push-size
+    arithmetic stay open, and `descriptors.toml` says what each would
+    take.
     - `musig2.toml` (159 of 1277): 6.29%, the lowest rate measured here,
     which is what a reference implementation's own vectors buy. Its two
     `% secp256k1.n` reductions turned `** secp256k1.n` are also the

--- a/tests/descriptors/miniscript_test.py
+++ b/tests/descriptors/miniscript_test.py
@@ -367,6 +367,42 @@ def test_the_type_properties_are_the_bip379_table() -> None:
     assert "u" not in parse("dv:older(1)").properties
 
 
+def test_a_composite_inherits_a_property_from_either_branch() -> None:
+    """Where the rules take the union of two branches, and not both of them.
+
+    The composition rules of BIP379 are written as a chain of terms, and
+    most of those terms select letters no other term can contribute: a
+    fragment's "u" comes from one place and its "z" from another, so the
+    chain could be a symmetric difference throughout and answer the same.
+    Four places are not like that, and they are the four asserted here --
+    each combines the *operands* rather than the terms, so a letter both
+    branches carry is a letter the composite keeps only if the rule is a
+    union.
+
+    - the timelocks of a conjunction and of a disjunction: two `older()`
+      branches are both height locks, so "h" is on both sides of it;
+    - `or_b`'s and `or_i`'s "m", non-malleability, which needs a
+      signature on *either* branch -- `_has(x | y, "s")` -- and holds for
+      two branches that both have one.
+
+    Measured the other way round as well: over the 97 expressions of
+    `miniscript_fixed_tests.json` and the composites above, no other
+    operator in those rules changes any fragment's properties when the
+    union it sits in becomes a symmetric difference.
+    """
+    assert parse("and_v(v:older(1),older(2))").properties == frozenset("Bfhkmxz")
+    assert parse("or_i(older(1),older(2))").properties == frozenset("Bfhkox")
+    assert parse("or_b(0,a:0)").properties == frozenset("Bdekmsux")
+    assert parse(
+        f"c:or_i(pk_k({KEY}),pk_k({CUSTODY_KEYS[1]}))"
+    ).properties == frozenset("Bdkmsu")
+
+    # and a height lock beside a time lock, where the union carries both
+    # letters: "g" to "j" are recorded per kind exactly so that a
+    # satisfaction can be refused for mixing them
+    assert parse("and_v(v:older(1),after(1))").properties == frozenset("Bfhjkmxz")
+
+
 def test_a_thresh_may_hold_a_dup_if_under_tapscript_alone() -> None:
     """Refuse under P2WSH the thresh() a tapscript accepts."""
     expression = (


### PR DESCRIPTION
Third round after [PR 558](https://github.com/btclib-org/btclib/pull/558)
and [PR 563](https://github.com/btclib-org/btclib/pull/563): the
`descriptors.toml` survivors, whose headline was the miniscript
type-property algebra.

## The class is smaller than the survivor list made it look

BIP379's composition rules are a chain of terms, and almost every term
selects letters no other term contributes — a fragment's "u" comes from
one place and its "z" from another. So the chain could be a symmetric
difference throughout and answer the same.

Measured rather than argued: over the 97 expressions of
`miniscript_fixed_tests.json` plus one composite of each family, **50 of
the 54 single-term unions in those rules change no fragment's properties**
when `|` becomes `^`. Equivalent by disjointness, not untested — which is
worth knowing before somebody reads the weekly report and starts writing
tests for fifty mutants that cannot be killed.

## The four that carry information

They combine the *operands* rather than the terms, so a letter both
branches carry survives only if the rule is a union:

| rule | fragment that shows it | `\|` | `^` |
|---|---|---|---|
| `(x \| y) & _t("ghij")` in `_and_properties` | `and_v(v:older(1),older(2))` | `Bfhkmxz` | loses `h` |
| the same in `_or_properties` | `or_i(older(1),older(2))` | `Bfhkox` | loses `h` |
| `_has(x \| y, "s")` for `or_b`'s `m` | `or_b(0,a:0)` | `Bdekmsux` | loses `m` |
| `_has(x \| y, "s")` for `or_i`'s `m` | `c:or_i(pk_k(A),pk_k(B))` | `Bdkmsu` | loses `m` |

The test asserts the exact property set of each, beside the leaf-fragment
assertions already there — on the properties themselves rather than on
something downstream of them, and with the letters explained: `h` is the
height-timelock property either branch can bring, `m` is
non-malleability, which needs a signature on either branch and `e` on
both.

All four mutants are dead, each measured alive before its test and dead
after, one at a time.

## Left open, with what each would take

- `satisfy`'s `index: int = 0` default wants a **ranged key**: with plain
  keys the index changes nothing, so the default is unobservable.
- `_decomposed`'s `1 + 2 ** (op_code - 76)` — the push-prefix width —
  wants a push wide enough to need OP_PUSHDATA, which no standard
  fragment writes: every key is 33 bytes and every hash 20 or 32.
- `_thresh_input`'s `count == node.threshold` and the two `reached[...]`
  indexes want a satisfaction with more satisfiable branches than the
  quorum needs, which is where choosing exactly `threshold` of them is
  what makes the witness non-malleable.

`descriptors.toml` records all of it. What remains after this is
`musig2.toml`'s ten survivors, most of which its own file already argues
are equivalences.

## Verification

`pre-commit run --all-files`, `pytest --cov` (18429 passed, 100%) and the
sphinx `-W` build pass. The mutant checks clear `__pycache__` between the
apply and the restore: a `.pyc` compiled from a mutant and read back after
the restore is a false kill, which happened once in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Assert miniscript fragment property behavior in union vs symmetric-difference cases and document the narrowed mutation-survivor class for descriptors.

New Features:
- Add a dedicated test that verifies miniscript composites inherit specific properties from either branch where BIP379 uses union over operands.

Enhancements:
- Clarify and expand descriptors mutation configuration comments to describe which miniscript property union mutants are now covered and what remains open.
- Update changelog notes for the descriptors mutation scope to reflect the refined understanding of surviving miniscript property mutants and remaining open cases.

Documentation:
- Refine explanatory comments in descriptors mutation configuration and changelog to document the tested miniscript property unions and outstanding mutation scenarios.