### PR TITLE
Read the parity of a y already in hand, without lifting its x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -562,6 +562,29 @@ documented at release-notes length in the first place, and are still in
   `CurveGroup.y`/`y_even` are still reached directly from
   `script.taproot` and `ecc.pedersen`, each with its own answer to
   whether it wants a coordinate or a predicate.
+- **The parity of a y in hand is a `%`, not a lift** (#619).
+  `_tweaked_prvkey` decided whether BIP341 wants the internal key
+  negated with `ec.y_even(P[0]) == P[1]`: a modular square root taking
+  the x of a point back to that point, to compare the y it recovers with
+  the y sitting beside it. `P[1] % 2 == 0` is the question, 0.032 µs
+  against 74.561 (min of nine repeats, secp256k1).
+
+  Unlike #615 and #288 this is a deletion and not a delegation, which is
+  what makes it worth having: the line is in the Python fallback,
+  reached when `_libsecp256k1_applicable` is False, so it is the one path
+  no amount of dispatching could have helped. Nothing changes for
+  secp256k1 with the bindings present, where `xonly.prvkey_tweak_add`
+  answers the whole function.
+
+  The two spellings agree on every point of the eight low-cardinality
+  curves and on the first 199 multiples of G on secp256r1 and secp256k1,
+  and differ on exactly one input: the infinity btclib writes as
+  `y == 0`, which `is_on_curve` accepts and `y_even` has no answer for.
+  `mult` of a key `int_from_prv_key` has refused zero for cannot be it,
+  so that is a comment rather than a guard.
+  `test_the_python_prvkey_tweak_lifts_nothing` patches `mod_sqrt` to
+  raise and runs both parities, the branch being the one that decides a
+  negation.
 
 ### The public API and the module layout
 

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -330,7 +330,15 @@ def _tweaked_prvkey(internal_prvkey: int, h: bytes, ec: Curve) -> int:
         return int.from_bytes(tweaked, "big")
 
     P = mult(internal_prvkey)
-    has_even_y = ec.y_even(P[0]) == P[1]
+    # the parity of a y already in hand: ec.y_even(P[0]) lifted the x
+    # back to the point P is -- 74.6 us of modular square root against
+    # 0.03 -- to compare its y with the one beside it (issue 619). Not a
+    # delegation but a deletion, which is what this path needed: it runs
+    # where the bindings do not, so there was nothing here to dispatch
+    # to. The two spellings differ on the infinity btclib writes as
+    # y == 0, and mult of a key int_from_prv_key has refused zero for
+    # cannot be it
+    has_even_y = P[1] % 2 == 0
     internal_prvkey = internal_prvkey if has_even_y else ec.n - internal_prvkey
     t = _tap_tweak(P[0].to_bytes(32, "big"), h, ec)
     return (internal_prvkey + t) % ec.n

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -18,7 +18,7 @@ import pytest
 
 from btclib import b32
 from btclib.alias import ScriptList
-from btclib.curves import bytes_from_point, mult
+from btclib.curves import bytes_from_point, curve_group, mult
 from btclib.exceptions import BTClibValueError
 from btclib.script import (
     TaprootScriptTree,
@@ -130,6 +130,45 @@ def test_the_python_tweak_is_the_bindings_tweak(
             no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
             assert output_pubkey(pub_key, script_tree) == delegated
             assert output_prvkey(prv_key, script_tree) == delegated_prvkey
+
+
+@pytest.mark.parametrize(
+    "prv_key, parity", [(0xC0FFEE, 1), (3, 0)], ids=["odd y", "even y"]
+)
+def test_the_python_prvkey_tweak_lifts_nothing(
+    prv_key: int, parity: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The internal key's parity is read off its y, not recomputed.
+
+    BIP341 negates the key whose public point has an odd y, and the
+    point is one `mult` has just returned: the y is in hand, so the
+    parity is a `%` and not a lift of the x back to the point it came
+    from (issue 619). What pins that is reaching no modular square root
+    at all, which is stronger than a stopwatch and does not depend on
+    the machine: mod_sqrt is patched to raise.
+
+    Both parities, because the branch this reads decides a negation:
+    with only the even key the answer would be right for a run that
+    never took it. The parity is asserted rather than trusted to the
+    id, a key whose point moved being a test that stopped testing.
+
+    The Python path is what the patch reaches -- the bindings answer the
+    whole tweak for secp256k1, and taproot is defined over no other
+    curve -- and its answer still has to be the bindings' answer.
+    """
+    assert mult(prv_key)[1] % 2 == parity
+    delegated = [output_prvkey(prv_key, tree) for tree in SCRIPT_TREES]
+
+    def refuse(*_: object) -> int:
+        raise AssertionError(  # pragma: no cover
+            "the internal point's x was lifted to read a parity"
+        )
+
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
+        no_bindings.setattr(curve_group, "mod_sqrt", refuse)
+        for tree, expected in zip(SCRIPT_TREES, delegated, strict=True):
+            assert output_prvkey(prv_key, tree) == expected
 
 
 def test_the_python_commitment_check_is_the_bindings_one(


### PR DESCRIPTION
Closes #619.

`_tweaked_prvkey` decided whether BIP341 wants the internal key negated
with `ec.y_even(P[0]) == P[1]`: a modular square root taking the x of a
point back to the point it came from, so that the y it recovers can be
compared with the y sitting beside it. The y was never missing.

| | |
| --- | --- |
| `ec.y_even(P[0]) == P[1]` | 74.561 µs |
| `P[1] % 2 == 0` | 0.032 µs |

min of nine repeats, secp256k1.

## Why this one is worth more than the ratio

Unlike [#615](https://github.com/btclib-org/btclib/pull/616) and issue
#288 this is a **deletion, not a delegation**. The line sits in the
Python fallback, taken when `_libsecp256k1_applicable` is False, so it is
the one path no amount of dispatching could ever have reached — a curve
with no bindings behind it pays this root today and would still pay it
after any amount of it. For secp256k1 with the bindings present nothing
changes: `xonly.prvkey_tweak_add` answers the whole function above.

## That the two agree

Checked, not argued: every point of the eight low-cardinality curves of
`tests/curves/curve_group_test.py`, plus the first 199 multiples of G on
secp256r1 and secp256k1 — 542 points, same answer.

They part on exactly one input, and it is not a point:

```
INF = (5, 0)
ec.y_even(INF[0]) == INF[1]  ->  False
INF[1] % 2 == 0              ->  True
```

btclib writes the affine infinity as `y == 0` and `is_on_curve` accepts
any such pair, so an exhaustive sweep hands it over as though it were a
point. Here it cannot arrive: `P = mult(internal_prvkey)` with
`internal_prvkey` from `int_from_prv_key`, which refuses zero. That is a
comment in the code rather than a guard.

## How it is pinned

`test_the_python_prvkey_tweak_lifts_nothing` patches `mod_sqrt` to raise
and asserts the answer still comes back and still equals the bindings'.
Verified to fail on `main`'s code, with the assertion the patch raises,
for both parametrizations.

Both parities, the branch being the one that decides a negation: with the
even key alone the test would pass over a negation it never performed.
The parity is asserted rather than left to the parametrize id — a key
whose point moved would otherwise be a test that quietly stopped testing.

## Not touched

`_tweaked_pubkey`, a few lines above, also calls `ec.y_even`, and there
the lift is real: the x-only key has to become a point before `ec.add`.

This line is also entangled with issue #618, which removes taproot's `ec`
parameter; whichever of the two lands second rebases over one line.

## Gates

`uv run pytest` (18572 passed, 6 skipped, rc 0), the coverage job's
command (100.00%, rc 0), `uv run pre-commit run --all-files` (rc 0), and
the sphinx `-W` build (rc 0).

## Summary by Sourcery

Optimize taproot private key tweaking by reading the internal point’s y parity directly instead of recomputing it via modular square root in the Python fallback path.

Enhancements:
- Simplify and speed up `_tweaked_prvkey` by replacing the modular square-root based parity check with a direct y-parity computation for the internal public point in the Python implementation.

Documentation:
- Document the taproot private-key tweak parity change and its rationale in the changelog, including performance and correctness notes for the Python fallback.

Tests:
- Add a taproot test ensuring the Python private-key tweak does not perform modular square roots and still matches the libsecp256k1-backed implementation across both y parities.