### PR TITLE
Pin CodeQL to a workflow in the tree

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -119,18 +119,18 @@ jobs:
     timeout-minutes: 20
     # the elevation, on the job that needs it and nowhere else: the
     # aggregate below declares nothing and inherits the workflow default.
-    # No packages: read either, which fetching a private CodeQL pack would
-    # want and the default query suite does not
     # security-events: write is what uploading a SARIF to code scanning
-    # takes, and the whole reason this job cannot run on the default
-    # read-only token. actions: read is redundant while this repository is
-    # public -- it is what the CodeQL action needs to read run metadata in
-    # a *private* one -- and it is written down so that the file does not
-    # quietly stop working the day the repository stops being public.
-    # The trailing comments are not a second copy of that for its own sake:
-    # zizmor's undocumented-permissions audit reads the line a permission
-    # is on and not the paragraph above the block, so a comment here is
-    # what keeps `--persona=auditor` at zero findings for this file
+    # takes, and the whole reason this job cannot run on the read-only
+    # token. actions: read is redundant while this repository is public --
+    # it is what the CodeQL action needs to read run metadata in a
+    # *private* one -- and it is written down so that the file does not
+    # quietly stop working the day the repository stops being public. No
+    # packages: read, which fetching a private CodeQL pack would want and
+    # the default query suite does not.
+    # The trailing comments below are not that paragraph again for its own
+    # sake: zizmor's undocumented-permissions audit reads the line a
+    # permission is on and not the prose above the block, so one word there
+    # is what keeps `--persona=auditor` at zero findings for this file
     permissions:
       security-events: write # the SARIF upload, and nothing else needs it
       contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,231 @@
