### PR TITLE
Keep the derived key serialized, and drop the point nothing read

### DIFF
--- a/.github/mutation/bip32.toml
+++ b/.github/mutation/bip32.toml
@@ -161,11 +161,11 @@ excluded-modules = []
 #   attribute`-style check in `dataclasses` never overwrites either way;
 #   `repr=False` already means "inherit the parent's", identical with or
 #   without the decorator; and the `__eq__` the decorator would add
-#   compares `prv_key_int`/`pub_key_point` beside the six inherited
-#   fields, but both are pure functions of `key` and `is_private`, values
-#   already in that comparison -- two instances equal on the six can
-#   never disagree on the two derived from them, so the wider or the
-#   narrower `__eq__` never differs in what it answers.
+#   compares `prv_key_int` beside the six inherited fields, but it is a
+#   pure function of `key` and `is_private`, values already in that
+#   comparison -- two instances equal on the six can never disagree on
+#   the one derived from them, so the wider or the narrower `__eq__`
+#   never differs in what it answers.
 # - `_rootxprv_from_seed`'s `bit_length < 128` and `> 512` widened by one
 #   to 127 and 513: `bit_length = len(seed) * 8` is always a multiple of
 #   8, so 127 and 513 are values no byte-sized seed can ever produce --

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -899,6 +899,33 @@ documented at release-notes length in the first place, and are still in
 
 ### Wallets
 
