### PR TITLE
Ask whether the HWI command line is there before running it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,26 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`hwi.available` says whether the command line is there, before it is
+  run** (#599). A caller that offers signers of several kinds decides
+  which to offer at all -- what to enumerate, whether to fall back to a
+  software signer, what to put in front of a user -- and that decision
+  comes before there is a device to ask about, so a refusal is not the
+  shape of the answer: `enumerate_devices` on a host with no HWI raises
+  `SignerNotFoundError`, which is the right answer to a question that was
+  asked and the wrong way to find out that there was nothing to ask.
+  Which part of an `executable` has to be on the PATH is this module's
+  own convention -- a name, or a whole argv like ``python -m hwilib``, of
+  which the first element is what runs -- so a caller writing
+  `shutil.which("hwi")` beside it takes that convention as read and
+  writes the default name a second time. `DEFAULT_EXECUTABLE` is that
+  name once, and the default of `available`, `enumerate_devices` and
+  `HwiSigner` alike: what is looked for and what is run cannot become two
+  different executables. True is not a promise that a device will answer,
+  or that what is on the PATH is HWI at all -- it is that there is
+  something to run, which is the half a caller cannot find out without
+  running one.
+
 - **`script.push_int` writes the shortest push of a number** (#598).
   `op_int` where the number has an op code of its own -- -1 to 16 -- and
   the CScriptNum encoding of it otherwise, as the hex a data push is

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -56,6 +56,10 @@ that is not about a device -- the executable is not installed -- is the
 `SignerNotFoundError` subclass, so that a caller which also offers
 signers of other kinds can tell "no hardware here" from "the hardware
 could not be reached" without matching on the text of a message.
+`available` is that one question asked *before* anything is run, which is
+when a caller deciding what to offer at all has to have the answer: a
+refusal is the right answer to a question that was asked, and the wrong
+way to find out there was nothing to ask.
 
 ## Wallet policies, and the multisig this cannot register
 
@@ -94,6 +98,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import tempfile
 import time
@@ -111,13 +116,21 @@ from btclib.psbt_signer import SignerCapabilities
 from btclib.utils import bytes_from_octets, is_integer
 
 __all__ = [
+    "DEFAULT_EXECUTABLE",
     "DEFAULT_MAX_OUTPUT",
     "DEFAULT_TIMEOUT",
     "NO_CAPABILITIES",
     "HwiDevice",
     "HwiSigner",
+    "available",
     "enumerate_devices",
 ]
+
+# the command HWI publishes, and the one name for it here: what
+# `available` looks for on the PATH and what every command runs are the
+# same string, so that "it is not installed" and "it is installed" cannot
+# be answers about two different executables
+DEFAULT_EXECUTABLE = "hwi"
 
 # a button press is what a signing command waits for, so the bound is on
 # a person and not on a computation: two minutes is long enough for a
@@ -189,6 +202,33 @@ def _executable(executable: str | Sequence[str]) -> list[str]:
     use to run a stand-in with no HWI installed.
     """
     return [executable] if isinstance(executable, str) else list(executable)
+
+
+def available(executable: str | Sequence[str] = DEFAULT_EXECUTABLE) -> bool:
+    """Whether the command line this module runs is there to be run.
+
+    Asked before running it, rather than read off a failure afterwards. A
+    caller that offers signers of several kinds decides which to offer at
+    all -- what devices to enumerate, whether to fall back to a software
+    signer, what to put in front of a user -- and that decision comes
+    before there is a device to ask about, so a refusal is not the shape
+    of the answer: `enumerate_devices` on a host with no HWI raises
+    `SignerNotFoundError`, which is the right answer to a question that
+    was asked and the wrong way to find out that there was nothing to ask.
+
+    What is looked for is argv[0] of what would be run, which is why this
+    belongs here and not in the caller: an `executable` is a name on the
+    PATH or a whole argv -- `["python", "-m", "hwilib"]`, a wrapper with
+    flags of its own -- and which part of it has to be on the PATH is
+    this module's own convention, `_executable`'s. A caller writing
+    `shutil.which("hwi")` beside it writes the default name a second
+    time and takes that convention as read.
+
+    True is not a promise that a device will answer, or that what is on
+    the PATH is HWI at all: it is that there is something to run, which
+    is the half of it a caller cannot find out without running one.
+    """
+    return shutil.which(_executable(executable)[0]) is not None
 
 
 def _watch(
@@ -373,7 +413,7 @@ def _device(entry: Any) -> HwiDevice:
 
 def enumerate_devices(
     *,
-    executable: str | Sequence[str] = "hwi",
+    executable: str | Sequence[str] = DEFAULT_EXECUTABLE,
     network: str = "mainnet",
     timeout: float = DEFAULT_TIMEOUT,
     max_output: int = DEFAULT_MAX_OUTPUT,
@@ -430,7 +470,7 @@ class HwiSigner:
         self,
         fingerprint: Octets | None = None,
         *,
-        executable: str | Sequence[str] = "hwi",
+        executable: str | Sequence[str] = DEFAULT_EXECUTABLE,
         network: str = "mainnet",
         timeout: float = DEFAULT_TIMEOUT,
         max_output: int = DEFAULT_MAX_OUTPUT,

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import json
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -45,10 +46,12 @@ from btclib.descriptors import Descriptor, at_index, parse
 from btclib.exceptions import BTClibValueError, SignerError, SignerNotFoundError
 from btclib.hwi import (
     _HWI_CHAIN,
+    DEFAULT_EXECUTABLE,
     DEFAULT_MAX_OUTPUT,
     DEFAULT_TIMEOUT,
     HwiDevice,
     HwiSigner,
+    available,
     enumerate_devices,
 )
 from btclib.psbt.psbt import Psbt
@@ -611,6 +614,29 @@ def test_the_defaults_are_the_two_bounds(hwi: list[str]) -> None:
     assert device.max_output == DEFAULT_MAX_OUTPUT == 1 << 20
     # and nothing of hwilib is imported to get any of this
     assert not [name for name in sys.modules if name.startswith("hwilib")]
+
+
+def test_whether_the_command_line_is_there_is_asked_before_it_is_run(
+    hwi: list[str], tmp_path: Path
+) -> None:
+    """`available` looks for argv[0] of what would be run, and nothing else.
+
+    The stand-in is `[sys.executable, script]`, so what has to be on the
+    PATH is the interpreter and not the script: which element that is is
+    this module's convention, which is the whole reason the question is
+    answered here rather than by a caller writing `shutil.which` beside
+    it. A path that names nothing is False, and it is False *before* any
+    subprocess -- the same fact `enumerate_devices` reports afterwards,
+    and by then it has run one.
+    """
+    assert available(hwi)
+    assert available(sys.executable)
+    assert not available(str(tmp_path / "nowhere"))
+    assert not available([str(tmp_path / "nowhere"), "--flag"])
+    # the default is the name every command here runs, so the two cannot
+    # be answers about different executables
+    assert DEFAULT_EXECUTABLE == "hwi"
+    assert available() == (shutil.which(DEFAULT_EXECUTABLE) is not None)
 
 
 def test_btclib_runs_the_commands_hwi_publishes(tmp_path: Path) -> None:


### PR DESCRIPTION
`hwi.available()` answers whether argv[0] of what this module would run
is on the PATH.

A caller that offers signers of several kinds decides which to offer *at
all* — what to enumerate, whether to fall back to a software signer,
what to put in front of a user — and that decision comes before there is
a device to ask about. A refusal is not the shape of that answer:
`enumerate_devices` on a host with no HWI raises `SignerNotFoundError`,
which is the right answer to a question that was asked and the wrong way
to find out that there was nothing to ask.

## Why it belongs here and not in the caller

Which part of an `executable` has to be on the PATH is this module's own
convention, `_executable`'s: it is a name, or a whole argv —
`["python", "-m", "hwilib"]`, an interpreter and a script, a wrapper
with flags of its own — of which the first element is what runs. A
caller writing

```python
shutil.which("hwi")     # two assumptions, both this module's
```

takes that convention as read *and* writes the default name a second
time. So the second half of this is `DEFAULT_EXECUTABLE`: the name once,
in `__all__`, and the default of `available`, `enumerate_devices` and
`HwiSigner` alike — so "it is not installed" and "it is installed"
cannot become answers about two different executables.

`True` is not a promise that a device will answer, or that what is on
the PATH is HWI at all. It is that there is something to run, which is
the half a caller cannot find out without running one.

## Gates

`pre-commit run --all-files`, the suite (18564 passed) at 100.00%
coverage, and `sphinx-build -W --keep-going`, all green locally. The new
test runs against the same stand-in the rest of the file uses —
`[sys.executable, script]`, which is what makes "the interpreter is what
must be on the PATH, not the script" an assertion rather than a claim.

Item B.4 of the checksig upstreaming roadmap: it lifts `hwi_available`
out of `checksig/hw.py`.

## Summary by Sourcery

Add an API to check for the presence of the HWI command-line executable before invoking it, and centralize the default HWI executable name used by this module.

New Features:
- Introduce an `available` function to report whether the configured HWI command line is present on the PATH before running any HWI commands.

Enhancements:
- Define and export `DEFAULT_EXECUTABLE` so that all HWI-related operations share a single configurable executable name instead of hardcoded strings.

Tests:
- Add tests ensuring `available` checks only argv[0], respects the module’s executable convention, and aligns with the default HWI executable configured in the module.