### PR TITLE
Pass --no-cov to the matrix cells, so coverage is measured once

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -105,5 +105,9 @@ jobs:
         with:
           enable-cache: true
           python-version: ${{ matrix.python }}
+      # --no-cov for the reason test.yml's suite job gives beside its own
+      # step: this matrix carries the same PyPy cells behind the same
+      # timeout, and the coverage job there is the one place the number is
+      # measured and gated
       - name: Run pytest
-        run: uv run --locked --no-default-groups --group test pytest
+        run: uv run --locked --no-default-groups --group test pytest --no-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,8 +138,19 @@ jobs:
           # fetching the same ones on every run of every commit
           enable-cache: true
           python-version: ${{ matrix.python }}
+      # --no-cov, against the --cov that pyproject.toml's addopts carries:
+      # what this matrix asks is whether every (os, architecture,
+      # interpreter) triple passes, and the job below is where coverage is
+      # measured and gated. Instrumenting these cells measures the same
+      # lines over again -- that job's comment is why they are the same
+      # lines -- and on the PyPy cells it costs enough wall clock to reach
+      # the timeout above with every test passed, coverage.py collecting
+      # there through a trace hook the JIT cannot compile through. It also
+      # keeps `fail_under` where pyproject.toml's comment argues it
+      # belongs, on the one interpreter the statement count was checked
+      # against, rather than enforced on every cell of the matrix
       - name: Run pytest
-        run: uv run --locked --no-default-groups --group test pytest
+        run: uv run --locked --no-default-groups --group test pytest --no-cov
 
   # coverage is measured once, not once per matrix job: the code base has
   # no platform- or version-conditional branch (no sys.platform, no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -256,6 +256,43 @@ documented at release-notes length in the first place, and are still in
   runs clean and changes nothing. Both branches are unit-tested in
   `tests/conftest_test.py`, the one that matters being unreachable from a
   whole run by construction.
