### PR TITLE
Say what the checks do, in the file that tells a contributor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,29 @@ documented at release-notes length in the first place, and are still in
   pull request's body is now written from, there being no pull request
   standing open for a cycle to write them into.
 
+- **CONTRIBUTING.md describes the CI that runs.** Read back from the
+  workflow files and the repository settings rather than remembered, it
+  was describing jobs and triggers that had moved: `Build the
+  documentation` as a second job of `lint.yml`, where it is `docs.yml`,
+  a workflow of its own; `test-py`, `coverage-py` and `dist-py`, since
+  renamed `suite`, `coverage` and `dist`, in RELEASING.md as well;
+  `published` as weekly, where its cron is monthly; `integration` as
+  gating nothing, where `Regtest against Bitcoin Core` is required on
+  `main` and runs on every pull request; and the declared bindings floor
+  as `>=0.7.1`, where `pyproject.toml` says `>=0.7.1.3`.
+
+  Three more follow from the same reading. The merge paragraph stated the
+  shape of the squash commit, and reads `squash_merge_commit_title` and
+  `squash_merge_commit_message` back from the repository instead: a
+  branch of one commit lands under that commit's own subject, with no
+  number appended. The names kept out of `__all__` gain `btclib.name`,
+  which `tests/all_test.py` records and the prose did not. And the
+  package counts in the `--python` warning are gone rather than
+  corrected: they had drifted, nothing checks them, and the mechanism
+  they illustrate does not need them. The "to do: document how to do it
+  in VS Code" line goes with them, "The editor" section below it being
+  that documentation.
+
 - **The links that named a branch name the one that is there.** The
   README's licence link and its pre-commit.ci badge, `pyproject.toml`'s
   `changelog` URL -- which PyPI publishes on the project page -- the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ tools, including those needed to build the documentation, is then created with:
 uv sync
 ```
 
-**The declared dependency is `btclib_libsecp256k1>=0.7.1`, with no
+**The declared dependency is `btclib_libsecp256k1>=0.7.1.3`, with no
 upper bound**, and the absence of a ceiling is a decision. The bindings are
 a btclib-org project developed by the same people, and their whole purpose
 is to be the bindings this library calls, so a breaking change there is
@@ -68,12 +68,12 @@ promise is about that pair — a bindings release keeps the runtime API the
 supported btclib needs, and an older btclib may one day stop installing or
 running against the newest bindings.
 
-The bound is the oldest final release this version supports, and
-`0.7.1rc1` is below it: the candidate is what the pin named while nothing
-final satisfied it. What a resolver does with prereleases is its own
-policy — pip and uv alike prefer a stable candidate and reach for a
-prerelease only when no stable one satisfies the constraints — so the
-bound states support and nothing else. See the
+The bound is the oldest final release this version supports, and a
+prerelease of it sorts below it rather than satisfying it. What a
+resolver does with prereleases is its own policy — pip and uv alike
+prefer a stable candidate and reach for a prerelease only when no stable
+one satisfies the constraints — so the bound states support and nothing
+else. See the
 [version-specifiers page](https://packaging.python.org/en/latest/specifications/version-specifiers/#handling-of-pre-releases)
 and
 [uv's prerelease handling](https://docs.astral.sh/uv/concepts/resolution/#pre-release-handling).
@@ -99,8 +99,8 @@ before it bites.** An interpreter other than the one already there makes uv
 report `Removed virtual environment at: .venv` and create it again — so
 whatever groups the command asks for are the only ones installed
 afterwards. With the group-restricted commands under "Reproducing what CI
-runs" below, that leaves an environment of 15 packages where `uv sync`
-leaves 84, and pre-commit is not among them. The git hook pre-commit
+runs" below, that leaves an environment holding one group where `uv sync`
+installs them all, and pre-commit is not in it. The git hook pre-commit
 installs `exec`s `.venv/bin/python -mpre_commit` by absolute path, and
 that python does exist, so the hook's own "did you forget to activate your
 virtualenv" fallback never runs: the next `git commit` dies with
@@ -188,8 +188,6 @@ formatter reflows it to 88 — and neither is yaml, at 100, an action
 pinned to a commit SHA being past 80 before anything else is said;
 `.yamllint.yaml` has that arithmetic.
 
-\[To do: document how to do it in VS Code\]
-
 One of those hooks needs maintenance, and only one. The test vectors under
 `tests/ecc/_data/` and `tests/script/_data/` are private keys by the
 hundred, so they are recorded in `.secrets.baseline` as already reviewed —
@@ -270,10 +268,10 @@ uv run --locked --only-group lint \
     pre-commit run --all-files --show-diff-on-failure
 ```
 
-That workflow has a second job, `Build the documentation`, whose command is
-the one below under "The documentation".
+`Build the documentation` is a workflow of its own, `docs.yml`, and its
+command is the one below under "The documentation".
 