+- **BIP32 derivation no longer builds a point nothing reads.**
+  `_BIP32KeyData` exists to carry the intermediate results a multi-level
+  derivation reuses, and `pub_key_point` stopped being one of them when
+  the arithmetic went to libsecp256k1 (#241): from then on it was written
+  in three places and read in none. It was not free to write.
+  Constructing the object lifted the key into a point --
+  `point_from_octets`, 3.7 us, one `ec_pubkey_parse` and one
+  `ec_pubkey_serialize` -- and `__pub_key_derivation` asked the bindings
+  for the *uncompressed* serialization at every level, so as to read a y
+  out of it, and then rebuilt the compressed spelling by hand from that
+  y's parity. Nothing looked at either. What the extended key holds is
+  the compressed form, which is now what the bindings are asked for and
+  what is stored unchanged.
+
+  The cost was one point per `_derive` call rather than one per level, so
+  it is a fixed 4 us off a derivation of any depth: `_derive(xpub_data,
+  "m/0/i")` is 34.0 us against 38.1, `derive(xpub, "m/0/i")` 55.1 against
+  58.8, and `derive(xpub, "m/0/0/0/0/0")` 98.8 against 101.7. Private
+  derivation is untouched at 39 us, its branch of the constructor having
+  set the field to the infinity point and stopped there.
+
+  `test_public_derivation_builds_no_point` pins the shape rather than a
+  stopwatch, as #615's test does: the class declares the one cache that
+  is read, the bindings are asked for the compressed form, and the key
+  that comes back is checked against the point the removed arithmetic
+  would have compressed by hand.
+
 - **`RangedWallet.assert_derives` reads a span of addresses back against
   the branch that derived it** (#596). A list of addresses written down
   -- a whitelist, a monitor's import, the deposit block a counterparty

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -30,7 +30,7 @@ from dataclasses import dataclass
 from btclib_libsecp256k1 import keys as libsecp256k1_keys
 
 from btclib import base58
-from btclib.alias import INF, BinaryData, Octets, Point, String
+from btclib.alias import BinaryData, Octets, String
 from btclib.bip32.der_path import (
     _HARDENED_OFFSET,
     DerPath,
@@ -38,7 +38,6 @@ from btclib.bip32.der_path import (
 )
 from btclib.curves import (
     bytes_from_prv_key_int,
-    point_from_octets,
     secp256k1,
 )
 from btclib.curves.curve import _is_x_coordinate
@@ -395,11 +394,14 @@ def xpub_from_xprv(xprv: BIP32Key) -> str:
 # scalar the inherited masking __repr__ exists to hide
 @dataclass(repr=False)
 class _BIP32KeyData(BIP32KeyData):
-    # extensions that cache intermediate results
-    # in multi-level derivation: do not rely on them elsewhere
+    # the one intermediate result multi-level derivation reuses: do not
+    # rely on it elsewhere. The public counterpart a private key needs is
+    # not cached beside it -- __prv_key_path_derivation computes it once,
+    # for the fingerprint, and hands it to the step that would recompute
+    # it; a point cached here would instead be built for every key,
+    # including the public ones that never look at it
 
     prv_key_int: int  # non-zero for private key only
-    pub_key_point: Point  # non-Infinity for public key only
 
     def __init__(
         self,
@@ -422,12 +424,9 @@ class _BIP32KeyData(BIP32KeyData):
             check_validity=False,
         )
 
-        if self.is_private:
-            self.prv_key_int = int.from_bytes(self.key[1:], "big", signed=False)
-            self.pub_key_point = INF
-        else:
-            self.prv_key_int = 0
-            self.pub_key_point = point_from_octets(self.key, secp256k1)
+        self.prv_key_int = (
+            int.from_bytes(self.key[1:], "big", signed=False) if self.is_private else 0
+        )
 
         if check_validity:
             self.assert_valid()
@@ -560,16 +559,14 @@ def __pub_key_derivation(xkey: _BIP32KeyData, index: int) -> None:
     # 33.4 of mult(offset) followed by a Python point addition, and the
     # key stays serialized throughout -- the parent's 33 bytes go in and
     # the child's come out, with no point built on either side.
-    # Uncompressed on the way out, deliberately: the y coordinate is
-    # what the cached point needs, and recovering it from a compressed
-    # key would be the lift of point_from_octets, 3.2 us against the 1.2
-    # of reading the y out of octets libsecp256k1 has already written --
-    # a lift the bindings answer rather than a modular square root, which
-    # is what makes the two comparable at all.
+    # Compressed on the way out, which is the spelling an extended key
+    # holds: asking for the uncompressed form to read a y out of it costs
+    # a second serialize and the parity arithmetic that follows, for a
+    # coordinate nothing here goes on to use.
     #
     # Not gated on the curve, BIP32 being defined for secp256k1 alone
     try:
-        sec = libsecp256k1_keys.pubkey_tweak_add(xkey.key, offset, compressed=False)
+        sec = libsecp256k1_keys.pubkey_tweak_add(xkey.key, offset, compressed=True)
     except ValueError as e:
         # past the range check above, the one sum libsecp256k1 refuses
         # is the point at infinity BIP32 refuses too
@@ -578,11 +575,7 @@ def __pub_key_derivation(xkey: _BIP32KeyData, index: int) -> None:
         ) from e
 
     xkey.chain_code = chain_code
-    y = int.from_bytes(sec[33:], byteorder="big", signed=False)
-    xkey.pub_key_point = (int.from_bytes(sec[1:33], byteorder="big", signed=False), y)
-    # the compressed spelling of what came back, as bytes_from_point
-    # writes it: the prefix is the parity of the y being dropped
-    xkey.key = (b"\x03" if y & 1 else b"\x02") + sec[1:33]
+    xkey.key = sec
 
 
 def __prv_key_path_derivation(xkey: _BIP32KeyData, indexes: list[int]) -> None:

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -6,9 +6,11 @@
 
 import hmac
 import re
+from dataclasses import fields
 from typing import Any
 
 import pytest
+from btclib_libsecp256k1 import keys as libsecp256k1_keys
 
 from btclib import base58
 from btclib.b58 import p2pkh
@@ -266,6 +268,46 @@ def test_public_key_validation_does_not_lift(
         BIP32KeyData.b58decode(bad_xpub)
     # a predicate has no exception to chain: the message is the whole error
     assert excinfo.value.__cause__ is None
+
+
+def test_public_derivation_builds_no_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Public derivation keeps the key serialized, end to end.
+
+    `_BIP32KeyData` carries the intermediate results derivation reuses,
+    and a cached point stopped being one of them when the arithmetic went
+    to libsecp256k1: it was built for every public extended key, so at
+    every level of every path, and read nowhere. What pins its removal is
+    the shape of the calls rather than a stopwatch -- the class declares
+    the one cache that is read, and the bindings are asked for the
+    compressed spelling an extended key holds, not for the uncompressed
+    one whose y went into that point.
+    """
+    inherited = {field.name for field in fields(BIP32KeyData)}
+    cached = [f.name for f in fields(_BIP32KeyData) if f.name not in inherited]
+    assert cached == ["prv_key_int"]
+
+    compressed_asked: list[bool] = []
+    tweak_add = libsecp256k1_keys.pubkey_tweak_add
+
+    def record(pubkey_bytes: Any, tweak: Any, compressed: bool = True) -> bytes:
+        compressed_asked.append(compressed)
+        return tweak_add(pubkey_bytes, tweak, compressed)
+
+    monkeypatch.setattr(libsecp256k1_keys, "pubkey_tweak_add", record)
+
+    xpub = "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
+    parent = _derive(xpub, "m/0")
+    compressed_asked.clear()
+    child = _derive(xpub, "m/0/1")
+    assert compressed_asked == [True, True]
+
+    # and it is the same key: what the bindings compress is what the
+    # parity of an uncompressed y used to be read off to rebuild
+    (tweak,) = pub_key_derivation_tweaks(parent.key, parent.chain_code, "m/1")
+    uncompressed = tweak_add(parent.key, tweak, False)
+    assert child.key == bytes_from_point(point_from_octets(uncompressed))
 
 
 def test_derive() -> None:


### PR DESCRIPTION
Closes [#630](https://github.com/btclib-org/btclib/issues/630).

`_BIP32KeyData` carries the intermediate results a multi-level derivation
reuses, and `pub_key_point` stopped being one of them when
[#241](https://github.com/btclib-org/btclib/pull/241) moved the arithmetic
to libsecp256k1: a public child had been `ec.add(parent_point,
mult(offset))`, which needed the parent as a point, and `pubkey_tweak_add`
takes the serialized key instead. From then on the field was written in
three places and read in none.

Writing it cost two things:

- the constructor lifted the key into a point for every public extended
  key — `point_from_octets`, 3.7 us, one `ec_pubkey_parse` and one
  `ec_pubkey_serialize` — once per `_derive` call, the object being
  constructed once and mutated down the path;
- `__pub_key_derivation` asked the bindings for the *uncompressed*
  serialization at every level, so as to read a y out of its second half,
  then rebuilt the compressed spelling by hand from that y's parity. What
  an extended key holds is the compressed form, which `compressed=True`
  returns directly and which is now stored unchanged.

## What it buys

Alternating old and new in one shell so machine drift shows as noise
rather than bias, best of five per case, macOS arm64, CPython 3.14:

| | before | after | |
| --- | --- | --- | --- |
| `_derive(xpub_data, "m/0/i")` | 38.1 us | **34.0 us** | −11% |
| `derive(xpub, "m/0/i")` | 58.8 us | **55.1 us** | −6% |
| `derive(xpub, "m/0/0/0/0/0")` | 101.7 us | **98.8 us** | −3% |
| `derive(xprv, "m/0/i")` | 39.2 us | 39.2 us | — |

A fixed ~4 us off a derivation of any depth, which is why the share falls
as the path lengthens: the point was built once per call, in the
constructor, and the per-level part is inside the noise. Private
derivation does not move, its branch of the constructor having assigned
`INF` and stopped there.

It is worth doing for the other reason too: a cached value nothing reads
is state a reader has to work out is dead, and `.github/mutation/bip32.toml`
already had to reason about it to explain an `__eq__` it does not want.

## The test

`test_public_derivation_builds_no_point` pins the shape rather than a
stopwatch, as [#615](https://github.com/btclib-org/btclib/issues/615)'s
test does: the class declares the one cache that is read, the bindings are
asked for the compressed form, and the key that comes back is checked
against the point the removed arithmetic would have compressed by hand.
Both halves were confirmed to fail against the parent commit.

## Gates

`uv run pre-commit run --all-files`, the sphinx `-W` build, and `uv run
pytest --cov` all exit 0 — 18586 passed, 100.00% coverage.

## Not in this PR

Profiling the same workload turned up two more findings, filed separately
rather than folded in here:

- [#633](https://github.com/btclib-org/btclib/issues/633) — `derive()`
  validates the same extended key three times, ~10.5 us of the ~55; one of
  the three is redundant, one is the boundary and must stay, and the third
  is a judgement call.
- [#634](https://github.com/btclib-org/btclib/issues/634) — bech32
  `_polymod` recomputes five conditional XORs per character where a
  32-entry table indexed by the five bits that select them does it in one
  lookup: 5-6x, verified equivalent exhaustively over the table's whole
  domain. Follows up [#627](https://github.com/btclib-org/btclib/issues/627),
  which named `_polymod` as the real cost in that module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Simplify BIP32 public key derivation by eliminating an unused cached point, keeping keys serialized in compressed form throughout derivation, and update tests, changelog, and mutation config to reflect the new behavior.

Enhancements:
- Streamline BIP32 public key derivation to operate purely on serialized compressed keys and remove the unused cached public key point from `_BIP32KeyData`.

Documentation:
- Document the BIP32 derivation change and its performance impact in the changelog.

Tests:
- Add a test that verifies BIP32 public derivation no longer constructs or uses a cached point and consistently requests compressed keys from libsecp256k1.

Chores:
- Update mutation testing configuration comments to reflect the simplified `_BIP32KeyData` equality semantics.
