### PR TITLE
Read a span of addresses back against the branch that derived it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -417,6 +417,39 @@ documented at release-notes length in the first place, and are still in
 
 ### Wallets
 
+- **`RangedWallet.assert_derives` reads a span of addresses back against
+  the branch that derived it** (#596). A list of addresses written down
+  -- a whitelist, a monitor's import, the deposit block a counterparty
+  was given -- is a file that outlives the process that wrote it and that
+  nobody re-derives afterwards. This is that file put back to the wallet:
+  the first address at `first_index`, the next at the index after it, to
+  the end of the span. It catches a list written under another key, or
+  under this key before a threshold or a device changed it, or shifted by
+  one position; and what makes it an answer rather than the same call
+  twice is when it is asked, since deriving a list and checking it in the
+  same breath says nothing.
+
+  Two refusals, each a different accident. An address that is not what
+  its position derives is named by that position, with what is written
+  and what the wallet computes. Two positions deriving one output is a
+  wallet whose script ignores its index -- the span is then one address
+  repeated, and every entry is "correct" where it sits, which the first
+  comparison cannot see and nothing downstream would either. No wallet
+  here can be built that way, a `ScriptWallet` with no `KeyGroup` in its
+  template being refused at construction and a descriptor that is not
+  ranged having no script past index 0, but `_script_pub_key` is one of
+  the three hooks a caller subclasses, so the test writes such a subclass
+  rather than calling the check unreachable. An empty span is refused
+  before either: there is nothing there to be right about.
+
+  Not the two ends through `position_of`, which is what a caller writes
+  by hand: that scans a branch from index 0 for each address, so a span
+  costs one scan per address and only the ends are affordable. Deriving
+  the position the span claims costs one derivation per address and
+  proves every entry. Outputs are named however the caller holds them, as
+  `position_of` takes them, and the ledger is left alone -- checking what
+  was handed out is not handing it out again.
+
 - **`ScriptWallet` is BIP174's Updater for the scripts no descriptor
   states** (#587). `DescriptorWallet` has `update_psbt_input` and
   `update_psbt_output` and this class had neither, so a caller spending a

--- a/btclib/wallet/wallet.py
+++ b/btclib/wallet/wallet.py
@@ -30,6 +30,8 @@ worth an abstraction:
   never because a key origin's four-byte fingerprint matches.
   `Descriptor.index_of` asks it of one descriptor and answers the index
   alone; a wallet has branches, so the answer here is the pair.
+  `assert_derives` runs it over a whole span at once, which is the
+  question a caller has about a list of addresses it wrote down.
 
 What a branch *is* differs, and the difference is the one thing not
 hidden: a key wallet and a script wallet derive it, `branch/index` below
@@ -56,6 +58,7 @@ https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 from btclib import b32
@@ -365,3 +368,57 @@ class RangedWallet(Wallet, ABC):
                 if self._script_pub_key(branch, index).script == script:
                     return branch, index
         return None
+
+    def assert_derives(
+        self,
+        addresses: Sequence[Octets | ScriptPubKey],
+        branch: int = 0,
+        first_index: int = 0,
+    ) -> None:
+        """Refuse a span of outputs that is not what this branch derives.
+
+        A list of addresses written down -- a whitelist, a monitor's
+        import, the deposit block a counterparty was given -- read back
+        against the wallet that is supposed to have derived it: the first
+        one at `first_index`, the next at the index after it, and so on to
+        the end of the span. What it catches is the list that was written
+        under another key, or under this key before a threshold or a
+        device changed it, or shifted by one position; and what makes it
+        an answer rather than the same call twice is *when* it is asked --
+        deriving a list and then checking it in the same breath says
+        nothing, and asking it of the file an environment has been
+        operating under says everything.
+
+        Two refusals, and each is a different accident. An address that is
+        not what the position derives names the position, what was
+        written and what the wallet computes. Two positions deriving one
+        output is a wallet whose script ignores its index -- a span that
+        is then one address repeated, every one of them "correct" at the
+        position it sits at -- which the comparison above cannot see and
+        nothing downstream would either.
+
+        An empty span is refused too: there is nothing to be right about,
+        and a caller that has written an empty file has not written a
+        span. Outputs are named however the caller holds them, as in
+        `position_of`, and the wallet's ledger is left alone -- checking
+        what was handed out is not handing it out again.
+        """
+        if not addresses:
+            err_msg = f"no addresses to check against branch {branch}"
+            raise BTClibValueError(err_msg)
+        scripts = [
+            self.script_pub_key(branch, first_index + offset).script
+            for offset in range(len(addresses))
+        ]
+        if len(set(scripts)) != len(scripts):
+            last_index = first_index + len(scripts) - 1
+            err_msg = f"branch {branch} derives one output twice"
+            err_msg += f" between {first_index} and {last_index}"
+            raise BTClibValueError(err_msg)
+        for offset, address in enumerate(addresses):
+            script = _script_from(address)
+            if script != scripts[offset]:
+                index = first_index + offset
+                err_msg = f"not what {branch}/{index} derives: {script.hex()}"
+                err_msg += f" is written where {scripts[offset].hex()} is derived"
+                raise BTClibValueError(err_msg)

--- a/tests/wallet/wallet_test.py
+++ b/tests/wallet/wallet_test.py
@@ -284,6 +284,84 @@ def test_position_of_searches_up_to_last_index_inclusive(
     assert wallet.position_of(script_pub_key, last_index=2) is None
 
 
+@BUILDERS
+def test_a_span_is_what_a_branch_derives_from_an_index_on(
+    build: Callable[[], RangedWallet],
+) -> None:
+    """A list of addresses read back against the wallet said to derive it.
+
+    Written however the caller holds them, as `position_of` takes them,
+    and asking hands nothing out: a span on disk is checked against the
+    wallet, not issued by it.
+    """
+    wallet = build()
+    span = [build().address(1, index) for index in range(3, 8)]
+    wallet.assert_derives(span, 1, 3)
+    wallet.assert_derives([ScriptPubKey.from_address(a) for a in span], 1, 3)
+    wallet.assert_derives(span[:1], 1, 3)
+    assert not len(wallet)
+
+
+@BUILDERS
+def test_a_span_filed_at_the_wrong_position_is_refused(
+    build: Callable[[], RangedWallet],
+) -> None:
+    """Shifted by one, on the other chain, or holding somebody else's output.
+
+    The three accidents that write a whitelist nobody re-derived, and
+    each is named by the position that disagrees rather than by the
+    span as a whole. An empty span is refused before any of them: there
+    is nothing there to be right about.
+    """
+    wallet = build()
+    span = [build().address(1, index) for index in range(3, 8)]
+
+    with pytest.raises(BTClibValueError, match="no addresses to check"):
+        wallet.assert_derives([], 1, 3)
+    with pytest.raises(BTClibValueError, match="not what 1/2 derives"):
+        wallet.assert_derives(span, 1, 2)
+    with pytest.raises(BTClibValueError, match="not what 0/3 derives"):
+        wallet.assert_derives(span, 0, 3)
+
+    span[2] = _ELSEWHERE
+    with pytest.raises(BTClibValueError, match="not what 1/5 derives"):
+        wallet.assert_derives(span, 1, 3)
+
+
+def test_a_span_of_one_output_repeated_is_no_span() -> None:
+    """Refuse a branch that derives the same output at every position.
+
+    The one accident the comparison above cannot see: a script that
+    ignores its index derives one address everywhere, so every entry of
+    the span is "what that position derives" and the file is that address
+    a hundred times. No wallet here can be built that way -- a
+    `ScriptWallet` with no `KeyGroup` in its template is refused, and a
+    descriptor that is not ranged has no script past index 0 -- but
+    `RangedWallet` is what a caller subclasses, and `_script_pub_key` is
+    theirs to write.
+    """
+
+    class OneOutput(RangedWallet):
+        """A wallet paying to the same anyone-can-spend script everywhere."""
+
+        @property
+        def is_watch_only(self) -> bool:
+            return True
+
+        @property
+        def branches(self) -> tuple[int, ...]:
+            return (0,)
+
+        def _script_pub_key(self, branch: int, index: int) -> ScriptPubKey:
+            return ScriptPubKey(b"\x51")
+
+    wallet = OneOutput()
+    assert wallet.is_watch_only
+    wallet.assert_derives([b"\x51"], 0, 0)
+    with pytest.raises(BTClibValueError, match="derives one output twice"):
+        wallet.assert_derives([b"\x51"] * 3, 0, 0)
+
+
 def test_a_wallet_that_names_no_branches_is_not_a_wallet() -> None:
     """`branches` is abstract, and a subclass leaving it out cannot be built.
 


### PR DESCRIPTION
`RangedWallet.assert_derives(addresses, branch, first_index)` reads a
list of addresses back against the wallet that is supposed to have
derived it: the first at `first_index`, the next at the index after it,
to the end of the span.

A list of addresses written down is a whitelist, a monitor's import, the
deposit block a counterparty was given — a file that outlives the
process that wrote it, and one nobody re-derives afterwards. What this
catches is the file written under another key, or under this key before
a threshold or a device changed it, or shifted by one position. What
makes it an answer rather than the same call twice is *when* it is
asked: deriving a list and checking it in the same breath says nothing,
and asking it of the file an environment has been operating under says
everything.

## Two refusals, and each is a different accident

- **an address that is not what its position derives** — named by the
  position, with what is written and what the wallet computes:
  `not what 1/5 derives: <script> is written where <script> is derived`;
- **two positions deriving one output** — a wallet whose script ignores
  its index, so the span is one address repeated and every entry is
  "correct" at the position it sits at. The comparison above cannot see
  it and nothing downstream would either.

No wallet in this package can be built the second way: a `ScriptWallet`
with no `KeyGroup` in its template is refused at construction ("a script
with no key to derive is one script"), and a descriptor that is not
ranged has no script past index 0. But `RangedWallet` is an abstract
class with `_script_pub_key` as one of its three subclass hooks, so the
wallet that derives one output everywhere is a subclass away — and the
test writes exactly that subclass rather than asserting the check is
unreachable.

An empty span is refused before either: there is nothing there to be
right about, and a caller that has written an empty file has not written
a span.

Outputs are named however the caller holds them, as `position_of` takes
them — `ScriptPubKey`, script bytes, hex, or the address — and the
ledger is left alone: checking what was handed out is not handing it out
again.

## Why not the ends with `position_of`

`position_of` scans a branch from index 0 for each address, so checking
a span with it costs one scan per address; deriving the position the
span *claims* costs one derivation per address and proves more — every
entry, not just the two that were affordable.

## Gates

`pre-commit run --all-files`, the suite (18562 passed) at 100.00%
coverage, and `sphinx-build -W --keep-going`, all green locally.

Item B.2 of the checksig upstreaming roadmap: it lifts `verify_span`
out of `checksig/wallet_address.py`.

## Summary by Sourcery

Add a wallet API to validate a span of addresses against a specific branch and index range, with safeguards against misaligned or degenerate derivations.

New Features:
- Introduce RangedWallet.assert_derives to verify that a sequence of outputs matches what a wallet branch derives from a given starting index.

Tests:
- Extend wallet tests to cover span validation, error conditions for empty or misaligned spans, and a degenerate wallet that derives the same output at every index.