### PR TITLE
Follow the bindings to btclib_secp256k1, distribution and repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
       value: >
         Not every bug reachable from btclib is a btclib bug: the elliptic
         curve operations are delegated to
-        [btclib_secp256k1](https://github.com/btclib-org/btclib-libsecp256k1/issues),
+        [btclib_secp256k1](https://github.com/btclib-org/btclib-secp256k1/issues),
         the Python bindings, and through them to
         [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1/issues).
         A traceback ending in either belongs there. If in doubt, report it

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -9,7 +9,7 @@ body:
       value: >
         Not every bug reachable from btclib is a btclib bug: the elliptic
         curve operations are delegated to
-        [btclib_libsecp256k1](https://github.com/btclib-org/btclib-libsecp256k1/issues),
+        [btclib_secp256k1](https://github.com/btclib-org/btclib-libsecp256k1/issues),
         the Python bindings, and through them to
         [bitcoin-core/secp256k1](https://github.com/bitcoin-core/secp256k1/issues).
         A traceback ending in either belongs there. If in doubt, report it
@@ -49,9 +49,9 @@ body:
   - type: input
     id: bindings-version
     attributes:
-      label: btclib_libsecp256k1 version
+      label: btclib_secp256k1 version
       description: >
-        `python -c "import btclib_libsecp256k1 as m; print(m.__version__)"`.
+        `python -c "import btclib_secp256k1 as m; print(m.__version__)"`.
         Anything signing or verifying goes through it, so which one is
         installed is part of the report.
       placeholder: "0.7.1"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -15,7 +15,7 @@ contact_links:
       maintainers alone; SECURITY.md gives an email address for anyone who
       would rather not use it.
   - name: Bug in the libsecp256k1 bindings
-    url: https://github.com/btclib-org/btclib-libsecp256k1/issues
+    url: https://github.com/btclib-org/btclib-secp256k1/issues
     about: Signing, verification and curve arithmetic are delegated there.
   - name: Chat with the developers
     url: https://bbt-training.slack.com/archives/C01CCJ85AES

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
         and prototyping as much as at production use: what belongs here is
         what a specification describes. Wrapping something libsecp256k1
         offers belongs in
-        [btclib_libsecp256k1](https://github.com/btclib-org/btclib-libsecp256k1/issues)
+        [btclib_secp256k1](https://github.com/btclib-org/btclib-libsecp256k1/issues)
         instead.
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
         and prototyping as much as at production use: what belongs here is
         what a specification describes. Wrapping something libsecp256k1
         offers belongs in
-        [btclib_secp256k1](https://github.com/btclib-org/btclib-libsecp256k1/issues)
+        [btclib_secp256k1](https://github.com/btclib-org/btclib-secp256k1/issues)
         instead.
 
   - type: textarea

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -78,7 +78,7 @@ on:
     # and macos Wednesday, Dependabot Thursday, integration Friday, and
     # the mutation session Sunday -- so a failure notification still names
     # the workflow by the day it arrived; and it is the day
-    # btclib-libsecp256k1 and bitcoin-core-rpc analyse on, so "did CodeQL
+    # btclib-secp256k1 and bitcoin-core-rpc analyse on, so "did CodeQL
     # go red anywhere" has one morning to read rather than three. Weekly, as
     # default setup was: what a scheduled analysis catches is a query
     # CodeQL added since the last commit, which arrives with the bundle

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -12,7 +12,7 @@ name: latest
 # uv.lock moves on a weekly dependabot pull request. A break upstream
 # therefore surfaces a week or more later, inside a pull request that has
 # to be reviewed anyway, and its cause is one entry in a diff of many.
-# btclib_libsecp256k1 is the entry that matters most here: a release of
+# btclib_secp256k1 is the entry that matters most here: a release of
 # the bindings is a release in another repository, which nothing in this
 # one has to change for the pair to stop working. test-bindings-latest
 # below asks about that one entry alone, precisely, rather than folding
@@ -112,7 +112,7 @@ jobs:
           # something did is the week this job has work to do anyway
           enable-cache: true
           python-version: ${{ matrix.python }}
-      # --upgrade re-resolves every entry, btclib_libsecp256k1 included:
+      # --upgrade re-resolves every entry, btclib_secp256k1 included:
       # this is what carries the bindings to their newest release, which
       # nothing else off a pull request does.
       # It prints one "Update <pkg> vA -> vB" line per package it moves,
@@ -131,7 +131,7 @@ jobs:
 
   # narrower than test-latest above, and for a different reason: that
   # job upgrades every dependency, so a red run there buries a release
-  # of btclib_libsecp256k1 behind a dozen other candidates. This
+  # of btclib_secp256k1 behind a dozen other candidates. This
   # upgrades only that one, so a red run here names it without a
   # bisect -- worth a job of its own because it is a sibling project
   # under the same org, released by the same maintainer, which makes
@@ -162,12 +162,12 @@ jobs:
           python-version: ${{ matrix.python }}
       # upgrades one entry rather than every one of them, which is the
       # whole difference from test-latest above: it prints "Update
-      # btclib_libsecp256k1 vA -> vB" when a release moved it and
+      # btclib_secp256k1 vA -> vB" when a release moved it and
       # nothing when it did not, so the log names the suspect without a
       # diff of uv.lock. Harmless on an ephemeral checkout; worth
       # knowing before running the same command in a working tree
       - name: Upgrade the bindings to their latest release
-        run: uv lock --upgrade-package btclib_libsecp256k1
+        run: uv lock --upgrade-package btclib_secp256k1
       - name: Run pytest
         run: uv run --locked --no-default-groups --group test pytest
 

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -26,7 +26,7 @@ name: published
 # from it is worth a look at the Actions tab before it is read as
 # green.
 #
-# What this is not: a sentinel for whether the newest btclib_libsecp256k1
+# What this is not: a sentinel for whether the newest btclib_secp256k1
 # breaks this tree. That question -- issue #397 -- belongs to latest.yml's
 # test-bindings-latest job instead: it is about drift against a tree not
 # yet published, asked before publication rather than after, and asking
@@ -93,7 +93,7 @@ jobs:
         # the two ends of the supported range, plus the free-threaded
         # interpreter: btclib itself ships one universal wheel, so what
         # varies across this matrix is entirely which wheel of
-        # btclib_libsecp256k1 each cell resolves to
+        # btclib_secp256k1 each cell resolves to
         python: ["3.10", "3.14", "3.14t"]
     timeout-minutes: 20
     steps:
@@ -137,7 +137,7 @@ jobs:
       # Nothing about btclib is arm64-specific here, and the gap is not
       # one a user falls into: 3.10 on a Windows arm64 machine *is* the
       # emulated x86-64 build, there being no other, so the resolver
-      # takes btclib_libsecp256k1's cp310-win_amd64 wheel and it runs
+      # takes btclib_secp256k1's cp310-win_amd64 wheel and it runs
       # under the same emulation the interpreter does. The bindings'
       # own wheel matrix says the same thing from the other side --
       # win_arm64 from cp311 up, cp310 win_amd64 alone -- because a
@@ -148,7 +148,7 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
           python-version: ${{ matrix.python }}
-      # --verbose so the log names the btclib_libsecp256k1 wheel this cell
+      # --verbose so the log names the btclib_secp256k1 wheel this cell
       # resolved to, which is the whole of what varies across the matrix.
       # A venv of its own, and every step below runs --no-project against
       # it: there is no checkout, so nothing of this repository is on the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -322,7 +322,7 @@ jobs:
       # Unconstrained, where dist-py pins the runtime dependencies to
       # uv.lock: no pull request waits on this job, so it can afford the
       # question a required check cannot -- whether the newest published
-      # btclib_libsecp256k1 satisfies the wheel about to be published,
+      # btclib_secp256k1 satisfies the wheel about to be published,
       # which is what a user installing it resolves. A release stopping
       # on that answer is the outcome wanted.
       # The three assertions are dist-py's, and there for the same

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ concurrency:
 
 jobs:
   # what the matrix buys: every (os, architecture, interpreter) triple
-  # selects a different published wheel of btclib_libsecp256k1, each with
+  # selects a different published wheel of btclib_secp256k1, each with
   # its own compiled libsecp256k1 inside, and the pure Python code meets a
   # distinct hashlib and OpenSSL.
   # windows-11-arm needs no special handling, and that is worth a word:
@@ -238,7 +238,7 @@ jobs:
         run: uv run --locked --only-group build pyroma --min 10 dist/*.tar.gz
       # what none of the three above does: install the wheel, and install
       # it alone, from an empty directory. The wheel is the only thing
-      # asked for, so what pulls btclib_libsecp256k1 in is the
+      # asked for, so what pulls btclib_secp256k1 in is the
       # `Requires-Dist` the wheel itself carries, resolved from the index
       # -- which is the question, metadata being what the three checks
       # above only read.
@@ -249,7 +249,7 @@ jobs:
       # the wheel's metadata doing the work while pinning the outcome to
       # what uv.lock resolved -- and pinning it is what keeps a required
       # check deterministic, since with `>=0.7.1` alone uv takes the
-      # newest release and a btclib_libsecp256k1 published this morning
+      # newest release and a btclib_secp256k1 published this morning
       # would redden every open pull request, none of which caused it.
       # Whether the newest bindings still work is asked on a schedule by
       # latest.yml, and again by the release workflow before it publishes.

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -9,7 +9,7 @@
   // and after the offending block
   // <!-- markdownlint-enable MD013 -->
 
-  // This file is the same in btclib, btclib-libsecp256k1 and
+  // This file is the same in btclib, btclib-secp256k1 and
   // bitcoin-core-rpc, deliberately: prose moves between the three, and a
   // paragraph that lints in one has to lint in the others. No rule is
   // disabled here -- what follows only names a style where markdownlint's

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -453,7 +453,7 @@ repos:
   # not the mirrors-mypy hook: it injects --ignore-missing-imports, which
   # turns an unresolved (or misspelled) import into Any, the opposite of
   # strict, and it type checks in an isolated environment, where every
-  # import of the btclib_libsecp256k1 bindings is exactly that. Declaring
+  # import of the btclib_secp256k1 bindings is exactly that. Declaring
   # them there would pin the bindings a second time, in additional
   # dependencies beside uv.lock and by hand, so the hook could type check
   # against a version the suite never ran. This is the very command the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,14 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **Their repository is renamed with them**, to
+  `btclib-org/btclib-secp256k1`, so the urls naming it here move: the
+  issue templates, `README.md`, `SECURITY.md`'s advisory link, and the
+  two comments that list the three repositories this file set is shared
+  with. GitHub redirects the old paths, so none of them was broken; an
+  address that answers through a redirect is still the wrong one to
+  publish. The entry below keeps `btclib-libsecp256k1#122` as written,
+  that being the number as it was announced.
 - **The secp256k1 bindings are required, and imported, as
   `btclib_secp256k1`**, where they were `btclib_libsecp256k1`
   (btclib-libsecp256k1#122). `lib` named the C library being wrapped, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,25 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **The secp256k1 bindings are required, and imported, as
+  `btclib_secp256k1`**, where they were `btclib_libsecp256k1`
+  (btclib-libsecp256k1#122). `lib` named the C library being wrapped, and
+  a python distribution is not that library: it is btclib's bindings to
+  secp256k1. The requirement moves to `>=0.8.0`, the first release under
+  the new name, and the twelve modules and four test files that import
+  them follow; the local aliases do not, `libsecp256k1_mult` and its
+  neighbours naming the C library, which is what they still call. Nothing
+  of btclib's own API moves, and nothing of the bindings' API does
+  either — the modules, every function, and the `ffi` and `lib` behind
+  them are what they were, so this is a name and nothing else.
+- **What this could not do until the bindings were published.** The lock
+  cannot name a distribution no index serves, so `uv lock` refuses the
+  requirement with `btclib-secp256k1 was not found in the package
+  registry` and every job that runs `uv sync --locked` fails on it. The
+  pull request therefore waited on the release of
+  `btclib_secp256k1` 0.8.0, and `uv lock` was the last commit on it. The
+  suite was run against the new name before that, from a wheel built out
+  of the bindings' own tree: 18586 passed.
 - **`--cov` is in pytest's addopts, so the ratchet is a local gate.** The
   100% threshold was reached only by the `coverage` job, which means a
   change met it after being pushed: the pull request that added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ if a workflow changes.
 ## Architecture
 
 Pure-Python bitcoin cryptography, with secp256k1 arithmetic delegated to
-the `btclib_libsecp256k1` cffi bindings — and delegated conditionally,
+the `btclib_secp256k1` cffi bindings — and delegated conditionally,
 which is the single most important thing to know before touching
 `btclib/curves/` or `btclib/ecc/`:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ tools, including those needed to build the documentation, is then created with:
 uv sync
 ```
 
-**The declared dependency is `btclib_libsecp256k1>=0.7.1.3`, with no
+**The declared dependency is `btclib_secp256k1>=0.7.1.3`, with no
 upper bound**, and the absence of a ceiling is a decision. The bindings are
 a btclib-org project developed by the same people, and their whole purpose
 is to be the bindings this library calls, so a breaking change there is
@@ -303,7 +303,7 @@ job's command verbatim.
 
 The `dist` job, which inspects what would be published and then
 installs it. The last commands ask for the wheel and nothing else, so
-what pulls btclib_libsecp256k1 in is the `Requires-Dist` the wheel
+what pulls btclib_secp256k1 in is the `Requires-Dist` the wheel
 carries; the lock arrives as constraints, which bind a version without
 requesting a package, so a release of the bindings cannot turn a required
 check red while the wheel's own metadata still does the work. They run
@@ -376,7 +376,7 @@ which moves every dependency, so a red run here names the one responsible
 instead of burying it behind a dozen others:
 
 ```shell
-uv lock --upgrade-package btclib_libsecp256k1
+uv lock --upgrade-package btclib_secp256k1
 uv run --locked --no-default-groups --group test pytest
 ```
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -40,6 +40,20 @@ full year, short month, short day (YYYY-M-D)
   the arithmetic behind it having always used secp256k1's generator
   whatever was passed.
 
+### The bindings are now `btclib_secp256k1`
+
+- **The secp256k1 bindings were renamed, and btclib requires the new
+  name**: `btclib_secp256k1>=0.8.0`, where it required
+  `btclib_libsecp256k1>=0.7.1.3`. `lib` named the C library, and a python
+  distribution is not that library. Nothing in btclib's own API moves,
+  and an install of btclib picks the new dependency up on its own.
+  What to act on, and only if you name the bindings yourself: the old
+  distribution stops at 0.7.1.3 and nothing on PyPI bridges the two, so a
+  project that pins `btclib_libsecp256k1` beside btclib pins a package
+  btclib no longer uses. The two can be installed at once — the import
+  package was renamed with the distribution, so neither shadows the other
+  — which is what makes moving one requirement at a time possible.
+
 ## v2026.8.9
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ including the few vectors that are btclib's own, having no upstream.
 
 The library is not limited to secp256k1, and for that curve it always
 calls
-[btclib_secp256k1](https://github.com/btclib-org/btclib-libsecp256k1),
+[btclib_secp256k1](https://github.com/btclib-org/btclib-secp256k1),
 FFI bindings to Bitcoin Core's optimized C library
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1). They are a
 required dependency and not an optional accelerator, so installing btclib

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ including the few vectors that are btclib's own, having no upstream.
 
 The library is not limited to secp256k1, and for that curve it always
 calls
-[btclib_libsecp256k1](https://github.com/btclib-org/btclib-libsecp256k1),
+[btclib_secp256k1](https://github.com/btclib-org/btclib-libsecp256k1),
 FFI bindings to Bitcoin Core's optimized C library
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1). They are a
 required dependency and not an optional accelerator, so installing btclib

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -129,7 +129,7 @@ pyroma), build, wheel smoke test — and publishes to
 Wednesday cron, because what it answers is cheaper to know before a version
 is consumed than after. It gates nothing, so it will not stop you:
 reading it is the point. Its `test-bindings-latest` job is the one worth
-reading closely: it asks about the newest btclib_libsecp256k1 release
+reading closely: it asks about the newest btclib_secp256k1 release
 alone, precisely, rather than folding it into the broader upgrade the
 rest of the workflow makes — a release of the bindings is a release in
 another repository, which nothing here has to change for the pair to
@@ -160,7 +160,7 @@ above says exactly this about the bindings; it is true of both, word for
 word, and step 1 asks it of both.
 
 1. Make sure the newest release of **each btclib-org dependency** —
-   btclib_libsecp256k1 and bitcoin-core-rpc — is the one this release
+   btclib_secp256k1 and bitcoin-core-rpc — is the one this release
    should depend on, and that `pyproject.toml`'s pin says so. Two
    questions, not one: whether the pin *resolves*, which the wheel smoke
    test of the `dist` job already answers on every pull request by
@@ -439,7 +439,7 @@ a mismatch as tampering:
   where they say they are. The attestation the rehearsal writes covers
   those, and no digest is shared with the release.
 
-`btclib_libsecp256k1` is not a third bound. It is a runtime dependency,
+`btclib_secp256k1` is not a third bound. It is a runtime dependency,
 resolved by whoever installs the wheel, and the only trace of it in either
 distribution file is the `Requires-Dist` pyproject.toml already spells and
 the pin `uv.lock` carries into the sdist — both of them text belonging to
@@ -468,7 +468,7 @@ above needs no `uv sync` to produce the published bytes.
   nothing was uploaded, but retagging would rebuild what was never at
   fault. A registration that matched once goes stale on its own — a
   repository rename is enough — and nothing here flags it before the
-  upload tries; sibling repository btclib_libsecp256k1 hit exactly this
+  upload tries; sibling repository btclib_secp256k1 hit exactly this
   on a real tag rather than a rehearsal. Fix the registration and re-run
   the publish job alone against what is already built:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ equally welcome.
 
 Signing, verification and generator multiplication on secp256k1 are
 delegated to
-[btclib_secp256k1](https://github.com/btclib-org/btclib-libsecp256k1/security/advisories/new),
+[btclib_secp256k1](https://github.com/btclib-org/btclib-secp256k1/security/advisories/new),
 the Python bindings, and through them to
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1/security/advisories/new)
 itself, which has its own security policy and its own address. A flaw in

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ equally welcome.
 
 Signing, verification and generator multiplication on secp256k1 are
 delegated to
-[btclib_libsecp256k1](https://github.com/btclib-org/btclib-libsecp256k1/security/advisories/new),
+[btclib_secp256k1](https://github.com/btclib-org/btclib-libsecp256k1/security/advisories/new),
 the Python bindings, and through them to
 [libsecp256k1](https://github.com/bitcoin-core/secp256k1/security/advisories/new)
 itself, which has its own security policy and its own address. A flaw in

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -27,7 +27,7 @@ import copy
 import hmac
 from dataclasses import dataclass
 
-from btclib_libsecp256k1 import keys as libsecp256k1_keys
+from btclib_secp256k1 import keys as libsecp256k1_keys
 
 from btclib import base58
 from btclib.alias import BinaryData, Octets, String

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -32,11 +32,11 @@ from math import isqrt
 from pathlib import Path
 from typing import Any
 
-from btclib_libsecp256k1.keys import parse as libsecp256k1_pubkey_parse
-from btclib_libsecp256k1.keys import pubkey_combine as libsecp256k1_pubkey_combine
-from btclib_libsecp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
-from btclib_libsecp256k1.keys import serialize as libsecp256k1_pubkey_serialize
-from btclib_libsecp256k1.mult import mult as libsecp256k1_mult
+from btclib_secp256k1.keys import parse as libsecp256k1_pubkey_parse
+from btclib_secp256k1.keys import pubkey_combine as libsecp256k1_pubkey_combine
+from btclib_secp256k1.keys import pubkey_tweak_mul as libsecp256k1_pubkey_tweak_mul
+from btclib_secp256k1.keys import serialize as libsecp256k1_pubkey_serialize
+from btclib_secp256k1.mult import mult as libsecp256k1_mult
 
 from btclib.alias import INF, HashF, Integer, JacPoint, Point
 from btclib.curves.curve_group import (

--- a/btclib/curves/sec_point.py
+++ b/btclib/curves/sec_point.py
@@ -6,8 +6,8 @@
 
 import contextlib
 
-from btclib_libsecp256k1.keys import parse as libsecp256k1_pubkey_parse
-from btclib_libsecp256k1.keys import (
+from btclib_secp256k1.keys import parse as libsecp256k1_pubkey_parse
+from btclib_secp256k1.keys import (
     pubkey_from_prvkey as libsecp256k1_pubkey_from_prvkey,
 )
 

--- a/btclib/ecc/commit_nonce.py
+++ b/btclib/ecc/commit_nonce.py
@@ -62,7 +62,7 @@ from __future__ import annotations
 
 from hashlib import sha256
 
-from btclib_libsecp256k1 import keys as libsecp256k1_keys
+from btclib_secp256k1 import keys as libsecp256k1_keys
 
 from btclib.alias import HashF, Octets, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1

--- a/btclib/ecc/dh.py
+++ b/btclib/ecc/dh.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from hashlib import sha256
 from math import ceil
 
-from btclib_libsecp256k1 import keys as libsecp256k1_keys
+from btclib_secp256k1 import keys as libsecp256k1_keys
 
 from btclib.alias import HashF, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -27,9 +27,9 @@ from hashlib import sha256
 from io import BytesIO
 from typing import overload
 
-from btclib_libsecp256k1 import dsa as libsecp256k1_dsa
-from btclib_libsecp256k1 import keys as libsecp256k1_keys
-from btclib_libsecp256k1 import recovery as libsecp256k1_recovery
+from btclib_secp256k1 import dsa as libsecp256k1_dsa
+from btclib_secp256k1 import keys as libsecp256k1_keys
+from btclib_secp256k1 import recovery as libsecp256k1_recovery
 
 from btclib import var_bytes
 from btclib.alias import BinaryData, HashF, JacPoint, Octets, Point

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -43,7 +43,7 @@ from __future__ import annotations
 
 import secrets
 
-from btclib_libsecp256k1 import ellswift as libsecp256k1_ellswift
+from btclib_secp256k1 import ellswift as libsecp256k1_ellswift
 
 from btclib.alias import Octets, Point
 from btclib.curves import Curve, bytes_from_point, mult, secp256k1

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -59,7 +59,7 @@ from dataclasses import dataclass
 from hashlib import sha256
 from typing import overload
 
-from btclib_libsecp256k1 import ssa as libsecp256k1_ssa
+from btclib_secp256k1 import ssa as libsecp256k1_ssa
 
 from btclib.alias import BinaryData, HashF, Integer, JacPoint, Octets, Point
 from btclib.bip32 import BIP32Key

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from btclib_libsecp256k1.dsa import verify as _libsecp256k1_dsa_verify
+from btclib_secp256k1.dsa import verify as _libsecp256k1_dsa_verify
 
 from btclib.alias import ScriptList
 from btclib.ecc.dsa import Sig

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 
-from btclib_libsecp256k1.ssa import verify as _libsecp256k1_ssa_verify
+from btclib_secp256k1.ssa import verify as _libsecp256k1_ssa_verify
 
 from btclib import var_bytes
 from btclib.alias import ScriptList

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -689,7 +689,7 @@ class ScriptPubKey(Script):
             pub_keyinfo_from_key(k, network, compressed)[0] for k in keys[1:]
         ]
         if lexicographic_sorting:
-            # btclib_libsecp256k1's keys.pubkey_sort is not called here:
+            # btclib_secp256k1's keys.pubkey_sort is not called here:
             # on compressed keys it gives the identical order, byte for
             # byte, at 11.0 us against sorted()'s 0.062 on three keys --
             # 180 times the cost for the same answer -- and it re-

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from io import BytesIO
 from typing import cast
 
-from btclib_libsecp256k1 import xonly as libsecp256k1_xonly
+from btclib_secp256k1 import xonly as libsecp256k1_xonly
 
 from btclib import var_bytes
 from btclib.alias import (

--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -485,7 +485,7 @@ carries it, and what the split costs.
   refactored for improved clarity, without care for backward
   compatibility" is exactly why the new repository needs an explicit
   compatibility contract — a supported btclib version range, declared
-  and tested, the way `btclib_libsecp256k1` is pinned from this side
+  and tested, the way `btclib_secp256k1` is pinned from this side
   (issue #325) — where the in-tree design had a rename break the
   command in the same commit and needed no such contract at all.
 
@@ -735,7 +735,7 @@ this one's conventions rather than sharing its configuration:
 The CLI's own documentation -- its README, its own sphinx or mkdocs
 pages if it has any -- lives in the new repository, not here.
 btclib's side of this is what a dependent project's is: at most a
-mention where README.md already lists `btclib_libsecp256k1`, once the
+mention where README.md already lists `btclib_secp256k1`, once the
 new repository exists to link to. Nothing in this repository's own
 CHANGELOG.md or HISTORY.md is owed an entry for a project the CLI's
 repository, not this one, releases and versions.

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -62,7 +62,7 @@ Installing
    python -m pip install --upgrade btclib
 
 btclib requires python 3.10 or later and pulls in
-``btclib_libsecp256k1``, which is a required dependency and not an
+``btclib_secp256k1``, which is a required dependency and not an
 optional accelerator: installing needs one of its wheels or a C
 toolchain to build it.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ license-files = ["LICENSE", "COPYRIGHT", "AUTHORS.md"]
 authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
 requires-python = ">=3.10"
 dependencies = [
-    "btclib_libsecp256k1>=0.7.1.3",
+    "btclib_secp256k1>=0.8.0",
     "bitcoin-core-rpc>=2026.8.8",
 ]
 keywords = [

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -10,7 +10,7 @@ from dataclasses import fields
 from typing import Any
 
 import pytest
-from btclib_libsecp256k1 import keys as libsecp256k1_keys
+from btclib_secp256k1 import keys as libsecp256k1_keys
 
 from btclib import base58
 from btclib.b58 import p2pkh

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -9,8 +9,8 @@ from hashlib import sha1, sha256, sha512
 from typing import Any
 
 import pytest
-from btclib_libsecp256k1 import dsa as libsecp256k1_dsa
-from btclib_libsecp256k1 import recovery as libsecp256k1_recovery
+from btclib_secp256k1 import dsa as libsecp256k1_dsa
+from btclib_secp256k1 import recovery as libsecp256k1_recovery
 
 from btclib.alias import INF, Point
 from btclib.curves import (

--- a/tests/ecc/ellswift_test.py
+++ b/tests/ecc/ellswift_test.py
@@ -16,7 +16,7 @@ import secrets
 from typing import Any
 
 import pytest
-from btclib_libsecp256k1 import ellswift as libsecp256k1_ellswift
+from btclib_secp256k1 import ellswift as libsecp256k1_ellswift
 
 from btclib.curves import mult, secp256k1
 from btclib.curves.curve import CURVES

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -10,7 +10,7 @@ from hashlib import sha256 as hf
 from typing import Any
 
 import pytest
-from btclib_libsecp256k1 import ssa as libsecp256k1_ssa
+from btclib_secp256k1 import ssa as libsecp256k1_ssa
 
 from btclib.alias import INF, Point, String
 from btclib.bip32 import BIP32KeyData

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -38,7 +38,7 @@ MODULE_NAMES = [
 def btclib_modules() -> list[str]:
     """Return the btclib modules in sys.modules, the bindings excluded."""
     # not startswith("btclib"), which would also catch the
-    # btclib_libsecp256k1 bindings: they are not part of this package, and
+    # btclib_secp256k1 bindings: they are not part of this package, and
     # reimporting a cffi extension module is another matter entirely
     return [
         name for name in sys.modules if name == "btclib" or name.startswith("btclib.")


### PR DESCRIPTION
btclib's side of btclib-org/btclib-secp256k1#122: `lib` named the C
library being wrapped, and a python distribution is not that library —
it is btclib's bindings to secp256k1.

Two halves, in two commits.

**The distribution and the import.** The requirement becomes
`btclib_secp256k1>=0.8.0`, the first release under the new name, and the
modules and tests that import them follow. The local aliases do not:
`libsecp256k1_mult` and its neighbours name the C library, which is what
they still call. Nothing of btclib's own API moves, and nothing of the
bindings' API does either — the modules, every function, and the `ffi`
and `lib` behind them are unchanged.

**The repository.** It is `btclib-org/btclib-secp256k1` now, renamed
after the distribution it holds, so the seven urls naming it here move
with it: the three issue templates, `README.md`, `SECURITY.md`'s advisory
link, and the two comments — in `codeql.yml` and `.markdownlint.jsonc` —
that list the three repositories this file set is shared with. GitHub
redirects the old paths, so none of them was broken; an address that
answers through a redirect is still the wrong one to publish.

The CHANGELOG entries describing what happened keep the old names,
`btclib-libsecp256k1#122` included, that being the number as announced.

## Why this is a draft, and what makes it green

`btclib_secp256k1` 0.8.0 is not on PyPI yet, and a lock cannot name a
distribution no index serves:

```
× No solution found when resolving dependencies
╰─▶ Because btclib-secp256k1 was not found in the package registry and
    your project depends on btclib-secp256k1>=0.8.0, ...
```

So `uv.lock` still names the old distribution, and every job that runs
`uv sync --locked` fails on that mismatch — which is every job. A draft
spends no runner here, by the condition the workflows already carry.

**The last commit this branch needs is `uv lock`,** after 0.8.0 is
published. Then it is ready for review in the ordinary sense.

`mypy` and `uv-lock` are skipped in both commits for that same single
reason, through the `SKIP` the pre-commit configuration documents.
Nothing else in the gate is skipped, and everything else passes.

## What was checked, without the lock

- **the suite, against the new name**: a wheel built out of the bindings'
  own tree and installed into a worktree — 18586 passed, 6 skipped (the
  integration tests that need a device or a regtest node)
- **mypy, in that same environment**: `Success: no issues found in 238
  source files`
- **every other hook**: green

## Order

1. 0.8.0 is published from btclib-org/btclib-secp256k1
2. `uv lock` here, as its own commit
3. mark ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)