+- **The matrix cells pass `--no-cov`, so coverage is measured once again**
+  (#686). The flag the entry above moved into addopts is inherited by
+  every command that does not say otherwise, and the suite step of
+  `test.yml` and of `macos.yml` is a bare `pytest`: so each cell of both
+  matrices began measuring the same lines the `coverage` job measures, and
+  the comment over that job -- "coverage is measured once, not once per
+  matrix job" -- stopped describing the file it sits in. What it costs is
+  not what the entry above measured on 3.14, where it is nearly free:
+  coverage.py collects with `sys.monitoring` there, `sys.settrace` on 3.10
+  and 3.11, and on PyPy through a trace hook the JIT cannot compile
+  through. The same `pypy3.11, ubuntu-24.04-arm` cell either side of it,
+  1.3 minutes at 17a47eed against 27.3 at 41bd4063, inside a
+  `timeout-minutes: 30` whose own comment says it is there to bound a hung
+  job. main at 72fbce69 is where that landed: every test passed, the job
+  was killed in teardown, and the run's conclusion is `cancelled`, which
+  is main red rather than a failure anybody gets told about. A pull
+  request hit the same wall on `windows-11-arm` and a re-run cleared it,
+  which is the shape of the problem -- nothing is broken, the cap is
+  simply where the suite now lands.
+
+  Three things this is not. Not raising the cap, the one option that keeps
+  paying the multiple for a number nothing reads, and that would leave the
+  bound useless for every cell that is not PyPy. Not dropping PyPy from
+  the slow platforms, which gives up what the matrix exists for. And not
+  taking `--cov` back out of addopts, which is the local gate the entry
+  above is. `fail_under` also goes back to being enforced only where
+  pyproject.toml's comment argues it belongs -- on the one interpreter the
+  statement count was checked against -- rather than on every cell that
+  inherited it.
+
+  `latest.yml` keeps `--cov`, which is not an oversight: its two matrices
+  run 3.10 and 3.14 and no PyPy at all, so the wall clock above is not
+  theirs, and it has no coverage job of its own. An upgraded coverage.py
+  meeting the ratchet is one of the things that workflow exists to find
+  out, and its header says so. The two blocks of CONTRIBUTING.md that
+  quote a matrix cell verbatim carry the flag with them, and the third,
+  the `coverage` job's, still spells out the `--cov` it always did.
 - **The Bitcoin Core regtest job runs for the code it checks** (#570).
   `integration.yml`'s `pull_request.paths` held the workflow file and
   `tests/integration/**` and nothing else, so a pull request changing the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,7 +112,8 @@ environment somewhere else:
 
 ```shell
 UV_PROJECT_ENVIRONMENT=.venv-3.10 \
-    uv run --locked --no-default-groups --group test --python 3.10 pytest
+    uv run --locked --no-default-groups --group test --python 3.10 pytest \
+    --no-cov
 ```
 
 `.gitignore` does not mention that directory and does not need to: uv
@@ -280,7 +281,7 @@ One cell of the `suite` matrix of `test.yml`. The interpreter is chosen with
 `pypy3.11` included, and downloads it if the machine has none:
 
 ```shell
-uv run --locked --no-default-groups --group test --python 3.10 pytest
+uv run --locked --no-default-groups --group test --python 3.10 pytest --no-cov
 ```
 
 That one rebuilds `.venv` with the test group alone, which is what breaks
@@ -288,6 +289,14 @@ the pre-commit hook until the next `uv sync`: see the note under "Getting
 started" above, and `UV_PROJECT_ENVIRONMENT` for running it without
 touching `.venv`. The command is what CI runs, verbatim, and CI has no
 `.venv` to lose.
+
+`--no-cov` is the matrix asking about the platform and not about the
+number: it undoes the `--cov` addopts carries, so what a cell reports is
+whether that (os, architecture, interpreter) triple passes. The job below
+is where coverage is measured, and `macos.yml` passes the flag for the
+same reason. `latest.yml` does not: it runs no PyPy cell and has no
+coverage job of its own, so the ratchet meeting an upgraded coverage.py
+is one of the things that workflow exists to find out.
 
 The `coverage` job, gated by `fail_under` in pyproject.toml:
 


### PR DESCRIPTION
`--cov` sits in pytest's addopts and the suite step is a bare `pytest`, so
every cell of `test.yml`'s and `macos.yml`'s matrices instruments a run
whose numbers nothing reads — the `coverage` job measures the same lines,
and the comment over it, "coverage is measured once, not once per matrix
job", had stopped describing the file it sits in.

This is the narrow fix #686 asks for: `--no-cov` on those two steps, the
`coverage` job's `pytest --cov` untouched, and the local gate that
07c348fb built left exactly as it is.

## What it costs today, re-derived rather than quoted

The same cell either side of `--cov` entering addopts, from the two runs
the issue names:

| cell | 17a47eed | 41bd4063 |
| --- | --- | --- |
| `pypy3.11, ubuntu-24.04-arm` | 1.3 min | 27.3 min |

```shell
gh api "repos/btclib-org/btclib/actions/runs/31545333285/jobs?per_page=100" \
    --jq '.jobs[] | select(.name | test("pypy3.11, ubuntu-24.04-arm")) |
          "\(.conclusion) \((((.completed_at|fromdate) -
          (.started_at|fromdate)) / 60))"'
```

Against a `timeout-minutes: 30` whose own comment says it is there to
bound a hung job. `main` at 72fbce69
([run 31574115645](https://github.com/btclib-org/btclib/actions/runs/31574115645))
passed every test, was killed in teardown, and concluded `cancelled` —
which is main red and nothing anyone is told about. The pull request the
issue also names hit the same wall on `windows-11-arm` and a re-run
cleared it, so that run reads `success` today; the shape of the problem is
that nothing is broken and the cap is simply where the suite now lands.

The spread is what coverage.py collects with: `sys.monitoring` on 3.12 and
newer, which is nearly free and is why 07c348fb measured no cost when it
moved the flag; `sys.settrace` on 3.10 and 3.11; and on PyPy a trace hook
the JIT cannot compile through.

## One place where the issue's proposal is narrowed

#686 says "`--no-cov` in the matrix step of both workflows", meaning
`test.yml` and `macos.yml`. **`latest.yml` deliberately keeps `--cov`**,
and it is worth saying why rather than leaving it looking forgotten:

- its two matrices run `3.10` and `3.14` and no PyPy at all, so the wall
  clock above is not theirs;
- it has no `coverage` job of its own, so its `pytest` steps are the only
  place an upgraded coverage.py meets the ratchet — which is one of the
  things that workflow exists to find out, and its header already argues
  exactly that.

`integration.yml` is also left alone: it runs `pytest tests/integration`,
a path selection, so `coverage_fail_under` gates it at zero already, and
it is one `ubuntu-latest` job on the default interpreter.

`fail_under` also goes back to being enforced only where pyproject.toml's
comment argues it belongs — on the one interpreter the statement count was
checked against — rather than on every cell that inherited it.

## Verified

Rebased onto `main` after #700, and every gate re-run on the rebased tip:

- `uv run pytest`: **18589 passed, 6 skipped**, exit 0 — the gated run,
  `--cov` being in addopts, so the 100% ratchet passed with it.
- `uv run pre-commit run --all-files`: every hook passes, `actionlint`,
  `zizmor`, `yamllint`, `markdownlint`, `mypy` strict, `uv-lock` and
  `check-manifest` included. Exit code checked, not filtered output.
- The sphinx build with `-W`, which is the half of the lint gate the hooks
  are not, and it matters here because `CONTRIBUTING.md` and
  `CHANGELOG.md` are both in the toctree through their `*_link.md` shims:
  `build succeeded`, exit 0.
- `--no-cov` itself, against the strict warning filter: `pytest --no-cov`
  over the whole suite is `18589 passed, 6 skipped`, exit 0, with no
  coverage report and no warning turned into an error — which is what the
  matrix cells will now run.

Closes #686.
