### PR TITLE
Sign a taproot script path, which is where the 65-byte shape comes from (#560)

### DIFF
--- a/.github/mutation/psbt.toml
+++ b/.github/mutation/psbt.toml
@@ -70,9 +70,8 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 # command, four other profiles sharing the machine: 780 killed, 107
 # survived, 12.06%. Sampled, and the sample is a third of the scope.
 #
-# The gaps, and the six of them closed by the tests beside this commit --
-# each measured surviving before its test and dying after, one mutant at a
-# time:
+# The gaps, and the ones a test now answers -- each measured surviving
+# before its test and dying after, one mutant at a time:
 #
 # - every lock-time bound had a side nothing asked for. BIP370's three
 #   fields are now asserted at the value each admits as well as the one
@@ -87,8 +86,19 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 # - `combine`'s `other_id != tx_id` weakened to `>` was tested with the
 #   ids in one arrangement only; the same disagreement combined the other
 #   way round closes it -- the shape fetch.toml closed for `tx.id`.
+# - `_assert_new_taproot_sigs_verify`'s `sig[:64]` widened to `sig[:65]`
+#   is equivalent for a 64-byte signature -- slicing past the end is not
+#   an error -- and differs only for the 65-byte shape, where the last
+#   byte is a sighash type that must not be verified as part of the
+#   signature. Both of its paths are now signed with an explicit type,
+#   and the answer run through `assert_signatures_only`. The script path
+#   needed a signer to produce one at all, which `sign` gained for this
+#   (#560): the only other source of a script path signature here is a
+#   BIP373 MuSig2 aggregation, and those partial signatures commit to
+#   SIGHASH_DEFAULT. The key path mutant beside it is the same hole, and
+#   is among the two thirds of the scope this session never ran.
 #
-# Three are left open, and each has a reason rather than a test owed:
+# What is left open has a reason rather than a test owed:
 #
 # - `parse_taproot_bip32`'s `len_ * LEAF_HASH_SIZE + FINGERPRINT_SIZE`
 #   with `^` for `+` is equivalent by arithmetic: `32 * len_` is a
@@ -98,16 +108,6 @@ exclude-operators = ["core/ReplaceBinaryOperator_BitOr_.*"]
 #   transaction is compared before the walk is reached: measured, a
 #   dropped output and a dropped input each answer "the transaction being
 #   signed was changed" first.
-# - `_assert_new_taproot_sigs_verify`'s `sig[:64]` widened to `sig[:65]`
-#   is equivalent for a 64-byte signature -- slicing past the end is not
-#   an error -- and differs only for the 65-byte shape, where the last
-#   byte is a sighash type that must not be verified as part of the
-#   signature. This tree cannot produce one for a taproot script path:
-#   the only source of such a signature here is a BIP373 MuSig2
-#   aggregation, whose partial signatures commit to SIGHASH_DEFAULT. A
-#   script-path signer taking an explicit sighash type is what would kill
-#   it, and is the test to write rather than an equivalence to accept:
-#   issue #560.
 #
 # The remaining classes are the ones documented elsewhere here: a
 # `check_validity` default, an `is` over interned ints, and a comparison

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -568,6 +568,38 @@ documented at release-notes length in the first place, and are still in
   `wsh()`, which btclib now reads -- what is left is the template, which is
   the expression with the keys lifted into a vector, and #469 is where it
   was asked for.
+- **`sign` signs a taproot script path, and a `KeyManager` answers for a
+  leaf key** (#560). A taproot input was offered its key path alone, so
+  `PSBT_IN_TAP_SCRIPT_SIG` was a field this library read, verified and
+  finalized and never wrote: the only script path signature the tree could
+  produce was a BIP373 MuSig2 aggregation, which is one leaf shape of the
+  several BIP371 describes.
+
+  A candidate is a key and a leaf, and the psbt names the two in different
+  fields: `PSBT_IN_TAP_BIP32_DERIVATION` files a key under the tapleaf
+  hashes it appears in, and `PSBT_IN_TAP_LEAF_SCRIPT` carries the leaves
+  themselves. Both are required, as Bitcoin Core's signer requires them --
+  a tapleaf hash the psbt names no script for is a commitment to a
+  condition this signer cannot read, and reading what is signed is what a
+  psbt is for. What the leaf demands *besides* this key is not asked: a
+  key in a threshold of CHECKSIGADD signs its own line, the rest of the
+  quorum being other signers' turn, and whether the leaf can then be
+  finalized is `single_leaf_key`'s question one role later.
+
+  `KeyManager.sign_schnorr_script_path` is the new method, and it is the
+  one whose key signs as it is: a script path spend proves the leaf, the
+  output key's tweak being what the control block carries, so there is no
+  merkle root to tweak by and nothing for the manager to apply. It is
+  handed the tapleaf hash that asked, one key being able to sit in more
+  than one leaf and each leaf being a different message, a different entry
+  of the field and a different condition to have a policy about.
+
+  Both paths of a taproot input are now offered and one input may come
+  back signed for both, which of the two is spent being the Finalizer's
+  choice. The sig_hash type the input asks for is appended to a script
+  path signature by BIP341's rule, the same rule and now the same code as
+  the key path's: 64 bytes for SIGHASH_DEFAULT, 65 with the type for
+  anything else.
 
 ### Wallets
 
@@ -1076,6 +1108,20 @@ documented at release-notes length in the first place, and are still in
   keys' at a position, and the private keys' -- and each of the four is
   asserted to be the one the script carries, the last of them being what
   says an xprv quorum and its xpub quorum are one wallet.
+- **A taproot script path signature is signed with an explicit sig_hash
+  type** (#560), which is what `.github/mutation/psbt.toml` left open: in
+  `_assert_new_taproot_sigs_verify`, `sig[:64]` widened to `sig[:65]`
+  survived, slicing past the end of a 64-byte signature not being an
+  error. Only the 65-byte shape tells the two apart, and the tree had no
+  way to make one for a script path -- a MuSig2 aggregation of the BIP373
+  vectors commits to SIGHASH_DEFAULT, and appending a type byte to that
+  signature is not the same signature, the hash a type commits to being
+  another. The script-path signer above is what produces one, and the
+  answer is checked by `assert_signatures_only` and by the script engine,
+  which is what says the type is the one the transaction was hashed with.
+  The key path mutant beside it was the same hole, and is closed by the
+  same assertion added to the key path test: the sampled session never ran
+  it, so it was a survivor nobody had seen.
 
 ## v2026.8.7
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -47,6 +47,16 @@ full year, short month, short day (YYYY-M-D)
   Two error messages read "wallet" where they read "keystore": an address
   the wallet never handed out, and the refusal to sign without a private
   key.
+- **a `KeyManager` has one method more.** `psbt.sign` now offers a taproot
+  input its script path as well as its key path, and asks for a leaf
+  signature through `sign_schnorr_script_path(pub_key, origin, msg_hash,
+  leaf_hash)`. A manager written against v2026.8.7 implements `sign_ecdsa`
+  and `sign_schnorr` only: mypy stops accepting it where the protocol is
+  asked for, and a taproot input carrying leaf scripts reaches it with an
+  `AttributeError`. The method signs with the leaf key untweaked -- the
+  tweak is what the control block proves -- and `None` from it is a
+  manager saying it holds no key for that leaf, as `None` from the other
+  two already is.
 - **`btclib.descriptors` is a package, and its three checksum tables moved
   with the module into it.** `INPUT_CHARSET`, `CHECKSUM_CHARSET` and
   `GENERATOR` are `btclib.descriptors.descriptors.INPUT_CHARSET` and its

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -2064,6 +2064,29 @@ class KeyManager(Protocol):
         """
         ...
 
+    def sign_schnorr_script_path(
+        self,
+        pub_key: bytes,
+        origin: BIP32KeyOrigin | None,
+        msg_hash: bytes,
+        leaf_hash: bytes,
+    ) -> bytes | None:
+        """Return the BIP342 signature of msg_hash by pub_key, or None.
+
+        The other half of a taproot spend, and the one method here whose
+        key signs as it is: pub_key is a key of the leaf script, x-only,
+        and a script path proves the leaf rather than the output key --
+        the tweak is what the control block carries, so there is nothing
+        for the manager to apply and no merkle root to apply it by.
+
+        leaf_hash is which leaf asked. One key can sit in more than one,
+        each leaf is a different message and a different entry of
+        `PSBT_IN_TAP_SCRIPT_SIG`, and a manager with a policy about
+        which conditions it signs under has only this to recognize them
+        by.
+        """
+        ...
+
 
 def _sign_ecdsa_input(psbt: Psbt, vin_i: int, key_manager: KeyManager) -> bool:
     """Write every partial signature key_manager gives for one input.
@@ -2093,6 +2116,21 @@ def _sign_ecdsa_input(psbt: Psbt, vin_i: int, key_manager: KeyManager) -> bool:
     return signed
 
 
+def _taproot_signature(sig: bytes, psbt_in: PsbtIn) -> bytes:
+    """Return a bare schnorr signature as the input's own sig_hash type.
+
+    BIP341 appends the type to the 64 bytes for every type but the
+    default one, which is appended as nothing rather than as its zero
+    byte: `_assert_taproot_sig_hash_type` is this rule read back, and
+    both taproot paths write through here so that the signature the
+    Signer files and the one the Finalizer checks are one shape.
+    """
+    hash_type = psbt_in.sig_hash_type or DEFAULT
+    if not hash_type:
+        return sig
+    return sig + hash_type.to_bytes(1, "big")
+
+
 def _sign_taproot_key_path(psbt: Psbt, vin_i: int, key_manager: KeyManager) -> bool:
     """Write the taproot key path signature key_manager gives, if any.
 
@@ -2115,30 +2153,74 @@ def _sign_taproot_key_path(psbt: Psbt, vin_i: int, key_manager: KeyManager) -> b
     )
     if sig is None:
         return False
-    hash_type = psbt_in.sig_hash_type or DEFAULT
-    if hash_type:
-        sig += hash_type.to_bytes(1, "big")
-    psbt_in.taproot_key_spend_signature = sig
+    psbt_in.taproot_key_spend_signature = _taproot_signature(sig, psbt_in)
     return True
+
+
+def _sign_taproot_script_path(psbt: Psbt, vin_i: int, key_manager: KeyManager) -> bool:
+    """Write every script path signature key_manager gives for one input.
+
+    A candidate is a key and a leaf, and BIP371 names the two in
+    different fields: `PSBT_IN_TAP_BIP32_DERIVATION` files a key under
+    the tapleaf hashes it appears in, and `PSBT_IN_TAP_LEAF_SCRIPT`
+    carries the leaves themselves. Both are asked for, as Bitcoin Core's
+    signer asks for both: a leaf hash the psbt names no script for is a
+    condition this signer cannot read, and a signature under a condition
+    nobody read is what a psbt exists to avoid -- the message commits to
+    the leaf hash and says nothing else about what the leaf demands.
+
+    What the leaf script demands *besides* this key is not asked: a key
+    in a threshold of CHECKSIGADD signs its own line, the rest of the
+    quorum being other signers' turn. Whether the leaf can then be
+    finalized is `single_leaf_key`'s question, one role later.
+    """
+    psbt_in = psbt.inputs[vin_i]
+    leaf_hashes = {
+        taproot.leaf_hash(leaf_version, script)
+        for script, leaf_version in psbt_in.taproot_leaf_scripts.values()
+    }
+    signed = False
+    for pub_key, (key_leaf_hashes, origin) in psbt_in.taproot_hd_key_paths.items():
+        for leaf_hash in key_leaf_hashes:
+            if leaf_hash not in leaf_hashes:
+                continue
+            key_data = pub_key + leaf_hash
+            if key_data in psbt_in.taproot_script_spend_signatures:
+                continue
+            msg_hash = taproot_sig_hash(psbt, vin_i, leaf_hash=leaf_hash)
+            sig = key_manager.sign_schnorr_script_path(
+                pub_key, origin, msg_hash, leaf_hash
+            )
+            if sig is None:
+                continue
+            psbt_in.taproot_script_spend_signatures[key_data] = _taproot_signature(
+                sig, psbt_in
+            )
+            signed = True
+    return signed
 
 
 def sign(psbt: Psbt, key_manager: KeyManager) -> tuple[Psbt, list[int]]:
     """Run the Signer role over every input key_manager answers for.
 
     Per input the candidates are what the psbt itself names: hd_key_paths
-    for an ECDSA spend, the taproot internal key and its own
-    taproot_hd_key_paths entry for a taproot one. None from key_manager
-    skips the key rather than raising -- one signer of an m-of-n holds
-    one key, and an input it cannot answer for is not an error but
-    somebody else's turn. What comes back besides the copy is which
-    inputs got a new signature, since a caller collecting a quorum needs
-    to tell "there was nothing for me" from "done".
+    for an ECDSA spend, the taproot internal key and the taproot
+    hd_key_paths entries for a taproot one. None from key_manager skips
+    the key rather than raising -- one signer of an m-of-n holds one key,
+    and an input it cannot answer for is not an error but somebody else's
+    turn. What comes back besides the copy is which inputs got a new
+    signature, since a caller collecting a quorum needs to tell "there
+    was nothing for me" from "done".
 
-    Taproot is limited to the key path: MuSig2's own Signer is
-    `btclib.psbt.musig2`, and a script path spend needs a leaf and a
-    control block `sign` does not choose between. Every other kind is
-    whatever `_finalized_input` can close over -- p2pk, p2pkh, p2wpkh,
-    p2sh-p2wpkh, p2wsh, bare and wrapped multisig.
+    A taproot input is offered both of its paths, the key path and every
+    leaf the psbt carries a script for, and one input may come back with
+    signatures for both: which of the two is spent is the Finalizer's
+    choice, and a signer that holds keys for both has no reason to be
+    asked twice. Which leaf a key belongs to is not `sign`'s guess
+    either -- `PSBT_IN_TAP_BIP32_DERIVATION` says it, and MuSig2's own
+    Signer is `btclib.psbt.musig2` for the aggregate case. Every other
+    kind is whatever `_finalized_input` can close over -- p2pk, p2pkh,
+    p2wpkh, p2sh-p2wpkh, p2wsh, bare and wrapped multisig.
 
     Raises where the psbt cannot be signed at all -- `assert_signable`'s
     question -- and where a candidate's own hash cannot be computed,
@@ -2151,7 +2233,12 @@ def sign(psbt: Psbt, key_manager: KeyManager) -> tuple[Psbt, list[int]]:
     signed_vins: list[int] = []
     for vin_i, psbt_in in enumerate(psbt.inputs):
         if is_p2tr(_spent_script(psbt_in)):
-            if _sign_taproot_key_path(psbt, vin_i, key_manager):
+            # both, and neither short-circuiting the other: an input can
+            # be signed for the key path and for a leaf, and `or` would
+            # leave the second unasked
+            key_path = _sign_taproot_key_path(psbt, vin_i, key_manager)
+            script_path = _sign_taproot_script_path(psbt, vin_i, key_manager)
+            if key_path or script_path:
                 signed_vins.append(vin_i)
             continue
         if _sign_ecdsa_input(psbt, vin_i, key_manager):

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -563,8 +563,9 @@ class SoftwareSigner:
     def capabilities(self) -> SignerCapabilities:
         """Return what this signer can be asked to sign.
 
-        Taproot always: `psbt.sign` signs the key path, which is what a
-        BIP341 output with no script tree is spent by. MuSig2 is a
+        Taproot always: `psbt.sign` signs the key path and every leaf the
+        psbt names this signer's keys in, which is both halves of a BIP341
+        output for a signer holding what they ask for. MuSig2 is a
         constructor argument and defaults to False, because the rounds of
         BIP373 are `psbt.musig2`'s and are played by a caller holding the
         secret nonce between them -- this signer signs in one call and
@@ -667,3 +668,27 @@ class SoftwareSigner:
             return None
         tweaked = output_prvkey_from_merkle_root(prv_key, merkle_root)
         return ssa.sign_(msg_hash, tweaked).serialize()
+
+    def sign_schnorr_script_path(
+        self,
+        pub_key: bytes,
+        origin: BIP32KeyOrigin | None,
+        msg_hash: bytes,
+        leaf_hash: bytes,
+    ) -> bytes | None:
+        """Return the BIP342 signature of msg_hash by pub_key, or None.
+
+        Untweaked, which is the `KeyManager` contract for a script path:
+        what the spend proves is the leaf, and the output key's tweak is
+        proved by the control block instead.
+
+        Every leaf the psbt names this key in is signed for. A device
+        would show the leaf script and ask, and `leaf_hash` is what it
+        would find it by; a signer holding keys at known paths and
+        answering in one call has no user to ask, so what it answers for
+        is decided by the same three conditions as the other two methods.
+        """
+        prv_key = self._prv_key(pub_key, origin)
+        if prv_key is None:
+            return None
+        return ssa.sign_(msg_hash, prv_key).serialize()

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -54,9 +54,10 @@ from btclib.script import (
     output_prvkey_from_merkle_root,
     serialize,
     sig_hash,
+    taproot,
 )
 from btclib.script.engine import verify_transaction
-from btclib.script.taproot import tree_helper
+from btclib.script.taproot import input_script_sig, tree_helper
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from tests import load, vector_id
@@ -3306,6 +3307,22 @@ class _KeyManager:
         tweaked = output_prvkey_from_merkle_root(prv_key, merkle_root)
         return ssa.sign_(msg_hash, tweaked).serialize()
 
+    def sign_schnorr_script_path(
+        self,
+        pub_key: bytes,
+        origin: BIP32KeyOrigin | None,
+        msg_hash: bytes,
+        leaf_hash: bytes,
+    ) -> bytes | None:
+        # no tweak, which is the whole difference from sign_schnorr
+        # above: a leaf key signs as itself, and leaf_hash is context
+        # this double has no policy to apply it to
+        prv_key = self._prv_key(pub_key, origin)
+        if prv_key is None:
+            return None
+        self.sign_calls += 1
+        return ssa.sign_(msg_hash, prv_key).serialize()
+
 
 def _unsigned_multisig_psbt() -> Psbt:
     """Build a one-input, unsigned native p2wsh 2-of-2 psbt.
@@ -3358,6 +3375,48 @@ def _taproot_key_path_psbt(
     psbt.inputs[0].taproot_merkle_root = (
         tree_helper(script_tree)[1] if script_tree else b""
     )
+    return psbt, [prev_out]
+
+
+_LEAF_PRV_KEY = _PRV_KEY + 3
+_LEAF_KEY = pub_keyinfo_from_prv_key(_LEAF_PRV_KEY)[0][1:]
+# the leaf spent below, and the one shape a Finalizer can build a witness
+# for: `single_leaf_key`'s <32-byte key> OP_CHECKSIG
+_LEAF_TREE: TaprootScriptTree = [(0xC0, [_LEAF_KEY, "OP_CHECKSIG"])]
+_LEAF_SCRIPT = taproot.serialize([_LEAF_KEY, "OP_CHECKSIG"])
+_LEAF_HASH = taproot.leaf_hash(0xC0, _LEAF_SCRIPT)
+
+
+def _taproot_script_path_psbt(
+    *, with_leaf_script: bool = True
+) -> tuple[Psbt, list[TxOut]]:
+    """Build a one-input, unsigned p2tr psbt spendable by a single leaf.
+
+    The Updater's half of a script path: the leaf script filed under the
+    control block that proves it, and the leaf's key filed under the
+    tapleaf hash it appears in, which is BIP371's way of saying that this
+    key signs for that leaf. The internal key is there too, and holds no
+    key any test here signs the key path with -- a script path spend of
+    an output that could also be spent by its owner is the ordinary
+    shape, and the one that says `sign` asks for both.
+
+    with_leaf_script drops `PSBT_IN_TAP_LEAF_SCRIPT` alone, leaving the
+    derivation naming a leaf the psbt does not carry the script of.
+    """
+    script_pub_key = ScriptPubKey.p2tr(_TAPROOT_PUB_KEY, _LEAF_TREE)
+    prev_out = TxOut(100_000, script_pub_key)
+    tx, _ = _spending_tx(prev_out)
+    control_block = input_script_sig(_TAPROOT_PUB_KEY, _LEAF_TREE, 0)[1]
+
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].witness_utxo = prev_out
+    psbt.inputs[0].taproot_internal_key = _TAPROOT_INTERNAL_KEY
+    psbt.inputs[0].taproot_merkle_root = tree_helper(_LEAF_TREE)[1]
+    if with_leaf_script:
+        psbt.inputs[0].taproot_leaf_scripts[control_block] = (_LEAF_SCRIPT, 0xC0)
+    psbt.inputs[0].taproot_hd_key_paths = {
+        _LEAF_KEY: ([_LEAF_HASH], BIP32KeyOrigin(b"\x00" * 4, "m/1"))
+    }
     return psbt, [prev_out]
 
 
@@ -3512,18 +3571,131 @@ def test_sign_appends_the_sig_hash_type_a_taproot_input_asks_for() -> None:
 
     Every other taproot test here leaves sig_hash_type unset, which is
     SIGHASH_DEFAULT and appends nothing; this is the other half.
+
+    `assert_signatures_only` is asked as well as the Finalizer, both
+    verifying the 64 bytes and not the 65: the type byte is what the
+    message was chosen by, and verifying it as part of the signature
+    fails an answer that is perfectly good.
     """
-    psbt, prevouts = _taproot_key_path_psbt()
-    psbt.inputs[0].sig_hash_type = 1  # ALL
+    request, prevouts = _taproot_key_path_psbt()
+    request.inputs[0].sig_hash_type = 1  # ALL
     key_manager = _KeyManager(by_pub_key={_TAPROOT_INTERNAL_KEY: _TAPROOT_PRV_KEY})
+
+    returned, signed_vins = sign(request, key_manager)
+
+    assert signed_vins == [0]
+    signature = returned.inputs[0].taproot_key_spend_signature
+    assert len(signature) == 65
+    assert signature[-1] == sig_hash.ALL
+    assert_signatures_only(request, returned)
+    verify_transaction(prevouts, extract_tx(finalize(returned), check_validity=False))
+
+
+def test_sign_writes_the_taproot_script_path_signature() -> None:
+    """A single-key leaf, signed and then finalized (issue #560).
+
+    The signature is filed under the key and the leaf hash together,
+    which is what `PSBT_IN_TAP_SCRIPT_SIG` is keyed by, and the witness
+    the Finalizer builds from it is what the engine is asked about: a
+    script path spend proves the leaf, so the leaf key signs untweaked
+    and the control block carries the rest of the proof.
+    """
+    psbt, prevouts = _taproot_script_path_psbt()
+    key_manager = _KeyManager(by_pub_key={_LEAF_KEY: _LEAF_PRV_KEY})
 
     result, signed_vins = sign(psbt, key_manager)
 
     assert signed_vins == [0]
-    signature = result.inputs[0].taproot_key_spend_signature
+    signatures = result.inputs[0].taproot_script_spend_signatures
+    assert list(signatures) == [_LEAF_KEY + _LEAF_HASH]
+    assert len(signatures[_LEAF_KEY + _LEAF_HASH]) == 64
+    verify_transaction(prevouts, extract_tx(finalize(result), check_validity=False))
+
+
+def test_sign_appends_the_sig_hash_type_to_a_script_path_signature() -> None:
+    """The 65-byte shape of a script path signature (issue #560).
+
+    The mutation session of PR 558 could reach it from no test at all,
+    the only script path signature this tree produced being a BIP373
+    aggregation of partial signatures that commit to SIGHASH_DEFAULT --
+    and appending a type byte to that one is not the same signature, the
+    hash a type commits to being another. So it is signed here, and
+    checked by the two readers of the byte: `assert_signatures_only`,
+    which verifies an answer over the 64 bytes and not the 65, and the
+    script engine, which is what says the type is the one the
+    transaction was hashed with.
+    """
+    request, prevouts = _taproot_script_path_psbt()
+    request.inputs[0].sig_hash_type = 1  # ALL
+    key_manager = _KeyManager(by_pub_key={_LEAF_KEY: _LEAF_PRV_KEY})
+
+    returned, signed_vins = sign(request, key_manager)
+
+    assert signed_vins == [0]
+    signature = returned.inputs[0].taproot_script_spend_signatures[
+        _LEAF_KEY + _LEAF_HASH
+    ]
     assert len(signature) == 65
     assert signature[-1] == sig_hash.ALL
-    verify_transaction(prevouts, extract_tx(finalize(result), check_validity=False))
+    assert_signatures_only(request, returned)
+    verify_transaction(prevouts, extract_tx(finalize(returned), check_validity=False))
+
+
+def test_sign_offers_a_taproot_input_both_of_its_paths() -> None:
+    """One manager holding both keys answers for both, and is asked once.
+
+    Which of the two spends the input is the Finalizer's choice, so a
+    signer that can answer for either has no reason to be asked twice --
+    and a second sign() over the result asks for neither again, the key
+    path signature and the leaf's entry each saying there is nothing
+    left to sign.
+    """
+    psbt, _ = _taproot_script_path_psbt()
+    key_manager = _KeyManager(
+        by_pub_key={_TAPROOT_INTERNAL_KEY: _TAPROOT_PRV_KEY, _LEAF_KEY: _LEAF_PRV_KEY}
+    )
+
+    once, signed_vins = sign(psbt, key_manager)
+    assert signed_vins == [0]
+    assert key_manager.sign_calls == 2
+    assert once.inputs[0].taproot_key_spend_signature
+    assert once.inputs[0].taproot_script_spend_signatures
+
+    twice, signed_vins_again = sign(once, key_manager)
+    assert signed_vins_again == []
+    assert key_manager.sign_calls == 2
+    assert (
+        twice.inputs[0].taproot_script_spend_signatures
+        == once.inputs[0].taproot_script_spend_signatures
+    )
+
+
+def test_sign_skips_a_leaf_key_the_key_manager_does_not_hold() -> None:
+    """None from sign_schnorr_script_path leaves the leaf unsigned."""
+    psbt, _ = _taproot_script_path_psbt()
+    result, signed_vins = sign(psbt, _KeyManager())
+
+    assert signed_vins == []
+    assert not result.inputs[0].taproot_script_spend_signatures
+
+
+def test_sign_skips_a_leaf_the_psbt_carries_no_script_for() -> None:
+    """A derivation naming a tapleaf hash is not on its own a candidate.
+
+    `PSBT_IN_TAP_LEAF_SCRIPT` is what says which condition the leaf
+    imposes, and without it there is nothing to read before signing: a
+    tapleaf hash alone is a commitment to a script this signer has never
+    seen, which is what a psbt exists to avoid. key_manager holds the
+    key and is never asked for it.
+    """
+    psbt, _ = _taproot_script_path_psbt(with_leaf_script=False)
+    key_manager = _KeyManager(by_pub_key={_LEAF_KEY: _LEAF_PRV_KEY})
+
+    result, signed_vins = sign(psbt, key_manager)
+
+    assert signed_vins == []
+    assert key_manager.sign_calls == 0
+    assert not result.inputs[0].taproot_script_spend_signatures
 
 
 def test_sign_raises_on_a_psbt_that_cannot_be_signed() -> None:

--- a/tests/psbt_signer_test.py
+++ b/tests/psbt_signer_test.py
@@ -96,6 +96,16 @@ class _KeyManager:
         """Answer for no taproot key: this double signs ECDSA only."""
         return None
 
+    def sign_schnorr_script_path(
+        self,
+        pub_key: bytes,
+        origin: BIP32KeyOrigin | None,
+        msg_hash: bytes,
+        leaf_hash: bytes,
+    ) -> bytes | None:
+        """Answer for no leaf key either, for the same reason."""
+        return None
+
 
 class _Signer:
     """A `PsbtSigner` double holding one extended private key.
@@ -225,13 +235,18 @@ def test_a_signer_holding_none_of_the_keys_adds_nothing() -> None:
     one whose capabilities say it cannot sign one. The answer passes the
     check and combines into a psbt that gained nothing, which is what a
     caller then sees.
+
+    The taproot input carries a leaf as well as an internal key, both of
+    them keys this signer derives: a taproot input is offered both of its
+    paths, so both are questions this double has to answer None to.
     """
     signer = _Signer()
     stranger = _Signer(rootxprv_from_seed("000102030405060708090a0b0c0d0e0f"))
     psbt, _ = account_psbt(stranger)
     assert not request_signatures(signer, psbt).inputs[0].partial_sigs
 
-    taproot = export_account(signer, "m/86h/0h/0h")[0]
+    key = export_account(signer, "m/86h/0h/0h")[0].key_expressions[0]
+    taproot = parse(f"tr({key},pk({key}))")
     script_pub_key = taproot.script_pub_key(0)
     prev_tx = Tx(
         vin=[TxIn(OutPoint(b"\x05" * 32, 0))], vout=[TxOut(10_000, script_pub_key)]
@@ -245,6 +260,7 @@ def test_a_signer_holding_none_of_the_keys_adds_nothing() -> None:
     assert not signer.capabilities().taproot
     signed = request_signatures(signer, taproot_psbt)
     assert not signed.inputs[0].taproot_key_spend_signature
+    assert not signed.inputs[0].taproot_script_spend_signatures
 
 
 def test_an_account_is_exported_from_two_answers() -> None:

--- a/tests/software_signer_test.py
+++ b/tests/software_signer_test.py
@@ -21,7 +21,8 @@ import pytest
 from btclib.bip32.bip32 import BIP32KeyData, derive, xpub_from_xprv
 from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.core_import import account_import_requests
-from btclib.descriptors import Descriptor, add_checksum
+from btclib.descriptors import Descriptor, add_checksum, parse
+from btclib.ecc import ssa
 from btclib.exceptions import BTClibValueError
 from btclib.psbt.psbt import Psbt, finalize
 from btclib.psbt_signer import (
@@ -121,6 +122,41 @@ def test_a_psbt_of_an_exported_account_is_signed_and_spends(purpose: int) -> Non
     verify_transaction(prevouts, tx)
 
 
+def test_a_taproot_script_path_is_signed_and_spends() -> None:
+    """The other half of a taproot output, end to end (issue #560).
+
+    The internal key is BIP341's NUMS point, which nobody holds: the leaf
+    is the only way into the output, so what finalizes here is a script
+    path witness -- the signature, the leaf script and the control block
+    -- and the engine is the oracle for it as it is for every other flow
+    in this file.
+
+    The descriptor is what makes the psbt answerable: `update_psbt_input`
+    writes the leaf script under its control block and files the leaf's
+    key under the tapleaf hash, which is how BIP371 says "this key signs
+    for that leaf" and is what the signer is asked by.
+    """
+    signer = SoftwareSigner(XPRV_ROOT)
+    key = f"[{signer.master_fingerprint().hex()}/86h/0h/0h]{signer.xpub('m/86h/0h/0h')}"
+    nums = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0"
+    receive = parse(add_checksum(f"tr({nums},pk({key}/0/*))"))
+    change = parse(add_checksum(f"tr({nums},pk({key}/1/*))"))
+    psbt, prevouts = spending(receive, change)
+
+    signed = request_signatures(signer, psbt)
+    assert not signed.inputs[0].taproot_key_spend_signature
+    ((key_data, signature),) = signed.inputs[0].taproot_script_spend_signatures.items()
+    assert key_data[:32] == receive.key_expressions[1].sec(0)[1:]
+    assert len(signature) == 64  # SIGHASH_DEFAULT appends no type byte
+
+    final = finalize(signed)
+    assert len(final.inputs[0].final_script_witness.stack) == 3
+    tx = final.tx
+    tx.vin[0].script_sig = final.inputs[0].final_script_sig
+    tx.vin[0].script_witness = final.inputs[0].final_script_witness
+    verify_transaction(prevouts, tx)
+
+
 def test_the_change_output_carries_what_a_device_reads() -> None:
     """What the signer is told about the output that comes back.
 
@@ -185,6 +221,16 @@ def test_the_signer_answers_for_its_own_keys_only() -> None:
     assert signer.sign_schnorr(x_only, tr_origin, msg_hash, b"") is not None
     assert signer.sign_schnorr(x_only, None, msg_hash, b"") is None
     assert signer.sign_schnorr(x_only, elsewhere, msg_hash, b"") is None
+
+    # and for a leaf key, which is the same three conditions again: what
+    # differs is the answer, which the key of the leaf verifies as it is
+    # -- the tweak of a script path spend is the control block's
+    leaf = b"\x08" * 32
+    signature = signer.sign_schnorr_script_path(x_only, tr_origin, msg_hash, leaf)
+    assert signature is not None
+    assert ssa.verify_(msg_hash, x_only, signature)
+    assert signer.sign_schnorr_script_path(x_only, None, msg_hash, leaf) is None
+    assert signer.sign_schnorr_script_path(x_only, elsewhere, msg_hash, leaf) is None
 
 
 def test_a_watch_only_signer_shows_and_derives_but_does_not_sign() -> None:


### PR DESCRIPTION
Closes [ISS560](https://github.com/btclib-org/btclib/issues/560).

`psbt.sign` offered a taproot input its key path alone, so
`PSBT_IN_TAP_SCRIPT_SIG` was a field this library read, verified and
finalized and never wrote: the only script path signature the tree could
produce was a BIP373 MuSig2 aggregation, whose partial signatures commit
to SIGHASH_DEFAULT. That is why the mutant of
[PR 558](https://github.com/btclib-org/btclib/pull/558)'s `psbt.toml`
survived — `_assert_new_taproot_sigs_verify`'s `sig[:64]` widened to
`sig[:65]`, which differs only for the 65-byte shape.

## The signer

A candidate is a key and a leaf, and BIP371 names the two in different
fields: `PSBT_IN_TAP_BIP32_DERIVATION` files a key under the tapleaf
hashes it appears in, and `PSBT_IN_TAP_LEAF_SCRIPT` carries the leaves.
Both are required, as Bitcoin Core's signer requires them: a leaf hash
the psbt names no script for is a condition this signer cannot read. What
the leaf demands *besides* this key is not asked — a key in a threshold
of CHECKSIGADD signs its own line.

`KeyManager.sign_schnorr_script_path(pub_key, origin, msg_hash,
leaf_hash)` is the new protocol method, and it is the one whose key signs
as it is: a script path spend proves the leaf, the output key's tweak
being what the control block carries. `SoftwareSigner` implements it.
Both paths of a taproot input are now offered and one input may come back
signed for both; the sig_hash type is appended by BIP341's rule, now
shared by the two paths.

Source-breaking for anyone who wrote a `KeyManager` against v2026.8.7, so
it has a bullet in HISTORY.md's breaking-changes list.

## The acceptance criterion

Both mutants measured surviving before the tests and dying after, one at
a time:

- `_assert_new_taproot_sigs_verify`'s script path `sig[:64]` → `sig[:65]`,
  the one the issue names;
- the key path `sig[:64]` beside it, the same hole and never run by the
  sampled session — `assert_signatures_only` added to the existing key
  path test closes it.

`.github/mutation/psbt.toml` moves the entry from what it left open to
what a test now answers.

Tests: a script path signed and finalized under the script engine, the
65-byte shape checked by `assert_signatures_only` and by the engine, both
paths offered and asked once, a leaf key the manager does not hold, a
tapleaf hash with no leaf script, and an end-to-end `SoftwareSigner` spend
of a `tr(NUMS,pk(...))` descriptor.

Gates: `uv run pytest --cov` at 100%, `pre-commit run --all-files`, and
the sphinx `-W` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add support for signing taproot script path spends alongside key path spends, including proper handling of 65-byte Schnorr signatures with explicit sighash types, and update documentation and tests accordingly.

New Features:
- Support signing taproot script path inputs via a new KeyManager.sign_schnorr_script_path protocol method that signs untweaked leaf keys identified by tapleaf hashes.
- Extend psbt.sign so a taproot input is offered both its key path and all script paths the PSBT names this signer's keys in, potentially producing signatures for both paths.
- Enable SoftwareSigner to sign taproot script path outputs from descriptors such as tr(NUMS,pk(...)) and produce spendable script path witnesses.

Bug Fixes:
- Ensure taproot key path and script path signatures correctly append the requested sighash type, producing 65-byte signatures when non-default types are used and avoiding verifying the type byte as part of the signature.
- Fix the gap where PSBT_IN_TAP_SCRIPT_SIG entries were only read and never written by psbt.sign, so script path signatures are now generated and finalized correctly.
- Prevent signing attempts for taproot leaf keys or leaf hashes that lack corresponding leaf scripts in the PSBT, avoiding unreadable or unintended script conditions.

Enhancements:
- Centralize taproot signature shape handling in a helper that enforces BIP341 sighash-type appending for both key and script paths.
- Clarify taproot signing and capability semantics in psbt_signer, including that taproot support now covers both paths for signers holding the relevant keys.

Documentation:
- Document taproot script path signing behaviour, the new KeyManager.sign_schnorr_script_path method, and the 65-byte script path signature shape in CHANGELOG.md and HISTORY.md.

Tests:
- Add taproot script path PSBT construction helpers and tests that sign, finalize, and engine-verify single-leaf script path spends, including non-default sighash types.
- Add tests asserting that both taproot paths are offered once, that leaf keys not held by the manager are skipped, and that leaf hashes without scripts are not treated as candidates.
- Add end-to-end SoftwareSigner tests for taproot script path spends derived from tr(NUMS,pk(...)) descriptors, and mutation-test coverage ensuring correct handling of 64- vs 65-byte taproot signatures.
- Extend PsbtSigner tests to cover the new script-path signing method and to ensure signers without keys add neither key-path nor script-path signatures.