### PR TITLE
Track the editor's workspace, and format yaml, toml and jsonc

### DIFF
--- a/.github/mutation/bip32.toml
+++ b/.github/mutation/bip32.toml
@@ -7,9 +7,9 @@
 
 [cosmic-ray]
 module-path = [
-  "btclib/bip32/bip32.py",
-  "btclib/bip32/key_origin.py",
-  "btclib/bip32/der_path.py",
+    "btclib/bip32/bip32.py",
+    "btclib/bip32/key_origin.py",
+    "btclib/bip32/der_path.py",
 ]
 
 test-command = "python -m pytest -x -q -n0 -p no:randomly tests/bip32"

--- a/.github/mutation/block.toml
+++ b/.github/mutation/block.toml
@@ -9,9 +9,9 @@
 
 [cosmic-ray]
 module-path = [
-  "btclib/block/block.py",
-  "btclib/block/block_header.py",
-  "btclib/block/proof_of_work.py",
+    "btclib/block/block.py",
+    "btclib/block/block_header.py",
+    "btclib/block/proof_of_work.py",
 ]
 
 test-command = "python -m pytest -x -q -n0 -p no:randomly tests/block"

--- a/.github/mutation/codecs.toml
+++ b/.github/mutation/codecs.toml
@@ -9,10 +9,10 @@
 
 [cosmic-ray]
 module-path = [
-  "btclib/base58.py",
-  "btclib/bech32.py",
-  "btclib/b58.py",
-  "btclib/b32.py",
+    "btclib/base58.py",
+    "btclib/bech32.py",
+    "btclib/b58.py",
+    "btclib/b32.py",
 ]
 
 # each module's own test file, in the order the pair builds on the codec:

--- a/.github/mutation/fetch.toml
+++ b/.github/mutation/fetch.toml
@@ -9,10 +9,10 @@
 
 [cosmic-ray]
 module-path = [
-  "btclib/fetch/transport.py",
-  "btclib/fetch/esplora.py",
-  "btclib/fetch/bitcoin_core.py",
-  "btclib/fetch/fetcher.py",
+    "btclib/fetch/transport.py",
+    "btclib/fetch/esplora.py",
+    "btclib/fetch/bitcoin_core.py",
+    "btclib/fetch/fetcher.py",
 ]
 
 test-command = "python -m pytest -x -q -n0 -p no:randomly tests/fetch"

--- a/.github/mutation/mnemonic.toml
+++ b/.github/mutation/mnemonic.toml
@@ -8,8 +8,8 @@
 
 [cosmic-ray]
 module-path = [
-  "btclib/mnemonic/bip39.py",
-  "btclib/mnemonic/entropy.py",
+    "btclib/mnemonic/bip39.py",
+    "btclib/mnemonic/entropy.py",
 ]
 
 test-command = """python -m pytest -x -q -n0 -p no:randomly \

--- a/.github/mutation/musig2.toml
+++ b/.github/mutation/musig2.toml
@@ -12,8 +12,8 @@
 # scheme and `psbt/musig2.py` the BIP373 role, which is why psbt.toml
 # names its five other modules one by one and leaves this one here
 module-path = [
-  "btclib/ecc/musig2.py",
-  "btclib/psbt/musig2.py",
+    "btclib/ecc/musig2.py",
+    "btclib/psbt/musig2.py",
 ]
 
 # both modules' own files, complete over the two -- measured with `--cov`

--- a/.github/mutation/numeric.toml
+++ b/.github/mutation/numeric.toml
@@ -9,9 +9,9 @@
 
 [cosmic-ray]
 module-path = [
-  "btclib/amount.py",
-  "btclib/fee.py",
-  "btclib/ecc/dh.py",
+    "btclib/amount.py",
+    "btclib/fee.py",
+    "btclib/ecc/dh.py",
 ]
 
 test-command = """python -m pytest -x -q -n0 -p no:randomly \

