### PR TITLE
Grind for a low-R signature when asked, as Core does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -937,6 +937,64 @@ documented at release-notes length in the first place, and are still in
   exactly six characters long; the alphabet stays lowercase-only, built
   once at import time, because `_decode` already lowers `bech` before
   reaching the lookup.
+- **`dsa.sign` grinds for a low-R signature when asked to** (#638). An `r`
+  with its highest bit set costs a `0x00` byte of DER pad, to keep it from
+  reading as negative, so a signer that does not like the `r` it drew signs
+  again with a counter as extra entropy until it draws one below `2**255`:
+  70 bytes of DER instead of 71, a byte off every input that carries the
+  signature, for one extra signature on average -- half of the draws are
+  low already. Core has done this by default since 0.17 (its PR 13666),
+  `electrum-ecc`'s `ECPrivkey.ecdsa_sign` and embit's `PrivateKey.sign` do
+  it too, and btclib ground nothing but `s`.
+
+  The retry sequence is Core's `CKey::Sign`, byte for byte, a ground
+  signature that reproduced only under btclib being worth nothing: attempt
+  0 passes no extra entropy at all -- so a first draw that is already low
+  is the plain RFC6979 signature, grinding or not -- and attempt i passes i
+  as 32 little-endian bytes, which is Core's `WriteLE32` into a zeroed
+  `extra_entropy[32]`, `counter.to_bytes(32, "little")` in the other two.
+  The counter reaches libsecp256k1 as `ndata` on the bindings path and
+  RFC6979's section 3.6 additional data on the Python one, which are the
+  same bytes in the same place, so the two arithmetics walk the same
+  nonces: `test_grinding_agrees_on_both_arithmetics` holds them to each
+  other byte for byte, `test_grinding_retries_with_cores_own_counter`
+  rebuilds the sequence from the bindings beside the loop -- an off-by-one,
+  a big-endian counter or 32 zero bytes for the first attempt all produce a
+  valid low-R signature and nothing else would notice -- and
+  `test_core_grinds_the_same_signatures` reproduces five of Core v31.1.0's
+  own, retries included. No attempt cap, as in Core: one would answer an
+  event of probability `2**-k` with an error a caller can do nothing about.
+
+  `grind=False` is the default, where Core has it on. A ground signature is
+  not the RFC6979 one for about half of all messages, and a caller pinning
+  btclib's deterministic signatures is entitled to keep getting them; the
+  five python-bitcoinlib vectors say the same thing from the other side,
+  four of the five having a high `r`, so grinding departs from exactly
+  those four -- `test_rfc6979_secp256k1_grinding_leaves_only_the_low_r_one`
+  beside the test that counts the four `s` values normalization moves.
+  Keyword-only, `ec` and `hf` being positional and a flag inserted before
+  them renumbering both.
+
+  Grinding is refused with a nonce of the caller's and with a
+  sign-to-contract commitment, each of which already owns what grinding
+  needs -- the nonce itself, and the extra entropy the counter travels
+  through. For the commitment that is more than a clash of encodings:
+  grinding a nonce is exactly the freedom the ECDSA anti-exfil protocol
+  takes away from a signing device, and `sign_` is the call that protocol
+  signs through. `sign_recoverable` takes no `grind` either, and there it
+  is not a matter of what owns the nonce: 65 bytes of `r`, `s` and the
+  recovery flag have no pad for a low `r` to save, which is why Core's
+  `SignCompact` does not grind. What grinding chooses is `r` and not the
+  encoded length: embit stops its loop at `len(sig.serialize()) > 70`,
+  which is the same question only for a low `s`, and with `lower_s=False`
+  btclib produces the 71-byte low-R signature Core cannot reach.
+
+  The private `_rfc6979_nonce_` takes `None` for no additional data now,
+  where it took `b""`, so one counter value travels down either path
+  unchanged: `None` and `b""` are the same absence in the Python
+  derivation, appending nothing being appending nothing, and the bindings
+  take `None` alone -- 32 bytes or no argument, a shorter one being a
+  caller mistake and not less entropy.
 
 ### The public API and the module layout
 

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -11,6 +11,10 @@ http://www.secg.org/sec1-v2.pdf
 specialized with bitcoin canonical 'lower-s' form
 to avoid accepting malleable signatures.
 
+``sign`` grinds for a low-R signature -- one byte shorter in DER -- when
+asked to, which is Core's default and not this library's: ``_grind_low_r``
+is the loop and says why.
+
 ``sign`` also takes a value to commit to inside the nonce,
 sign-to-contract style (see btclib.ecc.commit_nonce for the tweak), and
 the four ``anti_exfil_*`` functions here are the protocol that
@@ -22,6 +26,7 @@ from __future__ import annotations
 
 import contextlib
 import secrets
+from collections.abc import Callable
 from dataclasses import dataclass
 from hashlib import sha256
 from io import BytesIO
@@ -391,6 +396,57 @@ def _sign_(c: int, q: int, nonce: int, lower_s: bool, ec: Curve) -> Sig:
     return _sign_recoverable_(c, q, nonce, lower_s, ec)[0]
 
 
+def _is_low_r(r: int, ec: Curve) -> bool:
+    # Core's SigHasLowR, read off the scalar rather than off the 32 bytes
+    # it takes the top byte of: DER prepends a 0x00 to a value whose
+    # highest bit is set, to keep it from reading as negative, so r costs
+    # the pad exactly when it does not fit n_size bytes as a signed
+    # integer. On secp256k1 that is r < 2**255, and it is the size
+    # _serialize_scalar arrives at from the same bit_length
+    return r.bit_length() < 8 * ec.n_size
+
+
+def _grind_entropy(counter: int) -> bytes | None:
+    # None, not 32 zero bytes, for the first attempt: ndata is appended
+    # to the key and the message, so zeros are additional data like any
+    # other and the nonce would not be RFC6979's
+    return None if counter == 0 else counter.to_bytes(32, byteorder="little")
+
+
+def _grind_low_r(attempt: Callable[[int], Sig], grind: bool, ec: Curve) -> Sig:
+    """Sign until r is low, `attempt(counter)` being one signature.
+
+    Core's low-R grinding, from its PR 13666 and its default since 0.17:
+    an r with its highest bit set costs a byte of DER pad, in every input
+    that carries the signature, and re-signing with different extra
+    entropy draws another r. Half of the draws are low already, so the
+    expected cost is one extra signature and the expected saving half a
+    byte.
+
+    The sequence is Core's `CKey::Sign`, and it has to be, or a signature
+    is reproducible only against this library: attempt 0 passes no extra
+    entropy at all -- so a first draw that is already low is the plain
+    RFC6979 signature, grinding or not -- and attempt i passes i as 32
+    little-endian bytes, which is Core's `WriteLE32` into a zeroed
+    `extra_entropy[32]` for every counter it reaches, electrum-ecc's
+    `counter.to_bytes(32, "little")` and embit's the same.
+
+    No attempt cap. Core has none, and one would answer an event of
+    probability 2**-k with an error a caller can do nothing about; embit
+    breaks its loop at 200, which is a 2**-200 signature that is not low-R
+    rather than a refusal.
+    """
+    sig = attempt(0)
+    if not grind:
+        return sig
+
+    counter = 0
+    while not _is_low_r(sig.r, ec):
+        counter += 1
+        sig = attempt(counter)
+    return sig
+
+
 @overload
 def sign_(
     msg_hash: Octets,
@@ -400,6 +456,7 @@ def sign_(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
+    grind: bool = ...,
     commit_hash: None = None,
 ) -> Sig: ...
 
@@ -413,6 +470,7 @@ def sign_(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
+    grind: bool = ...,
     commit_hash: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -425,12 +483,22 @@ def sign_(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     *,
+    grind: bool = False,
     commit_hash: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """Sign a hf_len bytes message according to ECDSA signature algorithm.
 
     If the deterministic nonce is not provided, the RFC6979
     specification is used.
+
+    grind asks for a low-R signature, one byte shorter in DER: `_grind_low_r`
+    is the loop, Core's since its 0.17. Off by default, where Core has it
+    on, because it is a departure from RFC6979 for about half of all
+    messages -- the nonce of a ground signature is derived with a counter
+    in it -- and a caller pinning this library's deterministic signatures
+    is entitled to keep getting them. Keyword-only, rather than beside
+    lower_s where it belongs by subject: ec and hf are positional here and
+    a flag inserted before them would renumber both.
 
     commit_hash is a value to commit to inside the nonce, sign-to-contract
     style: the signature is an ordinary one, and the receipt returned
@@ -458,31 +526,59 @@ def sign_(
     if commit_hash is not None and nonce is not None:
         raise BTClibValueError("a commitment derives its own nonce")
 
+    # grinding is a search over nonces, so it needs the derivation to be
+    # its own: a nonce the caller chose is the nonce and there is nothing
+    # left to draw, and a commitment already owns the extra entropy the
+    # counter would travel through. The second is not only an encoding
+    # clash -- grinding a nonce is exactly the freedom the anti-exfil
+    # protocol takes away from a signing device, see
+    # anti_exfil_host_commit, and this is the call that protocol signs
+    # through
+    if grind and (nonce is not None or commit_hash is not None):
+        raise BTClibValueError("grinding derives its own nonce")
+
     # a nonce provided by the caller is the nonce, while what
     # libsecp256k1 takes is extra entropy for the RFC6979 nonce it
     # derives itself: the two cannot be the same argument, so a
     # requested nonce is for the Python implementation below to use.
     # A commitment is that same entropy, and the bindings' sign() does
-    # not expose it either, so it is the Python path that commits
+    # not expose it either, so it is the Python path that commits.
+    # A grinding counter is that entropy too, and this is the one place
+    # it is not the reason to decline: `ndata` is what the bindings take
+    # it as, so grinding stays where the signing is
     if (
         _libsecp256k1_applicable(ec, hf)
         and nonce is None
         and lower_s
         and commit_hash is None
     ):
-        return Sig.parse(libsecp256k1_dsa.sign(msg_hash, q))
+        return _grind_low_r(
+            lambda counter: Sig.parse(
+                libsecp256k1_dsa.sign(msg_hash, q, _grind_entropy(counter))
+            ),
+            grind,
+            ec,
+        )
 
     # the challenge
     c = challenge_(msg_hash, ec, hf)  # 4, 5
 
     if commit_hash is None:
         # nonce: an integer in the range 1..n-1.
-        if nonce is None:
-            nonce = _rfc6979_nonce_(c, q, ec, hf)  # 1
-        else:
-            nonce = int_from_prv_key(nonce, ec)
-        # second part delegated to helper function
-        return _sign_(c, q, nonce, lower_s, ec)
+        if nonce is not None:
+            # second part delegated to helper function
+            return _sign_(c, q, int_from_prv_key(nonce, ec), lower_s, ec)
+        return _grind_low_r(
+            lambda counter: _sign_(
+                c,
+                q,
+                _rfc6979_nonce_(c, q, ec, hf, _grind_entropy(counter)),  # 1
+                lower_s,
+                ec,
+            ),
+            grind,
+            ec,
+        )
 
     # the commitment enters twice: once as RFC6979 additional data, so
     # that this nonce belongs to this commitment, and once as the tweak.
@@ -503,6 +599,7 @@ def sign(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
+    grind: bool = ...,
     commit: None = None,
 ) -> Sig: ...
 
@@ -516,6 +613,7 @@ def sign(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
+    grind: bool = ...,
     commit: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -528,6 +626,7 @@ def sign(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     *,
+    grind: bool = False,
     commit: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """ECDSA signature with canonical low-s preference.
@@ -547,6 +646,9 @@ def sign(
 
     RFC6979 is used for deterministic nonce.
 
+    grind asks for a low-R signature, as in `sign_`, which is where the
+    loop and the default are explained.
+
     commit is a value to commit to inside the nonce, and is reduced by hf
     as msg is: `sign_` is the spelling that takes the two hashes.
 
@@ -555,9 +657,11 @@ def sign(
     """
     msg_hash = reduce_to_hlen(msg, hf)
     if commit is None:
-        return sign_(msg_hash, prv_key, nonce, lower_s, ec, hf)
+        return sign_(msg_hash, prv_key, nonce, lower_s, ec, hf, grind=grind)
     commit_hash = reduce_to_hlen(commit, hf)
-    return sign_(msg_hash, prv_key, nonce, lower_s, ec, hf, commit_hash=commit_hash)
+    return sign_(
+        msg_hash, prv_key, nonce, lower_s, ec, hf, grind=grind, commit_hash=commit_hash
+    )
 
 
 def sign_recoverable_(
@@ -582,6 +686,12 @@ def sign_recoverable_(
     keeps: the key_id is derivable from any signature by recovering the
     four candidates and seeing which is the signer's, so what this saves
     is that search and not a secret.
+
+    No `grind` either, and here it is not a matter of the shape: a
+    recoverable signature is 65 bytes of r, s and the flag, with no DER
+    pad for a low r to save. Core has the same asymmetry, `CKey::Sign`
+    grinding and `CKey::SignCompact` passing a null ndata and looping over
+    nothing.
     """
     # the message msg_hash: a hf_len array
     hf_len = hf().digest_size

--- a/btclib/ecc/rfc6979_nonce.py
+++ b/btclib/ecc/rfc6979_nonce.py
@@ -57,7 +57,7 @@ def challenge_(
 
 
 def _rfc6979_nonce_(
-    c: int, q: int, ec: Curve, hf: HashF, extra_entropy: bytes = b""
+    c: int, q: int, ec: Curve, hf: HashF, extra_entropy: bytes | None = None
 ) -> int:
     # https://www.rfc-editor.org/rfc/rfc6979.html section 3.2
 
@@ -68,8 +68,12 @@ def _rfc6979_nonce_(
     # section 3.6 additional data k', appended to the key and the message
     # rather than mixed in: the RFC leaves the encoding to the caller and
     # libsecp256k1 appends its 32-byte ndata here, which is what makes the
-    # sign-to-contract vectors of commit_nonce reproducible
-    bprvbm = q_bytes + c_bytes + extra_entropy
+    # sign-to-contract vectors of commit_nonce reproducible.
+    # None and b"" are the same absence of additional data here, appending
+    # nothing being appending nothing; the bindings take None alone -- 32
+    # bytes or no argument, a shorter one being a caller mistake and not
+    # less entropy -- so a caller holding either passes it unchanged
+    bprvbm = q_bytes + c_bytes + (extra_entropy or b"")
 
     hf_size = hf().digest_size
     v = b"\x01" * hf_size  # 3.2.b
@@ -115,11 +119,12 @@ def rfc6979_nonce_(
     extra_entropy is the section 3.6 additional data: two callers with
     the same key and message reach different nonces by passing different
     values, and the derivation stays deterministic in all of its inputs.
-    It is what a commitment travels through in commit_nonce, and what
+    It is what a commitment travels through in commit_nonce, what the
+    low-R grinding of ``dsa.sign_`` puts its counter in, and what
     libsecp256k1 calls ndata.
     """
     c = challenge_(msg_hash, ec, hf)
     q = int_from_prv_key(prv_key, ec)
-    extra = b"" if extra_entropy is None else bytes_from_octets(extra_entropy)
+    extra = None if extra_entropy is None else bytes_from_octets(extra_entropy)
 
     return _rfc6979_nonce_(c, q, ec, hf, extra)

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -533,6 +533,248 @@ def test_libsecp256k1() -> None:
     assert dsa.verify_(msg_hash, pub_key, libsecp256k1_sig)
 
 
+# Core's low-R grinding (issue #638): the loop is `dsa._grind_low_r`, and
+# what follows holds it to the three implementations that have it -- Core's
+# `CKey::Sign` since its PR 13666, electrum-ecc's `ECPrivkey.ecdsa_sign`
+# and embit's `PrivateKey.sign`. 2**255 is the bound all three grind
+# towards: r at or above it has its highest bit set, and DER then pays a
+# 0x00 byte to keep it from reading as negative
+_LOW_R = 2**255
+
+
+def test_grinding_lands_on_a_low_r() -> None:
+    """Every ground signature is low-R, and half of them were already.
+
+    Which is the whole of what grinding buys and what it costs: a 70-byte
+    DER encoding instead of 71, for the price of one extra signature on
+    average. Grinding starts from the plain RFC6979 signature and no extra
+    entropy at all, so a message whose r is low already is signed exactly
+    as `grind=False` signs it -- and that is about half of them, which is
+    what the count checks: an implementation whose first attempt carried a
+    counter would satisfy every other assertion here.
+
+    69 bytes is a scalar below 2**248, one draw in 256 for each of r and s,
+    hence the inequality rather than an equality on the length.
+    """
+    q, Q = dsa.gen_keys(0x1)
+    unchanged = 0
+    for i in range(64):
+        msg = f"btclib grind {i}".encode()
+        plain = dsa.sign(msg, q)
+        ground = dsa.sign(msg, q, grind=True)
+        assert ground.r < _LOW_R
+        assert len(ground.serialize()) <= 70
+        assert dsa.verify(msg, Q, ground)
+        # the two agree exactly where the plain signature is low-R
+        assert (plain == ground) == (plain.r < _LOW_R)
+        unchanged += plain == ground
+    # 32 expected, and the interval is what a fair coin gives over 64
+    # draws with room to spare: a one-sided implementation lands at 0 or 64
+    assert 20 < unchanged < 44
+
+
+def test_grinding_retries_with_cores_own_counter() -> None:
+    """The retry sequence, rebuilt from the bindings beside the loop.
+
+    Core signs with a null ndata and then re-signs with
+    `WriteLE32(extra_entropy, ++counter)` into a zeroed 32-byte buffer,
+    which is electrum-ecc's and embit's `counter.to_bytes(32, "little")`:
+    so the ground signature is the first low-R element of that sequence,
+    and nothing weaker says so. An off-by-one in the counter, or a
+    big-endian encoding, or 32 zero bytes for the first attempt, each
+    produces a valid low-R signature that no other assertion in this file
+    would object to.
+    """
+    q = prv_key_int
+    retries = []
+    for i in range(24):
+        msg_hash = reduce_to_hlen(f"btclib grind {i}".encode())
+        sequence = [
+            dsa.Sig.parse(
+                libsecp256k1_dsa.sign(
+                    msg_hash,
+                    q,
+                    None if counter == 0 else counter.to_bytes(32, "little"),
+                )
+            )
+            for counter in range(16)
+        ]
+        first_low = next(i for i, sig in enumerate(sequence) if sig.r < _LOW_R)
+        assert dsa.sign_(msg_hash, q, grind=True) == sequence[first_low]
+        retries.append(first_low)
+
+    # a signature that grinds and one that does not are both here, and so
+    # is a counter past its first value: the increment is asserted, not
+    # only the first step off zero
+    assert min(retries) == 0
+    assert max(retries) > 1
+
+
+def test_grinding_agrees_on_both_arithmetics(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The counter reaches the same nonce through ndata and through RFC6979.
+
+    libsecp256k1's nonce function appends its 32 bytes of ndata to the key
+    and the message inside HMAC-DRBG, which is where RFC6979's section 3.6
+    additional data goes, so the two grinds walk the same sequence of
+    nonces. They must agree byte for byte, or a ground signature would
+    depend on which arithmetic made it -- and the Python path is what
+    signs for every other curve and hash function, where there are no
+    bindings to fall back on.
+    """
+    q, Q = dsa.gen_keys(prv_key_int)
+    for i in range(16):
+        msg = f"btclib grind {i}".encode()
+        delegated = dsa.sign(msg, q, grind=True)
+        with monkeypatch.context() as no_dsa_bindings:
+            no_dsa_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            python = dsa.sign(msg, q, grind=True)
+        assert delegated == python
+        assert delegated.r < _LOW_R
+        assert dsa.verify(msg, Q, python)
+
+
+def test_grinding_is_about_r_and_not_about_the_encoded_length() -> None:
+    """Grinding chooses r, and the encoded length is what follows from it.
+
+    embit stops its loop at `len(sig.serialize()) > 70` where Core asks for
+    r < 2**255, and the two are one question only for a low s. With
+    `lower_s=False` the s that was computed stays, its own highest bit set
+    half of the time, so a ground signature is 71 bytes with a low r --
+    which is not a case Core can reach, libsecp256k1 handing back the low s
+    always, and is one btclib reaches on purpose. `lower_s=False` is also
+    one of the reasons the bindings are not asked, so this is the Python
+    grind, and sha512 below is another of those reasons.
+    """
+    q, Q = dsa.gen_keys(prv_key_int)
+    lengths = set()
+    for i in range(32):
+        msg = f"btclib grind {i}".encode()
+        sig = dsa.sign(msg, q, lower_s=False, grind=True)
+        assert sig.r < _LOW_R
+        assert dsa.verify(msg, Q, sig, lower_s=False)
+        lengths.add(len(sig.serialize()))
+    # both, and the 71 is the byte s asked for: grinding did not go looking
+    # for another s, and a loop on the length would have
+    assert lengths == {70, 71}
+
+    for i in range(8):
+        msg = f"btclib grind {i}".encode()
+        sig = dsa.sign(msg, q, hf=sha512, grind=True)
+        assert sig.r < _LOW_R
+        assert dsa.verify(msg, Q, sig, hf=sha512)
+
+
+def test_grinding_refuses_what_already_owns_the_nonce() -> None:
+    """A nonce of the caller's and a commitment leave nothing to grind.
+
+    Grinding is a search over nonces: with the nonce given there is nothing
+    to search, and a commitment already occupies the extra entropy the
+    counter travels through. The second is not only a clash of encodings --
+    grinding a nonce is exactly the freedom the anti-exfil protocol takes
+    away from a signing device -- and neither is refused without `grind`.
+    """
+    msg = b"Satoshi Nakamoto"
+    nonce = 0x9E5755E5A8FCC1B0A2FD1E0AD9E8D6B29B67D67E6C6A0DEE01E7E1F30DB9A0BE
+    err_msg = "grinding derives its own nonce"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        dsa.sign(msg, prv_key_int, nonce, grind=True)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        dsa.sign(msg, prv_key_int, grind=True, commit=b"a commitment")
+    with pytest.raises(BTClibValueError, match=err_msg):
+        dsa.sign_(reduce_to_hlen(msg), prv_key_int, grind=True, commit_hash=bytes(32))
+
+    _, Q = dsa.gen_keys(prv_key_int)
+    assert dsa.verify(msg, Q, dsa.sign(msg, prv_key_int, nonce))
+    sig, receipt = dsa.sign(msg, prv_key_int, commit=b"a commitment")
+    assert dsa.verify(msg, Q, sig, commit=b"a commitment", receipt=receipt)
+
+
+# Bitcoin Core v31.1.0 as the oracle, on a regtest node with no wallet:
+# `createrawtransaction` spends outpoint 0101..01:0 -- a p2wpkh output of
+# the key, worth 1 BTC -- into a p2wpkh output of the same key worth the
+# value named below, and `signrawtransactionwithkey` signs that with the
+# key's WIF and that prevout. Core grinds by default, so the witness item
+# it produces is its ground signature; `msg_hash` is btclib's own segwit v0
+# `sig_hash.from_tx` for the transaction Core built, which is what the
+# signature verifying under it confirms.
+#
+# Private key, message hash, DER signature with Core's sighash byte
+# dropped, and the number of retries grinding cost. That last field is
+# what makes these five more than one vector five times over: 0 is the
+# draw grinding leaves alone, and 2 and 7 pin the counter well past its
+# first value. The output values that re-derive them, in this order:
+# 0.999, 0.997, 0.998, 0.987 and 0.993 BTC.
+#
+# A list of pytest.param rather than a tuple of tuples: a DER signature is
+# two source lines wide, and implicit concatenation inside a collection
+# literal is what ruff's ISC004 objects to -- a missing comma away from
+# being one element instead of two
+_CORE_VECTORS = [
+    pytest.param(
+        0x1,
+        "133bf859d57c50cb522cff0ac5300f639c90a089914ff6103d095615b1d844f2",
+        "304402205a9cc47c9c726331dfe114f1f5d83800b0f3c67a70ac3d373e1a31bd8b6c6f11"
+        "0220734109a45cbc732e999c988842531dc1f20b2e5f590aed7732fa304e4ba27ee3",
+        0,
+        id=vector_id(0, "0-retries"),
+    ),
+    pytest.param(
+        0x1,
+        "d14c29beb26e63426a41b36a11183b54f5b22c33115d8e7f0ba49a58b336149e",
+        "30440220353bdc7e3946c2b75b87b5587677794c55533275fd129c6ef26d877ff37f7032"
+        "0220182f97be35ab386b1adea91a224876b1f00d43966f1b8de6517af8ed33f56c95",
+        1,
+        id=vector_id(1, "1-retry"),
+    ),
+    pytest.param(
+        0x1,
+        "e4a96c927ca0fb2a09bd17cb86aea29917199b304d075d23a191566a8cf61b09",
+        "3044022052b0cd32b4171b77bb22e83bc450d5123d257f961aa21521fa3a4eda7639e63b"
+        "022047e4aa600baaab959f5a460f0124a7153ccda22459775ccf8ac6ecc3c9326c09",
+        2,
+        id=vector_id(2, "2-retries"),
+    ),
+    pytest.param(
+        0xC28FCA386C7A227600B2FE50B7CAE11EC86D3BF1FBE471BE89827E19D72AA1D,
+        "f56caf9a85d192163762c9f99d39992c68e987c929ed859efc6a890c75012d8b",
+        "304402201b7fb7e26572ebc9c3613513b672fed24a81e3e98a76739f67ac457be0c47cd4"
+        "022028e43694137339433c0d40f68a1ae48293a5629f8fe08b9bb1722e8d0f951b4e",
+        3,
+        id=vector_id(3, "3-retries"),
+    ),
+    pytest.param(
+        0x1,
+        "367edb7a74cf12d6111efa368624d599a44fdda82a028059091f0967b61adba9",
+        "304402202efab9db55ab5abb9d78b5617ad5ec5117efdb36f5ba3150b462acf0297cd052"
+        "0220178fbc4d9f9817ddb0f35a2ed9cf9e0437f3ea261c00b4a176201b6558b722da",
+        7,
+        id=vector_id(4, "7-retries"),
+    ),
+]
+
+
+@pytest.mark.parametrize("prv_key, msg_hash, der, retries", _CORE_VECTORS)
+def test_core_grinds_the_same_signatures(
+    prv_key: int, msg_hash: str, der: str, retries: int
+) -> None:
+    """Reproduce Bitcoin Core's own low-R signatures, byte for byte."""
+    sig_hash = bytes.fromhex(msg_hash)
+    sig = dsa.sign_(sig_hash, prv_key, grind=True)
+    assert sig.serialize().hex() == der
+    assert sig.r < _LOW_R
+
+    _, Q = dsa.gen_keys(prv_key)
+    assert dsa.verify_(sig_hash, Q, sig)
+
+    # the retry count is a claim about which element of Core's sequence
+    # this is, so it is checked and not merely recorded: the plain
+    # signature for a count of zero, the counter's own signature otherwise
+    plain = dsa.sign_(sig_hash, prv_key)
+    assert (plain == sig) == (retries == 0)
+    ndata = None if retries == 0 else retries.to_bytes(32, "little")
+    assert sig.serialize() == libsecp256k1_dsa.sign(sig_hash, prv_key, ndata)
+
+
 def _recovered(
     key_id: int, msg: bytes, sig: dsa.Sig, lower_s: bool = True
 ) -> Point | None:

--- a/tests/ecc/rfc6979_test.py
+++ b/tests/ecc/rfc6979_test.py
@@ -132,6 +132,28 @@ def test_rfc6979_secp256k1_s_is_normalized() -> None:
     assert normalized == 4
 
 
+def test_rfc6979_secp256k1_grinding_leaves_only_the_low_r_one() -> None:
+    """Four of the five have a high r, which is what grinding re-signs.
+
+    The vectors are the plain RFC6979 signatures -- `grind=False`, this
+    library's default and the reason it is the default -- so `grind=True`
+    reproduces the one whose r is already below 2**255 and departs from the
+    other four, which is the whole of what the flag does to a
+    deterministic signature. `tests/ecc/dsa_test.py` is where the loop is
+    held to Core's, this being about the vectors: no vector is lost, and
+    the fourth is a vector for both spellings.
+    """
+    ground = 0
+    for prv_key, msg, _, r, _ in SECP256K1_VECTORS:
+        msg_hash = hashlib.sha256(msg.encode()).digest()
+        sig = dsa.sign_(msg_hash, prv_key, grind=True)
+        assert sig.r < 2**255
+        assert (sig.r == int(r, 16)) == (int(r, 16) < 2**255)
+        ground += sig.r != int(r, 16)
+        assert dsa.verify_(msg_hash, mult(prv_key), sig)
+    assert ground == 4
+
+
 def test_rfc6979_nonce_example() -> None:
     """Reproduce the worked example of RFC6979's section A.1."""
 


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/638, with the decision
recorded there: `grind: bool = False`, opt-in.

## What it does

`dsa.sign` and `dsa.sign_` take `grind`, keyword-only. An `r` with its
highest bit set costs a `0x00` byte of DER pad, so grinding re-signs with
a counter as extra entropy until `r < 2**255`: 70 bytes of DER instead of
71, a byte off every input that carries the signature, for one extra
signature on average.

The retry sequence is Core's `CKey::Sign`, byte for byte — attempt 0
passes no extra entropy at all, so a first draw that is already low is the
plain RFC6979 signature, and attempt i passes i as 32 little-endian bytes
(Core's `WriteLE32` into a zeroed `extra_entropy[32]`,
`counter.to_bytes(32, "little")` in electrum-ecc and embit). The counter
reaches libsecp256k1 as `ndata` on the bindings path and RFC6979's section
3.6 additional data on the Python one, which are the same bytes in the
same place, so the two arithmetics walk the same nonces. No attempt cap,
as in Core.

Grinding is refused with a nonce of the caller's and with a
sign-to-contract commitment, each of which already owns what grinding
needs; for the commitment that is more than a clash of encodings, grinding
a nonce being the freedom the anti-exfil protocol takes away from a
signing device. `sign_recoverable` takes no `grind`: 65 bytes of `r`, `s`
and the recovery flag have no pad to save, which is why Core's
`SignCompact` does not grind either.

## Evidence

- `test_core_grinds_the_same_signatures` reproduces five of **Bitcoin Core
  v31.1.0**'s own low-R signatures, byte for byte, at 0, 1, 2, 3 and 7
  retries. Built on a regtest node with no wallet:
  `signrawtransactionwithkey` over a p2wpkh spend, `msg_hash` being
  btclib's own segwit v0 `sig_hash.from_tx` for the transaction Core
  built. The retry count is asserted rather than recorded — each vector
  has to be that element of Core's sequence.
- `test_grinding_retries_with_cores_own_counter` rebuilds the sequence
  from the bindings beside the loop: an off-by-one, a big-endian counter,
  or 32 zero bytes for the first attempt each produce a valid low-R
  signature that nothing else would notice.
- `test_grinding_agrees_on_both_arithmetics` holds the bindings' grind and
  the Python one to each other byte for byte.
- `test_grinding_is_about_r_and_not_about_the_encoded_length`: embit stops
  at `len(sig.serialize()) > 70`, which is the same question only for a low
  `s`; with `lower_s=False` btclib produces the 71-byte low-R signature
  Core cannot reach.
- `test_rfc6979_secp256k1_grinding_leaves_only_the_low_r_one`: four of the
  five python-bitcoinlib vectors have a high `r`, so grinding departs from
  exactly those four and reproduces the fifth — which is also why the
  default is off.

Local gates, on the rebased tip: `uv run pytest` green with coverage at
100.00%, `uv run pre-commit run --all-files` green, and the sphinx `-W`
build green.

## The one thing to confirm

The issue's comment reads "fix the rfc6979 so that grind is set to true
only when the vendored signature result is known to be high-s". Taken as
low-R throughout, that is implemented two ways here: the bindings' fast
path is kept and re-signs only when the `r` it returned is high (grinding
never pushes signing onto the Python path), and in `rfc6979_test.py`
grinding is asserted to move exactly the vectors whose pinned `r` is high.
`_rfc6979_nonce_` also takes `None` for no additional data now, as the
bindings' `ndata` does, so one counter value travels down either path
unchanged. If "high-s" meant something else, say so and I will follow it.

## Summary by Sourcery

Add optional low-R signature grinding to ECDSA signing, aligned with Bitcoin Core’s behavior while keeping RFC6979 determinism as the default.

New Features:
- Introduce keyword-only grind flag to dsa.sign and dsa.sign_ to opt into low-R signature generation for secp256k1 and other supported curves.

Enhancements:
- Route libsecp256k1 and pure-Python signing through a shared low-R grinding loop so both implementations produce identical nonce sequences when grinding.
- Adjust RFC6979 nonce derivation helpers to treat absence of extra entropy consistently between bindings and Python, enabling reuse for grinding counters and sign-to-contract commitments.

Documentation:
- Document the new grind option, its default-off behavior, relation to Bitcoin Core’s low-R grinding, and constraints such as incompatibility with custom nonces, commitments, and recoverable signatures.
- Update the changelog to describe low-R grinding semantics, interoperability guarantees, and rationale for keeping the feature opt-in.

Tests:
- Add comprehensive tests validating low-R grinding behavior, parity with Bitcoin Core and other libraries, interaction with RFC6979 vectors, and refusal when a caller-supplied nonce or commitment is present.