### PR TITLE
Bind the last two required checks, and stop documenting what unbinds them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **Every required check names the app that produces it.** Three of the
+  five carried `app_id: 15368` and `Lint and type-check` and `Build the
+  documentation` carried none, which is not a weaker spelling of the same
+  rule: an unbound context is satisfied by *any* app that reports a check
+  run of that name, so anything installed on the organization with
+  `checks: write` could turn one green with no workflow having run. Both
+  are Actions checks -- `gh api
+  repos/btclib-org/btclib/commits/<sha>/check-runs` answers 15368 for each
+  -- so binding them changes nothing a run can see, and closes that.
+  REPOSITORY.md's rename recipe moves from `contexts` to `checks` with
+  them, and the two bodies in its code-scanning section carry the app on
+  every entry: `contexts` has no field for one, so a `PATCH` sending it
+  replaces the bound list with an unbound one, silently and with nothing
+  in a run to say so -- which is how the documented recipe would have
+  undone this the next time a check was renamed
 - **The website has a build that can fail.** btclib.org is this
   repository's own root, served by the classic Pages builder -- `gh api
   repos/btclib-org/btclib/pages` answers `build_type: legacy` -- which

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -65,28 +65,37 @@ that renames the job reports the name the rule now wants:
 
 ```shell
 branch=repos/btclib-org/btclib/branches/main
-gh api -X PATCH "$branch"/protection/required_status_checks \
-  -F strict=true \
-  -f 'contexts[]=test: every job passed' \
-  -f 'contexts[]=Lint and type-check' \
-  -f 'contexts[]=Build the documentation' \
-  -f 'contexts[]=Regtest against Bitcoin Core' \
-  -f 'contexts[]=codeql: every job passed'
+gh api -X PATCH "$branch"/protection/required_status_checks --input - <<'JSON'
+{
+  "strict": true,
+  "checks": [
+    {"context": "test: every job passed", "app_id": 15368},
+    {"context": "Lint and type-check", "app_id": 15368},
+    {"context": "Build the documentation", "app_id": 15368},
+    {"context": "Regtest against Bitcoin Core", "app_id": 15368},
+    {"context": "codeql: every job passed", "app_id": 15368}
+  ]
+}
+JSON
 ```
 
-That `PATCH` sends `contexts`, which names no app, and what is there is
-not uniformly that: some of the five are bound to the app that produces
-them and the rest to nothing, which lets any app reporting one of those
-names satisfy it. Read it before assuming either shape:
+**`checks` and not `contexts`, and that is not a style.** All five are
+bound to the app that produces them — 15368, Actions — so nothing else
+reporting one of those names can satisfy it. `contexts` has no field for
+an app, so a `PATCH` sending it replaces the bound list with an unbound
+one: the rule keeps working, silently accepting any app's check of that
+name, and nothing in a run says so. Read it back rather than assume:
 
 ```shell
 gh api repos/btclib-org/btclib/branches/main/protection \
-  --jq '.required_status_checks.checks'   # PATCH that sub-endpoint
+  --jq '.required_status_checks.checks'
 ```
 
-Binding all five is the stricter form — `checks` with an `app_id` in the
-body, 15368 for Actions, rather than the bare `contexts` list — and
-adopting it is a decision separate from this list.
+**A JSON body on stdin is what `app_id` takes**: `-f` sends every value as
+a string and the endpoint answers `422 Invalid request. For
+'properties/app_id', "15368" is not a null or integer`. A shell variable
+holds the path for the same reason the JSON is not on one line, which is
+80 columns.
 
 **PATCH that sub-endpoint, never PUT the whole protection object**: a
 partial PUT drops the reviews, the signatures and the rest. Repeat
@@ -169,16 +178,16 @@ gh api -X PATCH "$branch"/protection/required_status_checks --input - <<'JSON'
   "checks": [
     {"context": "test: every job passed", "app_id": 15368},
     {"context": "Regtest against Bitcoin Core", "app_id": 15368},
-    {"context": "Lint and type-check"},
-    {"context": "Build the documentation"}
+    {"context": "Lint and type-check", "app_id": 15368},
+    {"context": "Build the documentation", "app_id": 15368}
   ]
 }
 JSON
 ```
 
-Step 5 is that body with one entry added, bound to Actions because Actions
-is what reports it — the `CodeQL` it replaces was unbound for the opposite
-reason, the app producing it not being Actions:
+Step 5 is that body with one entry added, and every entry carries its app
+because every one of these checks is an Actions check — the `CodeQL` this
+replaces was the exception, the app producing it not being Actions:
 
 ```shell
 branch=repos/btclib-org/btclib/branches/main
@@ -189,8 +198,8 @@ gh api -X PATCH "$branch"/protection/required_status_checks --input - <<'JSON'
     {"context": "test: every job passed", "app_id": 15368},
     {"context": "Regtest against Bitcoin Core", "app_id": 15368},
     {"context": "codeql: every job passed", "app_id": 15368},
-    {"context": "Lint and type-check"},
-    {"context": "Build the documentation"}
+    {"context": "Lint and type-check", "app_id": 15368},
+    {"context": "Build the documentation", "app_id": 15368}
   ]
 }
 JSON


### PR DESCRIPTION
`Lint and type-check` and `Build the documentation` were the two contexts
the rule required without naming an app. That is not a weaker spelling of
the same rule: an unbound context is satisfied by **any** app reporting a
check run of that name, so anything installed on the organization with
`checks: write` could turn one green with no workflow having run.

Both are Actions checks, read from the commit rather than assumed:

```shell
sha=$(gh api repos/btclib-org/btclib/commits/main --jq '.sha')
gh api "repos/btclib-org/btclib/commits/$sha/check-runs?per_page=100" \
  --jq '[.check_runs[]
         | select(.name=="Lint and type-check"
               or .name=="Build the documentation")
         | "\(.name)@\(.app.id)"]'
# ["Build the documentation@15368","Lint and type-check@15368"]
```

So the binding changes nothing a run can see. It is applied — the rule is
a setting and not a file — and every context this repository requires now
reads `app_id: 15368`:

```shell
gh api repos/btclib-org/btclib/branches/main/protection \
  --jq '[.required_status_checks.checks[] | select(.app_id == null)] | length'
# 0
```

The rest of the protection object is unchanged: `strict`, one approving
review with `dismiss_stale_reviews`, required signatures, linear history,
resolved conversations, `enforce_admins` off.

## What is in the diff is the documentation that would have undone it

The rename recipe in `REPOSITORY.md` sent `contexts`. That field has no
place for an app, so following the recipe replaces the bound list with an
unbound one — the rule keeps working, silently accepting any app's check
of that name, and nothing in a run says so. It sends `checks` now, with
the JSON body on stdin that `app_id` requires.

The two bodies in the code-scanning section carried the app on the three
contexts that had one and omitted it for these two, which would have
un-bound them at step 1 or step 5 of the next switch. Every entry carries
it now.

## Companions

btclib-org/btclib-libsecp256k1 is bound the same way, and
btclib-org/bitcoin-core-rpc already was. All three read `app_id: 15368`
for every context they require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bind all required status checks to the Actions app and update documentation to reflect the stricter, app-bound branch protection configuration.

Documentation:
- Update REPOSITORY.md to use the JSON-based `checks` payload with `app_id` for branch protection changes instead of unbound `contexts`, and explain why app binding is required.
- Record in CHANGELOG.md that all required checks are now explicitly bound to the Actions app to prevent other apps from satisfying those contexts.