### PR TITLE
Move the wait out of the merge gate, and name every job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,117 @@
+---
+name: docs
+
+# the third gate, and a question of its own: does the documentation build.
+# It was the second job of lint.yml, and the two answer different things --
+# a failed sphinx build and a failed hook are different verdicts, and one
+# badge and one line in the checks list each is what says so. It installs a
+# different dependency group and needs no pre-commit cache, so the two share
+# nothing but the checkout
+
+on:
+  push:
+    # main only, for the reason lint.yml gives at the same key: a push to a
+    # branch with an open pull request would run this twice, in two
+    # concurrency groups that do not cancel each other, and the
+    # pull_request run is the one worth keeping. The run on main is also
+    # what writes a cache the pull requests can read
+    branches: [main]
+  pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft
+    types: [opened, reopened, synchronize, ready_for_review]
+  # lets the release workflow gate publication on this check too
+  workflow_call:
+  # the escape hatch: a run on demand for a branch whose pull request is
+  # not open yet
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies) can read the token, so it must not be able to
+# write to the repository
+permissions:
+  contents: read
+
+# cancel superseded runs on the same branch/PR.
+# The group is named literally rather than with github.workflow, which in a
+# called workflow is the caller's name: the release workflow calls this one
+# alongside test.yml and lint.yml, and with that expression they would share
+# a group and cancel each other
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Without this workflow nothing in CI builds the documentation, only read the
+  # docs does, with -W, so invalid reStructuredText in a docstring fails
+  # after the merge, on a service whose failure is not a check on the pull
+  # request -- a docstring naming bip340_nonce_, whose trailing underscore
+  # rst reads as a link reference, or a title underline left too short by
+  # a rename (issues 148, 151, 174).
+  #
+  # No hook can take this over: markdownlint does not read .rst, and ruff's
+  # pydocstyle rules check the form of a docstring rather than whether its
+  # body is valid rst.
+  #
+  docs:
+    # the name is the required check on main, and it did not change when
+    # this job moved out of lint.yml: branch protection matches a context by
+    # name and not by the workflow that reported it, which is what let the
+    # move happen without touching the rule
+    name: Build the documentation
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    # about ten seconds of sphinx; a job that takes minutes is hung
+    timeout-minutes: 20
+    steps:
+      # every action is pinned to a commit SHA, the tag in the comment
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # see the checkout of the test-py job in test.yml
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+      # the same command .readthedocs.yaml runs and CONTRIBUTING.md
+      # documents, so what CI checks is what gets published.
+      # Not --only-group docs: autodoc imports every module of the package,
+      # so btclib and its bindings have to be installed -- which is the
+      # defect issue 151 was opened for, read the docs having installed
+      # sphinx alone and rendered 70 empty module headings.
+      # -W makes a failed import a failed build, and --keep-going reports
+      # every problem in one run instead of one per push
+      - name: Build the docs
+        run: >
+          uv run --locked --no-default-groups --group docs
+          sphinx-build -W --keep-going -b html docs/source docs/build/html
+      # the one defect the build above cannot report on itself: a relative
+      # link myst cannot resolve is rendered as an anchor on the page it is
+      # already on -- href="#./CONTRIBUTING.md", an id nothing has -- so
+      # -W passes over a dead link (issue 195). conf.py resolves those
+      # links and no longer suppresses myst.xref_missing, which makes the
+      # build fail on the next one; this step is the same claim made about
+      # the artifact rather than about the configuration, and it is what
+      # would catch a suppression added back.
+      #
+      # Not lychee: links.yml reads the sources, where "./CONTRIBUTING.md"
+      # is a correct path, and pointing it at docs/build/html would mean
+      # building the documentation inside a workflow that gates nothing
+      # and re-requesting every external url these pages carry.
+      # Not a pre-commit hook either: it would have to build the
+      # documentation, which is the very reason this job exists apart from
+      # the lint one.
+      #
+      # Not narrowed to myst's own class="xref myst" either. The defect is
+      # an href to an id no page has, whoever emitted it, and the prose
+      # that could be mistaken for one cannot reach the attribute: the
+      # CHANGELOG entry for issue 195 quotes href="#./FILE.md" in so many
+      # words and lands in the page as href=&quot;#./, escaped, measured
+      # on the built html
+      - name: Check the built pages for unresolved links
+        run: |
+          if grep -rn 'href="#\./' docs/build/html --include='*.html'; then
+            echo "::error::the links above resolve to no page"
+            exit 1
+          fi

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,7 @@ name: integration
 # mutation workflow gates nothing: what it can go red on is a release of
 # Bitcoin Core, an unreachable bitcoincore.org or a runner slow enough to
 # miss the node's startup timeout, and none of those is the branch's
-# fault. It therefore does not appear in master's required checks, and
+# fault. It therefore does not appear in main's required checks, and
 # must not -- that rule lives outside the repository and names its checks
 # as literal strings.
 #
@@ -34,11 +34,20 @@ on:
     # unattended questions is answered on a day of its own and a failure
     # notification names the workflow by the day it arrived.
     # Cron runs from the default branch only, so this file asks nothing
-    # until it reaches master -- on dev it is reachable through the
+    # until it reaches the default branch -- elsewhere it is reachable
+    # through the
     # dispatch button below and nowhere else
     - cron: "29 4 * * 5"
-  # the escape hatch, and the way to ask a node about a branch that
-  # touches the psbt or the descriptor path before merging it
+  # the same trigger set as the other gates: main so that the commit a
+  # merge creates is asked the question too -- and so that a cache is
+  # written where every pull request can read it -- the pull request so that
+  # the merge result is, and workflow_call so release.yml can reuse the
+  # answer
+  push:
+    branches: [main]
+  workflow_call:
+  # the escape hatch, and the way to ask a node about a Core version the
+  # matrix does not carry
   workflow_dispatch:
   # so a change to the tests this runs, or to this file, is checked by the
   # thing it configures -- links.yml does the same for its ignore list.
