### PR TITLE
Compute Hasse's half-width in integer arithmetic (#573)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,27 @@ documented at release-notes length in the first place, and are still in
   warned with -- `warnings.warn` is what a warning is raised through, and
   `BTClibUserWarning` in `btclib.exceptions` is the class for it -- so
   nothing that filters warnings is affected.
+- **Hasse's half-width is computed in integer arithmetic** (#573).
+  `Curve` bounded `n` with `int(2 * sqrt(self.p))`, which rounds `p` to
+  the 53 bits of a float mantissa before truncating: on secp256k1 the
+  result is one above `floor(2*sqrt(p))`, so the interval the constructor
+  admitted was a shade wider than Hasse's. `isqrt(4 * self.p)` is that
+  floor exactly, `delta` being the largest `d` with `d*d <= 4*p`.
+
+  Not `2 * isqrt(self.p)`, which is the same number only when `p` is a
+  perfect square and is otherwise too small -- the two are 5 and 4 on
+  `p = 7`, and the second refuses the order-13 curve over it that
+  `tests/curves/curve_group_test.py` builds. The distinction is what the
+  new `test_hasse_half_width_is_exact` pins, against the exact
+  arithmetic rather than against a table of expected widths.
+
+  The cofactor estimate below it reads the same `delta` and was three
+  float divisions of 256-bit integers, each rounding before they were
+  added; it is `(1 + delta + self.p) // n` now. No catalogued curve and
+  no low-cardinality test curve changes what it is built as: the two
+  spellings were measured to agree on all 27 of the first and all of the
+  second, which is why this is a correctness fix with no behaviour to
+  record.
 
 ## v2026.8.9
 

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -28,7 +28,7 @@ import contextlib
 import json
 from collections.abc import Sequence
 from hashlib import sha256
-from math import sqrt
+from math import isqrt
 from pathlib import Path
 from typing import Any
 
@@ -193,7 +193,14 @@ class Curve(CurveGroup):
             err_msg = "n is not prime: "
             err_msg += f"{hex_string(n)}" if n > HEX_THRESHOLD else f"{n}"
             raise BTClibValueError(err_msg)
-        delta = int(2 * sqrt(self.p))
+        # Hasse's half-width, floor(2*sqrt(p)), in integer arithmetic:
+        # math.sqrt rounds p to 53 bits of mantissa before the truncation,
+        # which on a 256-bit p overshoots by one and widens the interval
+        # below by that much. isqrt(4*p) and not 2*isqrt(p): the two are
+        # the same number only when p is a perfect square, floor(2*sqrt(p))
+        # being what this is -- on p = 7 they are 5 and 4, and the second
+        # refuses an n of 13 that Hasse admits
+        delta = isqrt(4 * self.p)
         # also check n with Hasse Theorem
         if cofactor < 2 and not self.p + 1 - delta <= n <= self.p + 1 + delta:
             err_msg = "n not in p+1-delta..p+1+delta: "
@@ -225,7 +232,13 @@ class Curve(CurveGroup):
             raise BTClibValueError(err_msg)
 
         # 6. Check cofactor
-        exp_cofactor = int(1 / n + delta / n + self.p / n)
+        # floor((p + 1 + delta) / n), the upper end of the Hasse interval
+        # divided by the subgroup order, in integer arithmetic for the
+        # reason delta is: three float divisions of 256-bit integers each
+        # round before they are added, where the quotient of a curve with
+        # a cofactor of 1 sits one ulp above the integer it must truncate
+        # to
+        exp_cofactor = (1 + delta + self.p) // n
         if cofactor != exp_cofactor:
             err_msg = f"invalid cofactor: {cofactor}, expected {exp_cofactor}"
             raise BTClibValueError(err_msg)

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -8,6 +8,7 @@ import copy
 import itertools
 from functools import partial
 from hashlib import sha256, sha512
+from math import isqrt, sqrt
 
 import pytest
 
@@ -233,6 +234,42 @@ def test_curves_with_n_above_p() -> None:
             x_K = ec.x_aff_from_jac(mult_jac(q, ec.GJ, ec))
             assert x_K < ec.n
             assert x_K % ec.n == x_K
