### PR TITLE
Stop naming dev, the branch this repository no longer keeps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,15 @@
 # - the Gemfile is left out: GitHub builds the pages site on its own
 #   side, so github-pages is only ever resolved for a local preview
 # - the pre-commit hook revs are left out because dependabot has no
-#   pre-commit ecosystem; pre-commit.ci updates them instead, weekly and
-#   onto dev, as configured in the ci: block of .pre-commit-config.yaml
+#   pre-commit ecosystem; pre-commit.ci updates them instead, weekly, as
+#   configured in the ci: block of .pre-commit-config.yaml
 #
 # every pull request here runs the whole test matrix, so both ecosystems
-# group their updates into a single pull request; both target dev, master
-# only receiving merges from it.
+# group their updates into a single pull request. Neither declares a
+# target-branch: without one dependabot opens against the default branch,
+# which is the only branch a change lands on -- and a target-branch naming
+# a branch that is not there is not an error anywhere, it is a repository
+# where nothing is ever proposed.
 #
 # Weekly: the latest workflow upgrades everything uv resolves and runs
 # the suite, the lint gate and the packaging checks against it, on a
@@ -41,7 +44,6 @@ updates:
       # actions ecosystem nothing, which the sentinel does not cover, but
       # two schedules a day apart are one thing to remember instead of two
       day: thursday
-    target-branch: dev
     groups:
       actions:
         patterns: ["*"]
@@ -59,7 +61,6 @@ updates:
     schedule:
       interval: weekly
       day: thursday
-    target-branch: dev
     groups:
       dev-tooling:
         patterns: ["*"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,9 @@ ci:
   # where no workflow token can write and every action is pinned to a
   # commit SHA: a failing hook is fixed by its author
   autofix_prs: false
-  # onto dev, as dependabot does: master only receives merges from it
-  autoupdate_branch: dev
+  # no autoupdate_branch, as dependabot declares no target-branch: the
+  # default is the default branch, which is the only branch a change
+  # lands on
   autoupdate_commit_msg: "Update the pinned pre-commit hook revisions"
   autoupdate_schedule: weekly
   # the hooks pre-commit.ci cannot run: they shell out to uv, which is not


### PR DESCRIPTION
`main` is the only branch this repository has, and both bots are told to
open against it by not being told anything: `dependabot.yml` declares no
`target-branch` and `.pre-commit-config.yaml` no `autoupdate_branch`, so
each falls back to the default branch. That is what bitcoin-core-rpc
already does, and a setting that names nothing cannot name something
that is gone.

Neither failure was loud. Nothing in CI reports a target that does not
resolve, so what it cost is the pull requests that never arrived: `gh pr
list --repo btclib-org/btclib --author app/dependabot --state all`
returns nothing at all, while the action pins are commit SHAs frozen
until something moves them and `uv.lock` is the whole of what ruff, mypy,
pytest and sphinx resolve to.

The comments say the same thing the settings do, the two paragraphs that
described a `dev` feeding a `master` included.

## What is left

`REPOSITORY.md`, `CONTRIBUTING.md` and `CLAUDE.md` still describe the two
branches — branch protection, the worktree base, "work happens on `dev`",
Pages served from `master`. None of it configures a bot, so it is not in
here; it is a prose pass of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align automated dependency and pre-commit update workflows with the repository’s default main branch and remove references to the obsolete dev branch.

Bug Fixes:
- Ensure Dependabot opens update pull requests against the existing default branch instead of a non-existent dev branch.
- Ensure pre-commit.ci autoupdates run against the default branch by relying on its implicit branch selection instead of an invalid dev branch.

CI:
- Update Dependabot configuration comments and remove explicit target-branch settings that referenced the removed dev branch.
- Update pre-commit.ci configuration comments and drop the autoupdate_branch override that pointed to the dev branch.