### PR TITLE
Build the docs on one interpreter, and record the bot fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -368,9 +368,9 @@ repos:
   # and not this. A typo in a package-ecosystem or a directory is not an
   # error to GitHub -- it silently updates nothing, and the evidence is a
   # pull request that never arrives. That file is the whole of the answer
-  # to issue #158, both ecosystems targeting dev so that bot commits reach
-  # master through it, so "it stopped running and said nothing" is exactly
-  # the failure to guard against.
+  # to issue #158, both ecosystems reaching the default branch as a pull
+  # request, so "it stopped running and said nothing" is exactly the
+  # failure to guard against.
   # check-github-workflows is not added beside it: actionlint already
   # reads every workflow and goes further than the schema does, into
   # expressions, contexts and runner labels

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,11 +18,15 @@ version: 2
 
 # the interpreter is declared rather than left to whatever read the docs
 # defaults to: conf.py reads the version out of pyproject.toml with
-# tomllib, which is standard library from 3.11 on
+# tomllib, which is standard library from 3.11 on. Which version above that
+# floor is `.python-version`'s to say, 3.14 -- these docs are built twice,
+# here and by docs.yml, and one interpreter is what keeps the build read on
+# the website and the build that gates a merge from being two different
+# questions
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.13"
+    python: "3.14"
   # build.commands rather than the sphinx: and python: keys, which cannot
   # express this and are rejected when it is present.
   # autodoc has to import btclib, so btclib has to be installed, and what

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,25 @@ documented at release-notes length in the first place, and are still in
   say so -- and listing it would spend a runner on nearly every pull
   request, which is the cost this filter exists to avoid. The job still
   gates nothing and is still absent from master's required checks.
+- **Both update bots open against the branch this repository has.**
+  `.github/dependabot.yml` named a `target-branch` for each of its two
+  ecosystems and `.pre-commit-config.yaml` named an `autoupdate_branch`,
+  three settings pointing at a branch that is not there -- and neither
+  service treats that as an error. Dependabot opens nothing, pre-commit.ci
+  updates nothing, and the evidence either way is a pull request that never
+  arrives, which is indistinguishable from a week in which no dependency
+  moved. All three are dropped rather than corrected: without them each bot
+  targets the default branch, which is the one branch here, so there is no
+  second place left to keep in step with a rename. Security updates were
+  part of what stopped, so this is not only about tooling drift.
+- **Read the docs builds on the interpreter `docs.yml` builds on**, 3.14,
+  which is what `.python-version` says. The same documentation is built
+  twice, once for the website and once as a required check, and two
+  interpreters make those two different questions -- a docstring that
+  renders under one and fails `-W` under the other is then found after the
+  merge, on the service whose failure is not a check on the pull request.
+  btclib_libsecp256k1's own file says it matches this one and moves with
+  it.
 
 - **The distribution files are reproducible**: two checkouts of one commit
   build the same wheel and the same sdist, so the provenance attestation

--- a/uv.lock
+++ b/uv.lock
@@ -2120,7 +2120,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.6.1"
+version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -2129,9 +2129,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/89/1f3e8e1fc3e97de0fa963495832f581f025f29471602a309e48808244292/pre_commit-4.6.2.tar.gz", hash = "sha256:8f5d7bfb021ecdbcd9d49d89847082dd24172ccde534390081a679ad046e2441", size = 198670, upload-time = "2026-08-10T22:07:18.421Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e2/bbb7129c9e7999a6b8ee9cca3b66486c25c423ab5a75f34071798b74ce94/pre_commit-4.6.2-py2.py3-none-any.whl", hash = "sha256:e2dde9a75d3bce11bd3831c26d134df00a2803c1d818be6a0383c3dcda25dc4e", size = 226202, upload-time = "2026-08-10T22:07:16.942Z" },
 ]
 
 [[package]]
@@ -3117,7 +3117,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.7.3"
+version = "21.7.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -3126,9 +3126,9 @@ dependencies = [
     { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/10/8b7a5454efc032be50c1c5641467dbb5d31314500205212b2aa66d3c8af4/virtualenv-21.7.3.tar.gz", hash = "sha256:5e9e287f5c808070eea3b40403d3368248e64b24f1b60bd9a36e85ac841d2c3e", size = 5525482, upload-time = "2026-08-08T14:43:20.286Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/dc/a6eb1ddfa7f1e390fa599b078453c97edb3f6f846b34fb4eac3e8ea16401/virtualenv-21.7.4.tar.gz", hash = "sha256:c9d960c95fa458171e58222a5ccab7465298e4b6559977865e627c4719f1e825", size = 5345511, upload-time = "2026-08-10T22:54:33.316Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/2a/83d779d2dfb61f101d7b1c10073d18984e37262d8b4f171c99911a952430/virtualenv-21.7.3-py3-none-any.whl", hash = "sha256:26dfda3c34f29bf1a3ca167426a67658d59979b9954e705aef60a5f724ce1773", size = 5504590, upload-time = "2026-08-08T14:43:18.57Z" },
+    { url = "https://files.pythonhosted.org/packages/40/4c/eb2f52aeeaf30dbd073d315a251a63ae2b8263171ec4428c135140cb0802/virtualenv-21.7.4-py3-none-any.whl", hash = "sha256:376ec93cd6aab3044fa395d7db226db38043b7b5748948044b2a87168525e843", size = 5324444, upload-time = "2026-08-10T22:54:31.515Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
`.readthedocs.yaml` asked for 3.13 where `.python-version` says 3.14, so
the website and `docs.yml` built the same sources under two interpreters.
That makes them two questions rather than one: a docstring that renders
under 3.13 and fails `-W` under 3.14 is found after the merge, on the
service whose failure is not a check on the pull request.
btclib_libsecp256k1's file says it matches this one, and moves with it.

The comment in front of the check-dependabot hook still described the two
ecosystems as targeting dev to reach master. Both settings are gone, so it
now describes what they do, which is open against the default branch.

CHANGELOG.md gets that bot fix, which landed without an entry, and this
one. It is the branch rule, Dependabot security updates included, that
stopped proposing anything -- a reader of the release has to be able to
find out when it started again.

The lock takes pre-commit 4.6.2 and virtualenv 21.7.4, the whole of what
an upgrade resolves today; no runtime dependency moved, so none of it is a
user's concern and none of it is in CHANGELOG.md.

The hook revisions are unchanged, and not for want of asking: `pre-commit
autoupdate` offered typos on `v1` and pyroma on 5.1b1, the floating major
and the prerelease the `pinned-rev` hook exists to refuse. Everything else
is at its latest release, and so is every action SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)