### PR TITLE
Say which branch this repository has, in the three files that describe it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,27 @@ documented at release-notes length in the first place, and are still in
 
 ## v2026.9 (work in progress, not released yet)
 
+### Repository
+
+- **`main` is the only branch, and the three files a session reads say
+  so.** `REPOSITORY.md` documented a protected `master` fed by a `dev`
+  that carried no required check, `CONTRIBUTING.md` a website served from
+  `master` and a release merged into it with "Rebase and merge", and
+  `CLAUDE.md` a worktree based on `origin/dev` -- a base `git worktree
+  add` cannot resolve, in the one file whose job is to keep a session from
+  wasting itself. The branch rules live outside the tree, so nothing in a
+  checkout contradicts a file that describes them wrongly.
+
+  What replaces it is read from the repository rather than remembered:
+  `main` protected with the five checks and `strict`, one approving review
+  with `dismiss_stale_reviews`, required signatures, linear history,
+  resolved conversations and `enforce_admins` off; Pages serving `main`'s
+  root; both bots opening pull requests with no target branch named. Two
+  adjacent paragraphs of `REPOSITORY.md` claimed opposite things about the
+  required checks' app bindings, and the `gh api` call that answers it is
+  now beside the claim -- some of the five are bound to Actions and the
+  rest to nothing, which the `PATCH` above them cannot express.
+
 ### Packaging, linting and CI
 
 - **The Bitcoin Core regtest job runs for the code it checks** (#570).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,7 @@ lose. Reading it is fine — `git log`, `git show`, `git diff`, `gh`, and a
 
 ```shell
 WT=<scratchpad>/wt<issue>
-git worktree add -b <branch> "$WT" origin/dev
+git worktree add -b <branch> "$WT" origin/main
 cd "$WT" && uv sync --locked          # a second venv, about a minute
 # edit, gate and commit here, then
 git push origin HEAD:refs/heads/<branch>
@@ -92,8 +92,8 @@ git worktree remove --force "$WT"     # removing it is part of finishing
 ```
 
 The venv is the whole of the cost, and it buys the thing that matters: a
-commit cannot contain work that was never in it. Expect `origin/dev` to
-move while you work, so `git fetch && git rebase origin/dev` before
+commit cannot contain work that was never in it. Expect `origin/main` to
+move while you work, so `git fetch && git rebase origin/main` before
 pushing, resolving in favour of *both* sides (their change and yours,
 both CHANGELOG.md bullets).
 
@@ -107,24 +107,25 @@ the way the stash only looks to be. What is already lost is still in the
 object store — `git fsck --unreachable` names the commit and `git stash
 store <sha>` puts the ref back.
 
-**Do not rewrite `refs/heads/dev`, or advance it with work that is not
+**Do not rewrite `refs/heads/main`, or advance it with work that is not
 yours.** `git update-ref`, or a push carrying another session's commits,
 leaves every working tree's files alone and moves the base under them, so
 their next commit — built on the older copy — reverts what just landed.
 Your own branch is what you push, and the pull request is what moves
-`dev`: CONTRIBUTING.md's "Pull Request" section has how a branch under
+`main`: CONTRIBUTING.md's "Pull Request" section has how a branch under
 review is corrected and how it is merged.
 
 ## Non-obvious facts that will otherwise waste a session
 
-- **Work happens on `dev`**; `master` is the default branch and receives
-  merges from it. Dependabot and pre-commit.ci both target `dev`.
-- **A dev CI run is usually `cancelled`, not green.** `test.yml`'s
+- **`main` is the only branch**, and nothing is pushed to it directly:
+  every change lands through a pull request, Dependabot's and
+  pre-commit.ci's included, neither of them naming a branch. Branch
+  protection, and why it is what it is, is `REPOSITORY.md`.
+- **A branch's CI run can be `cancelled` rather than green.** `test.yml`'s
   concurrency group is `test-${{ github.ref }}` with cancel-in-progress,
-  so the next session's push to `dev` kills the run for the previous
-  commit. The local gates below are the evidence; `cancelled` is not
-  `failure`, and waiting for a busy afternoon to settle is waiting for
-  nothing.
+  so the next push kills the run for the previous commit. The local gates
+  below are the evidence; `cancelled` is not `failure`, and waiting for a
+  busy afternoon to settle is waiting for nothing.
 - **`.pre-commit-config.yaml` is the lint gate**, and `lint.yml`'s first
   job runs exactly it. Never add a second list of the same tools to a
   workflow. mypy is a *local* hook shelling out to uv on purpose: the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -537,14 +537,14 @@ its side; its findings appear under the Security tab.
 
 ### The website
 
-**btclib.org is this repository.** GitHub Pages serves it from `master`'s
+**btclib.org is this repository.** GitHub Pages serves it from `main`'s
 root, so a set of files at the top level are website sources rather than
 Jekyll leftovers, which is the opposite of the natural first assumption:
 
 ```shell
 gh api repos/btclib-org/btclib/pages
 # {"cname": "btclib.org", "build_type": "legacy",
-#  "source": {"branch": "master", "path": "/"}}
+#  "source": {"branch": "main", "path": "/"}}
 ```
 
 What that makes live:
@@ -563,7 +563,7 @@ Three consequences worth knowing before editing any of them:
 - **every README edit is a website deploy.** The README is also the PyPI
   long description, so a typo in it is visible in three places: GitHub,
   btclib.org and the PyPI project page.
-- **every other file in master's root is a URL under btclib.org** unless
+- **every other file in main's root is a URL under btclib.org** unless
   `_config.yml`'s `exclude:` says otherwise, the library itself included:
   drop that list's `btclib/` and `pyproject.toml` entries and
   `btclib.org/pyproject.toml` and `btclib.org/btclib/alias.py` answer with
@@ -575,10 +575,10 @@ Three consequences worth knowing before editing any of them:
   `<script src="/%20/assets/js/scale.fix.js">` for as long as it took
   someone to fetch the page and read the HTML.
 
-Because Pages serves from `master`, a website-only commit there also
+Because Pages serves from `main`, a website-only commit there also
 triggers the full test matrix; `test.yml`'s `push` trigger carries a
 `paths-ignore` for these files so that it does not. The `pull_request`
-trigger deliberately does not: those checks are required on `master`, and a
+trigger deliberately does not: those checks are required on `main`, and a
 required check that produces no run blocks the merge.
 
 To preview locally, with Ruby and Bundler installed:
@@ -590,7 +590,7 @@ bundle exec jekyll serve
 
 That is the one part of this project not driven by `uv`, and it is only a
 preview: what btclib.org serves is whatever the classic builder makes of
-`master`.
+`main`.
 
 ### Issues
 
@@ -758,25 +758,20 @@ commits the review is attached to: the reviewer loses the diff they read,
 check starts again from a commit nobody has seen. Add the fix on top, with
 a message saying what it fixes, and reply to the comment with the sha.
 
-Nothing is lost in `dev`'s history by doing so, because **a pull request
-into `dev` is merged with "Squash and merge"**: the branch becomes one
-commit whose subject is the PR title with its number, so the review's
-commits are the record of the review and `dev` keeps one commit per landed
-change. A merge commit would put the branch's steps into `dev` and a
-rebase merge would replay them one by one — `dev` is linear by branch
-rule, and one change is one commit there.
+Nothing is lost in `main`'s history by doing so, because **a pull request
+is merged with "Squash and merge"**: the branch becomes one commit whose
+subject is the PR title with its number, so the review's commits are the
+record of the review and `main` keeps one commit per landed change. A
+merge commit would put the branch's steps into `main` and a rebase merge
+would replay them one by one — `main` is linear by branch rule, and one
+change is one commit there.
 
-**The pull request that takes `dev` into `master` is merged with "Rebase
-and merge"**. Read the button before clicking it: all three methods are
-enabled on the repository, and GitHub offers whichever was used last. A
-squash there would fold every change `dev` has landed since the previous
-merge into a single commit, and that history would then be on `dev` alone.
-The rebase replays those commits onto `master`, which is linear by branch
-rule as `dev` is — the same rule that bars a merge commit. And nothing is
-deleted afterwards: the branch merged is `dev`.
+**Read the button before clicking it.** All three methods are enabled on
+the repository and GitHub offers whichever was used last, so the squash is
+a choice made once per pull request rather than a setting.
 
 The one force-push that stays right is the one that carries no new work: a
-`git rebase origin/dev` on a branch whose base has moved, which is how a
+`git rebase origin/main` on a branch whose base has moved, which is how a
 stale pull request is refreshed. Re-run the gates after it, never only
 before it, and say in the pull request that the head moved and why.
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -64,52 +64,50 @@ gh api -X PATCH "$branch"/protection/required_status_checks \
   -f 'contexts[]=CodeQL'
 ```
 
-`contexts` rather than `checks` with an `app_id`, which is the shape the
-rule already has here: binding each context to the app that produces it is
-the stricter form, and adopting it is a separate decision from this list.
-
-Each check is bound to the app that produces it — `checks` with an
-`app_id` rather than the bare `contexts` list, 15368 for Actions and
-57789 for CodeQL — so nothing else can satisfy one.
+That `PATCH` sends `contexts`, which names no app, and what is there is
+not uniformly that: some of the five are bound to the app that produces
+them and the rest to nothing, which lets any app reporting one of those
+names satisfy it. Read it before assuming either shape:
 
 ```shell
-gh api repos/btclib-org/btclib/branches/master/protection \
-  --jq '.required_status_checks'   # PATCH that sub-endpoint to change
+gh api repos/btclib-org/btclib/branches/main/protection \
+  --jq '.required_status_checks.checks'   # PATCH that sub-endpoint
 ```
+
+Binding all five is the stricter form — `checks` with an `app_id` in the
+body, 15368 for Actions, rather than the bare `contexts` list — and
+adopting it is a decision separate from this list.
 
 **PATCH that sub-endpoint, never PUT the whole protection object**: a
 partial PUT drops the reviews, the signatures and the rest. Repeat
 `strict: true` in the body, which replaces the object rather than merging
 into it.
 
-## Branch protection, both branches
+## Branch protection
 
-Both branches are protected, and differently on purpose.
-
-`master`: those four checks with `strict`, one approving review,
+`main` is the only branch, and everything reaches it through a pull
+request: the five checks above with `strict`, one approving review,
 `dismiss_stale_reviews`, **required signatures**, linear history, no force
 pushes, no deletions, `required_conversation_resolution`, and
 `enforce_admins` *off* — an administrator can bypass all of it.
 
-`dev`: no force pushes, no deletions, linear history, resolved
-conversations, and nothing beyond that — no required check, no review, no
-signature, so a direct push still works, which is what `uv run` and both
-bots rely on.
+That last one is what carries the review. A review cannot be satisfied by
+its author, GitHub not allowing self-approval, so on a solo-maintainer
+repository the rule as written stops every pull request the maintainer
+opens, and the bypass is what lets one merge at all. The trade is the
+review's other half: it is there for a contributor's pull request, where
+there *is* somebody else to ask.
 
-That asymmetry is the answer to issue #158, and it is a choice rather
-than a copy for two measured reasons. Commits on `dev` are **unsigned**
-(`git log --format='%G?'` prints `N`), so `required_signatures` there
-would reject every push, the bots' included. And one approving review
-cannot be satisfied by the author, GitHub not allowing self-approval, so
-on a solo-maintainer branch it is a stop rather than a speed bump.
+Required signatures cost the maintainer nothing for the same reason
+nothing here pushes to `main` directly: the only thing writing to it is a
+merge GitHub performs itself, and GitHub signs those with its web-flow
+key.
 
-What `dev` does buy is the thing the issue was about: Dependabot targets
-it for both ecosystems, pre-commit.ci autoupdates it, and Dependabot
-security updates are on, so bot-authored commits reach `master` through
-it — and the branch cannot be rewritten or deleted under them.
-
-Requiring the four checks on `dev` as well is the next step if one is
-wanted, and it costs the direct push.
+Dependabot, its security updates and pre-commit.ci all open pull requests
+here, none of them naming a target branch: what they get is the default
+branch, and it is the only branch there is. Issue #158 was the other
+arrangement — two bots pushing through an integration branch that carried
+no protection at all — and one branch is what closed it.
 
 ## Head branches after a merge
 
@@ -123,14 +121,14 @@ GitHub deletes the head branch of a pull request when it is merged, which
 is what keeps the branch list a list of live work rather than a history of
 every change ever made. It was turned on after a sweep that removed nine
 merged head branches from here, none of which anybody could tell from live
-work without comparing each against `dev` commit by commit.
+work without comparing each against the trunk commit by commit.
 
 Two cases it does not cover, both deliberate. A protected branch is never
-deleted, protection winning over this setting, so the release pull request
-that merges `dev` into `master` leaves `dev` where it is. And a pull
-request **closed without merging** keeps its head branch: GitHub cannot
-know whether that work was abandoned or is waiting, so those are the ones
-still worth looking at now and then.
+deleted, protection winning over this setting, which is why `main` cannot
+be removed by anything — including a pull request that somehow had it as a
+head. And a pull request **closed without merging** keeps its head branch:
+GitHub cannot know whether that work was abandoned or is waiting, so those
+are the ones still worth looking at now and then.
 
 ## Token permissions
 


### PR DESCRIPTION
`main` is the only branch. `REPOSITORY.md` described a protected `master`
fed by a `dev` that carried no required check, `CONTRIBUTING.md` a website
served from `master` and a release merged into it with "Rebase and merge",
and `CLAUDE.md` a worktree based on `origin/dev` — a base `git worktree
add` cannot resolve, in the file whose job is to keep a session from
wasting itself.

The branch rules live outside the tree, which is what `REPOSITORY.md`
exists for and also why nothing in a checkout contradicts it when it is
wrong. Every replacement here is read back from the repository rather than
remembered:

```shell
gh api repos/btclib-org/btclib/branches --jq '.[].name'
gh api repos/btclib-org/btclib/branches/main/protection
gh api repos/btclib-org/btclib/pages
```

## What that turned up

Two adjacent paragraphs of `REPOSITORY.md` claimed opposite things about
the required checks' app bindings — one said the rule uses bare
`contexts`, the next that each check is bound to the app that produces it,
"15368 for Actions and 57789 for CodeQL". Neither is what is configured:
two of the five carry `app_id` 15368 and three carry `null`, and no CodeQL
binding exists at all. The `PATCH` recipe above them sends `contexts`,
which names no app, so the file now says how to read the bindings instead
of asserting a shape.

The rest is the measured configuration: five required checks with
`strict`, one approving review with `dismiss_stale_reviews`, required
signatures, linear history, resolved conversations, `enforce_admins` off,
Pages serving `main`'s root, and both bots opening pull requests with no
target branch named — which is what btclib-org/btclib#603 left them doing.

`CHANGELOG.md` gets the entry under a `Repository` group.

## Still stale, and not in here

- [`RELEASING.md`](https://github.com/btclib-org/btclib/blob/main/RELEASING.md)
  is written around the two-branch release: merging `dev` into `master`,
  realigning `dev` afterwards, `git push origin origin/dev:master`. That is
  a process rewrite rather than a naming pass, and it wants deciding rather
  than editing.
- `CHANGELOG.md`'s older entries name `master` and `dev` as they were when
  written; they are the record and are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align repository documentation with the current single-branch setup and recorded GitHub configuration.

Enhancements:
- Add CHANGELOG entry under a new Repository section documenting the corrected branch description and protection settings across project docs.

Documentation:
- Update REPOSITORY.md to describe protection rules and required checks for the main branch based on live GitHub settings, including how status checks are bound to apps.
- Revise CONTRIBUTING.md to reference main as the GitHub Pages source, clarify required checks and merge strategy for pull requests, and modernize guidance around CI behavior and force-pushes.
- Adjust CLAUDE.md workflow instructions to work from origin/main and describe the current single-branch branching model and CI expectations.