### PR TITLE
Lift a ScriptWallet branch back into the descriptor it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,61 @@ documented at release-notes length in the first place, and are still in
   and, for a master key, the fingerprint itself -- so an origin that
   would send a signer to derive another key is refused where it is
   declared rather than written into a psbt.
+- **`ScriptWallet.descriptor(branch)` is the bridge to `DescriptorWallet`,
+  where a template turns out to have a descriptor after all.** The two
+  classes were sister sources of addresses with nothing between them, and
+  a caller holding the older one had no answer to "what do I hand a
+  monitor, or `importdescriptors`, for this wallet" -- while a good half
+  of the wallets that need a template need it for one detail of the
+  script and are sayable in BIP380 to BIP390 apart from it.
+
+  Built by lifting rather than by writing, which is what keeps it honest
+  about shapes this code has never seen: the wallet derives its own script
+  at index 0, `miniscript.from_script` reads those bytes back into the
+  expression they are, each derived key is traded for the ranged KEY
+  expression that produced it -- `[fingerprint/path]xpub/branch/*`, the
+  origin being the one its `KeyGroup` declares, the same one the psbt
+  Updater above writes -- and the text goes through `descriptors.parse`.
+  So the answer is the descriptor a reader of that text gets, not an
+  object assembled here,
+  and it is confirmed before it is handed back: the scripts it derives are
+  compared with the template's at `checked_indexes` positions, two being
+  the floor because index 0 is where the expression was read and a key
+  left as the hex it was derived to writes the right script exactly there.
+  A caller with a committed span of addresses to stand behind passes its
+  length instead.
+
+  A template that is a single `KeyGroup` and nothing else does not go
+  through miniscript at all: it is BIP383's quorum, so it is stated for
+  every order this class has -- `sortedmulti()` for the per-index one,
+  which is what that function follows, and `multi()` for the other two --
+  and in a legacy `sh()` too, where no miniscript could be read for want
+  of a context. `sh(sortedmulti(2,...))` is the pre-descriptor multisig
+  wallet, and it now comes back out of one.
+
+  `NoDescriptorError` is new in `btclib.exceptions` and is what the
+  refusals raise: the `<n> OP_CSV OP_DROP` timelock no fragment emits, a
+  quorum ordered after derivation *inside* a combinator, a legacy script
+  that is not a bare quorum, and an expression a descriptor may not hold
+  at all -- Bitcoin Core refusing an insane one, which is a wallet with no
+  safe spend rather than a text that failed to parse. It derives from
+  `BTClibValueError`, so `except BTClibValueError` around either half
+  keeps working, and it exists because those refusals are facts about the
+  wallet that will still hold at the next release: a caller catching one
+  watches the addresses instead, where a caller catching a parse failure
+  files a bug. A lift that was not faithful is the other outcome and is a
+  `BTClibRuntimeError`, that being this code's failure and not the
+  caller's wallet.
+
+  The deployment in `tests/descriptors/custody_wallet_test.py` is what
+  says the lift is right rather than merely plausible: the ranged shape of
+  a mainnet custody design, written as a template naming no `andor`, no
+  `or_i` and no `older`, lifts back to the very descriptor text that
+  custodian imports -- checksum included, for both wallets, both chains
+  and two independent deployments -- while the plain shape beside it
+  refuses. `ScriptWallet` gains no `from_script` and still has no text
+  format of its own; the direction that was refused for being ambiguous is
+  the one that stays refused.
 
 ## v2026.8.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -354,10 +354,15 @@ documented at release-notes length in the first place, and are still in
   A template that is a single `KeyGroup` and nothing else does not go
   through miniscript at all: it is BIP383's quorum, so it is stated for
   every order this class has -- `sortedmulti()` for the per-index one,
-  which is what that function follows, and `multi()` for the other two --
-  and in a legacy `sh()` too, where no miniscript could be read for want
-  of a context. `sh(sortedmulti(2,...))` is the pre-descriptor multisig
-  wallet, and it now comes back out of one.
+  which is BIP67 on the derived keys and what that function follows
+  exactly, and `multi()` for the other two -- and in a legacy `sh()` too,
+  where no miniscript could be read for want of a context.
+  `sh(sortedmulti(2,...))` is the pre-descriptor multisig wallet, and it
+  now comes back out of one. A per-index `sort_key` of the caller's own is
+  the exception, and is refused with the combinator: it is a third order,
+  which `sortedmulti()` does not state and `multi()` cannot: a key
+  function that happens to agree with byte order at every index is not
+  something this could know.
 
   `NoDescriptorError` is new in `btclib.exceptions` and is what the
   refusals raise: the `<n> OP_CSV OP_DROP` timelock no fragment emits, a

--- a/README.md
+++ b/README.md
@@ -154,7 +154,9 @@ Included features are:
   the private key that signs for an address — what `sign(address, msg)`
   needs — an output descriptor per chain, and a script template with
   multisig quorums in it, for the pre-descriptor wallets no descriptor
