### PR TITLE
A signer that wraps a signer, for the rule that is the caller's own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -267,6 +267,35 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`psbt_signer.SignerDecorator` is a signer wrapping a signer** (#600).
+  It forwards the five methods of the contract to the signer it holds, so
+  that a caller adding one rule in front of `sign_psbt` -- a whitelist of
+  outputs a device may pay to, a limit on what a psbt may spend, a prompt
+  somebody has to confirm -- overrides that one method and nothing else.
+  The rule is the caller's business and belongs nowhere near this
+  library; the forwarding is what goes wrong when it is written by hand,
+  a wrapper answering `capabilities` for itself telling a caller that a
+  taproot input cannot be signed by a signer that can, and one that
+  forgets `close` leaving a subprocess running after the caller closed
+  what it was holding.
+
+  The optional protocols survive the wrapping, which is the half a
+  copyist gets wrong in a way nothing reports. `AddressDisplay` and
+  `MessageSigner` are what a caller asks about with `isinstance`, so a
+  wrapper that never carries them turns a device that can show an address
+  into one that cannot, and one that always declares them turns a signer
+  that cannot into one that fails when asked: each operation is bound on
+  the instance, and only where the wrapped signer has it. On the instance
+  rather than through `__getattr__` because since 3.12 a
+  runtime-checkable protocol is checked with `inspect.getattr_static`,
+  which does not call `__getattr__` -- measured on both ends of the
+  supported range, the same wrapper over the same signer is an
+  `AddressDisplay` on 3.10 and is not on 3.14. A subclass that writes an
+  operation of its own keeps it, an attribute written by a class being
+  what says the subclass means to answer that question itself. Nothing
+  else is forwarded: this is the contract and not the surface of the
+  adapter underneath, and `.signer` is what a caller reads for that.
+
 - **`hwi.available` says whether the command line is there, before it is
   run** (#599). A caller that offers signers of several kinds decides
   which to offer at all -- what to enumerate, whether to fall back to a

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -40,6 +40,12 @@ parsed. A psbt has no field for a private key at all.
 Selecting *which* device answers, the transport it answers over, and the
 timeouts and output limits a subprocess needs are the adapter's, not this
 module's: this is the contract such an adapter implements (issue #381).
+
+`SignerDecorator` is the other thing a caller writes against the contract:
+a signer wrapping a signer, for the rules that are the caller's own -- a
+whitelist of outputs, a limit on what may be spent, a prompt somebody has
+to confirm. The rule belongs nowhere near this library and the forwarding
+does, being what goes wrong when it is written by hand.
 """
 
 from __future__ import annotations
@@ -69,6 +75,7 @@ __all__ = [
     "MessageSigner",
     "PsbtSigner",
     "SignerCapabilities",
+    "SignerDecorator",
     "SignerDevice",
     "SoftwareSigner",
     "assert_public",
@@ -206,6 +213,95 @@ class SignerDevice(Protocol):
     def error(self) -> str:
         """Return why the device could not be asked, empty if it could."""
         ...
+
+
+# the operations of the two optional protocols above, which is what a
+# wrapper has to carry over from the signer it wraps -- one name each,
+# and the protocol is that name being there
+_OPTIONAL_OPERATIONS = ("display_address", "sign_message")
+
+
+class SignerDecorator:
+    """A signer that wraps a signer, for a caller adding a rule to one.
+
+    The shape every "sign, but only if" is: a rule of the caller's own in
+    front of `sign_psbt`, and everything else answered by the signer
+    underneath. A whitelist of outputs a device may pay to, a limit on
+    what a psbt may spend, a log of every request, a prompt somebody has
+    to confirm -- what those have in common is not the rule, which is the
+    caller's business and belongs nowhere near this library, but the four
+    other methods, which have to keep answering exactly what the wrapped
+    signer answers. A subclass overrides the one it is about::
+
+        class Whitelisted(SignerDecorator):
+            def sign_psbt(self, psbt: Psbt) -> Psbt:
+                for out in psbt.tx.vout:
+                    ...          # the caller's rule, before the device
+                return super().sign_psbt(psbt)
+
+    Written out here because forwarding is what goes wrong when it is
+    written by hand: a wrapper that answers `capabilities` for itself
+    tells a caller a taproot input cannot be signed by a signer that can,
+    and one that forgets `close` leaves a subprocess running after the
+    caller closed what it was holding.
+
+    **Wrapping does not hide what the signer offers.** `AddressDisplay`
+    and `MessageSigner` are optional protocols a caller asks about with
+    `isinstance`, so a wrapper that never carries them turns a device
+    that can show an address into one that cannot, and a wrapper that
+    always declares them turns a signer that cannot into one that fails
+    when asked. Each operation is therefore bound on the *instance*, and
+    only where the wrapped signer has it, so `isinstance` answers what
+    the signer offers -- and a subclass that writes one of its own keeps
+    it, an attribute written by a class being what says the subclass
+    means to answer that question itself.
+
+    On the instance rather than through `__getattr__`, which is the way
+    this is usually written and is wrong in a way nothing reports: since
+    3.12 a runtime-checkable protocol is checked with
+    `inspect.getattr_static`, which does not call `__getattr__`, so a
+    wrapper delegating that way satisfies `isinstance` on 3.10 and 3.11
+    and stops satisfying it on 3.12 and after -- the same wrapper, the
+    same signer, a different answer per interpreter.
+
+    Nothing else is forwarded. What this is is the contract, not the
+    surface of the adapter underneath: a caller that wants an attribute
+    of the signer it wrapped reads `.signer`, which is what it passed in.
+    """
+
+    def __init__(self, signer: PsbtSigner) -> None:
+        """Wrap a signer, carrying over the operations it offers.
+
+        Whether what is passed is a signer at all is `psbt_signer_contract
+        .check_psbt_signer`'s question, asked of the signer itself and not
+        of the wrapper around it: repeating a weaker form of it here would
+        answer "it has five methods" to a caller who needs to know what
+        they answer.
+        """
+        self.signer = signer
+        for operation in _OPTIONAL_OPERATIONS:
+            if hasattr(signer, operation) and not hasattr(type(self), operation):
+                setattr(self, operation, getattr(signer, operation))
+
+    def master_fingerprint(self) -> bytes:
+        """Return the wrapped signer's master fingerprint."""
+        return self.signer.master_fingerprint()
+
+    def xpub(self, der_path: DerPath) -> str:
+        """Return the wrapped signer's extended public key at a path."""
+        return self.signer.xpub(der_path)
+
+    def sign_psbt(self, psbt: Psbt) -> Psbt:
+        """Return what the wrapped signer answers, this adding no rule."""
+        return self.signer.sign_psbt(psbt)
+
+    def capabilities(self) -> SignerCapabilities:
+        """Return what the wrapped signer can be asked to sign."""
+        return self.signer.capabilities()
+
+    def close(self) -> None:
+        """Close the wrapped signer, and whatever it was holding open."""
+        self.signer.close()
 
 
 def _fingerprint(fingerprint: Octets) -> bytes:

--- a/tests/psbt_signer_test.py
+++ b/tests/psbt_signer_test.py
@@ -39,6 +39,7 @@ from btclib.psbt_signer import (
     MessageSigner,
     PsbtSigner,
     SignerCapabilities,
+    SignerDecorator,
     assert_public,
     display_address,
     export_account,
@@ -463,3 +464,136 @@ def test_a_device_with_no_fingerprint_yet_is_kept_by_the_merge() -> None:
     also_locked = HwiDevice(type="trezor", model="one", path="b", error="locked")
 
     assert merge_devices([locked], [also_locked]) == [locked, also_locked]
+
+
+class _Counting(_Signer):
+    """A signer that records the psbts it was asked to sign."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.requests: list[Psbt] = []
+
+    def sign_psbt(self, psbt: Psbt) -> Psbt:
+        """Record the request, then sign it as the double does."""
+        self.requests.append(psbt)
+        return super().sign_psbt(psbt)
+
+
+class _Refusing(SignerDecorator):
+    """A decorator with one rule: no output may pay more than a limit.
+
+    The shape of every "sign, but only if" -- a whitelist, a spending
+    cap, a prompt -- written here as the smallest rule that can refuse.
+    """
+
+    def __init__(self, signer: PsbtSigner, limit: int) -> None:
+        super().__init__(signer)
+        self.limit = limit
+
+    def sign_psbt(self, psbt: Psbt) -> Psbt:
+        """Sign, unless an output pays more than the limit allows."""
+        for out in psbt.tx.vout:
+            if out.value > self.limit:
+                err_msg = f"{out.value} is over the {self.limit} limit"
+                raise SignerError(err_msg)
+        return super().sign_psbt(psbt)
+
+
+def test_a_decorated_signer_answers_what_the_signer_underneath_answers() -> None:
+    """Every method but the one a subclass is about, forwarded.
+
+    A wrapper that answered `capabilities` for itself would tell a caller
+    a taproot input cannot be signed by a signer that can, and one that
+    forgot `close` would leave what the signer holds open after the
+    caller closed it.
+    """
+    signer = _Signer()
+    wrapped = SignerDecorator(signer)
+    assert isinstance(wrapped, PsbtSigner)
+
+    assert wrapped.master_fingerprint() == signer.master_fingerprint()
+    assert wrapped.xpub(ACCOUNT) == signer.xpub(ACCOUNT)
+    assert wrapped.capabilities() == signer.capabilities()
+
+    psbt, _ = account_psbt(signer)
+    assert wrapped.sign_psbt(deepcopy(psbt)) == signer.sign_psbt(deepcopy(psbt))
+
+    wrapped.close()
+    assert signer.closed
+
+
+def test_a_rule_is_what_a_subclass_adds_and_the_only_thing_it_adds() -> None:
+    """The psbt reaches the signer, or nothing does."""
+    signer = _Counting()
+    psbt, _ = account_psbt(signer)
+
+    allowed = _Refusing(signer, 9_000)
+    assert allowed.sign_psbt(deepcopy(psbt)).inputs[0].partial_sigs
+    assert len(signer.requests) == 1
+
+    asked = _Counting()
+    refused = _Refusing(asked, 8_999)
+    with pytest.raises(SignerError, match="9000 is over the 8999 limit"):
+        refused.sign_psbt(deepcopy(psbt))
+    # and the signer underneath was never asked, which is what a rule in
+    # front of a device is for: a device that refuses is a device that
+    # was shown the transaction
+    assert not asked.requests
+
+
+def test_wrapping_a_signer_does_not_hide_what_it_offers() -> None:
+    """`isinstance` answers about the wrapped signer, either way.
+
+    The optional protocols are how a caller asks whether an operation is
+    there at all, so a wrapper that carried them would turn a signer that
+    cannot show an address into one that fails when asked, and a wrapper
+    that dropped them would turn one that can into one that cannot.
+    """
+    assert not isinstance(SignerDecorator(_Signer()), AddressDisplay)
+    assert not isinstance(SignerDecorator(_Signer()), MessageSigner)
+
+    display = SignerDecorator(_Display())
+    assert isinstance(display, AddressDisplay)
+    receive = export_account(display, ACCOUNT)[0]
+    assert display.display_address(receive, 3) == receive.address(3)
+
+    assert isinstance(SignerDecorator(_MessageSigner()), MessageSigner)
+
+
+def test_a_decorator_carries_the_contract_and_not_the_adapter() -> None:
+    """What the wrapper answers is the five methods and the two operations.
+
+    An attribute of the signer that is not part of either -- a timeout, a
+    path, whatever the adapter holds -- is read off `.signer`, which is
+    what the caller passed in: a wrapper that forwarded everything would
+    be answering for the wrong object, copying and pickling included.
+    """
+    signer = _Signer()
+    wrapped = SignerDecorator(signer)
+    assert wrapped.signer is signer
+    assert wrapped.signer.xprv == XPRV_ROOT
+    with pytest.raises(AttributeError):
+        _ = wrapped.xprv  # type: ignore[attr-defined]
+
+
+def test_a_subclass_that_writes_an_operation_keeps_it() -> None:
+    """An operation written by a class is the subclass answering it itself.
+
+    The wrapped signer's is bound on the instance, which would otherwise
+    shadow it: a subclass overriding `display_address` -- to refuse it,
+    to log it, to show something else -- has said what it means.
+    """
+
+    class _Silent(SignerDecorator):
+        """A wrapper over a device whose screen is not to be used."""
+
+        def display_address(self, descriptor: Descriptor, index: int = 0) -> str:
+            """Refuse to ask the device to show anything."""
+            err_msg = "this signer's screen is not to be used"
+            raise SignerError(err_msg)
+
+    silent = _Silent(_Display())
+    assert isinstance(silent, AddressDisplay)
+    receive = export_account(silent, ACCOUNT)[0]
+    with pytest.raises(SignerError, match="screen is not to be used"):
+        silent.display_address(receive)


### PR DESCRIPTION
`psbt_signer.SignerDecorator` forwards the five methods of the contract
to the signer it holds, so that a caller adding one rule in front of
`sign_psbt` overrides that one method and nothing else:

```python
class Whitelisted(SignerDecorator):
    def sign_psbt(self, psbt: Psbt) -> Psbt:
        for out in psbt.tx.vout:
            ...                  # the caller's rule, before the device
        return super().sign_psbt(psbt)
```

A whitelist of outputs a device may pay to, a limit on what a psbt may
spend, a log of every request, a prompt somebody has to confirm — what
those have in common is not the rule, which is the caller's business and
belongs nowhere near this library, but the four other methods, which
have to keep answering exactly what the wrapped signer answers. That is
what goes wrong when the forwarding is written by hand: a wrapper that
answers `capabilities` for itself tells a caller that a taproot input
cannot be signed by a signer that can, and one that forgets `close`
leaves a subprocess running after the caller closed what it was holding.

## The optional protocols survive the wrapping

`AddressDisplay` and `MessageSigner` are what a caller asks about with
`isinstance`. A wrapper that never carries them turns a device that can
show an address into one that cannot; a wrapper that always declares
them turns a signer that cannot into one that fails when asked. So each
operation is bound on the *instance*, and only where the wrapped signer
has it.

On the instance rather than through `__getattr__` — which is how this is
usually written, and is wrong in a way nothing reports. Since 3.12 a
runtime-checkable protocol is checked with `inspect.getattr_static`,
which does not call `__getattr__`. Measured on both ends of this
project's support range, with the same wrapper over the same signer:

```
3.10.20  hasattr True  isinstance True
3.14.6   hasattr True  isinstance False
```

A subclass that writes an operation of its own keeps it: an attribute
written by a class is what says the subclass means to answer that
question itself, and the instance binding steps aside for it.

Nothing else is forwarded. This is the contract, not the surface of the
adapter underneath — a caller that wants an attribute of the signer it
wrapped reads `.signer`, which is what it passed in. Whether that object
is a signer at all stays `psbt_signer_contract.check_psbt_signer`'s
question, asked of the signer rather than of the wrapper around it.

## Gates

`pre-commit run --all-files`, the suite (18569 passed) at 100.00%
coverage, and `sphinx-build -W --keep-going`, all green locally; the new
tests were also run under 3.10, this being a change whose subject is
what differs between interpreters.

Item B.5 of the checksig upstreaming roadmap: it is the generic half of
`WhitelistedSigner` in `checksig/hw.py`, the whitelist itself staying
there.

## Summary by Sourcery

Introduce a signer decorator that wraps an existing PSBT signer to add caller-defined rules while transparently forwarding the signer contract.

New Features:
- Add SignerDecorator, a wrapper around PsbtSigner that forwards core signer methods and optional protocols while allowing subclasses to inject custom signing rules.

Tests:
- Add tests covering SignerDecorator forwarding behavior, rule enforcement, protocol exposure via isinstance, attribute access, and subclass overrides of optional operations.