### PR TITLE
Price a child by the package it is mined in (#584)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,68 @@ documented at release-notes length in the first place, and are still in
   cycle. Naming that here because it is what the fix would have to move
   first.
 
+- **A child pays for its parent, and the arithmetic is `fee.package_fee`**
+  (#584). `fee_from_vsize` prices a transaction in isolation, and a
+  transaction spending an unconfirmed output is not mined in isolation:
+  it is mined with what it depends on or not at all, so the rate a miner
+  reads is the package's -- Core's mempool scores a transaction by
+  `fees.ancestor` over `ancestorsize`, both of `getmempoolentry` -- and
+  buying a rate for the child means buying it for everything unconfirmed
+  behind it, less what that already paid. `package_fee(vsize, fee_rate,
+  *, ancestor_vsize=0, ancestor_fee=0)` is the larger of the child's own
+  fee and the package's fee less `ancestor_fee`, with both totals
+  defaulting to zero, which is `fee_from_vsize`.
+
+  The two halves are each what a caller doing this by hand gets wrong,
+  and in the direction that costs money. Adding the two fees rounds
+  *twice*: at one satoshi per kvB, two 400 vB transactions owe a satoshi
+  each and the 800 vB package they make owes one, so the sum overpays.
+  Subtracting the ancestors' fee without a floor goes the other way and
+  hands the child a *discount* when a parent overpaid -- a child below the
+  rate it was priced at, which may not relay on its own -- so the maximum
+  is the rule and not a guard: it is why this is a function of its own
+  rather than two optional arguments on `fee_from_vsize`, which stays
+  exact ceiling division and nothing else.
+
+  What is **not** here is the mempool: which transactions are ancestors,
+  whether the set stops at the parents or walks the graph, and what each
+  of them paid is a node's answer, as are `-limitancestorcount` and
+  `-limitancestorsize`, which bound what a node accepts rather than what
+  a fee is. Given the two totals the answer is a function of its
+  arguments, which is the boundary the module docstring drew in #205 and
+  this stays inside of. The ancestors' virtual size is refused if
+  negative rather than added to `vsize`, where it would cancel against
+  the child's own size and price a package as smaller than the
+  transaction in it; their fee is money, so `valid_sats_amount` is the
+  gate and MAX_MONEY the bound this module does not restate.
+
+- **`FeeRate` reads the BTC/kvB that Core's RPC quotes** (#584).
+  `FeeRate` held sat/kvB and took sat/vB, and the numbers a caller has in
+  hand arrive in neither: `estimatesmartfee`'s `feerate`,
+  `getmempoolinfo`'s `mempoolminfee` and `minrelaytxfee`,
+  `getnetworkinfo`'s `relayfee` and the `-minrelaytxfee`, `-dustrelayfee`
+  and `-paytxfee` options are all quoted in BTC/kvB -- a unit of the
+  interface and of nothing the node stores, sat/kvB being what those
+  numbers are compared against internally. Converting it at the call site
+  is `float(reply["feerate"]) * 100_000`, which is a float in front of a
+  fee and the factor this type exists to keep out of call sites.
+  `FeeRate.from_btc_per_kvbyte` is the third constructor;
+  `getblockstats`, whose `minfeerate` and `avgfeerate` are sat/vB, is the
+  exception the docstring names so that the wrong one is not reached for.
+
+  A rate per kvB scales from BTC to satoshi by the factor an amount
+  does, so `sats_from_btc` is the conversion and its refusals are the
+  ones that apply, a quote naming a fraction of a satoshi per kvB
+  included; its complaints name a BTC amount, which is what is being
+  converted, and the 21-million cap comes with them, which costs a
+  caller nothing. One case is refused before it gets there:
+  `valid_btc_amount` reads `None` as zero, right for an amount and wrong
+  for a price, and `estimatesmartfee` answers an `errors` array with no
+  `feerate` key at all when it cannot estimate one -- so the missing quote
+  a caller reads out of that reply would have become a free transaction,
+  where paying nothing is not what "no estimate" says. A zero a caller
+  means is still a zero rate.
+
 ### Curves, signatures and keys
 
 - **A MOV-weak curve is a `BTClibValueError`** (#572). `Curve` refuses

--- a/README.md
+++ b/README.md
@@ -144,9 +144,11 @@ Included features are:
   obey, and conversion either way
 - [BIP21](https://github.com/bitcoin/bips/blob/master/bip-0021.mediawiki)
   `bitcoin:` payment URIs
-- fee rates carrying their unit (sat/kvB and sat/vB), the fee a virtual
-  size owes at one, and the dust threshold of any output type, computed as
-  Bitcoin Core computes it rather than tabulated
+- fee rates carrying their unit (sat/kvB, sat/vB, and the BTC/kvB Bitcoin
+  Core quotes one in), the fee a virtual size owes at one, what a child
+  owes for the unconfirmed ancestors it is mined with, and the dust
+  threshold of any output type, computed as Bitcoin Core computes it
+  rather than tabulated
 - wallets, three sources of addresses behind one vocabulary: an extended
   key at a BIP44 account or a set of individual keys, which also answer
   the private key that signs for an address — what `sign(address, msg)`

--- a/btclib/fee.py
+++ b/btclib/fee.py
@@ -2,25 +2,30 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Fee rates, the fee a virtual size owes, and the dust threshold.
+"""Fee rates, the fee a virtual size owes, package fees, and dust.
 
-Three answers, each a function of its arguments alone: what a fee rate
-is, what fee a transaction of a given virtual size owes at that rate, and
-how small an output has to be before the network refuses to relay it.
+Each answer is a function of its arguments alone: what a fee rate is,
+what fee a transaction of a given virtual size owes at that rate, what a
+child owes when the outputs it spends are unconfirmed, and how small an
+output has to be before the network refuses to relay it.
 
 A fee rate is a price, and the unit is where the mistakes are. Bitcoin
-Core states it in satoshi per kilo-virtual-byte, wallets and their users
-state it in satoshi per virtual byte, and the two differ by a factor of a
-thousand that a bare int does not record. `FeeRate` names the unit in the
-one constructor and in both accessors, so the factor is never the
-caller's to remember, and it refuses a sat/vB rate it could not hold
-exactly rather than truncating one.
+Core stores it in satoshi per kilo-virtual-byte, quotes it in BTC per
+kilo-virtual-byte wherever its RPC replies mention one, and wallets and
+their users state it in satoshi per virtual byte: three units and two
+factors that a bare int does not record. `FeeRate` names the unit in
+every constructor and accessor, so no factor is the caller's to
+remember, and it refuses a rate it could not hold exactly rather than
+truncating one.
 
 Explicitly not here, and the boundary is the point: everything downstream
 of a network. Mempool histograms, a fee estimate for a confirmation
 target, an ETA, a "how many blocks" slider -- those are policy fed by
 live data. They need a node, they answer differently every minute, and
-they belong to an application rather than to a library. What this module
+they belong to an application rather than to a library. `package_fee` is
+on this side of that line and its inputs are on the other: which
+ancestors are unconfirmed and what each of them paid is what a node
+answers, the arithmetic over those totals is not. What this module
 computes it computes from its arguments and from Bitcoin Core's
 constants, and the same arguments give the same answer forever.
 """
@@ -33,6 +38,7 @@ from typing import Any
 
 from btclib import var_int
 from btclib.alias import Octets
+from btclib.amount import sats_from_btc, valid_sats_amount
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.script.limits import MAX_SCRIPT_SIZE
 from btclib.script.script import BYTE_FROM_OP_CODE_NAME
@@ -44,6 +50,7 @@ __all__ = [
     "FeeRate",
     "dust_threshold",
     "fee_from_vsize",
+    "package_fee",
 ]
 
 # the kilo in sat/kvB, i.e. how many virtual bytes a rate is quoted over
@@ -140,6 +147,40 @@ class FeeRate:
             )
         return cls(sats_per_kvbyte=sats_per_kvbyte)
 
+    @classmethod
+    def from_btc_per_kvbyte(cls, btc_per_kvbyte: Any) -> FeeRate:
+        """Return the same rate in sat/kvB from a BTC/kvB quote.
+
+        BTC/kvB is the unit Bitcoin Core quotes a rate in wherever an
+        RPC reply carries one -- `estimatesmartfee`'s `feerate`,
+        `getmempoolinfo`'s `mempoolminfee` and `minrelaytxfee`,
+        `getnetworkinfo`'s `relayfee` -- and it is a unit of the
+        interface rather than of the node: what those numbers are
+        compared against internally is the sat/kvB this class holds.
+        `getblockstats` is the exception worth knowing, quoting its
+        `minfeerate` and `avgfeerate` in sat/vB, which is the
+        constructor above.
+
+        A rate per kvB scales from BTC to satoshi by the factor an
+        amount does, so `sats_from_btc` is the conversion and its
+        refusals are the ones that apply: what does not read as a
+        decimal number, what is not finite, a negative quote, and one
+        naming a fraction of a satoshi -- what sat/kvB cannot hold
+        exactly. Its complaints name a BTC amount, which is what is
+        being converted.
+        """
+        # `valid_btc_amount` reads None as zero, which is right for an
+        # amount -- no amount is no money -- and wrong for a price:
+        # `estimatesmartfee` answers an `errors` array and no `feerate`
+        # key at all when it cannot estimate one, so the missing quote a
+        # caller reads out of that reply would become a free
+        # transaction, and paying nothing is not what "no estimate"
+        # says. Only the absent quote is refused: a zero a caller means
+        # is a zero rate through this constructor like any other
+        if btc_per_kvbyte is None:
+            raise BTClibValueError(f"invalid BTC/kvB fee rate: {btc_per_kvbyte}")
+        return cls(sats_per_kvbyte=sats_from_btc(btc_per_kvbyte))
+
     @property
     def sats_per_vbyte(self) -> Decimal:
         """Return the rate in satoshi per virtual byte, exactly.
@@ -191,6 +232,69 @@ def fee_from_vsize(vsize: int, fee_rate: FeeRate) -> int:
     # also how Core answers for a rate it holds as no rate at all
     sats, remainder = divmod(fee_rate.sats_per_kvbyte * vsize, _VBYTES_PER_KVBYTE)
     return sats + 1 if remainder else sats
+
+
+def package_fee(
+    vsize: int,
+    fee_rate: FeeRate,
+    *,
+    ancestor_vsize: int = 0,
+    ancestor_fee: int = 0,
+) -> int:
+    """Return the fee in satoshi owed by a transaction and its ancestors.
+
+    Child pays for parent. A transaction spending an unconfirmed output
+    is mined with what it depends on or not at all, so the rate a miner
+    reads is the package's -- Core's mempool scores a transaction by
+    `fees.ancestor` over `ancestorsize`, both of `getmempoolentry` --
+    and buying a rate for the child means buying it for everything
+    unconfirmed behind it, less what that already paid.
+
+    The answer is the larger of two fees: what the child owes for its
+    own virtual size, and what the package owes for the sum of the
+    sizes, less `ancestor_fee`. The second is what lifts a package its
+    ancestors underpay. The first is what stands when they pay the rate
+    or more, where the difference would be a *discount* on the child --
+    a child cheaper than the rate because its parent overpaid, which is
+    a transaction that may not relay on its own and a fee no caller
+    asked for.
+
+    `ancestor_vsize` and `ancestor_fee` are totals over the unconfirmed
+    ancestors, the child itself excluded; zero for both, the default, is
+    a child with nothing unconfirmed behind it and the answer is
+    `fee_from_vsize`. Which transactions those are, whether the set
+    stops at the parents or walks the whole graph, and what each of them
+    paid is a mempool question, and it stays with the caller: an
+    ancestor's own descendants are not in it, and neither are Core's
+    `-limitancestorcount` and `-limitancestorsize`, which bound what it
+    will accept but not what a fee is.
+
+    Keyword-only, the two of them, because they are same-typed
+    non-negative ints beside each other: a swapped pair is a wrong fee
+    that nothing else in the arithmetic can notice.
+    """
+    if not is_integer(ancestor_vsize):
+        raise BTClibTypeError(f"non-integer ancestor virtual size: {ancestor_vsize}")
+    # bounded here rather than left to the sum below, where a negative
+    # total would cancel against `vsize` and price the package as
+    # something smaller than the child it holds
+    if ancestor_vsize < 0:
+        raise BTClibValueError(f"negative ancestor virtual size: {ancestor_vsize}")
+    # the ancestors' fee is money, so the amount validator is the gate:
+    # non-integer, negative and above MAX_MONEY are its answers to give,
+    # and that bound is one this module has no business restating
+    ancestor_fee = valid_sats_amount(ancestor_fee)
+
+    # `vsize` itself is checked where it is used, `fee_from_vsize` being
+    # the whole of the arithmetic here -- and not two optional arguments
+    # on that function, which is exact ceiling division and nothing else:
+    # the maximum below is the rule that a child is never priced under
+    # the rate it was asked for, and a rule reads better under a name of
+    # its own than as a branch inside the primitive every fee goes
+    # through
+    own_fee = fee_from_vsize(vsize, fee_rate)
+    package = fee_from_vsize(vsize + ancestor_vsize, fee_rate)
+    return max(own_fee, package - ancestor_fee)
 
 
 # Core's DUST_RELAY_TX_FEE, the default of its -dustrelayfee option. A

--- a/tests/fee_test.py
+++ b/tests/fee_test.py
@@ -28,6 +28,7 @@ from btclib.fee import (
     FeeRate,
     dust_threshold,
     fee_from_vsize,
+    package_fee,
 )
 from btclib.script import ScriptPubKey, serialize
 from btclib.script.limits import MAX_SCRIPT_SIZE
@@ -106,6 +107,90 @@ def test_a_rate_that_is_not_a_number(rate: Any) -> None:
     err_msg = "invalid sat/vB fee rate: "
     with pytest.raises(BTClibValueError, match=err_msg):
         FeeRate.from_sats_per_vbyte(rate)
+
+
+@pytest.mark.parametrize(
+    "btc_per_kvbyte, sats_per_kvbyte",
+    [
+        # Core's own defaults, quoted in the unit its options take them
+        # in: -minrelaytxfee and -incrementalrelayfee are 0.00001 BTC/kvB
+        # and -dustrelayfee 0.00003, which are 1000 and 3000 sat/kvB
+        ("0.00001", 1000),
+        ("0.00003", 3000),
+        # the finest a rate held as sat/kvB can be, and the coarsest a
+        # BTC quote can name: one satoshi per kilo-virtual-byte
+        ("0.00000001", 1),
+        (0, 0),
+        (Decimal("0.0001"), 10_000),
+        ("1", 100_000_000),
+        # a float is read through its repr here as well
+        (1e-8, 1),
+        ("1E-8", 1),
+    ],
+)
+def test_btc_per_kvbyte_quotes(btc_per_kvbyte: Any, sats_per_kvbyte: int) -> None:
+    """Read Core's BTC/kvB quote into the sat/kvB the same node stores."""
+    rate = FeeRate.from_btc_per_kvbyte(btc_per_kvbyte)
+    assert rate.sats_per_kvbyte == sats_per_kvbyte
+
+
+def test_the_three_units_agree_on_one_rate() -> None:
+    """1 sat/vB is 1000 sat/kvB is 0.00001 BTC/kvB, exactly.
+
+    The two factors are the whole of the unit trouble: a thousand
+    virtual bytes to the kvB and a hundred million satoshi to the BTC,
+    which is the 100_000 between a BTC/kvB quote and the sat/vB a user
+    reads.
+    """
+    assert FeeRate.from_btc_per_kvbyte("0.00001") == FeeRate(sats_per_kvbyte=1000)
+    assert FeeRate.from_btc_per_kvbyte("0.00001") == FeeRate.from_sats_per_vbyte(1)
+    assert FeeRate.from_btc_per_kvbyte("0.00003") == DUST_RELAY_FEE_RATE
+    # and the factor itself, at a rate no round number hides it behind
+    rate = FeeRate.from_btc_per_kvbyte("0.00002345")
+    assert rate.sats_per_vbyte == Decimal("2.345")
+
+
+def test_a_btc_quote_is_exact_or_it_is_an_error() -> None:
+    """A fraction of a satoshi per kvB is refused, not truncated."""
+    with pytest.raises(BTClibValueError, match="too many decimals"):
+        FeeRate.from_btc_per_kvbyte("0.000000001")
+
+
+@pytest.mark.parametrize(
+    "rate",
+    [
+        "NaN",
+        "Infinity",
+        "abc",
+        "1,2",
+        "",
+        [1],
+        # a price is not an amount in one respect: it has no cap of its
+        # own, but the conversion is an amount's and 21 million BTC per
+        # kvB is refused as an amount
+        "21000000.00000001",
+        # and a negative quote, which the amount validator refuses before
+        # __post_init__ has a rate to call negative
+        "-0.00001",
+    ],
+)
+def test_a_btc_quote_that_is_not_a_rate(rate: Any) -> None:
+    """Refuse what `sats_from_btc` refuses, in its own words."""
+    with pytest.raises(BTClibValueError, match="BTC amount"):
+        FeeRate.from_btc_per_kvbyte(rate)
+
+
+def test_a_missing_btc_quote_is_not_a_free_transaction() -> None:
+    """None is zero to an amount and no rate at all to a price.
+
+    `estimatesmartfee` answers an `errors` array and no `feerate` key
+    when it cannot estimate one, so the None a caller reads out of that
+    reply is the case this refusal is for.
+    """
+    with pytest.raises(BTClibValueError, match="invalid BTC/kvB fee rate: "):
+        FeeRate.from_btc_per_kvbyte(None)
+    # a zero a caller means is still a zero rate
+    assert FeeRate.from_btc_per_kvbyte("0") == FeeRate(sats_per_kvbyte=0)
 
 
 def test_a_rate_is_a_non_negative_integer_number_of_sats_per_kvbyte() -> None:
@@ -193,6 +278,110 @@ def test_a_virtual_size_is_a_non_negative_integer() -> None:
 
     with pytest.raises(BTClibValueError, match="negative virtual size: "):
         fee_from_vsize(-1, DUST_RELAY_FEE_RATE)
+
+
+_TEN_SATS_PER_VBYTE = FeeRate(sats_per_kvbyte=10_000)
+
+
+@pytest.mark.parametrize(
+    "ancestor_vsize, ancestor_fee, fee",
+    [
+        # nothing unconfirmed behind it: the child's own fee, and the
+        # answer `fee_from_vsize` gives for the same size and rate
+        (0, 0, 2000),
+        # a parent that paid 1 sat/vB where the child wants 10: the
+        # package is 1200 vB and owes 12000, of which 1000 is paid
+        (1000, 1000, 11000),
+        # the same parent having paid nothing at all -- a child lifting a
+        # zero-fee parent, which is what CPFP is for
+        (1000, 0, 12000),
+        # the boundary: a parent already paying exactly the rate leaves
+        # the child its own fee and not a satoshi more
+        (1000, 10_000, 2000),
+        # and a parent that overpaid, where the package arithmetic would
+        # hand the child a discount: refused by the maximum, so the child
+        # still pays the rate it asked for
+        (1000, 20_000, 2000),
+        (1000, 21_000_000 * 100_000_000, 2000),
+    ],
+)
+def test_a_child_pays_for_its_parent(
+    ancestor_vsize: int, ancestor_fee: int, fee: int
+) -> None:
+    """Price a 200 vB child at 10 sat/vB behind a 1000 vB parent."""
+    assert (
+        package_fee(
+            200,
+            _TEN_SATS_PER_VBYTE,
+            ancestor_vsize=ancestor_vsize,
+            ancestor_fee=ancestor_fee,
+        )
+        == fee
+    )
+
+
+def test_no_ancestors_is_the_plain_fee() -> None:
+    """The default arguments make this `fee_from_vsize`, at every size."""
+    rate = FeeRate.from_sats_per_vbyte("1.5")
+    assert all(
+        package_fee(vsize, rate) == fee_from_vsize(vsize, rate)
+        for vsize in (0, 1, 141, 1000, 100_000)
+    )
+
+
+def test_the_package_is_rounded_once_and_not_twice() -> None:
+    """The ceiling is taken over the package, not over each transaction.
+
+    At one satoshi per kvB a 400 vB transaction owes one satoshi, so two
+    of them owe two -- while the 800 vB package they make owes one. The
+    child pays what the package owes, and the difference is the rounding
+    that was not performed twice.
+    """
+    rate = FeeRate(sats_per_kvbyte=1)
+    assert fee_from_vsize(400, rate) + fee_from_vsize(400, rate) == 2
+    assert package_fee(400, rate, ancestor_vsize=400) == 1
+
+
+def test_a_zero_rate_owes_zero_however_much_was_paid() -> None:
+    """No discount goes the other way either: a fee is never negative."""
+    rate = FeeRate(sats_per_kvbyte=0)
+    assert package_fee(200, rate, ancestor_vsize=1000, ancestor_fee=50_000) == 0
+
+
+def test_an_ancestor_virtual_size_is_a_non_negative_integer() -> None:
+    """Refuse a float, a bool and a negative ancestor size."""
+    err_msg = "non-integer ancestor virtual size: "
+    with pytest.raises(BTClibTypeError, match=err_msg):
+        package_fee(200, DUST_RELAY_FEE_RATE, ancestor_vsize=1000.0)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match=err_msg):
+        package_fee(200, DUST_RELAY_FEE_RATE, ancestor_vsize=True)
+    # refused rather than added to `vsize`, where it would cancel against
+    # the child's own size and price the package below the child
+    with pytest.raises(BTClibValueError, match="negative ancestor virtual size: "):
+        package_fee(200, DUST_RELAY_FEE_RATE, ancestor_vsize=-1)
+
+
+def test_an_ancestor_fee_is_a_satoshi_amount() -> None:
+    """The amount validator is the gate, MAX_MONEY bound included."""
+    err_msg = "non-integer satoshi amount: "
+    with pytest.raises(BTClibTypeError, match=err_msg):
+        package_fee(200, DUST_RELAY_FEE_RATE, ancestor_fee=1000.5)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match=err_msg):
+        package_fee(200, DUST_RELAY_FEE_RATE, ancestor_fee=True)
+    err_msg = "invalid satoshi amount: "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        package_fee(200, DUST_RELAY_FEE_RATE, ancestor_fee=-1)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        package_fee(200, DUST_RELAY_FEE_RATE, ancestor_fee=21_000_000 * 10**8 + 1)
+    # and the child's own size is checked where every other fee checks it
+    with pytest.raises(BTClibTypeError, match="non-integer virtual size: "):
+        package_fee(200.0, DUST_RELAY_FEE_RATE, ancestor_vsize=1000)  # type: ignore[arg-type]
+
+
+def test_the_ancestor_totals_cannot_be_swapped_by_position() -> None:
+    """Two same-typed ints, so neither is positional."""
+    with pytest.raises(TypeError):
+        package_fee(200, _TEN_SATS_PER_VBYTE, 1000, 1000)  # type: ignore[call-arg]
 
 
 def _script_pub_keys() -> dict[str, bytes]:


### PR DESCRIPTION
Closes #584.

`btclib.fee` priced a transaction in isolation, and a transaction spending an unconfirmed output is not mined in isolation: it is mined with what it depends on or not at all, so the rate a miner reads is the package's — Core's mempool scores a transaction by `fees.ancestor` over `ancestorsize`, both of `getmempoolentry`. Buying a rate for the child means buying it for everything unconfirmed behind it, less what that already paid.

## `package_fee`

```python
package_fee(vsize, fee_rate, *, ancestor_vsize=0, ancestor_fee=0) -> int
```

The larger of two fees: what the child owes for its own virtual size, and what the package owes for the sum of the sizes less `ancestor_fee`. Both totals default to zero, which is a child with nothing unconfirmed behind it and the answer `fee_from_vsize` already gave.

Each half of that maximum is what a caller doing this by hand gets wrong, and in the direction that costs money:

| doing it by hand | at 1 sat/kvB, two 400 vB transactions | what `package_fee` answers |
|---|---|---|
| add the two fees | 1 + 1 = 2 sat, the ceiling taken twice | 1 sat, the 800 vB package rounded once |
| subtract the parent's fee, no floor | a parent that overpaid buys the child a *discount* | the child's own fee, never under the rate asked for |

A child priced below the rate it was given is a transaction that may not relay on its own, so the maximum is the rule rather than a guard — and that is why this is a function of its own rather than two optional arguments on `fee_from_vsize`, which stays exact ceiling division and nothing else.

Refusals: a negative `ancestor_vsize` is refused rather than added to `vsize`, where it would cancel against the child's own size and price a package as smaller than the transaction in it. `ancestor_fee` is money, so `valid_sats_amount` is the gate and MAX_MONEY the bound this module does not restate.

## `FeeRate.from_btc_per_kvbyte`

The class held sat/kvB and took sat/vB, and the numbers a caller has in hand arrive in neither: `estimatesmartfee`'s `feerate`, `getmempoolinfo`'s `mempoolminfee` and `minrelaytxfee`, `getnetworkinfo`'s `relayfee`, and the `-minrelaytxfee`, `-dustrelayfee` and `-paytxfee` options are all quoted in BTC/kvB. That is a unit of the interface and of nothing the node stores — sat/kvB is what those numbers are compared against internally — and converting it at the call site is `float(reply["feerate"]) * 100_000`, a float in front of a fee and the factor this type exists to keep out of call sites.

A rate per kvB scales from BTC to satoshi by the factor an amount does, so `sats_from_btc` is the conversion and its refusals are the ones that apply, a quote naming a fraction of a satoshi per kvB included. One case is refused before it gets there: `valid_btc_amount` reads `None` as zero, which is right for an amount and wrong for a price, and `estimatesmartfee` answers an `errors` array with **no `feerate` key at all** when it cannot estimate one — so the missing quote a caller reads out of that reply would have become a free transaction. A zero a caller means is still a zero rate.

`getblockstats` is the exception the docstring names, quoting `minfeerate` and `avgfeerate` in sat/vB, so that the wrong constructor is not reached for.

## What this does not do

No mempool, and the module docstring says where the line falls: which transactions are ancestors, whether the set stops at the parents or walks the graph, and what each of them paid is a node's answer, as are `-limitancestorcount` and `-limitancestorsize`, which bound what a node accepts rather than what a fee is. Given the two totals the answer is a function of its arguments, which is the boundary #205 drew and this stays inside of.

No `btc_per_kvbyte` accessor either: what is read here is an RPC reply, and nothing in btclib writes a request that quotes a rate.

## Gates

- `uv run pytest`: 18477 passed, 5 skipped
- `uv run --locked --no-default-groups --group test pytest --cov`: coverage ratchet at 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce package-aware fee calculation and support for BTC/kvB fee rate inputs.

New Features:
- Add package_fee helper to compute the required fee for a transaction plus its unconfirmed ancestors at a given fee rate.
- Add FeeRate.from_btc_per_kvbyte constructor to read Bitcoin Core BTC/kvB fee rate quotes into internal sat/kvB representation.

Enhancements:
- Extend fee module documentation and public API exports to cover package fees and BTC/kvB handling.
- Update README and changelog to describe package-aware fee calculation and BTC/kvB fee rate support.

Tests:
- Add comprehensive tests for FeeRate.from_btc_per_kvbyte, including unit consistency, invalid inputs, and None handling.
- Add comprehensive tests for package_fee covering ancestor fee/size interactions, rounding behavior, zero-rate handling, validation of ancestor inputs, and keyword-only enforcement.