-One cell of the `test-py` matrix. The interpreter is chosen with
+One cell of the `suite` matrix of `test.yml`. The interpreter is chosen with
 `--python`, which accepts any of the ones the matrix lists, `3.14t` and
 `pypy3.11` included, and downloads it if the machine has none:
 
@@ -287,7 +285,7 @@ started" above, and `UV_PROJECT_ENVIRONMENT` for running it without
 touching `.venv`. The command is what CI runs, verbatim, and CI has no
 `.venv` to lose.
 
-The `coverage-py` job, gated by `fail_under` in pyproject.toml:
+The `coverage` job, gated by `fail_under` in pyproject.toml:
 
 ```shell
 uv run --locked --no-default-groups --group test pytest --cov
@@ -298,7 +296,7 @@ What `--cov` measures and how it reports are `tool.coverage.run`'s
 and the `pytest --cov` above are the same measurement: the job cannot
 gate on a scope a contributor's run does not have.
 
-The `dist-py` job, which inspects what would be published and then
+The `dist` job, which inspects what would be published and then
 installs it. The last commands ask for the wheel and nothing else, so
 what pulls btclib_libsecp256k1 in is the `Requires-Dist` the wheel
 carries; the lock arrives as constraints, which bind a version without
@@ -334,7 +332,7 @@ uv version --short
 ```
 
 Its build job then repeats the smoke test above on the wheel it uploads,
-which is not the one `dist-py` built, and repeats it without the
+which is not the one `dist` built, and repeats it without the
 constraints. No pull request waits on that job and no branch rule names
 it, where `publish-testpypi` and `publish-pypi` both have it in `needs`:
 so it is the place to ask whether the newest published bindings satisfy
