### PR TITLE
Translate and chunk base58, instead of scanning the alphabet per character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -609,6 +609,39 @@ documented at release-notes length in the first place, and are still in
   already collapses that distinction.
   `test_refusing_an_r_takes_no_square_root` patches `mod_sqrt` to raise
   over five r, both kinds included.
+- **base58 translates and chunks, where it scanned the alphabet twice per
+  character** (#624). `_ALPHABET.index(char)` was 58 comparisons to find a
+  digit and `x not in _ALPHABET` 58 more to validate it, both per
+  character, and `result = _ALPHABET[idx : idx + 1] + result` copied the
+  whole string per digit. Two `bytes.maketrans` tables do the mapping in
+  one C pass each -- and the validity check becomes
+  `v.translate(None, _ALPHABET)`, every alphabet byte deleted so that
+  whatever is left is what is not one -- while the big-integer arithmetic
+  moves ten digits at a time: `58**10 < 2**64`, so a chunk's digits come
+  out of a machine int and the multiplication that costs O(size of the
+  accumulator) is paid once per ten. Digits go into a bytearray and are
+  reversed once, instead of being prepended to bytes.
+
+  Decoding an xpub is 4.32 µs against 7.86, encoding its payload 5.64
+  against 10.63, an address 1.40 against 2.24 and its payload 1.65 against
+  2.33. On the long strings the coefficient shows: 2.2 ms at 10k
+  characters against 12.8, 32 ms at 40k against 197, 510 ms at 160k
+  against 3193. Both loops are still quadratic in the length of the
+  string, the accumulator growing as it always did, so `MAX_LENGTH` and
+  the argument in the comment above it are unchanged -- what the comment
+  carries is a smaller coefficient, remeasured.
+
+  Nothing else moves. The two refusals are the same, `Base58 string
+  contains invalid characters` included; zero is still written as one
+  leading digit, which is what the `while i or not digits` of the second
+  loop is for; leading zeros are still counted before the integer
+  conversion rather than in it. And what the character-by-character check
+  accepted without saying so -- any iterable of byte values -- is kept by
+  one `v = bytes(v)`, free where it is already bytes: `to_prv_key` tries a
+  WIF before it gives up, so a Point handed to it arrives here as the
+  tuple `(5, 0)` and has to go on being refused as invalid characters
+  rather than as a missing method, which
+  `tests/to_prv_key_test.py::test_from_prv_key` is what says.
 
 ### The public API and the module layout
 

--- a/btclib/base58.py
+++ b/btclib/base58.py
@@ -57,14 +57,36 @@ __all__ = [
 _ALPHABET = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
 __BASE = len(_ALPHABET)
 
+# a digit for every byte value, and a byte value for every digit, so that
+# a whole string is translated in one C pass where reading it character by
+# character was a scan of the 58-byte alphabet per character:
+# `_ALPHABET.index(char)` for each of them, and `x not in _ALPHABET` for
+# each of them again to validate. maketrans leaves every byte it is not
+# given alone, which is why the validity check has to come first: a
+# character outside the alphabet would otherwise decode as itself
+_DIGIT_OF = bytes.maketrans(_ALPHABET, bytes(range(__BASE)))
+_CHAR_OF = bytes.maketrans(bytes(range(__BASE)), _ALPHABET)
+
+# how many digits are carried through the big-integer arithmetic at a
+# time. 58**10 < 2**64, so a chunk's ten digits come out of an int the
+# machine holds in a register, and the multiplication or division that
+# costs O(size of the number) is paid once per ten digits instead of once
+# per digit. Both loops stay quadratic in the length of the string -- the
+# accumulator grows -- with a tenth of the coefficient
+_CHUNK = 10
+_CHUNK_BASE = __BASE**_CHUNK
+
 # The longest string btclib legitimately decodes is a BIP32 extended
 # key: 78 bytes of payload plus 4 of checksum, which base58 writes in at
 # most 112 characters (an address takes 35, a WIF 52). The cap is what
 # keeps the quadratic accumulation of _b58decode_to_int away from
-# attacker-supplied text: measured 13 ms at 10k characters, 198 ms at
-# 40k and 3312 ms at 160k, four times the cost per doubling of the
-# input, and the checksum that would reject it is verified only once
-# the decoding has been paid for.
+# attacker-supplied text: measured 2.2 ms at 10k characters, 32 ms at
+# 40k and 510 ms at 160k, four times the cost per doubling of the input,
+# and the checksum that would reject it is verified only once the
+# decoding has been paid for. A sixth of what those three cost before
+# the chunking below -- 12.8 ms, 197 ms and 3193 ms -- which is a
+# smaller coefficient and the same curve, so the cap answers the same
+# argument it always did.
 # The encoder is deliberately left uncapped, being quadratic too: what
 # it is handed is data the caller already holds, not a string that
 # arrived from the network.
@@ -72,12 +94,25 @@ MAX_LENGTH = 112
 
 
 def _b58encode_from_int(i: int) -> bytes:
-    result = b""
-    while i or not result:
-        i, idx = divmod(i, __BASE)
-        result = _ALPHABET[idx : idx + 1] + result
-
-    return result
+    # least significant digit first into a bytearray, reversed once at the
+    # end, where prepending to a bytes object copied the whole string per
+    # digit -- and the digits translated to characters in one pass rather
+    # than sliced out of the alphabet one at a time
+    digits = bytearray()
+    while i >= _CHUNK_BASE:
+        # ten digits of a number whose higher part is not zero yet, so all
+        # ten are significant and the leading zeros among them are real
+        i, chunk = divmod(i, _CHUNK_BASE)
+        for _ in range(_CHUNK):
+            chunk, digit = divmod(chunk, __BASE)
+            digits.append(digit)
+    while i or not digits:
+        # the most significant digits, and `not digits` is zero itself:
+        # base58 writes it as one leading digit rather than as nothing
+        i, digit = divmod(i, __BASE)
+        digits.append(digit)
+    digits.reverse()
+    return bytes(digits).translate(_CHAR_OF)
 
 
 def _b58encode(v: bytes) -> bytes:
@@ -104,15 +139,34 @@ def encode(v: Octets, in_size: int | None = None) -> bytes:
 
 
 def _b58decode_to_int(v: bytes) -> int:
+    digits = v.translate(_DIGIT_OF)
     i = 0
-    for char in v:
-        i *= __BASE
-        i += _ALPHABET.index(char)
+    for start in range(0, len(digits), _CHUNK):
+        chunk = digits[start : start + _CHUNK]
+        value = 0
+        for digit in chunk:
+            value = value * __BASE + digit
+        # one multiplication of the accumulator per ten digits, by the
+        # power that matches the chunk actually read: the last one is
+        # shorter unless the string divides by ten
+        i = i * __BASE ** len(chunk) + value
     return i
 
 
 def _b58decode(v: bytes) -> bytes:
-    if any(x not in _ALPHABET for x in v):
+    # bytes for what the character-by-character check took without ever
+    # saying so: any iterable of byte values. That is how a caller's
+    # garbage reaches here -- `to_prv_key` tries a WIF before it gives up,
+    # so a Point handed to it arrives as the tuple (5, 0) -- and it has to
+    # go on being refused below as characters outside the alphabet, which
+    # is a BTClibValueError, rather than as a missing method. Free on the
+    # path that matters: bytes(b) is b for a bytes object, 29 ns
+    v = bytes(v)
+    # every alphabet byte deleted, so what is left is what is not one:
+    # the same question as `any(x not in _ALPHABET for x in v)` asked in
+    # one C pass instead of a 58-byte scan per character, and it has to be
+    # asked before _DIGIT_OF translates anything
+    if v.translate(None, _ALPHABET):
         msg = "Base58 string contains invalid characters"
         raise BTClibValueError(msg)
 


### PR DESCRIPTION
Closes #624, which has the measurement and the reasoning; this is the change.

Two `bytes.maketrans` tables for the digit mapping and the validity check, ten
digits at a time through the big-integer arithmetic, and a bytearray reversed
once instead of a bytes object prepended to per digit.

| | now | this branch | |
| --- | --- | --- | --- |
| decode an xpub (112 characters) | 7.86 us | **4.32 us** | 1.8x |
| encode an xpub payload | 10.63 us | **5.64 us** | 1.9x |
| decode an address (34 characters) | 2.24 us | **1.40 us** | 1.6x |
| encode an address payload | 2.33 us | **1.65 us** | 1.4x |
| decode 10 000 characters | 12.8 ms | **2.2 ms** | 5.8x |
| decode 40 000 characters | 197 ms | **32 ms** | 6.1x |
| decode 160 000 characters | 3193 ms | **510 ms** | 6.3x |

Paired, same machine and environment, the change stashed and unstashed, and the
last three are the numbers the `MAX_LENGTH` comment already carried: both loops
are still quadratic in the length of the string, so that comment's argument is
unchanged and its timings are remeasured rather than removed.

Nothing else moves: the two refusals, zero written as one leading digit, leading
zeros counted before the integer conversion, and what the character-by-character
check accepted without saying so -- any iterable of byte values, which is how a
Point handed to `to_prv_key` arrives here as `(5, 0)` and must go on being
refused as invalid characters. `tests/to_prv_key_test.py::test_from_prv_key` is
what says so, and it caught the first version of this.

`uv run pytest`: 18 578 passed, coverage 100.00%. `uv run pre-commit
run --all-files` clean.

## Summary by Sourcery

Improve base58 encoding/decoding performance while preserving existing behaviour and limits.

Enhancements:
- Optimize base58 integer encoding by accumulating digits in a bytearray, reversing once, and translating via a precomputed digit-to-character table.
- Speed up base58 decoding by translating the entire input to digit values with a lookup table and processing digits in fixed-size chunks to reduce big-integer operations.
- Update MAX_LENGTH documentation and timing measurements in the base58 module comment to reflect the new performance characteristics while keeping the same safety cap.
- Document the base58 performance and behavioural changes in the changelog, including that existing validation rules and edge-case handling remain unchanged.