### PR TITLE
Open the v2026.9 development cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Only v2026.8.7 and what follows it are here. The releases before it were
 documented at release-notes length in the first place, and are still in
 [HISTORY.md](./HISTORY.md) rather than duplicated here.
 
+## v2026.9 (work in progress, not released yet)
+
 ## v2026.8.9
 
 ### Descriptors and miniscript

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,8 @@ Notable changes to the codebase are documented here.
 Release names follow *[calendar versioning](https://calver.org/)*:
 full year, short month, short day (YYYY-M-D)
 
+## v2026.9 (work in progress, not released yet)
+
 ## v2026.8.9
 
 ### Breaking changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ name = "btclib"
 # file. Not a literal in btclib/__init__.py for setuptools to import and
 # conf.py to repeat: two declarations are two things a release workflow
 # has to compare before trusting either
-version = "2026.8.9"
+version = "2026.9"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.8.9"
+version = "2026.9"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
The last step of RELEASING.md for v2026.8.9, and the first of the cycle
after it: `pyproject.toml` takes the month-only placeholder `2026.9` so a
checkout of `dev` reports itself as work in progress rather than as a
release it is not, `uv.lock` follows, and HISTORY.md and CHANGELOG.md each
get their work-in-progress section above v2026.8.9's.

CHANGELOG.md's preamble needed an edit when the previous cycle opened and
does not need one now: "Only v2026.8.7 and what follows it are here" is
still what the file holds.

Gates on this tree: `pre-commit run --all-files`, `pytest --cov` (18441
passed, 100.00% coverage) and `sphinx-build -W --keep-going`, all green.

The draft pull request the cycle is described in, as work lands, follows
this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Open the v2026.9 development cycle and mark it as work in progress across metadata and release notes.

New Features:
- Add a work-in-progress v2026.9 section to CHANGELOG.md above v2026.8.9.
- Add a work-in-progress v2026.9 section to HISTORY.md above v2026.8.9.

Enhancements:
- Update the project version in pyproject.toml to the v2026.9 development placeholder so dev checkouts report work in progress.
- Refresh uv.lock to reflect the new development cycle state.