### PR TITLE
State the input-validation rule where the public surface is described

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,31 @@ documented at release-notes length in the first place, and are still in
   where a contributor meets those two fields. `bitcoin-core-rpc` and
   `btclib-libsecp256k1` carry the same setting and the same prose.
 
+- **CONTRIBUTING.md states the input-validation rule** (#684), under "The
+  public surface", where the `__all__` rule beside it already says what
+  being public means: every public function validates what it is handed,
+  deferring the work if it likes to a private twin that does not, and that
+  twin is what the library composes internally. Three things the section
+  had to say beyond the rule itself. That `check_validity=False` is not an
+  exemption -- it says "do not check *now*", and these are mutable
+  dataclasses whose fields are public and get reassigned in place, so
+  validity at construction is not validity at use, while passing the flag
+  is supported and `tests/check_validity_test.py` exercises it. That
+  `btclib.bip32` is the shape to copy, `derive` validating and `_derive`
+  not, with `_key_data_from_bip32_key` the one place a `BIP32Key` becomes a
+  validated `BIP32KeyData` and `descriptors` composing the twins directly.
+  And that a leading underscore therefore says a second thing here, beside
+  what `__all__` decides about publicity: the twin does not validate, and
+  calling it asserts that its caller did.
+
+  The exception is named rather than passed over, because a reader finding
+  a class that asks nothing needs to know which kind it is: where a
+  class's invariants are exactly the widths of its fields the decoding
+  enforces them by construction, so the check is unreachable by design
+  rather than missing. `btclib/utils.py`'s docstring is where that rule
+  lives and `OutPoint` and `TxIn` are the classes it holds for, so the new
+  paragraph points at it instead of restating it.
+
 ### Packaging, linting and CI
 
 - **Their repository is renamed with them**, to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -696,6 +696,40 @@ takes it from. `tests/all_test.py` checks all of this and finds the
 modules rather than listing them, so a new public name fails the suite
 until it is exported or recorded in that file's `UNEXPORTED` table.
 
+**Every public function validates its inputs.** Whatever it is handed — a
+string, octets, or an object somebody built earlier — a name a caller can
+reach checks it before acting on it, and a malformed argument leaves as a
+`BTClibTypeError` or a `BTClibValueError`, which is what the callers of
+this library are written to catch. The work itself may be deferred to a
+private twin that does not validate; that twin is then what the library
+composes internally, where the inputs have already been checked and
+checking them a second time buys nothing.
+
+`check_validity=False` is not an exemption from this. It says "do not
+check *now*", not "this object is exempt from here on": these are mutable
+dataclasses whose fields are public and get reassigned in place, so
+validity at construction is not validity at use. Passing it is supported —
+`tests/check_validity_test.py` exercises the flag across the library — so
+a public function that takes an already-built object and asks it nothing
+is one a caller can reach with an object the library itself would refuse.
+
+`btclib.bip32` is the shape to copy. `derive` validates and calls
+`_derive`, which does not, and `_key_data_from_bip32_key` is the one place
+a `BIP32Key` of any spelling becomes a validated `BIP32KeyData`, every
+public wrapper going through it. `descriptors` then composes the twins
+directly — `_xpub_from_xprv(_derive(_key_data_from_bip32_key(xprv),
+prefix))` — paying one validation instead of three, and no base58 round
+trip between them. So a leading underscore says a second thing here,
+beside what `__all__` already decides about publicity: the twin does not
+validate, and calling it asserts that its caller did.
+
+The exception is a boundary at which nothing can be invalid, and it is
+named rather than passed over: where a class's invariants are exactly the
+widths of its fields, the decoding enforces them by construction and the
+check is unreachable by design rather than missing. `btclib/utils.py`'s
+docstring is where that rule is written down, `OutPoint` and `TxIn` being
+the classes it holds for.
+
 #### Documentation and comments
 
 What "satisfied" means for the prose — docstrings, comments, the


### PR DESCRIPTION
The rule #684 decided:

> Every public function must always validate its inputs, optionally
> deferring the work itself to a private twin that does not validate and
> that can then be used wherever the inputs have already been validated
> and revalidating them makes no sense.

It governs the whole public surface and was written down in no file a
contributor reads. `CONTRIBUTING.md`'s "The public surface" says what
`__all__` makes public and said nothing about what a public name then owes
its caller, which is where this goes — one paragraph after the other.

## What the section had to say beyond the rule

- **`check_validity=False` is not an exemption.** It says "do not check
  *now*", not "this object is exempt from here on": these are mutable
  dataclasses whose fields are public and get reassigned in place, so
  validity at construction is not validity at use. Passing the flag is a
  supported thing to do — `tests/check_validity_test.py` exercises it
  across the library — so a public function that takes an already-built
  object and asks it nothing is reachable with an object the library
  itself would refuse.
- **`btclib.bip32` is the shape to copy**, being the one #643 already
  built: `derive` validates and `_derive` does not,
  `_key_data_from_bip32_key` is the single place a `BIP32Key` of any
  spelling becomes a validated `BIP32KeyData`, and `descriptors` composes
  the twins directly —
  `_xpub_from_xprv(_derive(_key_data_from_bip32_key(xprv), prefix))`,
  `btclib/descriptors/descriptors.py:2286` — paying one validation instead
  of three.
- **A leading underscore therefore says a second thing here**, beside what
  the paragraph above it already settles: publicity comes from `__all__`
  and not from the spelling, and the underscored twin is the one that does
  not validate. Calling it asserts that its caller did.
- **The exception is named rather than passed over.** Where a class's
  invariants are exactly the widths of its fields, the decoding enforces
  them by construction and the check is unreachable by design rather than
  missing. `btclib/utils.py`'s docstring is where that rule is written,
  with `OutPoint` and `TxIn` as the classes it holds for, so the new
  paragraph points at it rather than restating it — one fact in one place,
  as the section below asks.

## Why this is its own pull request, and first

Six issues are the rule's reproduced holes, each in a different module:
#688 (`ssa` batch verification, the one that changes an answer rather than
an exception type), #690, #691, #692, #693, #694. Their commit messages
cite the rule, so the rule is worth being in the tree before they are; and
the census of where the tree does not follow it stays in #684, which this
does not close.

## Verified

Rebased onto `main` after #700, and every gate re-run on the rebased tip:

- `uv run pytest`: **18589 passed, 6 skipped**, exit 0 — the gated run,
  `--cov` being in addopts, so the 100% ratchet passed with it.
- `uv run pre-commit run --all-files`: every hook passes, exit code
  checked rather than filtered output.
- The sphinx build with `-W`, which is the half of the lint gate the hooks
  are not, and which matters here because both files are in the toctree
  through their `*_link.md` shims: `build succeeded`, exit 0.

Prose only, so there is no behaviour to test. Advances #684 rather than
closing it.
