### PR TITLE
Keep the bitcoind download on https, redirects included

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -147,7 +147,12 @@ jobs:
         run: |
           base="https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION"
           tarball="bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz"
-          curl --fail --silent --show-error --location --retry 3 \
+          # --proto/--proto-redir: --location follows redirects, and a
+          # redirect to http:// would be followed too. The checksum below
+          # protects the integrity either way, so this is not a hole it
+          # closes -- it is the download refusing to leave https at all
+          curl --proto '=https' --proto-redir '=https' \
+            --fail --silent --show-error --location --retry 3 \
             --output "$tarball" "$base/$tarball"
           echo "$BITCOIND_SHA256  $tarball" | sha256sum --check --strict
           # the daemon alone: the tarball carries the cli, the wallet tool


### PR DESCRIPTION
`--location` follows redirects, and a redirect to `http://` would be
followed too.

The `sha256sum --check --strict` on the next line means this closes no
integrity hole — a tampered tarball fails there whichever scheme
delivered it. What `--proto '=https' --proto-redir '=https'` buys is
that the download never leaves https to begin with, rather than
relying on the check after it to notice.

One line, no behaviour change on a well-behaved endpoint.

## Where this comes from

An audit of [checksig](https://github.com/checksig-custody/checksig),
which downloads Bitcoin Core in its own test workflows and had no
integrity assertion at all. Fixing it there meant reading how this
repository does it — and this workflow is the model: the sha256 pinned
in `env` beside the version, attested by four guix builders, checked
before unpacking, with a comment saying where to re-read it from when
the version moves. checksig now pins the same way, and its
`x86_64-linux-gnu` sum for 31.1 matches the one here, arrived at
independently.

This flag is the one thing that seemed worth sending back.

## Summary by Sourcery

Enforce HTTPS-only downloads of the bitcoind tarball in the integration workflow while maintaining existing checksum verification.

Enhancements:
- Tighten the integration workflow curl configuration so that initial and redirected requests are restricted to HTTPS.
- Document the rationale for enforcing HTTPS-only downloads directly in the workflow script comments.