### PR TITLE
Make squash the only merge method, and say so where it is decided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,21 @@ documented at release-notes length in the first place, and are still in
   URL named. `_config.yml`'s exclude list also drops `RELEASE.md`,
   `master`'s name for RELEASING.md, which no branch carries now.
 
+- **Squash is the only merge method the repository enables.** The merge
+  commit was refused by `main`'s required linear history already, so
+  turning it off takes away a button that could not have worked; the
+  rebase merge could have, and what it would have done is replay a
+  branch's commits onto a trunk where one change is one commit. What a
+  single method takes away is not the choice on a pull request in front of
+  somebody: GitHub preselects whichever was used last and offers the same
+  dropdown in the dialog that switches auto-merge on, hours before
+  anything merges and with nothing asking again -- so "read the button
+  before clicking it" was advice CONTRIBUTING.md and RELEASING.md gave and
+  neither could enforce. REPOSITORY.md gains the section, and points at
+  CONTRIBUTING.md for what the commit a squash writes says, that being
+  where a contributor meets those two fields. `bitcoin-core-rpc` and
+  `btclib-libsecp256k1` carry the same setting and the same prose.
+
 ### Packaging, linting and CI
 
 - **`--cov` is in pytest's addopts, so the ratchet is a local gate.** The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -817,9 +817,10 @@ of several under the pull request's title with its number, and the body
 is the branch's commit messages either way — never the pull request's
 body, which stays on the pull request.
 
-**Read the button before clicking it.** All three methods are enabled on
-the repository and GitHub offers whichever was used last, so the squash is
-a choice made once per pull request rather than a setting.
+**It is a setting and not a choice made once per pull request.** Squash is
+the only method the repository enables, so there is no other button to
+read; REPOSITORY.md has that setting and what the other two would have
+cost.
 
 The one force-push that stays right is the one that carries no new work: a
 `git rebase origin/main` on a branch whose base has moved, which is how a

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -278,12 +278,11 @@ word, and step 1 asks it of both.
 
    And merge it the way every pull request here is merged, with **"Squash
    and merge"**: this branch carries a version bump and two retitles, not
-   a cycle of work, and CONTRIBUTING.md gives the rest of the reason. All
-   three methods are enabled and GitHub preselects whichever was used
-   last, so which button it is has to be read before it is pressed — a
-   merge commit is refused by `main`'s required linear history, and a
-   rebase merge would replay the branch's steps into a history whose rule
-   is one commit per landed change.
+   a cycle of work, and CONTRIBUTING.md gives the rest of the reason. It
+   is the only method the repository enables, so the button offers no
+   other — a merge commit was refused by `main`'s required linear history
+   anyway, and a rebase merge would have replayed the branch's steps into
+   a history whose rule is one commit per landed change.
 
    Then read `lint` and `test` on the commit `main` ends up at before
    tagging, rather than trust the pull request's own green run:

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -280,6 +280,36 @@ git log --format='%h %G?' origin/main..      # every commit G, none N
 git push origin <branch>:main
 ```
 
+## Merge methods
+
+**Squash is the only method enabled**, so it is a setting and not only the
+convention CONTRIBUTING.md states:
+
+```shell
+gh api repos/btclib-org/btclib \
+  --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge}'
+```
+
+answers `true` for the first and `false` for the other two.
+
+The merge commit was refused by the required linear history above already,
+so turning it off takes away a button that could not have worked. The
+rebase merge could have, and that is the one this removes: it replays a
+branch's commits onto `main`, where one change is one commit and the steps
+of a review belong to the pull request that carries them.
+
+What a single method buys is not the button on a pull request somebody is
+looking at. GitHub preselects whichever method was used last, and the
+dialog that switches auto-merge on carries the same dropdown — so the
+answer can be given hours before anything merges, by whoever switched it
+on, with nothing asking again. One method is one entry: there is no wrong
+one to preselect, and nothing to read before pressing.
+
+What the commit a squash writes then says is
+`squash_merge_commit_title` and `squash_merge_commit_message`, which
+CONTRIBUTING.md reads back and explains, both being where a contributor
+meets them.
+
 ## Head branches after a merge
 
 `delete_branch_on_merge` is on, since 7 August 2026:


### PR DESCRIPTION
`main`'s required linear history already refused a merge commit, so turning
that method off takes away a button that could not have worked. The rebase
merge could have worked, and what it would have done is replay a branch's
commits onto a trunk where one change is one commit.

What a single method takes away is not the choice on a pull request in
front of somebody. GitHub preselects whichever method was used last, and
the dialog that switches auto-merge on carries the same dropdown — so the
answer is given hours before anything merges, by whoever switched it on,
with nothing asking again. "Read the button before clicking it" was advice
CONTRIBUTING.md and RELEASING.md gave and neither could enforce.

The setting is already patched, this being a rule that lives outside the
repository:

```shell
gh api repos/btclib-org/btclib \
  --jq '{allow_squash_merge, allow_merge_commit, allow_rebase_merge}'
```

answers `true`, `false`, `false`. `bitcoin-core-rpc` and
`btclib-libsecp256k1` carry the same patch and the same prose, all three
having said the same thing about three methods being enabled.

- `REPOSITORY.md` gains a "Merge methods" section between branch
  protection and head branches: the `gh api` above, why each of the other
  two is off, the auto-merge dropdown that answers the question hours
  early, and a pointer to `CONTRIBUTING.md` for what the commit a squash
  writes says — that file already reads `squash_merge_commit_title` and
  `squash_merge_commit_message` back, which is where a contributor meets
  them.
- `CONTRIBUTING.md`'s "Read the button before clicking it" and
  `RELEASING.md`'s "all three methods are enabled" say what holds instead.

Gates, run locally: `pre-commit run --all-files` and `sphinx-build -W` both
exit 0. Markdown only, so the suite is untouched.

## Summary by Sourcery

Clarify that squash is the only merge method enabled for the repository and document its implications for branch history and contributor workflow.

Documentation:
- Add a "Merge methods" section in REPOSITORY.md documenting that only squash merges are enabled and explaining the rationale versus merge and rebase options.
- Update RELEASING.md to state that release branches are merged using squash as the only enabled method instead of choosing among three methods.
- Revise CONTRIBUTING.md to describe squash merging as a repository setting rather than a per-pull-request choice and to reference REPOSITORY.md for details.

Chores:
- Record in CHANGELOG.md that squash is now the only merge method enabled for the repository, aligning documentation with the existing repository settings.