### PR TITLE
Take no curve where BIP341 defines none

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -588,6 +588,40 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **Taproot takes no curve** (#618). `output_pubkey`,
+  `output_pubkey_from_merkle_root`, `output_prvkey`,
+  `output_prvkey_from_merkle_root` and `check_output_pubkey` ended in
+  `ec: Curve = secp256k1`, and none of the arithmetic behind them used
+  it. `mult(m)` defaults to secp256k1 and its generator, so
+  `_tweaked_pubkey` added a point of secp256k1 to a point of the
+  caller's curve and `_tweaked_prvkey` derived the internal point from
+  the wrong generator; `check_output_pubkey` did not even pretend,
+  naming `secp256k1` twice in a line reached for secp256k1 as well.
+  `_tweaked_prvkey(12345, b"", CURVES["secp256r1"])` therefore answered
+  with a number -- silently, computed against one curve and reduced
+  modulo another's `n` -- where the pubkey half at least raised `point
+  not on curve`.
+
+  Not honoured, because there is nothing to honour: BIP341 defines
+  taproot for secp256k1 and for no other curve, so "the taproot output
+  key" of secp256r1 names nothing this library could be right or wrong
+  about. None of the 57 call sites in `btclib/` and `tests/` passed a
+  curve. `secp256k1` is written out at each use instead, which is what
+  `btclib.bip32.bip32.ec` was replaced by for the same reason, and it is
+  a breaking change: HISTORY.md carries the bullet.
+
+  Two consequences worth naming. `_libsecp256k1_applicable(secp256k1)`
+  is now a constant, and the three guards keep the call rather than
+  saying so: it is the seam the suite patches to reach the Python
+  arithmetic, which is the reference implementation the bindings are
+  checked against and no longer a path any caller can take. And
+  `test_tweak_above_group_order` reached BIP341's `t >= n` refusal by
+  passing a toy curve, a 256-bit tweak always exceeding its order; on
+  secp256k1 that guard is a 2**-128 accident, so the test patches
+  `taproot.secp256k1` instead -- covering it by patching what stands in
+  the way, as CONTRIBUTING.md asks, rather than by a `pragma`. The same
+  toy curve does the same work from the other side of the call, and
+  `_tap_tweak` raises before any arithmetic can see the substitution.
 - **`psbt_signer.SignerDecorator` is a signer wrapping a signer** (#600).
   It forwards the five methods of the contract to the signer it holds, so
   that a caller adding one rule in front of `sign_psbt` -- a whitelist of

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,6 +29,16 @@ full year, short month, short day (YYYY-M-D)
   `UserWarning` has to catch `BTClibValueError` instead. The catalogued
   curves are unaffected: they are built with `weakness_check=False`, the
   check having been paid once in `test_catalogued_curves`.
+- **taproot takes no curve.** `output_pubkey`,
+  `output_pubkey_from_merkle_root`, `output_prvkey`,
+  `output_prvkey_from_merkle_root` and `check_output_pubkey` used to end
+  in `ec: Curve = secp256k1`, and a caller passing one positionally --
+  `output_pubkey(internal_key, script_tree, ec)`,
+  `check_output_pubkey(q, script, control, ec)` -- now gets a
+  `TypeError`. Dropping the argument is the whole of the change: BIP341
+  is defined for secp256k1 alone, and the parameter was never honoured,
+  the arithmetic behind it having always used secp256k1's generator
+  whatever was passed.
 
 ## v2026.8.9
 

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -27,7 +27,7 @@ from btclib.alias import (
     TaprootLeafPaths,
     TaprootScriptTree,
 )
-from btclib.curves import Curve, bytes_from_prv_key_int, mult, secp256k1
+from btclib.curves import bytes_from_prv_key_int, mult, secp256k1
 from btclib.curves.curve import _libsecp256k1_applicable, _y_even
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import tagged_hash
@@ -207,7 +207,7 @@ def _tree_helper(script_tree: TaprootScriptTree) -> tuple[TaprootLeafPaths, byte
     return ([((leaf_version, script), b"")], h)
 
 
-def _tap_tweak(pub_key: bytes, h: bytes, ec: Curve) -> int:
+def _tap_tweak(pub_key: bytes, h: bytes) -> int:
     """Return the BIP341 tweak an x-only key and a tree hash commit to.
 
     One function for the three tweaks, the two that build an output and
@@ -216,7 +216,7 @@ def _tap_tweak(pub_key: bytes, h: bytes, ec: Curve) -> int:
     """
     t = int.from_bytes(tagged_hash(b"TapTweak", pub_key + h), "big")
     # BIP341: fail if t is not smaller than the group order
-    if t >= ec.n:
+    if t >= secp256k1.n:
         raise BTClibValueError("Invalid script tree hash")
     return t
 
@@ -224,7 +224,6 @@ def _tap_tweak(pub_key: bytes, h: bytes, ec: Curve) -> int:
 def output_pubkey(
     internal_pubkey: Key | None = None,
     script_tree: TaprootScriptTree | None = None,
-    ec: Curve = secp256k1,
 ) -> tuple[bytes, int]:
     """Return a taproot output key and its parity, per BIP341.
 
@@ -245,34 +244,41 @@ def output_pubkey(
         _, h = tree_helper(script_tree)
     else:
         h = b""
-    return _tweaked_pubkey(pub_key, h, ec)
+    return _tweaked_pubkey(pub_key, h)
 
 
-def _tweaked_pubkey(pub_key: bytes, h: bytes, ec: Curve) -> tuple[bytes, int]:
+def _tweaked_pubkey(pub_key: bytes, h: bytes) -> tuple[bytes, int]:
     """Return the x-only key an internal key tweaked by h, and its parity.
 
     The half of BIP341's output key that does not care where h came
     from: a tree the caller built, or the merkle root a psbt carries.
     """
-    t = _tap_tweak(pub_key, h, ec)
+    t = _tap_tweak(pub_key, h)
 
     # secp256k1_xonly_pubkey_tweak_add is this very operation, parity
     # included, and it answers the pair this function returns. 12.0 us
     # against 109.3 for the three lines below, over 2000 tweaks: the
-    # Python path lifts the x-only key to a point with
-    # ec.y_even, i.e. a modular square root, which is 74 us of that on
-    # its own -- while libsecp256k1 needs no such lift, having the
-    # y coordinate as it goes
-    if _libsecp256k1_applicable(ec):
+    # Python path lifts the x-only key to a point with secp256k1.y_even,
+    # i.e. a modular square root, which is 74 us of that on its own --
+    # while libsecp256k1 needs no such lift, having the y coordinate as
+    # it goes.
+    #
+    # The predicate is a constant now that the curve is, and the three
+    # guards in this module keep it rather than saying so: it is the
+    # seam the suite patches -- taproot._libsecp256k1_applicable set to
+    # False -- to reach the Python arithmetic below, which is the
+    # reference implementation the bindings are checked against and not
+    # a path any caller takes. Stated here for all three
+    if _libsecp256k1_applicable(secp256k1):
         return libsecp256k1_xonly.tweak_add(pub_key, t)
 
     P_x = int.from_bytes(pub_key, "big")
-    Q = ec.add((P_x, ec.y_even(P_x)), mult(t))
+    Q = secp256k1.add((P_x, secp256k1.y_even(P_x)), mult(t))
     return Q[0].to_bytes(32, "big"), Q[1] % 2
 
 
 def output_pubkey_from_merkle_root(
-    internal_pubkey: Octets, merkle_root: Octets = b"", ec: Curve = secp256k1
+    internal_pubkey: Octets, merkle_root: Octets = b""
 ) -> tuple[bytes, int]:
     """Return a taproot output key from a merkle root, per BIP341.
 
@@ -289,13 +295,12 @@ def output_pubkey_from_merkle_root(
     reached them in.
     """
     internal_pubkey = bytes_from_octets(internal_pubkey, 32)
-    return _tweaked_pubkey(internal_pubkey, bytes_from_octets(merkle_root), ec)
+    return _tweaked_pubkey(internal_pubkey, bytes_from_octets(merkle_root))
 
 
 def output_prvkey(
     prv_key: PrvKey,
     script_tree: TaprootScriptTree | None = None,
-    ec: Curve = secp256k1,
 ) -> int:
     """Return the private key of the taproot output key, per BIP341.
 
@@ -305,10 +310,10 @@ def output_prvkey(
     exactly.
     """
     h = tree_helper(script_tree)[1] if script_tree else b""
-    return _tweaked_prvkey(int_from_prv_key(prv_key), h, ec)
+    return _tweaked_prvkey(int_from_prv_key(prv_key), h)
 
 
-def _tweaked_prvkey(internal_prvkey: int, h: bytes, ec: Curve) -> int:
+def _tweaked_prvkey(internal_prvkey: int, h: bytes) -> int:
     """Return the private key an internal one tweaked by h.
 
     The private half of `_tweaked_pubkey`, h coming from the same two
@@ -323,30 +328,28 @@ def _tweaked_prvkey(internal_prvkey: int, h: bytes, ec: Curve) -> int:
     # for themselves: 32.0 us against 82.3 over 2000 tweaks, the
     # difference being the point this path never materializes and
     # the square root it never takes to check that point's parity
-    if _libsecp256k1_applicable(ec):
-        pub_key = bytes_from_prv_key_int(internal_prvkey, ec)[1:]
-        t = _tap_tweak(pub_key, h, ec)
+    if _libsecp256k1_applicable(secp256k1):
+        pub_key = bytes_from_prv_key_int(internal_prvkey, secp256k1)[1:]
+        t = _tap_tweak(pub_key, h)
         tweaked = libsecp256k1_xonly.prvkey_tweak_add(internal_prvkey, t)
         return int.from_bytes(tweaked, "big")
 
     P = mult(internal_prvkey)
-    # the parity of a y already in hand: ec.y_even(P[0]) lifted the x
-    # back to the point P is -- 74.6 us of modular square root against
-    # 0.03 -- to compare its y with the one beside it (issue 619). Not a
-    # delegation but a deletion, which is what this path needed: it runs
-    # where the bindings do not, so there was nothing here to dispatch
-    # to. The two spellings differ on the infinity btclib writes as
-    # y == 0, and mult of a key int_from_prv_key has refused zero for
-    # cannot be it
+    # the parity of a y already in hand: secp256k1.y_even(P[0]) lifted
+    # the x back to the point P is -- 74.6 us of modular square root
+    # against 0.03 -- to compare its y with the one beside it (issue
+    # 619). Not a delegation but a deletion, which is what this path
+    # needed: it runs where the bindings do not, so there was nothing
+    # here to dispatch to. The two spellings differ on the infinity
+    # btclib writes as y == 0, and mult of a key int_from_prv_key has
+    # refused zero for cannot be it
     has_even_y = P[1] % 2 == 0
-    internal_prvkey = internal_prvkey if has_even_y else ec.n - internal_prvkey
-    t = _tap_tweak(P[0].to_bytes(32, "big"), h, ec)
-    return (internal_prvkey + t) % ec.n
+    internal_prvkey = internal_prvkey if has_even_y else secp256k1.n - internal_prvkey
+    t = _tap_tweak(P[0].to_bytes(32, "big"), h)
+    return (internal_prvkey + t) % secp256k1.n
 
 
-def output_prvkey_from_merkle_root(
-    prv_key: PrvKey, merkle_root: Octets = b"", ec: Curve = secp256k1
-) -> int:
+def output_prvkey_from_merkle_root(prv_key: PrvKey, merkle_root: Octets = b"") -> int:
     """Return the private key of a taproot output from a merkle root.
 
     `output_prvkey` with the root already in hand, the shape
@@ -355,9 +358,7 @@ def output_prvkey_from_merkle_root(
     field, never the script tree that produced the root, a psbt naming
     a script path by its leaf and control block instead.
     """
-    return _tweaked_prvkey(
-        int_from_prv_key(prv_key), bytes_from_octets(merkle_root), ec
-    )
+    return _tweaked_prvkey(int_from_prv_key(prv_key), bytes_from_octets(merkle_root))
 
 
 def input_script_sig(
@@ -383,9 +384,7 @@ def input_script_sig(
     return script, control
 
 
-def check_output_pubkey(
-    q: Octets, script: Octets, control: Octets, ec: Curve = secp256k1
-) -> bool:
+def check_output_pubkey(q: Octets, script: Octets, control: Octets) -> bool:
     """Answer whether the control block proves the script against the key.
 
     BIP341's control-block verification: the leaf hash is folded up
@@ -411,7 +410,7 @@ def check_output_pubkey(
             k = tagged_hash(b"TapBranch", e + k)
     p_bytes = control[1:33]
     p = int.from_bytes(p_bytes, "big")
-    t = _tap_tweak(p_bytes, k, ec)
+    t = _tap_tweak(p_bytes, k)
 
     # secp256k1_xonly_pubkey_tweak_add_check is the call libsecp256k1
     # provides for this very question, and it compares the serialized
@@ -421,7 +420,7 @@ def check_output_pubkey(
     # unequal either -- b"\x00" + 32 bytes reads as the same integer the
     # comparison below makes -- so the answer for it stays the Python
     # one rather than becoming an exception
-    if _libsecp256k1_applicable(ec) and len(q) == 32:
+    if _libsecp256k1_applicable(secp256k1) and len(q) == 32:
         try:
             return libsecp256k1_xonly.tweak_add_check(q, control[0] & 1, p_bytes, t)
         except ValueError as e:
@@ -432,7 +431,7 @@ def check_output_pubkey(
             # what they raise as well as on what they answer
             raise BTClibValueError(f"invalid internal public key: {e}") from e
 
-    # _y_even, i.e. ec.y_even with the lift delegated: this is the path a
+    # _y_even, i.e. secp256k1.y_even with the lift delegated: this is the path a
     # q of any other length takes, secp256k1 included, so the modular
     # square root is worth not taking here either
     P = (p, _y_even(p, secp256k1))

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -400,25 +400,32 @@ def test_serialization() -> None:
         assert parse(serialize([x])) == [f"{x:02X}"]
 
 
-def test_tweak_above_group_order() -> None:
+def test_tweak_above_group_order(monkeypatch: pytest.MonkeyPatch) -> None:
     """BIP341 rejects a tweak t that is not below the curve order.
 
-    With secp256k1 that is a 2**-128 tagged-hash accident; a toy curve
-    makes the same guard fire deterministically, since the 256-bit
-    tweak always exceeds its order. Not output_prvkey, though: there
-    the toy curve fails earlier, on the y parity of a secp256k1 point.
+    On secp256k1 that is a 2**-128 tagged-hash accident, so the guard is
+    reached by patching what stands in the way rather than left
+    uncovered: a toy curve, whose order a 256-bit tweak always exceeds,
+    put where `_tap_tweak` reads `secp256k1.n`.
+
+    The patch replaced an `ec` argument these functions used to take
+    (issue #618). It is the same toy curve doing the same work, from the
+    other side of the call, and it stops there: `_tap_tweak` raises
+    before any arithmetic, so nothing downstream sees the substitution.
+    `output_prvkey` is still not among them, its own path reaching the y
+    parity of a secp256k1 point first.
     """
-    ec = low_card_curves["ec13_11"]
+    monkeypatch.setattr(taproot, "secp256k1", low_card_curves["ec13_11"])
     err_msg = "Invalid script tree hash"
 
     script_tree: TaprootScriptTree = [(0xC0, ["OP_1"])]
     with pytest.raises(BTClibValueError, match=err_msg):
-        output_pubkey(None, script_tree, ec)
+        output_pubkey(None, script_tree)
 
     q = bytes(31) + b"\x01"
     control = b"\xc0" + bytes(32)
     with pytest.raises(BTClibValueError, match=err_msg):
-        check_output_pubkey(q, "51", control, ec)
+        check_output_pubkey(q, "51", control)
 
 
 def test_the_element_size_limit_is_reachable_not_only_crossable() -> None:


### PR DESCRIPTION
Closes #618.

`output_pubkey`, `output_pubkey_from_merkle_root`, `output_prvkey`,
`output_prvkey_from_merkle_root` and `check_output_pubkey` ended in
`ec: Curve = secp256k1`, and none of the arithmetic behind them used it.

```python
# _tweaked_pubkey                     mult(t) is on secp256k1
Q = ec.add((P_x, ec.y_even(P_x)), mult(t))
# _tweaked_prvkey                     so is this point
P = mult(internal_prvkey)
# check_output_pubkey                 which does not even pretend
P = (p, _y_even(p, secp256k1))
Q = secp256k1.add(P, mult(t))
```

`mult(m)` defaults to secp256k1 and its generator, so the first two add
a point of secp256k1 to a point of the caller's curve. The third names
`secp256k1` twice, in a line reached for secp256k1 as well whenever `q`
is not 32 bytes — the deliberate spelling rather than an oversight.

## What a caller got

```
_tweaked_prvkey(12345, b"", CURVES["secp256r1"])
  -> 67856885919469038205338506436839711332207972226461300386890540598589929552650
_tweaked_pubkey(<x of a secp256r1 point>, b"", CURVES["secp256r1"])
  -> BTClibValueError: point not on curve
```

The first is the one that mattered: a number, silently, computed against
one curve and reduced modulo another's `n`. Nothing caught it — the suite
reaches those lines through `no_bindings`, which patches the dispatch off
while leaving `ec == secp256k1`, where `mult(t)` happens to be right.

## Removed rather than honoured

BIP341 defines taproot for secp256k1 and no other curve, so "the taproot
output key" of secp256r1 names nothing this library could be right or
wrong about. None of the 57 call sites in `btclib/` and `tests/` passed
one. `secp256k1` is written out at each use instead — what
`btclib.bip32.bip32.ec` was replaced by, for the same reason.

Breaking: HISTORY.md carries the bullet, the "before" spelling checked
against `v2026.8.9`, where all five signatures still have it.

## Two consequences worth naming

**`_libsecp256k1_applicable(secp256k1)` is a constant now.** The three
guards keep the call rather than saying so: it is the seam the suite
patches to reach the Python arithmetic, which is the reference
implementation the bindings are checked against and no longer a path any
caller can take. Stated once, at the first of the three.

**`test_tweak_above_group_order` lost its handle.** It reached BIP341's
`t >= n` refusal by passing a toy curve, whose order a 256-bit tweak
always exceeds; on secp256k1 that guard is a 2⁻¹²⁸ tagged-hash accident.
With the argument gone the test patches `taproot.secp256k1` instead —
covering it by patching what stands in the way, as CONTRIBUTING.md asks,
rather than by a `pragma` over a consensus rule. The same toy curve doing
the same work from the other side of the call, and `_tap_tweak` raises
before any arithmetic can see the substitution.

## Rebased over #620

Issue #619's parity fix landed in `dfa68437` while this was being
written, and the two touch adjacent lines in `_tweaked_prvkey`. Resolved
in favour of both: the parity stays `P[1] % 2 == 0`, and the comment
above it now names `secp256k1.y_even` as what it replaced, there being no
`ec` left to name.

## Gates

`uv run pytest` (18580 passed, 6 skipped, 100.00%, rc 0),
`uv run pre-commit run --all-files` (rc 0), and the sphinx `-W` build
(rc 0).

## Summary by Sourcery

Align taproot script/key utilities strictly with BIP341 by hardcoding secp256k1 usage and removing the unused curve parameter from the public API.

Bug Fixes:
- Ensure taproot key tweaking and verification always operate on secp256k1 to prevent mixed-curve arithmetic and silent miscomputations when a different curve was passed.

Enhancements:
- Treat `_libsecp256k1_applicable(secp256k1)` as a constant and retain the libsecp256k1 fast path as a test seam for the Python reference implementation.
- Update the taproot tweak-above-group-order test to reach the `t >= n` guard by patching `taproot.secp256k1` instead of passing a toy curve argument.

Documentation:
- Document the taproot curve-parameter removal and its implications as a breaking change in CHANGELOG and HISTORY.