### PR TITLE
Walk the keys inside a miniscript (#592)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -331,6 +331,38 @@ documented at release-notes length in the first place, and are still in
 
 ### Descriptors and miniscript
 
+- **`at_index()` and `normalized()` reach the keys inside a miniscript**
+  (#592). `_mapped_keys` is the one walk both are written in terms of,
+  and `_mapped_field` decides what counts as a field holding a key: a
+  `KeyExpression`, a `MultiA`, a nested `Descriptor`, or a tuple of
+  those. A `Miniscript` was none of them, so `MiniscriptDescriptor.node`
+  came back as it stood and every key of the BIP379 half of the language
+  was left where it was -- both functions answering the descriptor they
+  had been given, and saying nothing about it.
+
+  What that cost is different on each side. `at_index` is what a reader
+  wanting *this* script has to be handed, an external signer displaying
+  one address among a range: handed the descriptor back unchanged it
+  named index 0 at every index, and `is_ranged` still answering True was
+  the shape of it, the post-condition of that function being that no
+  wildcard is left. `normalized` is `getdescriptorinfo`'s answer and what
+  an export to a watch-only wallet takes, and its refusal of a hardened
+  step with no private key could not fire either, the key never being
+  visited. A `tr()` leaf was the same gap, and shows it was about the
+  type and not about where it sits: what came back had the internal key
+  written at the index and the leaf's keys still ranged, one descriptor
+  half walked.
+
+  The walk has a `Miniscript` branch now, recursing through the node's
+  own `subs` and `keys`. What a node derives from its arguments is
+  `init=False`, so replacing those two fields recomputes the type, the
+  script size and the bounds from the keys that are there -- which is why
+  rebuilding bottom-up is the whole of it. What comes with it is the test
+  that would have caught this: both functions over every fragment the
+  language has, the list of them read from the parser's own `_ARITY`
+  table rather than written beside the test, so a fragment added later is
+  walked or is red.
+
 - **A tr() script tree is bounded at 128 nesting levels** (#571).
   `_parse_tree` recurses once per brace and had no bound, so a `tr()`
   expression nested a thousand deep exhausted the interpreter stack and

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -2278,22 +2278,43 @@ def _normalized_key(key: KeyExpression, prv_keys: PrvKeys | None) -> KeyExpressi
     )
 
 
+def _mapped_node(
+    node: Miniscript, key_map: Callable[[KeyExpression], KeyExpression]
+) -> Miniscript:
+    """Return the miniscript with `key_map` applied to every key in it.
+
+    The two fields of a node that can hold one: its own KEY expressions
+    and the subexpressions under it. What a node derives from those is
+    `init=False`, so rebuilding bottom-up is the whole of it -- `replace`
+    recomputes the type, the script size and the bounds from the keys
+    that are now there.
+    """
+    return replace(
+        node,
+        subs=tuple(_mapped_node(sub, key_map) for sub in node.subs),
+        keys=tuple(key_map(key) for key in node.keys),
+    )
+
+
 def _mapped_field(
     value: object, key_map: Callable[[KeyExpression], KeyExpression]
 ) -> object:
     """Return one field of a descriptor with every key in it mapped.
 
     Where a key can be: the field itself, a key of a ``multi_a()`` leaf, a
-    key of a fragment another one wraps, or an element of a script tree,
-    which is a tuple of tuples. Nothing else in a fragment holds one, and
-    a field added later that does will be walked here by construction --
-    which is the whole reason this is one function rather than a method
-    per fragment.
+    key of a miniscript node or of one nested under it, a key of a
+    fragment another one wraps, or an element of a script tree, which is a
+    tuple of tuples. Nothing else in a fragment holds one, and a field
+    added later that does will be walked here by construction -- which is
+    the whole reason this is one function rather than a method per
+    fragment.
     """
     if isinstance(value, KeyExpression):
         return key_map(value)
     if isinstance(value, MultiA):
         return replace(value, keys=tuple(key_map(key) for key in value.keys))
+    if isinstance(value, Miniscript):
+        return _mapped_node(value, key_map)
     if isinstance(value, Descriptor):
         return _mapped_keys(value, key_map)
     if isinstance(value, tuple):

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -31,6 +31,7 @@ the parser test asks is that each one expands and that every address it
 produces is the address of that very script.
 """
 
+from dataclasses import fields, is_dataclass
 from typing import get_args
 
 import pytest
@@ -67,6 +68,7 @@ from btclib.descriptors import (
     strip_checksum,
 )
 from btclib.descriptors.descriptors import __descsum_expand
+from btclib.descriptors.miniscript import _ARITY, Miniscript
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160, tagged_hash
@@ -2731,6 +2733,126 @@ def test_the_index_of_a_musig_is_written_where_the_range_is() -> None:
     fixed = at_index(tree, 2)
     assert not fixed.is_ranged
     assert fixed.script_pub_key() == tree.script_pub_key(2)
+
+
+# a key that is ranged and hardened at once, which is the one shape both
+# functions have something to do to: `at_index` writes the index the
+# wildcard stands for, `normalized` re-roots at the hardened step
+RANGED_A = f"{XPRV_ROOT}/1h/0/*"
+RANGED_B = f"{XPRV_ROOT}/1h/1/*"
+RANGED_C = f"{XPRV_ROOT}/1h/2/*"
+DIGEST_32 = "00" * 32
+DIGEST_20 = "00" * 20
+
+# every miniscript fragment there is, spread over the descriptors that
+# can hold one: `multi()` is a p2wsh and `multi_a()` a tapscript, so it
+# takes both contexts, and a `tr()` puts a key outside the miniscript as
+# well as in it. What holds this list to "every" is the test below, which
+# reads the parser's own table rather than a copy of it written here
+MINISCRIPT_CORPUS = (
+    f"wsh(and_v(vn:pk({RANGED_A}),older(5)))",
+    f"wsh(or_d(pk({RANGED_A}),and_v(v:pkh({RANGED_B}),dv:after(500))))",
+    (
+        f"wsh(andor(pk({RANGED_A}),older(5),"
+        f"j:and_v(v:pk({RANGED_B}),sha256({DIGEST_32}))))"
+    ),
+    f"wsh(thresh(2,pk({RANGED_A}),s:pk({RANGED_B}),s:pk({RANGED_C})))",
+    f"wsh(and_v(v:multi(2,{RANGED_A},{RANGED_B}),hash256({DIGEST_32})))",
+    f"wsh(or_b(pk({RANGED_A}),a:pk({RANGED_B})))",
+    f"wsh(or_i(and_v(or_c(pk({RANGED_A}),v:pk({RANGED_B})),ripemd160({DIGEST_20})),0))",
+    f"wsh(and_b(pk({RANGED_A}),a:and_v(v:pk({RANGED_B}),1)))",
+    (
+        f"tr({RANGED_A},{{multi_a(2,{RANGED_B},{RANGED_C}),"
+        f"and_v(v:multi_a(2,{RANGED_B},{RANGED_C}),hash160({DIGEST_20}))}})"
+    ),
+)
+
+
+def _fragments(value: object) -> set[str]:
+    """Return the name of every miniscript fragment inside a descriptor.
+
+    A walk of its dataclass fields, so that it finds a node wherever one
+    sits -- under a `wsh()`, in a script tree, or nested in another
+    fragment -- without being told where to look.
+    """
+    if isinstance(value, Miniscript):
+        return {value.fragment, *_fragments(value.subs)}
+    if isinstance(value, tuple):
+        return {name for item in value for name in _fragments(item)}
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            name
+            for field in fields(value)
+            for name in _fragments(getattr(value, field.name))
+        }
+    return set()
+
+
+def test_the_miniscript_corpus_covers_every_fragment() -> None:
+    """The corpus is taken from the parser's table, not written beside it.
+
+    `_ARITY` is what the parser reads a fragment name against -- thresh()
+    excepted, which takes one subexpression or more and is therefore not
+    in it -- so a fragment added to the language is a fragment this test
+    demands a descriptor for, and the two walks below then cover it or go
+    red. A list written here would have covered whatever it covered on
+    the day it was written.
+    """
+    covered: set[str] = set()
+    for descriptor in MINISCRIPT_CORPUS:
+        covered |= _fragments(parse(descriptor))
+    assert covered == {*_ARITY, "thresh"}
+
+
+def test_the_index_is_written_into_every_miniscript_key() -> None:
+    """Every key of a BIP379 expression, not the descriptor around it.
+
+    The post-condition of `at_index` is that no wildcard is left, and a
+    key inside a miniscript is a key like any other: the descriptor that
+    comes back names one script, and it is the script the ranged one
+    describes at that index.
+    """
+    for descriptor in MINISCRIPT_CORPUS:
+        prv_keys: dict[str, str] = {}
+        parsed = parse(descriptor, prv_keys=prv_keys)
+        assert parsed.is_ranged
+
+        fixed = at_index(parsed, 3)
+        assert not fixed.is_ranged
+        assert "*" not in str(fixed)
+        assert fixed.script_pub_keys(0, prv_keys) == parsed.script_pub_keys(3, prv_keys)
+        # and it is a descriptor like any other: written back and read again
+        assert str(parse(str(fixed))) == str(fixed)
+
+
+def test_the_normalized_form_re_roots_every_miniscript_key() -> None:
+    """The same walk, and what it is worth is the same claim as elsewhere.
+
+    Every key of the answer derives from an xpub, so the scripts are
+    computable with no private key at all -- which for a miniscript is a
+    claim `test_the_normalized_form_derives_from_an_xpub_alone` cannot
+    make, its descriptors having no fragment in them.
+    """
+    for descriptor in MINISCRIPT_CORPUS:
+        prv_keys: dict[str, str] = {}
+        parsed = parse(descriptor, prv_keys=prv_keys)
+        canonical = normalized(parsed, prv_keys)
+
+        # no prv_keys at all on the normalized side: that is the claim
+        assert canonical.script_pub_keys(3) == parsed.script_pub_keys(3, prv_keys)
+        assert str(parse(str(canonical))) == str(canonical)
+
+
+def test_normalizing_a_miniscript_without_the_key_says_so() -> None:
+    """A key the walk does not reach is a key that cannot be refused.
+
+    So the refusal is the evidence that it was visited: a hardened step
+    inside a fragment and no private key for it raises, where before the
+    descriptor came back quietly still needing one.
+    """
+    xpub = xpub_from_xprv(XPRV_ROOT)
+    with pytest.raises(BTClibValueError, match="no private key to normalize"):
+        normalized(parse(f"wsh(and_v(v:pk({xpub}/0h/1/*),older(5)))"))
 
 
 def test_the_account_descriptor_pair() -> None:


### PR DESCRIPTION
Closes #592.

`descriptors._mapped_keys` is the one walk both `at_index` and
`normalized` are written in terms of, and `_mapped_field` decided what
counts as a field holding a key: a `KeyExpression`, a `MultiA`, a nested
`Descriptor`, or a tuple of those. A `Miniscript` was none of them, so
`MiniscriptDescriptor.node` came back as it stood and every key of a
`wsh(and_v(...))` was left where it was — both functions answering the
descriptor they were given, silently, for the whole BIP379 half of the
language.

What that cost is different on each side: `at_index` named index 0 at
every index, with `is_ranged` still answering True where the
post-condition of that function is that no wildcard is left; and
`normalized` could not even raise for the private key a hardened step
needs, the key never being visited. A `tr()` leaf was the same gap and
shows it was about the type rather than the position — the internal key
was written at the index and the leaf's keys were not, one descriptor
half walked.

`_mapped_field` has a `Miniscript` branch now, recursing through the
node's own `subs` and `keys`. What a node derives from those is
`init=False`, so `replace` recomputes the type, the script size and the
bounds from the keys that are there, and rebuilding bottom-up is the
whole of it.

The test that would have caught it goes with it: both functions over a
corpus that holds every fragment the language has, the list of them read
from the parser's own `_ARITY` table rather than written beside the
test, so a fragment added later is walked or is red. All three new tests
fail on `dev` and pass here.

Gates: `pre-commit run --all-files`, the `-W` sphinx build, and
`pytest --cov` (18553 passed, 100% coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure descriptor key-walking utilities also traverse keys inside miniscript expressions so ranged and normalized descriptors handle the full miniscript language.

Enhancements:
- Extend descriptor key-mapping to recurse through miniscript nodes, updating all embedded keys for operations like at_index() and normalized().

Documentation:
- Document the miniscript key-walking fix and its impact on at_index() and normalized() in the changelog.

Tests:
- Add a miniscript corpus-based test suite ensuring all parser-known fragments are covered and that at_index() and normalized() correctly process every miniscript key, including erroring when required private keys are missing.