### PR TITLE
Fail on a %20 in an attribute, not on the prose that recounts one

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -116,11 +116,20 @@ jobs:
       # baseurl is empty renders `{{ '/x' | relative_url }}` as `/%20/x`
       # and jekyll exits zero, so the page is served with a script tag
       # pointing at a path nothing answers. The build is the claim about
-      # the sources; this is the same claim made about the artifact
+      # the sources; this is the same claim made about the artifact.
+      #
+      # An attribute of a real tag, not the string anywhere on the page:
+      # CHANGELOG.md, HISTORY.md, SECURITY.md and AUTHORS.md all recount
+      # that defect and quote the broken tag, and a rendered page carries
+      # that prose with the `<` escaped as `&lt;` -- so requiring an
+      # unescaped `<tag ... src="` is what separates the page that has the
+      # bug from the page that describes it. Measured: the first run of
+      # this workflow failed on six such lines and no real URL
       - name: The built pages carry no encoded-space URL
         run: |
-          if grep -rn '%20' _site --include='*.html'; then
-            echo "::error::a built page carries %20 in a URL"
+          if grep -rEn '<[a-zA-Z]+[^>]+(src|href)="[^"]*%20' \
+              _site --include='*.html'; then
+            echo "::error::a built page carries %20 in a src or href"
             exit 1
           fi
       # the homepage is README.md rendered, and _config.yml's exclude list


### PR DESCRIPTION
The first run of `website.yml` went red, and none of the six lines it
found was a URL:

```text
_site/SECURITY.html:295:  for /%20/assets/js/scale.fix.js and got a 404: …
_site/CHANGELOG.html:87:  <code …>&lt;script src="/%20/assets/js/scale.fix.js"&gt;</code> …
_site/HISTORY.html:1204: for /%20/assets/js/scale.fix.js and got a 404: …
```

`CHANGELOG.md`, `HISTORY.md`, `SECURITY.md` and `AUTHORS.md` all recount
the defect the step exists for, and quote the tag it produced. Rendered,
that prose carries the `<` escaped as `&lt;`, so requiring an unescaped
`<tag … src="` before the `%20` separates the page that *has* the bug from
the page that *describes* it.

The build itself passed on that run — the pinned `github-pages` 232, ruby
3.3.4 and `jekyll build --strict_front_matter` all did what they were
meant to, and so did the homepage and logo assertions. Only the grep was
too wide.

btclib-org/btclib#610 merged a minute before that run reported, the check
not being a required one, so `main` currently carries the wide grep and
this workflow is red on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Restrict the grep in the website workflow to src/href attributes containing %20 to avoid false positives from documentation text.