### PR TITLE
Record that the worker pool pays, and by how much

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,6 +179,25 @@ testpaths = ["tests"]
 # warning that scrolls past a hundred lines of dots, and --strict-markers
 # does the same for a marker nobody registered, which is how a misspelled
 # skipif silently stops skipping
+# -n auto pays here, and the number is worth writing down because a local
+# run says the opposite: on ten cores this suite is 18 seconds either way,
+# six alternating pairs splitting three to three, so a laptop cannot decide
+# this. CI can, and does. One dispatch of test.yml per configuration, the
+# `Run pytest` step compared cell by cell over the 28 of them plus coverage:
+# the pool wins in every single cell, 189s against 87s at the median, 2.2x,
+# and 106 minutes of suite time against 46 across a whole run -- an hour of
+# compute per run. The ratio rises where the runner is slowest: about 2.9x
+# on both arm images against 1.9x on the x86 ones, which is the shape of a
+# fixed startup cost amortised over more work. bitcoin-core-rpc measured the
+# same question and removed the flag, its 298 socket-free tests finishing
+# before ten workers start; the criterion the two share is in checksig's
+# docs/test-parallelism.md, and it is the length of a cell rather than the
+# count of its tests. To re-derive:
+#
+#     gh workflow run test.yml --ref <a branch with the flag removed>
+#     gh workflow run test.yml --ref main
+#     gh api repos/$GITHUB_REPOSITORY/actions/runs/<id>/jobs?per_page=100
+#
 # --dist worksteal rather than xdist's default `load`, because the cost
 # here is lopsided: the taproot vectors of
 # tests/script_engine/python_path_test.py carry most of the suite's slowest


### PR DESCRIPTION
`-n auto --dist worksteal` has sat in `addopts` with a measurement behind
**worksteal against `load`** — a different question from whether spreading the
suite across workers is worth its startup at all. Nobody had asked the second
one, and a laptop answers it wrongly.

**Locally it looks like a wash.** Six alternating pairs on ten cores: 18.6 s
serial against 17.7 s parallel at the median, three wins each, a median paired
difference of +0.1 s. On that evidence the flag looks removable.

**In CI it is not close.** One `workflow_dispatch` of `test.yml` per
configuration, the `Run pytest` step compared cell by cell:

| | serial | `-n auto` | ratio |
|---|---|---|---|
| median cell | 189 s | 87 s | **2.17×** |
| whole run, 29 cells | 106 min | 46 min | **an hour of compute saved** |
| ubuntu-24.04-arm, 7 cells | | | 2.93× |
| windows-11-arm, 7 cells | | | 2.84× |
| ubuntu-latest, 7 cells | | | 2.04× |
| windows-latest, 7 cells | | | 1.89× |
| coverage job | 164 s | 87 s | 1.89× |

**The pool wins in 29 of 29 cells**, worst case 1.44×, best 3.39×. The ratio
rises where the runner is slowest, which is a fixed startup cost amortised over
more work.

So the flag stays, and the reason is now in the file rather than in whoever
remembers the dispatch. The commands that re-derive it are in the comment.

**The sibling asked the same question and answered it the other way.**
[bitcoin-core-rpc#85](https://github.com/btclib-org/bitcoin-core-rpc/pull/85)
removed `-n auto`: 298 tests that open no socket finish before ten workers start,
1.8× the wrong way both locally and in CI. The criterion the two share is the
length of a cell, not the count of its tests, and checksig's
`docs/test-parallelism.md` states it — checksig keeps the flag because it starts
a bitcoind per test.

Comment only; no behaviour changes.

## Gates

```shell
uv run --locked --only-group lint pre-commit run --all-files      # 0
uv run --locked --no-default-groups --group test pytest --cov     # 0, 100.00%
```

The measurement branch that carried the serial arm is deleted; it was never
proposed for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)