### PR TITLE
Bound a declared count by what could hold it (#569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,57 @@ documented at release-notes length in the first place, and are still in
   request, which is the cost this filter exists to avoid. The job still
   gates nothing and is still absent from master's required checks.
 
+### Transactions, blocks and PSBT
+
+- **A declared count is bounded by what could hold it, before anything is
+  allocated for it** (#569). `var_int.parse`'s `MAX_SIZE` is Core's
+  `ReadCompactSize` range check and answers whether a CompactSize is one
+  a sane protocol would write; 33,554,432 is a sane CompactSize, so nine
+  octets naming that many maps or transactions were believed, and the
+  list comprehension that followed asked for an object per declared item.
+  What a parser also has to ask is whether what follows could possibly
+  hold this many, and the answer is consensus arithmetic rather than a
+  number this library picks: `MAX_BLOCK_WEIGHT` divided by the weight of
+  the smallest thing being counted.
+
+  Three bounds, all in `btclib.block.limits` beside the constants they
+  divide. `Block.parse` reads its transaction count with
+  `MAX_BLOCK_WEIGHT // MIN_SERIALIZABLE_TRANSACTION_WEIGHT`, 100,000 --
+  Core's *serializable* minimum and not the `MIN_TRANSACTION_WEIGHT`
+  beside it, what is being allocated for being a transaction that
+  deserializes. `Psbt.parse` holds its input and output map counts to
+  `MAX_TX_IN_COUNT` and `MAX_TX_OUT_COUNT`, 24,390 and 111,111: a PSBT's
+  maps are a transaction's inputs and outputs, so a count above what a
+  block has room for describes no transaction at all. Each refusal names
+  which of the two counts it was.
+
+  The PSBT bound is the one that pays: an empty input map is a single
+  octet on the wire and an object with a dozen fields in memory, so the
+  count believed is that amplification paid before the first map is read.
+  Measured on the issue's reproducer, a PSBTv2 declaring 100,000 empty
+  input maps in about 100 KB of payload: 125 MB of peak allocation
+  before, 0.1 MB and an immediate refusal now.
+
+  What is **not** bounded here is the witness stack, and the reason is
+  the one `btclib.script.limits` already states. The number that would
+  cap it is `MAX_STACK_SIZE`, and that is a rule about *executing* a
+  script: reading an execution limit in the decoder is what let a
+  1443-byte push be refused as unparsable when it was merely unspendable
+  (issue #123). A witness of a million items is unspendable and parses,
+  as it does for Core, whose deserializer bounds it by the size of the
+  message that carried it and not by the interpreter's stack. Its cost is
+  proportional to the input that declared it -- about 25 MB for the
+  issue's 1 MB reproducer -- which is what a parser costs rather than an
+  amplification; #569 stays open for that half.
+
+  `Tx.parse` is unchanged for a second reason: `TxIn.parse` raises on the
+  first short read, so a count with nothing behind it is refused in
+  microseconds already, and the bound that would refuse a count with
+  bytes behind it lives in `btclib.block.limits`, which `btclib.tx`
+  cannot import -- `btclib.block` imports `btclib.tx`, so the edge is a
+  cycle. Naming that here because it is what the fix would have to move
+  first.
+
 ### Curves, signatures and keys
 
 - **A MOV-weak curve is a `BTClibValueError`** (#572). `Curve` refuses

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -18,6 +18,7 @@ from btclib.block.block_header import BlockHeader
 from btclib.block.limits import (
     MAX_BLOCK_SIGOPS_COST,
     MAX_BLOCK_WEIGHT,
+    MIN_SERIALIZABLE_TRANSACTION_WEIGHT,
     WITNESS_SCALE_FACTOR,
 )
 from btclib.block.proof_of_work import MAINNET_POW_LIMIT_BITS
@@ -550,7 +551,16 @@ class Block:
         """Return a Block by parsing binary data."""
         stream = bytesio_from_binarydata(data)
         header = BlockHeader.parse(stream, check_validity=check_validity)
-        n = var_int.parse(stream)
+        # bounded by what this block could hold rather than by var_int's
+        # own MAX_SIZE, which would let nine octets ask for 33 million
+        # transactions before a byte of the first one is read (issue #569).
+        # MIN_SERIALIZABLE_TRANSACTION_WEIGHT and not the
+        # MIN_TRANSACTION_WEIGHT beside it: what is being allocated for is
+        # a transaction that deserializes, which is Core's own distinction
+        # between the two names
+        n = var_int.parse(
+            stream, MAX_BLOCK_WEIGHT // MIN_SERIALIZABLE_TRANSACTION_WEIGHT
+        )
         transactions = [
             Tx.parse(stream, check_validity=check_validity) for _ in range(n)
         ]

--- a/btclib/block/limits.py
+++ b/btclib/block/limits.py
@@ -21,15 +21,27 @@ Three of `consensus.h`'s constants are deliberately absent.
 bound and not a network rule, the weight being what consensus caps.
 `COINBASE_MATURITY` is a rule about spending an output, so it needs the
 chain the output was created on. `MAX_TIMEWARP` is BIP94's bound on the
-first block of a retarget period, which needs the previous block. The two
-`MIN_*_TRANSACTION_WEIGHT` bounds are about a transaction and are read by
-fee estimation rather than by consensus.
+first block of a retarget period, which needs the previous block.
+
+`MIN_SERIALIZABLE_TRANSACTION_WEIGHT` is here, where its neighbour
+`MIN_TRANSACTION_WEIGHT` is not, and the pair is what says why: the second
+is the smallest a *valid* transaction can be and is fee estimation's, the
+first the smallest one that *deserializes* -- so it is the one a parser
+divides MAX_BLOCK_WEIGHT by to bound how many transactions a block may
+declare before it allocates for them (issue #569). `btclib.tx.limits`
+derives the same kind of bound for a transaction's own inputs and outputs
+and reads the two constants above from here.
 """
 
 __all__ = [
     "MAX_BLOCK_SIGOPS_COST",
     "MAX_BLOCK_WEIGHT",
     "MAX_FUTURE_BLOCK_TIME",
+    "MAX_TX_IN_COUNT",
+    "MAX_TX_OUT_COUNT",
+    "MIN_SERIALIZABLE_TRANSACTION_WEIGHT",
+    "MIN_TX_IN_SIZE",
+    "MIN_TX_OUT_SIZE",
     "WITNESS_SCALE_FACTOR",
 ]
 
@@ -43,6 +55,25 @@ MAX_BLOCK_SIGOPS_COST = 80_000
 
 # The weight of a byte a legacy node sees, and the cost of a legacy sigop
 WITNESS_SCALE_FACTOR = 4
+
+# The smallest weight a transaction can deserialize from, ten octets being
+# Core's lower bound for the size of a serialized CTransaction
+MIN_SERIALIZABLE_TRANSACTION_WEIGHT = WITNESS_SCALE_FACTOR * 10
+
+# The smallest a TxIn serializes to: a 32-octet previous transaction id, a
+# four-octet output index, the one octet of a var_int announcing an empty
+# script_sig, and a four-octet sequence. The smallest a TxOut serializes
+# to: an eight-octet amount and the one octet of an empty script_pub_key
+MIN_TX_IN_SIZE = 32 + 4 + 1 + 4
+MIN_TX_OUT_SIZE = 8 + 1
+
+# How many inputs and outputs a transaction that can be mined may declare.
+# Neither is witness data, so each weighs WITNESS_SCALE_FACTOR times its
+# size, and a count above these names a transaction no block has room for
+# -- which is what lets a parser refuse it before allocating for it
+# (issue #569)
+MAX_TX_IN_COUNT = MAX_BLOCK_WEIGHT // (MIN_TX_IN_SIZE * WITNESS_SCALE_FACTOR)
+MAX_TX_OUT_COUNT = MAX_BLOCK_WEIGHT // (MIN_TX_OUT_SIZE * WITNESS_SCALE_FACTOR)
 
 # Maximum number of seconds a block timestamp may exceed the current time,
 # spelled as Core spells it

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -42,6 +42,7 @@ from btclib.bip32 import (
     decode_hd_key_paths,
     encode_to_bip32_derivs,
 )
+from btclib.block.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
@@ -178,6 +179,21 @@ HAS_SIG_HASH_SINGLE = 0b0000_0100
 # spells out: "if omitted, the sequence number is assumed to be the final
 # sequence number"
 _FINAL_SEQUENCE = 0xFFFFFFFF
+
+
+def _assert_map_count(count: int, maximum: int, what: str) -> None:
+    """Refuse a declared map count no transaction could have.
+
+    `btclib.tx.limits` is where the two bounds come from and why: a PSBT's
+    maps are a transaction's inputs and outputs, so the count that would
+    not fit in a block does not fit here either. What this buys over
+    finding out later is the allocation: an empty input map is one octet
+    on the wire and an object with a dozen fields in memory, so a count
+    believed is that amplification paid before the first map is read.
+    """
+    if count > maximum:
+        err_msg = f"too many {what} maps: {count}, max is {maximum}"
+        raise BTClibValueError(err_msg)
 
 
 def _global_version(global_map: Mapping[bytes, bytes]) -> int:
@@ -1127,6 +1143,16 @@ class Psbt:
         _settle_globals(tx, globals_, version)
         input_count = cast(int, globals_["input_count"])
         output_count = cast(int, globals_["output_count"])
+
+        # what a PSBT's maps describe are a transaction's inputs and
+        # outputs, so what bounds them is what bounds those: a count above
+        # it names a transaction no block has room for, and believing it
+        # is a map object allocated per declared input before a byte of
+        # the first one is read (issue #569). Checked here rather than in
+        # deserialize_count, which reads both counts and so could not say
+        # which one it was refusing
+        _assert_map_count(input_count, MAX_TX_IN_COUNT, "input")
+        _assert_map_count(output_count, MAX_TX_OUT_COUNT, "output")
 
         inputs = [
             PsbtIn.parse(stream, psbt_version=version) for _ in range(input_count)

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from btclib import var_int
 from btclib.block import (
     Block,
     BlockHeader,
@@ -28,6 +29,11 @@ from btclib.block import (
 from btclib.block.limits import (
     MAX_BLOCK_SIGOPS_COST,
     MAX_BLOCK_WEIGHT,
+    MAX_TX_IN_COUNT,
+    MAX_TX_OUT_COUNT,
+    MIN_SERIALIZABLE_TRANSACTION_WEIGHT,
+    MIN_TX_IN_SIZE,
+    MIN_TX_OUT_SIZE,
     WITNESS_SCALE_FACTOR,
 )
 from btclib.block.proof_of_work import REGTEST_POW_LIMIT_BITS
@@ -1350,3 +1356,69 @@ def test_the_pow_limit_is_the_callers_to_state() -> None:
 
     # and the same block is a block on the network those bits belong to
     block.assert_valid(REGTEST_POW_LIMIT_BITS)
+
+
+def test_a_declared_transaction_count_is_bounded_by_what_a_block_holds() -> None:
+    """A block's transaction count is refused before it is allocated for.
+
+    `var_int.parse`'s own MAX_SIZE answers whether a CompactSize is one a
+    sane protocol would write, and 33,554,432 transactions is a sane
+    CompactSize: nine octets, and a list comprehension over the count is
+    33 million objects asked for by nine octets (issue #569). What bounds
+    it instead is the block that must hold them --
+    MIN_SERIALIZABLE_TRANSACTION_WEIGHT is the smallest weight one
+    deserializes from, so MAX_BLOCK_WEIGHT divided by it is the most a
+    block may declare.
+
+    The refusal comes out of the var_int itself, before the header's own
+    bytes are past: the number is the argument, so nothing is read for a
+    count that cannot be honoured.
+    """
+    maximum = MAX_BLOCK_WEIGHT // MIN_SERIALIZABLE_TRANSACTION_WEIGHT
+    assert maximum == 100_000
+
+    filename = Path(__file__).parent / "_data" / "block_1.bin"
+    with filename.open("rb") as file_:
+        header = file_.read()[:80]
+
+    with pytest.raises(BTClibValueError, match="var_int too big"):
+        Block.parse(header + var_int.serialize(maximum + 1), check_validity=False)
+
+
+def test_the_transaction_count_bounds_are_what_consensus_derives() -> None:
+    """The three parser bounds are arithmetic on consensus, not choices.
+
+    Each is MAX_BLOCK_WEIGHT divided by the weight of the smallest thing
+    it counts, so none of them is a number this library picked: a count
+    above any of them names a transaction or a block no miner could
+    produce, which is what makes refusing it before allocating safe.
+    """
+    # a TxIn and a TxOut serialize to no less than this, and neither is
+    # witness data, so each weighs WITNESS_SCALE_FACTOR times its size
+    assert (
+        len(
+            TxIn(OutPoint(), b"", 0xFFFFFFFF, check_validity=False).serialize(
+                check_validity=False
+            )
+        )
+        == MIN_TX_IN_SIZE
+    )
+    assert (
+        len(
+            TxOut(0, ScriptPubKey(b""), check_validity=False).serialize(
+                check_validity=False
+            )
+        )
+        == MIN_TX_OUT_SIZE
+    )
+
+    assert MAX_TX_IN_COUNT == MAX_BLOCK_WEIGHT // (
+        MIN_TX_IN_SIZE * WITNESS_SCALE_FACTOR
+    )
+    assert MAX_TX_OUT_COUNT == MAX_BLOCK_WEIGHT // (
+        MIN_TX_OUT_SIZE * WITNESS_SCALE_FACTOR
+    )
+    # and they are what they compute to, so a change to either constant
+    # above is a change a reader of this test sees
+    assert MAX_TX_IN_COUNT == 24_390
+    assert MAX_TX_OUT_COUNT == 111_111

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -13,8 +13,9 @@ from typing import Any
 
 import pytest
 
-from btclib import var_bytes
+from btclib import var_bytes, var_int
 from btclib.bip32 import BIP32KeyOrigin
+from btclib.block.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
 from btclib.curves import sec_point
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
@@ -4330,3 +4331,50 @@ def test_b64decode_refuses_a_string_base64_cannot_read(psbt_str: str) -> None:
     """
     with pytest.raises(BTClibValueError, match="invalid base64 encoding"):
         Psbt.b64decode(psbt_str)
+
+
+def _psbt_v2_declaring(input_count: int, output_count: int) -> bytes:
+    """Return a PSBTv2 whose global map declares those two counts.
+
+    The maps themselves are not written: what is under test is the count
+    being believed, and the point of the check is that it is refused
+    before anything is allocated for what the count promised.
+    """
+
+    def count_field(type_: int, count: int) -> bytes:
+        value = var_int.serialize(count)
+        return bytes([1, type_, len(value)]) + value
+
+    global_map = (
+        bytes([1, 0xFB, 4])
+        + (2).to_bytes(4, "little")  # PSBT_GLOBAL_VERSION
+        + bytes([1, 0x02, 4])
+        + (2).to_bytes(4, "little")  # PSBT_GLOBAL_TX_VERSION
+        + count_field(0x04, input_count)
+        + count_field(0x05, output_count)
+        + b"\x00"
+    )
+    return b"psbt\xff" + global_map
+
+
+def test_a_declared_map_count_is_bounded_before_it_is_allocated_for() -> None:
+    """A count no transaction could have is refused, not believed (issue 569).
+
+    A PSBT's maps are a transaction's inputs and outputs, so a count
+    above what a block has room for describes no transaction at all --
+    `MAX_TX_IN_COUNT` and `MAX_TX_OUT_COUNT` in `btclib.block.limits`.
+    Believing one costs an object per declared map before the first is
+    read: an empty input map is a single octet on the wire and a dozen
+    fields in memory, which is the amplification the check exists to
+    refuse. Measured on the issue's own reproducer, a PSBTv2 declaring
+    100,000 empty input maps in about 100 KB: 125 MB of peak allocation
+    before, 0.1 MB now.
+
+    Both counts are checked because each names itself in the refusal,
+    which is what a caller reads to know which of the two was wrong.
+    """
+    with pytest.raises(BTClibValueError, match="too many input maps"):
+        Psbt.parse(_psbt_v2_declaring(MAX_TX_IN_COUNT + 1, 0))
+
+    with pytest.raises(BTClibValueError, match="too many output maps"):
+        Psbt.parse(_psbt_v2_declaring(0, MAX_TX_OUT_COUNT + 1))


### PR DESCRIPTION
Addresses #569 in part — see "What this does not do" below; the issue should stay open.

`var_int.parse`'s `MAX_SIZE` is Core's `ReadCompactSize` range check and answers whether a CompactSize is one a sane protocol would write. 33,554,432 *is* a sane CompactSize, so nine octets naming that many maps or transactions were believed and the comprehension that followed asked for an object per declared item. What a parser also has to ask is whether what follows could possibly hold this many — and the answer is consensus arithmetic, not a number this library picks.

## The bounds

All three in `btclib.block.limits`, beside the constants they divide:

| parser | bound | value |
|---|---|---|
| `Block.parse` | `MAX_BLOCK_WEIGHT // MIN_SERIALIZABLE_TRANSACTION_WEIGHT` | 100,000 |
| `Psbt.parse` inputs | `MAX_TX_IN_COUNT` | 24,390 |
| `Psbt.parse` outputs | `MAX_TX_OUT_COUNT` | 111,111 |

`MIN_SERIALIZABLE_TRANSACTION_WEIGHT` and not the `MIN_TRANSACTION_WEIGHT` beside it: what is being allocated for is a transaction that *deserializes*, which is Core's own distinction between the two names. A PSBT's maps are a transaction's inputs and outputs, so what bounds those bounds these.

## What it buys, measured

The issue's PSBTv2 reproducer — 100,000 empty input maps in ~100 KB of payload:

| | before | after |
|---|---|---|
| peak allocation | 125 MB | **0.1 MB** |
| outcome | parsed, then rejected on input 0 | refused immediately, naming the count |

An empty input map is a single octet on the wire and an object with a dozen fields in memory: the count believed is that amplification paid before the first map is read.

## What this does not do, and why

**The witness stack is not bounded.** The number that would cap it is `MAX_STACK_SIZE`, and that is a rule about *executing* a script. `btclib/script/limits.py` already states the principle: reading an execution limit in the decoder is what let a 1443-byte push be refused as unparsable when it was merely unspendable (#123). A witness of a million items is unspendable and parses — as it does for Core, whose deserializer bounds it by the size of the message that carried it, not by the interpreter's stack. Its cost stays proportional to the input that declared it, ~25 MB for the issue's 1 MB reproducer, which is what a parser costs rather than an amplification.

**`Tx.parse` is unchanged**, for two reasons: `TxIn.parse` raises on the first short read, so a count with nothing behind it is already refused in microseconds; and the bound that would refuse a count *with* bytes behind it lives in `btclib.block.limits`, which `btclib.tx` cannot import — `btclib.block` imports `btclib.tx`, so the edge is an import cycle (confirmed, not assumed). Moving those constants below both is the change that would unblock it, and it is a structural decision worth its own issue rather than a rider on this one.

So #569's first reproducer still parses, and the issue should stay open for the witness half and for `Tx.parse`.

## Gates

- `uv run pytest --cov`: 18446 passed, 5 skipped, coverage ratchet at 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bound transaction and PSBT map counts by consensus-derived limits so declared counts cannot exceed what a block can hold, preventing large over-allocation while keeping witness and Tx parsing unchanged.

New Features:
- Introduce consensus-based upper bounds for transaction counts in blocks and for PSBT input/output map counts, derived from MAX_BLOCK_WEIGHT and minimal serializable sizes.

Enhancements:
- Update Block.parse to cap the var_int transaction count using MIN_SERIALIZABLE_TRANSACTION_WEIGHT so blocks cannot declare more transactions than they can contain.
- Add MIN_SERIALIZABLE_TRANSACTION_WEIGHT, minimal TxIn/TxOut sizes, and MAX_TX_IN_COUNT/MAX_TX_OUT_COUNT constants to btclib.block.limits for shared consensus-based sizing.
- Strengthen PSBT parsing by rejecting input/output map counts above MAX_TX_IN_COUNT/MAX_TX_OUT_COUNT with clear error messages.
- Add tests that validate the new block transaction count bound, the derivation of TX_IN/TX_OUT count limits, and PSBT behavior when map counts exceed these bounds.

Documentation:
- Document the new consensus-based count bounds and their rationale, measurement impact, and remaining unbounded areas (witness stack and Tx.parse) in the unreleased v2026.9 changelog.

Tests:
- Add regression tests to ensure oversized block transaction counts are rejected before allocation and that PSBT input/output map overflows are refused with informative errors.
- Add tests confirming that MAX_TX_IN_COUNT and MAX_TX_OUT_COUNT are correctly derived from MAX_BLOCK_WEIGHT, witness scaling, and minimal TxIn/TxOut sizes.