@@ -377,7 +375,8 @@ uv lock --upgrade-package btclib_libsecp256k1
 uv run --locked --no-default-groups --group test pytest
 ```
 
-The `published` workflow, weekly and on demand, installs btclib itself
+The `published` workflow, monthly, on demand and as part of a release,
+installs btclib itself
 from PyPI, nothing checked out, and asks whether it works rather than
 whether it installs: `import btclib` runs `__init__.py` alone, and the
 files under `btclib/*/_data/` — the wordlists among them — are opened by
@@ -478,9 +477,11 @@ exits non-zero for one, which is the only thing the workflow is red about.
 Its docstring says why it reads the session file rather than `cosmic-ray
 dump`, which cannot read one of these sessions at all.
 
-The `integration` workflow, weekly and on demand, which gates nothing
-either and asks the one question the rest of CI cannot: whether Bitcoin
-Core accepts what btclib built. It downloads a pinned Core release,
+The `integration` workflow, which gates and is the exception here: it
+runs on every pull request, weekly besides, and `Regtest against Bitcoin
+Core` is required on `main`. It asks the one question the rest of CI
+cannot, whether Bitcoin Core accepts what btclib built. It downloads a
+pinned Core release,
 verifies its published sha256, and runs the tests `tests/README.md`
 documents with the binary named rather than found on PATH:
 
@@ -496,7 +497,7 @@ fixture stopped finding the node would stay green while asking Core
 nothing. The HWI tests skip there by design, needing a device or an
 emulator, and are not counted.
 
-The documentation, which the `Build the documentation` job of `lint.yml`
+The documentation, which the `Build the documentation` job of `docs.yml`
 runs with this same command, as read the docs does. `-W` is what makes an
 `automodule` whose module does not import a failure rather than an empty
 page — and what catches invalid reStructuredText in a docstring, which no
@@ -677,8 +678,9 @@ parent decides whether it is reachable.
 
 **A public name kept out of the list is a decision, and the docstring
 says why.** The `datadir` of `btclib.network` and of
-`btclib.curves.curve`, and the three checksum tables of
-`btclib.descriptors`, are the ones in the tree today; each stays
+`btclib.curves.curve`, the three checksum tables of
+`btclib.descriptors`, and `btclib`'s own `name`, are the ones in the tree
+today; each stays
 importable from the module that defines it, which is where the test suite
 takes it from. `tests/all_test.py` checks all of this and finds the
 modules rather than listing them, so a new public name fails the suite
@@ -781,12 +783,24 @@ check starts again from a commit nobody has seen. Add the fix on top, with
 a message saying what it fixes, and reply to the comment with the sha.
 
 Nothing is lost in `main`'s history by doing so, because **a pull request
-is merged with "Squash and merge"**: the branch becomes one commit whose
-subject is the PR title with its number, so the review's commits are the
-record of the review and `main` keeps one commit per landed change. A
-merge commit would put the branch's steps into `main` and a rebase merge
-would replay them one by one — `main` is linear by branch rule, and one
-change is one commit there.
+is merged with "Squash and merge"**: the branch becomes one commit, so
+the review's commits are the record of the review and `main` keeps one
+commit per landed change. A merge commit would put the branch's steps
+into `main` and a rebase merge would replay them one by one — `main` is
+linear by branch rule, and one change is one commit there.
+
+What that commit says is the repository's to answer, not this file's:
+
+```shell
+gh api repos/btclib-org/btclib --jq \
+  '{t: .squash_merge_commit_title, m: .squash_merge_commit_message}'
+# {"t": "COMMIT_OR_PR_TITLE", "m": "COMMIT_MESSAGES"}
+```
+
+so a branch of one commit lands under that commit's own subject, a branch
+of several under the pull request's title with its number, and the body
+is the branch's commit messages either way — never the pull request's
+body, which stays on the pull request.
 
 **Read the button before clicking it.** All three methods are enabled on
 the repository and GitHub offers whichever was used last, so the squash is

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -97,7 +97,7 @@ Already done for btclib-org/btclib; kept here for the record.
 ## Rehearse on TestPyPI
 
 A rehearsal runs the identical pipeline — lint gate, test matrix, the
-packaging checks of the `dist-py` job (twine, check-wheel-contents,
+packaging checks of the `dist` job (twine, check-wheel-contents,
 pyroma), build, wheel smoke test — and publishes to
 [TestPyPI](https://test.pypi.org/project/btclib/) instead of PyPI.
 
@@ -163,7 +163,7 @@ word, and step 1 asks it of both.
    btclib_libsecp256k1 and bitcoin-core-rpc — is the one this release
    should depend on, and that `pyproject.toml`'s pin says so. Two
    questions, not one: whether the pin *resolves*, which the wheel smoke
-   test of the `dist-py` job already answers on every pull request by
+   test of the `dist` job already answers on every pull request by
    failing when only an unreleased version satisfies it, and whether the
    floor should *move*, which nothing automates because only a person
    knows what the sibling's release was for. Both projects are pinned


### PR DESCRIPTION
CONTRIBUTING.md read back against the workflow files and the repository
settings rather than against memory. What had gone stale:

| the file said | the tree says |
| --- | --- |
| `Build the documentation` is a second job of `lint.yml` | it is `docs.yml`, a workflow of its own |
| the `test-py`, `coverage-py`, `dist-py` jobs | `suite`, `coverage`, `dist` — in RELEASING.md too |
| `published` runs weekly | its cron is monthly, plus a release and a dispatch |
| `integration` gates nothing | `Regtest against Bitcoin Core` is required on `main`, on every pull request |
| the bindings floor is `>=0.7.1` | `pyproject.toml` says `>=0.7.1.3` |

Three more come from the same reading rather than from a rename.

The merge paragraph stated the shape of the squash commit — "one commit
whose subject is the PR title with its number". What the repository does is
`COMMIT_OR_PR_TITLE` with `COMMIT_MESSAGES`, so a branch of one commit lands
under that commit's own subject with no number appended, which is what the
recent merges on `main` show. The paragraph now reads both settings back
with `gh api` instead of asserting the result.

The list of public names kept out of `__all__` did not include
`btclib.name`, which `tests/all_test.py`'s `UNEXPORTED` carries.

The `--python` warning counted the packages in each environment, 15 against
84; the lock now resolves 17 and 105. The numbers are dropped rather than
corrected: nothing checks them, they drift with every lock, and the point
they illustrate — the group-restricted command leaves an environment with no
pre-commit in it — does not need them. This file's own "Measure, don't
assert" asks for exactly that.

The "to do: document how to do it in VS Code" line goes as well: "The
editor" section below it is that documentation, `.vscode/settings.json` and
`.vscode/extensions.json` being tracked.

Not touched: the table's row for the required checks and the
`workflow_dispatch` sentence, both of which say the right thing on `main`
already.

Gates on this branch: `pre-commit run --all-files` clean, `sphinx-build -W
--keep-going` clean, `pytest --cov` 18569 passed at 100.00%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update contributor and release documentation to accurately describe current CI workflows, bindings version floor, and merge behavior.

Enhancements:
- Make CI and merge-process documentation more robust by deriving behavior from actual repo and workflow configuration instead of memory.

Documentation:
- Refresh CONTRIBUTING.md to match current workflow names, triggers, and required checks, including docs, test, coverage, dist, published, and integration workflows.
- Clarify the documented minimum btclib_libsecp256k1 version and prerelease handling to align with pyproject configuration.
- Explain squash-merge commit titles and messages based on repository settings rather than assumptions, and note that PR bodies are not used in commit messages.
- Include btclib.name in the documented set of public names intentionally kept out of __all__, consistent with the test suite.
- Simplify the --python environment warning by removing drifting package-count examples and drop the obsolete VS Code TODO line.
- Update RELEASING.md to refer to the renamed dist job in the release rehearsal and pin-check description.