-  states. Each answers `address(branch, index)`,
+  states — and, for the ones that turn out to have a descriptor after all,
+  the ranged descriptor lifted out of the script itself, confirmed against
+  the addresses it derives. Each answers `address(branch, index)`,
   `script_pub_key(branch, index)` and `position_of(script_pub_key)`, the
   last being "is this output mine", compared whole and never on a key
   origin's fingerprint

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -49,6 +49,7 @@ __all__ = [
     "InconclusiveError",
     "InvalidContributionError",
     "InvalidPrvKeyError",
+    "NoDescriptorError",
     "NotAPrvKeyError",
     "RpcError",
     "ScriptError",
@@ -263,6 +264,24 @@ class InconclusiveError(BTClibValueError):
     so that `btclib.bip322.verify` answers False without a second
     `except`: an inconclusive signature is not one that verified. A
     caller that means to tell the two apart names this class.
+    """
+
+
+class NoDescriptorError(BTClibValueError):
+    """No output descriptor states this script: it is not that a lift failed.
+
+    What `wallet.ScriptWallet.descriptor` refuses with, and the one
+    refusal there that is a fact about the wallet rather than about the
+    code asking: a script spelling its timelock `<n> OP_CSV OP_DROP`, or
+    ordering a quorum after derivation inside a combinator, is a script
+    BIP380 to BIP390 cannot write down -- and will still be one at the
+    next release. A caller catching this has an answer ("watch these
+    addresses instead"), where a caller catching a parse failure has a
+    bug report.
+
+    A BTClibValueError, so code catching that keeps catching this: the
+    refusal it most often stands in front of is
+    `miniscript.from_script`'s, which is one.
     """
 
 

--- a/btclib/wallet/__init__.py
+++ b/btclib/wallet/__init__.py
@@ -25,8 +25,12 @@ after:
   pair off BIP389's ``<0;1>`` spelling, and delegates the spend to it;
 - `script_wallet` is `ScriptWallet`, a script template with `KeyGroup`
   quorums in it, for the wallets no descriptor states -- and it imports
-  `descriptor_wallet` not at all, having no descriptor in it and no
-  business gaining one.
+  `descriptor_wallet` not at all, a wallet of templates being no wallet of
+  descriptors. What it does reach for is `btclib.descriptors`, one layer
+  below both: `ScriptWallet.descriptor` lifts the script of a branch back
+  into the expression it is, where there is one, so the wallets that
+  turned out to have a descriptor after all can be handed to a monitor
+  and the rest say so with `NoDescriptorError`.
 
 The flat surface is this package's: the classes above are read off
 `btclib.wallet`, the four modules being where they are written rather

--- a/btclib/wallet/script_wallet.py
+++ b/btclib/wallet/script_wallet.py
@@ -46,11 +46,30 @@ worse descriptor language is how this feature goes wrong, and a wallet
 that cannot be written down cannot be mistaken for one that can be
 handed to Bitcoin Core.
 
-**Not liftable, in either direction.** No `from_script`, and no
-`to_descriptor`. A wallet that a descriptor states should be one --
-`DescriptorWallet.from_descriptor` is where it goes -- and this class is for the
-ones no descriptor states; offering a conversion would re-open the
-ambiguity that refusing the script closes.
+**No `from_script`.** A template is not recoverable from a script: the
+bytes at one position say which keys are in it and not which account keys
+derived them, so a class reading one back would be guessing, and guessing
+is the parser this module refuses to have.
+`DescriptorWallet.from_descriptor` is where a wallet written down in
+BIP380's language is read.
+
+**`descriptor(branch)` is the other direction, and it is a lift rather
+than a conversion.** No shape is spelled out for it: the wallet derives
+its own script at index 0, `miniscript.from_script` reads those bytes
+back into the expression they are, each derived key is put back as the
+KEY expression that produced it -- `[fingerprint/path]xpub/branch/*` --
+and the text goes through `descriptors.parse`, so what comes back is the
+descriptor a reader of that text gets and not an object of this module's
+own making. A shape this file has never heard of therefore comes out
+right, and the two shapes this class exists for come out not at all:
+`NoDescriptorError` for the `OP_DROP` timelock, which is no miniscript,
+and for a quorum ordered per index inside a combinator, which no ranged
+expression covers. Nothing is guessed and nothing is approximated, which
+is what the old "no conversion either way" was guarding against, and the
+guard is now the check rather than the absence: the addresses the
+descriptor derives are compared with the wallet's own before it is handed
+back, so a lift that was not faithful is an exception and not a
+descriptor.
 
 **Not a signer, and an Updater.** `DescriptorWallet.satisfy` can assemble
 a spend because miniscript knows what satisfies a fragment; a template
@@ -68,7 +87,9 @@ one: BIP174 carries the master fingerprint and the path from the master
 key down, and an extended key below the root records neither -- the same
 reason `descriptors.account_descriptors` takes the fingerprint beside the
 key. A group given no origin is a wallet that computes addresses and
-writes no `hd_key_paths`, which is what a psbt of it then lacks.
+writes no `hd_key_paths`, which is what a psbt of it then lacks -- and
+what the `[fingerprint/path]` of its descriptor then lacks too, the two
+being one declaration read twice rather than two places to say it.
 
 **The order is a parameter because deployed wallets disagree about it**,
 and one of the three is why this class exists at all:
@@ -80,7 +101,9 @@ and one of the three is why this class exists at all:
   *inside* a combinator is nothing, BIP379 having no `sortedmulti`
   fragment and its `multi()` being the declared-order one. A timelocked
   branch is therefore where the order stops being expressible, which is
-  the wallet #538 pins and the reason for this parameter;
+  the wallet #538 pins and the reason for this parameter -- and the line
+  `descriptor()` draws: one quorum and nothing else is a
+  ``sortedmulti()``, the same quorum inside a combinator is nothing;
 - `"account"` sorts the account keys once, before deriving, so the order
   is fixed and `multi()` states it by listing the keys in it. What this
   saves a caller is the sort, not an inexpressible wallet;
@@ -97,15 +120,26 @@ https://github.com/bitcoin/bips/blob/master/bip-0067.mediawiki
 
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from copy import deepcopy
+from dataclasses import replace
 from typing import Any
 
 from btclib.alias import Command, EmbeddedScriptType, KeyOrder, ScriptList
-from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, derive_from_account
+from btclib.bip32.bip32 import (
+    BIP32Key,
+    BIP32KeyData,
+    derive_from_account,
+    xpub_from_xprv,
+)
 from btclib.bip32.der_path import str_from_index_int
 from btclib.bip32.key_origin import BIP32KeyOrigin
-from btclib.exceptions import BTClibValueError
+from btclib.descriptors.descriptors import Descriptor
+from btclib.descriptors.descriptors import parse as _parse_descriptor
+from btclib.descriptors.key_expression import KeyExpression
+from btclib.descriptors.miniscript import P2WSH, Miniscript
+from btclib.descriptors.miniscript import from_script as _miniscript_from_script
+from btclib.exceptions import BTClibRuntimeError, BTClibValueError, NoDescriptorError
 from btclib.psbt.psbt import Psbt
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
@@ -152,6 +186,45 @@ def _p2sh_p2wsh(script: bytes, network: str) -> ScriptPubKey:
     other.
     """
     return ScriptPubKey.p2sh(ScriptPubKey.p2wsh(script, network).script, network)
+
+
+# how the descriptor of a script is written, per script type: the
+# expression goes where the brace is. `sh(SCRIPT)` is BIP381's and holds a
+# BIP383 quorum here and nothing else -- a miniscript is P2WSH or
+# tapscript, there being no legacy context for one to be read in
+_DESCRIPTOR_FROM_SCRIPT_TYPE: dict[EmbeddedScriptType, str] = {
+    "p2sh": "sh({})",
+    "p2wsh": "wsh({})",
+    "p2sh-p2wsh": "sh(wsh({}))",
+}
+
+# how few positions a lift may be confirmed at, and why not one: index 0
+# is where the expression was read, so a key left as the fixed hex it was
+# derived to -- the one way a substitution can miss -- writes the very
+# script that was lifted there and a different one at every other index
+_MIN_CHECKED_INDEXES = 2
+
+
+def _lifted(node: Miniscript, expressions: Mapping[bytes, KeyExpression]) -> Miniscript:
+    """Return the miniscript with each key back as the expression it came from.
+
+    The tree rebuilt bottom-up, `Miniscript` being frozen and its derived
+    fields recomputed by `__post_init__` at every `replace`: what changes
+    is the KEY expressions of `pk_k()`, `pk_h()` and `multi()`, and a key
+    the mapping does not name is left exactly as it is. That last case is
+    a script holding a key no account of this wallet derives -- a literal
+    push in the template -- and BIP380 states one as the hex it is, so the
+    honest answer is a descriptor ranged in the other keys and fixed in
+    that one.
+    """
+    return replace(
+        node,
+        subs=tuple(_lifted(sub, expressions) for sub in node.subs),
+        keys=tuple(
+            expressions.get(key.pub_key, key) if key.pub_key else key
+            for key in node.keys
+        ),
+    )
 
 
 # the script and the network in, the output out
@@ -311,6 +384,9 @@ class ScriptWallet(RangedWallet):
         # lookup typed: `Wallet.script_type` is the str every wallet
         # answers, and a str is not a key of a table keyed by the three
         self._output = _SCRIPT_PUB_KEY_FROM_SCRIPT_TYPE[script_type]
+        # and the same for the descriptor function wrapping the expression,
+        # for the same reason and in the same place
+        self._descriptor_form = _DESCRIPTOR_FROM_SCRIPT_TYPE[script_type]
         self.order = order
         self.sort_key = sort_key
         self.template = tuple(template)
@@ -564,3 +640,215 @@ class ScriptWallet(RangedWallet):
             **psbt_map.hd_key_paths,
             **self._hd_key_paths(branch, index),
         }
+    def _key_origins(self) -> dict[str, BIP32KeyOrigin]:
+        """Return the origin of each account key, keyed by its xpub.
+
+        The groups' own `origins`, which is where a caller declares them
+        and what `_hd_key_paths` writes into a psbt: one fact, read twice,
+        rather than a second place to say it. Keyed by the neutered
+        spelling because that is what the answer carries, and what
+        `descriptors.PrvKeys` keys by for the same reason.
+
+        A key with no origin is absent, and its expression is written
+        without one -- which BIP380 allows and Bitcoin Core imports. What
+        it costs is the same thing an empty `hd_key_paths` costs: a signer
+        cannot tell that the key is its own.
+        """
+        return {
+            self._xpub(key): origin
+            for command in self.template
+            if isinstance(command, KeyGroup)
+            for key, origin in zip(command.keys, command.origins, strict=True)
+            if origin is not None
+        }
+
+    @staticmethod
+    def _xpub(key: BIP32KeyData) -> str:
+        """Return the public spelling of an account key.
+
+        A descriptor is text that gets handed to a monitor and written to
+        a log, so an xprv is neutered before it goes in one -- which is
+        `descriptors.parse`'s rule for a descriptor read the other way.
+        """
+        return xpub_from_xprv(key) if key.is_private else key.b58encode()
+
+    def _key_expression(
+        self, key: BIP32KeyData, branch: int, origins: Mapping[str, BIP32KeyOrigin]
+    ) -> KeyExpression:
+        """Return the KEY expression one account key of a group derives by.
+
+        `xpub/branch/*`, which is the ranged expression: the wildcard is
+        the index, and the branch is the step the group takes above it, so
+        one expression covers the whole of a chain.
+        """
+        xpub = self._xpub(key)
+        return KeyExpression(
+            origin=origins.get(xpub),
+            xkey=xpub,
+            der_path=(branch,),
+            wildcard=0,
+        )
+
+    def _quorum_expression(
+        self, branch: int, origins: Mapping[str, BIP32KeyOrigin]
+    ) -> str | None:
+        """Return the BIP383 quorum this wallet is, or None if it is more.
+
+        The one shape a descriptor states without reading the script at
+        all: a template that is a single group and nothing else is that
+        group, so ``multi()`` or ``sortedmulti()`` writes it whatever the
+        order and whatever the script type -- `sh(sortedmulti(2,...))` is
+        the legacy multisig wallet, and no miniscript can be read in a
+        legacy context.
+
+        ``sortedmulti()`` is what makes the per-index order expressible
+        here and nowhere else: it sorts the derived keys, in byte order,
+        which is `order="derived"` with no `sort_key` exactly. A
+        `sort_key` of its own is a third order that neither function
+        states, and `verify=True` is an OP_CHECKMULTISIGVERIFY, which is
+        no script on its own -- both fall through to the lift, which
+        refuses them with its own reason.
+        """
+        if len(self.template) != 1:
+            return None
+        group = self.template[0]
+        if not isinstance(group, KeyGroup) or group.verify:
+            return None
+        if self.order == "derived" and self.sort_key is not None:
+            return None
+        keys = ",".join(
+            str(self._key_expression(key, branch, origins))
+            for key in self._ordered_keys[0]
+        )
+        name = "sortedmulti" if self.order == "derived" else "multi"
+        return f"{name}({group.threshold},{keys})"
+
+    def _lifted_expression(
+        self, branch: int, origins: Mapping[str, BIP32KeyOrigin]
+    ) -> str:
+        """Return the miniscript of the script at index 0, keys put back.
+
+        Which is the lift: the concrete script of one position read back
+        into the expression it is, and each derived key traded for the
+        ranged expression that derived it. What the mapping is keyed by is
+        what `from_script` puts in the tree -- the SEC bytes of the key at
+        this branch and index 0 -- so the substitution is a lookup and
+        never a guess at which account key a script key came from.
+        """
+        if self.order == "derived":
+            err_msg = "a quorum sorted after derivation inside a combinator:"
+            err_msg += " the order is a property of the index, so no ranged"
+            err_msg += " expression states it -- sortedmulti() states one"
+            err_msg += " quorum that is the whole script, and BIP379 has no"
+            err_msg += " sortedmulti fragment to state one inside another"
+            raise NoDescriptorError(err_msg)
+        if self.script_type == "p2sh":
+            err_msg = "a p2sh script that is not a bare quorum: miniscript is"
+            err_msg += " read in a P2WSH or a tapscript context, and BIP379"
+            err_msg += " has no legacy one for this script to be read in"
+            raise NoDescriptorError(err_msg)
+        script = self._script(branch, 0)
+        try:
+            node = _miniscript_from_script(script, P2WSH)
+        except BTClibValueError as exception:
+            raise NoDescriptorError(str(exception)) from exception
+        expressions = {
+            self._derived_sec(key, branch, 0): self._key_expression(
+                key, branch, origins
+            )
+            for keys in self._ordered_keys.values()
+            for key in keys
+        }
+        return str(_lifted(node, expressions))
+
+    def _assert_lift(
+        self, descriptor: Descriptor, branch: int, checked_indexes: int
+    ) -> None:
+        """Require the descriptor and the template to write the same script.
+
+        The whole script and not the addresses, which is `position_of`'s
+        rule here too: a script type this wallet has no address for -- and
+        every position of it -- is compared just the same.
+
+        The range is checked first because a descriptor that has none has
+        no index 1 to compare at: every group key becomes a ranged
+        expression, so a lift where none did is one that put no key back
+        at all, and it would otherwise be reported as an index out of
+        range rather than as the substitution it is.
+        """
+        if not descriptor.is_ranged:
+            err_msg = "the lifted descriptor names one script and not a range:"
+            err_msg += " no key of the template came back as the expression it"
+            err_msg += " was derived from"
+            raise BTClibRuntimeError(err_msg)
+        for index in range(checked_indexes):
+            lifted = descriptor.script_pub_key(index).script
+            own = self._script_pub_key(branch, index).script
+            if lifted != own:
+                err_msg = f"the lifted descriptor pays to {lifted.hex()} at"
+                err_msg += f" {branch}/{index}, where this wallet pays to"
+                err_msg += f" {own.hex()}"
+                raise BTClibRuntimeError(err_msg)
+
+    def descriptor(
+        self, branch: int = 0, checked_indexes: int = _MIN_CHECKED_INDEXES
+    ) -> Descriptor:
+        """Return the ranged descriptor of a branch, confirmed, or refuse to.
+
+        The bridge between this class and `DescriptorWallet`, and the
+        answer to "what do I hand a monitor, or Bitcoin Core's
+        `importdescriptors`, for this wallet". `DescriptorWallet.descriptor`
+        is the same question of a wallet that was built from one; this
+        derives the answer, and the module docstring has how.
+
+        `NoDescriptorError` is the refusal, and it is about the wallet: the
+        `<n> OP_CSV OP_DROP` timelock no miniscript fragment emits, a
+        quorum ordered per index inside a combinator, a legacy p2sh script
+        that is not a bare quorum. Each of those is a script BIP380 to
+        BIP390 does not state, so a caller catching it has to watch the
+        addresses themselves -- which is what this class is for -- rather
+        than a bug to report.
+
+        The key origins are the groups' own, the same ones a psbt gets:
+        `[fingerprint/44h/0h/0h]` in front of a key expression is what a
+        hardware signer recognises its key by, it changes no script, and a
+        group given none is written without one -- a descriptor BIP380
+        allows and Core imports, and the same thing an empty
+        `hd_key_paths` says.
+
+        `checked_indexes` is how many positions the answer is confirmed at
+        before it is handed back: the descriptor's script is compared with
+        the template's at each, and a disagreement is a
+        `BTClibRuntimeError` -- the lift was not faithful, which is a
+        failure of this code and not of the caller's wallet. Two is the
+        floor and the default, being what tells a substituted key from a
+        fixed one; a caller with a committed span of addresses to stand
+        behind passes its length, and pays a derivation of every key at
+        every index for it.
+
+        A `DescriptorWallet` of both chains, where that is what a caller
+        wants, is `DescriptorWallet({b: w.descriptor(b) for b in
+        w.branches})` -- and the two wallets then answer the same
+        addresses, from the two sources.
+        """
+        self._assert_position(branch, 0)
+        if checked_indexes < _MIN_CHECKED_INDEXES:
+            err_msg = f"invalid checked_indexes: {checked_indexes} is fewer than"
+            err_msg += f" the {_MIN_CHECKED_INDEXES} a lift is confirmed at"
+            raise BTClibValueError(err_msg)
+        origins = self._key_origins()
+        expression = self._quorum_expression(
+            branch, origins
+        ) or self._lifted_expression(branch, origins)
+        text = self._descriptor_form.format(expression)
+        try:
+            descriptor = _parse_descriptor(text, self.network)
+        except BTClibValueError as exception:
+            # what a descriptor may hold and not what miniscript can read:
+            # Bitcoin Core refuses an insane expression -- one satisfiable
+            # without a signature, or whose witness a third party can
+            # rewrite -- and a wallet of that shape has no descriptor for
+            # the same reason it has no safe spend
+            raise NoDescriptorError(f"{text}: {exception}") from exception
+        self._assert_lift(descriptor, branch, checked_indexes)
+        return descriptor

--- a/btclib/wallet/script_wallet.py
+++ b/btclib/wallet/script_wallet.py
@@ -640,6 +640,7 @@ class ScriptWallet(RangedWallet):
             **psbt_map.hd_key_paths,
             **self._hd_key_paths(branch, index),
         }