--- a/.github/mutation/parsers.toml
+++ b/.github/mutation/parsers.toml
@@ -19,9 +19,9 @@
 # var_bytes -- the length prefix of every list and every script in a
 # transaction -- to a profile of their own, for 195 mutants
 module-path = [
-  "btclib/tx",
-  "btclib/var_int.py",
-  "btclib/var_bytes.py",
+    "btclib/tx",
+    "btclib/var_int.py",
+    "btclib/var_bytes.py",
 ]
 
 # tests/tx first, where most mutants die, and then the two files for the

--- a/.github/mutation/psbt.toml
+++ b/.github/mutation/psbt.toml
@@ -13,12 +13,12 @@
 # judged by the same two test files. Named one by one for that reason,
 # where descriptors.toml and wallet.toml can name their directory
 module-path = [
-  "btclib/psbt/psbt.py",
-  "btclib/psbt/psbt_in.py",
-  "btclib/psbt/psbt_out.py",
-  "btclib/psbt/psbt_utils.py",
-  "btclib/psbt/psbt_size.py",
-  "btclib/psbt/__init__.py",
+    "btclib/psbt/psbt.py",
+    "btclib/psbt/psbt_in.py",
+    "btclib/psbt/psbt_out.py",
+    "btclib/psbt/psbt_utils.py",
+    "btclib/psbt/psbt_size.py",
+    "btclib/psbt/__init__.py",
 ]
 
 # tests/psbt, which covers these six to a single line -- measured with

--- a/.github/mutation/script.toml
+++ b/.github/mutation/script.toml
@@ -15,14 +15,14 @@
 # script-size bound is derived from the stack and element limits rather
 # than copied
 module-path = [
-  "btclib/script/script.py",
-  "btclib/script/script_pub_key.py",
-  "btclib/script/taproot.py",
-  "btclib/script/witness.py",
-  "btclib/script/sig_ops.py",
-  "btclib/script/op_codes_tapscript.py",
-  "btclib/script/limits.py",
-  "btclib/script/__init__.py",
+    "btclib/script/script.py",
+    "btclib/script/script_pub_key.py",
+    "btclib/script/taproot.py",
+    "btclib/script/witness.py",
+    "btclib/script/sig_ops.py",
+    "btclib/script/op_codes_tapscript.py",
+    "btclib/script/limits.py",
+    "btclib/script/__init__.py",
 ]
 
 # tests/script first, where nearly every mutant dies, and four files after

--- a/.github/mutation/signatures.toml
+++ b/.github/mutation/signatures.toml
@@ -19,8 +19,8 @@
 
 [cosmic-ray]
 module-path = [
-  "btclib/ecc/ssa.py",
-  "btclib/ecc/dsa.py",
+    "btclib/ecc/ssa.py",
+    "btclib/ecc/dsa.py",
 ]
 
 # anti_exfil_test.py and commit_nonce_test.py are the sign-to-contract

--- a/.github/mutation/signer.toml
+++ b/.github/mutation/signer.toml
@@ -15,9 +15,9 @@
 # sharing one command would make every mutant here pay for a fake
 # `hwi.py` being started twenty times
 module-path = [
-  "btclib/psbt_signer.py",
-  "btclib/psbt_signer_contract.py",
-  "btclib/tx_or_psbt.py",
+    "btclib/psbt_signer.py",
+    "btclib/psbt_signer_contract.py",
+    "btclib/tx_or_psbt.py",
 ]
 
 # the three modules' own files plus tests/software_signer_test.py, which

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -67,14 +67,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            macos-26-intel,
-            macos-latest,
-            windows-latest,
-            windows-11-arm,
-          ]
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-26-intel
+          - macos-latest
+          - windows-latest
+          - windows-11-arm
         # the two ends of the supported range, plus the free-threaded
         # interpreter: btclib itself ships one universal wheel, so what
         # varies across this matrix is entirely which wheel of

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,14 +84,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          [
-            ubuntu-latest,
-            ubuntu-24.04-arm,
-            macos-26-intel,
-            macos-latest,
-            windows-latest,
-            windows-11-arm,
-          ]
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-26-intel
+          - macos-latest
+          - windows-latest
+          - windows-11-arm
         # 3.14t is the free-threaded interpreter, and it is in the matrix
         # for what it installs as much as for what it runs: the bindings
         # ship a py3-none dynamic wheel for it, and nothing else here
