### PR TITLE
Open the v2026.9 development cycle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ name = "btclib"
 # file. Not a literal in btclib/__init__.py for setuptools to import and
 # conf.py to repeat: two declarations are two things a release workflow
 # has to compare before trusting either
-version = "2026.8.9"
+version = "2026.9"
 description = "A library for 'bitcoin cryptography'"
 readme = "README.md"
 # PEP 639: a SPDX expression and the files it refers to, replacing the

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "btclib"
-version = "2026.8.9"
+version = "2026.9"
 source = { editable = "." }
 dependencies = [
     { name = "bitcoin-core-rpc" },


### PR DESCRIPTION
The last step of RELEASING.md for v2026.8.9: `pyproject.toml` takes the
month-only placeholder `2026.9`, so a checkout of `dev` reports itself as
work in progress rather than as a release it is not, and `uv.lock`
follows.

That is the whole diff, because the other half of the step is already
done. [PR 575](https://github.com/btclib-org/btclib/pull/575) landed while
v2026.8.9 was being published, and opened the work-in-progress sections of
HISTORY.md and CHANGELOG.md itself to have somewhere to put its own entry
— which is what those sections are for, and it is the right thing to have
done rather than a race to undo. An earlier attempt at this step
([PR 576](https://github.com/btclib-org/btclib/pull/576)) added the same
headings and conflicted with it; this one carries the version alone.
CHANGELOG.md's preamble needs no edit: "Only v2026.8.7 and what follows it
are here" is still what the file holds.

Gates on this tree: `pre-commit run --all-files`, `pytest --cov` (18441
passed, 100.00% coverage) and `sphinx-build -W --keep-going`, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Advance the project version to the v2026.9 development cycle.

Build:
- Update pyproject.toml to set the package version to the 2026.9 development placeholder.

Chores:
- Refresh uv.lock to align with the new development version.