### PR TITLE
Make the coverage ratchet a gate the local run reaches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,57 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`--cov` is in pytest's addopts, so the ratchet is a local gate.** The
+  100% threshold was reached only by the `coverage` job, which means a
+  change met it after being pushed: the pull request that added
+  `test_public_key_validation_does_not_lift` (#615) passed the whole
+  suite, every pre-commit hook and the sphinx build locally, and was red
+  in CI for one line of the new test the run never executes. Measured
+  before moving it, twice on a quiet machine: 36.74 s without and 36.65 s
+  with, coverage.py using `sys.monitoring` on the 3.14 `.python-version`
+  pins. The flag stays written out in `CONTRIBUTING.md`'s coverage-job
+  command, that being the job's command verbatim.
+
+  Its price is that `fail_under` applies to a partial report too, so
+  `pytest tests/bip32/bip32_test.py` would have ended in `Required test
+  coverage of 100.0% not reached. Total coverage: 6.33%` -- true of that
+  run, silent about the tree, and printed under two commands CLAUDE.md
+  documents. `coverage_fail_under` in `tests/conftest.py` answers that: a
+  run that selects a subset -- paths, `-k` or `-m` -- is gated at zero
+  and still reports, which is what makes measuring worthwhile while
+  iterating on one module. Not by switching coverage off, which would
+  throw the report away with the gate; and not `None`, which is the value
+  pytest-cov reads the configured threshold into and would put the gate
+  straight back.
+
+  Where the flag sits in addopts is load-bearing, and cost a red run to
+  find out: `--cov` takes an optional value, so as the last token it is
+  handed the first thing the command line goes on to say. `pytest
+  tests/ecc/dsa_test.py` became `--cov=tests/ecc/dsa_test.py` with no
+  path left to select on -- the whole suite ran, measured a directory
+  `omit` excludes, and reported 0.00% against a `fail_under` of 100,
+  which is how the regtest job (`pytest tests/integration`) went red on a
+  branch that touched nothing it runs. `pytest -q tests/...` hides it,
+  since a token starting with `-` is not consumed, so the habitual
+  spelling was green and the two documented ones were not.
+  `test_cov_is_not_the_last_token_of_addopts` reads the file and asserts
+  only that, no run being able to report its own addopts. The name is
+  spelled the long way round because the `typos` hook rewrites a singular
+  `addopt` to `adopt`, in place and in a test name.
+
+  Three things it deliberately does not do. It does not read `--lf`,
+  `--deselect` or an `-x` that stopped early: those shorten a run without
+  asking for a subset, so they keep the full threshold and can report a
+  shortfall the tree does not have -- inferring intent from all of them
+  would make conftest a second definition of what a real run is. It does
+  not overrule an explicit `--cov-fail-under`, which is the caller naming
+  the number. And it writes to `config.known_args_namespace` rather than
+  to `config.option`: pytest builds the first by parsing the known
+  arguments into a copy of the second, pytest-cov holds that copy from
+  `pytest_load_initial_conftests` on, and the obvious spelling therefore
+  runs clean and changes nothing. Both branches are unit-tested in
+  `tests/conftest_test.py`, the one that matters being unreachable from a
+  whole run by construction.
 - **The Bitcoin Core regtest job runs for the code it checks** (#570).
   `integration.yml`'s `pull_request.paths` held the workflow file and
   `tests/integration/**` and nothing else, so a pull request changing the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,9 @@ uv is the only tool that must be installed; it fetches interpreters,
 linters and packaging tools itself. `uv sync` creates the environment.
 
 ```shell
-uv run pytest                                   # the suite
-uv run pytest tests/ecc/dsa_test.py             # one file
-uv run pytest -k test_low_cardinality           # one test
+uv run pytest                                   # the suite, gated at 100%
+uv run pytest tests/ecc/dsa_test.py             # one file, not gated
+uv run pytest -k test_low_cardinality           # one test, not gated
 uv run pre-commit run --all-files               # every gate, see below
 uv run pre-commit run mypy --files btclib/curves/curve.py   # one hook
 uv run --python 3.10 pytest                     # another interpreter
@@ -126,6 +126,17 @@ review is corrected and how it is merged.
   so the next push kills the run for the previous commit. The local gates
   below are the evidence; `cancelled` is not `failure`, and waiting for a
   busy afternoon to settle is waiting for nothing.
+- **A bare `uv run pytest` is the coverage gate too**: `--cov` is in
+  addopts, so the 100% ratchet fails locally instead of only in the
+  `coverage` job. A run that selects a subset — paths, `-k`, `-m` — is
+  reported and not gated, `tests/conftest.py`'s `coverage_fail_under`
+  being what drops the threshold; `--lf`, `--deselect` and an early `-x`
+  are not selections and will fail on the tree's coverage. So a green
+  full run is the evidence, and a red partial one is worth re-reading
+  before believing. Setting the threshold from a plugin means writing to
+  `config.known_args_namespace`: pytest-cov reads that copy and never
+  `config.option`, so the obvious spelling changes nothing and fails
+  silently.
 - **`.pre-commit-config.yaml` is the lint gate**, and `lint.yml`'s first
   job runs exactly it. Never add a second list of the same tools to a
   workflow. mypy is a *local* hook shelling out to uv on purpose: the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,8 +142,11 @@ replaces passed everything above 99.985%, and the 99.9 before it ten
 times as much again. No slack, so a statement no test reaches is either
 covered by patching what stands in the way, as the ripemd160 fallback
 and electrum's round-trip check are, or marked `pragma: no cover` with
-the reason beside it. `pytest --cov` prints the total on every run, on
-the 3.14 the gate is checked on.
+the reason beside it. `--cov` is in pyproject.toml's addopts, so `uv run
+pytest` prints the total and enforces the ratchet on every whole run, on
+the 3.14 the gate is checked on — a run that selects a subset with paths,
+`-k` or `-m` reports without gating, since `fail_under` would otherwise
+fail it on the tree's coverage rather than on its own.
 See [Tests, code coverage, and profiling](./tests/README.md).
 
 These requirements are easily checked (and partially fixed) with:
@@ -293,8 +296,10 @@ uv run --locked --no-default-groups --group test pytest --cov
 
 What `--cov` measures and how it reports are `tool.coverage.run`'s
 `source` and `tool.coverage.report` in pyproject.toml, so this command
-and the `pytest --cov` above are the same measurement: the job cannot
-gate on a scope a contributor's run does not have.
+and the bare `uv run pytest` above are the same measurement: the job
+cannot gate on a scope a contributor's run does not have. The flag is
+written out here even though addopts already carries it, this being the
+job's command verbatim.
 
 The `dist` job, which inspects what would be published and then
 installs it. The last commands ask for the wheel and nothing else, so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,7 +221,25 @@ testpaths = ["tests"]
 # dataclasses, a tuple witness stack and per-call defaults, which this
 # re-checks on every run instead of at the tests written for each. Three
 # seeds were measured green before it went in
-addopts = "-ra --durations=8 -n auto --dist worksteal --strict-config --strict-markers"
+addopts = "-ra --cov --durations=8 -n auto --dist worksteal --strict-config --strict-markers"
+# --cov is here so that the ratchet below is what a bare `uv run pytest`
+# measures: it cost nothing to move (the suite is the same 37 seconds
+# either way on 3.14, coverage.py using sys.monitoring there), and a gate
+# only the coverage job runs is one a change meets after it is pushed.
+# What it does cost is that `fail_under` applies to a partial report too,
+# so a run of one file would fail on the tree's coverage rather than on
+# its own: tests/conftest.py's `coverage_fail_under` is where that is
+# answered, and why it is answered there.
+#
+# Its position is load-bearing, and this is the one line where that is
+# said: --cov takes an *optional* value, so as the last token here it
+# swallows the first argument the command line goes on to give. `pytest
+# tests/ecc/dsa_test.py` became `--cov=tests/ecc/dsa_test.py` with no
+# path left to select on -- the whole suite ran, measured a directory
+# that is in `omit` below, and reported 0.00% against a fail_under of
+# 100. Green under `pytest -q tests/...`, which is what hid it: a token
+# starting with `-` is not consumed. Anywhere but last is safe, and
+# --durations=8 after it is what keeps it that way
 # a test that was expected to fail and passed is a fixed bug still marked
 # as broken: strict turns it red instead of reporting xpass
 xfail_strict = true

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,13 +15,33 @@ Test execution is distributed across multiple cores,
 with the number of cores being chosen automatically:
 this can be changed in the addopts option of pyproject.toml
 
-The ultimate comprehensive way of running the tests is
+`--cov` is in those addopts, so the whole of it is one command:
 
 ```shell
-uv run pytest --cov-report term-missing:skip-covered --cov=btclib --cov=tests
+uv run pytest
 ```
 
-If you want to contribute to btclib, please ensure that it succeeds.
+That measures what `tool.coverage.run` in pyproject.toml names, reports
+how `tool.coverage.report` says, and is gated at the `fail_under` there.
+It is the same measurement the `coverage` job makes — the job cannot gate
+on a scope a contributor's run does not have — and it is what a change
+has to pass before it is pushed rather than after. It costs nothing to
+have it there: the suite takes the same time either way on the 3.14
+`.python-version` pins, coverage.py using `sys.monitoring` from 3.12 on.
+
+**A run that selects a subset is not gated.** `fail_under` applies to
+every report coverage writes, so `uv run pytest tests/bip32` would fail
+on the tree's coverage rather than on anything about that run. Naming
+paths, `-k` or `-m` therefore drops the threshold to zero:
+`coverage_fail_under` in `tests/conftest.py` is where that happens, and
+its docstring is why. The report still prints, which is what makes it
+worth reading while iterating on one module. Ways of shortening a run
+that are not a selection — `--lf`, `--deselect`, an `-x` that stops
+early — keep the full threshold and will report a shortfall the tree
+does not have.
+
+Passing `--cov-fail-under` names the threshold yourself, and outranks
+both of those.
 
 Coverage results can also be reported as html at htmlcov/index.html:
 
@@ -29,10 +49,11 @@ Coverage results can also be reported as html at htmlcov/index.html:
 uv run coverage html
 ```
 
-Finally, the fastest test execution can be accomplished running pytest only
+To run the tests without measuring anything, which is the one way to
+make them faster:
 
 ```shell
-uv run pytest
+uv run pytest --no-cov
 ```
 
 ## The integration tests, and why they are off by default

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""What the whole suite shares: hypothesis profiles, and one fixture.
+"""What the whole suite shares: hypothesis profiles, a fixture, a gate.
 
 Registered once here rather than passed to each `@given`: a settings
 profile is process-wide, and a decorator repeating it on every property
@@ -40,6 +40,78 @@ settings.register_profile("btclib", deadline=None, max_examples=500)
 settings.register_profile("thorough", deadline=None, max_examples=2_000)
 
 settings.load_profile(os.environ.get("HYPOTHESIS_PROFILE", "btclib"))
+
+
+def coverage_fail_under(
+    asked: float | None,
+    configured: float | None,
+    file_or_dir: list[str],
+    keyword: str,
+    markexpr: str,
+) -> float | None:
+    """Return the coverage threshold this run's selection has to meet.
+
+    `--cov` is in addopts, so the 100% ratchet is what a bare `uv run
+    pytest` measures rather than something only the coverage job reaches:
+    a gate that CI alone runs is one a change meets after it is pushed.
+    What that costs is this function. `fail_under` applies to every
+    report coverage writes, a partial one included, so `pytest
+    tests/bip32/bip32_test.py` would end in `Required test coverage of
+    100.0% not reached. Total coverage: 6.33%` -- true of that run and
+    saying nothing about the tree. Running one file and one test are
+    documented commands, and a gate that fails them is a gate read as
+    noise.
+
+    So a run that asked for a subset is gated at zero rather than having
+    coverage switched off: the report still prints, which is what makes
+    it worth measuring while iterating on one module. A whole run is
+    handed back `configured`, the threshold pytest-cov has already read
+    out of the coverage configuration, so pyproject.toml stays the one
+    place the number lives.
+
+    The two thresholds are two arguments because by the time any of this
+    runs they no longer agree. pytest-cov fills `cov_fail_under` from the
+    coverage configuration in `pytest_load_initial_conftests`, before
+    `pytest_configure`, so "the option is set" has stopped meaning
+    "somebody asked for it": what still means that is `config.option`,
+    which carries only what the command line and addopts put there. An
+    explicit `--cov-fail-under` is therefore `asked`, and is handed back
+    untouched whichever kind of run it is -- the caller naming the
+    threshold is the one thing this must not overrule.
+
+    A subset is what pytest was *asked* for: paths, `-k` or `-m`. Not
+    every way a run can be short -- `--lf`, `--deselect` and an `-x` that
+    stops early are not read -- so those still meet the full threshold
+    and report a shortfall the tree does not have. They are the flags of
+    an iteration whose next run is the whole suite, and reading intent
+    off all of them would make this a second definition of what a real
+    run is.
+    """
+    if asked is not None:
+        return asked
+    if file_or_dir or keyword or markexpr:
+        return 0
+    return configured
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Gate a whole run at `fail_under`, and a partial one at nothing.
+
+    The threshold is written to `known_args_namespace` and not to
+    `config.option`: pytest builds the first by parsing the known
+    arguments into a *copy* of the second, and pytest-cov holds on to
+    that copy. Writing to `config.option` instead runs without error and
+    changes nothing -- the plugin never reads it back, and the run still
+    fails on the whole tree's coverage.
+    """
+    namespace = config.known_args_namespace
+    namespace.cov_fail_under = coverage_fail_under(
+        config.option.cov_fail_under,
+        namespace.cov_fail_under,
+        config.option.file_or_dir,
+        config.option.keyword,
+        config.option.markexpr,
+    )
 
 
 @pytest.fixture

--- a/tests/conftest_test.py
+++ b/tests/conftest_test.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Tests for the golden-file check the suite's own fixture runs.
+"""Tests for the golden-file check and the coverage gate of conftest.
 
 Eleven modules compare a `to_dict()` against a committed json through
 `json_golden`, and the two paths that report a difference are the ones a
@@ -10,15 +10,23 @@ passing suite never takes: a golden that is missing and a golden that
 does not match. They are the reason the fixture exists, so they are
 tested here, against a tmp_path -- the source tree is what this check
 stopped writing into, and a test of it must not put that back.
+
+`coverage_fail_under` is the other one a passing suite cannot exercise
+on its own: the run that reaches it with a subset selected is, by
+construction, not the run that measures this file. The position of
+`--cov` in addopts is here for the same reason -- it is a property of
+the command line no run of that command line can report on.
 """
 
+import re
 from pathlib import Path
 
 import pytest
 
-from tests.conftest import REGENERATE, check_golden
+from tests.conftest import REGENERATE, check_golden, coverage_fail_under
 
 MODULE = "something_test.py"
+_ROOT = Path(__file__).parents[1]
 
 
 @pytest.fixture(autouse=True)
@@ -106,3 +114,74 @@ def test_regenerating_overwrites_a_mismatch(
     # property that makes regenerating leave no diff of its own
     monkeypatch.delenv(REGENERATE)
     check_golden(path, "net.json", {"a": 2}, MODULE)
+
+
+def test_a_whole_run_is_gated_at_what_pyproject_configured() -> None:
+    """No selection: the ratchet applies, and it is not restated here.
+
+    The number comes back as it was handed in, which is the property
+    worth pinning: pyproject.toml is where 100 is decided, and a copy of
+    it in this file would be a second place to change it.
+    """
+    assert coverage_fail_under(None, 100.0, [], "", "") == 100.0
+    assert coverage_fail_under(None, 42.0, [], "", "") == 42.0
+
+
+@pytest.mark.parametrize(
+    "file_or_dir, keyword, markexpr",
+    [
+        (["tests/bip32/bip32_test.py"], "", ""),
+        (["tests/bip32"], "", ""),
+        ([], "derive", ""),
+        ([], "", "integration"),
+        (["tests/bip32"], "derive", "integration"),
+    ],
+    ids=["one file", "one directory", "-k", "-m", "all three"],
+)
+def test_a_selected_subset_is_gated_at_nothing(
+    file_or_dir: list[str], keyword: str, markexpr: str
+) -> None:
+    """Any of the three selections drops the threshold to zero.
+
+    Zero and not None: None is what pytest-cov reads the configured
+    threshold into, so it would restore the very gate this removes.
+    """
+    assert coverage_fail_under(None, 100.0, file_or_dir, keyword, markexpr) == 0
+
+
+def test_cov_is_not_the_last_token_of_addopts() -> None:
+    """`--cov` last in addopts eats the first argument of the command.
+
+    It takes an optional value, so as the final token it is handed
+    whatever the command line goes on to say: `pytest
+    tests/ecc/dsa_test.py` became `--cov=tests/ecc/dsa_test.py`, leaving
+    no path to select on. The whole suite then ran, measured a directory
+    `omit` excludes, and reported 0.00% against a `fail_under` of 100 --
+    which is how the regtest job, whose command is `pytest
+    tests/integration`, went red on a branch that had touched none of it.
+
+    `pytest -q tests/...` hides it, a token starting with `-` not being
+    consumed, so the habitual spelling is green and the documented one is
+    not. Nothing about a run reports its own addopts, which is why this
+    reads the file: anywhere but last is safe, and the assertion is that
+    weak on purpose -- the order of the rest is nobody's business here.
+    """
+    text = (_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'^addopts = "(.*)"$', text, re.MULTILINE)
+    assert match, "pyproject.toml has no single-line 'addopts = \"...\"'"
+
+    addopts = match.group(1).split()
+    assert "--cov" in addopts, "the local coverage gate is --cov in addopts"
+    assert addopts[-1] != "--cov", (
+        "--cov is the last token of addopts, so it will swallow the first "
+        "positional argument of any command line that has one"
+    )
+
+
+def test_an_explicit_threshold_survives_either_kind_of_run() -> None:
+    """`--cov-fail-under` is the caller's, and outranks both branches."""
+    assert coverage_fail_under(90.0, 100.0, ["tests/bip32"], "", "") == 90.0
+    assert coverage_fail_under(90.0, 100.0, [], "", "") == 90.0
+    # zero is a threshold somebody asked for, not a missing answer: it
+    # has to survive the `is not None` test rather than be falsy
+    assert coverage_fail_under(0, 100.0, [], "", "") == 0


### PR DESCRIPTION
The 100% threshold was enforced by the `coverage` job alone, so a change
met it after being pushed rather than before. [#616](https://github.com/btclib-org/btclib/pull/616)
is the demonstration: the whole suite, every pre-commit hook and the
sphinx `-W` build were green locally, and CI was red for one line of a
new test that a passing run never executes.

## What changes

`--cov` moves into pytest's addopts, so a bare `uv run pytest` measures
and gates. It cost nothing to move — 36.74 s without and 36.65 s with,
measured twice on a quiet machine, coverage.py using `sys.monitoring` on
the 3.14 `.python-version` pins. The flag stays spelled out in
CONTRIBUTING.md's coverage-job command, that being the job's command
verbatim.

## Where it sits in that string is load-bearing

`--cov` takes an **optional** value, so as the last token it is handed
the first thing the command line goes on to say. `pytest
tests/ecc/dsa_test.py` became `--cov=tests/ecc/dsa_test.py` with no path
left to select on: the whole suite ran, measured a directory `omit`
excludes, and reported `0.00%` against a `fail_under` of 100 — which is
how the regtest job (`pytest tests/integration`) went red on a branch
that touches nothing it runs.

`pytest -q tests/...` hides it, a token starting with `-` not being
consumed, so the habitual spelling was green and the two documented ones
were not. `--cov` is second now, and
`test_cov_is_not_the_last_token_of_addopts` reads the file and asserts
that one property — no run can report its own addopts. Its name is
spelled the long way round because the `typos` hook rewrites a singular
`addopt` to `adopt`, in place and in a test name.

## The other price, and where it is paid

`fail_under` applies to a partial report too, so
`pytest tests/bip32/bip32_test.py` would end in `Required test coverage
of 100.0% not reached. Total coverage: 6.33%` — true of that run, silent
about the tree.

`coverage_fail_under` in `tests/conftest.py` answers it: a run that
**selects a subset** — paths, `-k`, `-m` — is gated at zero and still
reports, which is what makes measuring worthwhile while iterating on one
module. Not by switching coverage off, which would throw the report away
with the gate; and not by setting `None`, which is the value pytest-cov
reads the configured threshold into and would put the gate straight back.

## Three deliberate limits

- **`--lf`, `--deselect` and an early `-x` are not read.** They shorten a
  run without asking for a subset, so they keep the full threshold and
  can report a shortfall the tree does not have. Reading intent off all
  of them would make conftest a second definition of what a real run is.
- **An explicit `--cov-fail-under` outranks both branches** — the caller
  naming the number.
- **The threshold is written to `config.known_args_namespace`, not to
  `config.option`.** pytest builds the first by parsing the known
  arguments into a *copy* of the second; pytest-cov takes that copy in
  `pytest_load_initial_conftests` and never reads the other. The obvious
  spelling runs clean and changes nothing — it is how the first attempt
  here passed its own review and failed the behaviour.

A second trap behind the same one: by `pytest_configure` the option is
already non-`None`, pytest-cov having filled it from the coverage config
before conftest is reached. So "somebody asked for a threshold" cannot be
read off it, and `config.option` — which carries only what the command
line and addopts put there — is what the function takes as `asked`.

## Verified by exit code, not by reading output

| run | rc | result |
| --- | --- | --- |
| `pytest` (tree at 100%) | 0 | `Required test coverage of 100.0% reached`, 18578 passed |
| `pytest --deselect …::test_derive` | 1 | `Coverage failure: total of 99.72 is less than fail-under=100.00` |
| `pytest tests/ecc/dsa_test.py` | 0 | 433 tests, not the whole suite; no gate line |
| `pytest tests/integration --junitxml=…` | 0 | its 6, no gate line |
| `pytest -k test_low_cardinality` | 0 | 9 tests, no gate line |
| `pytest --cov-fail-under=99 tests/bip32/bip32_test.py` | 1 | `Required test coverage of 99% not reached` |

Rows three and four are the regression the last two commits fixed; row
two is also the demonstration that `--deselect` keeps the full threshold,
as documented above.

Both branches of `coverage_fail_under` are unit-tested in
`tests/conftest_test.py` — the one that matters is unreachable from a
whole run by construction, which is the same reason `check_golden` is
tested there.

## Docs

CLAUDE.md (the commands, and a bullet under the non-obvious facts),
CONTRIBUTING.md, `tests/README.md` and CHANGELOG.md.

## Gates

`uv run pytest` (18578 passed, 6 skipped, 100.00%, rc 0),
`uv run pre-commit run --all-files` (rc 0), the sphinx `-W` build (rc 0),
and the coverage job's command verbatim (rc 0).
