### PR TITLE
Validate the key and psbt entries that took an object unasked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -447,6 +447,24 @@ documented at release-notes length in the first place, and are still in
 
 ### Transactions, blocks and PSBT
 
+- **Three psbt entries took a psbt unasked** (#692, under the rule of #684).
+  `combine` merged the maps and returned a psbt with neither the inputs nor
+  the result validated anywhere, so an invalid psbt in gave an invalid psbt
+  out, presented as a combine that worked; `prevouts` returned the amounts
+  and scripts a BIP341 signature commits to, which is the list that most
+  wants to have been checked; `new_signers` compared two psbts by input
+  count and then read key data and origin fields raw out of both maps.
+  `combine` asks after the version and identifier checks rather than before
+  them: those two are what make the psbts one transaction's, so a caller
+  handing over two unrelated ones is told that instead of whichever of them
+  fails its own validation first.
+
+  Two tests carried fixtures that could not pass `Psbt.assert_valid`, and
+  both were loose rather than deliberate: the musig2 combine test used
+  `02aa…`, `02bb…` and `02cc…` as stand-in keys, which are not points, and
+  now uses real ones -- what it is about is two participant lists under one
+  aggregate key, not what either aggregates to.
+
 - **A pre-built `ScriptPubKey` is asked what octets are asked** (#694, under
   the rule of #684). `TxOut.__init__` validated the octets branch --
   `ScriptPubKey(script_bytes)` defaults to `check_validity=True` -- and
@@ -669,6 +687,22 @@ documented at release-notes length in the first place, and are still in
   that has none.
 
 ### Curves, signatures and keys
+
+- **Cracking refuses a child the library itself refuses** (#693).
+  `crack_prv_key` exists to demonstrate a known BIP32 weakness, so a wrong
+  answer from it is a wrong lesson: it subtracted the derivation offset
+  from a child whose key was the zero scalar and returned an xprv. Both
+  arguments now go through `_key_data_from_bip32_key`, the one place a
+  `BIP32Key` of either spelling becomes a validated `BIP32KeyData`; the
+  parent is still copied, being mutated into the answer.
+- **An unchecked key origin cannot enter a psbt, or its json** (#693).
+  `decode_hd_key_paths` ran `bytes_from_octets` over the mapping's keys and
+  copied the `BIP32KeyOrigin` values across untouched, so it was a public
+  entry through which an origin `assert_valid` refuses -- a three-byte
+  master fingerprint, say -- entered a psbt's `hd_key_paths`;
+  `encode_to_bip32_derivs` then wrote `master_fingerprint.hex()` of whatever
+  it held into the json. `assert_valid_hd_key_paths`, the validating
+  counterpart, was already sitting beside both.
 
 - **Batch verification validates every signature it is handed** (#688).
   `ssa.batch_verify_` answered `True` for a signature `ssa.verify_` answers
@@ -1073,6 +1107,20 @@ documented at release-notes length in the first place, and are still in
   arithmetic reported as a successful import of something else.
 
 ### Descriptors and miniscript
+
+- **An invalid output is refused, not answered about** (#691). `index_of`
+  answered `None` -- "this output is not mine" -- for a `ScriptPubKey` its
+  own `assert_valid` refuses, which is the worst shape a missing check can
+  take: `None` is exactly what a caller is told about a perfectly good
+  output belonging to somebody else, and nothing in the answer says the
+  question was malformed. `script_pub_key._script_from` stays the private
+  twin that converts several spellings and validates none;
+  `_validated_script_from` beside it is what the three public questions call
+  -- `Descriptor.index_of`, `DescriptorWallet.position_of` and
+  `RangedWallet.position_of`, the last reached by `assert_derives`, which
+  exists to be believed about a list of addresses somebody wrote down
+  (#596). One helper and not three copies, for the reason `_script_from`
+  gives about itself.
 
 - **`at_index()` and `normalized()` reach the keys inside a miniscript**
   (#592). `_mapped_keys` is the one walk both are written in terms of,

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -768,17 +768,17 @@ def crack_prv_key(parent_xpub: BIP32Key, child_xprv: BIP32Key) -> str:
     leaks the account. A hardened child is refused, its offset not
     being computable.
     """
-    if isinstance(parent_xpub, BIP32KeyData):
-        p = copy.copy(parent_xpub)
-    else:
-        p = BIP32KeyData.b58decode(parent_xpub)
+    # both arguments through the one place a BIP32Key becomes a validated
+    # BIP32KeyData: this function exists to demonstrate a known BIP32
+    # weakness, so an answer it gives for a child its own assert_valid
+    # refuses is a wrong lesson. Copied because the parent is mutated
+    # below into the answer, and the caller's object is not this
+    # function's to write to
+    p = copy.copy(_key_data_from_bip32_key(parent_xpub))
 
     if p.key[0] not in {2, 3}:
         raise BTClibValueError(_err_msg("parent", "not a public", p))
-    if isinstance(child_xprv, BIP32KeyData):
-        c = child_xprv
-    else:
-        c = BIP32KeyData.b58decode(child_xprv)
+    c = _key_data_from_bip32_key(child_xprv)
 
     if c.key[0] != 0:
         raise BTClibValueError(_err_msg("child", "not a private", c))

--- a/btclib/bip32/key_origin.py
+++ b/btclib/bip32/key_origin.py
@@ -168,7 +168,14 @@ def assert_valid_hd_key_paths(hd_key_paths: Mapping[bytes, BIP32KeyOrigin]) -> N
 def decode_hd_key_paths(map_: Mapping[Octets, BIP32KeyOrigin] | None) -> HdKeyPaths:
     """Return the dataclass element from its json representation."""
     hd_key_paths = {bytes_from_octets(k): v for k, v in map_.items()} if map_ else {}
-    return dict(sorted(hd_key_paths.items()))
+    hd_key_paths = dict(sorted(hd_key_paths.items()))
+    # the keys went through bytes_from_octets and the values came across
+    # untouched, so this is a public entry through which an unchecked
+    # origin enters a psbt's hd_key_paths -- and travels on to the json
+    # `encode_to_bip32_derivs` writes. The validating counterpart sits
+    # right above
+    assert_valid_hd_key_paths(hd_key_paths)
+    return hd_key_paths
 
 
 _BIP32Deriv = Mapping[str, str]
@@ -178,6 +185,7 @@ def encode_to_bip32_derivs(
     hd_key_paths: Mapping[bytes, BIP32KeyOrigin],
 ) -> list[_BIP32Deriv]:
     """Return the json representation of the dataclass element."""
+    assert_valid_hd_key_paths(hd_key_paths)
     return [
         {
             "pub_key": pub_key.hex(),

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -191,7 +191,7 @@ from btclib.psbt.psbt_out import PsbtOut
 from btclib.psbt.psbt_size import SIG_SIZE, SolutionSizer
 from btclib.script.script import op_int, serialize
 from btclib.script.script import parse as _parse_script
-from btclib.script.script_pub_key import ScriptPubKey, _script_from
+from btclib.script.script_pub_key import ScriptPubKey, _validated_script_from
 from btclib.script.taproot import (
     MAX_TREE_DEPTH,
     input_script_sig,
@@ -926,7 +926,7 @@ class Descriptor(ABC):
         to look is a policy this module has no view on. A descriptor that
         is not ranged has one script and answers 0 or None.
         """
-        script = _script_from(script_pub_key)
+        script = _validated_script_from(script_pub_key)
         last = last_index if self.is_ranged else 0
         for index in range(last + 1):
             if any(

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -1474,6 +1474,15 @@ def combine(psbts: Sequence[Psbt]) -> Psbt:
         if other_id != tx_id:
             raise BTClibValueError(f"mismatched psbt.tx.id: {other_id.hex()}")
 
+    # after the version and identifier checks and not before them: those
+    # two are what makes these psbts one transaction's, and a caller
+    # handing over two unrelated psbts is told that rather than whichever
+    # of them fails its own validation first. Nothing else here asks, so an
+    # invalid psbt in gave an invalid psbt out, presented as a combine that
+    # worked
+    for psbt in psbts:
+        psbt.assert_valid()
+
     final_psbt.tx_modifiable = _combined_tx_modifiable(psbts)
     for psbt in psbts[1:]:
         for i, inp in enumerate(final_psbt.inputs):
@@ -1770,6 +1779,10 @@ def prevouts(psbt: Psbt) -> list[TxOut]:
     transaction unsignable rather than one input of it -- which is why
     this raises where `_prev_out` answers None.
     """
+    # the amounts and scripts a taproot signature commits to under BIP341,
+    # which makes this the list that most wants to have been checked
+    psbt.assert_valid()
+
     outs: list[TxOut] = []
     for i, psbt_in in enumerate(psbt.inputs):
         prev_out = _prev_out(psbt_in)
@@ -2718,6 +2731,12 @@ def new_signers(request: Psbt, returned: Psbt) -> set[bytes]:
     caller's: it is the merge that must not happen before both have
     answered.
     """
+    # both of them: `returned` is what a signer sent back and `request`
+    # what was sent, and key data and origin fields are read raw out of
+    # each of the two maps below
+    returned.assert_valid()
+    request.assert_valid()
+
     if len(returned.inputs) != len(request.inputs):
         err_msg = "mismatched number of psbt inputs: "
         err_msg += f"{len(returned.inputs)} vs {len(request.inputs)}"

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -851,3 +851,24 @@ def _script_from(script_pub_key: Octets | ScriptPubKey) -> bytes:
     except ValueError as e:
         err_msg = f"neither a script nor an address: '{script_pub_key}'"
         raise BTClibValueError(err_msg) from e
+
+
+def _validated_script_from(script_pub_key: Octets | ScriptPubKey) -> bytes:
+    """`_script_from`, having first asked the object whether it is one.
+
+    What the public questions "is this output mine" owe their caller.
+    Answering `None` -- or "not what this branch derives" -- for a
+    `ScriptPubKey` its own `assert_valid` refuses is the worst shape a
+    missing check can take, the answer being a negative rather than an
+    error: it is what a caller is told about a perfectly good output
+    belonging to somebody else, and nothing in it says the question was
+    malformed.
+
+    Here rather than three times over in `Descriptor.index_of`,
+    `DescriptorWallet.position_of` and `RangedWallet.position_of`, for the
+    reason `_script_from` gives about itself: a second copy of the rule is
+    a second answer to give.
+    """
+    if isinstance(script_pub_key, ScriptPubKey):
+        script_pub_key.assert_valid()
+    return _script_from(script_pub_key)

--- a/btclib/wallet/wallet.py
+++ b/btclib/wallet/wallet.py
@@ -65,7 +65,7 @@ from btclib import b32
 from btclib.alias import Octets, String
 from btclib.exceptions import BTClibValueError
 from btclib.network import NETWORKS
-from btclib.script.script_pub_key import ScriptPubKey, _script_from
+from btclib.script.script_pub_key import ScriptPubKey, _validated_script_from
 
 __all__ = [
     "AddressInfo",
@@ -362,7 +362,7 @@ class RangedWallet(Wallet, ABC):
         paying to one script is a wallet whose source repeats itself, not
         something this has to choose between.
         """
-        script = _script_from(script_pub_key)
+        script = _validated_script_from(script_pub_key)
         for branch in self.branches:
             for index in range(last_index + 1):
                 if self._script_pub_key(branch, index).script == script:
@@ -416,7 +416,7 @@ class RangedWallet(Wallet, ABC):
             err_msg += f" between {first_index} and {last_index}"
             raise BTClibValueError(err_msg)
         for offset, address in enumerate(addresses):
-            script = _script_from(address)
+            script = _validated_script_from(address)
             if script != scripts[offset]:
                 index = first_index + offset
                 err_msg = f"not what {branch}/{index} derives: {script.hex()}"

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -1195,3 +1195,26 @@ def test_bip328_synthetic_xpub(
     # and a child of it is a child of the group: what the tweaks above
     # reach, which is the arithmetic a signer does instead of deriving
     assert derive(synthetic_xpub, "m/0") == derive(xkey, "m/0")
+
+
+def test_cracking_refuses_a_child_its_own_assert_valid_refuses() -> None:
+    """Both arguments through `_key_data_from_bip32_key` (issue 693).
+
+    This function exists to demonstrate a known BIP32 weakness, so an
+    answer it gives for a child the library itself refuses is a wrong
+    lesson: it subtracted the offset from a key set to the zero scalar and
+    returned an xprv. The parent is affected too, going through
+    `copy.copy` with only its `key[0]` prefix looked at.
+    """
+    root = rootxprv_from_seed("0102030405060708090a0b0c0d0e0f10")
+    parent_xpub = xpub_from_xprv(root)
+    child_xprv = derive(root, "m/0")
+    assert crack_prv_key(parent_xpub, child_xprv) == root
+
+    bad_child = BIP32KeyData.b58decode(child_xprv)
+    bad_child.key = b"\x00" * 33  # the zero scalar
+    err_msg = "invalid private key not in 1..n-1"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bad_child.assert_valid()
+    with pytest.raises(BTClibValueError, match=err_msg):
+        crack_prv_key(parent_xpub, bad_child)

--- a/tests/bip32/key_origin_test.py
+++ b/tests/bip32/key_origin_test.py
@@ -276,3 +276,24 @@ def test_bip32_derivs_check_validity() -> None:
     hd_key_paths = decode_from_bip32_derivs(bip32_derivs, check_validity=False)
     with pytest.raises(BTClibValueError, match="invalid master fingerprint length: "):
         assert_valid_hd_key_paths(hd_key_paths)
+
+
+def test_an_unchecked_origin_cannot_enter_a_psbt_or_its_json() -> None:
+    """The two public entries of this module (issue 693, rule of #684).
+
+    `decode_hd_key_paths` runs `bytes_from_octets` over the mapping's keys
+    and copied the `BIP32KeyOrigin` values across untouched, so it was a
+    public entry through which an unchecked origin entered a psbt's
+    `hd_key_paths`; `encode_to_bip32_derivs` then wrote
+    `master_fingerprint.hex()` of whatever it held into the json.
+    `assert_valid_hd_key_paths`, the validating counterpart, sits beside
+    both.
+    """
+    bad = BIP32KeyOrigin(b"\x01\x02\x03", [0], check_validity=False)
+    pub_key = b"\x02" * 33
+    err_msg = "invalid master fingerprint length: 3"
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        decode_hd_key_paths({pub_key: bad})
+    with pytest.raises(BTClibValueError, match=err_msg):
+        encode_to_bip32_derivs({pub_key: bad})

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -3013,3 +3013,25 @@ def test_the_normalized_origin_keeps_the_fingerprint_that_was_given() -> None:
     assert origin is not None
     assert origin.master_fingerprint == fingerprint(XPRV_ROOT)
     assert origin.description == f"{fingerprint(XPRV_ROOT).hex()}/44h/0h/0h"
+
+
+def test_an_invalid_output_is_refused_and_not_answered_about() -> None:
+    """A negative answer where a refusal belongs (issue 691).
+
+    The worst shape a missing check can take, the answer being a negative
+    rather than an error: `index_of` answered `None` for a `ScriptPubKey`
+    its own `assert_valid` refuses, which is exactly what it answers about
+    a perfectly good output belonging to somebody else, with nothing in the
+    answer to say the question was malformed. `_script_from` stays the
+    private twin that converts and does not validate;
+    `_validated_script_from` beside it is what the public questions call.
+    """
+    descriptor = parse(f"wpkh({KEY_A})")
+    assert descriptor.index_of(descriptor.script_pub_key()) == 0
+
+    bad = ScriptPubKey(b"\x51", "notanetwork", check_validity=False)
+    err_msg = "unknown network: notanetwork"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bad.assert_valid()
+    with pytest.raises(BTClibValueError, match=err_msg):
+        descriptor.index_of(bad)

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -2613,8 +2613,20 @@ def test_combining_refuses_two_participant_lists_for_one_aggregate_key() -> None
     """
     first = Psbt.b64decode(TO_BE_FINALIZED)
     second = deepcopy(first)
-    aggregate_pub_key = bytes.fromhex(f"02{'aa' * 32}")
-    participants = [bytes.fromhex(f"02{'bb' * 32}"), bytes.fromhex(f"02{'cc' * 32}")]
+    # real points, `Psbt.assert_valid` asking that of a participant list:
+    # what this test is about is two lists under one key, not what the
+    # aggregation of either comes to
+    aggregate_pub_key = bytes.fromhex(
+        "02f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"
+    )
+    participants = [
+        bytes.fromhex(
+            "02346b99593357107c9d3459e9deba8d3eaf44e6636c85c7f853eb90ba52e8cd00"
+        ),
+        bytes.fromhex(
+            "024fafd65f8169186fc2bfdb2233c77e630d10be280a24c7165c09a27611775c2c"
+        ),
+    ]
 
     first.inputs[0].musig2_participant_pub_keys = {aggregate_pub_key: participants}
     second.inputs[0].musig2_participant_pub_keys = {
@@ -4732,3 +4744,39 @@ def test_a_declared_map_count_is_bounded_before_it_is_allocated_for() -> None:
 
     with pytest.raises(BTClibValueError, match="too many output maps"):
         Psbt.parse(_psbt_v2_declaring(0, MAX_TX_OUT_COUNT + 1))
+
+
+def test_the_three_entries_that_took_a_psbt_unasked() -> None:
+    """`combine`, `prevouts` and `new_signers` (issue 692, under #684).
+
+    Each is public and each read a psbt `Psbt.assert_valid` refuses, and
+    handed back an answer as if nothing were wrong: an invalid psbt into
+    `combine` gave an invalid psbt out, presented as a combine that
+    worked; `prevouts` returned the amounts and scripts a BIP341
+    signature commits to, which is the list that most wants to have been
+    checked; `new_signers` compared two psbts and read key data and
+    origin fields raw out of both maps.
+
+    `combine` asks after the version and identifier checks rather than
+    before them: those two are what make the psbts one transaction's, so a
+    caller handing over two unrelated ones is told that instead of
+    whichever of them fails its own validation first.
+    """
+    good = Psbt.b64decode(TO_BE_FINALIZED)
+    witness_utxo = good.inputs[1].witness_utxo
+    assert witness_utxo is not None
+
+    bad = deepcopy(good)
+    bad.inputs[1].witness_utxo = TxOut(
+        2**64, witness_utxo.script_pub_key, check_validity=False
+    )
+    err_msg = "invalid satoshi amount: "
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bad.assert_valid()
+
+    with pytest.raises(BTClibValueError, match=err_msg):
+        combine([deepcopy(bad), deepcopy(bad)])
+    with pytest.raises(BTClibValueError, match=err_msg):
+        prevouts(deepcopy(bad))
+    with pytest.raises(BTClibValueError, match=err_msg):
+        new_signers(deepcopy(bad), deepcopy(good))


### PR DESCRIPTION
Three more of the #684 family, one rule: the public entry validates, the
private twin does not.

## #693 — cracking answered for a child the library refuses

`crack_prv_key` is the function that exists to demonstrate a known BIP32
weakness, so a wrong answer from it is a wrong lesson. It subtracted the
derivation offset from a child whose key was the zero scalar and returned an
xprv:

```console
child assert_valid: REFUSED -> invalid private key not in 1..n-1
crack_prv_key(<xpub>, <invalid child>) -> ACCEPTED, returned xprv9vXgzq5N...
```

Both arguments now go through `_key_data_from_bip32_key`, the one place a
`BIP32Key` of either spelling becomes a validated `BIP32KeyData` — the twin
#643 already built. The parent is still copied, being mutated into the
answer, so the caller's object is not written to.

`decode_hd_key_paths` and `encode_to_bip32_derivs` copied `BIP32KeyOrigin`
values across untouched, so a three-byte master fingerprint entered a
psbt's `hd_key_paths` and then the json `encode_to_bip32_derivs` writes.
`assert_valid_hd_key_paths` was already sitting beside both.

## #691 — a negative answer where a refusal belongs

`Descriptor.index_of` answered `None` — "this output is not mine" — for a
`ScriptPubKey` its own `assert_valid` refuses. That is the worst shape a
missing check can take: `None` is exactly what a caller is told about a
perfectly good output belonging to somebody else, and nothing in the answer
says the question was malformed.

`script_pub_key._script_from` stays the private twin that converts several
spellings and validates none. `_validated_script_from` beside it is what the
three public questions call — `Descriptor.index_of`,
`DescriptorWallet.position_of` and `RangedWallet.position_of`, the last
reached by `assert_derives`, which #596 added so a written-down list can be
put back to the wallet. One helper rather than three copies, for the reason
`_script_from` gives about itself: a second copy of the rule is a second
answer to give.

## #692 — three psbt entries took a psbt unasked

`combine`, `prevouts` and `new_signers`, all reproduced and all now
refusing. `combine` asks **after** the version and identifier checks rather
than before them: those two are what make the psbts one transaction's, so a
caller handing over two unrelated ones is told that instead of whichever of
them fails its own validation first.

Two test fixtures could not pass `Psbt.assert_valid`, and — unlike the
sig_hash cases of #701 — both were loose rather than deliberate: the musig2
combine test used `02aa…`, `02bb…`, `02cc…` as stand-in keys, which are not
points, and now uses real ones. What that test is about is two participant
lists under one aggregate key, not what either aggregates to.

## Verified

- `uv run pytest`: **18598 passed, 6 skipped**, exit 0 — the gated run, so
  the 100% ratchet passed with it.
- `uv run pre-commit run --all-files`: every hook, `mypy` strict included.
  Exit code checked, not filtered output. `tests/all_test.py` caught the new
  helper being spelled without its underscore, which is how it became
  `_validated_script_from`.
- The sphinx build with `-W --keep-going`: `build succeeded`, exit 0.

Closes #691. Closes #692. Closes #693.

What is left of the family, and each wants its own reproduction rather than
a line: the unconfirmed lists of #692 (`taproot_sig_hash`, `leaf_script`,
`psbt_size.estimated_input_sizes`, the six musig2 entry points, and
`psbt_signer.request_signatures`, which hands a psbt to an external signer
before anything checks it), the two names #691 names without reproducing
(`miniscript_sizer`, `miniscript_solver`), and the rest of #684's census —
`slip132` twice, `wallet.key_wallet`, `wallet.script_wallet`,
`descriptors.account_descriptors`, and the four `isinstance(...
BIP32KeyData)` sites that should become one call to
`_key_data_from_bip32_key`.

## Summary by Sourcery

Validate previously unchecked inputs to key, origin, and PSBT utilities so invalid objects are refused instead of silently processed.

Bug Fixes:
- Ensure `crack_prv_key` validates both parent and child BIP32 keys via `_key_data_from_bip32_key`, rejecting children that fail `assert_valid`.
- Require HD key path origins to pass `assert_valid_hd_key_paths` in both JSON decode and encode, preventing invalid fingerprints from entering PSBTs or their JSON form.
- Make `Descriptor.index_of`, wallet `position_of`, and `assert_derives` validate `ScriptPubKey` objects before use, raising on invalid outputs instead of returning misleading negatives.
- Have `Psbt.combine`, `prevouts`, and `new_signers` call `Psbt.assert_valid` on their PSBT inputs so invalid or mismatched transactions are rejected rather than propagated.

Enhancements:
- Introduce `_validated_script_from` as a shared helper for public "is this output mine" queries, centralizing ScriptPubKey validation.
- Tighten musig2 PSBT combine tests to use real public keys consistent with `Psbt.assert_valid`.
- Add regression tests covering the new validation behavior for cracking BIP32 keys, HD key path origins, descriptor output validation, and PSBT entry validation.

Documentation:
- Update CHANGELOG to document stricter validation for PSBT operations, BIP32 cracking, key origins, and descriptor output handling under the #684 rule family.