### PR TITLE
Refuse a MOV-weak curve with the class every other refusal uses (#572)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,31 @@ Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in
 [HISTORY.md](./HISTORY.md) rather than duplicated here.
 
+## v2026.9 (work in progress, not released yet)
+
+### Curves, signatures and keys
+
+- **A MOV-weak curve is a `BTClibValueError`** (#572). `Curve` refuses
+  nine kinds of unusable parameter and eight of them raise the class the
+  library documents; the embedding-degree check raised `UserWarning`,
+  which is a `Warning` and not a `BTClibValueError`, so it was the one
+  `raise` in the whole library outside the exception hierarchy. A caller
+  validating a curve of its own with the default `weakness_check=True`
+  -- the only way to reach the check, the catalogue passing `False` --
+  and catching `BTClibValueError` for the other eight did not catch this
+  one: the curve came back as an escaping `UserWarning` instead of as a
+  refusal. The n == p check one branch below refuses the other weak curve
+  as a `BTClibValueError`, so the two disagreed on the class of the same
+  answer.
+
+  The message now names the embedding degree that was found rather than
+  saying "weak curve" alone: the value is what tells a curve refused for
+  being pairing-friendly from one refused for anything else, and it is
+  the number SEC 1 v.2 3.1.1.2.1 step 8 bounds. `UserWarning` was never
+  warned with -- `warnings.warn` is what a warning is raised through, and
+  `BTClibUserWarning` in `btclib.exceptions` is the class for it -- so
+  nothing that filters warnings is affected.
+
 ## v2026.8.9
 
 ### Descriptors and miniscript

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,20 @@ Notable changes to the codebase are documented here.
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)
 
+## v2026.9 (work in progress, not released yet)
+
+### Breaking changes
+
+- **a MOV-weak curve is refused with `BTClibValueError`, not
+  `UserWarning`.** `Curve(p, a, b, G, n, cofactor)` with the default
+  `weakness_check=True` used to raise `UserWarning("weak curve")` for a
+  curve whose embedding degree is under 100, which no `except
+  BTClibValueError` catches; every other refusal in that constructor
+  already raised one. A caller that builds its own curves and catches
+  `UserWarning` has to catch `BTClibValueError` instead. The catalogued
+  curves are unaffected: they are built with `weakness_check=False`, the
+  check having been paid once in `test_catalogued_curves`.
+
 ## v2026.8.9
 
 ### Breaking changes

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -98,10 +98,19 @@ def _assert_mov_resistant(p: int, n: int) -> None:
     curve, once nG is gated: 5.2 ms of the 9.7 ms the catalogue would
     spend at import time, which is why the catalogue passes
     weakness_check=False and test_catalogued_curves runs it instead.
+
+    A BTClibValueError, as every other rejection in this constructor is:
+    the embedding degree is a parameter of the curve being refused, so
+    the caller that catches an unusable `n` catches this one too. The
+    n == p check below is the other weak-curve refusal, and the two
+    disagreeing on their class is what left this one uncatchable for
+    anyone holding the library to its own exception contract.
     """
     for i in range(1, 100):
         if pow(p, i, n) == 1:
-            raise UserWarning("weak curve")
+            err_msg = "weak curve: the embedding degree is "
+            err_msg += f"{i}, which is below 100"
+            raise BTClibValueError(err_msg)
 
 
 class Curve(CurveGroup):

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -173,7 +173,7 @@ def test_exceptions() -> None:
     with pytest.raises(BTClibValueError, match="invalid cofactor: "):
         Curve(13, 0, 2, (1, 9), 19, 2, False)
 
-    with pytest.raises(UserWarning, match="weak curve"):
+    with pytest.raises(BTClibValueError, match="weak curve: the embedding degree"):
         Curve(11, 2, 7, (6, 9), 7, 2, True)
 
 


### PR DESCRIPTION
Closes #572.

`Curve` refuses nine kinds of unusable parameter and eight of them raise `BTClibValueError`. `_assert_mov_resistant` raised `UserWarning("weak curve")` — a `Warning`, not an error, and the one `raise` in the whole library outside its own exception hierarchy.

A caller validating a curve of its own with the default `weakness_check=True` (the only way to reach the check: the catalogue passes `False`) and catching `BTClibValueError` for the other eight did not catch this one. The `n == p` check one branch below refuses the other weak curve as a `BTClibValueError`, so the two disagreed on the class of the same answer.

## Before

```python
>>> Curve(67, 1, 0, (6, 17), 17, 4, weakness_check=True)
UserWarning: weak curve
```

## After

```python
>>> Curve(67, 1, 0, (6, 17), 17, 4, weakness_check=True)
BTClibValueError: weak curve: the embedding degree is 2, which is below 100
```

The message names the embedding degree found rather than saying "weak curve" alone: it is what tells a curve refused for being pairing-friendly from one refused for anything else, and it is the quantity SEC 1 v.2 3.1.1.2.1 step 8 bounds.

`UserWarning` was never *warned* with here — `warnings.warn` is how a warning is raised, and `BTClibUserWarning` in `btclib.exceptions` is the class for it — so nothing that filters warnings is affected.

## Gates

- `uv run pytest --cov`: 18441 passed, 5 skipped, coverage ratchet at 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align curve embedding-degree weakness checks with the library’s exception hierarchy by treating MOV-weak curves as standard validation errors.

Bug Fixes:
- Raise `BTClibValueError` instead of `UserWarning` when `_assert_mov_resistant` detects a MOV-weak curve, ensuring callers can consistently catch unusable curve parameters.

Documentation:
- Document the new behavior and rationale for MOV-weak curve rejection in the unreleased v2026.9 sections of CHANGELOG and HISTORY.

Tests:
- Update curve exception tests to expect `BTClibValueError` and the new embedding-degree-specific error message for MOV-weak curves.