### PR TITLE
Vendor trezor's BIP39 vectors byte for byte, ours beside them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1436,6 +1436,31 @@ documented at release-notes length in the first place, and are still in
   format of its own; the direction that was refused for being ambiguous is
   the one that stays refused.
 
+### Tests
+
+- **The BIP39 vector file is upstream's file byte for byte** (#652).
+  `tests/mnemonic/_data/bip39_test_vectors.json` held all twelve language
+  arrays of `trezor/python-mnemonic`'s `vectors.json` plus a 25th english
+  case that is btclib's own -- the last vector respaced with tabs,
+  newlines, doubled spaces and a form feed, which is what says the
+  library normalises whitespace rather than `str.split` saying it. One
+  case of ours inside an upstream array is what makes a refresh a merge:
+  upstream regenerates that file whole with its own
+  `tools/generate_vectors.py`, so the obvious refresh is a copy over the
+  top, and a copy over the top drops the case without a word. It is now a
+  `pytest.param` in `tests/mnemonic/bip39_test.py`, appended to the list
+  the file feeds, so it runs in the same test against the same four
+  fields under the id `24-en-respaced`, and the refresh is the fetch
+  itself -- the command is in the entry.
+
+  `git hash-object` on the vendored copy now answers
+  `d362a5d4eb1ba800a52aec30116915cd4576e1fd`, the blob id its pin already
+  recorded, which is the check `tests/_data/README.md` describes and the
+  one an edited copy cannot pass. Its verdict moves from **extended** to
+  **identical**, leaving no file there carrying an edit of ours, and the
+  verdict list says so as the rule it now is: a case of btclib's own is
+  written in the test module that reads the file, never inside the file.
+
 ## v2026.8.9
 
 ### Descriptors and miniscript

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -54,10 +54,11 @@ the same in each: there is no upstream file whose name they could take
   `bip371_test_vectors.json`, `bip373_test_vectors.json` and
   `bip67_test_vectors.json` are transcribed from mediawiki prose. There is
   no upstream file, so the name is ours by necessity.
-- `bip39_test_vectors.json` holds all twelve language arrays of trezor's
-  `vectors.json`, plus one btclib case, and keeps the btclib name anyway:
-  `vectors.json` is taken in the very same directory, by SLIP-0039's own
-  file of that name, which is a different upstream's.
+- `bip39_test_vectors.json` is trezor's `vectors.json` byte for byte, and
+  keeps the btclib name anyway: `vectors.json` is taken in the very same
+  directory, by SLIP-0039's own file of that name, which is a different
+  upstream's. The blob id in its entry is what the naming cannot fool
+  here.
 - `descriptor_checksums.json` and `rfc6979.json` are transcribed from
   prose, and `electrum_test_vectors.json`,
   `electrum_language_vectors.json`, `btclib_test_vectors.json` and
@@ -92,7 +93,11 @@ verdict. The verdicts used:
 - **transcribed** — the upstream is prose (a BIP, an RFC), so there is no
   file to compare; the check is that every value in our copy appears
   verbatim in the pinned text.
-- **extended**, **edited** — characterised in the entry.
+- **extended**, **edited** — characterised in the entry. No file here
+  carries one, and that is the discipline rather than an accident: a case
+  of btclib's own is written in the test module that reads the file,
+  never inside the file, so refreshing a pin is a fetch and never a
+  merge.
 
 `pulled` is the date of the btclib commit that put the current content in
 the tree, from `git log --follow --diff-filter=A`. That is a fact in this
