### PR TITLE
Rebuild a release to the same bytes, and attest it

### DIFF
--- a/.github/scripts/normalize_sdist.py
+++ b/.github/scripts/normalize_sdist.py
@@ -1,0 +1,121 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Rewrite an sdist so that two builds of one commit are the same bytes.
+
+`SOURCE_DATE_EPOCH` is enough for the wheel and reaches nothing in the
+sdist. setuptools honours the variable in the wheel writer it vendors and
+in no other place, which is one file of the installed package and says so
+whichever release is current:
+
+    uv run --isolated --no-project --with setuptools python -c "
+    import pathlib, setuptools
+    root = pathlib.Path(setuptools.__file__).parent
+    print(setuptools.__version__, [str(p.relative_to(root))
+        for p in root.rglob('*.py')
+        if 'SOURCE_DATE_EPOCH' in p.read_text(encoding='utf-8')])"
+
+So every member of the `.tar.gz` keeps whichever clock produced it: the
+directory setuptools stages the sdist in carries the build's, and each
+file copied into that directory carries the checkout's. Both are
+sub-second, both land in a PAX `mtime` record, and two checkouts of one
+commit disagree in the digits after the point:
+
+    28 mtime=1786407122.0157955
+    28 mtime=1786407123.6693566
+
+What is *in* the archive is already deterministic; what is not is the
+metadata of the members. This rewrites that metadata and nothing else:
+every timestamp becomes `SOURCE_DATE_EPOCH`, ownership becomes root with
+no names, and the gzip header carries the same timestamp instead of the
+moment it was compressed. The order of the members and every byte of
+their content are the archive's own.
+
+`PAX_FORMAT` with the extended headers cleared, rather than
+`USTAR_FORMAT`: an integral timestamp needs no PAX record, so the two
+formats write the same bytes today -- and the day a path in the sdist
+outgrows ustar's 100 characters, pax records it and ustar would have
+refused it.
+
+Run it after `uv build` and before anything reads dist/:
+
+    uv run --no-project --python 3.14 \
+        .github/scripts/normalize_sdist.py dist/
+
+RELEASING.md has the command that verifies a published release against a
+rebuild of its tag, and the two bounds on what that proves.
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import os
+import sys
+import tarfile
+from pathlib import Path
+
+
+def normalize(archive: Path, epoch: int) -> None:
+    """Rewrite one archive in place, member metadata at `epoch`."""
+    members: list[tuple[tarfile.TarInfo, bytes | None]] = []
+    with tarfile.open(archive, "r:gz") as source:
+        for member in source.getmembers():
+            # extractfile returns None for anything that is not a regular
+            # file, and a directory member is one of the two cases this
+            # script exists for, so the two are told apart rather than
+            # asserted
+            stream = source.extractfile(member) if member.isfile() else None
+            members.append((member, stream.read() if stream is not None else None))
+
+    tar = io.BytesIO()
+    with tarfile.open(fileobj=tar, mode="w", format=tarfile.PAX_FORMAT) as target:
+        for member, content in members:
+            member.mtime = epoch
+            member.uid = member.gid = 0
+            member.uname = member.gname = ""
+            # the records this exists to remove: tarfile writes one per
+            # field it cannot express in the ustar header, and the
+            # sub-second mtime above was such a field. Replaced rather than
+            # cleared, the attribute being a Mapping to a type checker
+            member.pax_headers = {}
+            target.addfile(member, io.BytesIO(content) if content is not None else None)
+
+    compressed = io.BytesIO()
+    # mtime, not the clock, and filename empty: gzip stores both in its
+    # header, and the name of a temporary file is not the archive's
+    with gzip.GzipFile(
+        filename="", mode="wb", fileobj=compressed, mtime=epoch, compresslevel=9
+    ) as compressor:
+        compressor.write(tar.getvalue())
+    archive.write_bytes(compressed.getvalue())
+
+
+def main(argv: list[str]) -> int:
+    """Normalize every sdist in the directory named on the command line."""
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <dist directory>", file=sys.stderr)  # noqa: T201
+        return 2
+
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch is None:
+        # not a default of "now": a default would make the failure a
+        # reproducibility bug found by whoever tried to verify a release,
+        # which is the one person who cannot fix it
+        print("SOURCE_DATE_EPOCH is not set", file=sys.stderr)  # noqa: T201
+        return 1
+
+    archives = sorted(Path(argv[1]).glob("*.tar.gz"))
+    if not archives:
+        print(f"no sdist in {argv[1]}", file=sys.stderr)  # noqa: T201
+        return 1
+
+    for archive in archives:
+        normalize(archive, int(epoch))
+        print(f"normalized {archive}")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ permissions:
 # never two runs of this workflow at once, and never a cancellation: the
 # other workflows cancel a superseded run because their subject is the
 # commit, and a newer commit supersedes the answer. Here the subject is a
