### PR TITLE
Build the website where a failure can be seen

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,11 @@
 ---
-# two of the four ecosystems this repo has, deliberately:
-# - the Gemfile is left out: GitHub builds the pages site on its own
-#   side, so github-pages is only ever resolved for a local preview
-# - the pre-commit hook revs are left out because dependabot has no
+# three of the four ecosystems this repo has:
+# - the pre-commit hook revs are the one left out, because dependabot has no
 #   pre-commit ecosystem; pre-commit.ci updates them instead, weekly, as
 #   configured in the ci: block of .pre-commit-config.yaml
 #
-# every pull request here runs the whole test matrix, so both ecosystems
-# group their updates into a single pull request. Neither declares a
+# every pull request here runs the whole test matrix, so each ecosystem
+# groups its updates into a single pull request. None declares a
 # target-branch: without one dependabot opens against the default branch,
 # which is the only branch a change lands on -- and a target-branch naming
 # a branch that is not there is not an error anywhere, it is a repository
@@ -64,5 +62,22 @@ updates:
     groups:
       dev-tooling:
         patterns: ["*"]
+    cooldown:
+      default-days: 7
+
+  # the Gemfile, which is btclib.org rather than the library: one gem,
+  # github-pages, pinned to the version GitHub's own Pages builder runs.
+  # Nothing installs it to serve the site -- that build happens on
+  # GitHub's side -- so what a bump means here is that the builder itself
+  # moved, and website.yml is what then answers whether the site still
+  # renders under it. Ungrouped, a single gem having nothing to group
+  # with, and the cooldown left at the default above: this one tracks a
+  # release GitHub has already deployed, so the week is a formality rather
+  # than a quarantine
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: weekly
+      day: thursday
     cooldown:
       default-days: 7

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,133 @@
+---
+name: website
+
+# btclib.org is this repository's own root, served by GitHub Pages from
+# main with the classic builder -- `gh api repos/btclib-org/btclib/pages`
+# answers `build_type: legacy`, and REPOSITORY.md records the setting.
+# That builder is the reason this workflow exists: it runs on GitHub's
+# side, writes no log a maintainer can read, and reports a failure
+# nowhere. A layout it cannot render is served broken until somebody
+# fetches the page and reads the HTML, which is how
+# `<script src="/%20/assets/js/scale.fix.js">` stayed up.
+#
+# So the build is done here as well, where it can fail out loud. Not a
+# required check: it carries a `paths` filter, and a required check that
+# produces no run blocks a merge where a skipped one satisfies it --
+# REPOSITORY.md's "Required checks on main" is the whole of that argument.
+# What it buys without being required is a red X on the pull request that
+# breaks the site, which is earlier than a visitor finding it.
+#
+# The gem, the ruby and the theme are the ones Pages itself runs, and
+# https://pages.github.com/versions.json is what says so rather than a
+# guess repeated here: `github-pages` pins its own dependency set exactly,
+# so the Gemfile naming that one version is the whole of the lock -- there
+# is no Gemfile.lock to commit and none to keep in step. Dependabot's
+# bundler ecosystem moves it, which makes a Pages toolchain upgrade a pull
+# request that builds the site with it before anything is merged
+
+on:
+  push:
+    # main only, for the reason lint.yml gives at the same key: a push to a
+    # branch with an open pull request would run this twice, in two
+    # concurrency groups that do not cancel each other, and the
+    # pull_request run is the one worth keeping. On main it asks the
+    # question of the commit a merge creates, which is the commit Pages
+    # actually builds
+    branches: [main]
+    # what a Jekyll build reads, and nothing else. README.md is the
+    # homepage -- there is no index.md -- and _config.yml decides what
+    # else in the root is published at all. Written out twice rather than
+    # through a yaml anchor, which the workflow parser does not promise
+    paths:
+      - README.md
+      - _config.yml
+      - _layouts/**
+      - assets/**
+      - CNAME
+      - Gemfile
+      - .github/workflows/website.yml
+  pull_request:
+    # ready_for_review, so a pull request marked ready gets the run the
+    # draft condition below withheld while it was a draft
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - README.md
+      - _config.yml
+      - _layouts/**
+      - assets/**
+      - CNAME
+      - Gemfile
+      - .github/workflows/website.yml
+  # the escape hatch: a run on demand for a branch whose pull request is
+  # not open yet, and the way to ask the question after a Pages upgrade
+  # that touched no file here
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies) can read the token, so it must not be able to
+# write to the repository
+permissions:
+  contents: read
+
+# cancel superseded runs on the same branch/PR. The group is named
+# literally rather than with github.workflow, which in a called workflow
+# is the caller's name
+concurrency:
+  group: website-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  website:
+    name: Build the website
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    # a minute of bundler and seconds of jekyll; a job that takes ten is
+    # hung rather than slow
+    timeout-minutes: 15
+    steps:
+      # every action is pinned to a commit SHA, the tag in the comment
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # see the checkout of the test-py job in test.yml
+          persist-credentials: false
+      # 3.3.4 is what Pages runs, from the same versions.json the Gemfile
+      # names: a build that passes here on a ruby Pages does not have says
+      # nothing about the site GitHub serves.
+      # bundler-cache installs the gems and caches them, keyed by the
+      # Gemfile -- a fresh resolve every run would spend a minute on a
+      # dependency set that only moves when dependabot moves it
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
+        with:
+          ruby-version: "3.3.4"
+          bundler-cache: true
+      # PAGES_REPO_NWO is what jekyll-github-metadata resolves
+      # `site.github` from, and _layouts/default.html reads four of its
+      # fields. Unauthenticated, so the fields it cannot reach without a
+      # token are empty rather than wrong -- the claim this job makes is
+      # that the site builds and its own links are well formed, not that
+      # the metadata GitHub injects on its side is present here
+      - name: Build the site
+        env:
+          PAGES_REPO_NWO: ${{ github.repository }}
+        run: bundle exec jekyll build --strict_front_matter
+      # the defect the build cannot report on itself. A layout whose
+      # baseurl is empty renders `{{ '/x' | relative_url }}` as `/%20/x`
+      # and jekyll exits zero, so the page is served with a script tag
+      # pointing at a path nothing answers. The build is the claim about
+      # the sources; this is the same claim made about the artifact
+      - name: The built pages carry no encoded-space URL
+        run: |
+          if grep -rn '%20' _site --include='*.html'; then
+            echo "::error::a built page carries %20 in a URL"
+            exit 1
+          fi
+      # the homepage is README.md rendered, and _config.yml's exclude list
+      # is what decides it: an entry added there by mistake -- README.md
+      # itself, or _layouts/ -- leaves a site that builds and serves
+      # nothing, which is a green build and a 404 for every visitor
+      - name: The homepage and the logo are in the built site
+        run: |
+          test -s _site/index.html
+          test -s _site/assets/img/btclib-logo.jpg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,36 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The website has a build that can fail.** btclib.org is this
+  repository's own root, served by the classic Pages builder -- `gh api
+  repos/btclib-org/btclib/pages` answers `build_type: legacy` -- which
+  runs on GitHub's side, keeps no log a maintainer can read and reports a
+  failure nowhere: the layout served
+  `<script src="/%20/assets/js/scale.fix.js">` for as long as it took
+  somebody to fetch the page and read the HTML. `website.yml` builds the
+  same site with the same gem whenever a pull request touches `README.md`,
+  `_config.yml`, `_layouts/`, `assets/`, `CNAME` or the `Gemfile`, and
+  fails on a build error, on `%20` in a built URL, and on a homepage or a
+  logo missing from `_site`. Not a required check, deliberately: it
+  carries a `paths` filter, and a required check that produces no run
+  blocks a merge where a skipped one satisfies it
+- **The `Gemfile` pins `github-pages` to the version Pages runs**, 232,
+  and dependabot's bundler ecosystem is what moves it.
+  <https://pages.github.com/versions.json> is what says which version that
+  is -- it carries the ruby, 3.3.4, the jekyll, 3.10.0, and the
+  jekyll-theme-minimal 0.2.0 that `_config.yml` names -- and that gem pins
+  its own dependency set exactly, so the one line is the whole of the lock
+  and there is no `Gemfile.lock` here to keep in step. The ecosystem was
+  left out of `dependabot.yml` because GitHub builds the site on its own
+  side, which is still true and is now the reason to have it: a bump is
+  the news that the builder moved, and the pull request carrying it is
+  where the site is built under the new one before anything is served
+- **REPOSITORY.md records the Pages settings**, three of them, none in the
+  tree: the source branch and path, which are what make `README.md` the
+  homepage and every other root file a URL under btclib.org;
+  `build_type`, which decides whether a broken build is visible at all;
+  and the custom domain, whose `CNAME` file un-sets the setting on the
+  next push if it ever leaves the tree
 - **`main` is the only branch, and the three files a session reads say
   so.** `REPOSITORY.md` documented a protected `master` fed by a `dev`
   that carried no required check, `CONTRIBUTING.md` a website served from

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,6 +235,7 @@ read by every checkout of this repository.
 | `test` | pull request, push | 4 platforms × 7 interpreters |
 | `lint`, `docs` | pull request, push | — |
 | `integration` | pull request, push | a regtest node |
+| `website` | pull request, push, on website files | — |
 | `codeql` | pull request, push, Tuesday | 2 languages |
 | `macos` | Wednesday, a release | 2 macOS images × 7 interpreters |
 | `latest` | Wednesday | platforms sampled, deps upgraded |
@@ -564,7 +565,7 @@ What that makes live:
 | `_layouts/default.html` | the page template, header and footer |
 | `assets/` | the logo, the stylesheet and `scale.fix.js` |
 | `CNAME` | the custom domain; Pages reads it from the built site |
-| `Gemfile` | the `github-pages` gem, for a local `bundle exec jekyll serve` |
+| `Gemfile` | the `github-pages` gem, pinned to what Pages runs |
 
 Three consequences worth knowing before editing any of them:
 
@@ -581,7 +582,11 @@ Three consequences worth knowing before editing any of them:
   there are no build logs and no control over the Jekyll or theme version.
   A broken template fails silently: the layout served
   `<script src="/%20/assets/js/scale.fix.js">` for as long as it took
-  someone to fetch the page and read the HTML.
+  someone to fetch the page and read the HTML. `website.yml` is the answer
+  to that: it builds the same site with the same gem on every pull request
+  touching a file above, and fails on a build error, on `%20` in a built
+  URL, and on a missing homepage. It is not a required check — it carries a
+  `paths` filter, and a required check that produces no run blocks a merge.
 
 Because Pages serves from `main`, a website-only commit there also
 triggers the full test matrix; `test.yml`'s `push` trigger carries a
@@ -589,12 +594,21 @@ triggers the full test matrix; `test.yml`'s `push` trigger carries a
 trigger deliberately does not: those checks are required on `main`, and a
 required check that produces no run blocks the merge.
 
-To preview locally, with Ruby and Bundler installed:
+To preview locally, with Ruby and Bundler installed — `bundle exec jekyll
+build` is what `website.yml` runs, and `serve` is the same build with a
+server in front of it:
 
 ```shell
 bundle install
 bundle exec jekyll serve
 ```
+
+The `github-pages` gem is pinned to the version GitHub's builder runs, and
+<https://pages.github.com/versions.json> is what says which that is: it
+carries the Ruby, the Jekyll and the theme too, and the gem pins its own
+dependency set exactly, so there is no `Gemfile.lock` here to keep in
+step. Dependabot's bundler ecosystem moves that pin, which turns a Pages
+upgrade into a pull request the build above runs against.
 
 That is the one part of this project not driven by `uv`, and it is only a
 preview: what btclib.org serves is whatever the classic builder makes of

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,16 @@
+# The btclib.org website, and only that: GitHub Pages builds it on its own
+# side, so nothing here is installed to serve the site. What this file is
+# for is a build that can fail out loud -- .github/workflows/website.yml,
+# and a local `bundle exec jekyll serve` preview.
+#
+# github-pages is the gem GitHub publishes to reproduce that builder, and
+# it pins jekyll, the theme and everything under them exactly, which is
+# why there is no Gemfile.lock beside this: the version below is the lock.
+# 232 is what Pages runs today, and
+# https://pages.github.com/versions.json is what says so -- ruby 3.3.4,
+# jekyll 3.10.0, jekyll-theme-minimal 0.2.0, the theme _config.yml names.
+# Dependabot's bundler ecosystem moves this line, so the day GitHub
+# upgrades its builder arrives as a pull request that builds the site with
+# the new one rather than as a page that stopped rendering
 source 'https://rubygems.org'
-gem 'github-pages', group: :jekyll_plugins
+gem 'github-pages', '232', group: :jekyll_plugins

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -268,6 +268,38 @@ environments both require a review, and `pypi` is restricted to `v*`
 tags. `RELEASING.md` records the reasoning, including why self-review
 stays allowed.
 
+## Pages, which is btclib.org
+
+**The website is this repository's own root**, served by GitHub Pages, and
+the three things that decide it are settings rather than files:
+
+```shell
+gh api repos/btclib-org/btclib/pages \
+  --jq '{cname, build_type, source, https_enforced}'
+# {"cname": "btclib.org", "build_type": "legacy",
+#  "source": {"branch": "main", "path": "/"}, "https_enforced": true}
+```
+
+`source` is what makes `README.md` the homepage and every other file in
+the root a URL under btclib.org — CONTRIBUTING.md's "The website" section
+is what that costs and `_config.yml`'s `exclude:` is what limits it.
+Moving the source to `/docs` or to another branch would republish the site
+as whatever that path holds, silently and immediately.
+
+`build_type: legacy` is the classic Jekyll builder, and it is the reason
+`website.yml` exists. GitHub runs it on its own side, keeps no log a
+maintainer can read, and reports a failure nowhere: a layout it cannot
+render is served broken until somebody fetches the page. The workflow
+builds the same site with the same gem, where a failure is a red check.
+`build_type: workflow` would replace that builder with an Actions workflow
+and make the failure visible by itself; it is a change of its own, and
+what it costs is a deploy that no longer happens by pushing to `main`.
+
+`cname` is the custom domain, and `CNAME` in the root is the same value: A
+records for `btclib.org` and the `https_enforced` certificate hang off it.
+The file is what Pages reads on each build, so deleting it from the tree
+un-sets the setting on the next push.
+
 ## Plan-gated settings
 
 Some settings cannot be enabled and fail silently: secret scanning's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -323,8 +323,13 @@ OP_SUCCESSx = "OP_SUCCESSx"
 # then be one this repository never mentions. Fixed upstream or not, the
 # pinned revision in tests/_data/README.md is what this has to match
 UNKNWON_DEVICE_TYPE = "UNKNWON_DEVICE_TYPE"
-# GitHub Pages' name-with-owner variable, read by the Jekyll layout
+# GitHub Pages' name-with-owner variable, read by the Jekyll layout, and
+# the environment variable website.yml passes the same value in. The hook
+# runs with --write-changes, so without these two lines it rewrites `NWO`
+# as `NOW` and the build loses the repository whose metadata it was
+# resolving
 repository_nwo = "repository_nwo"
+PAGES_REPO_NWO = "PAGES_REPO_NWO"
 
 [tool.typos.default.extend-words]
 # "nd" is the Neutered Derivation of the bip32 docstrings, as for codespell


### PR DESCRIPTION
btclib.org is this repository's own root. Nothing in CI built it, and the
builder that does is the one that cannot tell you when it fails.

```shell
gh api repos/btclib-org/btclib/pages \
  --jq '{cname, build_type, source, https_enforced}'
# {"cname": "btclib.org", "build_type": "legacy",
#  "source": {"branch": "main", "path": "/"}, "https_enforced": true}
```

`build_type: legacy` is the classic Jekyll builder: it runs on GitHub's
side, keeps no log a maintainer can read, and reports a failure nowhere.
That is how the layout came to serve
`<script src="/%20/assets/js/scale.fix.js">` for as long as it took
somebody to fetch the page and read the HTML.

## The control

`website.yml` builds the same site with the same gem when a pull request
touches `README.md`, `_config.yml`, `_layouts/`, `assets/`, `CNAME` or the
`Gemfile`, and fails on three things:

- a build error, `jekyll build --strict_front_matter`
- `%20` in a URL of any built page — the recorded defect, asserted about
  the artifact rather than about the sources
- a missing `_site/index.html` or logo, which is what an `exclude:` entry
  added to `_config.yml` by mistake leaves behind: a green build serving
  404s

**Not a required check, and it should not become one** while it carries a
`paths` filter: a required check that produces no run blocks a merge where
a skipped one satisfies it. REPOSITORY.md's "Required checks on main" is
that argument in full.

## The update

The `Gemfile` pins `github-pages` to 232, and
<https://pages.github.com/versions.json> is what says that is the version
Pages runs — it carries the ruby, 3.3.4, and the `jekyll-theme-minimal`
0.2.0 that `_config.yml` names. That gem pins its own dependency set
exactly, so the one line is the whole of the lock: no `Gemfile.lock` to
commit, none to keep in step.

`dependabot.yml` gains the `bundler` ecosystem, which it deliberately left
out before. The reason against was that GitHub builds the site on its own
side; that is still true, and it is now the reason for. A bump is the news
that the builder moved, and the pull request carrying it is where the site
gets built under the new one.

## The documentation

`REPOSITORY.md` gains a Pages section: the three settings nothing in a
checkout can recover — the source branch and path, the build type, and the
custom domain whose `CNAME` file un-sets it if it leaves the tree.
`CONTRIBUTING.md`'s "The website" section names the new check and the pin,
and the workflow table gains its row.

## Gates

`pre-commit run --all-files` and sphinx `-W`: both green. The build itself
is not verified locally — the system ruby here is 2.6 and `github-pages`
needs 3.x — so the first run of this workflow is the one on this pull
request, which its own `paths` filter includes for exactly that reason.

Companion: btclib-org/btclib#608 moves CodeQL to Tuesday.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a GitHub Actions workflow to build the btclib.org Pages site so failures are visible, and document how the website is configured and maintained.

New Features:
- Introduce a website workflow that builds the GitHub Pages site on relevant pushes and pull requests and surfaces build or content issues as failing checks.

Enhancements:
- Pin the GitHub Pages Gemfile to the specific github-pages version used by GitHub and wire Dependabot to track and update that pin via the bundler ecosystem.
- Clarify repository and contributing documentation around Pages configuration, workflow triggers, and how the website build and preview behave.
- Extend typo configuration to support the environment variable used by the website workflow without false positives.

Build:
- Add a Ruby-based website build path using the github-pages gem version aligned with the production Pages builder, without introducing a Gemfile.lock.

CI:
- Add a dedicated website CI job that runs Jekyll with the Pages toolchain, verifies built URLs for encoded spaces, and asserts presence of the homepage and logo in the generated site.
- Configure website workflow triggers, permissions, and concurrency to align with existing CI patterns and avoid blocking merges when the workflow is skipped.

Deployment:
- Ensure btclib.org’s Pages configuration and custom domain behavior are documented and that site breakages are caught at PR time rather than after deployment.

Documentation:
- Expand REPOSITORY.md and CONTRIBUTING.md to document the Pages settings, the website workflow, the pinned builder version, and local preview instructions.

Chores:
- Update Dependabot configuration to include the bundler ecosystem for the website Gemfile so Pages toolchain changes arrive as manageable pull requests.