### PR TITLE
Update a psbt from a wallet whose script no descriptor states

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,7 @@ documented at release-notes length in the first place, and are still in
 ### Wallets
 
 - **`ScriptWallet` is BIP174's Updater for the scripts no descriptor
-  states**. `DescriptorWallet` has `update_psbt_input` and
+  states** (#587). `DescriptorWallet` has `update_psbt_input` and
   `update_psbt_output` and this class had neither, so a caller spending a
   script outside BIP380-390 wrote the psbt fields by hand: the witness
   script under each input, and, under every key of it, the origin a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,40 @@ documented at release-notes length in the first place, and are still in
   now repeats, the two parsers agreeing on the message as well as on the
   number.
 
+### Wallets
+
+- **`ScriptWallet` is BIP174's Updater for the scripts no descriptor
+  states**. `DescriptorWallet` has `update_psbt_input` and
+  `update_psbt_output` and this class had neither, so a caller spending a
+  script outside BIP380-390 wrote the psbt fields by hand: the witness
+  script under each input, and, under every key of it, the origin a
+  hardware signer derives that key from. Both are what the wallet has
+  computed anyway -- `redeem_script` and `witness_script` are the two
+  pre-images, and the keys are the ones the script carries -- so what was
+  left to a caller was the writing and not the knowing.
+
+  Being an Updater is not being a signer, which is the line this holds:
+  no language says what satisfies such a script, so the satisfaction
+  stays the caller's and `psbt.finalize` still cannot assemble the
+  witness. The output half refuses unless the output being paid is the
+  very script the position derives, as `Descriptor.update_psbt_output`
+  does: marking an output as one's own is a claim about where money goes,
+  and the whole script is the only evidence for it. What it writes is
+  every key of the template and not the quorum a spend would use -- an
+  output is not a signing instruction, and a reader wants the whole
+  script, the branch nobody is spending included.
+
+  `KeyGroup(threshold, keys, origins=...)` is where an origin comes from,
+  one entry per key and `None` for a key without one. It has to be given:
+  BIP174 carries the master fingerprint and the path from the master key
+  down, and an extended key below the root records neither, which is the
+  same reason `descriptors.account_descriptors` takes the fingerprint
+  beside the key. What the key does record is checked -- its depth
+  against the path's length, its own index against the path's last step,
+  and, for a master key, the fingerprint itself -- so an origin that
+  would send a signer to derive another key is refused where it is
+  declared rather than written into a psbt.
+
 ## v2026.8.9
 
 ### Descriptors and miniscript

--- a/btclib/wallet/script_wallet.py
+++ b/btclib/wallet/script_wallet.py
@@ -52,12 +52,23 @@ handed to Bitcoin Core.
 ones no descriptor states; offering a conversion would re-open the
 ambiguity that refusing the script closes.
 
-**Not a signer.** `DescriptorWallet.satisfy` can assemble a spend because
-miniscript knows what satisfies a fragment; a template does not, so
-neither the satisfaction nor the psbt Updaters are here. What is here is
-`redeem_script` and `witness_script`, which are the pre-images -- a caller
-holding a script no language describes already owns the spend, and those
-two are what a psbt needs from the wallet.
+**Not a signer, and an Updater.** `DescriptorWallet.satisfy` can assemble
+a spend because miniscript knows what satisfies a fragment; a template
+does not, so no satisfaction is here and a caller holding such a script
+owns the spend. BIP174's Updater is the role that does not need to know
+it: what it writes into a psbt is what the wallet has computed anyway --
+`redeem_script` and `witness_script`, the two pre-images, and the origin
+of each key -- and `update_psbt_input` and `update_psbt_output` are those
+fields written at a position. The output half is what says an output
+comes back, and it refuses unless the output being paid is the very
+script the position derives.
+
+An origin is a `KeyGroup` parameter because an account key cannot supply
+one: BIP174 carries the master fingerprint and the path from the master
+key down, and an extended key below the root records neither -- the same
+reason `descriptors.account_descriptors` takes the fingerprint beside the
+key. A group given no origin is a wallet that computes addresses and
+writes no `hd_key_paths`, which is what a psbt of it then lacks.
 
 **The order is a parameter because deployed wallets disagree about it**,
 and one of the three is why this class exists at all:
@@ -87,15 +98,21 @@ https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from copy import deepcopy
 from typing import Any
 
 from btclib.alias import Command, EmbeddedScriptType, KeyOrder, ScriptList
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, derive_from_account
+from btclib.bip32.der_path import str_from_index_int
+from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
+from btclib.psbt.psbt import Psbt
+from btclib.psbt.psbt_in import PsbtIn
+from btclib.psbt.psbt_out import PsbtOut
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE, MAX_SCRIPT_SIZE
 from btclib.script.script import op_int, serialize
 from btclib.script.script_pub_key import ScriptPubKey
-from btclib.to_pub_key import pub_keyinfo_from_key
+from btclib.to_pub_key import fingerprint, pub_keyinfo_from_key
 from btclib.wallet.wallet import RangedWallet
 
 __all__ = [
@@ -147,6 +164,38 @@ _SCRIPT_PUB_KEY_FROM_SCRIPT_TYPE: dict[
 }
 
 
+def _assert_origin(key: BIP32KeyData, origin: BIP32KeyOrigin) -> None:
+    """Refuse a key origin that is not this account key's own.
+
+    What an extended key records of where it came from is its depth and
+    its own index, and both are checked against the path: a path of
+    another length is a path that does not end at this key, and a last
+    step that is not the key's index is another key at the same depth.
+    The levels above cannot be checked -- nothing in an extended key
+    names them -- so the caller's word is taken for them, which is
+    `bip44._indexes_left_to_derive`'s bargain with the same two facts.
+
+    A master key is the one case where the fingerprint is checkable, and
+    it is checked: at depth zero the origin is the empty path under the
+    key's own fingerprint, and any other is a signer sent looking for a
+    master key nobody has.
+    """
+    if len(origin.der_path) != key.depth:
+        err_msg = f"invalid key origin {origin.description}:"
+        err_msg += f" {len(origin.der_path)} levels for a key at depth {key.depth}"
+        raise BTClibValueError(err_msg)
+    if key.depth and key.index != origin.der_path[-1]:
+        err_msg = f"invalid key origin {origin.description}: it ends at"
+        err_msg += f" {str_from_index_int(origin.der_path[-1])}, and the key's"
+        err_msg += f" own index is {str_from_index_int(key.index)}"
+        raise BTClibValueError(err_msg)
+    own = fingerprint(key.b58encode())
+    if not key.depth and origin.master_fingerprint != own:
+        err_msg = f"invalid key origin {origin.description}: the master key's"
+        err_msg += f" own fingerprint is {own.hex()}"
+        raise BTClibValueError(err_msg)
+
+
 def _account_sec(xkey: BIP32KeyData) -> bytes:
     """Return the public key of an account key, private or not.
 
@@ -180,15 +229,40 @@ class KeyGroup:
     opcode and nothing else about the group -- the same choice miniscript
     makes with its `v:` wrapper, and the form `and_v(v:multi(...), ...)`
     compiles to.
+
+    `origins` is where each key comes from -- the master fingerprint and
+    the path down to the account key, which is what BIP174 carries and
+    what an extended key below the root cannot say of itself -- one entry
+    per key and in the order the keys are given, `None` for a key whose
+    origin the caller does not have. It changes no script: what reads it
+    is `ScriptWallet.update_psbt_input` and `update_psbt_output`, and
+    what a group without it writes into a psbt is nothing.
     """
 
     def __init__(
-        self, threshold: int, keys: Sequence[BIP32Key], verify: bool = False
+        self,
+        threshold: int,
+        keys: Sequence[BIP32Key],
+        verify: bool = False,
+        origins: Sequence[BIP32KeyOrigin | None] | None = None,
     ) -> None:
         self.keys = tuple(
             key if isinstance(key, BIP32KeyData) else BIP32KeyData.b58decode(key)
             for key in keys
         )
+        # one per key, so that the pairing is positional and stays so
+        # through the account order, which sorts the keys and not this
+        self.origins: tuple[BIP32KeyOrigin | None, ...] = (
+            (None,) * len(self.keys) if origins is None else tuple(origins)
+        )
+        if len(self.origins) != len(self.keys):
+            err_msg = f"{len(self.origins)} origins for {len(self.keys)} keys:"
+            err_msg += " a key origin is positional, and None is what a key"
+            err_msg += " without one takes"
+            raise BTClibValueError(err_msg)
+        for key, origin in zip(self.keys, self.origins, strict=True):
+            if origin is not None:
+                _assert_origin(key, origin)
         n = len(self.keys)
         if not 0 < n <= _MAX_KEYS:
             err_msg = f"invalid n in {threshold}-of-{n}:"
@@ -368,3 +442,125 @@ class ScriptWallet(RangedWallet):
         if self.script_type == "p2sh":
             return b""
         return self._script(branch, index)
+
+    def _hd_key_paths(self, branch: int, index: int) -> dict[bytes, BIP32KeyOrigin]:
+        """Return where each key of the script at a position comes from.
+
+        BIP174's bip32_derivs, keyed by the derived public key the script
+        holds: the account key's own origin with the two levels
+        `derive_from_account` walks appended to it, which is the path a
+        signer has to take to reach that key. A key given no origin is
+        skipped rather than refused -- the field is keyed by key, and what
+        is missing is one entry of it.
+
+        The keys are read off the groups as declared, the order being the
+        script's business and not this mapping's.
+        """
+        hd_key_paths: dict[bytes, BIP32KeyOrigin] = {}
+        for command in self.template:
+            if not isinstance(command, KeyGroup):
+                continue
+            for key, origin in zip(command.keys, command.origins, strict=True):
+                if origin is None:
+                    continue
+                sec = self._derived_sec(key, branch, index)
+                der_path = [*origin.der_path, branch, index]
+                hd_key_paths[sec] = BIP32KeyOrigin(origin.master_fingerprint, der_path)
+        return hd_key_paths
+
+    def update_psbt_input(
+        self, psbt: Psbt, vin_i: int, branch: int = 0, index: int = 0
+    ) -> Psbt:
+        """Return the psbt with an input told what this position is.
+
+        BIP174's Updater, for an input spending an output of this wallet:
+        the pre-image the output commits to -- the redeem script of a
+        p2sh, the witness script of a p2wsh, both where one wraps the
+        other -- and the origin of every key the script names, which is
+        what a hardware signer derives its own key from. What still cannot
+        be answered here is the satisfaction: `psbt.finalize` assembles
+        such an input through the `solver` its caller passes, no language
+        saying what satisfies this script.
+
+        A copy, the psbt handed in being left alone, and the fields of the
+        copy written in place, as `Descriptor.update_psbt_input` does.
+
+        The origins are every key of the template's, as for an output:
+        which of them a spend will use is what the satisfaction decides,
+        and a signer signs with the keys it holds whatever else it is
+        told about.
+
+        What is not filled is what the wallet does not know: the utxo, the
+        sighash type, the signatures. Nor is the script checked against
+        the output being spent -- an input may not carry it yet, and
+        `Psbt.assert_signable` is the role after this one.
+        """
+        self._assert_position(branch, index)
+        # an IndexError out of a public method is not an answer, and a
+        # negative index would quietly update the input at the other end
+        if not 0 <= vin_i < len(psbt.inputs):
+            raise BTClibValueError(f"invalid input index: {vin_i}")
+        psbt = deepcopy(psbt)
+        self._update(psbt.inputs[vin_i], branch, index)
+        psbt.assert_valid()
+        return psbt
+
+    def update_psbt_output(
+        self, psbt: Psbt, vout_i: int, branch: int = 0, index: int = 0
+    ) -> Psbt:
+        """Return the psbt with an output told what this position is.
+
+        The Updater's other half, and what makes an output recognizable as
+        the wallet's own: a signer reads the script and the key origins,
+        derives the script for itself, and sees that the money comes back
+        rather than being asked to take it on trust.
+
+        Unlike the input half, the script *is* checked: the output being
+        paid is in the psbt already, so this refuses unless the wallet
+        derives exactly that script at this position. Marking an output as
+        one's own is a claim about where money goes, and the only evidence
+        for it is the whole script -- never a key origin whose four-byte
+        fingerprint matches, which is what `position_of` says.
+
+        Every key of the template, and not the quorum a spend will use:
+        an output is not a signing instruction, and what a reader wants of
+        it is the whole script, the branch nobody is spending included.
+        """
+        self._assert_position(branch, index)
+        # an IndexError out of a public method is not an answer, and a
+        # negative index would quietly update the output at the other end
+        if not 0 <= vout_i < len(psbt.outputs):
+            raise BTClibValueError(f"invalid output index: {vout_i}")
+        paid = psbt.tx.vout[vout_i].script_pub_key.script
+        if self._script_pub_key(branch, index).script != paid:
+            err_msg = f"output {vout_i} pays to {paid.hex()}, which is not the"
+            err_msg += f" script this wallet derives at {branch}/{index}"
+            raise BTClibValueError(err_msg)
+        psbt = deepcopy(psbt)
+        self._update(psbt.outputs[vout_i], branch, index)
+        psbt.assert_valid()
+        return psbt
+
+    def _update(self, psbt_map: PsbtIn | PsbtOut, branch: int, index: int) -> None:
+        """Write what this wallet knows of a position into a psbt map.
+
+        One method for an input and an output, as BIP174 gives the two
+        maps the same three fields: a redeem script, a witness script and
+        a key origin say what they say whether the psbt is spending the
+        script or paying to it.
+
+        The empty pre-image of a script type that has none is not written:
+        `b""` is what those fields hold already, and writing it back would
+        clear whatever an earlier Updater had put there. The key paths are
+        added to for the same reason -- BIP174 keys them by public key, so
+        another signer's entry stays and this wallet's wins for a key held
+        by both.
+        """
+        if redeem_script := self.redeem_script(branch, index):
+            psbt_map.redeem_script = redeem_script
+        if witness_script := self.witness_script(branch, index):
+            psbt_map.witness_script = witness_script
+        psbt_map.hd_key_paths = {
+            **psbt_map.hd_key_paths,
+            **self._hd_key_paths(branch, index),
+        }

--- a/tests/wallet/script_wallet_test.py
+++ b/tests/wallet/script_wallet_test.py
@@ -10,6 +10,10 @@ because those four calls are what a caller had to write before this class
 existed, and what it must keep answering. The deployed wallet that made
 the case for it is pinned in `tests/descriptors/custody_wallet_test.py`,
 against the mainnet addresses it holds coins at.
+
+The psbt half is asserted the same way: the key paths against the account
+path with the two derived levels appended, which is the path a signer
+walks, and the pre-images against `redeem_script` and `witness_script`.
 """
 
 from __future__ import annotations
@@ -19,10 +23,17 @@ import pytest
 from btclib.alias import Command
 from btclib.bip32 import bip32
 from btclib.bip32.bip32 import BIP32KeyData, derive_from_account
+from btclib.bip32.key_origin import BIP32KeyOrigin
 from btclib.exceptions import BTClibValueError
+from btclib.psbt.psbt import Psbt
 from btclib.script import script
 from btclib.script.script import op_int
 from btclib.script.script_pub_key import ScriptPubKey
+from btclib.to_pub_key import fingerprint
+from btclib.tx.out_point import OutPoint
+from btclib.tx.tx import Tx
+from btclib.tx.tx_in import TxIn
+from btclib.tx.tx_out import TxOut
 from btclib.wallet import KeyGroup, ScriptWallet
 
 # the "abandon abandon ... about" seed, and three account keys of it in an
@@ -42,6 +53,12 @@ _XPUBS = [bip32.xpub_from_xprv(xprv) for xprv in _XPRVS]
 # the timelock of the example in the module docstring, spelled the way the
 # wallets that need this class spell it: a push, OP_CSV, OP_DROP
 _TIMELOCK: list[Command] = ["9000", "OP_CHECKSEQUENCEVERIFY", "OP_DROP"]
+
+# where those three accounts came from, which is what a psbt carries
+# beside each key: the master fingerprint, which only the root key
+# supplies, and the path down to the account
+_FINGERPRINT = fingerprint(_ROOT)
+_ORIGINS = [BIP32KeyOrigin(_FINGERPRINT, account) for account in _ACCOUNTS]
 
 
 def _derived(xpub: str, branch: int, index: int) -> bytes:
@@ -333,3 +350,200 @@ def test_the_derivation_bounds_are_bip32s_own() -> None:
     assert wallet.branches == (0, 1)
     with pytest.raises(BTClibValueError, match="invalid address index"):
         wallet.address(0, 0x10000)
+
+
+def _psbt_spending(script_pub_key: ScriptPubKey) -> Psbt:
+    """Return a psbt whose one input spends an output of that script."""
+    prev_tx = Tx(
+        vin=[TxIn(OutPoint(b"\x02" * 32, 0))], vout=[TxOut(1000, script_pub_key)]
+    )
+    psbt = Psbt.from_tx(
+        Tx(vin=[TxIn(OutPoint(prev_tx.id, 0))], vout=[TxOut(900, script_pub_key)])
+    )
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    return psbt
+
+
+def _derived_path(account: str, branch: int, index: int) -> str:
+    """Return the path a signer walks to the key of a position.
+
+    The account path, which is the origin the caller declared, with the
+    two levels `derive_from_account` adds to it.
+    """
+    return f"{_FINGERPRINT.hex()}{account[1:]}/{branch}/{index}"
+
+
+def test_the_updater_writes_the_pre_image_and_the_key_origins() -> None:
+    """BIP174's Updater over a script no descriptor states.
+
+    Which is what a signer needs of a position and what it cannot derive
+    for itself: the script the output commits to, and the path down to
+    each key in it. What is not written is what the wallet does not know
+    -- the utxo, the sighash type, the signatures.
+    """
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS, origins=_ORIGINS)], "p2wsh", "derived")
+    psbt = _psbt_spending(wallet.script_pub_key(1, 2))
+
+    psbt_in = wallet.update_psbt_input(psbt, 0, 1, 2).inputs[0]
+    assert psbt_in.witness_script == wallet.witness_script(1, 2)
+    # `b""` is not written: a native p2wsh has no redeem script, and the
+    # field already holds the empty answer
+    assert not psbt_in.redeem_script
+    assert len(psbt_in.hd_key_paths) == len(_XPUBS)
+    for xpub, account in zip(_XPUBS, _ACCOUNTS, strict=True):
+        origin = psbt_in.hd_key_paths[_derived(xpub, 1, 2)]
+        assert origin.description == _derived_path(account, 1, 2)
+    assert not psbt_in.sig_hash_type
+    assert not psbt_in.partial_sigs
+
+    # the psbt handed in is left alone, the copy being what carries them
+    assert not psbt.inputs[0].hd_key_paths
+    assert not psbt.inputs[0].witness_script
+
+
+def test_an_output_is_marked_only_where_the_whole_script_says_so() -> None:
+    """The evidence for "this comes back to me" is the script itself.
+
+    A reader derives it at the position given and compares it with what
+    the output pays; a position that derives another script is refused
+    rather than marked, which is `position_of` asked as a claim.
+    """
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS, origins=_ORIGINS)], "p2wsh", "derived")
+    psbt = _psbt_spending(wallet.script_pub_key(1, 2))
+
+    psbt_out = wallet.update_psbt_output(psbt, 0, 1, 2).outputs[0]
+    assert psbt_out.witness_script == wallet.witness_script(1, 2)
+    # the same fields on either side of BIP174's two maps: what a script
+    # and a key origin say does not depend on which of them holds it
+    psbt_in = wallet.update_psbt_input(psbt, 0, 1, 2).inputs[0]
+    assert psbt_out.hd_key_paths == psbt_in.hd_key_paths
+    assert not psbt.outputs[0].hd_key_paths
+
+    with pytest.raises(BTClibValueError, match="which is not the script"):
+        wallet.update_psbt_output(psbt, 0, 1, 3)
+
+
+def test_both_pre_images_of_a_wrapped_script_and_every_key_of_it() -> None:
+    """A p2sh-p2wsh input pushes one and commits to the other.
+
+    And the key paths are the template's own, quorum by quorum: an output
+    is not a signing instruction, so the keys of the branch nobody is
+    spending are in it too -- which is what lets a reader rebuild the
+    whole script rather than the part a spend uses.
+    """
+    template: list[Command | KeyGroup] = [
+        "OP_IF",
+        KeyGroup(2, _XPUBS, origins=_ORIGINS),
+        "OP_ELSE",
+        *_TIMELOCK,
+        KeyGroup(1, _XPUBS[:1], origins=_ORIGINS[:1]),
+        "OP_ENDIF",
+    ]
+    wallet = ScriptWallet(template, "p2sh-p2wsh")
+    psbt = _psbt_spending(wallet.script_pub_key())
+
+    psbt_in = wallet.update_psbt_input(psbt, 0).inputs[0]
+    assert psbt_in.redeem_script == wallet.redeem_script()
+    assert psbt_in.witness_script == wallet.witness_script()
+    # the recovery key is the first account again, and the mapping is
+    # keyed by key: one entry per distinct key of the script, not per
+    # appearance of one
+    assert len(psbt_in.hd_key_paths) == len(_XPUBS)
+
+    plain = ScriptWallet(template, "p2sh")
+    psbt_in = plain.update_psbt_input(_psbt_spending(plain.script_pub_key()), 0).inputs[
+        0
+    ]
+    assert psbt_in.redeem_script == plain.redeem_script()
+    assert not psbt_in.witness_script
+
+
+def test_the_account_order_does_not_move_an_origin_off_its_key() -> None:
+    """The sort reorders the script, and the mapping is keyed by the key.
+
+    `order="account"` sorts the keys of a group before deriving them, so
+    the script carries them in an order the caller did not write. What
+    would be wrong silently is a path under the key of another
+    participant: a signer would derive a key it does not hold, or worse,
+    the wrong key of one it does.
+    """
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS, origins=_ORIGINS)], "p2wsh", "account")
+    # the sort is a reorder over this quorum, which is what leaves the
+    # assertion below something to say
+    assert sorted(_XPUBS, key=lambda xpub: BIP32KeyData.b58decode(xpub).key) != _XPUBS
+
+    psbt = _psbt_spending(wallet.script_pub_key())
+    hd_key_paths = wallet.update_psbt_input(psbt, 0).inputs[0].hd_key_paths
+    for xpub, account in zip(_XPUBS, _ACCOUNTS, strict=True):
+        assert hd_key_paths[_derived(xpub, 0, 0)].description == _derived_path(
+            account, 0, 0
+        )
+
+
+def test_a_group_given_no_origin_writes_no_key_path() -> None:
+    """Which is a wallet that computes addresses and updates nothing else.
+
+    An account key records neither the master fingerprint nor the path
+    down to itself, so a caller who has neither has nothing to declare,
+    and the psbt is short of exactly that field.
+    """
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "derived")
+    psbt = _psbt_spending(wallet.script_pub_key())
+
+    psbt_in = wallet.update_psbt_input(psbt, 0).inputs[0]
+    assert psbt_in.witness_script == wallet.witness_script()
+    assert not psbt_in.hd_key_paths
+
+    # and one origin among several is one entry, the missing ones being
+    # skipped rather than refused
+    partial = ScriptWallet(
+        [KeyGroup(2, _XPUBS, origins=[_ORIGINS[0], None, None])], "p2wsh", "derived"
+    )
+    psbt = _psbt_spending(partial.script_pub_key())
+    assert len(partial.update_psbt_input(psbt, 0).inputs[0].hd_key_paths) == 1
+
+
+def test_a_key_origin_is_checked_against_the_key_it_belongs_to() -> None:
+    """The depth and the index, which are what an extended key records.
+
+    The levels above cannot be checked -- nothing in the key names them --
+    so what is refused is a path that does not end at this key: another
+    length, or another index at the right depth. A master key is the one
+    whose fingerprint is checkable, and it is checked.
+    """
+    with pytest.raises(BTClibValueError, match="2 levels for a key at depth 3"):
+        KeyGroup(1, _XPUBS[:1], origins=[BIP32KeyOrigin(_FINGERPRINT, "m/48h/0h")])
+    with pytest.raises(BTClibValueError, match="it ends at 0h, and the key's own"):
+        KeyGroup(1, _XPUBS[:1], origins=[BIP32KeyOrigin(_FINGERPRINT, "m/48h/0h/0h")])
+    with pytest.raises(BTClibValueError, match="own fingerprint is"):
+        KeyGroup(1, [_ROOT], origins=[BIP32KeyOrigin("deadbeef", "m")])
+    # the root key with its own origin is the empty path, and passes
+    assert KeyGroup(1, [_ROOT], origins=[BIP32KeyOrigin(_FINGERPRINT, "m")]).origins
+
+    with pytest.raises(BTClibValueError, match="2 origins for 3 keys"):
+        KeyGroup(2, _XPUBS, origins=_ORIGINS[:2])
+    # no origin at all is the default, and it is one None per key rather
+    # than an empty tuple: the pairing is positional
+    assert KeyGroup(2, _XPUBS).origins == (None,) * len(_XPUBS)
+
+
+def test_the_updaters_refuse_a_position_or_a_psbt_index_they_have_not() -> None:
+    """An IndexError out of a public method is not an answer.
+
+    Nor is the input at the other end, which a negative index would
+    quietly update instead.
+    """
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS, origins=_ORIGINS)], "p2wsh", "derived")
+    psbt = _psbt_spending(wallet.script_pub_key())
+
+    with pytest.raises(BTClibValueError, match="invalid input index: 1"):
+        wallet.update_psbt_input(psbt, 1)
+    with pytest.raises(BTClibValueError, match="invalid input index: -1"):
+        wallet.update_psbt_input(psbt, -1)
+    with pytest.raises(BTClibValueError, match="invalid output index: 1"):
+        wallet.update_psbt_output(psbt, 1)
+    with pytest.raises(BTClibValueError, match="invalid output index: -1"):
+        wallet.update_psbt_output(psbt, -1)
+    for method in (wallet.update_psbt_input, wallet.update_psbt_output):
+        with pytest.raises(BTClibValueError, match="invalid branch: 2"):
+            method(psbt, 0, 2, 0)


### PR DESCRIPTION
`DescriptorWallet` has `update_psbt_input` and `update_psbt_output`;
`ScriptWallet` had neither, so a caller spending a script outside
BIP380-390 wrote those psbt fields by hand — the witness script under
each input, and, under every key of that script, the origin a hardware
signer derives its own key from. Both are what the wallet has computed
anyway: `redeem_script` and `witness_script` are the two pre-images, and
the keys are the ones the template writes into the script. What was left
to the caller was the writing, not the knowing.

## What this adds

| call | writes |
|---|---|
| `ScriptWallet.update_psbt_input(psbt, vin_i, branch, index)` | the pre-image the output commits to, and `hd_key_paths` |
| `ScriptWallet.update_psbt_output(psbt, vout_i, branch, index)` | the same fields, after checking the output pays that very script |
| `KeyGroup(threshold, keys, verify, origins)` | nothing — it is where an origin is declared |

Both return a copy and leave the psbt handed in alone, as
`Descriptor.update_psbt_input` does. Neither writes the `b""` of a script
type that has no such pre-image: a native p2wsh has no redeem script, and
writing the empty answer back would clear whatever an earlier Updater had
put there. The key paths are merged rather than replaced, BIP174 keying
them by public key.

## An Updater is not a signer

The class docstring said the psbt Updaters were outside for the reason
`satisfy` is, and only the second half of that holds: no language says
what satisfies such a script, so the satisfaction stays the caller's and
`psbt.finalize` reaches an input of this shape through the `solver` its
caller passes. The Updater needs none of that — it writes what the
position *is*, not how it is spent — so it is here, and the docstring now
says which of the two is which.

The output half refuses unless the output being paid is the very script
the position derives, exactly as `Descriptor.update_psbt_output` does:
marking an output as one's own is a claim about where money goes, and the
whole script is the only evidence for it — never a key origin whose
four-byte fingerprint matches, which is what `position_of` says. What it
writes is every key of the template and not the quorum a spend would use:
an output is not a signing instruction, and a reader wants the whole
script, the timelocked branch nobody is spending included.

## Where an origin comes from, and what checks it

`KeyGroup(threshold, keys, origins=[...])` takes one entry per key, in
the order the keys are given, `None` for a key whose origin the caller
does not have; a group given none writes no `hd_key_paths` at all, which
is what a psbt of such a wallet then lacks. It has to be given because an
account key cannot supply it: BIP174 carries the master fingerprint and
the path from the master key down, and an extended key below the root
records neither — the same reason `descriptors.account_descriptors` takes
the fingerprint beside the key.

What the key *does* record is checked, at declaration rather than on the
way into a psbt:

- its depth against the path's length — a path of another length does not
  end at this key;
- its own index against the path's last step — another key at the same
  depth;
- for a master key, the fingerprint itself, which is the one case where
  it is computable.

The levels above cannot be checked, nothing in an extended key naming
them, which is `bip44._indexes_left_to_derive`'s bargain with the same
two facts.

What a psbt gets is the account origin with the two levels
`derive_from_account` walks appended: `[fingerprint/48h/0h/0h]` declared
becomes `fingerprint/48h/0h/0h/1/2` under the key derived at `1/2`, which
is the path a signer walks. The mapping is keyed by the derived key, so
`order="account"` — which sorts the keys of a group before deriving them
— cannot move an origin onto another participant's key; there is a test
for that, over a quorum the sort actually reorders.

## Gates

- `uv run pytest --cov`: 18453 passed, 5 skipped, coverage ratchet at 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add PSBT updating support and key origin handling to ScriptWallet for non-descriptor scripts.

New Features:
- Introduce ScriptWallet.update_psbt_input and update_psbt_output to populate PSBT scripts and key origins for wallet positions.
- Allow KeyGroup to accept per-key BIP32 key origins and propagate them into PSBT hd_key_paths for derived keys.

Enhancements:
- Validate declared key origins against their associated BIP32 keys, rejecting inconsistent paths or fingerprints.
- Preserve existing PSBT data by deep-copying and merging hd_key_paths instead of overwriting fields when updating inputs or outputs.

Documentation:
- Update ScriptWallet documentation and changelog to describe its PSBT Updater role and the use of KeyGroup origins for BIP174 key paths.

Tests:
- Add ScriptWallet tests covering PSBT input/output updating, wrapped script handling, key origin mapping and ordering, missing origins, origin validation, and index/position bounds checking.