-# publication -- a version on an index, a release -- so a second run is a
-# second attempt at the same side effects, and cancelling one halfway is how
-# a version reaches PyPI with no release cut for it.
+# publication -- a version on an index, an attestation, a release -- so a
+# second run is a second attempt at the same side effects, and cancelling one
+# halfway is how a version reaches PyPI with no release cut for it.
 # Named literally, as everywhere else: github.workflow in a called workflow
-# is the caller's name, and this one calls four
+# is the caller's name, and this workflow is a caller
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -205,6 +205,17 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           enable-cache: false
+      # what makes the wheel this job publishes reproducible: without it
+      # setuptools stamps the zip entries with the mtimes of the checkout,
+      # so the same commit built twice gives two digests and the
+      # attestation below vouches for bytes nobody else can obtain. The
+      # commit date, not the tag's: `git log -1` on a shallow clone reads
+      # the tip, which is the commit the tag points at, and a lightweight
+      # tag has no date of its own to prefer.
+      # RELEASING.md has the command that rebuilds a released tag and
+      # verifies it against the attestation
+      - name: Pin the build timestamp to the commit
+        run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
       # TestPyPI refuses a version it has already seen: the rehearsal
       # appends .dev<run number>, unique per dispatch and sorted before
       # the release it rehearses (PEP 440). Re-running a finished
@@ -276,6 +287,20 @@ jobs:
       # too
       - name: Build the distribution files
         run: uv build
