### PR TITLE
Run the regtest job for the code a node is what checks (#570)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -55,6 +55,32 @@ on:
     paths:
       - .github/workflows/integration.yml
       - tests/integration/**
+      # and the implementation whose answer a node is what checks
+      # (issue #570). What the two regtest tests put in front of Core is
+      # a descriptor it imports, the request that carries it, a psbt it
+      # signs beside btclib, the transaction extracted from it and the
+      # script that spends: a change to any of those can be accepted by
+      # 18k offline vectors and refused by the node, which is the whole
+      # of why this workflow exists. Without them the job ran only when
+      # a test or this file changed, so the branch that could break the
+      # flow was the one branch it did not check.
+      - btclib/core_import.py
+      - btclib/descriptors/**
+      - btclib/psbt/**
+      - btclib/psbt_signer*.py
+      - btclib/script/**
+      - btclib/tx/**
+      # What is deliberately not here, both halves measured rather than
+      # guessed. `btclib/fetch/**` is imported by nothing under
+      # tests/integration: the tests drive the node through
+      # `bitcoin_core_rpc` directly, so a fetch backend has no answer of
+      # Core's to be checked against until issue #204 gives it one.
+      # And the cryptographic core -- curves, ecc, hashes, utils -- is in
+      # the transitive imports of the flow and stays out all the same:
+      # what it is held to is vectors, offline and on every push, so a
+      # change there is red in `test.yml` long before a node sees it,
+      # while listing it would spend a runner on nearly every pull
+      # request and leave "outside the covered paths" meaning nothing
 
 # least privilege for the GITHUB_TOKEN: nothing here writes, and the
 # tarball is fetched from bitcoincore.org, which does not know this token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,31 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### Packaging, linting and CI
+
+- **The Bitcoin Core regtest job runs for the code it checks** (#570).
+  `integration.yml`'s `pull_request.paths` held the workflow file and
+  `tests/integration/**` and nothing else, so a pull request changing the
+  descriptor, psbt, transaction, script or signer path did not ask a node
+  about it unless it happened to touch a test as well -- the branch that
+  could break the flow being the one branch the flow did not check, with
+  the scheduled Friday run finding out afterwards on `dev`. Six
+  implementation paths are on the filter now: `core_import.py`, which
+  builds the `importdescriptors` request; `descriptors/`, `psbt/`, `tx/`
+  and `script/`, whose output is what Core parses, accepts, relays and
+  validates; and `psbt_signer*.py`, which assembles it.
+
+  `fetch/` is not among them, and that is measured rather than assumed:
+  nothing under `tests/integration` imports it, those tests driving the
+  node through `bitcoin_core_rpc` directly, so there is no answer of
+  Core's for a backend to be checked against until issue #204 adds one.
+  Neither is the cryptographic core, which the flow does import: what
+  holds `curves`, `ecc` and `hashes` honest is vectors, offline and on
+  every push, so a change there is red in `test.yml` before a node could
+  say so -- and listing it would spend a runner on nearly every pull
+  request, which is the cost this filter exists to avoid. The job still
+  gates nothing and is still absent from master's required checks.
+
 ### Curves, signatures and keys
 
 - **A MOV-weak curve is a `BTClibValueError`** (#572). `Curve` refuses


### PR DESCRIPTION
Closes #570.

`integration.yml`'s `pull_request.paths` held the workflow file and `tests/integration/**` and nothing else, so a pull request changing the descriptor, psbt, transaction, script or signer path did not ask a node about it unless it happened to touch a test as well — the branch that could break the flow being the one branch the flow did not check, with the scheduled Friday run finding out afterwards on `dev`.

## What joins the filter

| path | why a node is what checks it |
|---|---|
| `btclib/core_import.py` | builds the `importdescriptors` request Core consumes |
| `btclib/descriptors/**` | the descriptor text Core parses |
| `btclib/psbt/**` | the psbt Core signs beside btclib |
| `btclib/tx/**` | the transaction Core relays |
| `btclib/script/**` | the script Core validates |
| `btclib/psbt_signer*.py` | what assembles the four above |

## What stays out, and why it is measured rather than assumed

**`btclib/fetch/**` — dropped from the list this issue suggested.** Nothing under `tests/integration` imports it: those tests drive the node through `bitcoin_core_rpc` directly, so there is no answer of Core's for a fetch backend to be checked against until #204 gives it one.

**The cryptographic core** — `curves`, `ecc`, `hashes`, `utils` — *is* in the flow's transitive imports and stays out all the same. What holds it honest is vectors, offline and on every push, so a change there is red in `test.yml` long before a node could say so; listing it would spend a runner on nearly every pull request and leave "outside the covered paths" meaning nothing.

`btclib/core_import.py` is the one addition the issue's list did not have, and it is the module the regtest test imports by name.

## Acceptance criteria

- a covered runtime path starts the job — the six above
- a change outside them does not spend a runner — the cryptographic core and everything else are untouched by the filter
- `schedule` and `workflow_dispatch` are unchanged
- the job still gates nothing and is still absent from master's required checks

## Gates

`uv run pre-commit run --all-files`: exit 0, `actionlint` and `zizmor` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust CI integration workflow triggers so the Bitcoin Core regtest job runs when relevant btclib implementation code changes, while avoiding unnecessary runs for unrelated paths.

Bug Fixes:
- Ensure regtest integration checks are executed for descriptor, PSBT, transaction, script and signer code changes that can affect node behavior.

Enhancements:
- Refine pull_request path filters in integration.yml to cover core_import, descriptor, PSBT, transaction and script implementations used by regtest tests, while explicitly excluding fetch and cryptographic core modules to control runner usage.

Documentation:
- Document the updated regtest CI behavior and path filters in the unreleased v2026.9 changelog under Packaging, linting and CI.