### PR TITLE
Validate at the public entry: ssa batch, TxOut, and five of the eight leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -447,6 +447,55 @@ documented at release-notes length in the first place, and are still in
 
 ### Transactions, blocks and PSBT
 
+- **A pre-built `ScriptPubKey` is asked what octets are asked** (#694, under
+  the rule of #684). `TxOut.__init__` validated the octets branch --
+  `ScriptPubKey(script_bytes)` defaults to `check_validity=True` -- and
+  stored the object branch as it came, so
+  `TxOut(1000, ScriptPubKey(b"\x51", "notanetwork", check_validity=False))`
+  was accepted with the default check on. A `TxOut` carries a script into a
+  `Tx`'s outputs, a `Block`'s transactions and `PsbtIn.witness_utxo`, and one
+  that passes its own `assert_valid` is taken as sound by all three. What is
+  asked is the network name and that the script is bytes, never that the
+  script parses: `Script.assert_valid` explains why nothing asks that, five
+  transactions in blocks 251718 to 299571 carrying scripts a parse refuses,
+  which is what issue #123 settled. In `assert_valid` as well as in the
+  constructor, so that deferring the check and asking it later answers the
+  same question; the class is frozen, so a field reassigned behind it is not
+  the reason.
+
+  The sibling constructors were audited with it and need nothing:
+  `Tx.assert_valid` walks every `TxIn` and `TxOut`, `Block.assert_valid` the
+  header and every transaction, `PsbtIn.assert_valid` both utxo fields, and
+  `PsbtOut.assert_valid` each of its own. `OutPoint` and `TxIn` are the
+  exceptions `btclib/utils.py` documents, their fields being the widths the
+  parse enforces.
+- **Five of the eight exception-contract leaks of #690.** A public function
+  handed an object its own `assert_valid` refuses raised what is not a
+  `ValueError` -- `OverflowError` is an `ArithmeticError` and
+  `AttributeError` neither -- so it flew past exactly the handler
+  `BTClibValueError` exists to be caught by. In the `sig_hash` family the
+  leak is a *width* and not a semantic rule, and that is what decides the
+  check: BIP143's amount is Core's `CAmount`, so `-1` is what eight `ff`
+  octets mean and the preimage commits to them either way (issue #388,
+  asserted both ways), which makes `valid_sats_amount` the wrong instrument
+  -- it would refuse a preimage Core writes. What is refused is an integer
+  no eight-byte signed field can hold, for `segwit_v0`'s amount and for
+  every prevout amount `taproot` and `from_tx` commit to, every prevout and
+  not only the one being signed. `Block.assert_valid_contextual` and
+  `psbt.ecdsa_sig_hash` take the object check instead,
+  `BlockContext.assert_valid` and `Psbt.assert_valid` being what they had no
+  call to.
+
+  Two are left, and neither is a line to add:
+  `merkle_root_and_mutated_from_transactions` serializes with
+  `check_validity=False` deliberately, which
+  `test_merkle_root_and_witness_commitment_serialize_without_judging` pins
+  -- a block's validity is `Block.assert_valid`'s, once, outside the loop --
+  and `legacy` leaks on `tx.version`, where `Tx.assert_valid` is the wrong
+  instrument too, eight tests handing it synthetic transactions to exercise
+  the script code. Refusing the width at the serialization boundary is what
+  those two want, and it is a decision of its own.
+
 - **A declared count is bounded by what could hold it, before anything is
   allocated for it** (#569). `var_int.parse`'s `MAX_SIZE` is Core's
   `ReadCompactSize` range check and answers whether a CompactSize is one
@@ -620,6 +669,23 @@ documented at release-notes length in the first place, and are still in
   that has none.
 
 ### Curves, signatures and keys
+
+- **Batch verification validates every signature it is handed** (#688).
+  `ssa.batch_verify_` answered `True` for a signature `ssa.verify_` answers
+  `False` for and `Sig.assert_valid` refuses outright: `assert_batch_as_valid_`
+  read `sig.r`, `sig.s` and `sig.ec` into the multi-scalar equation without
+  asking any of them whether they were a signature, and `s` and `s + n` are
+  congruent modulo the group order, so `mult(t)` cannot tell them apart.
+  Only the `batch_size == 1` shortcut was safe, and by accident, delegating
+  to `assert_as_valid_`. The check goes after the curve check rather than
+  before it, so a batch mixing curves is still told that. Nothing reaches it
+  from the wire -- `s + n` does not fit in 32 bytes, and an `r >= p` is
+  refused by `Sig.parse` and by the lift the equation needs -- so it takes a
+  caller building `Sig` objects with `check_validity=False`, which is
+  supported and is the case the rule of #684 exists for.
+  `test_a_batch_of_one_takes_the_single_signature_shortcut` asserted the
+  dispatch through a malformed `Sig` the general path let through, which is
+  what stops being true: it now asserts the dispatch itself.
 
 - **A MOV-weak curve is a `BTClibValueError`** (#572). `Curve` refuses
   nine kinds of unusable parameter and eight of them raise the class the

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -453,6 +453,12 @@ class Block:
         median time past. Each is a field of BlockContext away, once the
         chain state it reads is there to put in one.
         """
+        # the context is an object a caller builds, and `now` reaches
+        # datetime arithmetic below: unasked, a str for it raised
+        # AttributeError, which is no ValueError and flies past the handler
+        # the contract asks for
+        context.assert_valid()
+
         self.header.assert_valid_time(context.now)
 
         if context.bip34_active:

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -721,6 +721,11 @@ def assert_batch_as_valid_(
     -- and which signature failed is not in the answer, only that one
     did. Messages enter as they are; every signature must share one
     curve.
+
+    Every signature is asked whether it is one, this being a public
+    function handed objects somebody else built: the equation below is
+    not that question, and answers a different one for an s outside
+    0..n-1.
     """
     batch_size = len(Qs)
     if batch_size == 0:
@@ -737,6 +742,22 @@ def assert_batch_as_valid_(
     ec = sigs[0].ec
     if any(sig.ec != ec for sig in sigs):
         raise BTClibValueError("not the same curve for all signatures")
+
+    # from two upward the equation is what answers, and it is satisfied by
+    # a signature BIP340 calls invalid: s and s + n are congruent modulo
+    # the group order, so `mult(t)` cannot tell them apart, while
+    # assert_as_valid_ -- and the batch_size == 1 shortcut above with it --
+    # refuses the second. Nothing reaches this from the wire, a
+    # non-canonical s not fitting in 32 bytes, so what it takes is a caller
+    # building Sig objects with check_validity=False; that is supported,
+    # which is why the check belongs here rather than nowhere. The half of
+    # assert_valid the equation would catch anyway is r, whose lift below
+    # fails for a field element that is no x-coordinate.
+    # After the curve check and not before it, so a batch mixing curves is
+    # still told that, rather than being asked whether one signature's r is
+    # an x-coordinate of a curve the batch has no business holding
+    for sig in sigs:
+        sig.assert_valid()
     t = 0
     scalars: list[int] = []
     points: list[Point] = []

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -2026,6 +2026,7 @@ def ecdsa_sig_hash(psbt: Psbt, vin_i: int, *, hash_type: int | None = None) -> b
     a witness utxo alone -- every caller stops, that being an input no
     role may sign, verify or finalize.
     """
+    psbt.assert_valid()
     psbt_in = psbt.inputs[vin_i]
     if hash_type is None:
         hash_type = ALL if psbt_in.sig_hash_type is None else psbt_in.sig_hash_type

--- a/btclib/script/sig_hash.py
+++ b/btclib/script/sig_hash.py
@@ -284,6 +284,33 @@ def _zero_other_sequences(new_tx: Tx, vin_i: int) -> None:
             txin.sequence = 0
 
 
+# Core's CAmount is int64_t and the preimages here commit to the eight bytes
+# it serializes to, so what those bytes cannot stand for is what this
+# refuses. Not the money range: -1 is a signed CAmount and BIP143 hashes it
+# (issue 388), so `valid_sats_amount` would refuse a preimage Core writes
+_CAMOUNT = range(-(2**63), 2**63)
+
+
+def _assert_valid_camount(amount: int, name: str) -> None:
+    """Refuse an amount no eight-byte signed field can hold."""
+    if amount not in _CAMOUNT:
+        raise BTClibValueError(f"invalid {name}: {amount}")
+
+
+def _assert_valid_prevouts(prevouts: list[TxOut]) -> None:
+    """Ask every prevout what a preimage committing to all of them needs.
+
+    BIP341 commits to every spent amount and script_pub_key, so all of
+    them reach the serialization and not only the one being signed. The
+    amount by its field's width and not by the money range, for the reason
+    above; the script by what ScriptPubKey asks of itself, which is its
+    network name and that the script is bytes.
+    """
+    for prevout in prevouts:
+        _assert_valid_camount(prevout.value, "spent amount")
+        prevout.script_pub_key.assert_valid()
+
+
 def legacy(script_code: Octets, tx: Tx, vin_i: int, hash_type: int) -> bytes:
     """Return the pre-segwit hash one input's signature commits to.
 
@@ -467,6 +494,13 @@ def segwit_v0(
     `hash_type` is Core's `int32_t nHashType`, as `legacy`'s is, and every
     32-bit word has a preimage for the same reason.
     """
+    # the width of the field and not the money range: BIP143's amount is
+    # Core's CAmount, so -1 is what eight `ff` octets mean and the preimage
+    # commits to them either way (issue 388). What no reading of eight
+    # bytes can stand for is what leaked an OverflowError out of the
+    # serialization, where the contract promises a BTClibValueError
+    _assert_valid_camount(amount, "amount")
+
     script_code = bytes_from_octets(script_code)
 
     # precomputed, when given, must describe this very tx: it is the
@@ -547,6 +581,8 @@ def taproot(
     path -- empty for the key path. SIGHASH_SINGLE with no matching
     output is an error here, per BIP341, where legacy keeps the bug.
     """
+    _assert_valid_prevouts(prevouts)
+
     if hashtype not in SIG_HASH_TYPES:
         raise BTClibValueError(f"Unknown hash type: {hashtype}")
     if hashtype & 0x03 == SINGLE and input_index >= len(transaction.vout):
@@ -681,6 +717,8 @@ def from_tx(
     first. A verifier does not need the parameter and does not have the
     problem — the interpreter advances Core's `pbegincodehash` as it goes.
     """
+    _assert_valid_prevouts(prevouts)
+
     script = prevouts[vin_i].script_pub_key.script
 
     if is_p2tr(script):

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -70,6 +70,18 @@ class TxOut:
         if not isinstance(script_pub_key, ScriptPubKey):
             script_bytes = bytes_from_octets(script_pub_key)
             script_pub_key = ScriptPubKey(script_bytes)
+        elif check_validity:
+            # the object branch asks what the octets branch asks. Building
+            # one from octets validates it -- ScriptPubKey's own default --
+            # so without this a network name the class refuses enters here
+            # and travels on: a TxOut is what carries a script into a Tx's
+            # outputs, a Block's transactions and PsbtIn.witness_utxo, and
+            # assert_valid below judges the amount alone, on purpose.
+            # What it asks is the network name and that the script is
+            # bytes, not that the script parses -- Script.assert_valid
+            # explains why nothing asks that, and why this cannot refuse a
+            # script that is in a block
+            script_pub_key.assert_valid()
         object.__setattr__(self, "script_pub_key", script_pub_key)
 
         if check_validity:
@@ -78,9 +90,19 @@ class TxOut:
     def assert_valid(self) -> None:
         """Refuse a value that is not a valid satoshi amount."""
         valid_sats_amount(self.value)
-        # the amount and not the script: a script_pub_key on chain need
-        # not parse, and validating it here would refuse transactions
-        # that are in blocks -- bitcoin/bitcoin#320, and issue #123
+        # the amount and not the script's *contents*: a script_pub_key on
+        # chain need not parse, and validating that here would refuse
+        # transactions that are in blocks -- bitcoin/bitcoin#320, and issue
+        # #123. What the object is asked is what ScriptPubKey asks itself,
+        # the network name and that the script is bytes, neither of which
+        # is a property of anything on chain. Here as well as in the
+        # constructor, so that deferring the check and making it later
+        # answer the same question: `check_validity=False` followed by
+        # `assert_valid()` is the spelling every caller that builds a
+        # TxOut by hand and validates it afterwards uses, and without this
+        # that pair passed what the constructor alone refuses. The class is
+        # frozen, so a field reassigned behind it is not the reason
+        self.script_pub_key.assert_valid()
 
     def to_dict(self, *, check_validity: bool = True) -> dict[str, Any]:
         """Return the output as a dict of json-friendly values.

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -531,22 +531,70 @@ def test_batch_validation() -> None:
     assert not ssa.batch_verify_(ms, Qs, sigs)
 
 
-def test_a_batch_of_one_takes_the_single_signature_shortcut() -> None:
+def test_a_batch_of_one_takes_the_single_signature_shortcut(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """`batch_size == 1` dispatches to `assert_as_valid_`, not the general sum.
 
-    A malformed `Sig` (built with `check_validity=False`) tells the two
-    apart: the shortcut validates it and names the field, where the
-    general multi_mult equation below has nothing that checks a lone
-    signature's own shape and would just fail the sum instead, `!= 1`
-    weakened to `< 1` routing every batch there since batch_size is
-    never below 1 by the point this check runs.
+    What the shortcut buys is one verification instead of a multi-scalar
+    sum over a single term. What it does not decide is the answer: both
+    paths validate every signature they are handed, so a malformed `Sig`
+    no longer tells them apart, and the dispatch is what is asserted here
+    -- a stand-in on the single-signature entry, reached by a batch of one
+    and not by a batch of two.
     """
+    reached: list[bool] = []
+
+    def spy(*_args: object, **_kwargs: object) -> None:
+        reached.append(True)
+
+    monkeypatch.setattr(ssa, "assert_as_valid_", spy)
+
     q, x_Q = ssa.gen_keys()
     sig = ssa.sign(b"msg", q)
-    bad_sig = ssa.Sig(sig.r, sig.ec.n + 5, sig.ec, check_validity=False)
+    # the reducing spelling, `sign` having reduced too: the underscored one
+    # takes a prepared message, and a batch of two would fail the sum here
+    # for that reason rather than for the dispatch under test
+    ssa.assert_batch_as_valid([b"msg"], [x_Q], [sig])
+    assert reached == [True]
+
+    q_2, x_Q_2 = ssa.gen_keys(2)
+    sig_2 = ssa.sign(b"msg_2", q_2)
+    ssa.assert_batch_as_valid([b"msg", b"msg_2"], [x_Q, x_Q_2], [sig, sig_2])
+    assert reached == [True]
+
+
+@pytest.mark.parametrize("batch_size", [1, 2, 3])
+def test_batch_and_single_verification_agree_about_a_non_canonical_s(
+    batch_size: int,
+) -> None:
+    """One question, one answer, whatever the batch size (issue 688).
+
+    `s` and `s + n` are congruent modulo the group order, so the
+    multi-scalar equation is satisfied by both while BIP340, and
+    `Sig.assert_valid` with it, admit only the canonical one. No 64-byte
+    signature can carry `s + n`, so this takes a caller building `Sig`
+    objects with `check_validity=False` -- which `tests/check_validity_test`
+    shows is supported, and is what the batch equation used to be asked
+    without anything checking.
+    """
+    keys = [ssa.gen_keys(i) for i in range(1, batch_size + 1)]
+    msgs: list[String] = [bytes([i]) * 16 for i in range(1, batch_size + 1)]
+    sigs = [ssa.sign(m, q) for m, (q, _) in zip(msgs, keys, strict=True)]
+    Qs = [x_Q for _, x_Q in keys]
+
+    assert ssa.batch_verify(msgs, Qs, sigs)
+    assert all(ssa.verify(m, Q, s) for m, Q, s in zip(msgs, Qs, sigs, strict=True))
+
+    # the last signature, with n added to its s
+    last = sigs[-1]
+    sigs[-1] = ssa.Sig(last.r, last.s + last.ec.n, last.ec, check_validity=False)
+
+    assert not ssa.verify(msgs[-1], Qs[-1], sigs[-1])
+    assert not ssa.batch_verify(msgs, Qs, sigs)
     err_msg = "scalar s not in 0..n-1: "
     with pytest.raises(BTClibValueError, match=err_msg):
-        ssa.assert_batch_as_valid_([b"msg"], [x_Q], [bad_sig])
+        ssa.assert_batch_as_valid(msgs, Qs, sigs)
 
 
 def test_batch_validation_on_the_python_path(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/script/sig_hash_segwitv0_test.py
+++ b/tests/script/sig_hash_segwitv0_test.py
@@ -376,3 +376,36 @@ def test_hash_type_too_wide_for_its_four_bytes(hash_type: int) -> None:
     script_code = bytes.fromhex(_WITNESS_SCRIPT)
     with pytest.raises(BTClibValueError, match="sig_hash type too wide"):
         sig_hash.segwit_v0(script_code, tx, 0, hash_type, _AMOUNT)
+
+
+def test_an_amount_no_field_can_hold_is_refused_rather_than_overflowing() -> None:
+    """The contract is a ValueError, and OverflowError is not one (issue 690).
+
+    `BTClibValueError` subclasses `ValueError`, which is what a caller is
+    told to catch; `OverflowError` is an `ArithmeticError` and flies past
+    that handler. What leaked it was an integer too wide for the eight
+    bytes the preimage commits to -- reachable only from a caller building
+    the objects itself, `parse` and the constructors validating by default.
+
+    The width and not the money range: the test above asserts that -1 is a
+    signed CAmount whose octets the preimage carries, so `valid_sats_amount`
+    would refuse a preimage Core writes.
+    """
+    tx = Tx.parse(_BIP143_TX)
+    script_code = bytes.fromhex(_WITNESS_SCRIPT)
+
+    err_msg = "invalid amount: "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        sig_hash.segwit_v0(script_code, tx, 0, sig_hash.SINGLE, 2**63)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        sig_hash.segwit_v0(script_code, tx, 0, sig_hash.SINGLE, -(2**63) - 1)
+
+    # the widest each way is still hashed, as a signed field's value
+    assert sig_hash.segwit_v0(script_code, tx, 0, sig_hash.SINGLE, 2**63 - 1)
+    assert sig_hash.segwit_v0(script_code, tx, 0, sig_hash.SINGLE, -(2**63))
+
+    # the same rule for every prevout a taproot preimage commits to, and
+    # for their script_pub_keys
+    prevouts = [TxOut(2**63, tx.vout[0].script_pub_key, check_validity=False)]
+    with pytest.raises(BTClibValueError, match="invalid spent amount: "):
+        sig_hash.from_tx(prevouts, tx, 0, sig_hash.ALL)

--- a/tests/tx/tx_out_test.py
+++ b/tests/tx/tx_out_test.py
@@ -171,3 +171,38 @@ def test_req_sigs_is_gone() -> None:
     # a dict that still carries it is read all the same: from_dict never
     # looked at the key, so dropping it breaks no stored dict
     assert TxOut.from_dict({**tx_out.to_dict(), "reqSigs": None}) == tx_out
+
+
+def test_a_pre_built_script_pub_key_is_validated_as_octets_are() -> None:
+    """The object branch of __init__ asks what octets are asked (issue 684).
+
+    A `TxOut` carries a script into a `Tx`'s outputs, a `Block`'s
+    transactions and `PsbtIn.witness_utxo`, and one that passes its own
+    `assert_valid` is taken as sound by all three. What is asked is the
+    network name and that the script is bytes -- not that the script
+    parses, which `Script.assert_valid` explains nothing asks, five
+    transactions in blocks carrying scripts a parse refuses.
+
+    The sibling constructors were audited with it and need nothing:
+    `Tx.assert_valid` walks every `TxIn` and `TxOut`, `Block.assert_valid`
+    the header and every transaction, `PsbtIn.assert_valid` both utxo
+    fields, and `PsbtOut.assert_valid` each of its own. `OutPoint` and
+    `TxIn` are the exceptions `btclib/utils.py` documents: their fields are
+    the widths the parse enforces, so the check is unreachable by design.
+    """
+    bad = ScriptPubKey(b"\x51", "notanetwork", check_validity=False)
+    err_msg = "unknown network: notanetwork"
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        TxOut(1000, bad)
+
+    # check_validity=False defers the question, and asking it later gets
+    # the same answer: the pair is what a caller building a TxOut by hand
+    # and validating it afterwards writes, and it used to pass what the
+    # constructor alone refused
+    tx_out = TxOut(1000, bad, check_validity=False)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        tx_out.assert_valid()
+
+    # and there is no third case, the class being frozen: a field
+    # reassigned behind either check is what `test_frozen` above refuses


### PR DESCRIPTION
The rule #698 just wrote into CONTRIBUTING.md, applied to three of the six
reproduced holes: **#688** and **#694** are closed, and **#690** is five of
its eight, the other two being decisions of their own rather than lines to
add.

## #688 — batch verification answered a different question

`ssa.batch_verify_` answered `True` for a signature `ssa.verify_` answers
`False` for and `Sig.assert_valid` refuses outright, because
`assert_batch_as_valid_` read `sig.r`, `sig.s` and `sig.ec` into the
multi-scalar equation without asking any of them whether they were a
signature. `s` and `s + n` are congruent modulo the group order, so
`mult(t)` cannot tell them apart. Reproduced before and after:

```console
second signature with s += n:
  assert_valid : REFUSED -> scalar s not in 0..n-1
  verify   #2  : False
  batch_verify : True      <-- before,  False after
```

The check goes **after** the curve check, not before it, so a batch mixing
curves is still told that rather than being asked whether one signature's
`r` is an x-coordinate of a curve the batch has no business holding.

`test_a_batch_of_one_takes_the_single_signature_shortcut` asserted the
shortcut through a malformed `Sig` the general path let through — which is
exactly what stops being true, so it now asserts the dispatch itself. The
new test is the agreement, at three batch sizes.

## #694 — a pre-built ScriptPubKey entered unasked

The octets branch of `TxOut.__init__` validates; the object branch stored
what it was given, so `TxOut(1000, ScriptPubKey(b"\x51", "notanetwork",
check_validity=False))` was accepted **with the default check on**. What is
asked is the network name and that the script is bytes — never that the
script parses, `Script.assert_valid` explaining why nothing asks that and
issue #123 being where that was settled, so this cannot refuse a script that
is in a block.

In `assert_valid` as well as in the constructor, so `check_validity=False`
followed by `assert_valid()` answers the same question as the constructor
alone. **Not** because a field could be reassigned: the class is frozen, and
I had written that reason down before the suite corrected me.

The sibling audit the issue asks for: `Tx.assert_valid` walks every `TxIn`
and `TxOut`, `Block.assert_valid` the header and every transaction,
`PsbtIn.assert_valid` both utxo fields, `PsbtOut.assert_valid` each of its
own — so `TxOut` was the only hole. `OutPoint` and `TxIn` are named as the
exceptions `btclib/utils.py` documents.

## #690 — five of eight, and why not the other three

Two of the issue's premises do not survive contact with the suite, which is
the interesting part of this pull request:

- **The amount is a signed `CAmount`.** `test_the_bip143_amount_is_a_signed_camount`
  asserts that `-1` is what eight `ff` octets mean and that the preimage
  commits to them either way (issue #388). So `valid_sats_amount` is the
  wrong instrument — it would refuse a preimage Core writes. What is refused
  is an integer no eight-byte signed field can hold, which is what actually
  leaked: `segwit_v0`'s amount, and every prevout amount `taproot` and
  `from_tx` commit to (all of them, BIP341 committing to all of them).
- **The merkle-root loop does not judge, on purpose.**
  `test_merkle_root_and_witness_commitment_serialize_without_judging` pins
  that it serializes with `check_validity=False` rather than raising on the
  second transaction's own account, a block's validity being
  `Block.assert_valid`'s once, outside the loop. Validating there broke it.

So `merkle_root_and_mutated_from_transactions` is left alone, and `legacy`
with it: it leaks on `tx.version`, and `Tx.assert_valid` is the wrong
instrument there too — eight tests hand it synthetic transactions, a
coinbase script of invalid size among them, to exercise the script code.
Refusing the width at the serialization boundary is what those two want, and
that is a decision rather than a line, so it stays on #690, which this does
**not** close.

`Block.assert_valid_contextual` and `psbt.ecdsa_sig_hash` take the object
check, `BlockContext.assert_valid` and `Psbt.assert_valid` being what they
had no call to.

## Verified

- `uv run pytest`: **18594 passed, 6 skipped**, exit 0 — the gated run,
  `--cov` being in addopts, so the 100% ratchet passed with it.
- `uv run pre-commit run --all-files`: every hook, `mypy` strict included.
  Exit code checked, not filtered output. `ruff` caught `taproot` going over
  C901 on the way, which is why the prevout loop is a named helper shared
  with `from_tx` rather than two copies.
- The sphinx build with `-W --keep-going`: `build succeeded`, exit 0.

Closes #688 and #694. Advances #690 and #684.

Still open in the family, for the next pull request: #691, #692, #693 and
the rest of #684's census.

## Summary by Sourcery

Tighten public validation boundaries around batch signature verification, transaction outputs, and sig-hash helpers so callers cannot bypass documented error contracts or script/amount checks when constructing objects manually.

Bug Fixes:
- Ensure `ssa.batch_verify_` and its public entry ask each signature to validate itself so batch verification cannot accept non-canonical signatures that single verification refuses.
- Validate `TxOut` instances built with a pre-constructed `ScriptPubKey` in the same way as octet-based construction, aligning constructor and `assert_valid` behavior and preventing invalid networks from slipping through.
- Constrain segwit and taproot sig-hash helpers to refuse amounts that cannot fit in the underlying signed 64-bit field, converting previous OverflowError and AttributeError leaks into `BTClibValueError` as documented.

Enhancements:
- Add shared prevout validation for taproot and `from_tx` sig-hash computation, including amount-width and `ScriptPubKey` checks, to keep preimage construction consistent across helpers.
- Require `BlockContext.assert_valid` and `Psbt.assert_valid` at contextual validation and ECDSA sig-hash boundaries so malformed context or PSBT objects raise the expected library error types.
- Extend tests for batch verification, sig-hash amount handling, and `TxOut` construction to cover the corrected behaviors and agreement between single and batch verification.

Documentation:
- Document these validation and error-contract changes in the changelog under transactions/blocks/PSBT and curves/signatures/keys.