+      # SOURCE_DATE_EPOCH reaches every entry of the wheel and nothing at
+      # all in the sdist: setuptools honours it in the wheel writer it
+      # vendors and in no other place, so each member of the .tar.gz keeps
+      # a clock -- the checkout's for a file, the build's for the directory
+      # setuptools stages them in -- to sub-second precision, in a PAX
+      # record whose length changes with it. The script rewrites member
+      # metadata and no content, and its docstring has the measurement.
+      # --no-project, so this runs on the interpreter uv already fetched
+      # and installs nothing into the tree it is about to publish
+      - name: Make the sdist reproducible too
+        run: |
+          uv run --no-project --python 3.14 \
+            .github/scripts/normalize_sdist.py dist/
+          sha256sum dist/*
       # before anything is installed, and that ordering is the point: the
       # step below runs third-party code -- a `.pth` file in a dependency
       # executes at interpreter startup, before the first import -- while
@@ -364,8 +389,6 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
 
-  # only after PyPI has accepted the files: a GitHub release announces
-  # what users can already install
   # what RELEASING.md used to ask for by hand: the sentinel on what the
   # index serves, against the version this run just published. It waits for
   # the file to be served before installing, so it cannot pass by testing
@@ -380,14 +403,95 @@ jobs:
     with:
       version: ${{ github.ref_name }}
 
-  github-release:
-    name: Attach the files to the GitHub release
-    needs: publish-pypi
+  # the same files reach users by two routes and only one of them carries
+  # provenance: the publish action above generates PEP 740 attestations for
+  # the copies on the index, while the copies attached to the GitHub release
+  # below carry nothing. This job signs them, and the digests are the
+  # index's own, the dist artifact being downloaded here rather than
+  # rebuilt.
+  # A job of its own rather than two more permissions on github-release:
+  # this workflow elevates one job at a time, and the one that writes
+  # releases has no reason to also hold an OIDC token. It is not in the
+  # build job for the stronger form of the same reason -- that job runs the
+  # build backend and installs the wheel it just built, and a token minted
+  # there would be minted beside third-party code.
+  # After a publish and not after the build, so that a run reaching here is
+  # a run the environment approval already let through: without that, a
+  # dispatch from any branch would sign whatever that branch built.
+  # Whichever publish ran, though -- the rehearsal signs its own .dev files,
+  # and that is the point of it: everything else in this job is a permission
+  # and an API that would otherwise be exercised for the first time on
+  # release day, where a failure lands after PyPI has the files and the tag
+  # can no longer be moved
+  attest:
+    name: Attest the distribution files
+    needs: [publish-pypi, publish-testpypi]
+    # always(), the other publish job being skipped rather than run, and a
+    # skipped job is one `needs` treats as failed
+    if: >-
+      always() && (needs.publish-pypi.result == 'success' ||
+      needs.publish-testpypi.result == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      # the one job that writes to the repository, and what it writes is a
-      # release
+      # OIDC for the short-lived Sigstore signing certificate, and the
+      # write that persists the attestation against the repository
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download the distribution files
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+      # actions/attest and not the attest-build-provenance wrapper around
+      # it: as of v4 the wrapper is a composite that does nothing but call
+      # this, and its own README sends new callers here. No predicate input
+      # is what selects SLSA build provenance.
+      # One attestation, both files: the statement carries every subject the
+      # glob matched, so verifying either the wheel or the sdist against the
+      # bundle below works
+      - name: Attest the distribution files
+        id: attest
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: dist/*
+      # the bundle is the signed statement itself, and the job below
+      # attaches it to the release: that is what lets `gh attestation verify
+      # --bundle` read it from disk instead of from the attestations API,
+      # for whoever mirrors the releases page rather than trusting it live.
+      # Copied into the workspace rather than uploaded where the action left
+      # it, under $RUNNER_TEMP: an upload takes its layout from the paths it
+      # matched, and one outside the workspace is one more thing to be right
+      # about than a fixed name here
+      - name: Collect the attestation bundle
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+        run: cp "$BUNDLE_PATH" attestation.jsonl
+      - name: Upload the attestation bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: attestation
+          path: attestation.jsonl
+
+  # only after PyPI has accepted the files: a GitHub release announces what
+  # users can already install. Both jobs above it and not attest alone:
+  # attest runs in a rehearsal too, so naming it by itself would make this
+  # job -- which has no `if` of its own -- cut a release from a dispatch,
+  # where publish-pypi is skipped and a skipped need is what keeps this to
+  # the tag. attest earns its place in the list by producing the bundle
+  # attached below; a failure there leaves the version published and no
+  # release cut, which `gh run rerun --failed` finishes without rebuilding
+  # anything
+  github-release:
+    name: Attach the files to the GitHub release
+    needs: [publish-pypi, attest]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # the one job that writes to the repository through its token, and
+      # what it writes is a release; the attestation the job above signed
+      # went to the attestations API under a permission of its own
       contents: write
     steps:
       - name: Checkout code
@@ -399,6 +503,13 @@ jobs:
         with:
           name: dist
           path: dist/
+      # into a directory of its own, so that the dist/* glob below stays the
+      # distribution files and nothing else
+      - name: Download the attestation bundle
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: attestation
+          path: attestation/
       - name: Create the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -416,11 +527,16 @@ jobs:
             /^## / && found {exit}
             found {print}
           ' HISTORY.md > "$RUNNER_TEMP/notes.md"
+          # named for the tag only here, where the ref is one: nothing
+          # inside the bundle says which release it belongs to, the way the
+          # distribution files' own names do
+          bundle="$GITHUB_REF_NAME.attestation.jsonl"
+          cp attestation/attestation.jsonl "$bundle"
           if [ -s "$RUNNER_TEMP/notes.md" ]; then
-            gh release create "$GITHUB_REF_NAME" dist/* \
+            gh release create "$GITHUB_REF_NAME" dist/* "$bundle" \
               --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/notes.md"
           else
             echo "::warning::HISTORY.md has no $GITHUB_REF_NAME section"
-            gh release create "$GITHUB_REF_NAME" dist/* \
+            gh release create "$GITHUB_REF_NAME" dist/* "$bundle" \
               --title "$GITHUB_REF_NAME" --generate-notes
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,52 @@ documented at release-notes length in the first place, and are still in
   request, which is the cost this filter exists to avoid. The job still
   gates nothing and is still absent from master's required checks.
 
+- **The distribution files are reproducible**: two checkouts of one commit
+  build the same wheel and the same sdist, so the provenance attestation
+  below can be verified against a file the verifier built rather than one
+  they downloaded. `release.yml`'s build job exports `SOURCE_DATE_EPOCH`
+  from the commit date, which is the whole of it for the wheel, and runs
+  `.github/scripts/normalize_sdist.py` for the sdist -- the variable
+  reaching nothing in that archive, setuptools honouring it in the wheel
+  writer it vendors and in no other place. So every member of the
+  `.tar.gz` keeps a clock, the checkout's for a file and the build's for
+  the directory setuptools stages them in, to sub-second precision and in
+  a PAX record whose length changes with it; the script rewrites member
+  metadata and no content. Two worktrees of one commit with `uv build` in
+  each is the measurement, in three rounds: plain, the two wheels and the
+  two sdists differ; with `SOURCE_DATE_EPOCH` exported, the wheels agree
+  and the sdists still differ in all of their members; with the script,
+  the sdists agree too. `btclib_libsecp256k1` plays no part in it, an
+  isolated build installing `[build-system] requires` and nothing else,
+  so neither rebuild above needed a `uv sync` first. RELEASING.md has the
+  rebuild command and the two bounds on the guarantee: the build backend
+  is resolved rather than pinned, and a TestPyPI rehearsal is a different
+  version by construction.
+
+- **The distribution files attached to a GitHub release carry
+  provenance**, where only the copies on PyPI did: the publish action
+  generates PEP 740 attestations for what it uploads to the index, and the
+  byte-identical wheel and sdist on the releases page carried nothing, so
+  whoever pinned to a release asset url or mirrored the page had no way to
+  check where the files came from. `release.yml` gains an `attest` job --
+  `actions/attest`, one SLSA build provenance statement covering both
+  files, signed with a short-lived Sigstore certificate -- and `gh
+  attestation verify <file> --repo btclib-org/btclib` is what checks it.
+  The signed bundle is attached to the release too, so `--bundle
+  <tag>.attestation.jsonl` verifies the same signature without asking the
+  attestations API for it. The digests are the index's own, the job
+  downloading the `dist` artifact rather than rebuilding it. A job of its
+  own and not two more permissions on `github-release`: `id-token: write`
+  and `attestations: write` stay off the job that writes releases, and
+  further off the job that runs the build backend. It runs after whichever
+  publish job ran, so a dispatch from an arbitrary branch signs nothing
+  the `testpypi` environment approval did not already let through -- and
+  the TestPyPI rehearsal exercises it, which on the release path would
+  otherwise happen for the first time after PyPI has the files and the tag
+  can no longer be moved. `github-release` names both `publish-pypi` and
+  `attest` in `needs`: naming `attest` alone would let a dispatch cut a
+  release, that job running in a rehearsal too.
+
 ### Transactions, blocks and PSBT
 
 - **A declared count is bounded by what could hold it, before anything is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -339,6 +339,19 @@ what the publish jobs download: installing a dependency executes its
 code, and a compromised one must not reach a `dist/` that has still to
 be handed on.
 
+What that job builds is reproducible, and the two steps that make it so
+are the two lines below — the first is why two checkouts of one commit
+produce the same wheel, the second why they produce the same sdist:
+
+```shell
+export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+uv run --no-project --python 3.14 .github/scripts/normalize_sdist.py dist/
+```
+
+RELEASING.md's "Rebuild a release from its tag" has them in the order a
+verifier runs them, with the `gh attestation verify` that gives the
+rebuild a verdict and the two bounds on what that verdict means.
+
 The `latest` workflow, which upgrades every dependency uv resolves before
 running the suite, the lint gate and the packaging checks. The upgrade
 rewrites uv.lock, and here too `git checkout uv.lock` restores it; the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -346,7 +346,8 @@ word, and step 1 asks it of both.
    already built, rather than the whole matrix again. The upload itself
    is the point of no return, PyPI accepting no file name twice even
    after deletion; the GitHub release follows it, with the distribution
-   files attached and the HISTORY.md section as its body. Read those notes
+   files attached, `<tag>.attestation.jsonl` beside them, and the
+   HISTORY.md section as its body. Read those notes
    once it lands: a run that logs
    `HISTORY.md has no v<version> section` generated them from the merged
    pull requests instead — the fallback `version-check` exists to make
@@ -511,6 +512,60 @@ word, and step 1 asks it of both.
    it. Marking it ready and pressing **Rebase and merge** is what that
    step still is; this one is what makes reaching it with a body already
    written the ordinary case rather than the exception.
+
+## Rebuild a release from its tag
+
+The `build` job exports `SOURCE_DATE_EPOCH` from the commit date and
+normalizes the sdist, so a rebuild of a released tag is the same bytes as
+what was published. Anyone can check that, and the check is one command
+short of the provenance one above: verify the *rebuilt* file rather than a
+downloaded one, and it can only pass if the digests agree. A release whose
+assets carry `<tag>.attestation.jsonl` has the signed statement on disk
+too, so `--bundle <that file>` asks the same question of it without
+reaching the attestations API — which is the form for whoever mirrors the
+releases page rather than trusting it live. `--signer-workflow` is the
+flag that makes either form say *which* workflow signed: without it a
+valid attestation from any workflow in the repository passes.
+
+A worktree and not `git checkout`, for the reason CLAUDE.md gives: the
+primary checkout is the maintainer's, and a rebuild wants a tree of its
+own regardless.
+
+```shell
+git worktree add --detach /tmp/btclib-rebuild v<version>
+cd /tmp/btclib-rebuild
+export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
+uv build
+uv run --no-project --python 3.14 \
+  .github/scripts/normalize_sdist.py dist/
+repo=btclib-org/btclib
+gh attestation verify dist/btclib-<version>-py3-none-any.whl \
+  --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
+gh attestation verify dist/btclib-<version>.tar.gz \
+  --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
+```
+
+Two things bound that guarantee, and both are worth knowing before reading
+a mismatch as tampering:
+
+- **the build backend is resolved, not pinned.** `[build-system] requires`
+  asks for `setuptools>=77` and an isolated build takes whatever is
+  current, so a rebuild months later runs a setuptools the release never
+  saw. A mismatch dates the rebuild before it accuses anyone; pinning the
+  backend to a version is the fix, and the cost is a floor that ages.
+- **the rehearsal is a different version, by construction.** A TestPyPI
+  dispatch appends `.dev<run number>` to the version, so its files are not
+  a second build of the release's — they are their own artifact, published
+  where they say they are. The attestation the rehearsal writes covers
+  those, and no digest is shared with the release.
+
+`btclib_libsecp256k1` is not a third bound. It is a runtime dependency,
+resolved by whoever installs the wheel, and the only trace of it in either
+distribution file is the `Requires-Dist` pyproject.toml already spells and
+the pin `uv.lock` carries into the sdist — both of them text belonging to
+the tag. Nothing the build resolves is a runtime dependency: an isolated
+build installs `[build-system] requires` and no more, and the rebuild
+above needs no `uv sync` to produce the published bytes.
 
 ## If something goes wrong
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -135,10 +135,13 @@ still worth looking at now and then.
 ## Token permissions
 
 **The default `GITHUB_TOKEN` is read-only repository-wide**, so a job
-needing more must declare it. Only `release.yml`'s `github-release` does
-(`contents: write`), plus `id-token: write` on the two publish jobs. The
-workflow-level `permissions: contents: read` is belt and braces; keep it,
-it is what makes the intent readable in the file.
+needing more must declare it. Every job that does is in `release.yml`:
+`contents: write` on `github-release`, `id-token: write` on the two
+publish jobs, and `id-token: write` with `attestations: write` on
+`attest`. One elevation per job is the shape to keep — the job that writes
+releases holds no OIDC token, and the job that signs writes no release.
+The workflow-level `permissions: contents: read` is belt and braces; keep
+it, it is what makes the intent readable in the file.
 
 ## Publishing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,6 +55,25 @@ a workflow that no long-lived token can authenticate for (PyPI Trusted
 Publishing), so a distribution can be traced back to the workflow run and
 the commit it was built from.
 
+The same files are attached to the GitHub release, and those copies carry
+a build provenance attestation of their own, signed in the run that built
+them:
+
+```shell
+gh attestation verify btclib-<version>-py3-none-any.whl \
+  --repo btclib-org/btclib \
+  --signer-workflow btclib-org/btclib/.github/workflows/release.yml
+```
+
+`--signer-workflow` is what makes that say which workflow signed, rather
+than accepting any attestation this repository has. The signed statement
+is attached to the release as well, as `<tag>.attestation.jsonl`, so
+`--bundle <tag>.attestation.jsonl` runs the same check reading it from
+disk instead of asking GitHub for it; one attestation covers the wheel
+and the sdist both. Either file can also be rebuilt from its tag and
+verified without being downloaded at all, the build being reproducible:
+RELEASING.md has that command and the bounds on it.
+
 ## Limitations, not vulnerabilities
 
 These are known and inherent. They are worth stating because btclib is


### PR DESCRIPTION
A provenance attestation over a build nobody can reproduce is a statement
about bytes only one runner ever held. Two changes, in that order: make
the distribution files reproducible, then sign the copies attached to the
GitHub release, so a verifier can check a file they built themselves
rather than one they downloaded. Both are ported from
btclib-org/bitcoin-core-rpc, adapted where this repository differs.

## The measurement

Two worktrees of one commit (`237c86d4`), `uv build` in each, sha256 of
both artifacts. Three rounds:

| Round | wheel | sdist |
| --- | --- | --- |
| plain `uv build` | differs | differs |
| `SOURCE_DATE_EPOCH` from the commit date | **identical** | differs |
| plus `normalize_sdist.py` | **identical** | **identical** |

Round 1: wheels `6d148716…` / `3aa29bfa…`, sdists `a2a292d3…` /
`18c411e3…`. Round 2: wheel `848a2d2f…` both sides, sdists `3ca0e525…` /
`7741ae89…`. Round 3: wheel `848a2d2f…`, sdist `f0dd74f1…`, both sides.

`SOURCE_DATE_EPOCH` reaches nothing in the sdist here, which was checked
rather than assumed:

```shell
uv run --isolated --no-project --with setuptools python -c "
import pathlib, setuptools
root = pathlib.Path(setuptools.__file__).parent
print(setuptools.__version__, [str(p.relative_to(root))
    for p in root.rglob('*.py')
    if 'SOURCE_DATE_EPOCH' in p.read_text(encoding='utf-8')])"
```

answers `84.0.0 ['_vendor/wheel/wheelfile.py']` — the wheel writer and no
other file. So every member of the `.tar.gz` keeps a clock: the
checkout's for a file, the build's for the directory setuptools stages
them in, sub-second in both cases and in a PAX `mtime` record whose
length changes with it. Round 2 differed in every one of the archive's
members, not only the first.

The runtime dependency is not a third step, and that was checked too:
neither measurement worktree had a `.venv` at all, an isolated build
installing `[build-system] requires` and nothing else, and
`btclib_libsecp256k1` reaches a distribution file only as the
`Requires-Dist` pyproject.toml spells and the pin `uv.lock` carries into
the sdist — text belonging to the tag either way.

The normalized sdist is still a working sdist: `twine check --strict`,
`check-wheel-contents`, `pyroma --min 10` all pass on it, and building
and installing from it round-trips the BIP39 `TREZOR` vector.

## The attestation

`attest` is a job of its own rather than two more permissions on
`github-release`, so the job that writes releases holds no OIDC token and
the job that runs the build backend mints none. `actions/attest` and not
the `attest-build-provenance` wrapper, which as of v4 is a composite
doing nothing but calling it; one statement covers both files. Its `if`
is `always() && (needs.publish-pypi.result == 'success' ||
needs.publish-testpypi.result == 'success')`, so a TestPyPI rehearsal
exercises the permission and the API — the alternative is a first run on
release day, past the point where a tag can be moved.

`github-release` names both `publish-pypi` and `attest` in `needs`:
naming `attest` alone would let a dispatch cut a release, that job
running in a rehearsal too. The signed bundle is copied out of
`$RUNNER_TEMP` to a fixed name, uploaded, and attached to the release as
`<tag>.attestation.jsonl`, which is what lets `gh attestation verify
--bundle` read the statement from disk instead of from the attestations
API.

## Adapted, not copied

- the job names and the `build` job shape are this repository's; the
  version-suffix mechanism for the TestPyPI rehearsal was already here
  and is untouched
- `actions/checkout`, `astral-sh/setup-uv`, `actions/upload-artifact` and
  `actions/download-artifact` keep the SHAs already pinned here.
  `actions/attest` is new and pinned to `1e69f48…` (v4.2.2), the SHA
  bitcoin-core-rpc pins, verified with
  `gh api repos/actions/attest/git/ref/tags/v4.2.2`
- the script's prose states what was measured *here* — every member
  affected, not the staging directory alone
- RELEASING.md's rebuild command uses `git worktree add --detach` rather
  than `git checkout`, CLAUDE.md forbidding a branch switch in the
  primary checkout
- REPOSITORY.md's token-permission list gains the job, SECURITY.md the
  verification command for a release asset, CONTRIBUTING.md the two lines
  a contributor reproduces the build with — three files that each state a
  fact this change makes untrue otherwise

## Two things fixed in passing

Both in the comments the new job sits between: `github-release`'s opening
two lines had come loose from it and sat above `published`, and the
concurrency comment stated how many workflows this one calls — a count,
and the wrong one (five, not four). It says "this workflow is a caller"
now.

## Gates

Every command verbatim from CONTRIBUTING.md, exit codes read:

- `pre-commit run --all-files --show-diff-on-failure` — clean twice, with
  the new script staged so the file-based hooks actually see it
- `pytest --cov` — 18569 passed, 6 skipped, coverage 100.00%
- `sphinx-build -W --keep-going` — build succeeded; the
  `href="#\./"` grep exits 1
- `uv build`, `twine check --strict`, `check-wheel-contents`,
  `pyroma --min 10` — all pass, on a normalized sdist

No required check changes name, so no branch-rule edit is needed.

## Noticed, not touched

- CLAUDE.md, RELEASING.md and REPOSITORY.md still describe a `dev`/`master`
  model this repository no longer has (`main` is the only branch), and
  RELEASING.md still says to dispatch `published` by hand where
  `release.yml` now calls it
- REPOSITORY.md's "Branch protection" section says `master` requires four
  checks where the table above it lists five for `main`, and one `gh api`
  example still reads `branches/master/protection`
- CHANGELOG.md's newest entry refers to "master's required checks"

## Summary by Sourcery

Make release artifacts reproducible and add provenance attestations for the distribution files attached to GitHub releases.

Enhancements:
- Introduce an sdist normalization script and export SOURCE_DATE_EPOCH from the commit date so wheels and sdists built from the same commit are byte-identical.

CI:
- Extend the release workflow with an attestation job that signs built distribution artifacts using actions/attest, publishes the attestation bundle as an artifact, and attaches it to the GitHub release; adjust job dependencies and concurrency comments accordingly.

Documentation:
- Update RELEASING.md with a reproducible rebuild procedure and attestation verification commands, CHANGELOG.md with notes on reproducible distribution files and release asset provenance, SECURITY.md with guidance on verifying release asset attestations, CONTRIBUTING.md with the commands that make builds reproducible, and REPOSITORY.md with the expanded token permission model for the release workflow.