### PR TITLE
Analyse on the day the other two repositories analyse

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -69,19 +69,21 @@ on:
     # guessed: a mean of 40 seconds for the actions job and 72 for the
     # python one, the command in the aggregate's comment below
   schedule:
-    # Saturdays, 04:23 UTC. Not on the hour: GitHub queues scheduled
+    # Tuesdays, 04:23 UTC. Not on the hour: GitHub queues scheduled
     # workflows across every repository that asked for the same minute,
     # and the run can be dropped outright when the queue is long.
-    # Saturday is the day nothing else here asks for -- links Monday,
-    # latest and macos Wednesday, Dependabot Thursday, integration
-    # Friday, and the mutation session Sunday -- so a failure
-    # notification names the workflow by the day it arrived. Weekly, as
+    # Tuesday is a day nothing else here asks for -- links Monday, latest
+    # and macos Wednesday, Dependabot Thursday, integration Friday, and
+    # the mutation session Sunday -- so a failure notification still names
+    # the workflow by the day it arrived; and it is the day
+    # btclib-libsecp256k1 and bitcoin-core-rpc analyse on, so "did CodeQL
+    # go red anywhere" has one morning to read rather than three. Weekly, as
     # default setup was: what a scheduled analysis catches is a query
     # CodeQL added since the last commit, which arrives with the bundle
     # rather than with a branch.
     # Cron runs from the default branch only, so this asks nothing until
     # it reaches main; elsewhere the dispatch below is the way in
-    - cron: "23 4 * * 6"
+    - cron: "23 4 * * 2"
   # the escape hatch: an analysis on demand for a branch whose pull
   # request is not open yet
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,9 @@ documented at release-notes length in the first place, and are still in
   the `actions` and `python` languages, the `default` query suite and a
   weekly schedule -- so the file adds one job per language, an aggregate
   named `codeql: every job passed` for `main`'s rule to name, and a
-  Saturday cron, the one day the other schedules here leave free. The
+  Tuesday cron: a day the other schedules here leave free, and the one
+  btclib-libsecp256k1 and bitcoin-core-rpc analyse on, so a red analysis
+  anywhere is one morning to read rather than three. The
   query suite is expressed by adding nothing: `default` is precisely the
   state in which no `queries`, `packs` or `query-filters` are named, and
   neither CodeQL action takes an input that says it out loud. Ruby is not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ read by every checkout of this repository.
 | `test` | pull request, push | 4 platforms × 7 interpreters |
 | `lint`, `docs` | pull request, push | — |
 | `integration` | pull request, push | a regtest node |
-| `codeql` | pull request, push, Saturday | 2 languages |
+| `codeql` | pull request, push, Tuesday | 2 languages |
 | `macos` | Wednesday, a release | 2 macOS images × 7 interpreters |
 | `latest` | Wednesday | platforms sampled, deps upgraded |
 | `links`, `mutation` | weekly | — |


### PR DESCRIPTION
`codeql.yml` took Saturday because nothing else here asks for it: a failure
notification then names the workflow by the day it arrived.

Tuesday keeps that property — links Monday, latest and macos Wednesday,
dependabot Thursday, integration Friday, mutation Sunday, and Tuesday free
— and adds the one Saturday could not: it is the day
btclib-org/btclib-libsecp256k1 and btclib-org/bitcoin-core-rpc already
analyse on, so "did CodeQL go red anywhere" is one morning to read rather
than three.

The unreleased CHANGELOG entry that named Saturday names Tuesday. It
describes the release, and the release will carry this cron rather than the
one the entry was written for.

`CONTRIBUTING.md`'s "What runs when" table follows.

Companion: btclib-org/bitcoin-core-rpc#87 moves that repository's `latest`
and `macos` to Wednesday and its dependabot to Thursday, which is where the
other two already are. After both, every weekly question is asked on one
day across the three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align the CodeQL analysis schedule with other btclib repositories by moving the weekly cron run from Saturday to Tuesday and document the new timing.

Enhancements:
- Update the CodeQL workflow cron expression to run weekly on Tuesday instead of Saturday for consistent cross-repository analysis timing.

Documentation:
- Adjust CHANGELOG and CONTRIBUTING documentation to describe the CodeQL job as running on Tuesday and note its alignment with other btclib repositories.