+
     def _key_origins(self) -> dict[str, BIP32KeyOrigin]:
         """Return the origin of each account key, keyed by its xpub.
 

--- a/tests/descriptors/custody_wallet_test.py
+++ b/tests/descriptors/custody_wallet_test.py
@@ -44,14 +44,20 @@ as well, message included, because a later release that started *accepting*
 either spelling would change what a descriptor means, not just what it
 parses.
 
-Those same four calls are what a `wallet.ScriptWallet` is made of, and the
-last test below is the one that matters most to it: the plain shape
-written as a template with two `KeyGroup` quorums in it, answering the
-very addresses transcribed here. The addresses are the authority in both
-directions -- by hand and through the class -- so a `ScriptWallet` that
-ordered a quorum differently, or wrote the timelock as miniscript would,
-would be caught by the deployment rather than by a unit test agreeing with
-itself.
+Those same four calls are what a `wallet.ScriptWallet` is made of, and one
+of the tests below matters most to it: the plain shape written as a
+template with two `KeyGroup` quorums in it, answering the very addresses
+transcribed here. The addresses are the authority in both directions --
+by hand and through the class -- so a `ScriptWallet` that ordered a
+quorum differently, or wrote the timelock as miniscript would, would be
+caught by the deployment rather than by a unit test agreeing with itself.
+
+The ranged shape is where the two halves of the module meet, and it is
+`ScriptWallet.descriptor` that makes them: the same design written as a
+template lifts back to the very descriptor text above, checksum included,
+while the plain shape refuses to be lifted at all. So both directions of
+the boundary are pinned against a deployment rather than against an
+example -- what a lift must reproduce, and what no lift may invent.
 
 Every address below is a mainnet address that has held value. They are
 transcribed from the wallets' own committed address lists, and the two
@@ -70,7 +76,7 @@ from btclib.descriptors import (
     parse,
     strip_checksum,
 )
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibValueError, NoDescriptorError
 from btclib.script import Command, op_int, script
 from btclib.utils import encode_num
 from btclib.wallet import KeyGroup, ScriptWallet
@@ -341,6 +347,17 @@ def _older(blocks: int) -> list[Command]:
     return [encode_num(blocks).hex(), "OP_CHECKSEQUENCEVERIFY", "OP_DROP"]
 
 
+def _miniscript_older(blocks: int) -> list[Command]:
+    """Return the same timelock as `older()` compiles to: no OP_DROP.
+
+    The one opcode between the two shapes, and the whole of why one has a
+    descriptor and the other has none: `and_v(v:older(n),X)` leaves the
+    number for the fragment above it to consume, where the plain shape
+    drops it.
+    """
+    return [encode_num(blocks).hex(), "OP_CHECKSEQUENCEVERIFY"]
+
+
 def _plain_witness_script(wallet: str, branch: int, index: int) -> bytes:
     """Return the witness script of the plain shape, at one position."""
     if wallet == "vault":
@@ -490,3 +507,123 @@ def test_the_plain_shape_is_a_script_wallet(wallet: str, branch: int) -> None:
     # and the other half of what a wallet answers: this output is mine,
     # the whole script compared at each position of each branch
     assert script_wallet.position_of(addresses[7], 10) == (branch, 7)
+
+
+@pytest.mark.parametrize("wallet", ["vault", "transit"])
+@pytest.mark.parametrize("branch", [0, 1])
+def test_the_plain_shape_has_no_descriptor_to_lift(wallet: str, branch: int) -> None:
+    """`ScriptWallet.descriptor` refuses it, and the order is what it names.
+
+    The refusal a caller acts on: this deployment is watched by its
+    addresses, and there is no expression to hand a monitor instead. The
+    order is answered before the script is even read, being a property of
+    the wallet -- the OP_DROP is the second reason and is pinned above,
+    against `from_script` itself.
+    """
+    with pytest.raises(NoDescriptorError, match="sorted after derivation"):
+        _plain_script_wallet(wallet).descriptor(branch)
+
+
+# how many keys each quorum of the ranged shape holds, in the order the
+# expression reads them: `andor(X,Y,Z)` names its quorums X, Y, Z and
+# writes them into the script as X, Z, Y, so this is the order
+# `key_expressions` hands them back in and not the order of the template
+# below. The thresholds are the deployment's: 2-of-3 and 3-of-6 to spend
+# the vault, 2-of-3 after the timelock; 2-of-3 either way on the transit
+# wallet
+_RANGED_QUORUMS: dict[str, tuple[tuple[int, int], ...]] = {
+    "vault": ((2, 3), (3, 6), (2, 3)),
+    "transit": ((2, 3), (2, 3)),
+}
+
+
+def _ranged_script_wallet(deployment: str, wallet: str, branch: int) -> ScriptWallet:
+    """Return the ranged shape as a template, origins declared and all.
+
+    The account keys and their origins are read off the deployed
+    descriptor rather than transcribed a second time: the text above is
+    the authority, so a template built from its key expressions and lifted
+    back to it is a claim about the lift and not about a copy of the keys.
+    The order is `"none"` -- this shape sorts its keys once, before
+    deployment, so what the script carries is the order the descriptor
+    lists.
+    """
+    text, _ = _RANGED[deployment][wallet][branch]
+    keys = parse(text).key_expressions
+    quorums = []
+    read = 0
+    for threshold, count in _RANGED_QUORUMS[wallet]:
+        quorum = keys[read : read + count]
+        quorums.append(
+            KeyGroup(
+                threshold,
+                [key.xkey for key in quorum],
+                origins=[key.origin for key in quorum],
+            )
+        )
+        read += count
+
+    if wallet == "vault":
+        # andor(X,Y,Z) is `X NOTIF Z ELSE Y ENDIF`: the two quorums that
+        # spend together, and the timelocked one in the branch where the
+        # first of them does not sign
+        first, second, recovery = quorums
+        template: list[Command | KeyGroup] = [
+            first,
+            "OP_NOTIF",
+            KeyGroup(
+                recovery.threshold,
+                list(recovery.keys),
+                verify=True,
+                origins=list(recovery.origins),
+            ),
+            *_miniscript_older(_VAULT_RECOVERY_BLOCKS),
+            "OP_ELSE",
+            second,
+            "OP_ENDIF",
+        ]
+    else:
+        # or_i(X,Z) is `IF X ELSE Z ENDIF`, and the timelock is on the
+        # branch the deployment spends from every day
+        custodian, recovery = quorums
+        template = [
+            "OP_IF",
+            custodian,
+            "OP_ELSE",
+            KeyGroup(
+                recovery.threshold,
+                list(recovery.keys),
+                verify=True,
+                origins=list(recovery.origins),
+            ),
+            *_miniscript_older(_TRANSIT_PRIMARY_BLOCKS),
+            "OP_ENDIF",
+        ]
+    return ScriptWallet(template, "p2wsh")
+
+
+@pytest.mark.parametrize("deployment,wallet,branch", _POSITIONS)
+def test_the_ranged_shape_lifts_back_to_its_own_descriptor(
+    deployment: str, wallet: str, branch: int
+) -> None:
+    """A template of the deployed shape answers the deployed descriptor.
+
+    The strongest thing the deployment says about `ScriptWallet
+    .descriptor`: nothing in the template names `andor`, `or_i`, `and_v`
+    or `older`, and the text that comes back is the one this custodian
+    imports into Bitcoin Core -- checksum included, which is eight
+    characters over the whole expression and the one place a spelling
+    difference cannot hide.
+
+    Every address is confirmed on the way, `checked_indexes` being the
+    length of the transcribed list, so the addresses above are the
+    authority in a third direction: by hand, through the descriptor, and
+    now from the template through the descriptor the template lifts to.
+    """
+    text, addresses = _RANGED[deployment][wallet][branch]
+    script_wallet = _ranged_script_wallet(deployment, wallet, branch)
+    descriptor = script_wallet.descriptor(branch, len(addresses))
+    assert add_checksum(str(descriptor)) == text
+    assert [
+        script_wallet.address(branch, i) for i in range(len(addresses))
+    ] == addresses

--- a/tests/wallet/script_wallet_test.py
+++ b/tests/wallet/script_wallet_test.py
@@ -599,6 +599,8 @@ def test_the_updaters_refuse_a_position_or_a_psbt_index_they_have_not() -> None:
     for method in (wallet.update_psbt_input, wallet.update_psbt_output):
         with pytest.raises(BTClibValueError, match="invalid branch: 2"):
             method(psbt, 0, 2, 0)
+
+
 @pytest.mark.parametrize("branch", [0, 1])
 @pytest.mark.parametrize(
     "order, name",
@@ -798,6 +800,22 @@ def test_a_required_quorum_on_its_own_is_no_script_at_all() -> None:
     """
     wallet = ScriptWallet([KeyGroup(2, _XPUBS, verify=True)], "p2wsh")
     with pytest.raises(NoDescriptorError, match="not a miniscript script"):