@@ -52,35 +61,11 @@ on:
     # types do not include it, and without it a readied pull request
     # would wait for its next push to be checked at all
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - .github/workflows/integration.yml
-      - tests/integration/**
-      # and the implementation whose answer a node is what checks
-      # (issue #570). What the two regtest tests put in front of Core is
-      # a descriptor it imports, the request that carries it, a psbt it
-      # signs beside btclib, the transaction extracted from it and the
-      # script that spends: a change to any of those can be accepted by
-      # 18k offline vectors and refused by the node, which is the whole
-      # of why this workflow exists. Without them the job ran only when
-      # a test or this file changed, so the branch that could break the
-      # flow was the one branch it did not check.
-      - btclib/core_import.py
-      - btclib/descriptors/**
-      - btclib/psbt/**
-      - btclib/psbt_signer*.py
-      - btclib/script/**
-      - btclib/tx/**
-      # What is deliberately not here, both halves measured rather than
-      # guessed. `btclib/fetch/**` is imported by nothing under
-      # tests/integration: the tests drive the node through
-      # `bitcoin_core_rpc` directly, so a fetch backend has no answer of
-      # Core's to be checked against until issue #204 gives it one.
-      # And the cryptographic core -- curves, ecc, hashes, utils -- is in
-      # the transitive imports of the flow and stays out all the same:
-      # what it is held to is vectors, offline and on every push, so a
-      # change there is red in `test.yml` long before a node sees it,
-      # while listing it would spend a runner on nearly every pull
-      # request and leave "outside the covered paths" meaning nothing
+    # no `paths` filter any more: this workflow is a required check on
+    # main, and a required check that never runs blocks a merge where a
+    # skipped one satisfies it -- a filter and a required check cannot both
+    # be had. Every pull request pays it, documentation-only ones included,
+    # which is what 36 seconds of work buys
 
 # least privilege for the GITHUB_TOKEN: nothing here writes, and the
 # tarball is fetched from bitcoincore.org, which does not know this token
@@ -98,14 +83,12 @@ jobs:
   regtest:
     name: Regtest against Bitcoin Core
     # a draft pull request is work in progress and spends no runner
-    # here either, the release pull request excepted: dev -> master is
+    # here either: a draft is work its author is not asking anyone to
     # a draft from one release to the next, and its runs are what
-    # checks a commit merged into dev. The same condition lint.yml and
+    # read yet. The same condition lint.yml and
     # test.yml carry, and ready_for_review is a trigger type above for
     # the same reason
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     # the whole flow is seconds -- two tests, a node that answers its
     # first rpc call in well under a second, and a chain of a few blocks

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -21,7 +21,7 @@ name: latest
 # The obvious alternative, dropping --locked from test.yml and resolving
 # afresh on every run, is what this workflow exists instead of: a pull
 # request would go red for a release in somebody else's repository, with
-# master's required checks in front of it, and the contributor
+# main's required checks in front of it, and the contributor
 # holding the branch cannot fix any of it. pytest runs with
 # filterwarnings = ["error"] and coverage with a fail_under ratchet, so
 # the ways an upstream release turns this tree red without touching it are
@@ -85,8 +85,8 @@ jobs:
   # being tested against what everybody else runs. That is not a
   # hypothetical: 3.9 left the floor resolving 35 of the 132 locked
   # packages to older versions
-  test-latest:
-    name: "Test ${{ matrix.python }} on ${{ matrix.os }}, deps at latest"
+  suite-latest:
+    name: "Run the suite on ${{ matrix.python }}, ${{ matrix.os }}, dependencies at latest"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -140,9 +140,9 @@ jobs:
   # third-party wheel". Moved here from published.yml (issue #397): it
   # is a question about drift against a tree not yet published, which
   # belongs before publication rather than after
-  test-bindings-latest:
+  suite-bindings-latest:
     name: >-
-      Test ${{ matrix.python }} on ${{ matrix.os }}, bindings at latest
+      Run the suite on ${{ matrix.python }}, ${{ matrix.os }}, bindings at latest
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -179,7 +179,7 @@ jobs:
   # shells out to uv, mypy -- the tool whose new release adds a check the
   # existing code base fails, on a schedule of its own
   lint-latest:
-    name: Lint and type-check, deps at latest
+    name: Lint and type-check, dependencies at latest
     runs-on: ubuntu-latest
     # nothing here takes minutes; a job that does is hung
     timeout-minutes: 20
@@ -218,7 +218,7 @@ jobs:
   # pinned by uv.lock like everything else, and a new pyroma with a
   # stricter rating would fail --min 10 for the first time on a tag
   dist-latest:
-    name: Check the distribution files, deps at latest
+    name: Build the distribution and inspect it, dependencies at latest
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -12,7 +12,7 @@ name: links
 # returning 502 or throttling a runner would turn a red merge into a thing
 # to re-run rather than a thing to fix. Weekly, on demand, and red in the
 # Actions tab is where this belongs.
-# It therefore does not appear in master's required checks, and must not:
+# It therefore does not appear in main's required checks, and must not:
 # that rule lives outside the repository and names its checks as literal
 # strings
 
@@ -70,14 +70,12 @@ jobs:
   links:
     name: Check the documentation links
     # a draft pull request is work in progress and spends no runner
-    # here either, the release pull request excepted: dev -> master is
+    # here either: a draft is work its author is not asking anyone to
     # a draft from one release to the next, and its runs are what
-    # checks a commit merged into dev. The same condition lint.yml and
+    # read yet. The same condition lint.yml and
     # test.yml carry, and ready_for_review is a trigger type above for
     # the same reason
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     # a few hundred requests with retries; a job past this is hung on one
     timeout-minutes: 15

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,16 +12,16 @@ name: lint
 
 on:
   push:
-    # master only: a push to a branch that has an open pull request would
+    # main only: a push to a branch that has an open pull request would
     # run this workflow twice, once per event, and the two runs land in
-    # different concurrency groups (refs/heads/dev against
+    # different concurrency groups (refs/heads/<branch> against
     # refs/pull/N/merge) so neither cancels the other. The pull_request
     # run is the one worth keeping, because it lints the merge commit and
     # is the only run a fork's pull request produces at all.
-    # master keeps a trigger of its own because a merge creates a commit
+    # main keeps a trigger of its own because a merge creates a commit
     # that is not the one the pull request linted, and nothing else would
     # ever lint it. Tag pushes are covered by the release workflow
-    branches: [master]
+    branches: [main]
   pull_request:
     # ready_for_review, so a pull request marked ready gets the run the
     # draft condition below withheld while it was a draft: the default
@@ -58,12 +58,7 @@ jobs:
     # request is marked ready, which is why ready_for_review is a
     # trigger type above.
     # The exception is by base branch, and it is the release pull
-    # request: dev -> master stays a draft from one release to the
-    # next, and nothing here triggers on a push to dev, so without it
-    # a commit merged into dev would be linted by nothing at all
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     # nothing here takes minutes; a job that does is hung
     timeout-minutes: 20
@@ -131,80 +126,3 @@ jobs:
         run: >
           uv run --locked --only-group lint
           pre-commit run --all-files --show-diff-on-failure
-
-  # Without this job nothing in CI builds the documentation, only read the
-  # docs does, with -W, so invalid reStructuredText in a docstring fails
-  # after the merge, on a service whose failure is not a check on the pull
-  # request -- a docstring naming bip340_nonce_, whose trailing underscore
-  # rst reads as a link reference, or a title underline left too short by
-  # a rename (issues 148, 151, 174).
-  #
-  # No hook can take this over: markdownlint does not read .rst, and ruff's
-  # pydocstyle rules check the form of a docstring rather than whether its
-  # body is valid rst.
-  #
-  # A second job rather than more steps in the one above, and the reason is
-  # the branch rule: it names "Lint and type-check", so adding steps there
-  # would silently change what gates a merge on master, while a new job
-  # gates nothing until someone adds it to the rule. It also runs in
-  # parallel and installs a different dependency group.
-  docs:
-    name: Build the documentation
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
-    runs-on: ubuntu-latest
-    # about ten seconds of sphinx; a job that takes minutes is hung
-    timeout-minutes: 20
-    steps:
-      # every action is pinned to a commit SHA, the tag in the comment
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # see the checkout of the test-py job in test.yml
-          persist-credentials: false
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          enable-cache: true
-      # the same command .readthedocs.yaml runs and CONTRIBUTING.md
-      # documents, so what CI checks is what gets published.
-      # Not --only-group docs: autodoc imports every module of the package,
-      # so btclib and its bindings have to be installed -- which is the
-      # defect issue 151 was opened for, read the docs having installed
-      # sphinx alone and rendered 70 empty module headings.
-      # -W makes a failed import a failed build, and --keep-going reports
-      # every problem in one run instead of one per push
-      - name: Build the docs
-        run: >
-          uv run --locked --no-default-groups --group docs
-          sphinx-build -W --keep-going -b html docs/source docs/build/html
-      # the one defect the build above cannot report on itself: a relative
-      # link myst cannot resolve is rendered as an anchor on the page it is
-      # already on -- href="#./CONTRIBUTING.md", an id nothing has -- so
-      # -W passes over a dead link (issue 195). conf.py resolves those
-      # links and no longer suppresses myst.xref_missing, which makes the
-      # build fail on the next one; this step is the same claim made about
-      # the artifact rather than about the configuration, and it is what
-      # would catch a suppression added back.
-      #
-      # Not lychee: links.yml reads the sources, where "./CONTRIBUTING.md"
-      # is a correct path, and pointing it at docs/build/html would mean
-      # building the documentation inside a workflow that gates nothing
-      # and re-requesting every external url these pages carry.
-      # Not a pre-commit hook either: it would have to build the
-      # documentation, which is the very reason this job exists apart from
-      # the lint one.
-      #
-      # Not narrowed to myst's own class="xref myst" either. The defect is
-      # an href to an id no page has, whoever emitted it, and the prose
-      # that could be mistaken for one cannot reach the attribute: the
-      # CHANGELOG entry for issue 195 quotes href="#./FILE.md" in so many
-      # words and lands in the page as href=&quot;#./, escaped, measured
-      # on the built html
-      - name: Check the built pages for unresolved links
-        run: |
-          if grep -rn 'href="#\./' docs/build/html --include='*.html'; then
-            echo "::error::the links above resolve to no page"
-            exit 1
-          fi

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,109 @@
+---
+name: macos
+
+# the platform the merge gate does not wait for. test.yml runs four
+# operating systems on every pull request and this one runs the two macOS
+# images, weekly and before a release, because macOS is where the wait comes
+# from. Measured on one pull request run of the full six: 45 jobs, 93
+# minutes of work and 399 minutes of queueing, the macOS cells waiting 29.4
+# and 23.2 minutes on average for a runner -- one of them 42.2 -- against
+# 0.5 to 1.6 for ubuntu and windows. The command that re-derives it, for
+# whoever doubts the split later:
+#
+#     id=$(gh run list --workflow=test.yml --limit 1 \
+#         --json databaseId --jq '.[0].databaseId')
+#     gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id/jobs?per_page=100"
+#
+# What these cells buy is narrower than the count suggests: there is no
+# platform-conditional branch in this library, which is the property the
+# coverage job in test.yml records from the other side -- no sys.platform
+# and no sys.version_info anywhere, so every cell walks the same lines. What
+# runs here is the standard library under it, and the bindings wheel for the
+# one architecture pair this repository does not otherwise install on.
+#
+# A workflow of its own rather than a row in latest.yml, and that is the
+# whole design: this one holds the dependencies at the lock and moves the
+# platform, latest.yml moves the dependencies over the platforms it samples,
+# and the two are scheduled on the same morning half an hour apart. A red
+# macOS cell in latest.yml with this workflow green is an upgrade; red in
+# both is macOS. One variable each, and the pair reads as a difference.
+#
+# It gates no commit and no merge -- a macOS regression sits on main for at
+# most a week -- but release.yml calls it, so one cannot be published
+
+on:
+  schedule:
+    # Wednesday, the morning latest.yml also runs, and thirty minutes before
+    # it: the two answer halves of the same question and are worth reading
+    # together. A minute that is not the hour, as every schedule here, so
+    # the run does not queue behind everything else cron starts.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "13 4 * * 3"
+  # lets release.yml gate a publication on this platform too, which is what
+  # keeps a weekly sentinel from being the only thing that ever asks
+  workflow_call:
+  # the escape hatch: the platform on demand, for a branch that touches
+  # anything a path or a home directory reaches
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies) can read the token, so it must not be able to
+# write to the repository
+permissions:
+  contents: read
+
+# cancel superseded runs: the subject here is the commit, which a newer one
+# supersedes. Named literally rather than with github.workflow, which in a
+# called workflow is the caller's name -- release.yml calls this one
+# alongside test.yml, and with that expression the two would share a group
+# and cancel each other
+concurrency:
+  group: macos-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  suite-macos:
+    name: Run the suite on ${{ matrix.python }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # every cell to the end: which interpreter fails on which image is the
+      # whole answer, and stopping at the first one hides the rest
+      fail-fast: false
+      matrix:
+        # the two images test.yml no longer carries. Both, and not the
+        # newest alone: one is Apple silicon and the other Intel, and what
+        # differs between them is the architecture the interpreter and the
+        # bindings wheel target
+        os:
+          - macos-26-intel
+          - macos-latest
+        # the interpreter set test.yml runs, unchanged: this workflow moves
+        # the platform and nothing else, so a difference between the two is
+        # attributable to the platform
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
+          - "pypy3.11"
+    # far above what a run of the suite needs, and it bounds a hung job
+    # rather than a slow one: the queueing this workflow exists to move
+    # happens before a job starts and is not counted here
+    timeout-minutes: 30
+    steps:
+      # the three steps of test.yml's suite job, and each `with:` there
+      # carries the reason for itself
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+      - name: Run pytest
+        run: uv run --locked --no-default-groups --group test pytest

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -12,7 +12,7 @@ name: mutation
 # needs a number nobody has measured yet, and a survival rate is not a
 # regression: a mutant survives because a test is missing, so a red merge
 # would block whoever next touched the file for a hole somebody else left.
-# It therefore does not appear in master's required checks, and must not --
+# It therefore does not appear in main's required checks, and must not --
 # that rule lives outside the repository and names its checks as literal
 # strings.
 #
@@ -32,7 +32,8 @@ on:
     # different axis entirely -- the suite's own quality, not a
     # dependency's -- which is what leaves it the weekend on its own.
     # Cron runs from the default branch only, so this file gates nothing
-    # until it reaches master -- on dev it is reachable through the
+    # until it reaches the default branch -- elsewhere it is reachable
+    # through the
     # dispatch button below and nowhere else
     - cron: "41 3 * * 0"
   # the escape hatch, and the way to spend a whole afternoon on the engine

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -43,7 +43,24 @@ on:
     # tree not yet released.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
-    - cron: "31 4 * * 2"
+    - cron: "31 4 1 * *"
+  # after a release, which is the one moment this workflow's answer can
+  # change: RELEASING.md documented dispatching it by hand right there, and
+  # a call does not forget. Called by release.yml rather than triggered by
+  # workflow_run, which zizmor rates a dangerous trigger and rightly -- it
+  # runs the default branch's copy with the token of a push nobody reviewed
+  # -- where a call runs inside the release that gated it. The caller passes
+  # the tag, and only the caller does: the monthly run and a dispatch have
+  # no particular version in mind, which is the point of them
+  workflow_call:
+    inputs:
+      version:
+        description: >-
+          the tag whose version the index must serve before the matrix
+          installs anything, empty on a run with no release behind it
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job
@@ -60,8 +77,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  test-published:
-    name: "Install btclib ${{ matrix.python }} on ${{ matrix.os }}"
+  install-published:
+    name: "Install ${{ matrix.python }} from PyPI on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -80,6 +97,30 @@ jobs:
         python: ["3.10", "3.14", "3.14t"]
     timeout-minutes: 20
     steps:
+      # the index does not serve a new file the instant the upload returns,
+      # and this workflow installs whatever the resolver picks: a run that
+      # starts too early tests the *previous* version and reports a pass for
+      # it, which is worse than reporting nothing. So the release path waits
+      # for the version its tag names, and fails if it never arrives rather
+      # than measuring the wrong thing. Only there: the input is empty on
+      # every other trigger
+      - name: Wait for the index to serve the released version
+        if: inputs.version != ''
+        env:
+          TAG: ${{ inputs.version }}
+        run: |
+          version="${TAG#v}"
+          for attempt in $(seq 20); do
+            if curl -sf --max-time 10 -o /dev/null \
+                "https://pypi.org/pypi/btclib/${version}/json"; then
+              echo "the index serves ${version}"
+              exit 0
+            fi
+            echo "attempt ${attempt}: ${version} is not served yet"
+            sleep 15
+          done
+          echo "::error::${version} never appeared on the index"
+          exit 1
       # uv rather than actions/setup-python, which is what every other
       # workflow here already uses and what this one has to use for a
       # reason of its own: setup-python installs from the runner tool

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,18 @@ on:
 permissions:
   contents: read
 
+# never two runs of this workflow at once, and never a cancellation: the
+# other workflows cancel a superseded run because their subject is the
+# commit, and a newer commit supersedes the answer. Here the subject is a
+# publication -- a version on an index, a release -- so a second run is a
+# second attempt at the same side effects, and cancelling one halfway is how
+# a version reaches PyPI with no release cut for it.
+# Named literally, as everywhere else: github.workflow in a called workflow
+# is the caller's name, and this one calls four
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # what a version cannot survive being wrong about, checked before
   # anything is built and long before anything is uploaded: a version is
@@ -150,6 +162,7 @@ jobs:
 
   # the whole build/test matrix, exactly as a pull request runs it
   test:
+    name: Run the test workflow
     needs: version-check
     uses: ./.github/workflows/test.yml
 
@@ -157,9 +170,27 @@ jobs:
   # push could publish code the pre-commit hooks reject. Not gated on
   # version-check: this is the cheap one, and it runs in parallel with it
   lint:
+    name: Run the lint workflow
     uses: ./.github/workflows/lint.yml
 
+  # and the documentation build, for the reason the lint call above gives: a
+  # tag publishes the docstrings read the docs will render from it, so the
+  # build that would fail there fails here first. It has a workflow of its
+  # own now, so calling lint.yml no longer covers it
+  docs:
+    name: Run the docs workflow
+    uses: ./.github/workflows/docs.yml
+
+  # and the platform the merge gate does not wait for: macos.yml runs
+  # weekly, so a regression there could otherwise sit on main until the
+  # Wednesday after the tag. Cheap in work and the slowest call here in wall
+  # clock, which a release is the one place worth paying for
+  macos:
+    name: Run the macos workflow
+    uses: ./.github/workflows/macos.yml
+
   build:
+    name: Build the wheel and the sdist
     needs: version-check
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -286,7 +317,8 @@ jobs:
                 dsa.sign(b'btclib', 1))"
 
   publish-testpypi:
-    needs: [test, lint, build]
+    name: Publish to TestPyPI
+    needs: [test, lint, docs, macos, build]
     if: github.event_name == 'workflow_dispatch' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -309,7 +341,8 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   publish-pypi:
-    needs: [test, lint, build]
+    name: Publish to PyPI
+    needs: [test, lint, docs, macos, build]
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -333,7 +366,22 @@ jobs:
 
   # only after PyPI has accepted the files: a GitHub release announces
   # what users can already install
+  # what RELEASING.md used to ask for by hand: the sentinel on what the
+  # index serves, against the version this run just published. It waits for
+  # the file to be served before installing, so it cannot pass by testing
+  # the previous release, and it runs beside github-release rather than
+  # before it -- a release announcing files that do not install is worse
+  # than a release announced a minute later, but the announcement is not
+  # what makes them installable
+  published:
+    name: Install the published version from PyPI
+    needs: publish-pypi
+    uses: ./.github/workflows/published.yml
+    with:
+      version: ${{ github.ref_name }}
+
   github-release:
+    name: Attach the files to the GitHub release
     needs: publish-pypi
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,25 +3,28 @@ name: test
 
 on:
   push:
-    # master only: a push to a branch that has an open pull request would
+    # main only: a push to a branch that has an open pull request would
     # run this workflow twice, once per event, and the two runs land in
-    # different concurrency groups (refs/heads/dev against
+    # different concurrency groups (refs/heads/<branch> against
     # refs/pull/N/merge) so neither cancels the other. The pull_request
     # run is the one worth keeping, because it tests the merge commit and
     # is the only run a fork's pull request produces at all.
-    # master keeps a trigger of its own because a merge creates a commit
+    # main keeps a trigger of its own because a merge creates a commit
     # that is not the one the pull request tested, and nothing else would
-    # ever test it. Tag pushes are covered by the release workflow
-    branches: [master]
-    # GitHub Pages serves btclib.org from master's root, so a
+    # ever test it -- and because a cache is readable only from the branch
+    # that wrote it and from the default branch, so without a run here
+    # every pull request starts cold. Tag pushes are covered by the release
+    # workflow
+    branches: [main]
+    # GitHub Pages serves btclib.org from main's root, so a
     # website-only commit lands here and would otherwise run the whole
     # matrix.
     # None of these files is imported by the library or read by a test --
     # README.md is the homepage, not a doctest source; CONTRIBUTING.md is
     # checked by markdownlint, which is the lint workflow's business.
     # Only on push: the same list on pull_request would be wrong, because
-    # tests-passed is a required check on master and a required check that
-    # produces no run at all blocks the merge instead of passing it
+    # the aggregate below is a required check on main, and a required check
+    # that produces no run at all blocks the merge instead of passing it
     paths-ignore:
       - _config.yml
       - _layouts/**
@@ -66,28 +69,28 @@ jobs:
   # image, native arm64 for the versions it caches and emulated x86-64
   # for the ones uv has to download, and the wheel is selected for the
   # interpreter rather than for the host, so either one links
-  test-py:
+  suite:
+    name: Run the suite on ${{ matrix.python }}, ${{ matrix.os }}
     # a draft pull request is work in progress: every push to one spends
     # the whole matrix on a tree its author is not asking anyone to
     # review yet. The gate below carries the same condition, so a draft
     # skips uniformly and the gate does not read that skip as a job that
-    # should have run.
-    # The exception is by base branch, and it is the release pull
-    # request: dev -> master stays a draft from one release to the
-    # next, and nothing here triggers on a push to dev, so without it
-    # a commit merged into dev would be tested by nothing at all
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    # should have run
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        # four, and macos.yml carries the other two: on one run of the
+        # full six every macOS cell waited 29.4 and 23.2 minutes on average
+        # for a runner, against 0.5 to 1.6 here, so two rows of twelve set
+        # most of the wait of a pull request -- 45 jobs, 93 minutes of work
+        # and 399 minutes of queueing. What they sample is a platform this
+        # library has no branch for, which is worth a week rather than
+        # worth a review's patience
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - macos-26-intel
-          - macos-latest
           - windows-latest
           - windows-11-arm
         # 3.14t is the free-threaded interpreter, and it is in the matrix
@@ -151,11 +154,10 @@ jobs:
   # The number is a gate rather than a report: fail_under, in
   # tool.coverage.report, fails this job on a regression. It needs no
   # secret and no third party, and it applies to every run, where a
-  # coveralls.io upload happens only on pull requests targeting master
-  coverage-py:
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+  # coveralls.io upload happens only on a pull request
+  coverage:
+    name: Measure coverage, gated at 100%
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -197,10 +199,9 @@ jobs:
   # gate here rather than in the release workflow alone because the
   # bindings it resolves are published: while they were not, the step
   # could only be red, for a reason nobody could fix from a branch
-  dist-py:
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+  dist:
+    name: Build the distribution and install it
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -277,28 +278,35 @@ jobs:
             assert dsa.verify(b'btclib', pub_keyinfo_from_prv_key(1)[0], \
               dsa.sign(b'btclib', 1))"
 
-  # the single check master's branch protection requires from this
+  # the single check main's branch protection requires from this
   # workflow, and it exists because that rule names its checks as literal
   # strings, stored outside the repository. The matrix above produces one
-  # per (runner label, interpreter) pair, 42 of them today -- a count that
-  # moves whenever the matrix does: naming those directly means every
-  # matrix edit has to be mirrored in a setting no pull request can
+  # per (runner label, interpreter) pair -- `gh api` on a run's jobs counts
+  # them, and the count moves whenever the matrix does: naming those
+  # directly means every matrix edit has to be mirrored in a setting no
+  # pull request can
   # review, and a name that stops being produced -- macos-latest moving
   # on, 3.10 aging out in its turn -- becomes a required check that never
   # reports, which blocks every merge until someone remembers where the
   # rule lives.
   # This job depends on the others instead, so the rule names one thing
   # that never changes and adding a job here is enough to gate on it
-  tests-passed:
-    needs: [test-py, coverage-py, dist-py]
+  test-passed:
+    # the name and not the id is what branch protection matches, and it
+    # carries the workflow on purpose: a context is keyed by name alone, so
+    # two workflows with a job named "every job passed" would produce one
+    # ambiguous check. lint and docs need no aggregate of their own while
+    # they have one job each -- the job *is* the context there -- and the
+    # day either grows a second one, this pattern and a change to the rule
+    # are what that costs
+    name: "test: every job passed"
+    needs: [suite, coverage, dist]
     # not success(): a job whose dependencies failed is skipped, and a
     # skipped check reports "skipped", which branch protection counts as
     # satisfied. The gate has to run to be able to fail
     # and the draft condition every job above carries, so a draft
     # skips uniformly rather than tripping the skip check below
-    if: >-
-      ${{ always() && (!github.event.pull_request.draft
-      || github.base_ref == 'master') }}
+    if: ${{ always() && !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/vendored-vectors.yml
+++ b/.github/workflows/vendored-vectors.yml
@@ -46,17 +46,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
+  vectors:
     name: Check vendored vectors against upstream
     # a draft pull request is work in progress and spends no runner
-    # here either, the release pull request excepted: dev -> master is
+    # here either: a draft is work its author is not asking anyone to
     # a draft from one release to the next, and its runs are what
-    # checks a commit merged into dev. The same condition lint.yml and
+    # read yet. The same condition lint.yml and
     # test.yml carry, and ready_for_review is a trigger type above for
     # the same reason
-    if: >-
-      ${{ !github.event.pull_request.draft
-      || github.base_ref == 'master' }}
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,6 +34,33 @@ repos:
     hooks:
       - id: check-hooks-apply
       - id: check-useless-excludes
+  # this file checking itself further, on the two moves `autoupdate` makes
+  # that it must not take. A rev naming only a major version follows every
+  # future release of that major, which is the one thing a rev is here to
+  # prevent -- and a prerelease is not a release.
+  #
+  # Not hypothetical: pre-commit.ci's weekly pull request offered both in
+  # bitcoin-core-rpc, typos onto `v1` -- its repository keeps a floating
+  # major tag beside the versioned one, and autoupdate prefers the shorter
+  # name -- and pyroma onto 5.1b1, 5.1 having no released tag at all. One of
+  # the two was merged before anyone read the two-line diff. This hook is
+  # what makes the bot's pull request go red instead.
+  #
+  # pre-commit says the first half itself -- "appears to be a mutable
+  # reference (moving tag / branch) ... not supported" -- on stderr, on a run
+  # that then exits zero, which is the whole difference between a warning and
+  # a gate.
+  #
+  # A commit SHA stays acceptable, should a hook ever want one: the pattern
+  # requires the prerelease marker and its digits to end the value, which
+  # forty hex characters do not
+  - repo: local
+    hooks:
+      - id: pinned-rev
+        name: every pre-commit rev names a released version
+        language: pygrep
+        entry: '^ *rev: "?v?([0-9]+|[0-9][0-9.]*(a|b|rc|dev)[0-9]+)"?$'
+        files: ^\.pre-commit-config\.yaml$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1740,6 +1740,57 @@ edit.
 
 ### Repository
 
+- **A pull request no longer waits for macOS.** One run of the full matrix is
+  45 jobs, 93 minutes of compute and 399 minutes of queueing, and the two
+  macOS images account for most of the second number: 29.4 and 23.2 minutes
+  of mean wait for a runner, one of them 42.2, against 0.5 to 1.6 for ubuntu
+  and windows. So `test.yml` keeps all seven interpreters and drops to four
+  platforms, and the new `macos.yml` runs the two macOS images against the
+  same lock weekly, on demand, and from a release -- which is what keeps a
+  macOS regression from being published while nobody waits for one. It is
+  scheduled the same morning as `latest.yml`, half an hour before, so the two
+  read as a difference: red in both is the platform, red in `latest` alone is
+  the upgrade
+- **The documentation build is a workflow of its own**, `docs.yml`, where it
+  was the second job of `lint.yml`: a failed sphinx build and a failed hook
+  are different verdicts, and a workflow each is what gives them a badge each
+  and a line each in the checks list. The job keeps its name, `Build the
+  documentation`, so the required check did not have to move -- a context is
+  matched by name and not by the workflow that reported it
+- **`integration.yml` gates a merge**, where it gated only a release: 36
+  seconds of work for a disposable regtest node, less than the matrix it runs
+  beside, and it answers the one claim the recorded vectors cannot make. Its
+  `paths` filter goes with the promotion, a required check that never runs
+  blocking a merge where a skipped one satisfies it
+- **Every CI job has a name, and the names say what the job answers**, the
+  same vocabulary bitcoin-core-rpc uses: `suite`, `coverage`, `dist` and the
+  aggregate `test: every job passed` where the ids carried a `-py` suffix
+  that distinguished nothing, `suite-latest` and `install-published` where a
+  suffix does name a variant, and a sentence on each of the eleven jobs of
+  `release.yml`, which showed their ids in the checks list
+- **`published.yml` is called by `release.yml`** with the tag's version, and
+  waits for the index to serve it before installing -- so it can no longer
+  pass by testing the release before this one, which the dispatch
+  RELEASING.md asked for by hand could do. Its schedule goes from weekly to
+  monthly, the release path now answering the question the weekly stood in
+  for. Not a `workflow_run` trigger, which zizmor rates dangerous: that runs
+  the default branch's copy on a push nobody reviewed
+- **`release.yml` has a concurrency group**, the last workflow without one
+  and the only one whose runs have side effects, and it calls the docs and
+  macOS workflows beside the ones it already called
+- **A pre-commit rev that is not a released version fails the gate.** A local
+  pygrep hook rejects a rev naming only a major version, which follows every
+  future release of it, and a prerelease, which is not a release: the two
+  moves `autoupdate` offered in bitcoin-core-rpc, one of which was merged
+  before anyone read the diff. pre-commit warns about the first and exits
+  zero, which is the difference the hook makes
+- The dead `github.base_ref == 'master'` exception is gone from every job
+  that carried it, along with the prose describing a two-branch release flow:
+  `master` is not a branch here any more, so the clause could never be true
+  and `push` was aimed at a ref that does not exist -- which meant nothing
+  ran on the trunk, and no cache was written where a pull request could read
+  it
+
 - **`uv.lock` is at every dependency's newest release**, which closed the
   seven advisories the default branch was carrying: six on GitPython,
   reached through `cosmic-ray`, and one on `cryptography`, reached

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,6 +228,29 @@ Anything machine-local — an interpreter path, a telemetry answer, a theme —
 belongs in the editor's own user settings instead, those two files being
 read by every checkout of this repository.
 
+### What runs when
+
+| workflow | when | what it varies |
+| --- | --- | --- |
+| `test` | pull request, push | 4 platforms × 7 interpreters |
+| `lint`, `docs` | pull request, push | — |
+| `integration` | pull request, push | a regtest node |
+| `macos` | Wednesday, a release | 2 macOS images × 7 interpreters |
+| `latest` | Wednesday | platforms sampled, deps upgraded |
+| `links`, `mutation` | weekly | — |
+| `vendored-vectors` | monthly | upstream's vectors |
+| `published` | monthly, a release | what PyPI serves |
+| `release` | a tag | calls test, lint, docs, macos, published |
+
+The first three rows are what a merge waits for. macOS is not among them on
+purpose: it is the platform whose runners queue — 29.4 and 23.2 minutes of
+mean wait against 0.5 to 1.6 elsewhere, on a run of 45 jobs that spent 93
+minutes working and 399 waiting — so it answers weekly, and before a
+release, rather than before a review. `macos` and `latest` share a morning
+half an hour apart, which is what makes the pair readable: red in both is
+the platform, red in `latest` alone is the upgrade. Everything but the
+first three rows also takes `workflow_dispatch`.
+
 ### Reproducing what CI runs
 
 Every job of every workflow is a `uv` command, and `uv` fetches what it

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -9,28 +9,64 @@ The branch rules and the repository settings live *outside* the
 repository, so this file is the whole of them: nothing here can be
 recovered by reading the tree.
 
-## Required checks on master
+## Required checks on main
 
 **Never name matrix contexts in the branch rule.** The rule lives outside
 the repository, so a context that stops being produced blocks every merge
-with nothing in the tree to explain why. `tests-passed` is an aggregate
-job at the end of `test.yml` that `needs` the matrix; a new job in
-`test.yml` belongs in that job's `needs`, or it gates nothing.
+with nothing in the tree to explain why. `test: every job passed` is an
+aggregate job at the end of `test.yml` that `needs` the matrix; a new job in
+`test.yml` belongs in that job's `needs`, or it gates nothing. Its name
+carries the workflow because a context is keyed by name alone: two
+workflows with a job named the same thing produce one ambiguous check.
 
-`master` requires four checks, and only four:
+`main` requires five checks, and only five:
 
 | Check | Produced by |
 | --- | --- |
-| `tests-passed` | `test.yml`, aggregate over the matrix |
-| `Lint and type-check` | `lint.yml`, first job |
+| `test: every job passed` | `test.yml`, aggregate over the matrix |
+| `Lint and type-check` | `lint.yml`, its only job |
+| `Build the documentation` | `docs.yml`, its only job |
+| `Regtest against Bitcoin Core` | `integration.yml`, its only job |
 | `CodeQL` | CodeQL workflow |
-| `Build the documentation` | `lint.yml`, second job |
+
+A workflow with one job needs no aggregate: the job *is* the context, which
+is why three of the five are job names. The day one of them grows a second
+job, an aggregate and a change to this rule are what that costs.
 
 `Build the documentation` is named on its own on purpose: a rule naming
 `Lint and type-check` alone would leave a red docs build outside the
-required checks entirely. `lint.yml` triggers on `pull_request` with no
-branch and no `paths` filter, so both its jobs report on every pull
-request, forks included.
+required checks entirely. It moved from `lint.yml` to a workflow of its own
+without the rule changing, which is worth knowing before renaming anything:
+a context is matched by name, not by the workflow that reported it, so
+moving a job is free and renaming one is not — the pull request that renames
+a required check stops producing the old name and never produces one the
+rule is waiting for.
+
+`Regtest against Bitcoin Core` is the newest of the five, and it is here
+because its cost was measured rather than assumed: 36 seconds of work for a
+disposable regtest node, which is less than the matrix it runs beside. It
+answers the one claim the recorded vectors cannot make. `integration.yml`
+therefore carries no `paths` filter: a required check that never runs blocks
+a merge, where a skipped one satisfies it.
+
+Renaming a required check is the one change that cannot be made in a pull
+request, so the rule moves first, against the branch, and the pull request
+that renames the job reports the name the rule now wants:
+
+```shell
+branch=repos/btclib-org/btclib/branches/main
+gh api -X PATCH "$branch"/protection/required_status_checks \
+  -F strict=true \
+  -f 'contexts[]=test: every job passed' \
+  -f 'contexts[]=Lint and type-check' \
+  -f 'contexts[]=Build the documentation' \
+  -f 'contexts[]=Regtest against Bitcoin Core' \
+  -f 'contexts[]=CodeQL'
+```
+
+`contexts` rather than `checks` with an `app_id`, which is the shape the
+rule already has here: binding each context to the app that produces it is
+the stricter form, and adopting it is a separate decision from this list.
 
 Each check is bound to the app that produces it — `checks` with an
 `app_id` rather than the bare `contexts` list, 15368 for Actions and


### PR DESCRIPTION
The revision [bitcoin-core-rpc#76](https://github.com/btclib-org/bitcoin-core-rpc/pull/76)
took, in the same words wherever a job is the same job — two configurations that
differ only in wording cost more to hold in mind than one.

## The measurement

One run of the full matrix: **45 jobs, 93 minutes of compute, 399 minutes of
queueing.**

| runner | cells | mean queue | worst |
|---|---|---|---|
| `macos-latest` | 7 | **29.4 min** | 42.2 |
| `macos-26-intel` | 7 | **23.2 min** | 36.1 |
| windows ×2 | 14 | 1.4 – 1.6 min | 2.5 |
| ubuntu ×2 | 14 | 0.5 – 0.7 min | 2.7 |

Unlike bitcoin-core-rpc the compute is real here — a windows cell is 3 minutes
where its are under one — so this does not make the gate three minutes. It makes
it about ten, and that is a difference of degree, not of criterion.

## What changes

- **`test.yml`**: all seven interpreters kept, four platforms. 28 cells.
- **`macos.yml`** (new): the two macOS images × seven interpreters against the
  same lock, Wednesday 04:13 — half an hour before `latest`, so the pair reads
  as a difference. Gates nothing; `release.yml` calls it, so a regression cannot
  ship.
- **`docs.yml`** (new): the documentation build leaves `lint.yml`, keeping the
  name `Build the documentation` so the branch rule did not have to move.
- **`integration.yml`**: promoted to a required check — **36 seconds** of work
  for a disposable regtest node, less than the matrix it joins, and the one
  answer the recorded vectors cannot give. Its `paths` filter goes with the
  promotion.
- **`published.yml`**: called by `release.yml` with the tag's version, waiting
  for the index to serve it before installing. Weekly → monthly. Not
  `workflow_run`, which zizmor rates dangerous.
- **`release.yml`**: gains a concurrency group (the last workflow without one)
  and calls the docs and macOS workflows beside the ones it already called.
- **Names**: `test-py`/`coverage-py`/`dist-py` → `suite`/`coverage`/`dist`,
  `tests-passed` → `test: every job passed`, `test-latest` → `suite-latest`,
  `test-published` → `install-published`, and a sentence on each of the eleven
  jobs of `release.yml`. Same strings as bitcoin-core-rpc.
- **A pre-commit rev that is not a released version now fails the gate** — the
  hook from [bitcoin-core-rpc#78](https://github.com/btclib-org/bitcoin-core-rpc/pull/78).

## Two things that were dead, not merely stale

- **`push` was aimed at `master`**, which is not a branch here any more, so
  **nothing ran on the trunk at all** — and a cache is readable only from the
  branch that wrote it and from the default branch, so every pull request was
  starting cold, including the 158 MiB pre-commit environment.
- **`github.base_ref == 'master'` in nine jobs** could never be true. With the
  release pull request it existed for gone, the plain draft condition is what
  is left.

## The branch rule, for you to run — before merging

`tests-passed` stops being produced, so this cannot merge until the rule names
the new aggregate. `REPOSITORY.md` carries this too:

```shell
branch=repos/btclib-org/btclib/branches/main
gh api -X PATCH "$branch"/protection/required_status_checks \
  -F strict=true \
  -f 'contexts[]=test: every job passed' \
  -f 'contexts[]=Lint and type-check' \
  -f 'contexts[]=Build the documentation' \
  -f 'contexts[]=Regtest against Bitcoin Core' \
  -f 'contexts[]=CodeQL'
```

`contexts` rather than `checks` with an `app_id`, which is the shape this rule
already has — binding each context to the app that produces it is stricter, and
adopting it is a separate decision from this list.

## Gates

```shell
uv run --locked --only-group lint pre-commit run --all-files   # 0, and 0 on a second pass
uv run --locked --no-default-groups --group test pytest --cov  # 0, 18569 passed, 100.00%
uv run --locked --no-default-groups --group docs \
    sphinx-build -W --keep-going -b html docs/source docs/build/html   # 0
```

Triggers, crons, matrix shapes and every job's name verified with a yaml parse
of all eleven workflow files: `test` 28 cells, `macos` 14 on Wednesday 04:13,
`latest` unchanged on Wednesday 04:43, `published` monthly, no job left without
a name, every workflow with a literal concurrency group.

## What this gives up

A macOS regression is found within a week rather than within two minutes — it
cannot be published, but it can sit on `main`. macOS against upgraded
dependencies is covered only by whatever `latest` samples. And a
documentation-only pull request now pays `integration`'s 36 seconds, which is
the price of that answer being required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Decouple macOS and docs CI from the main test gate, promote regtest integration to a required check, and standardize workflow/job naming and branch protections around main.

New Features:
- Introduce a dedicated docs workflow to build and validate documentation independently.
- Add a separate macOS workflow to run the full Python matrix on macOS images on a schedule and from releases.
- Wire the published-version check into the release workflow so it installs the just-published version from PyPI.
- Document the CI workflow schedule and required checks in CONTRIBUTING and REPOSITORY.

Bug Fixes:
- Ensure pushes and branch protections target the existing main branch instead of the removed master branch.
- Prevent CI and caches from failing to run on trunk by restoring push triggers on main.
- Avoid testing the wrong PyPI version by waiting for the released version to appear on the index before install checks.

Enhancements:
- Reduce PR latency by removing macOS runners from the main test matrix while preserving macOS coverage via a separate workflow.
- Promote the integration (regtest) workflow to a required check and remove its paths filter so all PRs exercise it.
- Rename and add human-readable names to CI jobs and aggregates (suite, coverage, dist, test: every job passed, etc.) to align with bitcoin-core-rpc and clarify intent.
- Add concurrency groups to release and other workflows to avoid overlapping runs and cancellations with side effects.
- Tighten pre-commit policy by rejecting mutable tags and prerelease versions as hook revs, ensuring only released versions are pinned.
- Align latest/published/mutation/links/vectors workflows with main and simplify draft/branch conditions.

CI:
- Refactor lint/test workflows to use main, simplify draft conditions, and move the docs job into its own workflow while keeping its required-check name.
- Adjust test matrix to four platforms (dropping macOS into its own workflow) and rename aggregate and matrix jobs to stable contexts.
- Hook release.yml into test, lint, docs, macos, and published workflows, add names to all jobs, and add a release-specific concurrency group.
- Retune latest and vendored-vectors job names and descriptions for consistency, and clarify non-required workflows (links, mutation).

Documentation:
- Update REPOSITORY and CONTRIBUTING to describe required checks, workflow triggers, and how branch protection contexts map to jobs.
- Extend the changelog with details of the CI restructuring, macOS schedule change, integration gating, and pre-commit policy.

Tests:
- Make the integration/regtest workflow run on PRs and pushes without path filters, ensuring consistent coverage of descriptor/PSBT/script/tx flows.