### PR TITLE
Record what the CodeQL switch did not take away

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,9 @@ name: codeql
 # unsafe checkouts in these very workflows was itself the part of CI
 # nobody could audit.
 #
-# What the setting held is reproduced rather than invented:
+# What the setting held is reproduced rather than invented. Read from the
+# API while it still held it -- the same command answers
+# `state: not-configured` now, the switch having been made:
 #
 #   gh api repos/btclib-org/btclib/code-scanning/default-setup
 #   # {"state":"configured","languages":["actions","python"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,7 +186,13 @@ documented at release-notes length in the first place, and are still in
   dropping the context costs a window in which nothing scans, where
   disabling the setting first costs a required check that cannot report
   and a merge nobody can perform -- and names `codeql: every job passed`
-  after the merge, that check not existing on `main` before it.
+  after the merge, that check not existing on `main` before it. Two things
+  survive the exchange: the `CodeQL` context still reports on a pull
+  request's head, `neutral` now and summarised `1 configuration not found`,
+  and a generated `dynamic/github-code-scanning/codeql` workflow keeps
+  running, uploading code quality results rather than security ones. Code
+  quality is a separate setting, which `code-scanning/default-setup` does
+  not report.
 
 ### Transactions, blocks and PSBT
 

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -118,7 +118,7 @@ rather than absent — which is why the exchange has an order. These five
 steps are the order that never leaves `main` unmergeable, and 1, 2 and 5
 are a token rather than a pull request, so only a human can perform them:
 
-1. patch the rule to drop the `CodeQL` context, the other four staying;
+1. patch the rule to drop the `CodeQL` context, every other one staying;
 1. disable default setup;
 1. re-run the pull request's checks: the upload that was refused is
    accepted now, so `codeql: every job passed` goes green;
@@ -129,6 +129,26 @@ Step 2 is what makes the setting let go of the analysis. It is not the
 command that enabled default setup and there is no need to keep that one:
 what a browser switched on, this switches off, and the tree is where the
 configuration lives afterwards.
+
+Two things survive step 2, and neither is explained by the endpoint this
+section tells you to read. A generated
+`dynamic/github-code-scanning/codeql` workflow stays `active` and keeps
+running `Analyze (ruby)` and `Analyze (python)`, but it uploads *code
+quality* results now — `ruby.quality.sarif` in its log, where the security
+analysis produced `python.sarif` and `actions.sarif`. Code quality is a
+separate setting, and `code-scanning/default-setup` does not report it:
+
+```shell
+gh api repos/btclib-org/btclib/actions/workflows \
+  --jq '.workflows[] | select(.path | startswith("dynamic/"))
+        | {name, path, state}'
+```
+
+And the `CodeQL` context itself does not stop: it still reports on a pull
+request's head, `neutral` where it was `success`, summarised
+`1 configuration not found`. Whether a rule naming it would be satisfied by
+that is untested, and testing it means deadlocking `main` to find out —
+which is an argument for the order above rather than against it.
 
 ```shell
 gh api -X PATCH \


### PR DESCRIPTION
This repository already carries the right account of the collision — "the
setting does not decline to let the workflow run: the analysis completes and
the SARIF uploads, and processing answers ..." — which is more than its two
siblings could say. What is missing is what the switch *left behind*, and
nothing here explains it.

## Two things survive step 2

Neither is reported by `code-scanning/default-setup`, which is the endpoint
this section tells you to read.

**A workflow.** GitHub keeps a generated
`dynamic/github-code-scanning/codeql`, still `active`, still running
`Analyze (ruby)` and `Analyze (python)`. Its log now reads:

```text
Post-processing sarif files: [".../results/ruby.quality.sarif"]
##[group]Uploading code quality results
```

where the security analysis produced `python.sarif` and `actions.sarif`.
**Code quality is a separate setting.** So:

```shell
gh api repos/btclib-org/btclib/actions/workflows \
  --jq '.workflows[] | select(.path | startswith("dynamic/"))
        | {name, path, state}'
```

This is also why the ruby job the header explains has not gone away: it now
runs for code quality rather than for code scanning.

**The `CodeQL` context.** It still reports on a pull request's head:

| head | conclusion | summary |
| --- | --- | --- |
| before the switch | success | No new alerts in code changed by this pull request |
| `e7a3adb`, after | **neutral** | **1 configuration not found** |

No mechanism is offered for the `neutral`, because it is not understood:
`bitcoin-core-rpc` reads the same, while `btclib-libsecp256k1` still reads
`success / No new alerts`. And whether a rule naming `CodeQL` would be
*satisfied* by a neutral conclusion is untested — testing it means
deadlocking `main` to find out, which is an argument for the five-step
order rather than against it. The file says both of those out loud instead
of guessing.

## Two smaller ones

- The header quoted `{"state":"configured", ...}` as what the endpoint
  answers. It has not answered that since the switch. It is now labelled as
  the reading taken while the setting still held, with what the command
  answers today.
- Step 1 said "the other four staying" — a count a sixth required check
  would falsify, in a file nobody rereads before adding one.

## Companion pull requests

Same reading, adapted rather than copied:
[bitcoin-core-rpc#88](https://github.com/btclib-org/bitcoin-core-rpc/pull/88)
and
[btclib-libsecp256k1#118](https://github.com/btclib-org/btclib-libsecp256k1/pull/118)
— the latter is the larger one, three places there still claiming GitHub
refuses to *run* an advanced workflow.

## Gates

Two `pre-commit` passes, exit 0 both, the first exiting 0 being what says
no fixer rewrote anything; `actionlint` and `zizmor` at zero findings;
`tests/release_notes_test.py` passing, which is what fails on a stated count
in CHANGELOG.md; `sphinx-build -W --keep-going` exit 0. Nothing here touches
Python.

## Summary by Sourcery

Clarify the documented behavior and consequences of switching off CodeQL default setup while keeping the main branch mergeable.

Enhancements:
- Annotate the CodeQL workflow configuration with the current API response, noting the transition from a configured to a not-configured default setup state.

Documentation:
- Update repository documentation to describe the surviving CodeQL workflow and neutral CodeQL context after disabling default setup, and note that code quality is managed separately from security scanning.
- Refine the described sequence of required checks to state that all other checks remain when dropping the CodeQL context and to record the two artifacts that persist after the switch.