+---
+name: codeql
+
+# the static analysis GitHub runs on its side, moved into the tree.
+#
+# It ran from default setup, a repository setting, which made it the one
+# required check whose definition no diff could review: every other check
+# in main's rule is a file here, with its actions pinned to commit SHAs
+# that a pull request can be read for. A setting is edited in a browser by
+# whoever holds the token, leaves no history a reviewer sees, and cannot
+# be branched -- so the analysis that looks for injected expressions and
+# unsafe checkouts in these very workflows was itself the part of CI
+# nobody could audit.
+#
+# What the setting held is reproduced rather than invented:
+#
+#   gh api repos/btclib-org/btclib/code-scanning/default-setup
+#   # {"state":"configured","languages":["actions","python"],
+#   #  "query_suite":"default","threat_model":"remote",
+#   #  "schedule":"weekly","runner_type":"standard"}
+#
+# Ruby is not in that list and not in the matrix below, which is worth a
+# word because default-setup runs here have carried an `Analyze (ruby)`
+# job: GitHub Pages serves btclib.org from main's root, so a Gemfile sits
+# beside the library and autodetection sees it. It analyses nothing -- of
+# the analyses this repository has ever received, every one is python or
+# actions, and none is ruby:
+#
+#   gh api "repos/btclib-org/btclib/code-scanning/analyses?per_page=100" \
+#     --jq '[.[] | .category] | group_by(.) | map({cat: .[0], n: length})'
+#
+# `threat_model: remote` is CodeQL's own default, so nothing here sets it;
+# it would take a `config:` block naming `threat-models` to depart from.
+#
+# REPOSITORY.md has the order in which the switch is thrown, and it
+# matters: while default setup is enabled GitHub refuses to run an
+# advanced workflow, so this file produces no check at all until the
+# setting is turned off, and the branch rule has to stop naming `CodeQL`
+# before that happens or nothing can merge in between.
+
+on:
+  push:
+    # main only: a push to a branch that has an open pull request would
+    # run this workflow twice, once per event, and the two runs land in
+    # different concurrency groups (refs/heads/<branch> against
+    # refs/pull/N/merge) so neither cancels the other. The pull_request
+    # run is the one worth keeping, because it analyses the merge commit
+    # and is the only run a fork's pull request produces at all.
+    # main keeps a trigger of its own because a merge creates a commit
+    # that is not the one the pull request analysed, and because code
+    # scanning compares a pull request's alerts against the default
+    # branch's: without a run here every alert on every branch reads as
+    # new
+    branches: [main]
+  pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft: the default
+    # types do not include it, and without it a readied pull request
+    # would wait for its next push to be checked at all
+    types: [opened, reopened, synchronize, ready_for_review]
+    # no `paths` filter, on either trigger: the aggregate at the end of
+    # this file is a required check on main, and a required check that
+    # never runs blocks a merge where a skipped one satisfies it -- the
+    # same trade integration.yml makes, and for the same reason. Every
+    # pull request pays it, documentation-only ones included, and what
+    # that costs was read off the runs default setup produced rather than
+    # guessed: a mean of 40 seconds for the actions job and 72 for the
+    # python one, the command in the aggregate's comment below
+  schedule:
+    # Saturdays, 04:23 UTC. Not on the hour: GitHub queues scheduled
+    # workflows across every repository that asked for the same minute,
+    # and the run can be dropped outright when the queue is long.
+    # Saturday is the day nothing else here asks for -- links Monday,
+    # latest and macos Wednesday, Dependabot Thursday, integration
+    # Friday, and the mutation session Sunday -- so a failure
+    # notification names the workflow by the day it arrived. Weekly, as
+    # default setup was: what a scheduled analysis catches is a query
+    # CodeQL added since the last commit, which arrives with the bundle
+    # rather than with a branch.
+    # Cron runs from the default branch only, so this asks nothing until
+    # it reaches main; elsewhere the dispatch below is the way in
+    - cron: "23 4 * * 6"
+  # the escape hatch: an analysis on demand for a branch whose pull
+  # request is not open yet
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies, the CodeQL bundle itself) can read the token, so
+# the workflow default must not be able to write to the repository. The
+# analysis job elevates for itself, one elevation on the one job that
+# needs it, which is the shape REPOSITORY.md keeps
+permissions:
+  contents: read
+
+# cancel superseded runs on the same branch/PR.
+# The group is named literally rather than with github.workflow, which in
+# a called workflow is the caller's name: nothing calls this one today,
+# and the expression would be a trap for whatever does
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    # one job per language rather than one job analysing both, so a
+    # failure names the language in the checks list instead of sending a
+    # reader into the log to find out which half broke -- and so the two
+    # run in parallel, which is what default setup did too
+    name: Analyze ${{ matrix.language }}
+    # a draft pull request is work in progress: every push to one spends
+    # runners on a tree its author is not asking anyone to review yet.
+    # The gate below carries the same condition, so a draft skips
+    # uniformly and the gate does not read that skip as a job that should
+    # have run
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    # far above what either language needs; what it bounds is a hung job
+    # holding a runner for six hours
+    timeout-minutes: 20
+    # the elevation, on the job that needs it and nowhere else: the
+    # aggregate below declares nothing and inherits the workflow default.
+    # No packages: read either, which fetching a private CodeQL pack would
+    # want and the default query suite does not
+    # security-events: write is what uploading a SARIF to code scanning
+    # takes, and the whole reason this job cannot run on the default
+    # read-only token. actions: read is redundant while this repository is
+    # public -- it is what the CodeQL action needs to read run metadata in
+    # a *private* one -- and it is written down so that the file does not
+    # quietly stop working the day the repository stops being public.
+    # The trailing comments are not a second copy of that for its own sake:
+    # zizmor's undocumented-permissions audit reads the line a permission
+    # is on and not the paragraph above the block, so a comment here is
+    # what keeps `--persona=auditor` at zero findings for this file
+    permissions:
+      security-events: write # the SARIF upload, and nothing else needs it
+      contents: read
+      actions: read # run metadata, which only a private repository gates
+    strategy:
+      # one language failing must not cancel the other: which of the two
+      # is red is the information, and cancelling throws half of it away
+      fail-fast: false
+      matrix:
+        language:
+          - actions
+          - python
+    steps:
+      # every action is pinned to a commit SHA, the tag in the comment: a
+      # tag, let alone a branch, is a name its owner can move, and these
+      # run in a job that can write security events
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # see the checkout of the suite job in test.yml
+          persist-credentials: false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: ${{ matrix.language }}
+          # both languages are interpreted, so no build step sits between
+          # init and analyze and no autobuild is attempted. Written out
+          # rather than left to the default because it is the input that
+          # would have to change first if a compiled language ever joined
+          # the matrix, and because it is what default setup used here:
+          # every analysis this repository has received carries
+          # `"build-mode":"none"` in its environment --
+          #   gh api repos/btclib-org/btclib/code-scanning/analyses \
+          #     --jq '.[0].environment'
+          build-mode: none
+          # no `queries`, no `packs` and no `config`, which is not an
+          # omission: `query_suite: "default"` is precisely the state in
+          # which nothing has been added, the action running the default
+          # code-scanning suite when the default queries are not disabled
+          # and no packs, queries or query-filters are named. Neither
+          # init nor analyze takes a `query_suite` input to say it with,
+          # so anything written here would widen the analysis rather than
+          # pin it -- `queries: security-extended` is the widening, and
+          # it is a decision separate from moving the file into the tree
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          # code scanning keys an analysis by category, so without one
+          # per language the second upload of a commit replaces the first
+          # and every alert of the other language reads as fixed. The
+          # spelling is default setup's own, from the `category` its
+          # analyses carry, so the history of alerts survives the switch
+          # rather than starting again
+          category: "/language:${{ matrix.language }}"
+
+  # the single check main's branch protection requires from this
+  # workflow, and it exists because that rule names its checks as literal
+  # strings, stored outside the repository. The matrix above produces one
+  # check per language, so naming those directly would mean a rule to
+  # edit -- in a setting no pull request can review -- every time the
+  # matrix moves, and a name that stops being produced becomes a required
+  # check that never reports, which blocks every merge until somebody
+  # remembers where the rule lives.
+  # This job depends on the matrix instead, so the rule names one thing
+  # that never changes and adding a language here is enough to gate on it
+  codeql-passed:
+    # the name and not the id is what branch protection matches, and it
+    # carries the workflow on purpose: a context is keyed by name alone,
+    # so two workflows with a job named "every job passed" would produce
+    # one ambiguous check. The pattern, and the reasoning behind every
+    # line of it, is test.yml's own aggregate
+    name: "codeql: every job passed"
+    needs: [analyze]
+    # not success(): a job whose dependencies failed is skipped, and a
+    # skipped check reports "skipped", which branch protection counts as
+    # satisfied. The gate has to run to be able to fail.
+    # And the draft condition the matrix carries, so a draft skips
+    # uniformly rather than tripping the skip check below
+    if: ${{ always() && !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # the condition reads the whole needs context rather than testing
+      # each job by name, so a job added to needs above is covered
+      # without touching this. "skipped" is a failure here too: nothing
+      # in this workflow is conditional, so a skip means something
+      # upstream did not run.
+      # What a run of it costs, whenever the number is wanted again:
+      #   gh api repos/btclib-org/btclib/actions/runs/<id>/jobs \
+      #     --jq '.jobs[] | "\(.name) \(.started_at) \(.completed_at)"'
+      - name: Fail unless every job above succeeded
+        if: >-
+          contains(needs.*.result, 'failure') ||
+          contains(needs.*.result, 'cancelled') ||
+          contains(needs.*.result, 'skipped')
+        run: |
+          echo "::error::a job this gate depends on did not succeed"
+          exit 1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,11 +32,13 @@ name: codeql
 # `threat_model: remote` is CodeQL's own default, so nothing here sets it;
 # it would take a `config:` block naming `threat-models` to depart from.
 #
-# REPOSITORY.md has the order in which the switch is thrown, and it
-# matters: while default setup is enabled GitHub refuses to run an
-# advanced workflow, so this file produces no check at all until the
-# setting is turned off, and the branch rule has to stop naming `CodeQL`
-# before that happens or nothing can merge in between.
+# REPOSITORY.md has the order in which the two are exchanged, and it
+# matters, because the setting does not refuse to let this file run: the
+# analysis completes and the SARIF uploads, and processing then answers
+# "CodeQL analyses from advanced configurations cannot be processed when
+# the default setup is enabled". Both jobs below are therefore red rather
+# than absent while the setting is on, so the branch rule stops naming
+# `CodeQL` before the setting goes off and names the aggregate after.
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,13 +153,16 @@ documented at release-notes length in the first place, and are still in
   analyses this repository has received, every one is python or actions
   and none is ruby.
 
-  The switch cannot be thrown by a pull request, and REPOSITORY.md has the
-  order in which it is: GitHub refuses to run an advanced workflow while
-  default setup is enabled, so this file produced no check on the pull
-  request that added it, and the branch rule had to stop naming `CodeQL`
-  before the setting could be turned off. Dropping the context first costs
-  a window in which nothing scans; disabling the setting first costs a
-  required check that cannot report and a merge nobody can perform.
+  The exchange cannot be made by a pull request, and REPOSITORY.md has the
+  order it takes. The setting does not decline to let the workflow run:
+  the analysis completes and the SARIF uploads, and processing answers
+  that an advanced configuration cannot be processed while default setup
+  is enabled, so both jobs are red rather than absent until the setting
+  goes off. The branch rule therefore stops naming `CodeQL` first --
+  dropping the context costs a window in which nothing scans, where
+  disabling the setting first costs a required check that cannot report
+  and a merge nobody can perform -- and names `codeql: every job passed`
+  after the merge, that check not existing on `main` before it.
 
 ### Transactions, blocks and PSBT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,34 @@ documented at release-notes length in the first place, and are still in
   `attest` in `needs`: naming `attest` alone would let a dispatch cut a
   release, that job running in a rehearsal too.
 
+- **CodeQL runs from a file in the tree**, `.github/workflows/codeql.yml`,
+  where it ran from default setup: a repository setting, edited in a
+  browser, leaving no history a reviewer sees. That made the analysis
+  looking for an injected expression or an unsafe checkout in these
+  workflows the one required check whose own definition no diff could
+  review, while every other one is a file with its actions pinned to
+  commit SHAs. What the setting held is reproduced rather than reinvented
+  -- `gh api repos/btclib-org/btclib/code-scanning/default-setup` reported
+  the `actions` and `python` languages, the `default` query suite and a
+  weekly schedule -- so the file adds one job per language, an aggregate
+  named `codeql: every job passed` for `main`'s rule to name, and a
+  Saturday cron, the one day the other schedules here leave free. The
+  query suite is expressed by adding nothing: `default` is precisely the
+  state in which no `queries`, `packs` or `query-filters` are named, and
+  neither CodeQL action takes an input that says it out loud. Ruby is not
+  in the matrix although default-setup runs here have carried an `Analyze
+  (ruby)` job, GitHub Pages putting a Gemfile beside the library: of the
+  analyses this repository has received, every one is python or actions
+  and none is ruby.
+
+  The switch cannot be thrown by a pull request, and REPOSITORY.md has the
+  order in which it is: GitHub refuses to run an advanced workflow while
+  default setup is enabled, so this file produced no check on the pull
+  request that added it, and the branch rule had to stop naming `CodeQL`
+  before the setting could be turned off. Dropping the context first costs
+  a window in which nothing scans; disabling the setting first costs a
+  required check that cannot report and a merge nobody can perform.
+
 ### Transactions, blocks and PSBT
 
 - **A declared count is bounded by what could hold it, before anything is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,6 +235,7 @@ read by every checkout of this repository.
 | `test` | pull request, push | 4 platforms × 7 interpreters |
 | `lint`, `docs` | pull request, push | — |
 | `integration` | pull request, push | a regtest node |
+| `codeql` | pull request, push, Saturday | 2 languages |
 | `macos` | Wednesday, a release | 2 macOS images × 7 interpreters |
 | `latest` | Wednesday | platforms sampled, deps upgraded |
 | `links`, `mutation` | weekly | — |
@@ -242,14 +243,17 @@ read by every checkout of this repository.
 | `published` | monthly, a release | what PyPI serves |
 | `release` | a tag | calls test, lint, docs, macos, published |
 
-The first three rows are what a merge waits for. macOS is not among them on
-purpose: it is the platform whose runners queue — 29.4 and 23.2 minutes of
-mean wait against 0.5 to 1.6 elsewhere, on a run of 45 jobs that spent 93
-minutes working and 399 waiting — so it answers weekly, and before a
-release, rather than before a review. `macos` and `latest` share a morning
-half an hour apart, which is what makes the pair readable: red in both is
-the platform, red in `latest` alone is the upgrade. Everything but the
-first three rows also takes `workflow_dispatch`.
+The first four rows are what a merge waits for, and between them they report
+the five required checks: `lint` and `docs` share a row and report one
+each. macOS is not among them on purpose: it is the platform whose runners
+queue — 29.4 and 23.2 minutes of mean wait against 0.5 to 1.6 elsewhere, on
+a run of 45 jobs that spent 93 minutes working and 399 waiting — so it
+answers weekly, and before a release, rather than before a review. `macos`
+and `latest` share a morning half an hour apart, which is what makes the
+pair readable: red in both is the platform, red in `latest` alone is the
+upgrade. Every workflow in the table also takes `workflow_dispatch`, the
+gates included: a branch whose pull request is not open yet has no other way
+to ask.
 
 ### Reproducing what CI runs
 
@@ -532,8 +536,12 @@ to answer. Keep them deterministic, which for `ssa.sign` means passing
 those pages a published test vector, so that a reader who copies one copies
 something already known to the world.
 
-The only check with no local equivalent is CodeQL, which GitHub runs on
-its side; its findings appear under the Security tab.
+The only check with no local equivalent is `codeql`: the analysis needs the
+CodeQL bundle and a database, which is a download rather than a `uv`
+command, so `.github/workflows/codeql.yml` is where it is configured and
+GitHub's runners are where it happens. Its findings appear under the
+Security tab, and `REPOSITORY.md` has why the workflow is in the tree at
+all.
 
 ### The website
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -27,7 +27,7 @@ workflows with a job named the same thing produce one ambiguous check.
 | `Lint and type-check` | `lint.yml`, its only job |
 | `Build the documentation` | `docs.yml`, its only job |
 | `Regtest against Bitcoin Core` | `integration.yml`, its only job |
-| `CodeQL` | CodeQL workflow |
+| `codeql: every job passed` | `codeql.yml`, aggregate over the languages |
 
 A workflow with one job needs no aggregate: the job *is* the context, which
 is why three of the five are job names. The day one of them grows a second
@@ -49,6 +49,16 @@ answers the one claim the recorded vectors cannot make. `integration.yml`
 therefore carries no `paths` filter: a required check that never runs blocks
 a merge, where a skipped one satisfies it.
 
+`codeql: every job passed` is the only one of the five whose predecessor was
+not a file at all. Code scanning ran from default setup, a repository
+setting, which made the check that reads these workflows for an injected
+expression the one part of CI no diff could review — while every other check
+is a workflow with its actions pinned to commit SHAs. `codeql.yml` holds it
+now, one job per language and an aggregate over them, for the reason
+`test.yml` has one; the section below has how the switch was thrown, because
+the two cannot be exchanged in either order without a step that blocks
+every merge.
+
 Renaming a required check is the one change that cannot be made in a pull
 request, so the rule moves first, against the branch, and the pull request
 that renames the job reports the name the rule now wants:
@@ -61,7 +71,7 @@ gh api -X PATCH "$branch"/protection/required_status_checks \
   -f 'contexts[]=Lint and type-check' \
   -f 'contexts[]=Build the documentation' \
   -f 'contexts[]=Regtest against Bitcoin Core' \
-  -f 'contexts[]=CodeQL'
+  -f 'contexts[]=codeql: every job passed'
 ```
 
 That `PATCH` sends `contexts`, which names no app, and what is there is
@@ -82,6 +92,82 @@ adopting it is a decision separate from this list.
 partial PUT drops the reviews, the signatures and the rest. Repeat
 `strict: true` in the body, which replaces the object rather than merging
 into it.
+
+## Code scanning
+
+`codeql.yml` is the analysis; what keeps it in this file is that **GitHub
+refuses to run an advanced workflow while default setup is enabled**. The
+file produces no check at all until that setting is off — not even on the
+pull request that adds it — and the branch rule meanwhile cannot name a
+check nothing produces. Read the setting before touching either end of it:
+
+```shell
+gh api repos/btclib-org/btclib/code-scanning/default-setup
+```
+
+Five steps, and this order is the one that never leaves `main` unmergeable:
+dropping the context first costs a window in which nothing scans, where
+disabling the setting first costs a required check that cannot report and a
+merge nobody can perform. Steps 1, 2 and 5 are a token rather than a pull
+request, so only a human can perform them:
+
+1. patch the rule to drop the `CodeQL` context, the other four staying;
+1. disable default setup;
+1. re-run the checks on the pull request, which now execute `codeql.yml`
+   and report `codeql: every job passed`;
+1. merge;
+1. patch the rule to add `codeql: every job passed`.
+
+Step 2 is what makes the setting let go of the analysis. It is not the
+command that enabled default setup and there is no need to keep that one:
+what a browser switched on, this switches off, and the tree is where the
+configuration lives afterwards.
+
+```shell
+gh api -X PATCH \
+  repos/btclib-org/btclib/code-scanning/default-setup \
+  -F state=not-configured
+```
+
+Steps 1 and 5 patch the `checks` array rather than `contexts`, so that the
+bindings the rule already has survive the edit, and **a JSON body on stdin
+is what that takes**: `-f` sends every value as a string and the endpoint
+answers 422 for a string `app_id`. Step 1:
+
+```shell
+branch=repos/btclib-org/btclib/branches/main
+gh api -X PATCH "$branch"/protection/required_status_checks --input - <<'JSON'
+{
+  "strict": true,
+  "checks": [
+    {"context": "test: every job passed", "app_id": 15368},
+    {"context": "Regtest against Bitcoin Core", "app_id": 15368},
+    {"context": "Lint and type-check"},
+    {"context": "Build the documentation"}
+  ]
+}
+JSON
+```
+
+Step 5 is that body with one entry added, bound to Actions because Actions
+is what reports it — the `CodeQL` it replaces was unbound for the opposite
+reason, the app producing it not being Actions:
+
+```shell
+branch=repos/btclib-org/btclib/branches/main
+gh api -X PATCH "$branch"/protection/required_status_checks --input - <<'JSON'
+{
+  "strict": true,
+  "checks": [
+    {"context": "test: every job passed", "app_id": 15368},
+    {"context": "Regtest against Bitcoin Core", "app_id": 15368},
+    {"context": "codeql: every job passed", "app_id": 15368},
+    {"context": "Lint and type-check"},
+    {"context": "Build the documentation"}
+  ]
+}
+JSON
+```
 
 ## Branch protection
 
@@ -133,11 +219,18 @@ are the ones still worth looking at now and then.
 ## Token permissions
 
 **The default `GITHUB_TOKEN` is read-only repository-wide**, so a job
-needing more must declare it. Every job that does is in `release.yml`:
-`contents: write` on `github-release`, `id-token: write` on the two
-publish jobs, and `id-token: write` with `attestations: write` on
-`attest`. One elevation per job is the shape to keep — the job that writes
-releases holds no OIDC token, and the job that signs writes no release.
+needing more must declare it. Four of those declarations are in
+`release.yml`: `contents: write` on `github-release`, `id-token: write` on
+the two publish jobs, and `id-token: write` with `attestations: write` on
+`attest`. The fifth is `codeql.yml`'s `analyze`, whose
+`security-events: write` is what uploading a SARIF to code scanning takes,
+with `actions: read` beside it — redundant while this repository is public,
+and written down so that the file does not quietly stop working the day it
+is not. Its aggregate job needs none of that and declares none of it: one
+elevation per job is the shape to keep — the job that writes releases holds
+no OIDC token, and the job that signs writes no release — and
+`vendored-vectors.yml` is the one place that departs from it, declaring
+`issues: write` at the workflow level where its only job would do.
 The workflow-level `permissions: contents: read` is belt and braces; keep
 it, it is what makes the intent readable in the file.
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -95,26 +95,33 @@ into it.
 
 ## Code scanning
 
-`codeql.yml` is the analysis; what keeps it in this file is that **GitHub
-refuses to run an advanced workflow while default setup is enabled**. The
-file produces no check at all until that setting is off — not even on the
-pull request that adds it — and the branch rule meanwhile cannot name a
-check nothing produces. Read the setting before touching either end of it:
+The analysis runs from `codeql.yml`, and default setup — the repository
+setting that used to hold it — is off:
 
 ```shell
 gh api repos/btclib-org/btclib/code-scanning/default-setup
+# {"state":"not-configured", ...}
 ```
 
-Five steps, and this order is the one that never leaves `main` unmergeable:
-dropping the context first costs a window in which nothing scans, where
-disabling the setting first costs a required check that cannot report and a
-merge nobody can perform. Steps 1, 2 and 5 are a token rather than a pull
-request, so only a human can perform them:
+**The two cannot both be on**, and what that costs is not a workflow that
+declines to run. The workflow runs, the analysis completes, the SARIF
+uploads, and processing answers:
+
+```text
+Code Scanning could not process the submitted SARIF file:
+CodeQL analyses from advanced configurations cannot be processed when the
+default setup is enabled
+```
+
+So while the setting is on, the analysing jobs and the aggregate are red
+rather than absent — which is why the exchange has an order. These five
+steps are the order that never leaves `main` unmergeable, and 1, 2 and 5
+are a token rather than a pull request, so only a human can perform them:
 
 1. patch the rule to drop the `CodeQL` context, the other four staying;
 1. disable default setup;
-1. re-run the checks on the pull request, which now execute `codeql.yml`
-   and report `codeql: every job passed`;
+1. re-run the pull request's checks: the upload that was refused is
+   accepted now, so `codeql: every job passed` goes green;
 1. merge;
 1. patch the rule to add `codeql: every job passed`.
 


### PR DESCRIPTION
## Status: steps 1 and 2 are already done. Step 5 is what is left.

Read live, not remembered:

```shell
gh api repos/btclib-org/btclib/code-scanning/default-setup \
  --jq '.state'                                    # not-configured
gh api repos/btclib-org/btclib/branches/main/protection \
  --jq '.required_status_checks.contexts'          # CodeQL is gone
gh pr checks 607 | grep -i codeql   # codeql: every job passed  pass
```

**After merging, one call remains** — adding the new context to the rule.
Only a human can make it:

```shell
branch=repos/btclib-org/btclib/branches/main
gh api -X PATCH "$branch"/protection/required_status_checks --input - <<'JSON'
{
  "strict": true,
  "checks": [
    {"context": "test: every job passed", "app_id": 15368},
    {"context": "Regtest against Bitcoin Core", "app_id": 15368},
    {"context": "codeql: every job passed", "app_id": 15368},
    {"context": "Lint and type-check"},
    {"context": "Build the documentation"}
  ]
}
JSON
```

`checks` and not `contexts`, so the Actions bindings the rule already has
survive the edit, and **a JSON body on stdin**: `-f` sends every value as a
string and the endpoint answers 422 for a string `app_id`. The new context
is bound to Actions (15368) because Actions is what reports it; the `CodeQL`
it replaces was unbound for the opposite reason, the app producing it not
being Actions. Until that call is made, `main` requires four checks and this
workflow gates nothing.

## What default setup actually refuses, measured on this branch

The claim this pull request opened with — that GitHub will not run an
advanced workflow while default setup is enabled, so nothing would report
here — is wrong, and the branch is the evidence. The workflow runs. The
analysis completes, the SARIF uploads, and *processing* is what refuses:

```text
Successfully uploaded results
Analysis upload status is failed.
##[error]Code Scanning could not process the submitted SARIF file:
CodeQL analyses from advanced configurations cannot be processed when the
default setup is enabled
```

So the two `Analyze` jobs and the aggregate are **red rather than absent**
while both are on. Two runs of the same file, either side of step 2:

| run | default setup | outcome |
| --- | --- | --- |
| `31450022559` | configured | all three jobs failed, at the upload |
| `31452031739` | not-configured | `Analysis upload status is complete.` |

```shell
gh run view 31450022559 --log-failed | grep -i 'could not process'
gh run view 31452031739 --log | grep -i 'upload status'
```

The three files that carried the wrong claim now carry that one instead.
The order of the exchange does not change, and the reason for its first
step sharpens: the rule stops naming `CodeQL` before the setting goes off
because that is the context nothing produces afterwards.

For a repository where this has yet to be done, the order in full — 1, 2
and 5 are a token rather than a pull request:

1. patch the rule to drop the `CodeQL` context, the others staying;
1. `gh api -X PATCH repos/<owner>/<repo>/code-scanning/default-setup -F
   state=not-configured`;
1. re-run the pull request's checks; the refused upload is accepted now;
1. merge;
1. patch the rule to add `codeql: every job passed`.

Dropping the context first costs a window in which nothing scans.
Disabling the setting first costs a required check that cannot report and a
merge nobody can perform. Adding the new context before the merge names a
check `main` does not yet produce.

## Why the file exists

`CodeQL` was the only required check whose definition a diff could not
review: a repository setting, edited in a browser, with no history a
reviewer sees and no way to branch it — while every other check is a file
here with its actions pinned to commit SHAs. The analysis that looks for an
injected expression or an unsafe checkout in these very workflows was the
part of CI nobody could audit.

## What was reproduced, and how it was read

```shell
gh api repos/btclib-org/btclib/code-scanning/default-setup
# {"state":"configured","languages":["actions","python"],
#  "query_suite":"default","threat_model":"remote","schedule":"weekly",
#  "runner_type":"standard","runner_label":""}
```

- **languages**: `actions` and `python`, one matrix job each, so a failure
  names the language in the checks list.
- **query suite**: `default`, expressed by adding nothing. Neither
  `github/codeql-action/init` nor `.../analyze` has a `query_suite` input —
  measured by reading both `action.yml` at the pinned SHA — and the
  action's own `config-utils.ts` states the equivalence: the default
  code-scanning suite is what runs when `disable-default-queries` is not
  true and no `packs`, `queries` or `query-filters` are named. Anything
  written there would widen the analysis rather than pin it, so the pin is
  the absence, and the comment in the file says so.
- **threat model**: `remote` is CodeQL's own default; departing from it
  would take a `config:` block naming `threat-models`, so nothing sets it.
- **build mode**: `none`, which is what this repository's own analyses
  carry — `gh api repos/btclib-org/btclib/code-scanning/analyses --jq
  '.[0].environment'` → `{"build-mode":"none","category":"/language:python",
  ...}`. Written out rather than left to the default because it is the
  input a compiled language would have to change first.
- **category**: `/language:<language>`, default setup's own spelling, so
  the alert history survives the switch instead of every alert of the
  second language reading as fixed when the first uploads.
- **schedule**: weekly, Saturday 04:23 UTC. Saturday is the one day no
  other schedule here asks for — `grep -rn 'cron:' .github/workflows/`
  gives links Monday, macos and latest Wednesday, integration Friday,
  mutation Sunday, published and vendored-vectors monthly on the 1st, and
  `.github/dependabot.yml` takes Thursday. A minute that is not the hour,
  as every schedule here.

### Ruby is not in the matrix

Default-setup runs here produced an `Analyze (ruby)` job — Pages serves
btclib.org from `main`'s root, so a `Gemfile` sits beside the library and
autodetection sees it; with the setting now off, the API even reports
`["actions","python","ruby"]` as what it would configure. It was not in the
configured languages, and it has never produced an analysis:

```shell
gh api "repos/btclib-org/btclib/code-scanning/analyses?per_page=100" \
  --jq '[.[] | .category] | group_by(.) | map({cat: .[0], n: length})'
# [{"cat":"/language:actions","n":50},{"cat":"/language:python","n":50}]
```

## The action pin

`github/codeql-action` at `5595ccaf912efad79be6eef63a5619ff05969be3`,
tagged `v4.37.6`, both steps.

A deviation worth naming: `gh api repos/github/codeql-action/releases/latest`
answers `codeql-bundle-v2.26.2`, whose tag dereferences to
`18420e3271f74589575af831a523c833acda327f`. That commit is **61 commits
behind** `v4.37.6`, which is the newest release by date
(`2026-08-04T13:34:40Z`, `draft: false`, `prerelease: false`) and the tag
shape Dependabot's `github-actions` ecosystem bumps, alongside the `v7.0.1`
and `v9.0.0` pins already in this tree.

```shell
gh api 'repos/github/codeql-action/releases?per_page=6' \
  --jq '.[] | "\(.tag_name)  \(.published_at)"'
gh api repos/github/codeql-action/git/ref/tags/v4.37.6 --jq '.object'
gh api repos/github/codeql-action/git/tags/<annotated-tag-sha> \
  --jq '.object.sha'
gh api repos/github/codeql-action/compare/18420e32...5595ccaf \
  --jq '{status, ahead_by, behind_by}'   # {"ahead_by":61,"behind_by":0}
```

## What a run costs

Read off the runs default setup produced rather than estimated:

```shell
gh api repos/btclib-org/btclib/actions/runs/<id>/jobs \
  --jq '.jobs[] | "\(.name) \(.started_at) \(.completed_at)"'
```

Over the six most recent completed runs: `Analyze (actions)` mean 40 s
(max 45 s, n=4), `Analyze (python)` mean 72 s (max 86 s, n=6). No `paths`
filter on either trigger, for integration.yml's reason — a required check
that never runs blocks a merge where a skipped one satisfies it.

## The documentation that stopped being true

- `REPOSITORY.md`: the required-check table row, the `PATCH` command's
  context list, a paragraph on why this check was different, and a new
  **Code scanning** section holding the five steps and both `PATCH` bodies.
- `REPOSITORY.md`, token permissions: "Every job that does is in
  `release.yml`" now has `codeql.yml`'s `analyze` beside those four — and
  it was already inexact, `vendored-vectors.yml` declaring `issues: write`
  at the workflow level, where its only job would do. That is stated, not
  changed.
- `CONTRIBUTING.md`: a `codeql` row in "What runs when", and "the first
  three rows are what a merge waits for" becomes four. Its last sentence
  claimed that "everything but the first three rows also takes
  `workflow_dispatch`"; every one of the eleven workflows has it —
  `for f in .github/workflows/*.yml; do grep -c workflow_dispatch: "$f";
  done` — so the sentence now says that instead.
- `CONTRIBUTING.md`: "the only check with no local equivalent is CodeQL,
  which GitHub runs on its side" — still no local equivalent, but the
  configuration is a file here now, and the sentence points at it.
- `CHANGELOG.md`: one entry under "Packaging, linting and CI". Nothing in
  `HISTORY.md`: a user acts on none of this.

## Gates

Every command from `CONTRIBUTING.md`, exit codes read rather than filtered
output, in a worktree off `origin/main` at `44e93c11`, re-run after each of
the three commits:

| gate | result |
| --- | --- |
| `pre-commit run --all-files`, pass 1 | exit 0 |
| `pre-commit run --all-files`, pass 2 | exit 0, rewrote nothing |
| `pytest --cov` | exit 0, 18569 passed, 6 skipped, `fail_under` met |
| `sphinx-build -W --keep-going` | exit 0, build succeeded |
| `actionlint` (a hook, in the passes above) | zero findings |
| `zizmor` default persona (ditto) | zero findings |
| `zizmor --persona=auditor` on `codeql.yml` | zero findings |

`zizmor --persona=auditor` over `.github/workflows` reports 8 findings with
this file and 8 without it: all pre-existing, none in `codeql.yml`. Getting
the new file to zero under that persona is why the two elevated permissions
carry *trailing* comments — the audit reads the line a permission is on and
not the paragraph above the block, which is also why `release.yml`'s four
commented elevations are among the eight.