@@ -106,15 +104,13 @@ jobs:
         # inputs with a version nobody else runs, on the older of the two
         # PyPy releases; pypy3.11 covers the implementation
         python:
-          [
-            "3.10",
-            "3.11",
-            "3.12",
-            "3.13",
-            "3.14",
-            "3.14t",
-            "pypy3.11",
-          ]
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
+          - "pypy3.11"
     # far above what a run of the suite needs: what it bounds is a hung
     # job holding a runner for six hours
     timeout-minutes: 30

--- a/.gitignore
+++ b/.gitignore
@@ -108,8 +108,13 @@ ENV/
 # ruff
 .ruff_cache/
 
-# vscode
-.vscode/
+# vscode: the workspace files are tracked, and the rest of what the editor
+# writes there is not. The directory itself cannot be the pattern -- git does
+# not descend into an excluded directory, so a negation under `.vscode/` never
+# matches -- which is why this excludes the contents and re-admits two names
+.vscode/*
+!.vscode/settings.json
+!.vscode/extensions.json
 
 # PyCharm
 .idea/

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,5 +1,4 @@
 {
-
   // rules https://github.com/DavidAnson/markdownlint
 
   // See https://github.com/DavidAnson/markdownlint-cli2 and
@@ -35,7 +34,7 @@
   // MD007/ul-indent - Unordered list indentation
   "MD007": {
     // Spaces for indent
-    "indent": 4
+    "indent": 4,
   },
 
   // MD029/ol-prefix - every item numbered "1.", the renderer numbering
@@ -57,6 +56,5 @@
   // MD049/MD050 - asterisks for both, so that *emphasis* and **strong**
   // are told apart by how many rather than by which character
   "MD049": { "style": "asterisk" },
-  "MD050": { "style": "asterisk" }
-
+  "MD050": { "style": "asterisk" },
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,13 @@ repos:
       # - id: fix-encoding-pragma
       - id: check-yaml
       - id: check-json
+        # `.vscode` is jsonc and not json: VSCode reads a comment in its own
+        # settings.json and extensions.json, and what those two files carry
+        # besides the settings is the reason for each of them. A json parser
+        # rejects the file at the first one. It is not a gap: prettier below
+        # is given that directory and fails on what it cannot parse, which
+        # is the question this hook asks
+        exclude: ^\.vscode/
       # both of this hook's defaults are wrong for this tree: at
       # --indent=2 nearly every json file here fails, the golden-file
       # fixture writing json.dumps(indent=4) (tests/conftest.py) -- so at
@@ -103,13 +110,19 @@ repos:
         # rather than a blob -- because the default for anything else in
         # that directory has to stay "not touched". (?x) is verbose mode,
         # i.e. the newlines below are not part of the pattern
+        # `.vscode` is the second name in the alternation and is there for
+        # the reason check-json above is given the same exclude: those files
+        # are jsonc, this hook parses json, and prettier below is what
+        # formats and parses them instead -- at its own indent, which is not
+        # this hook's 4 and does not have to be, no file being read by both
         exclude: |
-          (?x)^tests/([^/]+/)?_data/
-          (?!btclib_test_vectors\.json
-            |descriptor_checksums\.json
-            |rfc6979\.json
-            |electrum_test_vectors\.json
-            |unspendable_script_pub_keys\.json)
+          (?x)^(\.vscode/
+            |tests/([^/]+/)?_data/
+            (?!btclib_test_vectors\.json
+              |descriptor_checksums\.json
+              |rfc6979\.json
+              |electrum_test_vectors\.json
+              |unspendable_script_pub_keys\.json))
       - id: check-merge-conflict
       - id: check-vcs-permalinks
       - id: detect-private-key
@@ -237,6 +250,47 @@ repos:
       - id: markdownlint-cli2
         name: markdownlint-cli2 (in place fixes)
         args: [--fix]
+  # what ruff-format is for Python, on the structured files ruff does not
+  # read: yaml, and the jsonc that carries a comment. Before yamllint below,
+  # so the linter judges the formatted file and not the one that was typed.
+  #
+  # Not the archived pre-commit/mirrors-prettier, which stopped at prettier
+  # 2. The default configuration and no .prettierrc: what this tree already
+  # writes is what prettier writes, the exception being an inline sequence
+  # long enough to be exploded, and a block sequence -- which prettier
+  # leaves alone -- is the spelling that keeps one entry per line whatever
+  # the width.
+  #
+  # `files` is an allow list and not an exclude, because prettier reads more
+  # than it should be given here. markdown is markdownlint's, whose config
+  # settles the styles prettier would also have an opinion about; the json
+  # under tests is golden-file output and vendored vectors, which
+  # pretty-format-json above and tests/_data/README.md have the say over;
+  # .secrets.baseline is detect-secrets' own output. What is in scope is the
+  # yaml, `.vscode` and .markdownlint.jsonc, and prettier is also what
+  # parses the last two -- check-json cannot read a comment
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.9.6
+    hooks:
+      - id: prettier
+        name: prettier (yaml and jsonc, in place fixes)
+        files: ^(.*\.ya?ml|\.vscode/.*\.json|\.markdownlint\.jsonc)$
+  # the same for toml, which here is pyproject.toml and the mutation
+  # sessions under .github: .taplo.toml holds the formatting choices and the
+  # reasoning for them, as .yamllint.yaml does for the width of a yaml line.
+  # uv.lock is toml to identify and therefore matched by the hook's own
+  # types, and it is uv's file to write. It runs before toml-comment-width
+  # below, which reads a comment line and is the one thing here a formatter
+  # does not settle -- taplo aligns a comment that trails a value and
+  # rewraps none. taplo-lint is not enabled beside this: it validates
+  # against a schema catalogue it fetches, and pyroma and check-manifest
+  # below read the metadata offline
+  - repo: https://github.com/ComPWA/taplo-pre-commit
+    rev: v0.9.3
+    hooks:
+      - id: taplo-format
+        name: taplo (toml, in place fixes)
+        exclude: ^uv\.lock$
   # the width of a yaml line, which nothing else here measured: the hook
   # above holds markdown to 80 columns and ruff holds Python comments and
   # docstrings to the same, and the workflows were a place prose could

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,23 @@
+# taplo's configuration, in a file of its own for the same reason
+# .yamllint.yaml is one: the reasoning below needs more room than a hook
+# argument has. taplo finds this file by name in the directory it runs from,
+# which for a pre-commit hook is the repository root, so the hook needs no
+# flag.
+#
+# What is *not* set matters as much: reorder_keys stays at its default of
+# false, the order of a table here being an argument rather than an accident
+# -- [project] reads top to bottom, and the ruff rule sets are grouped by
+# what they cover rather than sorted.
+[formatting]
+# four spaces, which is what pyproject.toml already uses and what
+# ruff-format writes in the Python beside it. The mutation configurations
+# under .github/mutation are the files this moves: they were written with
+# two, and one indent for every toml in the tree is the point of having a
+# formatter at all
+indent_string = "    "
+# an array that is exploded stays exploded: one entry per line is what makes
+# adding a module to a mutation session, or a rule set to ruff, a one-line
+# diff, and the default would collapse a short array onto one line and
+# expand it again when it outgrows the width -- churn driven by a column
+# count
+array_auto_collapse = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,55 @@
+{
+  // one entry per tool the lint gate already runs, so the editor reports
+  // what .pre-commit-config.yaml would report at commit time. Nothing here
+  // is a tool the gate does not have: an extension with no hook behind it
+  // is a second opinion, and a finding no workflow enforces is noise
+  "recommendations": [
+    // ruff-check and ruff-format
+    "charliermarsh.ruff",
+    // the local mypy hook, which runs the project environment's mypy
+    "ms-python.mypy-type-checker",
+    // the interpreter, the test explorer and the debugger under them
+    "ms-python.python",
+    "ms-python.debugpy",
+    // the markdownlint-cli2 hook, reading this repository's own
+    // .markdownlint.jsonc with no further configuration
+    "DavidAnson.vscode-markdownlint",
+    // the typos hook, the same tool as a language server, reading
+    // [tool.typos] in pyproject.toml. There is no equivalent for codespell,
+    // the other spell checker: what exists on the marketplace carries its
+    // own dictionary rather than codespell's builtin, and a different
+    // dictionary is a different set of findings
+    "tekumara.typos-vscode",
+    // check-yaml, and the schemas check-dependabot and check-readthedocs
+    // validate against: this attaches them by filename, so a key
+    // dependabot.yml or .readthedocs.yaml does not accept is flagged where
+    // it is typed
+    "redhat.vscode-yaml",
+    // the workflows: expression and syntax checking in the editor. Not
+    // actionlint, which the gate also runs and no maintained extension
+    // wraps -- shellcheck inside a `run:` block stays a hook finding
+    "github.vscode-github-actions",
+    // the prettier hook, so what formats yaml and jsonc on save is the tool
+    // that formats it at commit time and not the copy the yaml extension
+    // embeds
+    "esbenp.prettier-vscode",
+    // check-toml, the pyproject.toml schema over it, and the taplo hook:
+    // this extension *is* taplo, and it reads .taplo.toml
+    "tamasfe.even-better-toml",
+    // docs/source is reStructuredText and the lint workflow builds it with
+    // sphinx -W. Highlighting only, deliberately: the heavier
+    // reStructuredText extensions want esbonio, doc8 or rstcheck installed
+    // to say anything, none of which is in the gate
+    "trond-snekvik.simple-rst"
+  ],
+  // the reflex installs that would each fight a hook: ruff formats, ruff
+  // sorts the imports with "I", and ruff's "PL" set is the pylint rules the
+  // gate selected. A second formatter on save reformats what ruff-format
+  // just wrote, and the commit hook writes it back
+  "unwantedRecommendations": [
+    "ms-python.black-formatter",
+    "ms-python.isort",
+    "ms-python.flake8",
+    "ms-python.pylint"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,108 @@
+{
+  // this file mirrors .pre-commit-config.yaml, which is the lint gate: what
+  // the editor fixes on save is what the hook would have fixed, so nothing
+  // reaches `git commit` for the first time there. extensions.json beside it
+  // names the tool each setting drives. What no extension wraps --
+  // codespell, yamllint, actionlint, zizmor, detect-secrets, check-manifest,
+  // pyroma, toml-comment-width -- is only ever seen by
+  //
+  //   uv run pre-commit run --all-files
+  //
+  // A machine-local preference does not belong here, this file being tracked
+  // and read by every checkout: what belongs is a choice this project has
+  // made and an editor cannot read from pyproject.toml
+
+  // there is no pyright among the hooks and mypy is the type gate, so what
+  // Pylance reports is a second opinion nothing enforces. Off rather than at
+  // its own default, and that is measured: on this tree the default reports
+  // errors mypy strict does not, over __all__ re-exports and a handful of
+  // narrowing differences in the tests. Some of them may well be worth
+  // fixing, which is a separate question from what the editor should say
+  // while typing; the survey is
+  //
+  //   uvx pyright --pythonpath .venv/bin/python btclib tests
+  //
+  // Completion, hover and go-to-definition are unaffected by this setting
+  "python.analysis.typeCheckingMode": "off",
+
+  // the mypy hook is a local one, running the project environment's mypy
+  // rather than an isolated copy, and the editor has to use that same one:
+  // the mypy the extension bundles is older than the locked one, and an
+  // `enable_error_code` name it does not know is dropped with a warning no
+  // extension surfaces. The environment is the .venv uv sync creates, which
+  // is also what makes `import btclib` resolve, the install in it being
+  // editable
+  "mypy-type-checker.importStrategy": "fromEnvironment",
+  // reportingScope stays at its default: the extension checks the file in
+  // the editor, the hook checks btclib, tests and .github/scripts
+
+  // the two ruff hooks, `ruff-check --fix` and `ruff-format`, on save.
+  // "always" rather than "explicit" because an auto-save on focus change is
+  // not an explicit save -- with "explicit" the formatter would run there
+  // and the fixes would not. `source.organizeImports.ruff` is absent on
+  // purpose: "I" is in the selected rule set, so the import order is
+  // already one of the fixes
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "always"
+    },
+    // the one place here that copies a number instead of naming a tool, so
+    // it is the one to revisit when either moves: 88 is what ruff-format
+    // reflows code to, and 80 is [tool.ruff.lint.pycodestyle]
+    // max-doc-length, which W505 holds a comment and a docstring to
+    "editor.rulers": [80, 88]
+  },
+
+  // `markdownlint-cli2 --fix`, which arrives as a code action and not as a
+  // formatter: the extension registers no document formatter, and the fix
+  // corrects rule violations rather than reflowing a paragraph. The ruler is
+  // MD013, tables included, and it is where the wrapping stays a judgement
+  // -- markdownlint reports a long line and rewraps no prose
+  "[markdown]": {
+    "editor.codeActionsOnSave": {
+      "source.fixAll.markdownlint": "always"
+    },
+    "editor.rulers": [80]
+  },
+
+  // the prettier and taplo hooks, on save and by the same two tools:
+  // prettier for yaml and for the jsonc that carries a comment, taplo for
+  // toml, reading the .taplo.toml the hook reads. `yaml.format.enable`
+  // stays off -- the yaml extension embeds a prettier of its own version,
+  // and two of them formatting one file is how a diff the hook did not ask
+  // for gets in
+  "yaml.format.enable": false,
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true
+  },
+  // json and jsonc are two languages to the editor, and the difference is
+  // the one the hooks draw: the json under tests is golden-file output and
+  // vendored vectors, held by pretty-format-json at indent 4 and by the
+  // pins tests/_data/README.md records, so an editor formatting one on save
+  // would break a test or void a verdict
+  "[json]": {
+    "editor.formatOnSave": false
+  },
+  "[toml]": {
+    "editor.defaultFormatter": "tamasfe.even-better-toml",
+    "editor.formatOnSave": true
+  },
+
+  // trailing-whitespace, end-of-file-fixer and `mixed-line-ending --fix=lf`.
+  // The first hook passes no --markdown-linebreak-ext, so a hard break
+  // spelled as two trailing spaces does not survive it either, and trimming
+  // one here is no loss
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true,
+  "files.trimFinalNewlines": true,
+  "files.eol": "\n",
+  // fix-byte-order-marker: "utf8bom" writes the mark that hook removes
+  "files.encoding": "utf8"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,6 +215,19 @@ baseline rather than an exclusion: what appears in it is what nobody has
 looked at yet, so regenerating without reading turns the review into a
 rubber stamp and the hook into decoration.
 
+### The editor
+
+`.vscode/settings.json` and `.vscode/extensions.json` are tracked, and they
+hold no preference: the recommended extensions are the tools
+`.pre-commit-config.yaml` already runs, and the settings put the fixing ones
+on save. Installing them is optional and changes nothing about what a commit
+enforces — what they buy is learning of a finding while typing rather than
+at the commit that trips over it.
+
+Anything machine-local — an interpreter path, a telemetry answer, a theme —
+belongs in the editor's own user settings instead, those two files being
+read by every checkout of this repository.
+
 ### Reproducing what CI runs
 
 Every job of every workflow is a `uv` command, and `uv` fetches what it

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,11 @@ include *.jsonc
 include pyproject.toml
 include uv.lock
 include .python-version
+# taplo's, for the same reason .secrets.baseline below is here: a hook the
+# gate runs reads it, and the gate has to be runnable from an unpacked sdist.
+# Named rather than covered by a glob, `include *.yaml` and `include *.jsonc`
+# above having no toml equivalent -- pyproject.toml is named on its own too
+include .taplo.toml
 # the sdist already carries .pre-commit-config.yaml, which points at this
 include .secrets.baseline
 # the Jekyll sources of btclib.org, which is served from this repository's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,10 @@ namespaces = true
 # exclude rules, which read as packaging decisions while matching nothing
 # any include has added
 ignore = [
+    # the editor's workspace: tracked, so that a checkout is told what the
+    # gate enforces, and no more part of a distribution than the website
+    # below is
+    ".vscode/*",
     "CNAME",
     "Gemfile",
     "_config.yml",
@@ -208,7 +212,9 @@ xfail_strict = true
 # BTCLIB_INTEGRATION in the environment, so the marker is for selecting
 # them (`-m integration`) and for excluding them from a run that has the
 # variable set for other reasons
-markers = ["integration: needs an external program, opt-in via BTCLIB_INTEGRATION"]
+markers = [
+    "integration: needs an external program, opt-in via BTCLIB_INTEGRATION",
+]
 # a deprecation warning is the early form of a break, emitted years before
 # the removal that will fail the suite: on a 3.10 to 3.14 spread, plus
 # pypy, there is time to act on it only if it is not silent.
@@ -280,13 +286,13 @@ ignore-regex = '`[^`]*`'
 # and the hook runs with --write-changes, so that is a rewrite of every
 # mnemonic derived from that list, not a report
 extend-exclude = [
-  "**/_data/*.json",
-  "**/_data/*.csv",
-  "**/_data/*.txt",
-  "**/_data/*.bin",
-  "**/_generated_files/*",
-  ".secrets.baseline",
-  "uv.lock",
+    "**/_data/*.json",
+    "**/_data/*.csv",
+    "**/_data/*.txt",
+    "**/_data/*.bin",
+    "**/_generated_files/*",
+    ".secrets.baseline",
+    "uv.lock",
 ]
 
 [tool.typos.default]
@@ -547,11 +553,11 @@ explicit-preview-rules = true
 # refusing them outright, and a codebase that finishes what it starts
 # wants the second
 select = [
-    "A",    # flake8-builtins: a name that shadows a builtin
-    "B",    # flake8-bugbear
-    "BLE",  # flake8-blind-except
-    "C4",   # flake8-comprehensions
-    "C90",  # mccabe, at ruff's default with noqa'd exceptions: see below
+    "A",   # flake8-builtins: a name that shadows a builtin
+    "B",   # flake8-bugbear
+    "BLE", # flake8-blind-except
+    "C4",  # flake8-comprehensions
+    "C90", # mccabe, at ruff's default with noqa'd exceptions: see below
     # flake8-copyright, replacing the copyright-notice pre-commit hook:
     # ed6e8014 found that hook checking only staged files unless given
     # --enforce-all, so "pre-commit run --all-files" -- what the lint


### PR DESCRIPTION
The same change [bitcoin-core-rpc#67](https://github.com/btclib-org/bitcoin-core-rpc/pull/67)
makes, adapted to this tree rather than copied: `pretty-format-json`,
`toml-comment-width` and the mutation sessions under `.github` have no
counterpart there.

## The editor is told what the gate enforces

`.vscode/settings.json` and `.vscode/extensions.json` are tracked —
`.gitignore` excludes the *contents* of that directory, git not descending
into an excluded one. Recommendations are one extension per tool the gate
runs; black, isort, flake8 and pylint are unwanted rather than absent, each
being the reflex install that would rewrite what `ruff-format` just wrote.

**Pylance is off, and that is measured.** At its own default it reports 8
errors and 41 warnings on this tree — `__all__` re-exports in
`btclib/__init__.py` and `btclib/script/__init__.py`, plus some narrowing in
the tests — none of which mypy strict reports. Some look worth a look on
their own; the survey command is in the file:

```shell
uvx pyright --pythonpath .venv/bin/python btclib tests
```

## yaml, toml and jsonc get a formatter

- **prettier** for yaml and jsonc, and not yamlfix: yamlfix rewrites the
  space before a trailing comment, moving every `uses: <sha> # <tag>` pin away
  from what dependabot writes when it bumps one — the reason `.yamllint.yaml`
  leaves the `comments` rule off — and drops the blank line between comment
  blocks.
- `files` is an allow list: the json under `tests` is golden-file output and
  vendored vectors, whose say belongs to `pretty-format-json` and to the pins
  in `tests/_data/README.md`; markdown is markdownlint's. `.vscode` is in
  scope, which is also what parses it — `check-json` cannot read a comment, and
  both it and `pretty-format-json` now exclude that directory.
- The three workflow matrices become **block sequences**, a shape prettier
  leaves alone, so one entry per line is structural rather than a consequence
  of the line being too long to collapse.
- **taplo** for toml, configured in `.taplo.toml`: four spaces, which
  `pyproject.toml` already uses and the mutation sessions did not; arrays left
  exploded; keys not reordered. `uv.lock` excluded by name. It runs before
  `toml-comment-width`, which reads a comment line — the one thing a formatter
  does not settle here.
- `MANIFEST.in` gains `.taplo.toml` (the gate runs from an unpacked sdist);
  `check-manifest` ignores `.vscode`.

No `CHANGELOG.md` entry: a contributor notices this, a user does not.

## Gates

```shell
uv run --locked --only-group lint pre-commit run --all-files   # 0, and 0 on a second pass
uv run --locked --no-default-groups --group test pytest --cov  # 0, 18553 passed, 100.00%
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html   # 0
uv build && twine check --strict dist/* && check-wheel-contents dist/*.whl   # 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Track the editor workspace and introduce automated formatting for YAML, TOML and JSONC while keeping test and data fixtures stable.

New Features:
- Add tracked VS Code workspace files to guide recommended extensions and on-save formatting behavior.
- Enable Prettier-based formatting for YAML and JSONC files, including VS Code config and markdownlint configuration.
- Enable Taplo-based formatting for TOML files with a shared formatting configuration across mutation configs.

Enhancements:
- Exclude VS Code JSONC files from JSON validation hooks that cannot parse comments, delegating them to Prettier.
- Clarify packaging configuration to treat the editor workspace as non-distribution content and update manifest handling.
- Standardize indentation and array layout in TOML mutation configuration files via Taplo.
- Reformat GitHub Actions workflow matrices to use block sequences for clearer, stable YAML structure.
- Document editor setup and expectations for contributors in CONTRIBUTING.md.

Build:
- Update packaging and manifest configuration to ignore editor workspace in distributions and include Taplo config for sdist-based gates.

CI:
- Adjust pre-commit configuration to add Prettier and Taplo hooks and refine JSON validation scopes for CI linting.

Documentation:
- Add contributor documentation describing tracked editor configuration and how recommended extensions relate to pre-commit hooks.

Chores:
- Introduce repository-local VS Code settings and extension recommendations without affecting runtime behavior.