@@ -1183,21 +1188,37 @@ pulled  2018-06-01, refreshed 2026-08-02
 behind  0 revisions
 ```
 
-Verdict: **extended**, and reformatted. All twelve language arrays are
-ours, in order, value for value; ours has one vector upstream does not,
-a 25th English case repeating the last with tabs, newlines and doubled
-spaces sprinkled through the mnemonic, to exercise whitespace
-normalisation. btclib's, not upstream's.
+Verdict: **identical**. All twelve language arrays, in order and value
+for value, at the indentation upstream writes them with, so
+`git hash-object` on our copy answers the blob id above and a refresh is
+the fetch itself:
 
-Held to the `english` array alone until 2026-08-02, when the other eleven
-word-lists became languages btclib reads: the pin was the earliest
-revision providing that array, since it has not changed in any of them,
-and the pin is now the current revision because the arrays taken are all
-of them.
+```shell
+gh api -H 'Accept: application/vnd.github.raw' \
+    '/repos/trezor/python-mnemonic/contents/vectors.json?ref=master' \
+    > tests/mnemonic/_data/bip39_test_vectors.json
+```
 
-The name is btclib's rather than upstream's, and stays so now that all
-twelve arrays are here: `vectors.json` is taken in this very directory,
-by SLIP-0039's own file of that name, which is a different upstream's.
+Upstream generates the file with its own `tools/generate_vectors.py`
+rather than maintaining it by hand, which is what makes that one command
+the whole of a refresh -- and why nothing of btclib's is inside it. The
+one case that is ours, the last English vector with tabs, newlines,
+doubled spaces and a form feed through the mnemonic, is a `pytest.param`
+in `tests/mnemonic/bip39_test.py` beside the ones the file feeds: in the
+array it would have to be re-added by hand at every refresh, and would
+go missing the once nobody remembered.
+
+Two `pulled` dates because the `english` array was here on its own for
+as long as english was the only BIP39 language btclib read; that array
+has not changed in any revision, so the earlier pull and this one hold
+the same file for it, and `behind 0 revisions` is now about the whole of
+the file rather than about one array of it.
+
+The name is btclib's rather than upstream's, which the naming rule above
+allows for one reason and this is it: `vectors.json` is taken in this
+very directory, by SLIP-0039's own file of that name, which is a
+different upstream's. The blob id is what checks the file behind the
+name.
 
 ### `tests/mnemonic/_data/test_JP_BIP39.json`
 
@@ -1610,8 +1631,8 @@ Against a pinned upstream blob:
   `script_tests.json`, `tx_valid.json`, `tx_invalid.json`,
   `key_io_valid.json`, `key_io_invalid.json`,
   `base58_encode_decode.json`, `blockfilters.json`,
-  `checkblock_valid.json`, `checkblock_invalid.json`, and the eight
-  BIP327 vector files.
+  `checkblock_valid.json`, `checkblock_invalid.json`,
+  `bip39_test_vectors.json`, and the eight BIP327 vector files.
 - identical but for a trailing newline:
   `script_assets_test.json`, `vectors.json`.
 - identical but for CRLF against LF: `bip340_test_vectors.csv` and the
@@ -1619,7 +1640,6 @@ Against a pinned upstream blob:
 - JSON-equal, reformatted: `pubkey.json`, `ecdsa_sig.json`,
   `ecdsa_custom_nonce_sig.json`, `signmessage.json`,
   `test_JP_BIP39.json`.
-- upstream plus one btclib case: `bip39_test_vectors.json`.
 
 No upstream blob exists for the rest:
 

--- a/tests/mnemonic/_data/bip39_test_vectors.json
+++ b/tests/mnemonic/_data/bip39_test_vectors.json
@@ -143,12 +143,6 @@
             "void come effort suffer camp survey warrior heavy shoot primary clutch crush open amazing screen patrol group space point ten exist slush involve unfold",
             "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
             "xprv9s21ZrQH143K39rnQJknpH1WEPFJrzmAqqasiDcVrNuk926oizzJDDQkdiTvNPr2FYDYzWgiMiC63YmfPAa2oPyNB23r2g7d1yiK6WpqaQS"
-        ],
-        [
-            "f585c11aec520db57dd353c69554b21a89b20fb0650966fa0a9d6f74fd989d8f",
-            " void come  effort suffer   camp survey\nwarrior heavy  shoot primary\tclutch crush\r\nopen amazing\fscreen patrol\rgroup space point ten exist slush involve unfold  ",
-            "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998",
-            "xprv9s21ZrQH143K39rnQJknpH1WEPFJrzmAqqasiDcVrNuk926oizzJDDQkdiTvNPr2FYDYzWgiMiC63YmfPAa2oPyNB23r2g7d1yiK6WpqaQS"
         ]
     ],
     "chinese_simplified": [

--- a/tests/mnemonic/bip39_test.py
+++ b/tests/mnemonic/bip39_test.py
@@ -70,13 +70,38 @@ LANGUAGES = {
     "turkish": "tr",
 }
 
+VECTORS = load("mnemonic", "_data", "bip39_test_vectors.json", encoding="utf-8")
+
 BIP39_VECTORS = [
     pytest.param(lang, *vector, id=vector_id(index, lang, vector[0]))
     for name, lang in LANGUAGES.items()
-    for index, vector in enumerate(
-        load("mnemonic", "_data", "bip39_test_vectors.json", encoding="utf-8")[name]
-    )
+    for index, vector in enumerate(VECTORS[name])
 ]
+
+# btclib's own case, and the only one not in the file: the last english
+# vector again, its mnemonic respaced with everything split() treats as a
+# separator -- doubled spaces, a tab, a newline, a CRLF, a form feed, a
+# bare CR, and a run of spaces at each end. It is written here rather
+# than appended to the vendored array so that the file stays upstream's
+# bytes and a refresh stays a fetch; a case of ours inside it would have
+# to be put back by hand every time, and would go missing the once
+# nobody remembered
+RESPACED = (
+    " void come  effort suffer   camp survey\nwarrior heavy  shoot"
+    " primary\tclutch crush\r\nopen amazing\fscreen patrol\rgroup space"
+    " point ten exist slush involve unfold  "
+)
+ENTROPY, _, SEED, XPRV = VECTORS["english"][-1]
+BIP39_VECTORS.append(
+    pytest.param(
+        "en",
+        ENTROPY,
+        RESPACED,
+        SEED,
+        XPRV,
+        id=vector_id(len(VECTORS["english"]), "en", "respaced"),
+    )
+)
 
 
 @pytest.mark.parametrize("lang, entr, mnemonic, seed, xprv", BIP39_VECTORS)
@@ -85,13 +110,13 @@ def test_vectors(lang: str, entr: str, mnemonic: str, seed: str, xprv: str) -> N
 
     https://github.com/trezor/python-mnemonic/blob/master/vectors.json
 
-    Upstream's arrays, in order and value for value, plus a 25th English
-    case that is btclib's own: the last one repeated with tabs, newlines
-    and doubled spaces through the mnemonic. tests/_data/README.md pins
-    the revision.
+    Upstream's arrays, in order and value for value: the vendored file is
+    that file byte for byte, blob id included, and tests/_data/README.md
+    pins the revision. The one case that is btclib's own is appended
+    above, outside it.
 
-    The sentence a vector holds is what the library is handed, that 25th
-    one included: rejoining it here first would ask
+    The sentence a vector holds is what the library is handed, the
+    respaced one included: rejoining it here first would ask
     `" ".join(mnemonic.split())` whether it collapses whitespace, and
     never ask btclib. Only the *expected* sentence is rejoined, and on
     the language's own separator -- the ideographic space for japanese,


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/652.

The twelve-language matrix ISS652 asks for is already here — it landed
with https://github.com/btclib-org/btclib/pull/253, pinned at the very
revision the issue names, `b57a5ad7`, and it runs through
`test_vectors` rather than a parallel test path. What was left of the
issue is its third bullet: adopt the regenerable-vectors convention
rather than hand-editing a committed vector file.

`tests/mnemonic/_data/bip39_test_vectors.json` was hand-edited: all
twelve arrays of upstream's `vectors.json` plus a 25th english case that
is btclib's own, the last vector respaced with tabs, newlines, doubled
spaces and a form feed. Upstream regenerates that file whole with
`tools/generate_vectors.py`, so a refresh is a copy over the top — and a
copy over the top drops a case sitting inside it without a word.

The case is now a `pytest.param` in `tests/mnemonic/bip39_test.py`,
appended to the list the file feeds, so it runs in the same test against
the same four fields, under the id `24-en-respaced`. The file is
upstream's bytes:

```shell
$ git hash-object tests/mnemonic/_data/bip39_test_vectors.json
d362a5d4eb1ba800a52aec30116915cd4576e1fd
```

which is the blob id the pin in `tests/_data/README.md` already
recorded, so the check that file describes — our blob against upstream's
tree entry — now has one comparison to make instead of an entry saying
why it cannot match. The verdict moves from **extended** to
**identical**; no file there carries an edit of ours any more, and the
verdict list states that as the rule.

Gates, all green locally: `uv run pytest` (18598 passed, 100.00%
coverage), `uv run pre-commit run --all-files`, and the sphinx `-W`
build.

## Summary by Sourcery

Vendor trezor’s BIP39 test vectors byte-for-byte and move btclib’s custom whitespace-normalisation case into the test module.

Documentation:
- Update tests/_data/README.md to document that bip39_test_vectors.json is an identical vendored copy of trezor’s vectors.json, with btclib-specific cases living only in tests.
- Add a changelog entry describing the BIP39 vector vendoring change and the relocation of btclib’s custom test case.

Tests:
- Load BIP39 vectors from the vendored JSON once, append a dedicated respaced-English pytest case in code, and keep the parametrized test behavior unchanged.