### PR TITLE
Ask whether the y exists, where BIP32 computed and dropped it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -481,6 +481,36 @@ documented at release-notes length in the first place, and are still in
   spellings were measured to agree on all 27 of the first and all of the
   second, which is why this is a correctness fix with no behaviour to
   record.
+- **An extended public key is validated by a predicate, not by a lift**
+  (#615). `_assert_valid_key` computed the y of the 33 bytes with
+  `secp256k1.y` and threw it away, the call being there for the
+  exception: the question asked is whether the x is an x-coordinate at
+  all, which is what `curves.curve._is_x_coordinate` answers --
+  `ec_pubkey_parse` of `0x02 || x`, 2.5 µs against the 75 of the Python
+  modular square root. `BIP32KeyData.b58decode` of an xpub is 12.4 µs
+  against 86.3, `derive(xpub, "m/0/1")` 65.9 against 288,
+  `slip132.address_from_xkey` 33.5 against 257, `xpub_from_xprv` 33.2
+  against 108. The check is paid once per extended key object, so every
+  level of every derivation path paid the root -- three of them for
+  `m/0/1` -- which is what makes this more than a microbenchmark: a
+  downstream suite deriving whitelists over multisig branches spent 56%
+  of its Python CPU in `mod_sqrt`.
+
+  Issue #288 delegated the same square root where a compressed key is
+  parsed into a point, and this call site did not come along with it
+  because it reaches `CurveGroup.y` directly rather than through
+  `point_from_octets`. `_y_even` would answer here too and is barely
+  dearer, but it materializes a point nobody wants and falls back to the
+  Python root to phrase a refusal: half of the field elements are not
+  x-coordinates, so that is the square root paid on exactly the inputs
+  meant to be cheap, which is the trade `_is_x_coordinate` exists not to
+  make. The refusal is unchanged, `invalid public key: 0x...` naming the
+  whole 33 bytes; what goes is its `__cause__`, a predicate having no
+  "invalid x-coordinate" to chain from. The private-key branch is a
+  scalar range check with no curve arithmetic and is untouched, and
+  `CurveGroup.y`/`y_even` are still reached directly from
+  `script.taproot` and `ecc.pedersen`, each with its own answer to
+  whether it wants a coordinate or a predicate.
 
 ### The public API and the module layout
 

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -41,6 +41,7 @@ from btclib.curves import (
     point_from_octets,
     secp256k1,
 )
+from btclib.curves.curve import _is_x_coordinate
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import NETWORKS, XPRV_VERSIONS_ALL, XPUB_VERSIONS_ALL
@@ -118,11 +119,16 @@ def _assert_valid_key(version: bytes, key: bytes) -> None:
             err_msg = "invalid public key prefix not in (0x02, 0x03): "
             err_msg += f"0x{key[:1].hex()}"
             raise BTClibValueError(err_msg)
-        try:
-            secp256k1.y(int.from_bytes(key[1:], byteorder="big", signed=False))
-        except BTClibValueError as e:
-            err_msg = f"invalid public key: 0x{key.hex()}"
-            raise BTClibValueError(err_msg) from e
+        # existence and nothing else, the y having been computed and
+        # dropped: this is the caller _is_x_coordinate's docstring
+        # describes, and the square root it exists not to pay was paid
+        # once per extended key, so by every level of every derivation
+        # path (issue 615). A predicate has no exception to chain, so
+        # the message below is the whole of the error where it used to
+        # be raised from curve_group's "invalid x-coordinate"
+        x = int.from_bytes(key[1:], byteorder="big", signed=False)
+        if not _is_x_coordinate(x, secp256k1):
+            raise BTClibValueError(f"invalid public key: 0x{key.hex()}")
     else:
         raise BTClibValueError(f"unknown extended key version: 0x{version.hex()}")
 

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -27,6 +27,7 @@ from btclib.bip32.der_path import _indexes_from_der_path_str
 from btclib.curves import (
     bytes_from_point,
     bytes_from_prv_key_int,
+    curve_group,
     mult,
     point_from_octets,
 )
@@ -228,6 +229,43 @@ def test_invalid_bip32_xkeys(xkey: str, err_msg: str) -> None:
     """
     with pytest.raises(BTClibValueError, match=re.escape(err_msg)):
         BIP32KeyData.b58decode(xkey)
+
+
+def test_public_key_validation_does_not_lift(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Validating an extended public key asks for existence, not for y.
+
+    The y computed to validate an xpub was thrown away, and the modular
+    square root that found it was paid once per extended key -- so by
+    every level of every derivation path (issue 615). What pins the
+    predicate in place of the lift is reaching no square root at all,
+    not a stopwatch: mod_sqrt is patched to raise, and the accepted key
+    and the refused one both have to get their answer without it.
+    """
+
+    def refuse(*_: object) -> int:
+        # a green suite is one where this never runs, which is the pragma
+        # curve_test.no_bindings carries for the same reason
+        raise AssertionError(  # pragma: no cover
+            "the y of an extended public key was computed"
+        )
+
+    monkeypatch.setattr(curve_group, "mod_sqrt", refuse)
+
+    xpub = "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
+    assert BIP32KeyData.b58decode(xpub).b58encode() == xpub
+    assert derive(xpub, "m/0/1")
+
+    # 0x02 || 7, the x of no point: BIP32 test vector #5's "invalid
+    # pubkey 0200...07", which bip32_invalid_keys.json carries in full
+    decoded = base58.decode(xpub)
+    bad_xpub = base58.encode(decoded[:45] + b"\x02" + (7).to_bytes(32, "big"), 78)
+    err_msg = "invalid public key: 0x02000000"
+    with pytest.raises(BTClibValueError, match=err_msg) as excinfo:
+        BIP32KeyData.b58decode(bad_xpub)
+    # a predicate has no exception to chain: the message is the whole error
+    assert excinfo.value.__cause__ is None
 
 
 def test_derive() -> None:


### PR DESCRIPTION
Closes #615.

`bip32._assert_valid_key` validated the public key of an extended key by
calling `secp256k1.y` on its x and discarding the coordinate — the call
was there for the exception it raises. The question asked is existence,
and `curves.curve._is_x_coordinate` is the function that answers exactly
that, delegating to `ec_pubkey_parse` for secp256k1: 2.5 µs against the
75 of the Python modular square root, and its docstring already named
this caller in the abstract.

## What it buys

The check is paid once per extended key object, so every level of every
derivation path paid the root — three of them for `m/0/1`. Measured on
this branch with the issue's script, min-of-repeat so that a loaded
machine cannot inflate it:

| | before | after | |
| --- | --- | --- | --- |
| `BIP32KeyData.b58decode(xpub)` | 86.3 µs | 12.4 µs | 7.0x |
| `derive(xpub, "m/0/1")` | 288 µs | 65.9 µs | 4.4x |
| `slip132.address_from_xkey(xpub)` | 257 µs | 33.5 µs | 7.7x |
| `xpub_from_xprv(xprv)` | 108 µs | 33.2 µs | 3.2x |

## The choices behind it

**`_is_x_coordinate` and not `_y_even`.** The second would answer here
too and is barely dearer, but it materializes a point nobody wants, and
it falls back to the Python root to phrase a refusal: half of the field
elements are not x-coordinates, so that is the square root paid on
exactly the inputs meant to be cheap — the trade `_is_x_coordinate`
exists not to make.

**The error is unchanged**, `invalid public key: 0x…` naming the whole
33 bytes, and the 16 keys of BIP32 test vector #5 are still refused with
the messages `bip32_invalid_keys.json` pins. What goes is its
`__cause__`: a predicate has no `invalid x-coordinate` to chain from.
Nothing in the suite asserted on it.

**The private-key branch is untouched** — a scalar range check with no
curve arithmetic.

**The tail this leaves.** `CurveGroup.y`/`y_even` are still reached
directly from `script/taproot.py` and `ecc/pedersen.py`; each has its own
answer to whether it wants a coordinate or a predicate, and neither is
this pull request's.

## How it is pinned

`test_public_key_validation_does_not_lift` patches `curve_group.mod_sqrt`
to raise and asserts that both answers — the accepted xpub's and the
refused one's — come back without it, `__cause__` included. It fails on
`main`'s code with the assertion the patch raises, which is what makes it
a test of the predicate rather than a stopwatch. Issue #288 delegated the
same square root where a compressed key is parsed into a point; this call
site did not come along because it reaches `CurveGroup.y` directly rather
than through `point_from_octets`.

## Gates

`uv run pytest` (18570 passed, 6 skipped), `uv run pre-commit run
--all-files`, and the sphinx `-W` build, all green locally.

## Summary by Sourcery

Validate BIP32 extended public keys using an x-coordinate existence predicate instead of computing and discarding the y-coordinate, improving performance while preserving error messages.

Bug Fixes:
- Avoid unnecessary elliptic-curve point lifting when validating extended public keys, ensuring invalid x-coordinates are still rejected with the same user-visible error message.

Enhancements:
- Use the curve-level x-coordinate existence check for BIP32 public key validation to significantly reduce repeated modular square-root computations along derivation paths.
- Document the change in the changelog, including its performance impact and remaining call sites that still perform full point lifting.

Tests:
- Add a regression test that patches modular square root to fail and asserts that BIP32 public key validation no longer relies on computing the y-coordinate, and that invalid keys raise unchained errors.