+        wallet.descriptor()
+
+
+def test_a_per_index_sort_that_is_not_bip67_is_stated_by_nothing() -> None:
+    """``sortedmulti()`` is byte order on the derived keys, and only that.
+
+    So the one quorum that has a descriptor in the plain per-index order
+    stops having one as soon as the sort is the caller's own: the function
+    would state a different order, and `multi()` cannot state this one
+    either, it not being a property of the wallet. Refused whatever the
+    key function computes -- one that happens to agree with byte order at
+    every index is not something this could know, and a descriptor is
+    right or it is not offered.
+    """
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh", "derived", sort_key=bytes.hex)
+    with pytest.raises(NoDescriptorError, match="sorted after derivation"):
         wallet.descriptor()
 
 

--- a/tests/wallet/script_wallet_test.py
+++ b/tests/wallet/script_wallet_test.py
@@ -14,6 +14,13 @@ against the mainnet addresses it holds coins at.
 The psbt half is asserted the same way: the key paths against the account
 path with the two derived levels appended, which is the path a signer
 walks, and the pre-images against `redeem_script` and `witness_script`.
+
+`descriptor()` too: the expression is written out by hand from the keys
+the quorum names, and what the lift produces has to be that text -- so a
+change of spelling is a failure here rather than a descriptor somebody
+imports and finds derives something else. The same method against a
+deployment, which is the authority the addresses give it, is in that
+other module too.
 """
 
 from __future__ import annotations
@@ -24,7 +31,12 @@ from btclib.alias import Command
 from btclib.bip32 import bip32
 from btclib.bip32.bip32 import BIP32KeyData, derive_from_account
 from btclib.bip32.key_origin import BIP32KeyOrigin
-from btclib.exceptions import BTClibValueError
+from btclib.descriptors import KeyExpression, add_checksum, parse
+from btclib.exceptions import (
+    BTClibRuntimeError,
+    BTClibValueError,
+    NoDescriptorError,
+)
 from btclib.psbt.psbt import Psbt
 from btclib.script import script
 from btclib.script.script import op_int
@@ -34,7 +46,8 @@ from btclib.tx.out_point import OutPoint
 from btclib.tx.tx import Tx
 from btclib.tx.tx_in import TxIn
 from btclib.tx.tx_out import TxOut
-from btclib.wallet import KeyGroup, ScriptWallet
+from btclib.wallet import DescriptorWallet, KeyGroup, ScriptWallet
+from btclib.wallet import script_wallet as script_wallet_module
 
 # the "abandon abandon ... about" seed, and three account keys of it in an
 # order that none of the sorts below answers: the account keys sort one
@@ -50,15 +63,54 @@ _ACCOUNTS = ["m/48h/0h/1h", "m/48h/0h/0h", "m/48h/0h/5h"]
 _XPRVS = [bip32.derive(_ROOT, account) for account in _ACCOUNTS]
 _XPUBS = [bip32.xpub_from_xprv(xprv) for xprv in _XPRVS]
 
+# two more accounts of the same seed, for the tests that need a second
+# quorum: a descriptor naming one key twice is refused as insane, so a
+# combinator whose two branches share a key has no descriptor for a reason
+# that is not the one under test
+_RECOVERY = [
+    bip32.xpub_from_xprv(bip32.derive(_ROOT, account))
+    for account in ("m/48h/0h/7h", "m/48h/0h/9h")
+]
+
 # the timelock of the example in the module docstring, spelled the way the
 # wallets that need this class spell it: a push, OP_CSV, OP_DROP
 _TIMELOCK: list[Command] = ["9000", "OP_CHECKSEQUENCEVERIFY", "OP_DROP"]
 
 # where those three accounts came from, which is what a psbt carries
-# beside each key: the master fingerprint, which only the root key
-# supplies, and the path down to the account
+# beside each key, and what a descriptor writes in front of it: the master
+# fingerprint, which only the root key supplies, and the path down to the
+# account
 _FINGERPRINT = fingerprint(_ROOT)
 _ORIGINS = [BIP32KeyOrigin(_FINGERPRINT, account) for account in _ACCOUNTS]
+
+# the same 144 blocks as miniscript writes them, which is the whole
+# difference between a wallet that has a descriptor and one that does not:
+# `older(144)` compiles to the push and OP_CSV, and leaves the number on
+# the stack for the fragment above it to consume
+_MINISCRIPT_TIMELOCK: list[Command] = ["9000", "OP_CHECKSEQUENCEVERIFY"]
+
+
+def _key_expression(xpub: str, branch: int, origins: bool = True) -> str:
+    """Return the ranged KEY expression of an account key, as text.
+
+    With the origin the group declared in front of it, where the wallet
+    under test declared one: a key of a group given none is written as the
+    xpub alone, which is what `origins=False` asks for here.
+    """
+    prefix = f"[{_ORIGINS[_XPUBS.index(xpub)].description}]" if origins else ""
+    return f"{prefix}{xpub}/{branch}/*"
+
+
+def _multi(
+    threshold: int,
+    xpubs: list[str],
+    branch: int,
+    name: str = "multi",
+    origins: bool = True,
+) -> str:
+    """Return the BIP383 quorum of some account keys, written out."""
+    keys = ",".join(_key_expression(xpub, branch, origins) for xpub in xpubs)
+    return f"{name}({threshold},{keys})"
 
 
 def _derived(xpub: str, branch: int, index: int) -> bytes:
@@ -547,3 +599,284 @@ def test_the_updaters_refuse_a_position_or_a_psbt_index_they_have_not() -> None:
     for method in (wallet.update_psbt_input, wallet.update_psbt_output):
         with pytest.raises(BTClibValueError, match="invalid branch: 2"):
             method(psbt, 0, 2, 0)
+@pytest.mark.parametrize("branch", [0, 1])
+@pytest.mark.parametrize(
+    "order, name",
+    [("none", "multi"), ("account", "multi"), ("derived", "sortedmulti")],
+)
+def test_one_quorum_is_a_descriptor_in_every_order(
+    order: str, name: str, branch: int
+) -> None:
+    """A template that is one group is BIP383's, per-index order included.
+
+    Which is the one place `sortedmulti()` states the order a quorum is
+    given after derivation: it is a descriptor function and not a
+    miniscript fragment, so it says this and cannot say it inside a
+    combinator. `multi()` states the other two orders by listing the keys
+    in the order the script carries them, so the account sort shows up in
+    the text and not only in the script.
+    """
+    group = KeyGroup(2, _XPUBS, origins=_ORIGINS)
+    wallet = ScriptWallet([group], "p2wsh", order)  # type: ignore[arg-type]
+    ordered = (
+        sorted(_XPUBS, key=lambda xpub: BIP32KeyData.b58decode(xpub).key)
+        if order == "account"
+        else _XPUBS
+    )
+    descriptor = wallet.descriptor(branch)
+    assert str(descriptor) == f"wsh({_multi(2, ordered, branch, name)})"
+    assert descriptor.is_ranged
+    # the addresses of the branch, which is what the descriptor is for and
+    # what makes the equality above more than a claim about text
+    assert [descriptor.address(i) for i in range(5)] == [
+        wallet.address(branch, i) for i in range(5)
+    ]
+    # and the text is a descriptor to whoever reads it back, checksum and
+    # all: what `descriptor()` returns is what `parse` answers for it
+    assert parse(add_checksum(str(descriptor))) == descriptor
+
+
+def test_the_lift_reads_the_script_and_puts_the_keys_back() -> None:
+    """A shape no argument of this class names, out of the script itself.
+
+    The timelocked spending path miniscript *does* state -- OP_CSV with no
+    OP_DROP after it -- and the lift is what recognizes it: nothing here
+    says `or_i`, `and_v` or `older`, the script says them and
+    `miniscript.from_script` reads them.
+    """
+    template: list[Command | KeyGroup] = [
+        "OP_IF",
+        KeyGroup(2, _XPUBS, origins=_ORIGINS),
+        "OP_ELSE",
+        KeyGroup(2, _RECOVERY, verify=True),
+        *_MINISCRIPT_TIMELOCK,
+        "OP_ENDIF",
+    ]
+    wallet = ScriptWallet(template, "p2wsh")
+    descriptor = wallet.descriptor(1, 8)
+    recovery = _multi(2, _RECOVERY, 1, origins=False)
+    assert str(descriptor) == (
+        f"wsh(or_i({_multi(2, _XPUBS, 1)},and_v(v:{recovery},older(144))))"
+    )
+    # the recovery group declared no origin, so its keys are written
+    # without one -- the same thing an empty `hd_key_paths` says, and a
+    # descriptor BIP380 allows
+    assert "[" not in recovery
+    assert [descriptor.address(i) for i in range(8)] == [
+        wallet.address(1, i) for i in range(8)
+    ]
+    # and the wallet of the pair of descriptors answers the same addresses
+    # from the other source, which is the bridge this method is
+    both = DescriptorWallet({b: wallet.descriptor(b) for b in wallet.branches})
+    assert both.address(0, 3) == wallet.address(0, 3)
+    assert both.position_of(wallet.script_pub_key(1, 5), 6) == (1, 5)
+
+
+def test_a_key_the_wallet_does_not_derive_stays_the_key_it_is() -> None:
+    """A literal push in the template is a fixed key in the descriptor.
+
+    The honest answer rather than a refusal: BIP380 states a public key as
+    the hex it is, so what comes out is ranged in the keys of the groups
+    and fixed in the one the template wrote down -- which is exactly what
+    the wallet computes at every index.
+    """
+    literal = _derived(_RECOVERY[0], 0, 0).hex()
+    wallet = ScriptWallet(
+        [literal, "OP_CHECKSIGVERIFY", KeyGroup(1, _XPUBS[:1], origins=_ORIGINS[:1])],
+        "p2wsh",
+    )
+    descriptor = wallet.descriptor()
+    assert str(descriptor) == (
+        f"wsh(and_v(v:pk({literal}),{_multi(1, _XPUBS[:1], 0)}))"
+    )
+    assert [descriptor.address(i) for i in range(4)] == [
+        wallet.address(0, i) for i in range(4)
+    ]
+
+
+@pytest.mark.parametrize(
+    "script_type, text",
+    [
+        ("p2sh", "sh({})"),
+        ("p2wsh", "wsh({})"),
+        ("p2sh-p2wsh", "sh(wsh({}))"),
+    ],
+)
+def test_a_quorum_has_a_descriptor_for_each_way_it_becomes_an_output(
+    script_type: str, text: str
+) -> None:
+    """Including the legacy p2sh one, which no miniscript can be read in.
+
+    `sh(sortedmulti(2,...))` is the pre-descriptor multisig wallet, and it
+    is BIP381 wrapping BIP383 rather than a miniscript: the quorum is
+    written from the groups, so the script type is the only thing that
+    changes here.
+    """
+    group = KeyGroup(2, _XPUBS, origins=_ORIGINS)
+    wallet = ScriptWallet([group], script_type, "derived")  # type: ignore[arg-type]
+    descriptor = wallet.descriptor()
+    assert str(descriptor) == text.format(_multi(2, _XPUBS, 0, "sortedmulti"))
+    assert descriptor.address(3) == wallet.address(0, 3)
+
+
+def test_an_xprv_in_a_quorum_is_not_written_into_the_descriptor() -> None:
+    """A descriptor is text that gets logged, and `parse` neuters one too.
+
+    The origins are looked up under the xpub for the same reason: it is
+    the spelling the answer carries, whichever of the two the group was
+    given.
+    """
+    signing = ScriptWallet([KeyGroup(2, _XPRVS, origins=_ORIGINS)], "p2wsh")
+    watching = ScriptWallet([KeyGroup(2, _XPUBS, origins=_ORIGINS)], "p2wsh")
+    assert not signing.is_watch_only
+    assert signing.descriptor() == watching.descriptor()
+    assert all(xprv not in str(signing.descriptor()) for xprv in _XPRVS)
+
+
+def test_a_quorum_ordered_per_index_inside_a_combinator_has_no_descriptor() -> None:
+    """The refusal the class exists for, and the one nothing can widen.
+
+    `sortedmulti()` states the order of a quorum that is the whole script;
+    inside a combinator BIP379 has no fragment that states it, so the
+    order is a property of the index and no ranged expression covers it.
+    """
+    template: list[Command | KeyGroup] = [
+        "OP_IF",
+        KeyGroup(2, _XPUBS),
+        "OP_ELSE",
+        KeyGroup(2, _RECOVERY, verify=True),
+        *_MINISCRIPT_TIMELOCK,
+        "OP_ENDIF",
+    ]
+    wallet = ScriptWallet(template, "p2wsh", "derived")
+    with pytest.raises(NoDescriptorError, match="sorted after derivation"):
+        wallet.descriptor()
+    # the very same template in the declared order does have one, which is
+    # what leaves the refusal above about the order and nothing else
+    declared = ScriptWallet(template, "p2wsh").descriptor()
+    assert str(declared).startswith("wsh(or_i(multi(2,")
+
+
+def test_a_script_no_miniscript_reads_has_no_descriptor() -> None:
+    """`<n> OP_CSV OP_DROP` closes no fragment: the deployed spelling.
+
+    The message is `from_script`'s own, this being a refusal about the
+    script rather than one this class works out for itself.
+    """
+    template: list[Command | KeyGroup] = [
+        "OP_IF",
+        KeyGroup(2, _XPUBS),
+        "OP_ELSE",
+        *_TIMELOCK,
+        KeyGroup(2, _RECOVERY),
+        "OP_ENDIF",
+    ]
+    err_msg = "not a miniscript: op code 0x75 closes no fragment"
+    with pytest.raises(NoDescriptorError, match=err_msg):
+        ScriptWallet(template, "p2wsh").descriptor()
+
+
+def test_a_legacy_script_that_is_not_a_bare_quorum_has_no_descriptor() -> None:
+    """A p2sh miniscript is not a thing: P2WSH and tapscript are the two."""
+    template: list[Command | KeyGroup] = [
+        "OP_IF",
+        KeyGroup(2, _XPUBS),
+        "OP_ELSE",
+        KeyGroup(1, _RECOVERY[:1]),
+        "OP_ENDIF",
+    ]
+    with pytest.raises(NoDescriptorError, match="no legacy one"):
+        ScriptWallet(template, "p2sh").descriptor()
+
+
+def test_a_required_quorum_on_its_own_is_no_script_at_all() -> None:
+    """An OP_CHECKMULTISIGVERIFY leaves nothing on the stack: a V, not a B.
+
+    Which the lift is what says: a template of one group is BIP383's
+    quorum, and `verify=True` is not that quorum -- so it falls through to
+    `from_script`, where the type of the expression is the answer.
+    """
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS, verify=True)], "p2wsh")
+    with pytest.raises(NoDescriptorError, match="not a miniscript script"):
+        wallet.descriptor()
+
+
+def test_an_expression_no_descriptor_may_hold_has_no_descriptor() -> None:
+    """Sane or refused, which is Bitcoin Core's rule for a descriptor.
+
+    The lift reads the script and `parse` judges it, so a wallet whose two
+    spending paths share a key is refused with the reason a descriptor is
+    refused for -- not with a failure to read the script, which read fine.
+    """
+    template: list[Command | KeyGroup] = [
+        "OP_IF",
+        KeyGroup(2, _XPUBS),
+        "OP_ELSE",
+        KeyGroup(2, _XPUBS[:2], verify=True),
+        *_MINISCRIPT_TIMELOCK,
+        "OP_ENDIF",
+    ]
+    with pytest.raises(NoDescriptorError, match="it repeats a public key"):
+        ScriptWallet(template, "p2wsh").descriptor()
+
+
+def test_a_substitution_that_put_no_key_back_is_not_a_range(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A lift that missed every key describes one script, and says so.
+
+    Which is the first thing the confirmation asks, and it has to be
+    asked before the comparison: a descriptor of one script has no index 1
+    to compare at, so a caller would otherwise be told the index is out of
+    range and left to work out why.
+    """
+    template: list[Command | KeyGroup] = [
+        "OP_IF",
+        KeyGroup(2, _XPUBS),
+        "OP_ELSE",
+        KeyGroup(2, _RECOVERY, verify=True),
+        *_MINISCRIPT_TIMELOCK,
+        "OP_ENDIF",
+    ]
+    # the quorum path writes the key expressions itself, so the lift is
+    # only reached by a template a combinator makes of it
+    monkeypatch.setattr(script_wallet_module, "_lifted", lambda node, expressions: node)
+    with pytest.raises(BTClibRuntimeError, match="not a range"):
+        ScriptWallet(template, "p2wsh").descriptor()
+
+
+def test_a_lift_that_derives_something_else_is_not_handed_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The confirmation, on a substitution that is ranged and wrong.
+
+    A key expression naming the other chain is the shape of the mistake
+    this guards against: every key is put back, the descriptor is ranged,
+    and what it derives is a wallet nobody has. The addresses are what
+    tells the two apart, which is why they are compared rather than
+    trusted.
+    """
+
+    def other_branch(
+        self: ScriptWallet,
+        key: BIP32KeyData,
+        branch: int,
+        origins: object,
+    ) -> KeyExpression:
+        return KeyExpression(xkey=key.b58encode(), der_path=(1 - branch,), wildcard=0)
+
+    monkeypatch.setattr(ScriptWallet, "_key_expression", other_branch)
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh")
+    with pytest.raises(BTClibRuntimeError, match="where this wallet pays to"):
+        wallet.descriptor()
+
+
+def test_a_lift_is_confirmed_at_two_positions_or_the_call_is_refused() -> None:
+    """One is index 0, which is where the expression was read: no evidence."""
+    wallet = ScriptWallet([KeyGroup(2, _XPUBS)], "p2wsh")
+    with pytest.raises(BTClibValueError, match="invalid checked_indexes: 1"):
+        wallet.descriptor(0, 1)
+    # and a branch this wallet has no chain at is refused as everywhere
+    # else, the position being checked before anything is derived
+    with pytest.raises(BTClibValueError, match="invalid branch: 2"):
+        wallet.descriptor(2)


### PR DESCRIPTION
`ScriptWallet` and `DescriptorWallet` were sister sources of addresses
with nothing between them: a caller holding the older shape had no answer
to "what do I hand a monitor, or `importdescriptors`, for this wallet" —
while a good half of the wallets that need a template need it for one
detail of the script and are sayable in BIP380 to BIP390 apart from it.
`ScriptWallet.descriptor(branch)` is that bridge, and `NoDescriptorError`
is what the other half gets.

## Built by lifting, not by writing

No shape is spelled out anywhere in the implementation. The wallet derives
its own script at index 0, `miniscript.from_script` reads those bytes back
into the expression they are, each derived key is traded for the ranged
KEY expression that produced it — `[fingerprint/path]xpub/branch/*` — and
the text goes through `descriptors.parse`. So the answer is the descriptor
a reader of that text gets rather than an object assembled here, a shape
the module has never heard of comes out right, and an expression a
descriptor may not hold at all — Bitcoin Core refuses an insane
miniscript — is refused with the reason a descriptor is refused for.

The key origins are the groups' own — `KeyGroup(threshold, keys,
origins=[...])`, which #587 added for the psbt Updater and which this
reads rather than asking a second time: one declaration, two readers. They
change no script, a hardware signer needs them, and a group given none is
written without one, which is what an empty `hd_key_paths` says too.

**And then confirmed.** The scripts the descriptor derives are compared
with the template's at `checked_indexes` positions before it is handed
back. Two is the floor and the default, because index 0 is where the
expression was read: a key left as the fixed hex it was derived to writes
exactly the right script there and a wrong one at every other index. A
caller with a committed span of addresses to stand behind passes its
length instead. A lift that does not agree is a `BTClibRuntimeError` —
this code's failure, not the caller's wallet.

## The bare quorum does not go through miniscript

A template that is a single `KeyGroup` and nothing else is BIP383's
quorum, so it is stated for every order this class has — `sortedmulti()`
for the per-index one, which is what that function follows, and `multi()`
for the other two — and inside a legacy `sh()` too, where no miniscript
could be read for want of a context. `sh(sortedmulti(2,...))` is the
pre-descriptor multisig wallet, and it now comes back out of one.

That is also where the per-index order stops being refusable: the refusal
is a quorum sorted after derivation *inside a combinator*, BIP379 having
no `sortedmulti` fragment, and not the sort itself.

## What says it is right

`tests/descriptors/custody_wallet_test.py` already pins a mainnet custody
design in its two deployed shapes, against the addresses it holds coins
at. The ranged shape is now also built as a template — naming no `andor`,
no `or_i`, no `and_v` and no `older` — and lifted: what comes back is the
very descriptor text that custodian imports, checksum included, for both
wallets, both chains and two independent deployments. The plain shape
beside it refuses, so both directions of the boundary are pinned against a
deployment rather than against an example.

`tests/wallet/script_wallet_test.py` writes the expected expression out by
hand from the keys each quorum names, for the three orders, the three
script types, an xprv wallet, a literal key in the template, and each
refusal by its message. The confirmation itself is exercised on a lift
made wrong on purpose, both ways it can be: one that puts no key back —
which describes one script and not a range — and one that is ranged and
derives another wallet's addresses.

## What it does not add

No `from_script`, and no text format of `ScriptWallet`'s own. A template
is not recoverable from a script — the bytes at one position say which
keys are in it, not which account keys derived them — so the direction
that was refused for being ambiguous stays refused; what is added is the
one direction that can be checked by deriving from its own answer.
