### PR TITLE
Refuse an r with the predicate, not with the lift it made expensive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -585,6 +585,30 @@ documented at release-notes length in the first place, and are still in
   `test_the_python_prvkey_tweak_lifts_nothing` patches `mod_sqrt` to
   raise and runs both parities, the branch being the one that decides a
   negation.
+- **Refusing a BIP340 r no longer costs more than verifying a good
+  signature** (#622). `ssa.Sig.assert_valid` asked whether r is an
+  x-coordinate by lifting it with `_y_even` and dropping the y. That is
+  the delegated lift, 2.9 µs against 75, on the *accepting* path only:
+  `_y_even` falls back to `ec.y_even` for an x the bindings refuse,
+  since that is where the message naming the value comes from, so a
+  refusal paid the whole Python square root. `Sig.parse` of a bad r was
+  78.70 µs and `verify_` of one 78.75, against the 22.43 of verifying a
+  good signature — the expensive answer for the cheap input, half of the
+  field elements being no x-coordinate and costing nothing to produce.
+  `_is_x_coordinate` makes both 3.8 µs. The accepting path saves 0.65 µs,
+  3% of a verification, and is not the reason.
+
+  The refusal is `Sig`'s to phrase now, which is the second half of the
+  change rather than its price: `r is not a valid x-coordinate: '0x…'`
+  says which of the two fields is wrong where `invalid x-coordinate` did
+  not, and matches the `scalar s not in 0..n-1` immediately below it and
+  the sentence `dsa.Sig` already phrases for the same reason — without
+  its `(congruent to)`, r being a field element here and not a scalar
+  reduced mod n. Two messages become one: an r outside the field used to
+  come back as `ec.y`'s `x-coordinate not in 0..p-1`, and `dsa.Sig`
+  already collapses that distinction.
+  `test_refusing_an_r_takes_no_square_root` patches `mod_sqrt` to raise
+  over five r, both kinds included.
 
 ### The public API and the module layout
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -65,6 +65,7 @@ from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
 from btclib.bip32 import BIP32Key
 from btclib.curves import Curve, secp256k1
 from btclib.curves.curve import (
+    _is_x_coordinate,
     _jac_double_mult,
     _libsecp256k1_applicable,
     _y_even,
@@ -150,13 +151,27 @@ class Sig:
     def assert_valid(self) -> None:
         """Refuse an r that is no x-coordinate, or an s outside 0..n-1."""
         # r is a field element, fail if r is not a valid x-coordinate.
-        # Asking for the y is how that is asked, and the y is discarded:
-        # BIP340 fixes it even, and verification recomputes the point from
-        # the scalars rather than lifting this r. Through the delegating
-        # lift of curves.curve, 2.9 us against 75 -- and no congruence
-        # loop, r being a field element here and not a scalar reduced mod
-        # n as it is in dsa.Sig
-        _y_even(self.r, self.ec)
+        # The question is existence: BIP340 fixes the y even, and
+        # verification recomputes the point from the scalars rather than
+        # lifting this r, so _is_x_coordinate and not the _y_even that
+        # was here (issue 622). The delegated lift was already 2.9 us
+        # against 75 on the accepting path, and 0.65 of that is not the
+        # reason: _y_even falls back to ec.y_even for an x the bindings
+        # refuse -- that being where the message naming the value comes
+        # from -- so refusing cost the whole Python square root, 78.7 us
+        # against the 22.4 of verifying a good signature. The expensive
+        # answer was the one an attacker picks, half of the field
+        # elements being no x-coordinate and costing nothing to produce.
+        #
+        # A bool leaves the message here, which is where it belongs: r is
+        # this signature's, and "invalid x-coordinate" did not say which
+        # of the two fields was wrong. dsa.Sig phrases its own for the
+        # same reason, with the congruence this one has no use for -- r
+        # is a field element here, not a scalar reduced mod n
+        if not _is_x_coordinate(self.r, self.ec):
+            err_msg = "r is not a valid x-coordinate: "
+            err_msg += f"'{hex_string(self.r)}'" if self.r > 0xFFFFFFFF else f"{self.r}"
+            raise BTClibValueError(err_msg)
 
         # s is a scalar, fail if s is not in [0, n-1]
         if not 0 <= self.s < self.ec.n:

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -14,7 +14,7 @@ from btclib_libsecp256k1 import ssa as libsecp256k1_ssa
 
 from btclib.alias import INF, Point, String
 from btclib.bip32 import BIP32KeyData
-from btclib.curves import bytes_from_point, double_mult, mult, secp256k1
+from btclib.curves import bytes_from_point, curve_group, double_mult, mult, secp256k1
 from btclib.curves.curve import CURVES, Curve
 from btclib.curves.curve_group import jac_from_aff
 from btclib.ecc import second_generator, ssa
@@ -75,7 +75,11 @@ def test_signature() -> None:
 
     sig_invalid = ssa.Sig(sig.ec.p, sig.s, check_validity=False)
     assert not ssa.verify(msg, x_Q, sig_invalid)
-    err_msg = "x-coordinate not in 0..p-1: "
+    # r outside the field and r inside it with no point are one refusal
+    # now, phrased by Sig rather than by the lift it no longer takes
+    # (issue 622): "x-coordinate not in 0..p-1" was ec.y's, reached
+    # through _y_even, and a predicate has no such message to pass on
+    err_msg = "r is not a valid x-coordinate: "
     with pytest.raises(BTClibValueError, match=err_msg):
         ssa.assert_as_valid(msg, x_Q, sig_invalid)
 
@@ -192,6 +196,44 @@ def test_parse_takes_64_bytes_and_no_other_number(
         err_msg = f"{length - 64} bytes after the BIP340 signature"
     with pytest.raises(BTClibValueError, match=err_msg):
         ssa.Sig.parse(truncated_or_extended, check_validity=check_validity)
+
+
+@pytest.mark.parametrize(
+    "r",
+    [5, secp256k1.p - 1, secp256k1.p, secp256k1.p + 1, 2**256],
+    ids=["no point has it", "the last field element", "p", "p + 1", "above 2**256"],
+)
+def test_refusing_an_r_takes_no_square_root(
+    r: int, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The r of a signature is refused by a predicate, not by a lift.
+
+    Refusing used to cost more than verifying: `_y_even` falls back to
+    `ec.y_even` for an x the bindings reject, that being where the
+    message naming the value came from, so a bad r paid the whole Python
+    square root -- 78.7 us against the 22.4 of verifying a good
+    signature (issue 622). Half of the field elements are no
+    x-coordinate and cost nothing to produce, so that was the expensive
+    answer for the cheap input.
+
+    mod_sqrt is patched to raise rather than timed: what the change has
+    to be is a refusal that reaches no square root, on this machine and
+    on a loaded one alike.
+
+    Five r, because the refusal now covers two messages that used to be
+    distinct: `invalid x-coordinate` for a field element no point has,
+    and `x-coordinate not in 0..p-1` for one outside the field, which
+    `Sig` never phrased itself. p - 1 is the last r that is inside it.
+    """
+
+    def refuse(*_: object) -> int:
+        raise AssertionError(  # pragma: no cover
+            "an r was lifted to a point in order to refuse it"
+        )
+
+    monkeypatch.setattr(curve_group, "mod_sqrt", refuse)
+    with pytest.raises(BTClibValueError, match="r is not a valid x-coordinate: "):
+        ssa.Sig(r, 1)
 
 
 def test_the_sighash_type_of_a_witness_signature_is_the_callers() -> None:


### PR DESCRIPTION
Closes #622.

`ssa.Sig.assert_valid` asked whether r is an x-coordinate by lifting it
with `_y_even` and dropping the y. The comment beside it said the lift
was delegated, 2.9 µs against 75 — true of the **accepting** path only.
`_y_even` falls back to `ec.y_even` for an x the bindings refuse, that
being where the message naming the value comes from, so a refusal paid
the whole Python square root.

Which put the two costs the wrong way round. secp256k1, min of seven
repeats:

| | as on main | with the predicate | |
| --- | --- | --- | --- |
| `Sig.parse`, valid r | 3.77 µs | 3.12 µs | 1.2x |
| **`Sig.parse`, invalid r** | **78.70 µs** | 3.76 µs | **21x** |
| `verify_`, good signature | 22.43 µs | 21.73 µs | 1.0x |
| **`verify_`, invalid r** | **78.75 µs** | 3.78 µs | **21x** |

Refusing garbage cost **3.5x what verifying a real signature does**.
Half of the field elements are no x-coordinate and cost nothing to
produce, so the expensive answer was the one an attacker picks and the
cheap one what an honest peer gets — and `assert_as_valid_` calls
`assert_valid` or `Sig.parse` before anything else, so this sat in front
of every BIP340 verification btclib performs. The 0.65 µs the accepting
path saves is 3% of a verification and is not the reason.

## The message is the second half of the change, not its price

`r is not a valid x-coordinate: '0x…'` says which of the signature's two
fields is wrong, where `invalid x-coordinate` did not. It matches the
`scalar s not in 0..n-1` three lines below it, and the sentence
`dsa.Sig.assert_valid` already phrases for exactly this reason — less
its `(congruent to)`, r being a field element here and not a scalar
reduced mod n, so there is no congruence loop to run.
`_is_x_coordinate`'s own docstring asks for it: "the value that names
itself in an error message is the caller's and not this x".

**Two messages become one.** An r outside the field used to come back as
`ec.y`'s `x-coordinate not in 0..p-1`, which `Sig` never phrased itself,
and `ssa_test.test_signature` asserted it for `r = ec.p`. `dsa.Sig`
already collapses that same distinction. The exception class does not
change, which is what the script engine catches.

## How it is pinned

`test_refusing_an_r_takes_no_square_root` patches `mod_sqrt` to raise
over five r — `5`, `p - 1`, `p`, `p + 1`, `2**256` — so both kinds of
refusal are covered and neither may reach a lift. All five fail on
`main`'s code with the assertion the patch raises. A stopwatch would not
have done: this has to hold on a loaded machine too.

## Not touched

`_y_even` stays where the coordinate is wanted: `:235`, `:240`, `:245`,
`:670` and `:732` of this module.

## Gates

`uv run pytest` (18585 passed, 6 skipped, 100.00%, rc 0),
`uv run pre-commit run --all-files` (rc 0), and the sphinx `-W` build
(rc 0).

## Summary by Sourcery

Validate BIP340 signatures by checking r with an x-coordinate predicate instead of lifting to a point, improving performance and clarifying error reporting for invalid r values.

Bug Fixes:
- Ensure invalid BIP340 r values are rejected without invoking modular square root computations, eliminating an excessive cost for refusing bad signatures.

Enhancements:
- Introduce explicit error messaging that identifies r as not being a valid x-coordinate, unifying previous separate refusal messages for out-of-field and non-point x values.
- Use the _is_x_coordinate predicate in BIP340 signature validation to avoid unnecessary point lifting while keeping verification semantics unchanged.

Documentation:
- Document the performance and error-message changes for BIP340 r validation in the changelog, including the rationale and test coverage.

Tests:
- Add a parametrized test that patches mod_sqrt to ensure refusing invalid r values never reaches a square root operation and uses the new unified error message.