### PR TITLE
Bound the counts a cycle and a principle had left unbounded (#569)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,50 +53,64 @@ documented at release-notes length in the first place, and are still in
   allocated for it** (#569). `var_int.parse`'s `MAX_SIZE` is Core's
   `ReadCompactSize` range check and answers whether a CompactSize is one
   a sane protocol would write; 33,554,432 is a sane CompactSize, so nine
-  octets naming that many maps or transactions were believed, and the
-  list comprehension that followed asked for an object per declared item.
-  What a parser also has to ask is whether what follows could possibly
-  hold this many, and the answer is consensus arithmetic rather than a
-  number this library picks: `MAX_BLOCK_WEIGHT` divided by the weight of
-  the smallest thing being counted.
+  octets naming that many maps, transactions, inputs or witness elements
+  were believed, and the list comprehension that followed asked for an
+  object per declared item. What a parser also has to ask is whether what
+  follows could possibly hold this many, and the answer is consensus
+  arithmetic rather than a number this library picks: `MAX_BLOCK_WEIGHT`
+  divided by the weight of the smallest thing being counted.
 
-  Three bounds, all in `btclib.block.limits` beside the constants they
-  divide. `Block.parse` reads its transaction count with
-  `MAX_BLOCK_WEIGHT // MIN_SERIALIZABLE_TRANSACTION_WEIGHT`, 100,000 --
-  Core's *serializable* minimum and not the `MIN_TRANSACTION_WEIGHT`
-  beside it, what is being allocated for being a transaction that
-  deserializes. `Psbt.parse` holds its input and output map counts to
-  `MAX_TX_IN_COUNT` and `MAX_TX_OUT_COUNT`, 24,390 and 111,111: a PSBT's
-  maps are a transaction's inputs and outputs, so a count above what a
-  block has room for describes no transaction at all. Each refusal names
-  which of the two counts it was.
+  Every count a parser reads before allocating is bounded now.
+  `Block.parse` reads its transaction count with `MAX_BLOCK_WEIGHT //
+  MIN_SERIALIZABLE_TRANSACTION_WEIGHT`, 100,000 -- Core's *serializable*
+  minimum and not the `MIN_TRANSACTION_WEIGHT` beside it, what is being
+  allocated for being a transaction that deserializes. `Tx.parse` and
+  `Psbt.parse` hold their input and output counts to `MAX_TX_IN_COUNT`
+  and `MAX_TX_OUT_COUNT`, 24,390 and 111,111: a PSBT's maps are a
+  transaction's inputs and outputs, so a count above what a block has
+  room for describes no transaction at all, and each refusal names which
+  of the two counts it was. `Witness.parse` holds its element count to
+  `MAX_WITNESS_STACK_ITEMS`: a witness octet weighs one and an element
+  costs at least the octet announcing it empty, so the weight a block may
+  not exceed is the count no witness in it can exceed either.
 
-  The PSBT bound is the one that pays: an empty input map is a single
-  octet on the wire and an object with a dozen fields in memory, so the
-  count believed is that amplification paid before the first map is read.
-  Measured on the issue's reproducer, a PSBTv2 declaring 100,000 empty
-  input maps in about 100 KB of payload: 125 MB of peak allocation
-  before, 0.1 MB and an immediate refusal now.
+  Two of them pay in memory. A PSBTv2 declaring 100,000 empty input maps
+  in about 100 KB of payload, the issue's own reproducer: 125 MB of peak
+  allocation before, 0.1 MB and an immediate refusal now -- an empty
+  input map being a single octet on the wire and an object with a dozen
+  fields in memory. A witness declaring the CompactSize maximum over
+  4 MB of empty elements, which is a count with the octets behind it to
+  keep the old parser allocating until the stream ran out: 34.7 MB
+  before, refused for what the count says now. The transaction counts pay
+  in the answer rather than in memory: `TxIn.parse` and `TxOut.parse`
+  raise on the first short read, so a count with nothing behind it was
+  already refused in microseconds, and what the bound adds is a refusal
+  that names the number that was wrong before a byte of the first input
+  is read.
 
-  What is **not** bounded here is the witness stack, and the reason is
-  the one `btclib.script.limits` already states. The number that would
-  cap it is `MAX_STACK_SIZE`, and that is a rule about *executing* a
-  script: reading an execution limit in the decoder is what let a
-  1443-byte push be refused as unparsable when it was merely unspendable
-  (issue #123). A witness of a million items is unspendable and parses,
-  as it does for Core, whose deserializer bounds it by the size of the
-  message that carried it and not by the interpreter's stack. Its cost is
-  proportional to the input that declared it -- about 25 MB for the
-  issue's 1 MB reproducer -- which is what a parser costs rather than an
-  amplification; #569 stays open for that half.
+  `MAX_WITNESS_STACK_ITEMS` is **not** `MAX_STACK_SIZE`, and the
+  difference is the one `btclib.script.limits` states: the interpreter's
+  cap is a rule about *executing* a script, and reading an execution
+  limit in the decoder is what let a 1443-byte push be refused as
+  unparsable when it was merely unspendable (issue #123). A witness of a
+  million items is unspendable and parses, here as it does for Core --
+  about 25 MB for the issue's 1 MB reproducer, which is what a parser
+  costs rather than an amplification. What consensus arithmetic refuses
+  is the count nothing could have carried, which is the whole of what a
+  decoder can say.
 
-  `Tx.parse` is unchanged for a second reason: `TxIn.parse` raises on the
-  first short read, so a count with nothing behind it is refused in
-  microseconds already, and the bound that would refuse a count with
-  bytes behind it lives in `btclib.block.limits`, which `btclib.tx`
-  cannot import -- `btclib.block` imports `btclib.tx`, so the edge is a
-  cycle. Naming that here because it is what the fix would have to move
-  first.
+  The bounds a transaction and a witness divide by could not be read
+  where they were. `btclib.block` imports `btclib.tx`, which imports
+  `btclib.script`, so either edge back is a cycle, and
+  `MAX_BLOCK_WEIGHT` and `WITNESS_SCALE_FACTOR` now live in the new
+  `btclib.consensus`, a module below all three that imports nothing.
+  `btclib.block.limits` names both still -- a caller reading a block's
+  rules reads them where the rest of Core's header is -- and
+  `btclib.tx.limits` is the new home of the input and output counts, with
+  the minimum sizes they divide by. `tests/all_test.py` records the
+  re-export beside the two the `bitcoin-core-rpc` package already had,
+  with the module each name is canonical in: the same object under the
+  name a caller already had, rather than a second declaration of it.
 
 - **A child pays for its parent, and the arithmetic is `fee.package_fee`**
   (#584). `fee_from_vsize` prices a transaction in isolation, and a

--- a/btclib/__init__.py
+++ b/btclib/__init__.py
@@ -85,6 +85,7 @@ __all__ = [
     "bip44",
     "bip322",
     "block",
+    "consensus",
     "core_import",
     "curves",
     "descriptors",

--- a/btclib/block/limits.py
+++ b/btclib/block/limits.py
@@ -4,8 +4,8 @@
 
 """The consensus limits on a block, with Bitcoin Core's names.
 
-Core declares the first three in `consensus/consensus.h` and
-`MAX_FUTURE_BLOCK_TIME` in `chain.h`, beside the wider window the wallet
+Core declares all but `MAX_FUTURE_BLOCK_TIME` in `consensus/consensus.h`,
+and that one in `chain.h`, beside the wider window the wallet
 compares its own timestamps against; it is a consensus bound all the same,
 and `ContextualCheckBlockHeader` rejects `time-too-new` with it.
 
@@ -15,6 +15,13 @@ a rule about a block being *accepted*. `WITNESS_SCALE_FACTOR` is not a
 limit but the unit the other two are expressed in -- a byte outside the
 witness weighs four, and so does one legacy signature check -- which is
 why it is here rather than beside the arithmetic that reads it.
+
+It and `MAX_BLOCK_WEIGHT` are defined in `btclib.consensus` and re-exported
+here, which is a layering fact and not a second home for them: what a
+transaction and a witness may declare is arithmetic on the block that has
+to hold them, and neither `btclib.tx` nor `btclib.script` can import this
+package. `btclib.consensus` says why; a caller reading a block's rules
+still names this module, which is where the rest of Core's header is.
 
 Three of `consensus.h`'s constants are deliberately absent.
 `MAX_BLOCK_SERIALIZED_SIZE` is marked in Core's own comment as a buffer
@@ -29,51 +36,27 @@ is the smallest a *valid* transaction can be and is fee estimation's, the
 first the smallest one that *deserializes* -- so it is the one a parser
 divides MAX_BLOCK_WEIGHT by to bound how many transactions a block may
 declare before it allocates for them (issue #569). `btclib.tx.limits`
-derives the same kind of bound for a transaction's own inputs and outputs
-and reads the two constants above from here.
+derives the same kind of bound for a transaction's own inputs and outputs.
 """
+
+from btclib.consensus import MAX_BLOCK_WEIGHT, WITNESS_SCALE_FACTOR
 
 __all__ = [
     "MAX_BLOCK_SIGOPS_COST",
     "MAX_BLOCK_WEIGHT",
     "MAX_FUTURE_BLOCK_TIME",
-    "MAX_TX_IN_COUNT",
-    "MAX_TX_OUT_COUNT",
     "MIN_SERIALIZABLE_TRANSACTION_WEIGHT",
-    "MIN_TX_IN_SIZE",
-    "MIN_TX_OUT_SIZE",
     "WITNESS_SCALE_FACTOR",
 ]
-
-# Maximum allowed weight for a block, see BIP141 (network rule)
-MAX_BLOCK_WEIGHT = 4_000_000
 
 # Maximum allowed cost of the signature check operations in a block
 # (network rule); the cost of a legacy sigop is WITNESS_SCALE_FACTOR, so
 # the bound is 20,000 of them
 MAX_BLOCK_SIGOPS_COST = 80_000
 
-# The weight of a byte a legacy node sees, and the cost of a legacy sigop
-WITNESS_SCALE_FACTOR = 4
-
 # The smallest weight a transaction can deserialize from, ten octets being
 # Core's lower bound for the size of a serialized CTransaction
 MIN_SERIALIZABLE_TRANSACTION_WEIGHT = WITNESS_SCALE_FACTOR * 10
-
-# The smallest a TxIn serializes to: a 32-octet previous transaction id, a
-# four-octet output index, the one octet of a var_int announcing an empty
-# script_sig, and a four-octet sequence. The smallest a TxOut serializes
-# to: an eight-octet amount and the one octet of an empty script_pub_key
-MIN_TX_IN_SIZE = 32 + 4 + 1 + 4
-MIN_TX_OUT_SIZE = 8 + 1
-
-# How many inputs and outputs a transaction that can be mined may declare.
-# Neither is witness data, so each weighs WITNESS_SCALE_FACTOR times its
-# size, and a count above these names a transaction no block has room for
-# -- which is what lets a parser refuse it before allocating for it
-# (issue #569)
-MAX_TX_IN_COUNT = MAX_BLOCK_WEIGHT // (MIN_TX_IN_SIZE * WITNESS_SCALE_FACTOR)
-MAX_TX_OUT_COUNT = MAX_BLOCK_WEIGHT // (MIN_TX_OUT_SIZE * WITNESS_SCALE_FACTOR)
 
 # Maximum number of seconds a block timestamp may exceed the current time,
 # spelled as Core spells it

--- a/btclib/consensus.py
+++ b/btclib/consensus.py
@@ -1,0 +1,47 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The consensus constants more than one package measures against.
+
+Two names of Bitcoin Core's `consensus/consensus.h` and one bound derived
+from them, in a module that imports nothing and is therefore below every
+package that reads them. `btclib.block.limits` is where the rest of that
+header is and where a caller reading a block's own rules goes; these two
+are here because of who else divides by them. A transaction's input and
+output counts (`btclib.tx.limits`) and a witness stack's element count are
+arithmetic on `MAX_BLOCK_WEIGHT`, and neither `btclib.tx` nor
+`btclib.script` can import `btclib.block`: `btclib.block` imports
+`btclib.tx`, which imports `btclib.script`, so either edge back closes a
+cycle on a half-initialized package -- issue #147's shape, and what
+`tests/imports_test.py` reports.
+
+`btclib.block.limits` re-exports both, so nothing that reads them from
+there has to move.
+
+`MAX_WITNESS_STACK_ITEMS` is here and not in `btclib.script.limits` for a
+second reason on top of the layering. That module holds the five caps the
+script *engine* enforces, and reading an execution limit in a decoder is
+what let a 1443-byte push be refused as unparsable when it was merely
+unspendable (issue #123). The bound below is not `MAX_STACK_SIZE`: it
+refuses a count no block could carry, not a witness no script could run.
+"""
+
+__all__ = [
+    "MAX_BLOCK_WEIGHT",
+    "MAX_WITNESS_STACK_ITEMS",
+    "WITNESS_SCALE_FACTOR",
+]
+
+# Maximum allowed weight for a block, see BIP141 (network rule)
+MAX_BLOCK_WEIGHT = 4_000_000
+
+# The weight of a byte a legacy node sees, and the cost of a legacy sigop
+WITNESS_SCALE_FACTOR = 4
+
+# How many elements a witness stack may declare. An element costs at least
+# the one octet of the var_int announcing it empty, and a witness octet
+# weighs one, so the weight a block may not exceed is the count no witness
+# in it can exceed either -- which is what lets a parser refuse a count
+# before allocating a Python object per declared element (issue #569)
+MAX_WITNESS_STACK_ITEMS = MAX_BLOCK_WEIGHT

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -42,7 +42,6 @@ from btclib.bip32 import (
     decode_hd_key_paths,
     encode_to_bip32_derivs,
 )
-from btclib.block.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
@@ -83,6 +82,7 @@ from btclib.script import (
 )
 from btclib.script.sig_hash import ALL, DEFAULT, assert_valid_hash_type
 from btclib.tx import Tx, TxIn, TxOut
+from btclib.tx.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
 from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,

--- a/btclib/script/witness.py
+++ b/btclib/script/witness.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 
 from btclib import var_bytes, var_int
 from btclib.alias import BinaryData, Octets
+from btclib.consensus import MAX_WITNESS_STACK_ITEMS
 from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
@@ -111,7 +112,16 @@ class Witness:
         octet case is what a PSBT_IN_FINAL_SCRIPTWITNESS value is.
         """
         stream = bytesio_from_binarydata(data)
-        n = var_int.parse(stream)
+        # bounded by the block that would have to carry the stack rather
+        # than by var_int's own MAX_SIZE, which answers whether a
+        # CompactSize is sane and not whether anything could hold this
+        # many: an element costs a witness octet at least, so a count
+        # above MAX_WITNESS_STACK_ITEMS is one no transaction was ever
+        # serialized with (issue #569). Not MAX_STACK_SIZE, which is the
+        # interpreter's -- a stack of a million elements is unspendable
+        # and parses, here as it does for Core, and refusing it here would
+        # be issue #123 again
+        n = var_int.parse(stream, MAX_WITNESS_STACK_ITEMS)
         stack = [var_bytes.parse(stream) for _ in range(n)]
         assert_no_trailing(data, stream, "witness")
         return cls(stack, check_validity=check_validity)

--- a/btclib/tx/limits.py
+++ b/btclib/tx/limits.py
@@ -1,0 +1,44 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""How many inputs and outputs a transaction may declare.
+
+A module of its own, as `block/limits.py` and `script/limits.py` are and
+for the same reason: `tx.py` is the dataclass and its serialization, while
+each name here is a rule about the transaction the wire declares.
+
+Core has no constant for either count. What it has is the weight a block
+may not exceed, and a transaction that does not fit in a block is one no
+parser has to allocate for: each count below is `MAX_BLOCK_WEIGHT` divided
+by the weight of the smallest thing it counts, so neither is a number this
+library picked (issue #569). `btclib.consensus` is where the two constants
+divided here come from, and its docstring is why they are not read from
+`btclib.block.limits` beside the rest of Core's header.
+
+The minimum sizes are the same arithmetic's other half, and they are
+`tests/tx`'s to check against a serialization rather than to be believed.
+"""
+
+from btclib.consensus import MAX_BLOCK_WEIGHT, WITNESS_SCALE_FACTOR
+
+__all__ = [
+    "MAX_TX_IN_COUNT",
+    "MAX_TX_OUT_COUNT",
+    "MIN_TX_IN_SIZE",
+    "MIN_TX_OUT_SIZE",
+]
+
+# The smallest a TxIn serializes to: a 32-octet previous transaction id, a
+# four-octet output index, the one octet of a var_int announcing an empty
+# script_sig, and a four-octet sequence. The smallest a TxOut serializes
+# to: an eight-octet amount and the one octet of an empty script_pub_key
+MIN_TX_IN_SIZE = 32 + 4 + 1 + 4
+MIN_TX_OUT_SIZE = 8 + 1
+
+# How many inputs and outputs a transaction that can be mined may declare.
+# Neither is witness data, so each weighs WITNESS_SCALE_FACTOR times its
+# size, and a count above these names a transaction no block has room for
+# -- which is what lets a parser refuse it before allocating for it
+MAX_TX_IN_COUNT = MAX_BLOCK_WEIGHT // (MIN_TX_IN_SIZE * WITNESS_SCALE_FACTOR)
+MAX_TX_OUT_COUNT = MAX_BLOCK_WEIGHT // (MIN_TX_OUT_SIZE * WITNESS_SCALE_FACTOR)

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -20,6 +20,7 @@ from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash256
 from btclib.script.sig_ops import sig_op_count as script_sig_op_count
 from btclib.script.witness import Witness
+from btclib.tx.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
 from btclib.tx.tx_in import TX_IN_COMPARES_WITNESS, TxIn
 from btclib.tx.tx_out import TxOut
 from btclib.utils import (
@@ -380,10 +381,18 @@ class Tx:  # noqa: PLW1641
             # Change stream position: seek to byte offset relative to position
             stream.seek(-len(marker), SEEK_CUR)  # current position
 
-        n = var_int.parse(stream)
+        # each count bounded by the block that would have to hold the
+        # transaction rather than by var_int's own MAX_SIZE, which answers
+        # whether a CompactSize is sane and not whether anything could
+        # hold this many (issue #569). What this adds to the short read
+        # that TxIn.parse and TxOut.parse already raise on is the message:
+        # a count above the bound is refused for what it says, before a
+        # byte of the first input is read, rather than for the bytes it
+        # turned out not to be followed by
+        n = var_int.parse(stream, MAX_TX_IN_COUNT)
         vin = [TxIn.parse(stream, check_validity=check_validity) for _ in range(n)]
 
-        n = var_int.parse(stream)
+        n = var_int.parse(stream, MAX_TX_OUT_COUNT)
         vout = [TxOut.parse(stream, check_validity=check_validity) for _ in range(n)]
 
         if segwit:

--- a/docs/source/btclib.rst
+++ b/docs/source/btclib.rst
@@ -85,6 +85,13 @@ btclib.bip44 module
    :members:
    :show-inheritance:
 
+btclib.consensus module
+-----------------------
+
+.. automodule:: btclib.consensus
+   :members:
+   :show-inheritance:
+
 btclib.core_import module
 -------------------------
 

--- a/docs/source/btclib.tx.rst
+++ b/docs/source/btclib.tx.rst
@@ -4,6 +4,13 @@ btclib.tx package
 Submodules
 ----------
 
+btclib.tx.limits module
+-----------------------
+
+.. automodule:: btclib.tx.limits
+   :members:
+   :show-inheritance:
+
 btclib.tx.out\_point module
 ---------------------------
 

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -46,6 +46,7 @@ import btclib.ecc
 import btclib.mnemonic
 import btclib.psbt
 import btclib.script
+from btclib import consensus
 from btclib.curves import curve_group, curve_group_2
 from btclib.psbt import psbt_utils
 from btclib.script import script_pub_key
@@ -66,33 +67,51 @@ UNEXPORTED = {
 }
 
 # what a module exports without defining it, which for a module rather than a
-# package is a leak -- and these two are the exception, both of it one
-# decision. The `bitcoin-core-rpc` package is the canonical source of the rpc
-# client and of the transport under it, and btclib depends on it rather than
-# carrying a copy; the two modules below are where those objects were before
-# it was a package of its own, and they alias them rather than declaring a
-# second of anything. A transport has one bounded-read policy, and
-# an import path that used to work still does.
+# package is a leak -- and these three are the exception, on two decisions.
+# The `bitcoin-core-rpc` package is the canonical source of the rpc client and
+# of the transport under it, and btclib depends on it rather than carrying a
+# copy; the first two modules below are where those objects were before it was
+# a package of its own, and they alias them rather than declaring a second of
+# anything. A transport has one bounded-read policy, and an import path that
+# used to work still does.
+#
+# `btclib.consensus` is the second: a transaction's counts and a witness
+# stack's are arithmetic on the block weight, and neither `btclib.tx` nor
+# `btclib.script` can import `btclib.block`, so the two constants they divide
+# by are defined below all three. `btclib.block.limits` names them still,
+# being where the rest of Core's header is and where a caller reading a
+# block's own rules goes.
 #
 # So a name here is not a name about to leak: it is the same object under the
-# name a caller already had. What would be a leak is a *fourth* module, or a
-# name in these three that the canonical file does not export
+# name a caller already had, which each entry records its canonical module for
+# and the test below asserts. What would be a leak is a *fourth* module, or a
+# name in these three that the canonical module does not export
 REEXPORTED = {
-    "btclib.fetch.bitcoin_core": [
-        "COOKIE_USER",
-        "DEFAULT_DATADIR",
-        "BitcoinCoreRpcClient",
-        "chain_from_network",
-        "cookie_auth",
-    ],
-    "btclib.fetch.transport": [
-        "DEFAULT_MAX_BODY_SIZE",
-        "DEFAULT_TIMEOUT",
-        "MAX_ERROR_BODY_SIZE",
-        "HttpTransport",
-        "http_request",
-        "urlopen_transport",
-    ],
+    "btclib.fetch.bitcoin_core": (
+        bitcoin_core_rpc,
+        [
+            "COOKIE_USER",
+            "DEFAULT_DATADIR",
+            "BitcoinCoreRpcClient",
+            "chain_from_network",
+            "cookie_auth",
+        ],
+    ),
+    "btclib.fetch.transport": (
+        bitcoin_core_rpc,
+        [
+            "DEFAULT_MAX_BODY_SIZE",
+            "DEFAULT_TIMEOUT",
+            "MAX_ERROR_BODY_SIZE",
+            "HttpTransport",
+            "http_request",
+            "urlopen_transport",
+        ],
+    ),
+    "btclib.block.limits": (
+        consensus,
+        ["MAX_BLOCK_WEIGHT", "WITNESS_SCALE_FACTOR"],
+    ),
 }
 
 # every direct child module of every package, on the side of the decision
@@ -188,7 +207,7 @@ CHILD_MODULES = {
     },
     "btclib.tx": {
         "groups": [],
-        "unpublished": ["out_point", "tx", "tx_in", "tx_out"],
+        "unpublished": ["limits", "out_point", "tx", "tx_in", "tx_out"],
     },
     "btclib.wallet": {
         "groups": [],
@@ -555,35 +574,39 @@ def test_no_module_exports_a_name_it_imported() -> None:
     module with a reason to re-export something is a conversation to have
     with this test, not around it.
 
-    `REEXPORTED` is that conversation, held once: the two modules whose
+    `REEXPORTED` is that conversation, held twice: the two modules whose
     objects moved into the `bitcoin-core-rpc` package alias them back under
     the names callers had, a transport having one bounded-read policy to
-    keep.
+    keep; and `btclib.block.limits` names the two constants `btclib.consensus`
+    defines below the package, which is where a caller reading a block's
+    rules looks for them.
 
     Asserted both ways, because a skip list is only half a table: it says
     which names may be re-exported and nothing about whether they still are,
     so dropping one of these aliases from an `__all__` would have been
     invisible to every test in this file. The recorded names and the
     re-exported ones must be the same set, and each must be the canonical
-    object rather than a same-named one -- which is the property the whole
-    arrangement exists for.
+    object of the module the entry records rather than a same-named one --
+    which is the property the whole arrangement exists for.
     """
     for module in library_modules():
         if hasattr(module, "__path__"):  # a package re-exports for a living
             continue
         imported = imported_names(module)
         leaked = {name for name in module.__all__ if name in imported}
-        allowed = REEXPORTED.get(module.__name__)
-        if allowed is None:
+        recorded = REEXPORTED.get(module.__name__)
+        if recorded is None:
             assert not leaked, f"{module.__name__} re-exports {sorted(leaked)}"
             continue
+        canonical, allowed = recorded
         assert leaked == set(allowed), (
             f"{module.__name__} re-exports {sorted(leaked)}, where REEXPORTED"
             f" records {sorted(allowed)}"
         )
         for name in allowed:
-            assert getattr(module, name) is getattr(bitcoin_core_rpc, name), (
-                f"{module.__name__}.{name} is not the canonical bitcoin_core_rpc.{name}"
+            assert getattr(module, name) is getattr(canonical, name), (
+                f"{module.__name__}.{name} is not the canonical"
+                f" {canonical.__name__}.{name}"
             )
 
 

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -29,11 +29,7 @@ from btclib.block import (
 from btclib.block.limits import (
     MAX_BLOCK_SIGOPS_COST,
     MAX_BLOCK_WEIGHT,
-    MAX_TX_IN_COUNT,
-    MAX_TX_OUT_COUNT,
     MIN_SERIALIZABLE_TRANSACTION_WEIGHT,
-    MIN_TX_IN_SIZE,
-    MIN_TX_OUT_SIZE,
     WITNESS_SCALE_FACTOR,
 )
 from btclib.block.proof_of_work import REGTEST_POW_LIMIT_BITS
@@ -1383,42 +1379,3 @@ def test_a_declared_transaction_count_is_bounded_by_what_a_block_holds() -> None
 
     with pytest.raises(BTClibValueError, match="var_int too big"):
         Block.parse(header + var_int.serialize(maximum + 1), check_validity=False)
-
-
-def test_the_transaction_count_bounds_are_what_consensus_derives() -> None:
-    """The three parser bounds are arithmetic on consensus, not choices.
-
-    Each is MAX_BLOCK_WEIGHT divided by the weight of the smallest thing
-    it counts, so none of them is a number this library picked: a count
-    above any of them names a transaction or a block no miner could
-    produce, which is what makes refusing it before allocating safe.
-    """
-    # a TxIn and a TxOut serialize to no less than this, and neither is
-    # witness data, so each weighs WITNESS_SCALE_FACTOR times its size
-    assert (
-        len(
-            TxIn(OutPoint(), b"", 0xFFFFFFFF, check_validity=False).serialize(
-                check_validity=False
-            )
-        )
-        == MIN_TX_IN_SIZE
-    )
-    assert (
-        len(
-            TxOut(0, ScriptPubKey(b""), check_validity=False).serialize(
-                check_validity=False
-            )
-        )
-        == MIN_TX_OUT_SIZE
-    )
-
-    assert MAX_TX_IN_COUNT == MAX_BLOCK_WEIGHT // (
-        MIN_TX_IN_SIZE * WITNESS_SCALE_FACTOR
-    )
-    assert MAX_TX_OUT_COUNT == MAX_BLOCK_WEIGHT // (
-        MIN_TX_OUT_SIZE * WITNESS_SCALE_FACTOR
-    )
-    # and they are what they compute to, so a change to either constant
-    # above is a change a reader of this test sees
-    assert MAX_TX_IN_COUNT == 24_390
-    assert MAX_TX_OUT_COUNT == 111_111

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -15,7 +15,6 @@ import pytest
 
 from btclib import var_bytes, var_int
 from btclib.bip32 import BIP32KeyOrigin
-from btclib.block.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
 from btclib.curves import sec_point
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
@@ -61,6 +60,7 @@ from btclib.script.engine import verify_transaction
 from btclib.script.taproot import input_script_sig, tree_helper
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
+from btclib.tx.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
 from tests import load, vector_id
 from tests.conftest import JsonGolden
 
@@ -4362,7 +4362,7 @@ def test_a_declared_map_count_is_bounded_before_it_is_allocated_for() -> None:
 
     A PSBT's maps are a transaction's inputs and outputs, so a count
     above what a block has room for describes no transaction at all --
-    `MAX_TX_IN_COUNT` and `MAX_TX_OUT_COUNT` in `btclib.block.limits`.
+    `MAX_TX_IN_COUNT` and `MAX_TX_OUT_COUNT` in `btclib.tx.limits`.
     Believing one costs an object per declared map before the first is
     read: an empty input map is a single octet on the wire and a dozen
     fields in memory, which is the amplification the check exists to

--- a/tests/script/witness_test.py
+++ b/tests/script/witness_test.py
@@ -8,6 +8,9 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 
+from btclib import var_int
+from btclib.consensus import MAX_WITNESS_STACK_ITEMS
+from btclib.exceptions import BTClibValueError
 from btclib.script import Witness
 from tests.conftest import JsonGolden
 
@@ -83,3 +86,26 @@ def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
     assert len(witness2.stack) > 0
 
     assert witness == witness2
+
+
+def test_a_declared_stack_size_is_bounded_before_allocation() -> None:
+    """A count no block could carry is refused (issue 569).
+
+    An element costs a witness octet at least, so MAX_BLOCK_WEIGHT is the
+    count no witness in a block can exceed -- and it is that, and not the
+    interpreter's MAX_STACK_SIZE, that a decoder may read: a stack of a
+    million elements is unspendable and parses here as it does for Core,
+    refusing it being issue #123 all over again.
+
+    What the bound buys is measured on a payload that carries the octets
+    to keep the old parser going: the var_int maximum declared over 4 MB
+    of empty elements peaked at 34.7 MB before, allocating until the
+    stream ran out, and is refused now for what the count says.
+    """
+    payload = var_int.serialize(0x02000000) + bytes(4_000_000)
+    with pytest.raises(BTClibValueError, match="var_int too big"):
+        Witness.parse(payload)
+
+    # the bound itself is not refused: what stops that one is the stream
+    with pytest.raises(BTClibValueError, match="not enough binary data"):
+        Witness.parse(var_int.serialize(MAX_WITNESS_STACK_ITEMS))

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -19,9 +19,17 @@ from typing import Any
 
 import pytest
 
+from btclib import var_int
+from btclib.consensus import MAX_BLOCK_WEIGHT, WITNESS_SCALE_FACTOR
 from btclib.exceptions import BTClibValueError
 from btclib.script import ScriptPubKey, Witness, sig_op_count
 from btclib.tx import OutPoint, Tx, TxIn, TxOut, join
+from btclib.tx.limits import (
+    MAX_TX_IN_COUNT,
+    MAX_TX_OUT_COUNT,
+    MIN_TX_IN_SIZE,
+    MIN_TX_OUT_SIZE,
+)
 from btclib.tx.tx import _assert_valid_coinbase
 from tests.conftest import JsonGolden
 
@@ -844,3 +852,79 @@ def test_eq_witness(monkeypatch: pytest.MonkeyPatch) -> None:
     # is about is the answer rather than the two types
     not_an_input: object = "not an input"
     assert tx_with().vin[0] != not_an_input
+
+
+def test_the_transaction_count_bounds_are_what_consensus_derives() -> None:
+    """Each bound is arithmetic on consensus rather than a choice.
+
+    MAX_BLOCK_WEIGHT divided by the weight of the smallest thing being
+    counted, so neither is a number this library picked: a count above
+    either names a transaction no miner could produce, which is what makes
+    refusing it before allocating for it safe.
+
+    The minimum sizes are checked against a serialization rather than
+    believed, an off-by-one in either being a bound too generous by the
+    same factor.
+    """
+    # a TxIn and a TxOut serialize to no less than this, and neither is
+    # witness data, so each weighs WITNESS_SCALE_FACTOR times its size
+    assert (
+        len(
+            TxIn(OutPoint(), b"", 0xFFFFFFFF, check_validity=False).serialize(
+                check_validity=False
+            )
+        )
+        == MIN_TX_IN_SIZE
+    )
+    assert (
+        len(
+            TxOut(0, ScriptPubKey(b""), check_validity=False).serialize(
+                check_validity=False
+            )
+        )
+        == MIN_TX_OUT_SIZE
+    )
+
+    assert MAX_TX_IN_COUNT == MAX_BLOCK_WEIGHT // (
+        MIN_TX_IN_SIZE * WITNESS_SCALE_FACTOR
+    )
+    assert MAX_TX_OUT_COUNT == MAX_BLOCK_WEIGHT // (
+        MIN_TX_OUT_SIZE * WITNESS_SCALE_FACTOR
+    )
+    # and they are what they compute to, so a change to either constant
+    # above is a change a reader of this test sees
+    assert MAX_TX_IN_COUNT == 24_390
+    assert MAX_TX_OUT_COUNT == 111_111
+
+
+def test_a_declared_input_or_output_count_is_bounded_before_allocation() -> None:
+    """A count no block could hold is refused where it is read (issue 569).
+
+    `var_int.parse`'s own MAX_SIZE answers whether a CompactSize is one a
+    sane protocol would write, and 33,554,432 inputs is a sane
+    CompactSize: nine octets asking for a list comprehension of 33 million
+    objects. What bounds each count instead is the block that would have
+    to hold the transaction.
+
+    TxIn.parse and TxOut.parse raise on the first short read, so a count
+    with nothing behind it never allocated much either; what the bound
+    adds is the answer given for the count itself, before a byte of the
+    first input is read, and a refusal that says which number was wrong
+    rather than reporting the bytes that failed to follow it.
+    """
+    version = (2).to_bytes(4, "little")
+
+    with pytest.raises(BTClibValueError, match="var_int too big"):
+        Tx.parse(version + var_int.serialize(MAX_TX_IN_COUNT + 1))
+
+    # the output count is read after the inputs, so an empty input list is
+    # what gets the parser there
+    with pytest.raises(BTClibValueError, match="var_int too big"):
+        Tx.parse(
+            version + var_int.serialize(0) + var_int.serialize(MAX_TX_OUT_COUNT + 1)
+        )
+
+    # and the bound is not off by one: the count itself is not refused,
+    # the first input's short read is what answers instead
+    with pytest.raises(BTClibValueError, match="not enough data for the outpoint"):
+        Tx.parse(version + var_int.serialize(MAX_TX_IN_COUNT))


### PR DESCRIPTION
Closes the half of ISS569 that PR https://github.com/btclib-org/btclib/pull/581
left open: `Tx.parse`'s input and output counts, and a witness stack's
element count. Both reasons for leaving them are addressed rather than
worked around.

## The cycle

`MAX_TX_IN_COUNT` and `MAX_TX_OUT_COUNT` lived in `btclib.block.limits`,
which `btclib.tx` cannot import: `btclib.block` imports `btclib.tx`,
which imports `btclib.script`, so either edge back closes on a
half-initialized package.

`MAX_BLOCK_WEIGHT` and `WITNESS_SCALE_FACTOR` now live in the new
`btclib.consensus`, a module that imports nothing and is therefore below
all three. `btclib.tx.limits` derives the two counts and the minimum
sizes there — the module both the `block.limits` and the `psbt.py`
docstrings already named — and `btclib.block.limits` names the two
constants still, so no import that worked stops working. Nothing
released moves: the four names leaving `block.limits` arrived in #581 and
are unreleased.

## The principle

What would cap a witness stack is `MAX_STACK_SIZE`, and that is a rule
about *executing* a script — reading an execution limit in a decoder is
what let a 1443-byte push be refused as unparsable when it was merely
unspendable (ISS123). `MAX_WITNESS_STACK_ITEMS` is not that number: a
witness octet weighs one and an element costs at least the octet
announcing it empty, so the weight a block may not exceed is the count no
witness in it can exceed either. Consensus arithmetic, refusing what
nothing could have carried and nothing else.

The issue's first reproducer therefore still parses, and still costs
about 25 MB for its 1 MB of declared elements: it is a count with the
octets behind it, unspendable and well-formed, and Core deserializes it
too. That is the decision this PR takes, and the one line to revert if
you want the other one.

## Measured

| case | before | after |
|---|---|---|
| witness declaring the CompactSize maximum over 4 MB of empty elements | 34.7 MB peak, refused on the short read | refused for the count, 0.002 MB |
| `Tx.parse` with a count above the bound | short read, message about missing bytes | refusal naming the count, before the first input |
| ISS569 reproducer 1 (1M elements, all present) | 24.9 MB, parses | 24.9 MB, parses |

## Also

`tests/all_test.py`'s `REEXPORTED` records what a module may export
without defining it; its docstring calls a new entry a conversation to
have with the test. `btclib.block.limits` is the third entry, and each
now records the module its names are canonical in — the assertion that
kept the `bitcoin-core-rpc` aliases the same objects, generalized rather
than dropped.

## Gates

`uv run pre-commit run --all-files`, `uv run pytest --cov` (18,452
passed) and the sphinx `-W` build, all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce consensus-derived bounds on transaction and witness element counts while refactoring consensus constants into a dedicated module to break import cycles and keep exports canonical.

Bug Fixes:
- Prevent unbounded allocations when parsing oversized transaction input/output counts and witness stack sizes by rejecting counts that exceed what a block can carry.

Enhancements:
- Introduce a consensus module for shared consensus constants and derive transaction input/output and witness stack limits from block weight to align parsers with consensus arithmetic.
- Refactor transaction and PSBT parsing to use transaction-specific limit constants and provide clearer errors when declared counts exceed allowed bounds.
- Extend the re-export tracking test to cover consensus constants and ensure re-exported names remain canonical across modules.

Documentation:
- Update changelog and module/docstrings to document the new consensus module, transaction/witness bounds, and re-export semantics.

Tests:
- Add and update tests to verify transaction input/output bounds, witness stack bounds, and the correctness of consensus-derived limits, including regression coverage for issue 569.