### PR TITLE
Read the two answers Core gives about an import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,70 @@ documented at release-notes length in the first place, and are still in
   second, which is why this is a correctness fix with no behaviour to
   record.
 
+### The public API and the module layout
+
+- **`core_import` reads the two answers Core gives about an import, which
+  is what makes importing a descriptor twice idempotent** (#585). The
+  module built the requests `importdescriptors` takes and read neither
+  reply, and both of them carry something a caller cannot work out from
+  outside: `assert_imported`, `watched_range` and `widened_range` are the
+  three functions of a reply the caller already has -- still no rpc call
+  and no client, which is this module's own rule.
+
+  `assert_imported(requests, answers)` is the first.
+  `ProcessDescriptorImport` catches its own `JSONRPCError` and answers
+  `{"success": false, "error": {...}}` for that request, so
+  `importdescriptors` replies 200 with a result and the rpc layer has
+  nothing to raise: a caller not reading every element of the list goes on
+  believing the wallet watches what was asked for, and the first thing to
+  say otherwise is a balance short of a deposit. The requests are read in
+  step with the answers because an answer carries the error and not the
+  descriptor it was for, and a reply of the wrong length is itself a node
+  that did not answer this. A `BTClibRuntimeError`: the request was one
+  Core parsed, and what it refused is the state of a wallet, which no
+  argument of the caller's spells.
+
+  `widened_range(wanted, watched)` is the second, and the rule behind it
+  is why re-importing was not idempotent. Core tops any ranged descriptor
+  up to `next_index` plus its keypool -- a thousand scripts by default --
+  whatever range the request asked for, and `AddWalletDescriptor` then
+  refuses every later import that would narrow what it widened to
+  ("range must include current range"), the whole request failing on it.
+  So the range to ask for is the union of the one wanted and the one
+  already there, and `DEFAULT_RANGE` stands in for a descriptor the wallet
+  does not hold yet -- what Core would widen a first import to anyway, and
+  asking for it makes the reply state which indexes were imported instead
+  of leaving them to be assumed. A node whose keypool is not the default
+  needs no allowance: whatever it widened to is what the next
+  `listdescriptors` says.
+
+  `watched_range(descriptor, reply)` is what reads that, and reads it past
+  two normalizations. The entry echoes the checksum Core computed and the
+  hardening symbol Core was *given*, so a wallet imported by another tool
+  holds the same descriptor spelled with apostrophes: compared literally
+  it is a descriptor never seen, and the import that follows is the one
+  Core refuses. By text and not by `parse`, which would be the stronger
+  comparison and the wrong one -- an entry is any descriptor that wallet
+  holds, a `<0;1>` multipath step among them, and a lookup that raises
+  over another entry answers nothing about the one asked about. The answer
+  is the union of the entries that match, a wallet being allowed to hold
+  one expression as both of its chains while `listdescriptors`
+  distinguishes them by `internal` for an active descriptor alone.
+
+  Every one of those claims is about Core and about nothing in this
+  library, so a unit test can only restate them:
+  `tests/integration/regtest_test.py` asks a node instead -- an import of
+  one index comes back widened to [0, 999], the import that would narrow
+  it is refused inside the reply, and the same wanted range widened by
+  what the wallet answered goes through. Green against Bitcoin Core
+  v31.1.0.
+
+  `import_request`'s range checks moved into `_assert_key_range` on the
+  way, `widened_range` refusing the range it is *given* rather than the
+  one it computes: an inverted `(20, 5)` unioned with the keypool is a
+  valid range and not the one asked for, which would be a caller's
+  arithmetic reported as a successful import of something else.
+
 ### Descriptors and miniscript
 
 - **A tr() script tree is bounded at 128 nesting levels** (#571).

--- a/btclib/core_import.py
+++ b/btclib/core_import.py
@@ -48,21 +48,43 @@ the second element of a two-element step as the internal descriptor, while
 `descriptors.parse` refuses a ``<a;b>`` step outright and
 `multipath_descriptors` is what expands one. So the pair of requests is
 what this module has, and it says the same thing in two objects.
+
+Two of Core's answers are read here too, for the reason the requests are
+built here: both are knowledge of how the node behaves rather than of the
+protocol, and neither needs a node to be reached, being a function of a
+reply the caller already has. `assert_imported` reads what
+`importdescriptors` answered, which reports a refusal inside the reply
+instead of failing the call. `watched_range` reads what `listdescriptors`
+answered, and `widened_range` turns it into the range a second import may
+ask for: Core widens any ranged import to its keypool and then refuses
+every later one that would narrow what it widened to, so importing the
+same descriptor twice is idempotent only for a caller that asks for at
+least what is there already.
 """
 
 from __future__ import annotations
 
+# imported at runtime and not under TYPE_CHECKING, which the annotations
+# below would not need and the documentation build does: with the names
+# missing from the module, `get_type_hints` fails on the signatures using
+# them and autodoc falls back to the text of the annotation, where
+# `Descriptor` is a cross-reference with two targets -- one sphinx warning,
+# which `lint.yml` runs with -W
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from btclib.descriptors import Descriptor, add_checksum, parse
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.utils import is_integer
 
 __all__ = [
     "DEFAULT_RANGE",
     "NOW",
     "account_import_requests",
+    "assert_imported",
     "import_request",
+    "watched_range",
+    "widened_range",
 ]
 
 # what Core substitutes the current chain time for, and what a caller
@@ -124,14 +146,11 @@ def _assert_no_label(label: str, why: str) -> None:
         raise BTClibValueError(f"a {why} descriptor takes no label")
 
 
-def _range_fields(
-    key_range: tuple[int, int] | None, next_index: int | None
-) -> dict[str, Any]:
-    """Return the range fields of a request, checked against each other.
+def _assert_key_range(start: int, end: int) -> None:
+    """Refuse a range Core's ParseDescriptorRange would refuse.
 
-    Both ends of the range are inclusive, which is how Core reads them --
-    it adds one to the second itself -- and `next_index` is where the
-    wallet carries on from, so it is inside the range or it is nothing.
+    Both ends are inclusive, which is how Core reads them -- it adds one to
+    the second itself -- so an end below its start is no range at all.
 
     The two bounds are `ParseDescriptorRange`'s, which `importdescriptors`
     calls on this field: an end of 2**31 or above is "End of range is too
@@ -144,15 +163,8 @@ def _range_fields(
     A rule of Core's that is deliberately not repeated: every numeric
     field arrives through `UniValue::getInt<int64_t>`, which refuses what
     does not fit. After the bounds above, `start` and `end` are inside
-    [0, 2**31) and `next_index` is between them, so nothing here can
-    reach it.
+    [0, 2**31), so nothing here can reach it.
     """
-    if key_range is None:
-        if next_index is not None:
-            raise BTClibValueError("next_index without a range to be inside of")
-        return {}
-
-    start, end = key_range
     if not 0 <= start <= end:
         raise BTClibValueError(f"invalid range: [{start}, {end}]")
     if end >> 31:
@@ -161,6 +173,25 @@ def _range_fields(
         err_msg = f"range is too large: {end - start + 1} indexes, "
         err_msg += f"max is {_MAX_RANGE_SPAN}"
         raise BTClibValueError(err_msg)
+
+
+def _range_fields(
+    key_range: tuple[int, int] | None, next_index: int | None
+) -> dict[str, Any]:
+    """Return the range fields of a request, checked against each other.
+
+    The range is `_assert_key_range`'s, and `next_index` is where the
+    wallet carries on from, so it is inside the range or it is nothing --
+    which is the one rule of the two fields that is about the pair rather
+    than about either.
+    """
+    if key_range is None:
+        if next_index is not None:
+            raise BTClibValueError("next_index without a range to be inside of")
+        return {}
+
+    start, end = key_range
+    _assert_key_range(start, end)
     fields: dict[str, Any] = {"range": [start, end]}
     if next_index is not None:
         if not start <= next_index <= end:
@@ -269,3 +300,130 @@ def account_import_requests(
             change, timestamp, internal=True, active=active, key_range=key_range
         ),
     ]
+
+
+def _comparable(descriptor: Descriptor | str) -> str:
+    """Return the text of a descriptor as one is compared to another.
+
+    The expression without its checksum, every hardened step spelled `h`:
+    `listdescriptors` echoes the checksum Core computed and the hardening
+    symbol Core was given, and neither is a difference between two
+    descriptors describing the same scripts. An expression this library
+    wrote carries `h` already -- `str_from_index_int` writes the symbol
+    Core's own `FormatHDKeypath` writes -- and one a wallet was imported
+    with by another tool can carry apostrophes, which is the case this
+    normalization is for: read as a descriptor never seen, it would be
+    imported a second time over a range Core refuses to narrow.
+
+    `partition` and not `strip_checksum`, which verifies what it strips: an
+    entry of a wallet is any descriptor that wallet holds, including one
+    whose checksum or charset this library would refuse, and such an entry
+    is still not the descriptor being looked for -- a lookup that raises
+    over it answers nothing about the one asked about.
+    """
+    text = descriptor if isinstance(descriptor, str) else str(descriptor)
+    expression, _, _checksum = text.partition("#")
+    return expression.replace("'", "h")
+
+
+def watched_range(
+    descriptor: Descriptor | str, reply: Mapping[str, Any]
+) -> tuple[int, int] | None:
+    """Return the range of a descriptor a wallet watches, None for none.
+
+    `reply` is what `listdescriptors` answered, which is a wallet's account
+    of itself: one entry per descriptor it holds, echoing the expression it
+    was imported with and the range it ended up with. This is the question a
+    caller has to ask before importing a descriptor a second time, Core
+    refusing an import that would narrow that range, and `widened_range` is
+    what the answer is for.
+
+    None is a descriptor the wallet does not hold, and equally one it holds
+    unranged: an entry with no `range` watches one script and has no index
+    to be widened from, which is the same "nothing to include" to whoever
+    is building the next request.
+
+    The union of the entries where a wallet holds the same expression more
+    than once -- the same descriptor imported as both the receiving and the
+    change chain, which Core allows and which `listdescriptors`
+    distinguishes only for an active descriptor, `internal` being defined
+    for those alone. Asking for the union is accepted for either of them,
+    where asking for one entry's range can be a narrowing of the other's.
+    """
+    wanted = _comparable(descriptor)
+    ranges = [
+        entry["range"]
+        for entry in reply["descriptors"]
+        if _comparable(str(entry["desc"])) == wanted and "range" in entry
+    ]
+    if not ranges:
+        return None
+    return (
+        min(int(key_range[0]) for key_range in ranges),
+        max(int(key_range[1]) for key_range in ranges),
+    )
+
+
+def widened_range(
+    wanted: tuple[int, int], watched: tuple[int, int] | None = None
+) -> tuple[int, int]:
+    """Return the range to import: the one wanted, and never a narrower one.
+
+    Core widens every ranged import to its keypool -- `next_index` plus a
+    thousand scripts by default, whatever the request asked for -- and then
+    refuses any later import that would narrow what it widened to: "New
+    range must include current range" is what the second request is
+    answered, and the whole import fails on it. So a caller whose range has
+    grown asks for the union of the two, which is this, and importing a
+    descriptor again is idempotent because of it.
+
+    `watched` is what `watched_range` read of the wallet, and None is the
+    descriptor it does not hold yet: `DEFAULT_RANGE` stands in for it, that
+    being what Core widens a first import to anyway -- asking for it makes
+    the reply state which indexes were imported instead of leaving a caller
+    to assume them. A node whose keypool is not the default needs no
+    allowance here: whatever it widened to is what the next
+    `listdescriptors` says, and the union with that is what the next import
+    asks for.
+
+    What the widening costs is worth stating where it is decided: a wallet
+    watches every script of the range, so the addresses past the ones a
+    caller meant are the node's too, and money paid to one of them is money
+    that wallet reports. An import of exactly what is meant, and no
+    keypool, is what an unranged descriptor per script is for.
+    """
+    start, end = wanted
+    _assert_key_range(start, end)
+    watched_start, watched_end = DEFAULT_RANGE if watched is None else watched
+    return (min(start, watched_start), max(end, watched_end))
+
+
+def assert_imported(
+    requests: Sequence[Mapping[str, Any]], answers: Sequence[Mapping[str, Any]]
+) -> None:
+    """Refuse an `importdescriptors` reply that did not honour every request.
+
+    Core answers one object per request instead of failing the call, so a
+    request it did not honour arrives as `success: false` inside what the
+    rpc layer calls a reply -- a result, which nothing under the caller has
+    any reason to doubt. Left unread, a wallet goes on watching less than
+    its owner believes it does, and the first thing to say so is a balance
+    short of a deposit.
+
+    The request is what names the failure: an answer carries the error and
+    not the descriptor it was for, so the two are read in step, and a reply
+    of the wrong length is itself a node that did not answer this.
+
+    `warnings` is not read, that being what Core says about a request it
+    did honour -- "Range not given, using default keypool range" is the one
+    `DEFAULT_RANGE` exists to avoid -- and neither is a refusal turned into
+    a value error: the request was one Core parsed, and what it refused is
+    the state of a wallet, which no argument of the caller's spells.
+    """
+    if len(requests) != len(answers):
+        err_msg = f"{len(requests)} import requests, {len(answers)} answers"
+        raise BTClibRuntimeError(err_msg)
+    for request, answer in zip(requests, answers, strict=True):
+        if not answer.get("success"):
+            err_msg = f"import refused for {request.get('desc')}: {answer.get('error')}"
+            raise BTClibRuntimeError(err_msg)

--- a/tests/core_import_test.py
+++ b/tests/core_import_test.py
@@ -15,6 +15,11 @@ which is what the citations in the module docstring are for.
 Every request built here is checked to be json, because that is what it is
 for: a dict Python is happy with and `json.dumps` refuses is a request
 that fails at the rpc boundary rather than here.
+
+The replies read back are Core's too, `listdescriptors` and
+`importdescriptors` as their help declares them; what a node really
+answers, and what it does with a range it was asked for, is
+`tests/integration/regtest_test.py`, where a node is what says so.
 """
 
 from __future__ import annotations
@@ -28,7 +33,10 @@ from btclib.core_import import (
     DEFAULT_RANGE,
     NOW,
     account_import_requests,
+    assert_imported,
     import_request,
+    watched_range,
+    widened_range,
 )
 from btclib.descriptors import (
     Descriptor,
@@ -37,7 +45,7 @@ from btclib.descriptors import (
     from_address,
     parse,
 )
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 
 # the "abandon abandon ... about" root of BIP39, which BIP84 publishes:
 # the same key `tests/bip44_test.py` walks, so the account descriptors
@@ -268,3 +276,163 @@ def test_the_pair_passes_its_arguments_through() -> None:
         assert request["timestamp"] == 1455191478
         assert request["active"] is False
         assert request["range"] == [3, 8]
+
+
+def listed(*entries: dict[str, Any]) -> dict[str, Any]:
+    """Return the entries as the reply `listdescriptors` wraps them in.
+
+    A wallet name and the list, which is the shape of the answer and the
+    reason the whole reply is what is passed: a caller hands on what the
+    node said rather than the one field of it that is read.
+    """
+    return {"wallet_name": "watcher", "descriptors": list(entries)}
+
+
+def entry(
+    descriptor: Descriptor | str, key_range: list[int] | None = None, **fields: Any
+) -> dict[str, Any]:
+    """Return one entry of that reply, checksummed as Core echoes it."""
+    text = descriptor if isinstance(descriptor, str) else str(descriptor)
+    listing: dict[str, Any] = {
+        "desc": add_checksum(text),
+        "timestamp": 1455191478,
+        "active": False,
+        **fields,
+    }
+    if key_range is not None:
+        listing["range"] = key_range
+        listing["next"] = 0
+    return listing
+
+
+def test_a_descriptor_the_wallet_does_not_hold_has_no_watched_range() -> None:
+    """Which is the descriptor about to be imported for the first time."""
+    receive, change = account_pair()
+    assert watched_range(receive, listed()) is None
+    assert watched_range(receive, listed(entry(change, [0, 999]))) is None
+
+
+def test_the_watched_range_is_matched_past_the_checksum_and_the_hardening() -> None:
+    """Core echoes the checksum it computed and the symbol it was given.
+
+    A wallet imported by another tool can hold the very same descriptor
+    spelled with apostrophes: read as one never seen, it would be imported
+    again over a range Core refuses to narrow, which is a failed import
+    rather than a wrong number -- and the failure is of the whole request.
+    """
+    receive = account_pair()[0]
+    apostrophes = str(receive).replace("h/", "'/")
+    assert apostrophes != str(receive)
+
+    assert watched_range(receive, listed(entry(apostrophes, [0, 999]))) == (0, 999)
+    # the text of a descriptor asks the same question as the object does,
+    # a checksum on either side being no part of the comparison
+    assert watched_range(str(receive), listed(entry(receive, [0, 5]))) == (0, 5)
+    # and an entry this library would refuse to parse is another
+    # descriptor's, not an answer to the question asked
+    multipath = str(receive).replace("/0/*", "/<0;1>/*")
+    assert watched_range(receive, listed(entry(multipath, [0, 999]))) is None
+
+
+def test_an_unranged_entry_watches_one_script_and_no_range() -> None:
+    """So there is nothing for the next import to have to include."""
+    address = from_address(ADDRESS)
+    assert watched_range(address, listed(entry(address))) is None
+
+
+def test_the_watched_range_is_the_union_of_the_entries_that_match() -> None:
+    """A wallet can hold one expression twice, as both of its chains.
+
+    `listdescriptors` tells the two apart by `internal`, which Core defines
+    for an active descriptor alone, so which entry an import is checked
+    against is not always readable: the union is the range that no entry
+    can be narrowed by.
+    """
+    receive = account_pair()[0]
+    reply = listed(
+        entry(receive, [0, 999], active=True, internal=False),
+        entry(receive, [5, 1500], active=True, internal=True),
+    )
+    assert watched_range(receive, reply) == (0, 1500)
+
+
+def test_a_first_import_asks_for_the_keypool_core_would_widen_it_to() -> None:
+    """A range narrower than the keypool is a range Core overrides.
+
+    Asked for, the reply states which indexes were imported; left to Core,
+    the caller has a warning to read and a keypool size to assume.
+    """
+    assert widened_range((0, 0)) == DEFAULT_RANGE
+    assert widened_range((0, 0), None) == DEFAULT_RANGE
+    # and a caller wanting more than the keypool gets what it wanted
+    assert widened_range((0, 1500)) == (0, 1500)
+
+
+def test_a_later_import_asks_for_the_union_with_what_is_watched() -> None:
+    """Core's refusal is "New range must include current range", avoided here.
+
+    The committed span grows, the wallet's range only grows with it, and an
+    import of a span already inside the range is not a narrowing of it.
+    """
+    assert widened_range((0, 1500), (0, 999)) == (0, 1500)
+    assert widened_range((0, 0), (0, 1500)) == (0, 1500)
+    assert widened_range((0, 1500), (0, 1500)) == (0, 1500)
+    # both ends, an entry imported from an index that is not zero being
+    # one this has to include too
+    assert widened_range((7, 20), (5, 30)) == (5, 30)
+    # a node whose keypool is under Core's default needs no allowance: what
+    # it widened to is what is measured, and the union with it is asked for
+    assert widened_range((0, 3), (0, 499)) == (0, 499)
+
+
+def test_the_range_wanted_is_the_one_a_request_would_be_refused_for() -> None:
+    """Refused where it is written, and not where min and max hide it.
+
+    An inverted range unioned with the keypool is a valid range and not the
+    one asked for, which is a caller's arithmetic gone wrong reported as a
+    successful import of something else.
+    """
+    with pytest.raises(BTClibValueError, match=r"invalid range: \[20, 5\]"):
+        widened_range((20, 5))
+    with pytest.raises(BTClibValueError, match="end of range is too high"):
+        widened_range((0, 2**31))
+    with pytest.raises(BTClibValueError, match="range is too large"):
+        widened_range((0, 1_000_000))
+
+
+def test_an_import_the_node_refused_is_not_read_as_one_it_did() -> None:
+    """`importdescriptors` reports a refusal inside a reply of its own.
+
+    A wallet that imported nothing goes on answering every balance with
+    what it does watch, so the deposit it never heard of is missing from a
+    number nobody has reason to doubt: the reply is the one place that says
+    so, and the request is what names which descriptor it was.
+    """
+    requests = account_import_requests(*account_pair())
+    assert_imported(requests, [{"success": True}, {"success": True}])
+    # warnings are what Core says about a request it did honour
+    assert_imported(requests, [{"success": True, "warnings": ["odd"]}] * 2)
+
+    refused: list[dict[str, Any]] = [
+        {"success": True},
+        {"success": False, "error": {"message": "no"}},
+    ]
+    with pytest.raises(BTClibRuntimeError, match="import refused for wpkh"):
+        assert_imported(requests, refused)
+    with pytest.raises(BTClibRuntimeError, match="'message': 'no'"):
+        assert_imported(requests, refused)
+    # an answer that says nothing is not one that said yes
+    with pytest.raises(BTClibRuntimeError, match="import refused"):
+        assert_imported(requests, [{}, {}])
+
+
+def test_a_reply_of_the_wrong_length_answered_something_else() -> None:
+    """One answer per request is the shape of the reply, and the check.
+
+    Read in step with anything else, the answers name the wrong
+    descriptors -- an import refused for the change chain reported as one
+    refused for the receiving chain.
+    """
+    requests = account_import_requests(*account_pair())
+    with pytest.raises(BTClibRuntimeError, match="2 import requests, 1 answers"):
+        assert_imported(requests, [{"success": True}])

--- a/tests/integration/regtest_test.py
+++ b/tests/integration/regtest_test.py
@@ -10,6 +10,9 @@ counterparty is the one that decides:
 - `descriptors.account_descriptors` builds the pair, and Bitcoin Core
   imports it through `core_import.account_import_requests` — so Core's
   own parser, checksum rule and range handling are what accept it;
+- and the range handling is the node's alone: `core_import.widened_range`
+  claims Core widens a ranged import to its keypool and then refuses to be
+  narrowed, which nothing but a node can confirm;
 - Core derives the addresses of that account itself and pays one, so the
   scripts btclib computes are the scripts Core watches;
 - btclib builds the psbt, updates both halves, and
@@ -34,7 +37,15 @@ from bitcoin_core_rpc import BitcoinCoreRpcClient
 
 from btclib.amount import sats_from_btc
 from btclib.bip32.bip32 import rootxprv_from_seed
-from btclib.core_import import account_import_requests
+from btclib.core_import import (
+    DEFAULT_RANGE,
+    account_import_requests,
+    assert_imported,
+    import_request,
+    watched_range,
+    widened_range,
+)
+from btclib.exceptions import BTClibRuntimeError
 from btclib.network import NETWORKS
 from btclib.psbt_signer import SoftwareSigner, export_account, request_signatures
 from tests.integration.conftest import as_regtest, broadcast, fund, spending_psbt
@@ -55,6 +66,7 @@ ROOT = rootxprv_from_seed("0f" * 16, NETWORKS["regtest"].bip32_prv)
 # then answers for the test that asked
 RELAY_ACCOUNT = "m/84h/1h/0h"
 DECODE_ACCOUNT = "m/84h/1h/1h"
+RANGE_ACCOUNT = "m/84h/1h/2h"
 
 
 def test_core_imports_what_btclib_exports_and_relays_what_it_signs(
@@ -105,6 +117,53 @@ def test_core_imports_what_btclib_exports_and_relays_what_it_signs(
     # and Core names the path it came down: the change chain, index zero,
     # which is the descriptor imported as `internal`
     assert "/1/0]" in change_utxo[0]["desc"]
+
+
+def test_core_widens_a_range_to_its_keypool_and_refuses_to_be_narrowed(
+    wallets: tuple[BitcoinCoreRpcClient, BitcoinCoreRpcClient],
+) -> None:
+    """The rule `widened_range` is written against, with the node as judge.
+
+    Every claim of that docstring is a claim about Core and about nothing
+    in this library: it widens a ranged import to its keypool whatever
+    range was asked for, it refuses any later import that would narrow
+    what it widened to, and the refusal arrives as `success: false` inside
+    a reply rather than as a failed call. A unit test can only restate
+    them; this is what can be wrong about them.
+    """
+    watcher = wallets[1]
+    receive = export_account(SoftwareSigner(ROOT), RANGE_ACCOUNT)[0]
+
+    # nothing is watched before the first import
+    assert watched_range(receive, watcher.call("listdescriptors")) is None
+
+    # which asks for one index, and Core widens it to a keypool's worth
+    one = import_request(receive, active=False, key_range=(0, 0))
+    assert_imported([one], watcher.call("importdescriptors", [[one]]))
+    watched = watched_range(receive, watcher.call("listdescriptors"))
+    assert watched == DEFAULT_RANGE
+    # so `widened_range` asks for that from the start, and the reply then
+    # states the indexes the caller would otherwise have to assume
+    assert widened_range((0, 0)) == watched
+
+    # a span grown past the keypool is imported over the union of the two
+    wider = import_request(receive, active=False, key_range=widened_range((0, 1500)))
+    assert_imported([wider], watcher.call("importdescriptors", [[wider]]))
+    watched = watched_range(receive, watcher.call("listdescriptors"))
+    assert watched == (0, 1500)
+
+    # and the import that would narrow it back is refused, inside a reply
+    narrow = import_request(receive, active=False, key_range=(0, 999))
+    with pytest.raises(BTClibRuntimeError, match="import refused for wpkh"):
+        assert_imported([narrow], watcher.call("importdescriptors", [[narrow]]))
+    # where the same wanted range, widened by what the wallet answered, is
+    # the import that goes through: a span already inside the range is
+    # nothing left to import, and not a narrowing of it
+    again = import_request(
+        receive, active=False, key_range=widened_range((0, 999), watched)
+    )
+    assert_imported([again], watcher.call("importdescriptors", [[again]]))
+    assert watched_range(receive, watcher.call("listdescriptors")) == watched
 
 
 def test_the_change_output_is_what_the_node_calls_change(


### PR DESCRIPTION
Closes #585.

`btclib.core_import` built the requests `importdescriptors` takes and read
neither answer Core gives back. Three functions of a reply the caller
already has — still no rpc call and no client, which is the module's own
rule — and importing the same descriptor twice becomes idempotent instead
of a failed import.

## `assert_imported(requests, answers)`

`ProcessDescriptorImport` catches its own `JSONRPCError` and returns
`{"success": false, "error": {...}}` for that request, so
`importdescriptors` replies 200 with a result and the rpc layer has
nothing to raise. A caller not reading every element of the list goes on
believing the wallet watches what was asked for, and the first thing to
say otherwise is a balance short of a deposit.

Requests are read in step with the answers, because an answer carries the
error and not the descriptor it was for, and a reply of the wrong length
is itself a node that did not answer this. A `BTClibRuntimeError`: the
request was one Core parsed, and what it refused is the state of a wallet,
which no argument of the caller's spells. `warnings` is not read, being
what Core says about a request it *did* honour.

## `widened_range(wanted, watched)`

Core tops any ranged descriptor up to `next_index` plus its keypool — a
thousand scripts by default — whatever range the request asked for, and
`AddWalletDescriptor` then refuses every later import that would narrow
what it widened to ("range must include current range"), failing the whole
request. So the range to ask for is the union of the one wanted and the
one already there.

`DEFAULT_RANGE` stands in for a descriptor the wallet does not hold yet:
what Core would widen a first import to anyway, and asking for it makes
the reply state which indexes were imported instead of leaving them to be
assumed. A node whose keypool is not the default needs no allowance —
whatever it widened to is what the next `listdescriptors` says.

The widening costs what the docstring now says it costs: the wallet
watches every script of the range, so addresses past the ones a caller
meant are the node's too, and money paid to one of them is money that
wallet reports.

## `watched_range(descriptor, reply)`

Reads that range out of `listdescriptors`, past two normalizations. The
entry echoes the checksum Core computed and the hardening symbol Core was
*given*, so a wallet imported by another tool holds the same descriptor
spelled with apostrophes: compared literally it is a descriptor never
seen, and the import that follows is the one Core refuses.

By text and not by `parse`, which would be the stronger comparison and the
wrong one here — an entry is any descriptor that wallet holds, a `<0;1>`
multipath step among them, and a lookup that raises over another entry
answers nothing about the one asked about. The answer is the union of the
entries that match, a wallet being allowed to hold one expression as both
of its chains while `listdescriptors` distinguishes them by `internal` for
an active descriptor alone.

## The node is what says so

Every claim above is about Core and about nothing in this library, so a
unit test can only restate it. `tests/integration/regtest_test.py` asks a
node instead: an import asking for `(0, 0)` comes back widened to
`[0, 999]`, the import that would narrow it is refused inside the reply,
and the same wanted range widened by what the wallet answered goes
through. Green against Bitcoin Core v31.1.0; `core_import.py` is already
on `integration.yml`'s paths filter (#570), so a pull request touching it
asks a node.

## What it cost

`import_request`'s range checks moved into `_assert_key_range`, so
`widened_range` refuses the range it is *given* rather than the one it
computes: an inverted `(20, 5)` unioned with the keypool is a valid range
and not the one asked for, which would be a caller's arithmetic reported
as a successful import of something else.

`Mapping` and `Sequence` are imported at runtime rather than under
`TYPE_CHECKING`, with the reason in a comment: without them in the module,
`get_type_hints` fails on the signatures using them, autodoc falls back to
the text of the annotation, and `Descriptor` is then a cross-reference
with two targets — one warning, and `lint.yml` runs sphinx with `-W`.

Local gates: `pre-commit run --all-files`, the suite at 100% coverage,
sphinx with `-W`, and `BTCLIB_INTEGRATION=1 pytest tests/integration`
against v31.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make descriptor imports idempotent by interpreting Bitcoin Core descriptor import replies and aligning requested ranges with what the node already watches.

New Features:
- Expose helper functions to read descriptor import/list replies (`assert_imported`, `watched_range`, `widened_range`) from existing Core RPC responses without adding new RPC calls.

Bug Fixes:
- Ensure failed `importdescriptors` entries are surfaced as runtime errors instead of silently treating them as successful, preventing wallets from missing watched descriptors.
- Avoid second descriptor imports failing due to Core's range-widening rules by adjusting requested ranges to include the wallet's current watched range.

Enhancements:
- Refactor range validation into `_assert_key_range` to clarify and centralize descriptor key-range checks.
- Import `Mapping` and `Sequence` at runtime to keep Sphinx type hint introspection and documentation builds warning-free.

Documentation:
- Document the new descriptor import behaviour and helper functions in the changelog, including Core's range-widening and error-reporting semantics.

Tests:
- Add unit tests for `watched_range`, `widened_range`, and `assert_imported` covering normalization, range union, and failure handling.
- Extend integration tests against Bitcoin Core to verify actual range widening, refusal of narrowed ranges, and idempotent re-imports.