+
+
+def test_hasse_half_width_is_exact() -> None:
+    """The Hasse half-width is floor(2*sqrt(p)), computed as isqrt(4*p).
+
+    Two spellings are wrong and each is wrong in its own direction.
+    `int(2 * sqrt(p))` rounds p to 53 bits of mantissa first, so on a
+    256-bit p it lands one above the truncation it means and admits an n
+    Hasse excludes; `2 * isqrt(p)` truncates the root before doubling it,
+    which is the same number only when p is a perfect square and is
+    otherwise too small -- on p = 7 the three are 5, 5 and 4, and the last
+    refuses the ec7_13 curve of the low-cardinality set.
+
+    Checked against the exact arithmetic rather than against a table:
+    delta is the largest d with d*d <= 4*p, which is what isqrt answers
+    and what neither float spelling promises.
+    """
+    for ec in all_curves.values():
+        delta = isqrt(4 * ec.p)
+        assert delta * delta <= 4 * ec.p < (delta + 1) * (delta + 1)
+        # the curve was built, so its own n and cofactor satisfy what the
+        # constructor computed from this delta
+        assert ec.cofactor == (1 + delta + ec.p) // ec.n
+
+    # p = 7 is where 2*isqrt(p) and isqrt(4*p) part company, and the curve
+    # of order 13 over it -- curve_group_test's own -- is the one that
+    # would stop being buildable. weakness_check=False as that test builds
+    # it: 7^12 = 1 (mod 13) makes it MOV-weak, which is a different
+    # refusal and not the one under test here
+    assert 2 * isqrt(7) == 4
+    assert isqrt(4 * 7) == 5
+    assert Curve(7, 0, 3, (1, 2), 13, 1, False).cofactor == 1
+
+    # and secp256k1 is where the float spelling parted company with both:
+    # one too many, on the widest p this library catalogues
+    assert int(2 * sqrt(secp256k1.p)) == isqrt(4 * secp256k1.p) + 1
 
 
 def test_catalogued_curves() -> None:


### PR DESCRIPTION
Closes #573.

`Curve` bounded `n` with `int(2 * sqrt(self.p))`. `math.sqrt` rounds `p` to the 53 bits of a float mantissa before the truncation, so on secp256k1 the result is one above `floor(2*sqrt(p))` and the interval the constructor admits is a shade wider than Hasse's. `isqrt(4 * self.p)` is that floor exactly: `delta` is the largest `d` with `d*d <= 4*p`.

## Not `2 * isqrt(p)` — which is what the issue proposed, and it is wrong

The two agree only when `p` is a perfect square; otherwise `2 * isqrt(p)` is *too small*. On `p = 7` they are 5 and 4, and 4 refuses the order-13 curve over it that `tests/curves/curve_group_test.py` builds. Measured before writing the fix, which is why the issue's suggested spelling is not the one here.

| p | `int(2*sqrt(p))` | `2*isqrt(p)` | `isqrt(4*p)` |
|---|---|---|---|
| 7 | 5 | 4 ← refuses a valid curve | 5 |
| secp256k1's | …912 ← one too many | …910 | …911 |

## The cofactor estimate

It reads the same `delta` and was `int(1 / n + delta / n + self.p / n)` — three float divisions of 256-bit integers, each rounding before they were added. It is `(1 + delta + self.p) // n` now.

## No curve changes what it is built as

The float and integer spellings were measured to agree on all 27 catalogued curves and on every low-cardinality test curve, Hasse verdict and cofactor alike, so this is a correctness fix with no behaviour to record in HISTORY.md.

`test_hasse_half_width_is_exact` pins the result against the exact arithmetic (`delta*delta <= 4*p < (delta+1)**2`) rather than against a table of expected widths, and pins both places the three spellings part company.

## Gates

- `uv run pytest --cov`: 18442 passed, 5 skipped, coverage ratchet at 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Compute Hasse’s half-width and cofactor bounds using exact integer arithmetic rather than floating-point operations, ensuring the curve constructor’s validations match Hasse’s theorem precisely without changing any existing catalogued or test curves.

Bug Fixes:
- Correct the Hasse half-width bound for curve order n from a float-based approximation to an exact integer value, eliminating off-by-one and underestimation cases on non-square primes.
- Fix the cofactor validation to use an exact integer formula based on the Hasse interval instead of rounded float divisions.

Enhancements:
- Add a dedicated test that verifies the Hasse half-width and cofactor computation against exact arithmetic across all catalogued and low-cardinality curves.

Documentation:
- Document the switch to integer arithmetic for Hasse’s half-width and cofactor estimation in the changelog, including the rationale and impact on curve construction.