### PR TITLE
Ask a script whether it is the miniscript it reads as

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -362,6 +362,34 @@ documented at release-notes length in the first place, and are still in
   language has, the list of them read from the parser's own `_ARITY`
   table rather than written beside the test, so a fragment added later is
   walked or is red.
+- **`miniscript.reads_back` asks a script whether it is the expression it
+  reads as** (#594). The round trip put as a question: the script is read
+  back into an expression, the expression writes a script, and the answer
+  is whether those are the same bytes. What it is asked about is a script
+  somebody else wrote -- a witness script off a psbt, the pre-image a
+  wallet computes -- where "this is a 2-of-3 with a timelock" is an
+  intention and reading it back is the only thing that says the bytes
+  agree with it: a script well formed by accident hashes to a perfectly
+  good address, so the address is derived and the deposit watched, and
+  what cannot be spent is found out at the spend. False wherever no
+  language reads the script, which is an answer and not a refusal -- not
+  every script is a miniscript, and `from_script` is what says which part
+  of one is not.
+
+  `from_script` documents itself as the inverse of `Miniscript.script`,
+  and one input made that false. The decoder earns the claim everywhere
+  else by refusing every second spelling of one expression -- a
+  non-minimal push, a number with a byte to spare, a VERIFY written as
+  two op codes -- but `key_hashes` is the caller's answer to "which key
+  is behind this hash160", that being all a ``pk_h()`` leaves in the
+  script, and the answer was believed: a mapping filing a key under a
+  hash that is not its own read the script into an expression whose
+  `script()` writes somebody else's output. It is held to what `script()`
+  would write now, and refused where it does not hold, which is also why
+  this function can be written as the round trip rather than as "the
+  decoder accepted it". A caller answering a 33-byte compressed key for a
+  tapscript ``pk_h()`` meets the same refusal, correctly: a tapscript
+  hashes the 32 x-only bytes, so that was never the key behind that hash.
 
 - **A tr() script tree is bounded at 128 nesting levels** (#571).
   `_parse_tree` recurses once per brace and had no bound, so a `tr()`

--- a/btclib/descriptors/miniscript.py
+++ b/btclib/descriptors/miniscript.py
@@ -10,7 +10,10 @@ read rather than something it has to recognize. `parse` reads the text
 BIP379 defines and `from_script` reads a script back into it; `str` and
 `Miniscript.script` are the two ways out. The round trip is the point:
 `from_script(node.script())` is `node` again, so a signer handed a witness
-script can say what it means without being told.
+script can say what it means without being told. `reads_back` is that
+round trip asked of a script instead of assumed of it -- whether the bytes
+in hand are the expression they look like -- which is the question a
+caller has about a script somebody else wrote.
 
 `satisfy` is the third thing it does: the witness that spends the script,
 which for a miniscript is a choice and not an assembly -- several branches
@@ -97,6 +100,7 @@ __all__ = [
     "SpendContext",
     "from_script",
     "parse",
+    "reads_back",
 ]
 
 # the two contexts BIP379 is specified for, P2SH and bare scripts being
@@ -2289,8 +2293,18 @@ class _Decoder:
             if key_hash not in self.key_hashes:
                 err_msg = f"no public key for the hash160 {key_hash.hex()}"
                 raise BTClibValueError(err_msg)
+            sec = self.key_hashes[key_hash]
+            # the answer is checked against the question, which is the one
+            # thing the script itself cannot say: a mapping filing a key
+            # under a hash that is not its own reads the script into an
+            # expression writing a different script back, and the inverse
+            # this module documents would hold for every input but that one
+            if hash160(sec) != key_hash:
+                err_msg = f"the key answered for the hash160 {key_hash.hex()}"
+                err_msg += f" hashes to {hash160(sec).hex()}"
+                raise BTClibValueError(err_msg)
             self.pos += 5
-            key = _key_from_sec(self.key_hashes[key_hash], self.context)
+            key = _key_from_sec(sec, self.context)
             return Miniscript("pk_h", self.context, keys=(key,))
         return None
 
@@ -2611,7 +2625,12 @@ def from_script(
     fragment that keeps no key in the script: ``pk_h()`` and its sugared
     ``pkh()`` write the hash alone, so a script holding one is readable
     only where the key is supplied. Bitcoin Core asks a signing provider
-    the same question.
+    the same question, and the answer is held to it: a key filed under a
+    hash that is not its own is refused rather than read, that being the
+    one input for which the inverse above did not hold.
+
+    `reads_back` is this question asked without the refusal, for a caller
+    that holds a script and wants to know whether any language reads it.
     """
     script = bytes_from_octets(script)
     if len(script) > _max_script_size(context):
@@ -2635,6 +2654,43 @@ def from_script(
         err_msg = f"not a miniscript script: {node} is a {basic}, not a B"
         raise BTClibValueError(err_msg)
     return node
+
+
+def reads_back(
+    script: Octets,
+    context: str = P2WSH,
+    key_hashes: Mapping[Octets, Octets] | None = None,
+) -> bool:
+    """Whether a script is the miniscript it reads as.
+
+    The round trip as a question: the script is read back into an
+    expression and the expression writes a script, and the answer is
+    whether those are the same bytes. What it is asked about is a script
+    somebody else wrote -- a witness script off a psbt, the pre-image a
+    wallet computes -- where "this is a 2-of-3 with a timelock" is an
+    intention, and reading it back is the only thing that says the bytes
+    agree with it. A script that is well formed by accident hashes to a
+    perfectly good address, and nothing else notices.
+
+    False is the answer wherever no language reads the script: not every
+    script is a miniscript -- an ``OP_DROP`` where nothing drops, a
+    quorum whose count does not match its keys -- and a caller wanting to
+    know *what* is wrong with it calls `from_script` and reads the
+    refusal.
+
+    Written as the round trip rather than as "`from_script` accepted it",
+    which is what it comes to today: the decoder refuses every second
+    spelling of one expression -- a non-minimal push, a number with a
+    byte to spare, a VERIFY written as two op codes -- and a key answered
+    for the wrong hash, so what it accepts writes itself back. That is
+    the claim, and this is the proof of it rather than a restatement.
+    """
+    script = bytes_from_octets(script)
+    try:
+        node = from_script(script, context, key_hashes)
+    except BTClibValueError:
+        return False
+    return node.script() == script
 
 
 def _assert_sane(node: Miniscript) -> None:

--- a/tests/descriptors/miniscript_test.py
+++ b/tests/descriptors/miniscript_test.py
@@ -60,6 +60,7 @@ from btclib.descriptors.miniscript import (
     SpendContext,
     from_script,
     parse,
+    reads_back,
 )
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
@@ -164,9 +165,12 @@ def test_core_fixed_vector(vector: dict[str, Any], context: str) -> None:
     ):
         if vector[name] is not None:
             assert bound == vector[name], name
-    # the two round trips: through the text, and through the script
+    # the two round trips: through the text, and through the script --
+    # the second asked of the bytes as well, `reads_back` being that
+    # comparison for a caller who holds a script and not an expression
     assert parse(str(node), context) == node
     assert from_script(script, context, key_hashes(node)).script() == script
+    assert reads_back(script, context, key_hashes(node))
 
 
 def and_b_chain(count: int) -> str:
@@ -656,6 +660,38 @@ def test_a_key_hash_without_its_key_cannot_be_read() -> None:
         from_script(script)
     node = from_script(script, P2WSH, {hash160(bytes.fromhex(KEY)): KEY})
     assert str(node) == f"pkh({KEY})"
+
+
+def test_a_key_answered_for_a_hash_that_is_not_its_own_is_refused() -> None:
+    """Refuse a mapping whose key does not hash to the hash it is filed under.
+
+    The one input for which reading a script back gave an expression
+    writing a different script: the hash is all the script holds, so a
+    caller's answer to "which key is this" is believed, and a wrong one
+    put a key in the expression that hashes elsewhere. The script it
+    writes is then somebody else's output, which is the opposite of what
+    reading a script back is for.
+    """
+    script = parse(f"pkh({KEY})").script()
+    key_hash = hash160(bytes.fromhex(KEY))
+    lying: dict[Octets, Octets] = {key_hash: CUSTODY_KEYS[1]}
+    with pytest.raises(BTClibValueError, match="the key answered for the hash160"):
+        from_script(script, P2WSH, lying)
+    assert not reads_back(script, P2WSH, lying)
+    assert reads_back(script, P2WSH, {key_hash: KEY})
+
+
+def test_a_script_says_whether_it_is_the_expression_it_reads_as() -> None:
+    """Answer the round trip as a question, over the three answers there are.
+
+    A miniscript reads back as itself; a script no language reads is
+    False rather than a refusal, not every script being a miniscript;
+    and so are bytes that are no script at all, a caller holding a
+    witness script off a psbt having no promise about them either.
+    """
+    assert reads_back(parse(f"and_v(v:pk({KEY}),older(36))").script())
+    assert not reads_back(serialize(["OP_DROP", "OP_1"]))
+    assert not reads_back("21" + KEY[:-2])
 
 
 def test_a_script_too_large_for_its_context_is_refused() -> None:


### PR DESCRIPTION
`miniscript.reads_back(script, context, key_hashes)` is the round trip
put as a question: the script is read back into an expression, the
expression writes a script, and the answer is whether those are the same
bytes.

What it is asked about is a script somebody else wrote — a witness
script off a psbt, the pre-image a wallet computes — where "this is a
2-of-3 with a timelock" is an intention, and reading it back is the only
thing that says the bytes agree with it. A script that is well formed by
accident hashes to a perfectly good address, so nothing downstream
notices: the address is derived, the deposit is watched, and what cannot
be spent is found out at the spend.

`False` wherever no language reads the script, and that is an answer
rather than a refusal: not every script is a miniscript — an `OP_DROP`
where nothing drops, a quorum whose count does not match its keys — and
a caller that wants to know *what* is wrong with it calls `from_script`
and reads the message.

## The one input for which the documented inverse did not hold

`from_script` says it is the inverse of `Miniscript.script`, and the
decoder earns that on every other input: `_assert_minimal_push` refuses
a push written the long way, `_script_number` refuses a number with a
byte to spare, `_decomposed` refuses a VERIFY written as two op codes.
Each of those is a second spelling of one expression, and refusing them
is what makes the expression write the very bytes it was read from.

`key_hashes` was the exception. A `pk_h()` leaves the hash160 in the
script and no key, so the caller answers which key is behind it — the
question Bitcoin Core puts to a signing provider — and the answer was
believed. A mapping filing a key under a hash that is not its own read
the script into an expression whose `script()` writes *somebody else's*
output:

```python
>>> script = parse(f"pkh({KEY})").script()
>>> node = from_script(script, P2WSH, {hash160(KEY): OTHER_KEY})   # before
>>> node.script() == script
False
```

It is checked now, against what `script()` would write, and refused
where it does not hold: `the key answered for the hash160 <h> hashes to
<h'>`. That is also the reason `reads_back` can be written as the round
trip rather than as "the decoder accepted it" — the two agree, and the
comparison is the proof of it rather than a restatement.

A caller that answered a 33-byte compressed key for a tapscript
`pk_h()` is refused by the same check, correctly: a tapscript hashes
the 32 x-only bytes, so what it was answering was never the key behind
that hash.

## Tests and gates

- every Core fixed vector now asserts `reads_back(script, context,
  key_hashes(node))` beside the two round trips it already asserted, in
  both contexts;
- the lying mapping is refused, and `reads_back` is `False` for it;
- `reads_back` over the three answers there are: a miniscript, a script
  no language reads, and bytes that are no script at all.

Local gates, all green: `pre-commit run --all-files`, the suite (18551
passed) with the coverage ratchet met, and
`sphinx-build -W --keep-going`.

Beyond the vectors, 400k random scripts built from a miniscript-shaped
alphabet were fed to `from_script` while this was written: 2690 were
accepted and every one of them wrote itself back. That is what says the
decoder's refusals cover the second spellings, and it is a measurement
rather than a test — the vectors are the test.

Item B.1 of the checksig upstreaming roadmap: it lifts
`_assert_script_is_read_back` out of `checksig/wallet_address.py`.

## Summary by Sourcery

Add a helper to verify that a given script round-trips through miniscript decoding and encoding, and tighten key-hash validation when decoding pk_h/pkh fragments.

New Features:
- Introduce a reads_back helper that reports whether a script round-trips through miniscript decoding and encoding for a given context and key mapping.

Bug Fixes:
- Reject key-hash mappings where the provided public key does not hash to the script’s hash160, preventing decoded miniscripts from re-encoding to a different script.

Tests:
- Extend miniscript core vector tests to assert reads_back on all fixed vectors.
- Add tests covering rejection of mismatched key-hash mappings and the behavior of reads_back on valid miniscripts, unreadable scripts, and non-scripts.