### PR TITLE
Bound a tr() script tree at the depth a control block can prove (#571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,32 @@ documented at release-notes length in the first place, and are still in
   `BTClibUserWarning` in `btclib.exceptions` is the class for it -- so
   nothing that filters warnings is affected.
 
+### Descriptors and miniscript
+
+- **A tr() script tree is bounded at 128 nesting levels** (#571).
+  `_parse_tree` recurses once per brace and had no bound, so a `tr()`
+  expression nested a thousand deep exhausted the interpreter stack and
+  left through `RecursionError` -- a class `btclib.exceptions` does not
+  declare, which no `except BTClibValueError` around `parse` catches, and
+  which a descriptor arriving from a counterparty could therefore raise.
+  The miniscript half of the same parser was already bounded; this was
+  the BIP386 TREE half alone.
+
+  128 is `taproot.MAX_TREE_DEPTH`, new in this release and Core's
+  `TAPROOT_CONTROL_MAX_NODE_COUNT` under btclib's name: a leaf deeper
+  than that is proved by a merkle path the control block has no room for
+  -- `TAPROOT_CONTROL_MAX_SIZE` being 33 + 32 * 128 -- so the expression
+  describes an output nobody can spend rather than a large one. The
+  constant is declared in `btclib.script.taproot`, beside the control
+  block it bounds, and `check_output_pubkey` reads its own cap off it
+  instead of the literal 4129 it carried.
+
+  Both sides of the boundary are checked against Bitcoin Core v31.1.0's
+  `getdescriptorinfo`, which takes 128, refuses 129, and phrases the
+  refusal "tr() supports at most 128 nesting levels" -- the words btclib
+  now repeats, the two parsers agreeing on the message as well as on the
+  number.
+
 ## v2026.8.9
 
 ### Descriptors and miniscript

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -191,7 +191,12 @@ from btclib.psbt.psbt_size import SIG_SIZE, SolutionSizer
 from btclib.script.script import op_int, serialize
 from btclib.script.script import parse as _parse_script
 from btclib.script.script_pub_key import ScriptPubKey, _script_from
-from btclib.script.taproot import input_script_sig, leaf_hash, tree_helper
+from btclib.script.taproot import (
+    MAX_TREE_DEPTH,
+    input_script_sig,
+    leaf_hash,
+    tree_helper,
+)
 from btclib.script.witness import Witness
 from btclib.to_pub_key import fingerprint
 from btclib.tx.tx_in import TxIn
@@ -1936,8 +1941,23 @@ def _parse_leaf_miniscript(expression: str, prv_keys: dict[str, str]) -> Miniscr
     return node
 
 
-def _parse_tree(expression: str, prv_keys: dict[str, str]) -> DescriptorTree:
-    """Return the script tree of a BIP386 TREE expression."""
+def _parse_tree(
+    expression: str, prv_keys: dict[str, str], depth: int = 0
+) -> DescriptorTree:
+    """Return the script tree of a BIP386 TREE expression.
+
+    `depth` is how many braces enclose this subtree, and bounding it is
+    what keeps a hostile expression from recursing past the interpreter's
+    stack: without it a tree nested a thousand deep left through
+    `RecursionError`, which is not a class this library raises and not one
+    a caller of `parse` catches. MAX_TREE_DEPTH is the bound because a
+    leaf below it has no control block to be spent with, so the
+    expression describes no output rather than a large one -- and it is
+    where Core stops too, "tr() supports at most 128 nesting levels".
+    """
+    if depth > MAX_TREE_DEPTH:
+        err_msg = f"tr() supports at most {MAX_TREE_DEPTH} nesting levels"
+        raise BTClibValueError(err_msg)
     if expression.startswith("{"):
         if not expression.endswith("}"):
             raise BTClibValueError(f"unbalanced braces: {expression}")
@@ -1946,8 +1966,8 @@ def _parse_tree(expression: str, prv_keys: dict[str, str]) -> DescriptorTree:
             err_msg = f"a tr() branch takes two subtrees, {len(branches)} given"
             raise BTClibValueError(err_msg)
         return (
-            _parse_tree(branches[0], prv_keys),
-            _parse_tree(branches[1], prv_keys),
+            _parse_tree(branches[0], prv_keys, depth + 1),
+            _parse_tree(branches[1], prv_keys, depth + 1),
         )
     name = expression.partition("(")[0]
     if name in _TREE_FUNCTIONS:

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -43,6 +43,7 @@ from btclib.to_pub_key import Key, pub_keyinfo_from_key
 from btclib.utils import bytes_from_octets, bytesio_from_binarydata
 
 __all__ = [
+    "MAX_TREE_DEPTH",
     "assert_valid_control_block",
     "check_output_pubkey",
     "input_script_sig",
@@ -55,6 +56,19 @@ __all__ = [
     "serialize",
     "tree_helper",
 ]
+
+# How deep a script tree may be, which is Core's
+# TAPROOT_CONTROL_MAX_NODE_COUNT in script/interpreter.h. One number for
+# two things that cannot differ: a leaf at depth d is proved by a merkle
+# path of d nodes, and the control block carrying that path is capped at
+# TAPROOT_CONTROL_MAX_SIZE = 33 + 32 * 128 -- so a leaf deeper than this
+# has no control block to be spent with, whatever built the tree.
+#
+# Here rather than in script/limits.py, whose five caps are the ones at
+# the top of Core's script/script.h: this one is BIP341's, declared
+# beside the control block it bounds and read by the descriptor parser
+# through this name
+MAX_TREE_DEPTH = 128
 
 
 def serialize(script: ScriptList) -> bytes:
@@ -375,7 +389,7 @@ def check_output_pubkey(
     q = bytes_from_octets(q)
     script = bytes_from_octets(script)
     control = bytes_from_octets(control)
-    if len(control) > 4129:  # 33 + 32 * 128
+    if len(control) > 33 + 32 * MAX_TREE_DEPTH:
         raise BTClibValueError("control block too long")
     m = (len(control) - 33) // 32
     if len(control) != 33 + 32 * m:

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -1021,6 +1021,42 @@ def test_unparsable(descriptor: str, message: str) -> None:
         parse(descriptor)
 
 
+def _nested_tree(depth: int) -> str:
+    """Return a tr() whose only leaf sits under `depth` braces."""
+    leaf = f"pk({XONLY})"
+    return f"tr({XONLY}," + "{" * depth + leaf + f",{leaf}}}" * depth + ")"
+
+
+def test_tr_tree_depth_is_bounded() -> None:
+    """A tr() deeper than the control block can prove is refused (issue 571).
+
+    The parser recurses once per brace, so without a bound a deep enough
+    expression exhausts the interpreter stack and leaves through
+    `RecursionError` -- which `btclib.exceptions` does not declare and no
+    caller of `parse` catches. 1000 braces did exactly that at the
+    default recursion limit.
+
+    128 is the bound because it is `taproot.MAX_TREE_DEPTH`, i.e. Core's
+    TAPROOT_CONTROL_MAX_NODE_COUNT: a leaf below it is proved by a merkle
+    path the control block has no room for, so what the expression
+    describes is not a spendable output. Both sides of the boundary are
+    pinned here, and both were checked against Core v31.1.0's
+    `getdescriptorinfo`, which takes 128, refuses 129, and phrases the
+    refusal in the words this one repeats.
+    """
+    assert taproot.MAX_TREE_DEPTH == 128
+
+    # the deepest tree a control block can prove, and one deeper
+    parse(_nested_tree(taproot.MAX_TREE_DEPTH))
+    err_msg = "tr\\(\\) supports at most 128 nesting levels"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        parse(_nested_tree(taproot.MAX_TREE_DEPTH + 1))
+
+    # what used to be a RecursionError, well past the interpreter's limit
+    with pytest.raises(BTClibValueError, match=err_msg):
+        parse(_nested_tree(5000))
+
+
 # what is a descriptor, is not implemented, and is refused by name rather
 # than read wrong
 # BIP387's own test vectors, transcribed from `bip-0387.mediawiki`: a


### PR DESCRIPTION
Closes #571.

`_parse_tree` recurses once per brace and had no bound, so a `tr()` expression nested a thousand deep exhausted the interpreter stack and left through `RecursionError` — a class `btclib.exceptions` does not declare, which no `except BTClibValueError` around `parse` catches, and which a descriptor arriving from a counterparty could therefore raise. The miniscript half of the same parser was already bounded; this was the BIP386 TREE half alone.

## The bound is 128, and it is not arbitrary

`taproot.MAX_TREE_DEPTH`, new in this PR, is Core's `TAPROOT_CONTROL_MAX_NODE_COUNT` under btclib's name. A leaf deeper than 128 is proved by a merkle path the control block has no room for — `TAPROOT_CONTROL_MAX_SIZE` is `33 + 32 * 128` — so such an expression describes an output nobody can spend rather than a large one.

The constant is declared in `btclib.script.taproot`, beside the control block it bounds, rather than in `script/limits.py`, whose five caps are the ones at the top of Core's `script/script.h`. `check_output_pubkey` now reads its own cap off it instead of the literal `4129` it carried.

## Checked against Core, not only against the BIP

Bitcoin Core v31.1.0, `getdescriptorinfo` on regtest:

| depth | Core | btclib (this PR) |
|---|---|---|
| 127 | accepted | accepted |
| 128 | accepted | accepted |
| 129 | `tr() supports at most 128 nesting levels` | `tr() supports at most 128 nesting levels` |

The two parsers agree on the boundary and on the wording of the refusal.

## Before / after

```python
>>> parse(nested_tr(1000))   # 1000 braces, default recursion limit
RecursionError: maximum recursion depth exceeded      # before
BTClibValueError: tr() supports at most 128 nesting levels   # after
```

`test_tr_tree_depth_is_bounded` pins both sides of the boundary and the 5000-deep case that used to be the `RecursionError`.

## Gates

- `uv run pytest --cov`: 18442 passed, 5 skipped, coverage ratchet at 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bound tr() descriptor script trees to the maximum provable Taproot control block depth to prevent unbounded recursion and align behavior with Bitcoin Core limits.

Bug Fixes:
- Reject tr() descriptors that exceed the supported tree depth instead of raising an uncaught RecursionError when parsing deeply nested trees.

Enhancements:
- Introduce taproot.MAX_TREE_DEPTH (128) derived from Core’s TAPROOT_CONTROL_MAX_NODE_COUNT and use it to cap descriptor tree parsing and control block size validation.

Documentation:
- Document the new tr() nesting limit and taproot.MAX_TREE_DEPTH in the changelog, including its rationale and alignment with Bitcoin Core.

Tests:
- Add descriptor tests that pin the accepted tr() tree depth boundary, verify the error message for excessive nesting, and cover previously failing deep recursion cases.