### PR TITLE
Reach the Python path by the hash rather than by a patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1494,9 +1494,41 @@ documented at release-notes length in the first place, and are still in
   Strauss-Shamir sum inside `_jac_double_mult` land on infinity.
 
   BIP340 gains nothing here: Wycheproof publishes no Schnorr vectors for
-  secp256k1. The sha512, sha3 and shake variants of ECDSA are left for
-  later -- `dsa.sign` and `dsa.verify` take any hash function, so they are
-  a further file each and not a further question.
+  secp256k1.
+- **Wycheproof's sha512 and SHA3 files follow, and reach the Python path
+  without a patch** (#706). `dsa.verify_` takes any hash function, so
+  these are the same call with a different `hf`: sha512, SHA3-256 and
+  SHA3-512 in DER, and sha512 in P1363. None of them is a bitcoin
+  signature -- bitcoin signs with sha256 and nothing else -- and that is
+  the point of taking them: what they hold to account is the generic
+  ECDSA the API promises, and they are the only adversarial vectors that
+  reach it.
+
+  `_libsecp256k1_applicable` compares the hash by identity and admits
+  sha256 alone, so every one of these lands on the Python arithmetic by
+  construction rather than by patching the dispatch off -- the path
+  `SECURITY.md` publishes as not constant-time, under an adversary for
+  the first time. Which is also why they run once where the sha256 files
+  run twice: a second run named `bindings` would be the same Python
+  arithmetic under a name saying what did not happen, and `_paths` in
+  the test module reads that off the hash instead of asserting it. The
+  wide digests are the other half: `challenge_` truncates to the
+  leftmost `nlen` bits, which sha256 vectors cannot exercise at all.
+
+  Two sets were measured and deliberately left out, each with an entry in
+  `tests/_data/README.md` saying so -- "not taken" and "not noticed" look
+  the same in a directory listing otherwise.
+  `ecdh_secp256k1_webcrypto_test.json` is the ECDH file already vendored,
+  re-encoded as JWK: its valid cases yield 468 distinct shared secrets and
+  all 468 are that file's, its invalid classes a strict subset, so it
+  would add a base64url reader and no arithmetic. The four SHAKE files are
+  blocked on a type rather than on their data: an XOF has no fixed output,
+  so `hashlib.shake_128` fails `alias.HashObject` under mypy and, at run
+  time, makes `challenge_` demand a zero-length message hash -- which
+  `verify_` catches and reports as `False`, so every valid vector would
+  read as a bad signature rather than as an unsupported hash. Whether
+  `HashF` should admit an XOF is a public-surface question and is left
+  open.
 
 ## v2026.8.9
 

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -121,7 +121,7 @@ what their `pulled` says: the eight BIP327 files, the three Core files
 and the two python-bitcoinlib block files added here; Core's
 `blockfilters.json`, the psbts of BIP370 and BIP373 and the two BIP324
 csv files followed on 2026-08-03, at the tip of their paths too, the
-two BIP322 files on 2026-08-08, and the four Wycheproof files with the
+two BIP322 files on 2026-08-08, and the seven Wycheproof files with the
 licence beside them on 2026-08-13.
 
 A vector btclib fails is vendored anyway and marked `xfail`, never left
@@ -1324,19 +1324,22 @@ regenerates each of the four mnemonics word for word from the master
 secret. The other 11 are recovery only, a 2-of-3 share being random by
 construction.
 
-### C2SP/wycheproof: four files under `tests/ecc/_data/`
+### C2SP/wycheproof: eight files under `tests/ecc/_data/`
 
 The adversarial vectors, and the one upstream here published under a
 licence that is not MIT: Apache-2.0, whose condition on redistribution
-is a copy of the licence, so `WYCHEPROOF_COPYING` is vendored beside the
-four and has its own entry below. There is no `NOTICE` file at the pin
+is a copy of the licence, so `WYCHEPROOF_COPYING` is vendored beside
+them and has its own entry below. There is no `NOTICE` file at the pin
 to carry with it.
 
-All four are pinned to the same commit, `5722833c` of 2026-08-11, and
-all four live in `testvectors_v1/`. Not `testvectors/`, which upstream
-removed on 2025-09-02 and which no refresh can reach again. They are
-read by `tests/ecc/wycheproof_test.py`, which is also where the split
-between the two ECDSA profiles is explained.
+All are pinned to the same commit, `5722833c` of 2026-08-11, and all
+live in `testvectors_v1/`. Not `testvectors/`, which upstream removed
+on 2025-09-02 and which no refresh can reach again. They are read by
+`tests/ecc/wycheproof_test.py`, which is also where the split between
+the two ECDSA profiles is explained, and where the sha512 and SHA3
+files' one difference from the rest is: `_libsecp256k1_applicable`
+admits sha256 alone, so those reach the Python arithmetic without the
+dispatch being patched off, and are run once rather than twice.
 
 `ecdsa_secp256k1_sha256_bitcoin_test.json` is the one file of the four
 with no schema in upstream's `schemas/`, its own README listing it among
@@ -1388,6 +1391,65 @@ behind  0 revisions; that commit is the tip of the path
 Verdict: **identical**. IEEE P1363 encoding, raw `r` and `s` side by
 side, which reaches `Sig` with no DER in front of it.
 
+### `tests/ecc/_data/ecdsa_secp256k1_sha512_test.json`
+
+```text
+repo    C2SP/wycheproof
+path    testvectors_v1/ecdsa_secp256k1_sha512_test.json
+commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
+blob    612e1912bfb5e523fbe8183e0d12f468e8309a08
+pulled  2026-08-13
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**. A digest wider than the order, so `challenge_`'s
+truncation to the leftmost `nlen` bits is under adversarial input here
+and nowhere else.
+
+### `tests/ecc/_data/ecdsa_secp256k1_sha3_256_test.json`
+
+```text
+repo    C2SP/wycheproof
+path    testvectors_v1/ecdsa_secp256k1_sha3_256_test.json
+commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
+blob    5c6c5901f4d41af8a992cafc4aa31b6bc7b87163
+pulled  2026-08-13
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**. A Keccak digest of the order's own width, which
+is the pair to the file above: same width as sha256, different function,
+so what it varies is the dispatch and not the arithmetic.
+
+### `tests/ecc/_data/ecdsa_secp256k1_sha3_512_test.json`
+
+```text
+repo    C2SP/wycheproof
+path    testvectors_v1/ecdsa_secp256k1_sha3_512_test.json
+commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
+blob    2a5770e00be1c4d1218b79e8a805f52a0a1c7f26
+pulled  2026-08-13
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**. Wide digest and Keccak both, the fourth corner
+of the two the files above vary one at a time.
+
+### `tests/ecc/_data/ecdsa_secp256k1_sha512_p1363_test.json`
+
+```text
+repo    C2SP/wycheproof
+path    testvectors_v1/ecdsa_secp256k1_sha512_p1363_test.json
+commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
+blob    089040205b9d99313d284154cdcdc646079d1d43
+pulled  2026-08-13
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **identical**. The wide digest without DER around it, which is
+what says the P1363 size rule is the encoding's and not the hash's: r
+and s stay `n_size` each while the message hash doubles.
+
 ### `tests/ecc/_data/ecdh_secp256k1_test.json`
 
 ```text
@@ -1428,6 +1490,51 @@ which is false, the BIP and rustyrussell files beside it having their
 own terms and btclib's own `LICENSE` being at the root. The upstream
 name is in the entry above instead, where the pin already is. It is the
 name bitcoin-core/secp256k1 gives its copy for the same reason.
+
+### Not vendored: `ecdh_secp256k1_webcrypto_test.json`
+
+```text
+repo    C2SP/wycheproof
+path    testvectors_v1/ecdh_secp256k1_webcrypto_test.json
+commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
+pulled  never
+behind  0 revisions; that commit is the tip of the path
+```
+
+Verdict: **not vendored, measured to be a re-encoding**. It is the same
+agreement as `ecdh_secp256k1_test.json` above with the keys written as
+JWK -- `crv: "P-256K"`, base64url `x`, `y` and `d` -- rather than as
+X.509. Its valid cases yield 468 distinct shared secrets, and all 468
+are exactly that file's; its invalid cases are a strict subset of that
+file's classes, JWK having no ASN.1 for `InvalidAsn` or
+`InvalidEncoding` to attack.
+
+So what it would add is a base64url and JWK reader under `tests/`, and
+no arithmetic btclib does not already answer for. Recorded here rather
+than left silent because "we did not take it" and "we did not notice
+it" look the same in a directory listing, and a later refresh would
+otherwise have to measure this again.
+
+### Not vendored: the four SHAKE files
+
+`ecdsa_secp256k1_shake128_test.json`,
+`ecdsa_secp256k1_shake128_p1363_test.json`,
+`ecdsa_secp256k1_shake256_test.json` and
+`ecdsa_secp256k1_shake256_p1363_test.json`, at the same pin.
+
+Verdict: **not vendored, blocked on the type rather than on the data**.
+`hashlib.shake_128` is not a `HashF`: an XOF has no fixed output, so
+`digest_size` reads 0 and `digest()` takes the length as an argument,
+which `alias.HashObject.digest()` does not declare -- mypy refuses the
+assignment, and at run time `challenge_` asks
+`bytes_from_octets(msg_hash, 0)` and rejects every message hash. The
+failure is quiet where it matters most: `verify_` catches that
+`ValueError` and answers `False`, so every `valid` vector of those files
+would read as a bad signature rather than as an unsupported hash.
+
+Whether `HashF` should admit an XOF is a public-surface question, and
+answering it inside a test module would answer it in the one place
+`btclib/alias.py` cannot see. Left to the issue that raised it.
 
 ## Chain data, not a repository
 
@@ -1742,8 +1849,8 @@ Against a pinned upstream blob:
   `key_io_valid.json`, `key_io_invalid.json`,
   `base58_encode_decode.json`, `blockfilters.json`,
   `checkblock_valid.json`, `checkblock_invalid.json`,
-  `bip39_test_vectors.json`, the eight BIP327 vector files, and the four
-  Wycheproof vector files.
+  `bip39_test_vectors.json`, the eight BIP327 vector files, and the
+  seven Wycheproof vector files.
 - identical but for a trailing newline:
   `script_assets_test.json`, `vectors.json`, `WYCHEPROOF_COPYING`.
 - identical but for CRLF against LF: `bip340_test_vectors.csv` and the
@@ -1767,6 +1874,9 @@ No upstream blob exists for the rest:
 - response bodies under `tests/fetch/_data/`, whose envelopes are
   composed from Core's and Esplora's own source and whose payload is
   chain data two of the entries above already hold.
+- deliberately not vendored, each with an entry saying why it was
+  measured and left: Wycheproof's `ecdh_secp256k1_webcrypto_test.json`
+  and its four SHAKE files.
 - not vendored: `rfc6979.json` (an RFC), `electrum_test_vectors.json`,
   `electrum_language_vectors.json`, `fakeenglish.txt` and
   `btclib_test_vectors.json` (btclib's own). The last is the only one

--- a/tests/ecc/_data/ecdsa_secp256k1_sha3_256_test.json
+++ b/tests/ecc/_data/ecdsa_secp256k1_sha3_256_test.json
@@ -1,0 +1,6881 @@
+{
+  "algorithm": "ECDSA",
+  "schema": "ecdsa_verify_schema_v1.json",
+  "numberOfTests": 474,
+  "header": [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
+  "notes": {
+    "ArithmeticError": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
+      "cves": [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature": {
+      "bugType": "BER_ENCODING",
+      "description": "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect": "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves": [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero": {
+      "bugType": "LEGACY",
+      "description": "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect": "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves": [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "ValidSignature": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "",
+          "sig": "3046022100fc0f737a79d525eefe3c940c162173cc6fd9a6d5cc5017754026c4113d0f15cc022100894d6fb59cc79199b89cf12b556ba49f8623b66da8c11a55e267e3318497688c",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "4d7367",
+          "sig": "3043022076bae33ffa376b496bde93c7748d50a3a8b73bac045e54c40c7fcd344a10fa83021f3e25a20716a902d524d656ead090b7bbe1ac25ff71269d7038d4b08db5b1d7",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220016e2dfac600c8c994c0bb815b1072bb5bb680774121d342f93fe0a994f72c09022100c378944de05aaca70c71ed9a7fe4eed2b36ab3ddb4b32d09d53eebd91f2f9217",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "sig": "3045022100a33c4acb033f3d0d50d244249a1277448b6a52f524e30f4b73d595fb955e924702207f31b50c698a971c8fab98521ef3a1d6fa483a676230467c8af3018452bf1de1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx": "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy": "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 5,
+          "comment": "signature malleability",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022100bbdbc26e1099b2713ada34df9cfa8edaf905a4a6d2a1f449f05de03df8c2a696",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "Legacy: ASN encoding of r misses leading 0",
+          "flags": [
+            "MissingZero"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 7,
+          "comment": "valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "length of sequence [r, s] uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308145022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 9,
+          "comment": "length of sequence [r, s] contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30820045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "length of sequence [r, s] uses 70 instead of 69",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 11,
+          "comment": "length of sequence [r, s] uses 68 instead of 69",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 12,
+          "comment": "uint32 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30850100000045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "uint64 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3089010000000000000045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "length of sequence [r, s] = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30847fffffff022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "length of sequence [r, s] = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308480000000022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "length of sequence [r, s] = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3084ffffffff022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "length of sequence [r, s] = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085ffffffffff022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "length of sequence [r, s] = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3088ffffffffffffffff022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "incorrect length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30ff022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "removing sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "lonely sequence tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "appending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "prepending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30470000022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "appending unused 0's to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "appending null value to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a4981773045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304925003045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "appending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30473045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "including undefined tags",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304daa00bb00cd003045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d2229aa00bb00cd00022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2512228aa00bb00cd00022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "truncated length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3081",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "including undefined tags to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304baa02aabb3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "using composition with indefinite length for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30803045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 36,
+          "comment": "using composition with wrong tag for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30803145022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 37,
+          "comment": "Replacing sequence [r, s] with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 38,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2e45022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 39,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2f45022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 40,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3145022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 41,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3245022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 42,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "ff45022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 43,
+          "comment": "dropping value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 44,
+          "comment": "using composition for sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304930010230442100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 45,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 46,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30442100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 47,
+          "comment": "sequence [r, s] of size 4166 to check for overflows",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30821046022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 48,
+          "comment": "indefinite length",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 49,
+          "comment": "indefinite length with truncated delimiter",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 50,
+          "comment": "indefinite length with additional element",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab05000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 51,
+          "comment": "indefinite length with truncated element",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab060811220000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 52,
+          "comment": "indefinite length with garbage",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000fe02beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 53,
+          "comment": "indefinite length with nonempty EOC",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0002beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 54,
+          "comment": "prepend empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30473000022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 55,
+          "comment": "append empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 56,
+          "comment": "append zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 57,
+          "comment": "append garbage with high tag number",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aabbf7f00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 58,
+          "comment": "append null with explicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aaba0020500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 59,
+          "comment": "append null with implicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aaba000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 60,
+          "comment": "sequence of sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30473045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 61,
+          "comment": "truncated sequence: removed last 1 elements",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3023022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251",
+          "result": "invalid"
+        },
+        {
+          "tcId": 62,
+          "comment": "repeating element in sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3067022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 63,
+          "comment": "flipped bit 0 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304300eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe250022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 64,
+          "comment": "flipped bit 32 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304300eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e457534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 65,
+          "comment": "flipped bit 48 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304300eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e0e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 66,
+          "comment": "flipped bit 64 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304300eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73784e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 67,
+          "comment": "length of r uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304602812100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 68,
+          "comment": "length of r contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30470282002100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 69,
+          "comment": "length of r uses 34 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022200eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 70,
+          "comment": "length of r uses 32 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022000eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 71,
+          "comment": "uint32 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a0285010000002100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 72,
+          "comment": "uint64 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e028901000000000000002100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 73,
+          "comment": "length of r = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902847fffffff00eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 74,
+          "comment": "length of r = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902848000000000eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 75,
+          "comment": "length of r = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30490284ffffffff00eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 76,
+          "comment": "length of r = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a0285ffffffffff00eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 77,
+          "comment": "length of r = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d0288ffffffffffffffff00eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 78,
+          "comment": "incorrect length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502ff00eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 79,
+          "comment": "replaced r by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045028000eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 80,
+          "comment": "removing r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3022022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 81,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302302022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 82,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3024022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe25102",
+          "result": "invalid"
+        },
+        {
+          "tcId": 83,
+          "comment": "appending 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022300eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510000022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 84,
+          "comment": "prepending 0's to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30470223000000eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 85,
+          "comment": "appending unused 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510000022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 86,
+          "comment": "appending null value to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022300eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510500022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 87,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a2226498177022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 88,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304922252500022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 89,
+          "comment": "appending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d2223022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510004deadbeef022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 90,
+          "comment": "truncated length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30240281022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 91,
+          "comment": "including undefined tags to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b2227aa02aabb022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 92,
+          "comment": "using composition with indefinite length for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492280022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510000022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 93,
+          "comment": "using composition with wrong tag for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492280032100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510000022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 94,
+          "comment": "Replacing r with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30240500022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 95,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045002100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 96,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045012100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 97,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045032100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 98,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045042100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 99,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045ff2100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 100,
+          "comment": "dropping value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30240200022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 101,
+          "comment": "using composition for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304922250201000220eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 102,
+          "comment": "modifying first byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022102eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 103,
+          "comment": "modifying last byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2d1022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 104,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022000eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 105,
+          "comment": "r of size 4130 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308210480282102200eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 106,
+          "comment": "leading ff in r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30460222ff00eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 107,
+          "comment": "replaced r by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025090180022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 108,
+          "comment": "replacing r with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025020100022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 109,
+          "comment": "flipped bit 0 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3043022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe25144243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aaa",
+          "result": "invalid"
+        },
+        {
+          "tcId": 110,
+          "comment": "flipped bit 32 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3043022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe25144243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4fd7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 111,
+          "comment": "flipped bit 48 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3043022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe25144243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf757e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 112,
+          "comment": "flipped bit 64 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3043022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe25144243d91ef664d8ec525cb2063057123c1a9383fdca6abf0cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 113,
+          "comment": "length of s uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe25102812044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 114,
+          "comment": "length of s contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510282002044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 115,
+          "comment": "length of s uses 33 instead of 32",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022144243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 116,
+          "comment": "length of s uses 31 instead of 32",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251021f44243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 117,
+          "comment": "uint32 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510285010000002044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 118,
+          "comment": "uint64 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251028901000000000000002044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 119,
+          "comment": "length of s = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe25102847fffffff44243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 120,
+          "comment": "length of s = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe25102848000000044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 121,
+          "comment": "length of s = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510284ffffffff44243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 122,
+          "comment": "length of s = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510285ffffffffff44243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 123,
+          "comment": "length of s = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510288ffffffffffffffff44243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 124,
+          "comment": "incorrect length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe25102ff44243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 125,
+          "comment": "replaced s by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251028044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 126,
+          "comment": "appending 0's to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022244243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 127,
+          "comment": "prepending 0's to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510222000044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 128,
+          "comment": "appending null value to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022244243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 129,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2512225498177022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 130,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe25122242500022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 131,
+          "comment": "appending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2512222022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 132,
+          "comment": "truncated length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510281",
+          "result": "invalid"
+        },
+        {
+          "tcId": 133,
+          "comment": "including undefined tags to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2512226aa02aabb022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 134,
+          "comment": "using composition with indefinite length for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2512280022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 135,
+          "comment": "using composition with wrong tag for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2512280032044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 136,
+          "comment": "Replacing s with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 137,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251002044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 138,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251012044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 139,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251032044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 140,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251042044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 141,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251ff2044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 142,
+          "comment": "dropping value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510200",
+          "result": "invalid"
+        },
+        {
+          "tcId": 143,
+          "comment": "using composition for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2512224020144021f243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 144,
+          "comment": "modifying first byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022046243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 145,
+          "comment": "modifying last byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739a2b",
+          "result": "invalid"
+        },
+        {
+          "tcId": 146,
+          "comment": "truncated s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251021f44243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739a",
+          "result": "invalid"
+        },
+        {
+          "tcId": 147,
+          "comment": "truncated s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251021f243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 148,
+          "comment": "s of size 4129 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30821048022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510282102144243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 149,
+          "comment": "leading ff in s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe2510221ff44243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 150,
+          "comment": "replaced s by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251090180",
+          "result": "invalid"
+        },
+        {
+          "tcId": 151,
+          "comment": "replacing s with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 152,
+          "comment": "replaced r by r + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022101eb044a2e719d94a33837717ce9bc5ff94062cf047015777244b442e323862392022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 153,
+          "comment": "replaced r by r - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220eb044a2e719d94a33837717ce9bc5ffbcb051537118436fac50f85c98319a110022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 154,
+          "comment": "replaced r by r + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "304602220100eb044a2e719d94a33837717ce9bc5eb53490d8cd096d12f65740712689912351022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 155,
+          "comment": "replaced r by -r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30450221ff14fbb5d18e626b5cc7c88e831643a0057a4c0de23f3328c97b1e1ba9acb01daf022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 156,
+          "comment": "replaced r by n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022014fbb5d18e626b5cc7c88e831643a00434faeac8ee7bc9053af07a367ce65ef0022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 157,
+          "comment": "replaced r by -n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30450221fe14fbb5d18e626b5cc7c88e831643a006bf9d30fb8fea888dbb4bbd1cdc79dc6e022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 158,
+          "comment": "replaced r by r + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022101eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 159,
+          "comment": "replaced r by r + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304d0229010000000000000000eb044a2e719d94a33837717ce9bc5ffa85b3f21dc0ccd73684e1e456534fe251022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 160,
+          "comment": "replaced s by s + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "304502210144243d91ef664d8ec525cb20630571227c5815268bef4c2d8f46dcdba7a9dbec022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 161,
+          "comment": "replaced s by s - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30450221ff44243d91ef664d8ec525cb206305712506fa5b592d5e0bb60fa21fc2073d596a022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 162,
+          "comment": "replaced s by s + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30460222010044243d91ef664d8ec525cb2063056fde70861eef2546e7b1a1d30b1f0db4dbab022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 163,
+          "comment": "replaced s by -s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220bbdbc26e1099b2713ada34df9cfa8edc3e56c7c02359540e308b81b1288c6555022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 164,
+          "comment": "replaced s by -n - s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30450221febbdbc26e1099b2713ada34df9cfa8edd83a7ead97410b3d270b9232458562414022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 165,
+          "comment": "replaced s by s + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304502210144243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 166,
+          "comment": "replaced s by s - 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30450221ff44243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 167,
+          "comment": "replaced s by s + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304d022901000000000000000044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab022044243d91ef664d8ec525cb2063057123c1a9383fdca6abf1cf747e4ed7739aab",
+          "result": "invalid"
+        },
+        {
+          "tcId": 168,
+          "comment": "Signature with special case values r=0 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 169,
+          "comment": "Signature with special case values r=0 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 170,
+          "comment": "Signature with special case values r=0 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 171,
+          "comment": "Signature with special case values r=0 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 172,
+          "comment": "Signature with special case values r=0 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 173,
+          "comment": "Signature with special case values r=0 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 174,
+          "comment": "Signature with special case values r=0 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 175,
+          "comment": "Signature with special case values r=0 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 176,
+          "comment": "Signature with special case values r=1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 177,
+          "comment": "Signature with special case values r=1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 178,
+          "comment": "Signature with special case values r=1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 179,
+          "comment": "Signature with special case values r=1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 180,
+          "comment": "Signature with special case values r=1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 181,
+          "comment": "Signature with special case values r=1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 182,
+          "comment": "Signature with special case values r=1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 183,
+          "comment": "Signature with special case values r=1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 184,
+          "comment": "Signature with special case values r=-1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 185,
+          "comment": "Signature with special case values r=-1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 186,
+          "comment": "Signature with special case values r=-1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 187,
+          "comment": "Signature with special case values r=-1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 188,
+          "comment": "Signature with special case values r=-1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 189,
+          "comment": "Signature with special case values r=-1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 190,
+          "comment": "Signature with special case values r=-1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 191,
+          "comment": "Signature with special case values r=-1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 192,
+          "comment": "Signature with special case values r=n and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 193,
+          "comment": "Signature with special case values r=n and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 194,
+          "comment": "Signature with special case values r=n and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 195,
+          "comment": "Signature with special case values r=n and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 196,
+          "comment": "Signature with special case values r=n and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 197,
+          "comment": "Signature with special case values r=n and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 198,
+          "comment": "Signature with special case values r=n and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 199,
+          "comment": "Signature with special case values r=n and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 200,
+          "comment": "Signature with special case values r=n - 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 201,
+          "comment": "Signature with special case values r=n - 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 202,
+          "comment": "Signature with special case values r=n - 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 203,
+          "comment": "Signature with special case values r=n - 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 204,
+          "comment": "Signature with special case values r=n - 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 205,
+          "comment": "Signature with special case values r=n - 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 206,
+          "comment": "Signature with special case values r=n - 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 207,
+          "comment": "Signature with special case values r=n - 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 208,
+          "comment": "Signature with special case values r=n + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 209,
+          "comment": "Signature with special case values r=n + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 210,
+          "comment": "Signature with special case values r=n + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 211,
+          "comment": "Signature with special case values r=n + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 212,
+          "comment": "Signature with special case values r=n + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 213,
+          "comment": "Signature with special case values r=n + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 214,
+          "comment": "Signature with special case values r=n + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 215,
+          "comment": "Signature with special case values r=n + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 216,
+          "comment": "Signature with special case values r=p and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 217,
+          "comment": "Signature with special case values r=p and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 218,
+          "comment": "Signature with special case values r=p and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 219,
+          "comment": "Signature with special case values r=p and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 220,
+          "comment": "Signature with special case values r=p and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 221,
+          "comment": "Signature with special case values r=p and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 222,
+          "comment": "Signature with special case values r=p and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 223,
+          "comment": "Signature with special case values r=p and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 224,
+          "comment": "Signature with special case values r=p + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 225,
+          "comment": "Signature with special case values r=p + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 226,
+          "comment": "Signature with special case values r=p + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 227,
+          "comment": "Signature with special case values r=p + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 228,
+          "comment": "Signature with special case values r=p + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 229,
+          "comment": "Signature with special case values r=p + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 230,
+          "comment": "Signature with special case values r=p + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 231,
+          "comment": "Signature with special case values r=p + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 232,
+          "comment": "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020100090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 233,
+          "comment": "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 234,
+          "comment": "Signature encoding contains incorrect types: r=0, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 235,
+          "comment": "Signature encoding contains incorrect types: r=0, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 236,
+          "comment": "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 237,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 238,
+          "comment": "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 239,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 240,
+          "comment": "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 241,
+          "comment": "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020101090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 242,
+          "comment": "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 243,
+          "comment": "Signature encoding contains incorrect types: r=1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 244,
+          "comment": "Signature encoding contains incorrect types: r=1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 245,
+          "comment": "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 246,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 247,
+          "comment": "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 248,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201013000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 249,
+          "comment": "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201013003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 250,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 251,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 252,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 253,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 254,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 255,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 256,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 257,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 258,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 259,
+          "comment": "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 260,
+          "comment": "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 261,
+          "comment": "Signature encoding contains incorrect types: r=n, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 262,
+          "comment": "Signature encoding contains incorrect types: r=n, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 263,
+          "comment": "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 264,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 265,
+          "comment": "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 266,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641413000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 267,
+          "comment": "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641413003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 268,
+          "comment": "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 269,
+          "comment": "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 270,
+          "comment": "Signature encoding contains incorrect types: r=p, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 271,
+          "comment": "Signature encoding contains incorrect types: r=p, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 272,
+          "comment": "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 273,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 274,
+          "comment": "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 275,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 276,
+          "comment": "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 277,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a090380fe01090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 278,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 279,
+          "comment": "Signature encoding contains incorrect types: r=True, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 280,
+          "comment": "Signature encoding contains incorrect types: r=False, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 281,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300405000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 282,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30040c000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 283,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c01300c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 284,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300430003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 285,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a30030201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 286,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008090380fe01020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 287,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 288,
+          "comment": "Signature encoding contains incorrect types: r=True, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 289,
+          "comment": "Signature encoding contains incorrect types: r=False, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 290,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050500020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 291,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050c00020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 292,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c0130020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 293,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30053000020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 294,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30083003020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 295,
+          "comment": "Edge case for Shamir multiplication",
+          "flags": [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg": "3232333836",
+          "sig": "3046022100dd1b7d09a7bd8218961034a39a87fecf5314f00c4d25eb58a07ac85e85eab516022100b98c5232f0100d55db14eb0fe9e943fb45d8f192bbdd38147850f4d950f16a91",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313930393433323838",
+          "sig": "3046022100840a6cd819f21a2a3c3be7461bf516f5191c32d059eea09699ac4132f794881902210094c53906a1595cf9fe14831b5298b4e297219afb895c18a19f4508fa4f6e0394",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "383433343734313535",
+          "sig": "304502205928b7eeb84242914d4d5b871feb3b0d789455e44a41e3b60e0e43856a4a7a39022100d650930d76eb2444713b63b501a8e8b39615784306f1f2fa90915066e4f60192",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353732363936383239",
+          "sig": "304502202ff05b06077811e7bf8a1b8804fa6bb7db793b0a8927745f5b543998dab306b3022100c9e7da07e2b2d28f169924bab22d90a107ca97f5022eac08d0a4577f30d89988",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353931383333343239",
+          "sig": "3045022019c5e74fd3ab3847d1ba8ec6ff682b184ed2ae466622890deb4206385c31b0a5022100c959ebce99b3446aacee56eecdbae1898fc71a6bacb4464a6a4b0276821b32e7",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3832353330383232353839",
+          "sig": "3045022054bb584a67c79e19d3f9627cc1eadacce8075e3f5c03e45c807b46d505ca73ab022100ab37fbc790a0400debbbde06b9771b63732d79de6a56e87275a968e0d4aaefbf",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3133373334383238313432",
+          "sig": "30450220699d4d68c233f44bf1d3f70001a9acac7be906e09ac440c8d16044364696b94d0221009990c2cd8d7c6a227dce6a94900bc7b69a8ee6cf0ba062767c09d9e5b12e413c",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313733383135363430",
+          "sig": "3046022100e779c882a97701293daa1413f9fe49ab97bd8f742331461d0e3b93333c1db5bb022100ad3fd904ab463ec8bc7ff988c142acdbc5dd73d8dce919b458987c1f32ba3e9b",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353533343636353034",
+          "sig": "3046022100d121d4639e90e4741919d9cb3888d69c46d6fdc84980b5ecc249fa01cae19be5022100ac0559aa580e535e401ea9e2710f067a375ec69dc49fba668d7a14d8bde42d0d",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313833303339313937",
+          "sig": "3046022100de04d387ddd0189ef2ec494594ed056675788d6cac25f9826e50fec66f47be6f022100a55cbc3e87809b4dcc634cea32fc23cf7ac70f71ef1731de41414c0a71891cb5",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130353236313736353435",
+          "sig": "304502205a8d2d504831a047c7277d9c13f7f456fd9569a311c5be93cbfa9a3122534ff3022100d0f9586630564236e9b133a7b53202b29d3a3caeb28f5d2360adfea238f41529",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353031353339393836",
+          "sig": "304502200e2dc3e0b7c51be950c814b4cd74b8707753bc5a7543d6589ae1464c93227bf70221009cea04df1218bb7a0c851da9fef4069cfca9fc00ef08c37976adfc4ec7b5e2b2",
+          "result": "valid"
+        },
+        {
+          "tcId": 307,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134393533313634363139",
+          "sig": "304502200c93646c509040bac868258bf3f2d13d26e98993e8680f0da846c1712be95109022100c65386f8b0a12fef25791cd93a045140af9c24fe3d3d700e02d23b1ce2da05f3",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303633383532393036",
+          "sig": "30450221009906860d728638f6a260e13495f2c6099838e5c2f94828f10caf2c58970d3bf802204853235fd511b8db3956bd25b772fab54bad3867d1c637a9984016f785fdc6cf",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37383339373634393932",
+          "sig": "3045022100c6d609fc861a35134b4dc180a3b2a7b13ad8477358e80286f90499c58bd37dd302200978e0b21055dcc81844d297d6bbecbd074f09717b46c695ae60799d564a1f9f",
+          "result": "valid"
+        },
+        {
+          "tcId": 310,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313239323634343639",
+          "sig": "304502201496fd7a5023faf78b0e1008b054f25c509d34713d4594cfabf24c1b2229643d022100f660ac1daa7700a55189d6710a373b350ea2446ae76fc8a3522df3e01a2bc2f1",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34383332303432363833",
+          "sig": "3044022031007f0306f171eb56c9bc7f7c0cd7d776acd86be680f600d3729aedc03aa9ef022059f529aecb6c8e7469830daea5065e6da8c349688ab4fa0ebec364035a68e58a",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333635323231383136",
+          "sig": "3046022100fbe1a139e3c74cef01d21d9c5a47a783080dbd9b86a202e933872a71a4b53838022100fe3164ad51c080ddd4126f42979e6b519075b2ec96060e02f9dd6fb6f9f3bfdf",
+          "result": "valid"
+        },
+        {
+          "tcId": 313,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3234393137313236393635",
+          "sig": "3044022004518c6be6586ceb5559014ff40311fe7e6d0ffcdfc655b6a06bbe203a185ed602201e0b927e43125aa196329bb0f09bf75d0481dba924f91e3e39e3e0878a972a83",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32363232373930373738",
+          "sig": "3046022100ad67c0270ea088a9daa805788b6aa5161c6e7e12d237515518914ab66d1dcb66022100c5fa3b243e9148e1dcfc27abd9991a2c0c2d25bde9822ce26f344bc9e03f9ee7",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313031323537373238393237",
+          "sig": "3045022100edd7e3fb8581ded7c0961f7365a1a39c6fa301d9728000aeb84c41d918c17dbb022025cfb4fdade11816359ccfd2001cc2b0e509de9cca0c1aa7eaae719637e11156",
+          "result": "valid"
+        },
+        {
+          "tcId": 316,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303530383732323032",
+          "sig": "304402204ca5021a99c50916f997009a2f6addc6cb2a57cada7b1eb72821f66ec353516d022043d471d4043f8fbb0765c059d1b5386b49a530a626d26d2bed4323c0aea5d24a",
+          "result": "valid"
+        },
+        {
+          "tcId": 317,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353037373237303332",
+          "sig": "3045022100eb3a1a9165de050206fa045882f7f3bd06bd02c2e825740d72d8cb2a07f45cfb0220394fa8625004c62cb1c8eea02c3411e6a036b4afe14727d497b31d7251d4a20c",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373139333435393339",
+          "sig": "304502207921badf49f2beba3bc6d696494e7f6c74edc3b722247adbc9cf54d02527ef30022100a45ef9b623bad9a24433afc7e4e2b25270cf07ab20e29ee822255b6ee8da233d",
+          "result": "valid"
+        },
+        {
+          "tcId": 319,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363337333035373633",
+          "sig": "304402203e2c342f84cb36f986b72bd19867c359ad195046ef30ca7549df842d33a51ccb02205b8bfcfc785ff44ccc2651b893b5dfbc12739cc3973988dbb209cd60f4c1b4e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 320,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34323431323733373133",
+          "sig": "3046022100919eb36b4949e319427b2113927fd40f767c11d2c6a991c558438790959c00710221009e4bfd8bcca87632071bdc109cd47e45c90f7cbbff3ff05a1591585b2f0f6537",
+          "result": "valid"
+        },
+        {
+          "tcId": 321,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343735363134373337",
+          "sig": "3045022100e36e3c1918e378f12ccaefe24954c4fb77d8a227f7a234a045c2fa69ec0184c4022065f7b5def112fd96d3c3ddf3aa5bce418ae5cb7322387b18b5b15e2caa78f209",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37313632333237373334",
+          "sig": "304602210089674f75b7440869f9de0cdde21ef47003309be9f0ff7f858c6f43a3b9067096022100d37781ff993210da5470ba8ce3c16a088e58e79d7fd0f5e2d2336443d9b1aeb8",
+          "result": "valid"
+        },
+        {
+          "tcId": 323,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323232343034313239",
+          "sig": "30440220584c05af98b487e9a0b5dd5e0154d124aeefa55eb48a274721365e597549ec98022047b4127c6c09077615a921be38942baa053a88b73884dfadd6a745cc9c6fa096",
+          "result": "valid"
+        },
+        {
+          "tcId": 324,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353234353833333638",
+          "sig": "304402205f21b554fd91ca9cdd5109a00ab3ecb2d8b5137b4fd05c254c3faaa377b3da0602205d036a7dbebf9351c88d3bbe03991690cb7b67d3b5ca4266eb25029e3a1f75e6",
+          "result": "valid"
+        },
+        {
+          "tcId": 325,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3331363334333936",
+          "sig": "304402206a309780826539059b3b2c9d4315bbb83b4c3afc218d440acf2d01ec0a5cdf8302205d3ea569a5ad21db62e4bc0b60251e5f65b01158f2c8821973ee6c47cd15fc34",
+          "result": "valid"
+        },
+        {
+          "tcId": 326,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36353332353938343339",
+          "sig": "3045022041d51f04d6fdcc5f5cacf88e50e418ef0067f8d854dc991615003f1e49927a53022100c6f7c10cad03b89460a9794a171f2e10d84982c462cbf075b06738b3f904cc5c",
+          "result": "valid"
+        },
+        {
+          "tcId": 327,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373338353138353034",
+          "sig": "3046022100da8e729ac23689e868129854fbbde5c9130ebad0e555047f6c4ffccdb0d75fde022100b693c1a3ccd93e2989f84e77e0ea5983b758f4c1a2a8c4b6219b6b006e9ba1e5",
+          "result": "valid"
+        },
+        {
+          "tcId": 328,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343635323636353739",
+          "sig": "304502200793b70b17c7db1ee4f84a0fcc27115355bca4036e33830bddb58aaaf21db1e9022100b884dc3329f826a3cc1766ab7f67cd31ad17b4d48e81b8641d6cf70400c80649",
+          "result": "valid"
+        },
+        {
+          "tcId": 329,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303334383839343934",
+          "sig": "304402203ee201732af7f4fb862991d162a11f79fae57233ff964782db1b35b2dee67f60022078e00f30babf2d483c9e9729c50ac07df9abe878ff8edd3cd7ea3cecc30b724e",
+          "result": "valid"
+        },
+        {
+          "tcId": 330,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34343730383836373835",
+          "sig": "30460221008f2c4f9daeae645deb8237f2598485a7c3ac3b0e0b945641e4f24f59ffe7845a022100a7f781e40a73cc4f49159ed982ffb264097c5f34382314ba0128a52c9144fd33",
+          "result": "valid"
+        },
+        {
+          "tcId": 331,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353537363430343436",
+          "sig": "30450220750dad3a83d3c3621a78dcd92f7da948c6fc68d7f0d9603835b2488515c539ae022100a0736c57503c76c2342e3f13e55f6dfb6637b1fb6ba5caf00b9e540daa7f70c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 332,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36333434393536363038",
+          "sig": "3046022100b3d14a7f7dd693c7fd62d073cb6bc77504431d8a992cc64af774703a981db0a1022100ab8a35acce773242850c086013869631e99cf9c5378d39d0fe10ca7b504c0cf9",
+          "result": "valid"
+        },
+        {
+          "tcId": 333,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34393432383039303331",
+          "sig": "3046022100ff35621d420e7a8343d222f18acb46ae5a5a29320f88e2f0977acfd96d7014410221009fc29bfd8a80a24959bd4494de1b3c0a3366131aefef4fe9d33f1f91d118bb27",
+          "result": "valid"
+        },
+        {
+          "tcId": 334,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323636353831393339",
+          "sig": "30450220051291f27408436b4c56cc8993b3891c5c3a4bf3747041b4d915fdccc1c67a59022100f8d6971a948332617564b4c9581850f8992752f1afe30370a4d36af72376672f",
+          "result": "valid"
+        },
+        {
+          "tcId": 335,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33333332323134313134",
+          "sig": "3046022100b820f2163d1a902e847c69392da7124bc31f56ecad5f73c3db142c9c8220cc6502210089c527e55e559aa5efb263860fbac04f1ce556f82bcccb49991bc2c575808aa7",
+          "result": "valid"
+        },
+        {
+          "tcId": 336,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363136353237373135",
+          "sig": "304402200180c08e97d4fe407c0eab2eb7d17bae60e8ca9ad459e57cdf48389ed9ed953602207d5eaeffffba65afbf1ba9ca9bc0fe1181da76e5e41ade8687799b09e9104597",
+          "result": "valid"
+        },
+        {
+          "tcId": 337,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333539393535383133",
+          "sig": "3046022100985f15f0eecc62112817bc234784d60404804ea7dba48f8c09cc02401c4e13ae022100c73d1bed7077734492c700ede8e6800e048523ef9bcffb53cc79945805ff711e",
+          "result": "valid"
+        },
+        {
+          "tcId": 338,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323931333631393538",
+          "sig": "3046022100d9a5ae9012bcacfc12fa3db623d2099657d4f321460d0135bc731a70478b79bc022100a5d882aa5cf390737839443ab059d68282064d3d827bfef52fc176d0de60ed46",
+          "result": "valid"
+        },
+        {
+          "tcId": 339,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363230393033333936",
+          "sig": "3046022100f070e1285c47106a1ad23a774756a3d3453a48d245401604ef59a96b9a1910c2022100b43cf52041613dbf8d3a136a0d0f6bce87cd74262224e620f355ddeced20e5bd",
+          "result": "valid"
+        },
+        {
+          "tcId": 340,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33333633313032383432",
+          "sig": "3046022100963a3ae4b0a7ae86047e47f375c7e42de035f28fb430c408d0d815caebefa344022100a1edd8c2d39f04f99e05a793b7970dfa76f4b1fc0663d308edee9d3ecd077d66",
+          "result": "valid"
+        },
+        {
+          "tcId": 341,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363237373433343931",
+          "sig": "3046022100e6adb9139cf47dae0890006732629c8e095c13df370717a42a8bc6e8936678ef022100a8df8acc7ee7551cf0409e8c1c2fd0df6e7e9b3827e95727fa492c274e4668fc",
+          "result": "valid"
+        },
+        {
+          "tcId": 342,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33383536373938313437",
+          "sig": "3044022007662a36a2bb779a276145e78543c360c7d0a22a1749f69ead2788c75750d24802207c0a4dba499b27cc249a705ba7bbf512a7484b93f9a83ca9305dd49cde6a302b",
+          "result": "valid"
+        },
+        {
+          "tcId": 343,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383831313830363430",
+          "sig": "3045022036df003efdbec3bf53a2a45248c1e96e60c9bcf10b4f5dfb220744d2da51fc8e022100e5f103b3a74fa1d0a78e74d604f31889e6637cff2acbb31a70726e72f392d4ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 344,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130393537333934363738",
+          "sig": "30440220712dc3233f462b0a37f020ec559bb1a19d879ae36210c75efcb9c071915116e1022006a981761249cc1929f5c18d6f2a76eef487bbda0c4470bb098b87b91328083f",
+          "result": "valid"
+        },
+        {
+          "tcId": 345,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353432373131393834",
+          "sig": "3044022010e373d1cb4c05295b63ce7103817b7c0fd096d7c63f65f56d950a61e455c1cb022044cb5c8270c069ac408a6c9f31ace9229ab6078a36adc465107f0a3d6ddfea66",
+          "result": "valid"
+        },
+        {
+          "tcId": 346,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313530303334333235",
+          "sig": "3045022100cd1274f4c89ab194203ccb5c39e7d0bc364537b84b9dd48d922e43e79e4258c2022042e1fcf72eb65d76b13128d3065daa31312bf9c110f18b4799dce8eccae52d67",
+          "result": "valid"
+        },
+        {
+          "tcId": 347,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393939383231333931",
+          "sig": "30450220516c983fe6567ac700f93028da6affc598dfa95391896c544c8f73c96314a0a0022100bfa56a1833668acfd14899e8cc160b79c5e92a30055dd7c700484f6bfce42cfd",
+          "result": "valid"
+        },
+        {
+          "tcId": 348,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393731323039323631",
+          "sig": "3045022052279b3df58e2aa7ddaee1e5de155cb75d4f00ec7db74ae913a6ed33dea896d4022100ef5823ff9977fa492483bcbfc1d0bd765fd6dfa78cc11e658b4984b543e0e79e",
+          "result": "valid"
+        },
+        {
+          "tcId": 349,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353731383338383537",
+          "sig": "3045022001c2a04eef5827e7e04eb51802cc3859af6d84fe35aee4da4bc1b0ee154b7ef3022100dc57a107da6bb12624313660233cbdcc55ff7147ecb3a328af3e86225c89be53",
+          "result": "valid"
+        },
+        {
+          "tcId": 350,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38363832323639383935",
+          "sig": "304502201ce1bb1fc78a38d4af211b5fceebd01126c10ceab1de6401e1df1dc495dbf5b5022100c9b564a0a5b9675eece3cbe33498634e7943893fe16c61ef894bd4be349a6874",
+          "result": "valid"
+        },
+        {
+          "tcId": 351,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353438383536303331",
+          "sig": "3045022100b7ae42b36f060c15c6745ea4d8bd91ae2eafe0e196c52cfac4e16ab74d3048b60220421bc2dcd0854dd4e69a3e930b2cb646557bd68c800c5a2ca7bbb3ddd32370aa",
+          "result": "valid"
+        },
+        {
+          "tcId": 352,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34393935373031333139",
+          "sig": "3045022100d51dc206df9cfb7198e22b957c644357542264badf5aede3f7474534da0d5b220220266d172a6d6775963f9ed4fb59065c8f1948c48a51463fe79bbf1b45df7e57b9",
+          "result": "valid"
+        },
+        {
+          "tcId": 353,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343536363831373835",
+          "sig": "3045022100f881b3e21684fbf899f762c8fc7c7423a2ad2c276257c99eae86b66ee39e4ae1022027207d5ccff773b26bf0d282d884b3c3a6724ba06a1671c9f9be8cbe6e3589e4",
+          "result": "valid"
+        },
+        {
+          "tcId": 354,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313835333731323336",
+          "sig": "304402202455ebf62b50f958781792fdc705755923a30c0eb7d515a0988c1a14de62caad022010bd68c881416205bd95a5f2765d69726e0bce5b2a0ec525aeb1bba7d35d8e4a",
+          "result": "valid"
+        },
+        {
+          "tcId": 355,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373237383439303034",
+          "sig": "30450221009119d7949d9e4c55e4c712d257c4ba3ab9d657c7e0aa7840091cb2acfb4fc25a022042524fd0c4ae8b50644cba34f86c21a42ee045ce7c15b4eb817affc78d20fdb3",
+          "result": "valid"
+        },
+        {
+          "tcId": 356,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353632383139333138",
+          "sig": "30450220191e716669d84631a04cc085f03b2f1a4f55810f70bebbaf5ee13d68f2598ffb02210090f208a9f1c27911b5fb8d867bdf123dd601639c2dfa1f6a61fd2f82cadb1361",
+          "result": "valid"
+        },
+        {
+          "tcId": 357,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3231383739393238333836",
+          "sig": "30460221008cc2cab9f257928181c4d3685d544bec0b88b95cbbdb8ad1b0543b46b24144730221009d1d158dab8e91c68b372ade107aac5c22f8be64463b0c23340dfc828d7b7df3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0427504e893fd62d0bfdeaa073106b16e8f8d2726a9762529764cfe8fe8a38460e21bb0ddff040b7aff8f08a60d5ae1a59472f394846ae4f58c4be0cc8a2a36501",
+        "wx": "27504e893fd62d0bfdeaa073106b16e8f8d2726a9762529764cfe8fe8a38460e",
+        "wy": "21bb0ddff040b7aff8f08a60d5ae1a59472f394846ae4f58c4be0cc8a2a36501"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000427504e893fd62d0bfdeaa073106b16e8f8d2726a9762529764cfe8fe8a38460e21bb0ddff040b7aff8f08a60d5ae1a59472f394846ae4f58c4be0cc8a2a36501",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJ1BOiT/WLQv96qBzEGsW6PjScmqXYlKX\nZM/o/oo4Rg4huw3f8EC3r/jwimDVrhpZRy85SEauT1jEvgzIoqNlAQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 358,
+          "comment": "k*G has a large x-coordinate",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30360211014551231950b75fc4402da1722fc9baeb022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        },
+        {
+          "tcId": 359,
+          "comment": "r too large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f131f6dddde59bae7b0090a47bafbb33c157ac6da439324a6681bf67f575f90beccc2fb2c0be318fda9335bb83488bcafd33be82c38318bcf845fd0e5017c248",
+        "wx": "00f131f6dddde59bae7b0090a47bafbb33c157ac6da439324a6681bf67f575f90b",
+        "wy": "00eccc2fb2c0be318fda9335bb83488bcafd33be82c38318bcf845fd0e5017c248"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f131f6dddde59bae7b0090a47bafbb33c157ac6da439324a6681bf67f575f90beccc2fb2c0be318fda9335bb83488bcafd33be82c38318bcf845fd0e5017c248",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE8TH23d3lm657AJCke6+7M8FXrG2kOTJK\nZoG/Z/V1+QvszC+ywL4xj9qTNbuDSIvK/TO+gsODGLz4Rf0OUBfCSA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 360,
+          "comment": "r,s are large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041101c496d5f8910a7749efff9dc46f68a7fd02d6975fdf15bf90efb70463cb4ede199e46e67d463aa8c752cac8a342b8fe0e9a5ba9a67416c8865c45e478007e",
+        "wx": "1101c496d5f8910a7749efff9dc46f68a7fd02d6975fdf15bf90efb70463cb4e",
+        "wy": "00de199e46e67d463aa8c752cac8a342b8fe0e9a5ba9a67416c8865c45e478007e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041101c496d5f8910a7749efff9dc46f68a7fd02d6975fdf15bf90efb70463cb4ede199e46e67d463aa8c752cac8a342b8fe0e9a5ba9a67416c8865c45e478007e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEEQHEltX4kQp3Se//ncRvaKf9AtaXX98V\nv5DvtwRjy07eGZ5G5n1GOqjHUsrIo0K4/g6aW6mmdBbIhlxF5HgAfg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 361,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02203e9a7582886089c62fb840cf3b83061cd1cff3ae4341808bb5bdee6191174177",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e43a5c63ad0bc8d178a745192671c06500f0dbd757c3f2eae65089aaf0d648982954ff60c3460a27748445525c6cd30701725e1697891cb7f32feed128a3ae7",
+        "wx": "6e43a5c63ad0bc8d178a745192671c06500f0dbd757c3f2eae65089aaf0d6489",
+        "wy": "0082954ff60c3460a27748445525c6cd30701725e1697891cb7f32feed128a3ae7"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e43a5c63ad0bc8d178a745192671c06500f0dbd757c3f2eae65089aaf0d648982954ff60c3460a27748445525c6cd30701725e1697891cb7f32feed128a3ae7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbkOlxjrQvI0XinRRkmccBlAPDb11fD8u\nrmUImq8NZImClU/2DDRgondIRFUlxs0wcBcl4Wl4kct/Mv7tEoo65w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 362,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022024238e70b431b1a64efdf9032669939d4b77f249503fc6905feb7540dea3e6d2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ef4e8b5732f51a4b2547c6581381ccf750bb6d30a07cb758865414d9a45017fbf10247bcaa4ca73d5c9ad4c8a03a60a7f5cfa07fb57437b5a6f0a9bd381d78a5",
+        "wx": "00ef4e8b5732f51a4b2547c6581381ccf750bb6d30a07cb758865414d9a45017fb",
+        "wy": "00f10247bcaa4ca73d5c9ad4c8a03a60a7f5cfa07fb57437b5a6f0a9bd381d78a5"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ef4e8b5732f51a4b2547c6581381ccf750bb6d30a07cb758865414d9a45017fbf10247bcaa4ca73d5c9ad4c8a03a60a7f5cfa07fb57437b5a6f0a9bd381d78a5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE706LVzL1GkslR8ZYE4HM91C7bTCgfLdY\nhlQU2aRQF/vxAke8qkynPVya1MigOmCn9c+gf7V0N7Wm8Km9OB14pQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 363,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a973c15a44d2dcd50558e033d242155a29808b87491576566a83821b650e6f2dfc5ecd5482fa591f578308b09f2e704116a375ba1e2837912bae2972d340414d",
+        "wx": "00a973c15a44d2dcd50558e033d242155a29808b87491576566a83821b650e6f2d",
+        "wy": "00fc5ecd5482fa591f578308b09f2e704116a375ba1e2837912bae2972d340414d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a973c15a44d2dcd50558e033d242155a29808b87491576566a83821b650e6f2dfc5ecd5482fa591f578308b09f2e704116a375ba1e2837912bae2972d340414d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEqXPBWkTS3NUFWOAz0kIVWimAi4dJFXZW\naoOCG2UOby38Xs1UgvpZH1eDCLCfLnBBFqN1uh4oN5Errily00BBTQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 364,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020102",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048cd31f1656b21ec27276a533c35bf51d95490bfec57868a9b94433eda4579d61bb2c8e80c45d949bcaf6f0bbc76bc27c95939945052ad1a11014756556c6f978",
+        "wx": "008cd31f1656b21ec27276a533c35bf51d95490bfec57868a9b94433eda4579d61",
+        "wy": "00bb2c8e80c45d949bcaf6f0bbc76bc27c95939945052ad1a11014756556c6f978"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048cd31f1656b21ec27276a533c35bf51d95490bfec57868a9b94433eda4579d61bb2c8e80c45d949bcaf6f0bbc76bc27c95939945052ad1a11014756556c6f978",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEjNMfFlayHsJydqUzw1v1HZVJC/7FeGip\nuUQz7aRXnWG7LI6AxF2Um8r28LvHa8J8lZOZRQUq0aEQFHVlVsb5eA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 365,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020103",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047f70598f1e6a18c55fa199a858cf3a825792ed14b856a5b9b8435890cd1275b559c12d120bf363568ceb79941d793f200a7bc4262bf40264a7a05dae0ab92093",
+        "wx": "7f70598f1e6a18c55fa199a858cf3a825792ed14b856a5b9b8435890cd1275b5",
+        "wy": "59c12d120bf363568ceb79941d793f200a7bc4262bf40264a7a05dae0ab92093"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047f70598f1e6a18c55fa199a858cf3a825792ed14b856a5b9b8435890cd1275b559c12d120bf363568ceb79941d793f200a7bc4262bf40264a7a05dae0ab92093",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEf3BZjx5qGMVfoZmoWM86gleS7RS4VqW5\nuENYkM0SdbVZwS0SC/NjVozreZQdeT8gCnvEJiv0AmSnoF2uCrkgkw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 366,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04df0005c3f4290809c6fc7c924cd389b44980d4b127db6f0d85a9e65b1f54a931a51e735ca524d208a684575630fd09f090562c8985756480cb6b0a86313b9147",
+        "wx": "00df0005c3f4290809c6fc7c924cd389b44980d4b127db6f0d85a9e65b1f54a931",
+        "wy": "00a51e735ca524d208a684575630fd09f090562c8985756480cb6b0a86313b9147"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004df0005c3f4290809c6fc7c924cd389b44980d4b127db6f0d85a9e65b1f54a931a51e735ca524d208a684575630fd09f090562c8985756480cb6b0a86313b9147",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3wAFw/QpCAnG/HySTNOJtEmA1LEn228N\nhanmWx9UqTGlHnNcpSTSCKaEV1Yw/QnwkFYsiYV1ZIDLawqGMTuRRw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 367,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020102",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045ab9318981cb3e597dd819205d9392e8ec750c517054ceeaf103b3e0f0ba8a365f330cc411e8b3821f4e1d5a17ee2fe7b8b1cacc36fed324d9837df7b4080b20",
+        "wx": "5ab9318981cb3e597dd819205d9392e8ec750c517054ceeaf103b3e0f0ba8a36",
+        "wy": "5f330cc411e8b3821f4e1d5a17ee2fe7b8b1cacc36fed324d9837df7b4080b20"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045ab9318981cb3e597dd819205d9392e8ec750c517054ceeaf103b3e0f0ba8a365f330cc411e8b3821f4e1d5a17ee2fe7b8b1cacc36fed324d9837df7b4080b20",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEWrkxiYHLPll92BkgXZOS6Ox1DFFwVM7q\n8QOz4PC6ijZfMwzEEeizgh9OHVoX7i/nuLHKzDb+0yTZg333tAgLIA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 368,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020103",
+          "result": "valid"
+        },
+        {
+          "tcId": 369,
+          "comment": "r is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143020103",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0446e91a1e5fd2f2e2175dd6d86d0f63329b56a4b89af1a1689879c7b372afbbf07ef4e53c35856995f1964c59dca422b2b16c34e7c248d8bf1396e65361a7091c",
+        "wx": "46e91a1e5fd2f2e2175dd6d86d0f63329b56a4b89af1a1689879c7b372afbbf0",
+        "wy": "7ef4e53c35856995f1964c59dca422b2b16c34e7c248d8bf1396e65361a7091c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000446e91a1e5fd2f2e2175dd6d86d0f63329b56a4b89af1a1689879c7b372afbbf07ef4e53c35856995f1964c59dca422b2b16c34e7c248d8bf1396e65361a7091c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAERukaHl/S8uIXXdbYbQ9jMptWpLia8aFo\nmHnHs3Kvu/B+9OU8NYVplfGWTFncpCKysWw058JI2L8TluZTYacJHA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 370,
+          "comment": "s is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020102022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd04917c8",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d4f41c9c4c15f02a199264a51266ed793952a7cea79125dcded805ed7a54c1350314fa927966b90b6c4e57cb521666fce4cb81b7e4d3550d729fe6dd6bbe5ab",
+        "wx": "6d4f41c9c4c15f02a199264a51266ed793952a7cea79125dcded805ed7a54c13",
+        "wy": "50314fa927966b90b6c4e57cb521666fce4cb81b7e4d3550d729fe6dd6bbe5ab"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d4f41c9c4c15f02a199264a51266ed793952a7cea79125dcded805ed7a54c1350314fa927966b90b6c4e57cb521666fce4cb81b7e4d3550d729fe6dd6bbe5ab",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbU9BycTBXwKhmSZKUSZu15OVKnzqeRJd\nze2AXtelTBNQMU+pJ5ZrkLbE5Xy1IWZvzky4G35NNVDXKf5t1rvlqw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 371,
+          "comment": "small r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302702020101022100c58b162c58b162c58b162c58b162c58a1b242973853e16db75c8a1a71da4d39d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043bd4a602119bc50cfd05aa395c3c9f753b383bdd9539d27a1a143033fcfcaaa892d75438eba5af693196d4b7953184e2d649a0845d11af3c7d39e3b1f5449c19",
+        "wx": "3bd4a602119bc50cfd05aa395c3c9f753b383bdd9539d27a1a143033fcfcaaa8",
+        "wy": "0092d75438eba5af693196d4b7953184e2d649a0845d11af3c7d39e3b1f5449c19"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043bd4a602119bc50cfd05aa395c3c9f753b383bdd9539d27a1a143033fcfcaaa892d75438eba5af693196d4b7953184e2d649a0845d11af3c7d39e3b1f5449c19",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEO9SmAhGbxQz9Bao5XDyfdTs4O92VOdJ6\nGhQwM/z8qqiS11Q466WvaTGW1LeVMYTi1kmghF0Rrzx9OeOx9UScGQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 372,
+          "comment": "smallish r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302c02072d9b4d347952cc022100fcbc5103d0da267477d1791461cf2aa44bf9d43198f79507bd8779d69a13108e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047c981d6870575725427fc84ce6b5f706af6e8c62b4b5f7f72c3ee2860836996d29f07476cbf3f93a34e73f737658070642c66d0e34f5d56c715a26b099078413",
+        "wx": "7c981d6870575725427fc84ce6b5f706af6e8c62b4b5f7f72c3ee2860836996d",
+        "wy": "29f07476cbf3f93a34e73f737658070642c66d0e34f5d56c715a26b099078413"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047c981d6870575725427fc84ce6b5f706af6e8c62b4b5f7f72c3ee2860836996d29f07476cbf3f93a34e73f737658070642c66d0e34f5d56c715a26b099078413",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEfJgdaHBXVyVCf8hM5rX3Bq9ujGK0tff3\nLD7ihgg2mW0p8HR2y/P5OjTnP3N2WAcGQsZtDjT11WxxWiawmQeEEw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 373,
+          "comment": "100-bit r and small s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3032020d1033e67e37b32b445580bf4efc022100906f906f906f906f906f906f906f906ed8e426f7b1968c35a204236a579723d2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d75a78cf296b58aeb52faee6a9348385bcdc61f980da8ad6f28654d86fe516e20ce9952182f5f06cba50db8c65aa6f8cf1a32f2a46599c0a2abb4c1402cef467",
+        "wx": "00d75a78cf296b58aeb52faee6a9348385bcdc61f980da8ad6f28654d86fe516e2",
+        "wy": "0ce9952182f5f06cba50db8c65aa6f8cf1a32f2a46599c0a2abb4c1402cef467"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d75a78cf296b58aeb52faee6a9348385bcdc61f980da8ad6f28654d86fe516e20ce9952182f5f06cba50db8c65aa6f8cf1a32f2a46599c0a2abb4c1402cef467",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE11p4zylrWK61L67mqTSDhbzcYfmA2orW\n8oZU2G/lFuIM6ZUhgvXwbLpQ24xlqm+M8aMvKkZZnAoqu0wUAs70Zw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 374,
+          "comment": "small r and 100 bit s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020201010220783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040a35a42fb4057e11e332442d73729cdc684e7e0a7875ec933337e74ab1e17de62152e3a6558865d7f30a950c64e9f2e9d2f06c2703d2a1984a79445d3870a1cf",
+        "wx": "0a35a42fb4057e11e332442d73729cdc684e7e0a7875ec933337e74ab1e17de6",
+        "wy": "2152e3a6558865d7f30a950c64e9f2e9d2f06c2703d2a1984a79445d3870a1cf"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040a35a42fb4057e11e332442d73729cdc684e7e0a7875ec933337e74ab1e17de62152e3a6558865d7f30a950c64e9f2e9d2f06c2703d2a1984a79445d3870a1cf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECjWkL7QFfhHjMkQtc3Kc3GhOfgp4deyT\nMzfnSrHhfeYhUuOmVYhl1/MKlQxk6fLp0vBsJwPSoZhKeURdOHChzw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 375,
+          "comment": "100-bit r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3031020d062522bbd3ecbe7c39e93e7c260220783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04705e0c3ea1ca443a0105896e7af2b891a08243cca510cb5fffaebdd86ec6fc8c25d116fcf912e8246a64d5878436dfc958b59d4662a4b227a006876b5042fa58",
+        "wx": "705e0c3ea1ca443a0105896e7af2b891a08243cca510cb5fffaebdd86ec6fc8c",
+        "wy": "25d116fcf912e8246a64d5878436dfc958b59d4662a4b227a006876b5042fa58"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004705e0c3ea1ca443a0105896e7af2b891a08243cca510cb5fffaebdd86ec6fc8c25d116fcf912e8246a64d5878436dfc958b59d4662a4b227a006876b5042fa58",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEcF4MPqHKRDoBBYluevK4kaCCQ8ylEMtf\n/6692G7G/Iwl0Rb8+RLoJGpk1YeENt/JWLWdRmKksiegBodrUEL6WA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 376,
+          "comment": "r and s^-1 are close to n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03640c1022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fce5ea1fb9571f170fd246c0eaf46e987d1fd3cd1dac1dc80828fb57e7b400f9610daa982627a64cff6cba23ba753de757dd772fb8055d33dfd6a5f4173f76ea",
+        "wx": "00fce5ea1fb9571f170fd246c0eaf46e987d1fd3cd1dac1dc80828fb57e7b400f9",
+        "wy": "610daa982627a64cff6cba23ba753de757dd772fb8055d33dfd6a5f4173f76ea"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fce5ea1fb9571f170fd246c0eaf46e987d1fd3cd1dac1dc80828fb57e7b400f9610daa982627a64cff6cba23ba753de757dd772fb8055d33dfd6a5f4173f76ea",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE/OXqH7lXHxcP0kbA6vRumH0f080drB3I\nCCj7V+e0APlhDaqYJiemTP9suiO6dT3nV913L7gFXTPf1qX0Fz926g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 377,
+          "comment": "r and s are 64-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30160209009c44febf31c3594d020900839ed28247c2b06b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a49b1e3904315d7b9eccdb36fad8160ed6274ee4cf0c7effcb00d7ebcba5f1987a7f70c69a7bb789ad3cb33d5953f93eda39011490d1754c898f12f5a6b5c65b",
+        "wx": "00a49b1e3904315d7b9eccdb36fad8160ed6274ee4cf0c7effcb00d7ebcba5f198",
+        "wy": "7a7f70c69a7bb789ad3cb33d5953f93eda39011490d1754c898f12f5a6b5c65b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a49b1e3904315d7b9eccdb36fad8160ed6274ee4cf0c7effcb00d7ebcba5f1987a7f70c69a7bb789ad3cb33d5953f93eda39011490d1754c898f12f5a6b5c65b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpJseOQQxXXuezNs2+tgWDtYnTuTPDH7/\nywDX68ul8Zh6f3DGmnu3ia08sz1ZU/k+2jkBFJDRdUyJjxL1prXGWw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 378,
+          "comment": "r and s are 100-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "301e020d09df8b682430beef6f5fd7c7cf020d0fd0a62e13778f4222a0d61c8a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0418e9a2cc13f31868988806d92026684bd6a6c18a4c5ddad4a03de692fe7302b8cfcc5578f705ee864035bef8c5ea2d2d766f63b2b3bb45b0d4b73902d241c3ae",
+        "wx": "18e9a2cc13f31868988806d92026684bd6a6c18a4c5ddad4a03de692fe7302b8",
+        "wy": "00cfcc5578f705ee864035bef8c5ea2d2d766f63b2b3bb45b0d4b73902d241c3ae"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000418e9a2cc13f31868988806d92026684bd6a6c18a4c5ddad4a03de692fe7302b8cfcc5578f705ee864035bef8c5ea2d2d766f63b2b3bb45b0d4b73902d241c3ae",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGOmizBPzGGiYiAbZICZoS9amwYpMXdrU\noD3mkv5zArjPzFV49wXuhkA1vvjF6i0tdm9jsrO7RbDUtzkC0kHDrg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 379,
+          "comment": "r and s are 128-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30260211008a598e563a89f526c32ebec8de26367a02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046fcfda69628fe333e4dbb6237fd420a7d91965591d761bd2c1595e8029c4b194750d82e9f366db1304472248240549b3c95d2ddcb0e7944b1ba217c432c7d064",
+        "wx": "6fcfda69628fe333e4dbb6237fd420a7d91965591d761bd2c1595e8029c4b194",
+        "wy": "750d82e9f366db1304472248240549b3c95d2ddcb0e7944b1ba217c432c7d064"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046fcfda69628fe333e4dbb6237fd420a7d91965591d761bd2c1595e8029c4b194750d82e9f366db1304472248240549b3c95d2ddcb0e7944b1ba217c432c7d064",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEb8/aaWKP4zPk27Yjf9Qgp9kZZVkddhvS\nwVlegCnEsZR1DYLp82bbEwRHIkgkBUmzyV0t3LDnlEsbohfEMsfQZA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 380,
+          "comment": "r and s are 160-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0bdf021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e322c7aad4a70024c4f80ea373e7e85f23dcbd11f186d55d5a744cd0f459f6db71d54db09ec66eeadbedbacfe2255bb87d0c1a737b3d3b1c7b76ce78d6342d7c",
+        "wx": "00e322c7aad4a70024c4f80ea373e7e85f23dcbd11f186d55d5a744cd0f459f6db",
+        "wy": "71d54db09ec66eeadbedbacfe2255bb87d0c1a737b3d3b1c7b76ce78d6342d7c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e322c7aad4a70024c4f80ea373e7e85f23dcbd11f186d55d5a744cd0f459f6db71d54db09ec66eeadbedbacfe2255bb87d0c1a737b3d3b1c7b76ce78d6342d7c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4yLHqtSnACTE+A6jc+foXyPcvRHxhtVd\nWnRM0PRZ9ttx1U2wnsZu6tvtus/iJVu4fQwac3s9Oxx7ds541jQtfA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 381,
+          "comment": "s == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1020101",
+          "result": "valid"
+        },
+        {
+          "tcId": 382,
+          "comment": "s == 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1020100",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040d41fafcb0d752323bb2f5baae661dca8564a82bb685faf7869a1944bf1f9c6e5c5639c7a3018b84cfd509cbac7bd1913d8adf7e4d4d416ba9e8f0fed6bf20d8",
+        "wx": "0d41fafcb0d752323bb2f5baae661dca8564a82bb685faf7869a1944bf1f9c6e",
+        "wy": "5c5639c7a3018b84cfd509cbac7bd1913d8adf7e4d4d416ba9e8f0fed6bf20d8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040d41fafcb0d752323bb2f5baae661dca8564a82bb685faf7869a1944bf1f9c6e5c5639c7a3018b84cfd509cbac7bd1913d8adf7e4d4d416ba9e8f0fed6bf20d8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEDUH6/LDXUjI7svW6rmYdyoVkqCu2hfr3\nhpoZRL8fnG5cVjnHowGLhM/VCcuse9GRPYrffk1NQWup6PD+1r8g2A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 383,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220419d981c515af8cc82545aac0c85e9e308fbb2eab6acd7ed497e0b4145a18fd9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dc1fec92e7b225ada1677018b6362c614ea5c5a670f836ac485ce893d376ab24bd06303b42c4e6b568e8fb8a37e603f805bc4b2cc9e0e9daa635db16cdae9e79",
+        "wx": "00dc1fec92e7b225ada1677018b6362c614ea5c5a670f836ac485ce893d376ab24",
+        "wy": "00bd06303b42c4e6b568e8fb8a37e603f805bc4b2cc9e0e9daa635db16cdae9e79"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dc1fec92e7b225ada1677018b6362c614ea5c5a670f836ac485ce893d376ab24bd06303b42c4e6b568e8fb8a37e603f805bc4b2cc9e0e9daa635db16cdae9e79",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3B/skueyJa2hZ3AYtjYsYU6lxaZw+Das\nSFzok9N2qyS9BjA7QsTmtWjo+4o35gP4BbxLLMng6dqmNdsWza6eeQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 384,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102201b21717ad71d23bbac60a9ad0baf75b063c9fdf52a00ebf99d022172910993c9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0478fc8e5b816f37ee0d0fee4fa449b0dfacfbb9667a850bf2e62f6582606a8a0d4176387e658fbb0794b08659e984131fbdf2c855439232e0b2485fa2734b8092",
+        "wx": "78fc8e5b816f37ee0d0fee4fa449b0dfacfbb9667a850bf2e62f6582606a8a0d",
+        "wy": "4176387e658fbb0794b08659e984131fbdf2c855439232e0b2485fa2734b8092"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000478fc8e5b816f37ee0d0fee4fa449b0dfacfbb9667a850bf2e62f6582606a8a0d4176387e658fbb0794b08659e984131fbdf2c855439232e0b2485fa2734b8092",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEePyOW4FvN+4ND+5PpEmw36z7uWZ6hQvy\n5i9lgmBqig1Bdjh+ZY+7B5SwhlnphBMfvfLIVUOSMuCySF+ic0uAkg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 385,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102202f588f66018f3dd14db3e28e77996487e32486b521ed8e5a20f06591951777e9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040a17ab990fe429a96a0d6a6d297795128f66e4ecc3e83913d1846a0c0bfb4daeb90a3909bb40d9d61d9c0419dd6f01788621a3cbb036db2cc4b21a35680d733d",
+        "wx": "0a17ab990fe429a96a0d6a6d297795128f66e4ecc3e83913d1846a0c0bfb4dae",
+        "wy": "00b90a3909bb40d9d61d9c0419dd6f01788621a3cbb036db2cc4b21a35680d733d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040a17ab990fe429a96a0d6a6d297795128f66e4ecc3e83913d1846a0c0bfb4daeb90a3909bb40d9d61d9c0419dd6f01788621a3cbb036db2cc4b21a35680d733d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEChermQ/kKalqDWptKXeVEo9m5OzD6DkT\n0YRqDAv7Ta65CjkJu0DZ1h2cBBndbwF4hiGjy7A22yzEsho1aA1zPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 386,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220091a08870ff4daf9123b30c20e8c4fc8505758dcf4074fcaff2170c9bfcf74f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0439a08df231316804509067d6f25523c055726326df3e3efa94c419e288d377bf0e06e100b23d85472fb0788007e2e1bb7f60db6ecd832f276e0739ae5bbe7830",
+        "wx": "39a08df231316804509067d6f25523c055726326df3e3efa94c419e288d377bf",
+        "wy": "0e06e100b23d85472fb0788007e2e1bb7f60db6ecd832f276e0739ae5bbe7830"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000439a08df231316804509067d6f25523c055726326df3e3efa94c419e288d377bf0e06e100b23d85472fb0788007e2e1bb7f60db6ecd832f276e0739ae5bbe7830",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEOaCN8jExaARQkGfW8lUjwFVyYybfPj76\nlMQZ4ojTd78OBuEAsj2FRy+weIAH4uG7f2Dbbs2DLyduBzmuW754MA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 387,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102207c370dc0ce8c59a8b273cba44a7c1191fc3186dc03cab96b0567312df0d0b250",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479071e08d1bace014c34b92e6c29ccbe1dcfc7e80f16c3d92855e7cefe669eca5d3a11a4e45e54377cfb3ea394db876c354e1e90d35382799fbf95ae491cf935",
+        "wx": "79071e08d1bace014c34b92e6c29ccbe1dcfc7e80f16c3d92855e7cefe669eca",
+        "wy": "5d3a11a4e45e54377cfb3ea394db876c354e1e90d35382799fbf95ae491cf935"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479071e08d1bace014c34b92e6c29ccbe1dcfc7e80f16c3d92855e7cefe669eca5d3a11a4e45e54377cfb3ea394db876c354e1e90d35382799fbf95ae491cf935",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeQceCNG6zgFMNLkubCnMvh3Px+gPFsPZ\nKFXnzv5mnspdOhGk5F5UN3z7PqOU24dsNU4ekNNTgnmfv5WuSRz5NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 388,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022070b59a7d1ee77a2f9e0491c2a7cfcd0ed04df4a35192f6132dcc668c79a6160e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0490d871670e972d948d86e0833b12935697a38cc17c96f4c6f11861c4967231adad5ec81f335e44d269956a0a36ec30e391d84f6147c945e50336d1158017ba06",
+        "wx": "0090d871670e972d948d86e0833b12935697a38cc17c96f4c6f11861c4967231ad",
+        "wy": "00ad5ec81f335e44d269956a0a36ec30e391d84f6147c945e50336d1158017ba06"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000490d871670e972d948d86e0833b12935697a38cc17c96f4c6f11861c4967231adad5ec81f335e44d269956a0a36ec30e391d84f6147c945e50336d1158017ba06",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEkNhxZw6XLZSNhuCDOxKTVpejjMF8lvTG\n8RhhxJZyMa2tXsgfM15E0mmVago27DDjkdhPYUfJReUDNtEVgBe6Bg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 389,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102202736d76e412246e097148e2bf62915614eb7c428913a58eb5e9cd4674a9423de",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0482914065bdb591606c6e4b4c430231155a55ac14fdd776d3ddb5460a5ab257e1a6b739fc234dba288922b9797ade8f87912784632348c5326708133247a43209",
+        "wx": "0082914065bdb591606c6e4b4c430231155a55ac14fdd776d3ddb5460a5ab257e1",
+        "wy": "00a6b739fc234dba288922b9797ade8f87912784632348c5326708133247a43209"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000482914065bdb591606c6e4b4c430231155a55ac14fdd776d3ddb5460a5ab257e1a6b739fc234dba288922b9797ade8f87912784632348c5326708133247a43209",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEgpFAZb21kWBsbktMQwIxFVpVrBT913bT\n3bVGClqyV+Gmtzn8I026KIkiuXl63o+HkSeEYyNIxTJnCBMyR6QyCQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 390,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102204a1e12831fbe93627b02d6e7f24bccdd6ef4b2d0f46739eaf3b1eaf0ca117770",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04be0ae560e37ac967a77da53d0aed473242c7eebeeaf8d9e423d3e7f3f36ac5ed9a5123407ea4cde90bfa2b7697dfabbee4fd8641f1e4a4b51ae5c8cf5a05006c",
+        "wx": "00be0ae560e37ac967a77da53d0aed473242c7eebeeaf8d9e423d3e7f3f36ac5ed",
+        "wy": "009a5123407ea4cde90bfa2b7697dfabbee4fd8641f1e4a4b51ae5c8cf5a05006c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004be0ae560e37ac967a77da53d0aed473242c7eebeeaf8d9e423d3e7f3f36ac5ed9a5123407ea4cde90bfa2b7697dfabbee4fd8641f1e4a4b51ae5c8cf5a05006c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEvgrlYON6yWenfaU9Cu1HMkLH7r7q+Nnk\nI9Pn8/Nqxe2aUSNAfqTN6Qv6K3aX36u+5P2GQfHkpLUa5cjPWgUAbA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 391,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022006c778d4dfff7dee06ed88bc4e0ed34fc553aad67caf796f2a1c6487c1b2e877",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048cfd6bf55f472fb38463580e07fca982248759ec780e2899a9395d57256c6fa2916c93ec5410f0403471fbd6385c83aa7d051cb18bf49453b030b16f814e50c2",
+        "wx": "008cfd6bf55f472fb38463580e07fca982248759ec780e2899a9395d57256c6fa2",
+        "wy": "00916c93ec5410f0403471fbd6385c83aa7d051cb18bf49453b030b16f814e50c2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048cfd6bf55f472fb38463580e07fca982248759ec780e2899a9395d57256c6fa2916c93ec5410f0403471fbd6385c83aa7d051cb18bf49453b030b16f814e50c2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEjP1r9V9HL7OEY1gOB/ypgiSHWex4DiiZ\nqTldVyVsb6KRbJPsVBDwQDRx+9Y4XIOqfQUcsYv0lFOwMLFvgU5Qwg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 392,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102204de459ef9159afa057feb3ec40fef01c45b809f4ab296ea48c206d4249a2b451",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04db40ec05765b314b30d6d3856a7b60fb19ce16e0f79943aecb454c0e67d58956a0c608b9c60dbb59fe04dc0d33e8a884ec922a1ed3a35f6055949e7c9563a99d",
+        "wx": "00db40ec05765b314b30d6d3856a7b60fb19ce16e0f79943aecb454c0e67d58956",
+        "wy": "00a0c608b9c60dbb59fe04dc0d33e8a884ec922a1ed3a35f6055949e7c9563a99d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004db40ec05765b314b30d6d3856a7b60fb19ce16e0f79943aecb454c0e67d58956a0c608b9c60dbb59fe04dc0d33e8a884ec922a1ed3a35f6055949e7c9563a99d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE20DsBXZbMUsw1tOFantg+xnOFuD3mUOu\ny0VMDmfViVagxgi5xg27Wf4E3A0z6KiE7JIqHtOjX2BVlJ58lWOpnQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 393,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220745d294978007302033502e1acc48b63ae6500be43adbea1b258d6b423dbb416",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043301d39ed85ef80f592718086252f897e4db67f3e1d6edb2cf9ad936b1f0f8976f5fc066c02ddf19634e8e9ba2f62e2874f4157af3342348cdf082979ef2d6ac",
+        "wx": "3301d39ed85ef80f592718086252f897e4db67f3e1d6edb2cf9ad936b1f0f897",
+        "wy": "6f5fc066c02ddf19634e8e9ba2f62e2874f4157af3342348cdf082979ef2d6ac"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043301d39ed85ef80f592718086252f897e4db67f3e1d6edb2cf9ad936b1f0f8976f5fc066c02ddf19634e8e9ba2f62e2874f4157af3342348cdf082979ef2d6ac",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMwHTnthe+A9ZJxgIYlL4l+TbZ/Ph1u2y\nz5rZNrHw+JdvX8BmwC3fGWNOjpui9i4odPQVevM0I0jN8IKXnvLWrA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 394,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102207b2a785e3896f59b2d69da57648e80ad3c133a750a2847fd2098ccd902042b6c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b2545a3088538196d9c37af2ba1fa243380c78fb68a68b11f16dbdf6dbf53892017edaf2d350277e5ecbb595e4facfc38dfdb8a61ff1c1dd349ca00842d208ff",
+        "wx": "00b2545a3088538196d9c37af2ba1fa243380c78fb68a68b11f16dbdf6dbf53892",
+        "wy": "017edaf2d350277e5ecbb595e4facfc38dfdb8a61ff1c1dd349ca00842d208ff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b2545a3088538196d9c37af2ba1fa243380c78fb68a68b11f16dbdf6dbf53892017edaf2d350277e5ecbb595e4facfc38dfdb8a61ff1c1dd349ca00842d208ff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEslRaMIhTgZbZw3ryuh+iQzgMePtoposR\n8W299tv1OJIBftry01Anfl7LtZXk+s/Djf24ph/xwd00nKAIQtII/w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 395,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022071ae94a72ca896875e7aa4a4c3d29afdb4b35b6996273e63c47ac519256c5eb1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0493147e90217bd5a82bf39d7687dbd0c37f6e076629cb65f7d5d1328641ef1f38f4c81dd74368522382c1d566aac6d5ac71e4082bc7376df5d2b9aa5257ef3959",
+        "wx": "0093147e90217bd5a82bf39d7687dbd0c37f6e076629cb65f7d5d1328641ef1f38",
+        "wy": "00f4c81dd74368522382c1d566aac6d5ac71e4082bc7376df5d2b9aa5257ef3959"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000493147e90217bd5a82bf39d7687dbd0c37f6e076629cb65f7d5d1328641ef1f38f4c81dd74368522382c1d566aac6d5ac71e4082bc7376df5d2b9aa5257ef3959",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEkxR+kCF71agr8512h9vQw39uB2Ypy2X3\n1dEyhkHvHzj0yB3XQ2hSI4LB1WaqxtWsceQIK8c3bfXSuapSV+85WQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 396,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102200fa527fa7343c0bc9ec35a6278bfbff4d83301b154fc4bd14aee7eb93445b5f9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043f7dcde1421597eb180d5c5ca1a9d68683ed7818b3c3d4b04b6fc913c48506085cb4f64eb20d31fea8408e66f714dce4351e04c7d299ad1b21c8dfc781b528c3",
+        "wx": "3f7dcde1421597eb180d5c5ca1a9d68683ed7818b3c3d4b04b6fc913c4850608",
+        "wy": "5cb4f64eb20d31fea8408e66f714dce4351e04c7d299ad1b21c8dfc781b528c3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043f7dcde1421597eb180d5c5ca1a9d68683ed7818b3c3d4b04b6fc913c48506085cb4f64eb20d31fea8408e66f714dce4351e04c7d299ad1b21c8dfc781b528c3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEP33N4UIVl+sYDVxcoanWhoPteBizw9Sw\nS2/JE8SFBghctPZOsg0x/qhAjmb3FNzkNR4Ex9KZrRshyN/HgbUoww==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 397,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102206539c0adadd0525ff42622164ce9314348bd0863b4c80e936b23ca0414264671",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044b242ee4a0a37835c590f6abe1af6668476c9c12c15b8aff776c7e7a8a452319b720cffae6423cf47aa375fe3b84346a83b09e0efa245eb89d99b2585451603d",
+        "wx": "4b242ee4a0a37835c590f6abe1af6668476c9c12c15b8aff776c7e7a8a452319",
+        "wy": "00b720cffae6423cf47aa375fe3b84346a83b09e0efa245eb89d99b2585451603d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044b242ee4a0a37835c590f6abe1af6668476c9c12c15b8aff776c7e7a8a452319b720cffae6423cf47aa375fe3b84346a83b09e0efa245eb89d99b2585451603d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESyQu5KCjeDXFkPar4a9maEdsnBLBW4r/\nd2x+eopFIxm3IM/65kI89Hqjdf47hDRqg7CeDvokXridmbJYVFFgPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 398,
+          "comment": "point at infinity during verify",
+          "flags": [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f9532aa189138b5e203f8f3a9acf03affa80794f37b647ac289267e8293ededc61ac8ac734bc4c7676bbbf57ead50b4981d9bceee0172e947c22c05f4424c9b2",
+        "wx": "00f9532aa189138b5e203f8f3a9acf03affa80794f37b647ac289267e8293ededc",
+        "wy": "61ac8ac734bc4c7676bbbf57ead50b4981d9bceee0172e947c22c05f4424c9b2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f9532aa189138b5e203f8f3a9acf03affa80794f37b647ac289267e8293ededc61ac8ac734bc4c7676bbbf57ead50b4981d9bceee0172e947c22c05f4424c9b2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+VMqoYkTi14gP486ms8Dr/qAeU83tkes\nKJJn6Ck+3txhrIrHNLxMdna7v1fq1QtJgdm87uAXLpR8IsBfRCTJsg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 399,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040f2256392bbc44714d5fd698b611b7140c3031845f14f8660baea5ec830088f5d5650dc0f784bd907f41b13936a2d13d0e05deb103efb069f8a771b527322155",
+        "wx": "0f2256392bbc44714d5fd698b611b7140c3031845f14f8660baea5ec830088f5",
+        "wy": "00d5650dc0f784bd907f41b13936a2d13d0e05deb103efb069f8a771b527322155"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040f2256392bbc44714d5fd698b611b7140c3031845f14f8660baea5ec830088f5d5650dc0f784bd907f41b13936a2d13d0e05deb103efb069f8a771b527322155",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEDyJWOSu8RHFNX9aYthG3FAwwMYRfFPhm\nC66l7IMAiPXVZQ3A94S9kH9BsTk2otE9DgXesQPvsGn4p3G1JzIhVQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 400,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04260b66d47b3a3be44364f1fbdd576b824893ce43c78e474db3c1b25106fb486503620b6068877f8b9018efe98191b24cf667053c09ca94da7bcf854bf6924332",
+        "wx": "260b66d47b3a3be44364f1fbdd576b824893ce43c78e474db3c1b25106fb4865",
+        "wy": "03620b6068877f8b9018efe98191b24cf667053c09ca94da7bcf854bf6924332"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004260b66d47b3a3be44364f1fbdd576b824893ce43c78e474db3c1b25106fb486503620b6068877f8b9018efe98191b24cf667053c09ca94da7bcf854bf6924332",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJgtm1Hs6O+RDZPH73VdrgkiTzkPHjkdN\ns8GyUQb7SGUDYgtgaId/i5AY7+mBkbJM9mcFPAnKlNp7z4VL9pJDMg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 401,
+          "comment": "u1 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b802205731b7c4bd04cb9efb836935ff2e547bf2909f86824af4d8df78acf76d7b3d4e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0430549bef5174962c5650944bbd7833220338e2e31f27775666f7d124d8ed7783f43ee6599a8458c9d786dd50cc676babf489757ade3e267d87bf2654a34adb20",
+        "wx": "30549bef5174962c5650944bbd7833220338e2e31f27775666f7d124d8ed7783",
+        "wy": "00f43ee6599a8458c9d786dd50cc676babf489757ade3e267d87bf2654a34adb20"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000430549bef5174962c5650944bbd7833220338e2e31f27775666f7d124d8ed7783f43ee6599a8458c9d786dd50cc676babf489757ade3e267d87bf2654a34adb20",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMFSb71F0lixWUJRLvXgzIgM44uMfJ3dW\nZvfRJNjtd4P0PuZZmoRYydeG3VDMZ2ur9Il1et4+Jn2HvyZUo0rbIA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 402,
+          "comment": "u1 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022100a8ce483b42fb3461047c96ca00d1ab82c81e3d602cfdab62e059b19562bb03f3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0422283ca6f055439e8540454f63ff02e2e1141d10e34a54737599fae66266636dc8fef97c98fa1160f829b7c1326a069e0bb442428f1503e8cfbb616cd8118832",
+        "wx": "22283ca6f055439e8540454f63ff02e2e1141d10e34a54737599fae66266636d",
+        "wy": "00c8fef97c98fa1160f829b7c1326a069e0bb442428f1503e8cfbb616cd8118832"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000422283ca6f055439e8540454f63ff02e2e1141d10e34a54737599fae66266636dc8fef97c98fa1160f829b7c1326a069e0bb442428f1503e8cfbb616cd8118832",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEIig8pvBVQ56FQEVPY/8C4uEUHRDjSlRz\ndZn65mJmY23I/vl8mPoRYPgpt8EyagaeC7RCQo8VA+jPu2Fs2BGIMg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 403,
+          "comment": "u2 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04068f523d44cbb14a249394861c4f417c19dba72f74e1b123b4cbb89c74541b4144cd654d2b5871942e8d181f9e38f3946b3a73755a20e68ba555d56de6e290f4",
+        "wx": "068f523d44cbb14a249394861c4f417c19dba72f74e1b123b4cbb89c74541b41",
+        "wy": "44cd654d2b5871942e8d181f9e38f3946b3a73755a20e68ba555d56de6e290f4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004068f523d44cbb14a249394861c4f417c19dba72f74e1b123b4cbb89c74541b4144cd654d2b5871942e8d181f9e38f3946b3a73755a20e68ba555d56de6e290f4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEBo9SPUTLsUokk5SGHE9BfBnbpy904bEj\ntMu4nHRUG0FEzWVNK1hxlC6NGB+eOPOUazpzdVog5oulVdVt5uKQ9A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 404,
+          "comment": "u2 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9d1c9e899ca306ad27fe1945de0242b89",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04123670ccceb86a9d5fce24f070de8dfab093ee66047b17c1d7cca4734820daed76495f92804999f894c0184f72235b2db0a7d8ad077427b346d41f24eb2210a1",
+        "wx": "123670ccceb86a9d5fce24f070de8dfab093ee66047b17c1d7cca4734820daed",
+        "wy": "76495f92804999f894c0184f72235b2db0a7d8ad077427b346d41f24eb2210a1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004123670ccceb86a9d5fce24f070de8dfab093ee66047b17c1d7cca4734820daed76495f92804999f894c0184f72235b2db0a7d8ad077427b346d41f24eb2210a1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEEjZwzM64ap1fziTwcN6N+rCT7mYEexfB\n18ykc0gg2u12SV+SgEmZ+JTAGE9yI1stsKfYrQd0J7NG1B8k6yIQoQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 405,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02201d109296e9ac43dfa92bcdbcaa64c6d3fb858a822b6e519d9fd2e45279d3bf1a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f5ab53b565f170a3a83e61dc8cb5bb3a217398f0880db80c41da746d533993973d113d69a23e02aeb2e335b28b85490ace7df18279e2f4a7bd6f69c656fe6763",
+        "wx": "00f5ab53b565f170a3a83e61dc8cb5bb3a217398f0880db80c41da746d53399397",
+        "wy": "3d113d69a23e02aeb2e335b28b85490ace7df18279e2f4a7bd6f69c656fe6763"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f5ab53b565f170a3a83e61dc8cb5bb3a217398f0880db80c41da746d533993973d113d69a23e02aeb2e335b28b85490ace7df18279e2f4a7bd6f69c656fe6763",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE9atTtWXxcKOoPmHcjLW7OiFzmPCIDbgM\nQdp0bVM5k5c9ET1poj4CrrLjNbKLhUkKzn3xgnni9Ke9b2nGVv5nYw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 406,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02203a8a53a9b98a2111e0c5e758a61f57822ead6ac1b9489d7b1bae29dc1dda7a87",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d0abcee886b680233390f1e6d5ce27056cbfec35ba9231725849a3714b06e8285bb11395652a85301cf5110d75d404a1f449ab2ac4767013fd586a9b58114006",
+        "wx": "00d0abcee886b680233390f1e6d5ce27056cbfec35ba9231725849a3714b06e828",
+        "wy": "5bb11395652a85301cf5110d75d404a1f449ab2ac4767013fd586a9b58114006"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d0abcee886b680233390f1e6d5ce27056cbfec35ba9231725849a3714b06e8285bb11395652a85301cf5110d75d404a1f449ab2ac4767013fd586a9b58114006",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0KvO6Ia2gCMzkPHm1c4nBWy/7DW6kjFy\nWEmjcUsG6ChbsROVZSqFMBz1EQ111ASh9EmrKsR2cBP9WGqbWBFABg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 407,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100ac2416840b83e89e188d94463bd19cdc296fb2f891782dbd736b7241d371e890",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040f82392f4912bad8f4fcb151b290003174526a8cb27091d38c2aed163040698cdc34e9542d264ecffcd6339963804d68fc8a7376312b8a590d836e1ce1a9e637",
+        "wx": "0f82392f4912bad8f4fcb151b290003174526a8cb27091d38c2aed163040698c",
+        "wy": "00dc34e9542d264ecffcd6339963804d68fc8a7376312b8a590d836e1ce1a9e637"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040f82392f4912bad8f4fcb151b290003174526a8cb27091d38c2aed163040698cdc34e9542d264ecffcd6339963804d68fc8a7376312b8a590d836e1ce1a9e637",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAED4I5L0kSutj0/LFRspAAMXRSaoyycJHT\njCrtFjBAaYzcNOlULSZOz/zWM5ljgE1o/IpzdjErilkNg24c4anmNw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 408,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202ec9288261d8fbcda8ce483b42fb3460c908624c8869161e6b15d76e66ec5dff",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043b8497a00342aa0ca81408f40de05e938a151e6207a912bc35a13ab8ce8682d475d9d40f07fa88a7418e10d0f92bd10f646016be181c04af65e9ac1858f8e145",
+        "wx": "3b8497a00342aa0ca81408f40de05e938a151e6207a912bc35a13ab8ce8682d4",
+        "wy": "75d9d40f07fa88a7418e10d0f92bd10f646016be181c04af65e9ac1858f8e145"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043b8497a00342aa0ca81408f40de05e938a151e6207a912bc35a13ab8ce8682d475d9d40f07fa88a7418e10d0f92bd10f646016be181c04af65e9ac1858f8e145",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEO4SXoANCqgyoFAj0DeBek4oVHmIHqRK8\nNaE6uM6GgtR12dQPB/qIp0GOEND5K9EPZGAWvhgcBK9l6awYWPjhRQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 409,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0221009288261d8fbcda8ce483b42fb34610470f37567e692db81ce2caa2fe67594614",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e95914e5d692f4c30724c50a232d432a09664e1d485ecfc3a8299b7007b990b501a21060c529f3776a1df1b3828157dbcd432e84d3ac229585bc9234341788a8",
+        "wx": "00e95914e5d692f4c30724c50a232d432a09664e1d485ecfc3a8299b7007b990b5",
+        "wy": "01a21060c529f3776a1df1b3828157dbcd432e84d3ac229585bc9234341788a8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e95914e5d692f4c30724c50a232d432a09664e1d485ecfc3a8299b7007b990b501a21060c529f3776a1df1b3828157dbcd432e84d3ac229585bc9234341788a8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE6VkU5daS9MMHJMUKIy1DKglmTh1IXs/D\nqCmbcAe5kLUBohBgxSnzd2od8bOCgVfbzUMuhNOsIpWFvJI0NBeIqA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 410,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022025104c3b1f79b519c907685f668c208f63bfd0162312cffe05c2e76ffe7c4ae7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04af3e088449e97df3df478c59536965a18598122efc5bb20d23b9f5e41bc84e8a403177e836fa23bb3ba2b8fe6005c8d79e1392dc3b726dca4eca14e88c00fdfd",
+        "wx": "00af3e088449e97df3df478c59536965a18598122efc5bb20d23b9f5e41bc84e8a",
+        "wy": "403177e836fa23bb3ba2b8fe6005c8d79e1392dc3b726dca4eca14e88c00fdfd"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004af3e088449e97df3df478c59536965a18598122efc5bb20d23b9f5e41bc84e8a403177e836fa23bb3ba2b8fe6005c8d79e1392dc3b726dca4eca14e88c00fdfd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErz4IhEnpffPfR4xZU2lloYWYEi78W7IN\nI7n15BvITopAMXfoNvojuzuiuP5gBcjXnhOS3DtybcpOyhTojAD9/Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 411,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022061d8fbcda8ce483b42fb3461047c96c9847a30c583c9b9f495591fa1e037b4fe",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04acaf208d26995e464ebcc54a683b04985c7be74448927e5c15332852886e6d748b182e2468f86cae75d045dc426383d2da3c7e3ab515580f3ff6523f03ce40dc",
+        "wx": "00acaf208d26995e464ebcc54a683b04985c7be74448927e5c15332852886e6d74",
+        "wy": "008b182e2468f86cae75d045dc426383d2da3c7e3ab515580f3ff6523f03ce40dc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004acaf208d26995e464ebcc54a683b04985c7be74448927e5c15332852886e6d748b182e2468f86cae75d045dc426383d2da3c7e3ab515580f3ff6523f03ce40dc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErK8gjSaZXkZOvMVKaDsEmFx750RIkn5c\nFTMoUohubXSLGC4kaPhsrnXQRdxCY4PS2jx+OrUVWA8/9lI/A85A3A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 412,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100856739764fc50a930e4201325d77815bcf9b7681ed11213a053e816c5df8e6c6",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047821e20d3938bbb48240ff48096e928e404ed91eefa37ea7cb2c8f339347b6ee6f7ada5c814f0f06eae9516a7848361cc3ac2eb4450a4455743d363f84f0dd1d",
+        "wx": "7821e20d3938bbb48240ff48096e928e404ed91eefa37ea7cb2c8f339347b6ee",
+        "wy": "6f7ada5c814f0f06eae9516a7848361cc3ac2eb4450a4455743d363f84f0dd1d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047821e20d3938bbb48240ff48096e928e404ed91eefa37ea7cb2c8f339347b6ee6f7ada5c814f0f06eae9516a7848361cc3ac2eb4450a4455743d363f84f0dd1d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCHiDTk4u7SCQP9ICW6SjkBO2R7vo36n\nyyyPM5NHtu5vetpcgU8PBurpUWp4SDYcw6wutEUKRFV0PTY/hPDdHQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 413,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220512c9e1178d280d8464412f2bdf2dd9a7e8065b7ba9216f700779794c9a849bd",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049b0ef17c0bd3dea11be2c3358058a1e10b0283108bf79aaae34355c2329e84a0955f5cf7cb593ee756cf4c9f2f0a488a2993aeba923320bfab98c6f72e079d73",
+        "wx": "009b0ef17c0bd3dea11be2c3358058a1e10b0283108bf79aaae34355c2329e84a0",
+        "wy": "00955f5cf7cb593ee756cf4c9f2f0a488a2993aeba923320bfab98c6f72e079d73"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049b0ef17c0bd3dea11be2c3358058a1e10b0283108bf79aaae34355c2329e84a0955f5cf7cb593ee756cf4c9f2f0a488a2993aeba923320bfab98c6f72e079d73",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEmw7xfAvT3qEb4sM1gFih4QsCgxCL95qq\n40NVwjKehKCVX1z3y1k+51bPTJ8vCkiKKZOuupIzIL+rmMb3Lgedcw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 414,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100c9e4be241bd52c69a2486b6d22291f502f64efab87e244d33cacce68672fd44b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044ba97363a7e14ce09480bd3b88491a7a501b5d4871b470498abc9a698c0699558ce9e198c1d48ec6650d59c15f9e1fb40dc0adccdea6329613e3a9a4decc80f8",
+        "wx": "4ba97363a7e14ce09480bd3b88491a7a501b5d4871b470498abc9a698c069955",
+        "wy": "008ce9e198c1d48ec6650d59c15f9e1fb40dc0adccdea6329613e3a9a4decc80f8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044ba97363a7e14ce09480bd3b88491a7a501b5d4871b470498abc9a698c0699558ce9e198c1d48ec6650d59c15f9e1fb40dc0adccdea6329613e3a9a4decc80f8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAES6lzY6fhTOCUgL07iEkaelAbXUhxtHBJ\niryaaYwGmVWM6eGYwdSOxmUNWcFfnh+0DcCtzN6mMpYT46mk3syA+A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 415,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100b0a10528cded5f2b80520ac549338c3f61bbb6f69877aa1b2fe9129c0ce717f2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040bad8d9f015770ed8ac654528717734214fff813809b5eb886f87c46d1bac68fc9134ebed0d79a82321cec4c77d5b91c1c7e3c34f6a69cc10140127421b87b92",
+        "wx": "0bad8d9f015770ed8ac654528717734214fff813809b5eb886f87c46d1bac68f",
+        "wy": "00c9134ebed0d79a82321cec4c77d5b91c1c7e3c34f6a69cc10140127421b87b92"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040bad8d9f015770ed8ac654528717734214fff813809b5eb886f87c46d1bac68fc9134ebed0d79a82321cec4c77d5b91c1c7e3c34f6a69cc10140127421b87b92",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEC62NnwFXcO2KxlRShxdzQhT/+BOAm164\nhvh8RtG6xo/JE06+0NeagjIc7Ex31bkcHH48NPamnMEBQBJ0Ibh7kg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 416,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100f177b6b48b29de102b6a1921aacd9c94bcec17a59991776cefe8ec63934c61b4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ab53f0d664c621138893fc5ee2b26ad2d686bbbb67eda1ee0dfb9609a3f5777afcf2d72bbd357bea8a1545fd4f162f3faf43bf74666cf23914c7e3d8dde79e97",
+        "wx": "00ab53f0d664c621138893fc5ee2b26ad2d686bbbb67eda1ee0dfb9609a3f5777a",
+        "wy": "00fcf2d72bbd357bea8a1545fd4f162f3faf43bf74666cf23914c7e3d8dde79e97"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ab53f0d664c621138893fc5ee2b26ad2d686bbbb67eda1ee0dfb9609a3f5777afcf2d72bbd357bea8a1545fd4f162f3faf43bf74666cf23914c7e3d8dde79e97",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEq1Pw1mTGIROIk/xe4rJq0taGu7tn7aHu\nDfuWCaP1d3r88tcrvTV76ooVRf1PFi8/r0O/dGZs8jkUx+PY3eeelw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 417,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100e2ef6d691653bc2056d43243559b392abf29526483da4e9e1fff7a3a56628227",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04418698cfe9d564e0e5d04a901c062042d864091573f2820f4592d40027dcfe2634909e2b92b3cbc595203553121ca46efdda2c23ca990e1e56137365c5a5b795",
+        "wx": "418698cfe9d564e0e5d04a901c062042d864091573f2820f4592d40027dcfe26",
+        "wy": "34909e2b92b3cbc595203553121ca46efdda2c23ca990e1e56137365c5a5b795"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004418698cfe9d564e0e5d04a901c062042d864091573f2820f4592d40027dcfe2634909e2b92b3cbc595203553121ca46efdda2c23ca990e1e56137365c5a5b795",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQYaYz+nVZODl0EqQHAYgQthkCRVz8oIP\nRZLUACfc/iY0kJ4rkrPLxZUgNVMSHKRu/dosI8qZDh5WE3NlxaW3lQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 418,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100d467241da17d9a30823e4b650068d5c0c1668d236e2325cf501608111978a29a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dc0515e400e3527d2785e4a21d105af4cae862b31e07de117f11c9cd8dc9bc9b034eef9d96a56c0e74efa10a9f75e2a44d1337e8008175fbb40fe1c700144601",
+        "wx": "00dc0515e400e3527d2785e4a21d105af4cae862b31e07de117f11c9cd8dc9bc9b",
+        "wy": "034eef9d96a56c0e74efa10a9f75e2a44d1337e8008175fbb40fe1c700144601"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dc0515e400e3527d2785e4a21d105af4cae862b31e07de117f11c9cd8dc9bc9b034eef9d96a56c0e74efa10a9f75e2a44d1337e8008175fbb40fe1c700144601",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3AUV5ADjUn0nheSiHRBa9MroYrMeB94R\nfxHJzY3JvJsDTu+dlqVsDnTvoQqfdeKkTRM36ACBdfu0D+HHABRGAQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 419,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022056120b4205c1f44f0c46ca231de8ce6e14b7d97c48bc16deb9b5b920e9b8f448",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0453ff623b312669b48cc8a120b76a811e48a930548de8476d2c4607a5524ce592477ae28b239f626067a1d3dee97d769d37b41b184bae95009e401e443e930ef7",
+        "wx": "53ff623b312669b48cc8a120b76a811e48a930548de8476d2c4607a5524ce592",
+        "wy": "477ae28b239f626067a1d3dee97d769d37b41b184bae95009e401e443e930ef7"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000453ff623b312669b48cc8a120b76a811e48a930548de8476d2c4607a5524ce592477ae28b239f626067a1d3dee97d769d37b41b184bae95009e401e443e930ef7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEU/9iOzEmabSMyKEgt2qBHkipMFSN6Edt\nLEYHpVJM5ZJHeuKLI59iYGeh097pfXadN7QbGEuulQCeQB5EPpMO9w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 420,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100d55555555555555555555555555555547c74934474db157d2a8c3f088aced62a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d2d5348db9d837537c90e930ce35d4cd90e7d7a3460b1384790b632281b98ce843cc7b9a20c8734ac2c62a7d207105f5b2d85c2418939d35e3886f3893cb21b4",
+        "wx": "00d2d5348db9d837537c90e930ce35d4cd90e7d7a3460b1384790b632281b98ce8",
+        "wy": "43cc7b9a20c8734ac2c62a7d207105f5b2d85c2418939d35e3886f3893cb21b4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d2d5348db9d837537c90e930ce35d4cd90e7d7a3460b1384790b632281b98ce843cc7b9a20c8734ac2c62a7d207105f5b2d85c2418939d35e3886f3893cb21b4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0tU0jbnYN1N8kOkwzjXUzZDn16NGCxOE\neQtjIoG5jOhDzHuaIMhzSsLGKn0gcQX1sthcJBiTnTXjiG84k8shtA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 421,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100c1777c8853938e536213c02464a936000ba1e21c0fc62075d46c624e23b52f31",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c5fe4159e0b606879fc2a11088d658030ed7fef2e6711aab04869612fd09c3daac9dc7e198495afc0f43f4de434b8da233d8492cda28db460e8480aecb0a88f5",
+        "wx": "00c5fe4159e0b606879fc2a11088d658030ed7fef2e6711aab04869612fd09c3da",
+        "wy": "00ac9dc7e198495afc0f43f4de434b8da233d8492cda28db460e8480aecb0a88f5"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c5fe4159e0b606879fc2a11088d658030ed7fef2e6711aab04869612fd09c3daac9dc7e198495afc0f43f4de434b8da233d8492cda28db460e8480aecb0a88f5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAExf5BWeC2BoefwqEQiNZYAw7X/vLmcRqr\nBIaWEv0Jw9qsncfhmEla/A9D9N5DS42iM9hJLNoo20YOhICuywqI9Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 422,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022030bbb794db588363b40679f6c182a50d3ce9679acdd3ffbe36d7813dacbdc818",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049a72b785c90a695b8e355f5d8fc151046c360d739136241c7fd1e77a0e8b8545a470b4b9a54d1d42956ac43b9c9f2f0f5489da16130b7ba1da38516c912009bc",
+        "wx": "009a72b785c90a695b8e355f5d8fc151046c360d739136241c7fd1e77a0e8b8545",
+        "wy": "00a470b4b9a54d1d42956ac43b9c9f2f0f5489da16130b7ba1da38516c912009bc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049a72b785c90a695b8e355f5d8fc151046c360d739136241c7fd1e77a0e8b8545a470b4b9a54d1d42956ac43b9c9f2f0f5489da16130b7ba1da38516c912009bc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEmnK3hckKaVuONV9dj8FRBGw2DXORNiQc\nf9Hneg6LhUWkcLS5pU0dQpVqxDucny8PVInaFhMLe6HaOFFskSAJvA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 423,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202c37fd995622c4fb7fffffffffffffffc7cee745110cb45ab558ed7c90c15a2f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0481e427bc8f0509b19a14c16e8883b12641d1d68e070c36ab49d1690e5decd061a993d77e9bc0f2b66edc6cd7ca8e32becf32596405622ea2756006deb3e8ac5f",
+        "wx": "0081e427bc8f0509b19a14c16e8883b12641d1d68e070c36ab49d1690e5decd061",
+        "wy": "00a993d77e9bc0f2b66edc6cd7ca8e32becf32596405622ea2756006deb3e8ac5f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000481e427bc8f0509b19a14c16e8883b12641d1d68e070c36ab49d1690e5decd061a993d77e9bc0f2b66edc6cd7ca8e32becf32596405622ea2756006deb3e8ac5f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEgeQnvI8FCbGaFMFuiIOxJkHR1o4HDDar\nSdFpDl3s0GGpk9d+m8Dytm7cbNfKjjK+zzJZZAViLqJ1YAbes+isXw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 424,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02207fd995622c4fb7ffffffffffffffffff5d883ffab5b32652ccdcaa290fccb97d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04756279b4827c83372130d4feab66a4397ed4463ac9ee1dc8adcaddcfcec59269b6323337d89af4208ad8818b67e26f9b8080316bc43fab53d1b3b7cea5db9947",
+        "wx": "756279b4827c83372130d4feab66a4397ed4463ac9ee1dc8adcaddcfcec59269",
+        "wy": "00b6323337d89af4208ad8818b67e26f9b8080316bc43fab53d1b3b7cea5db9947"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004756279b4827c83372130d4feab66a4397ed4463ac9ee1dc8adcaddcfcec59269b6323337d89af4208ad8818b67e26f9b8080316bc43fab53d1b3b7cea5db9947",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEdWJ5tIJ8gzchMNT+q2akOX7URjrJ7h3I\nrcrdz87Fkmm2MjM32Jr0IIrYgYtn4m+bgIAxa8Q/q1PRs7fOpduZRw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 425,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100ffb32ac4589f6ffffffffffffffffffebb107ff56b664ca599b954521f9972fa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cf9345e850417aa81b01a941a02c5546950c27830841a435f4f3654927c6926d1ec53d04954a47f37915dddb48272fe733322d8250783991709b37d87fa296ef",
+        "wx": "00cf9345e850417aa81b01a941a02c5546950c27830841a435f4f3654927c6926d",
+        "wy": "1ec53d04954a47f37915dddb48272fe733322d8250783991709b37d87fa296ef"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cf9345e850417aa81b01a941a02c5546950c27830841a435f4f3654927c6926d1ec53d04954a47f37915dddb48272fe733322d8250783991709b37d87fa296ef",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEz5NF6FBBeqgbAalBoCxVRpUMJ4MIQaQ1\n9PNlSSfGkm0exT0ElUpH83kV3dtIJy/nMzItglB4OZFwmzfYf6KW7w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 426,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02205622c4fb7fffffffffffffffffffffff928a8f1c7ac7bec1808b9f61c01ec327",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f95f625795e6cc17b4c28b1ec643c36a34989084aa6a513812c3aa9bec0730312b22ce0eeeee9d45cee863c1b1d05381ac8b2c896a2cb17d3e9070d41d68bbea",
+        "wx": "00f95f625795e6cc17b4c28b1ec643c36a34989084aa6a513812c3aa9bec073031",
+        "wy": "2b22ce0eeeee9d45cee863c1b1d05381ac8b2c896a2cb17d3e9070d41d68bbea"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f95f625795e6cc17b4c28b1ec643c36a34989084aa6a513812c3aa9bec0730312b22ce0eeeee9d45cee863c1b1d05381ac8b2c896a2cb17d3e9070d41d68bbea",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+V9iV5XmzBe0wosexkPDajSYkISqalE4\nEsOqm+wHMDErIs4O7u6dRc7oY8Gx0FOBrIssiWossX0+kHDUHWi76g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 427,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022044104104104104104104104104104103b87853fd3b7d3f8e175125b4382f25ed",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c3f0aadef8675dc8832a29b397488d6a4fb54780e5967e8b43449498c16ad4bdcb391b545464668d4d0a80b8e283132448a3c0be0abed304cf0839b5920f3867",
+        "wx": "00c3f0aadef8675dc8832a29b397488d6a4fb54780e5967e8b43449498c16ad4bd",
+        "wy": "00cb391b545464668d4d0a80b8e283132448a3c0be0abed304cf0839b5920f3867"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c3f0aadef8675dc8832a29b397488d6a4fb54780e5967e8b43449498c16ad4bdcb391b545464668d4d0a80b8e283132448a3c0be0abed304cf0839b5920f3867",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEw/Cq3vhnXciDKimzl0iNak+1R4Dlln6L\nQ0SUmMFq1L3LORtUVGRmjU0KgLjigxMkSKPAvgq+0wTPCDm1kg84Zw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 428,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202739ce739ce739ce739ce739ce739ce705560298d1f2f08dc419ac273a5b54d9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0476b920709a9e5dc54a91bd4772ab2593a76f38841dae2880f547c3bb753ae7c15f01e6779d5e3aba75997bcf7e3f320868ba8f0bc1210ab80b42760a6a701206",
+        "wx": "76b920709a9e5dc54a91bd4772ab2593a76f38841dae2880f547c3bb753ae7c1",
+        "wy": "5f01e6779d5e3aba75997bcf7e3f320868ba8f0bc1210ab80b42760a6a701206"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000476b920709a9e5dc54a91bd4772ab2593a76f38841dae2880f547c3bb753ae7c15f01e6779d5e3aba75997bcf7e3f320868ba8f0bc1210ab80b42760a6a701206",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEdrkgcJqeXcVKkb1Hcqslk6dvOIQdriiA\n9UfDu3U658FfAeZ3nV46unWZe89+PzIIaLqPC8EhCrgLQnYKanASBg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 429,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100b777777777777777777777777777777688e6a1fe808a97a348671222ff16b863",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e3895147f4e36a13c3483ac00c88a78a8ffa42478afc2e9d8386205b0b1df8b2b4156b56ba217b1ca08bd77f819abb52d742f6b2f7d61353e4cc5663da487317",
+        "wx": "00e3895147f4e36a13c3483ac00c88a78a8ffa42478afc2e9d8386205b0b1df8b2",
+        "wy": "00b4156b56ba217b1ca08bd77f819abb52d742f6b2f7d61353e4cc5663da487317"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e3895147f4e36a13c3483ac00c88a78a8ffa42478afc2e9d8386205b0b1df8b2b4156b56ba217b1ca08bd77f819abb52d742f6b2f7d61353e4cc5663da487317",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE44lRR/TjahPDSDrADIinio/6QkeK/C6d\ng4YgWwsd+LK0FWtWuiF7HKCL13+BmrtS10L2svfWE1PkzFZj2khzFw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 430,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02206492492492492492492492492492492406dd3a19b8d5fb875235963c593bd2d3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e733999ce348cf7b363dcf931953cf1c247c3a887408c064b9791c178ad350290b0849329da7008e6a2d00142883f8041b9917528fcc4c5bd3f795accff28eb6",
+        "wx": "00e733999ce348cf7b363dcf931953cf1c247c3a887408c064b9791c178ad35029",
+        "wy": "0b0849329da7008e6a2d00142883f8041b9917528fcc4c5bd3f795accff28eb6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e733999ce348cf7b363dcf931953cf1c247c3a887408c064b9791c178ad350290b0849329da7008e6a2d00142883f8041b9917528fcc4c5bd3f795accff28eb6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5zOZnONIz3s2Pc+TGVPPHCR8Ooh0CMBk\nuXkcF4rTUCkLCEkynacAjmotABQog/gEG5kXUo/MTFvT95Wsz/KOtg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 431,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100955555555555555555555555555555547c74934474db157d2a8c3f088aced62c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04069b66f716902cbd51dadff61644ac74c6a35e8c776ea22c9c3492d1d3faa2ece4905cc480bc967ce389b82c8e6692b159d3fe9a268bfc12010993934d7e24dd",
+        "wx": "069b66f716902cbd51dadff61644ac74c6a35e8c776ea22c9c3492d1d3faa2ec",
+        "wy": "00e4905cc480bc967ce389b82c8e6692b159d3fe9a268bfc12010993934d7e24dd"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004069b66f716902cbd51dadff61644ac74c6a35e8c776ea22c9c3492d1d3faa2ece4905cc480bc967ce389b82c8e6692b159d3fe9a268bfc12010993934d7e24dd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEBptm9xaQLL1R2t/2FkSsdMajXox3bqIs\nnDSS0dP6ouzkkFzEgLyWfOOJuCyOZpKxWdP+miaL/BIBCZOTTX4k3Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 432,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3e3a49a23a6d8abe95461f8445676b17",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049543bfd3a0b678654fc65458e3e62269b30bbd2a40282d92058c3311a61bd885333d78221d9aa0a9663a5df5123d95c3ff4a02606278666179e33c94fe1e0cd1",
+        "wx": "009543bfd3a0b678654fc65458e3e62269b30bbd2a40282d92058c3311a61bd885",
+        "wy": "333d78221d9aa0a9663a5df5123d95c3ff4a02606278666179e33c94fe1e0cd1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049543bfd3a0b678654fc65458e3e62269b30bbd2a40282d92058c3311a61bd885333d78221d9aa0a9663a5df5123d95c3ff4a02606278666179e33c94fe1e0cd1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAElUO/06C2eGVPxlRY4+YiabMLvSpAKC2S\nBYwzEaYb2IUzPXgiHZqgqWY6XfUSPZXD/0oCYGJ4ZmF54zyU/h4M0Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 433,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100bffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a6884e6218642518a211f67b03aef6a84d3b32d18eea445b31913e8a1a00f4c531a318166cfcbce34307572eb823edc5d0334c5e5373af4e832e730047996aca",
+        "wx": "00a6884e6218642518a211f67b03aef6a84d3b32d18eea445b31913e8a1a00f4c5",
+        "wy": "31a318166cfcbce34307572eb823edc5d0334c5e5373af4e832e730047996aca"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a6884e6218642518a211f67b03aef6a84d3b32d18eea445b31913e8a1a00f4c531a318166cfcbce34307572eb823edc5d0334c5e5373af4e832e730047996aca",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpohOYhhkJRiiEfZ7A672qE07MtGO6kRb\nMZE+ihoA9MUxoxgWbPy840MHVy64I+3F0DNMXlNzr06DLnMAR5lqyg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 434,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220185ddbca6dac41b1da033cfb60c152869e74b3cd66e9ffdf1b6bc09ed65ee40c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bd4c6f9ab363a204fd1abe0f7158b84417cca2e0d355277ddc17cac22abdbc2dc66469bb8e8e04186e81a2b693cc2121ef22cb61803a2b4ebe1a3e0d367b295d",
+        "wx": "00bd4c6f9ab363a204fd1abe0f7158b84417cca2e0d355277ddc17cac22abdbc2d",
+        "wy": "00c66469bb8e8e04186e81a2b693cc2121ef22cb61803a2b4ebe1a3e0d367b295d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bd4c6f9ab363a204fd1abe0f7158b84417cca2e0d355277ddc17cac22abdbc2dc66469bb8e8e04186e81a2b693cc2121ef22cb61803a2b4ebe1a3e0d367b295d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEvUxvmrNjogT9Gr4PcVi4RBfMouDTVSd9\n3BfKwiq9vC3GZGm7jo4EGG6BoraTzCEh7yLLYYA6K06+Gj4NNnspXQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 435,
+          "comment": "point duplication during verification",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022032b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda022100eaafe4ce77ccd9137f39edc5370d26b73f4dc6ceadfb40a488b2dc6c93f1993c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bd4c6f9ab363a204fd1abe0f7158b84417cca2e0d355277ddc17cac22abdbc2d399b96447171fbe7917e5d496c33dede10dd349e7fc5d4b141e5c1f1c984d2d2",
+        "wx": "00bd4c6f9ab363a204fd1abe0f7158b84417cca2e0d355277ddc17cac22abdbc2d",
+        "wy": "399b96447171fbe7917e5d496c33dede10dd349e7fc5d4b141e5c1f1c984d2d2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bd4c6f9ab363a204fd1abe0f7158b84417cca2e0d355277ddc17cac22abdbc2d399b96447171fbe7917e5d496c33dede10dd349e7fc5d4b141e5c1f1c984d2d2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEvUxvmrNjogT9Gr4PcVi4RBfMouDTVSd9\n3BfKwiq9vC05m5ZEcXH755F+XUlsM97eEN00nn/F1LFB5cHxyYTS0g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 436,
+          "comment": "duplication bug",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022032b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda022100eaafe4ce77ccd9137f39edc5370d26b73f4dc6ceadfb40a488b2dc6c93f1993c",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e1815bb1653b8146a2e9160fb0e946112b8994b9d90ef8a36a8ef2ba187b705d11b344caed87db94b9c9eab8a5e3277a9aa46b31768cee5406c3cbcffce0a945",
+        "wx": "00e1815bb1653b8146a2e9160fb0e946112b8994b9d90ef8a36a8ef2ba187b705d",
+        "wy": "11b344caed87db94b9c9eab8a5e3277a9aa46b31768cee5406c3cbcffce0a945"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e1815bb1653b8146a2e9160fb0e946112b8994b9d90ef8a36a8ef2ba187b705d11b344caed87db94b9c9eab8a5e3277a9aa46b31768cee5406c3cbcffce0a945",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4YFbsWU7gUai6RYPsOlGESuJlLnZDvij\nao7yuhh7cF0Rs0TK7YfblLnJ6ril4yd6mqRrMXaM7lQGw8vP/OCpRQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 437,
+          "comment": "comparison with point at infinity ",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0022033333333333333333333333333333332f222f8faefdb533f265d461c29a47373",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042be9265c148fc61379ca147e651e7f0a1c602cdd66f70b4b6ada2e83f56c1a71f5e1ede0139baa93af588cc7ec1b479b91d230c811575cb143af12c631d16a61",
+        "wx": "2be9265c148fc61379ca147e651e7f0a1c602cdd66f70b4b6ada2e83f56c1a71",
+        "wy": "00f5e1ede0139baa93af588cc7ec1b479b91d230c811575cb143af12c631d16a61"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042be9265c148fc61379ca147e651e7f0a1c602cdd66f70b4b6ada2e83f56c1a71f5e1ede0139baa93af588cc7ec1b479b91d230c811575cb143af12c631d16a61",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEK+kmXBSPxhN5yhR+ZR5/ChxgLN1m9wtL\natoug/VsGnH14e3gE5uqk69YjMfsG0ebkdIwyBFXXLFDrxLGMdFqYQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 438,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04af3b3f73a409ffa51b10f3cdfa272d9b42358ca9aed2840bfaf5bd67e61fd1c49d07371ca919a069e46c473e6e45b2f2cd019fa21f84d0abfa285be5513781fb",
+        "wx": "00af3b3f73a409ffa51b10f3cdfa272d9b42358ca9aed2840bfaf5bd67e61fd1c4",
+        "wy": "009d07371ca919a069e46c473e6e45b2f2cd019fa21f84d0abfa285be5513781fb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004af3b3f73a409ffa51b10f3cdfa272d9b42358ca9aed2840bfaf5bd67e61fd1c49d07371ca919a069e46c473e6e45b2f2cd019fa21f84d0abfa285be5513781fb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErzs/c6QJ/6UbEPPN+ictm0I1jKmu0oQL\n+vW9Z+Yf0cSdBzccqRmgaeRsRz5uRbLyzQGfoh+E0Kv6KFvlUTeB+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 439,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022100b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e155240c3be314924ed787354325fdc3dcfe46d603798f2491152448e0e413b6ce1124313eb0048292f6edf9f248ff9624936e41be6c93dce2df9ab7997289fc",
+        "wx": "00e155240c3be314924ed787354325fdc3dcfe46d603798f2491152448e0e413b6",
+        "wy": "00ce1124313eb0048292f6edf9f248ff9624936e41be6c93dce2df9ab7997289fc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e155240c3be314924ed787354325fdc3dcfe46d603798f2491152448e0e413b6ce1124313eb0048292f6edf9f248ff9624936e41be6c93dce2df9ab7997289fc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4VUkDDvjFJJO14c1QyX9w9z+RtYDeY8k\nkRUkSODkE7bOESQxPrAEgpL27fnySP+WJJNuQb5sk9zi35q3mXKJ/A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 440,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee502210099999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0487d4de4ed890da42d7e11a95e56070c95901500c53dd55b62952679884d2598ddf8a37ce6d8f86f4e8b3580d6e6a448520cb740888a3b0eac92bc9a2f1589b4e",
+        "wx": "0087d4de4ed890da42d7e11a95e56070c95901500c53dd55b62952679884d2598d",
+        "wy": "00df8a37ce6d8f86f4e8b3580d6e6a448520cb740888a3b0eac92bc9a2f1589b4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000487d4de4ed890da42d7e11a95e56070c95901500c53dd55b62952679884d2598ddf8a37ce6d8f86f4e8b3580d6e6a448520cb740888a3b0eac92bc9a2f1589b4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEh9TeTtiQ2kLX4RqV5WBwyVkBUAxT3VW2\nKVJnmITSWY3fijfObY+G9OizWA1uakSFIMt0CIijsOrJK8mi8VibTg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 441,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022066666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048c03d72664214f3bdaa6a2e1003b14864000e5993b41b71b68cdebc4a08f628a4a490efc9172983bec203e6096dd9778bec26f6e443e1dde67060dac18ca2440",
+        "wx": "008c03d72664214f3bdaa6a2e1003b14864000e5993b41b71b68cdebc4a08f628a",
+        "wy": "4a490efc9172983bec203e6096dd9778bec26f6e443e1dde67060dac18ca2440"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048c03d72664214f3bdaa6a2e1003b14864000e5993b41b71b68cdebc4a08f628a4a490efc9172983bec203e6096dd9778bec26f6e443e1dde67060dac18ca2440",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEjAPXJmQhTzvapqLhADsUhkAA5Zk7Qbcb\naM3rxKCPYopKSQ78kXKYO+wgPmCW3Zd4vsJvbkQ+Hd5nBg2sGMokQA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 442,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022049249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041ae8bf7b21b3ae00fd01d19b4f72ae6b47bf752edf476cc5cdfa1c2345588e7154dc306165f4f907802478ed2aed41ec54ddf870bc62c2c373971194308411f0",
+        "wx": "1ae8bf7b21b3ae00fd01d19b4f72ae6b47bf752edf476cc5cdfa1c2345588e71",
+        "wy": "54dc306165f4f907802478ed2aed41ec54ddf870bc62c2c373971194308411f0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041ae8bf7b21b3ae00fd01d19b4f72ae6b47bf752edf476cc5cdfa1c2345588e7154dc306165f4f907802478ed2aed41ec54ddf870bc62c2c373971194308411f0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGui/eyGzrgD9AdGbT3Kua0e/dS7fR2zF\nzfocI0VYjnFU3DBhZfT5B4AkeO0q7UHsVN34cLxiwsNzlxGUMIQR8A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 443,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee502200eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c5dad21249273cd72ad06943b4e3be0822595bf9fa0459223d27354dea24179b97340abb326afd1eb6de5e525a23aad4929f8a09244c972841a0cb76680ff060",
+        "wx": "00c5dad21249273cd72ad06943b4e3be0822595bf9fa0459223d27354dea24179b",
+        "wy": "0097340abb326afd1eb6de5e525a23aad4929f8a09244c972841a0cb76680ff060"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c5dad21249273cd72ad06943b4e3be0822595bf9fa0459223d27354dea24179b97340abb326afd1eb6de5e525a23aad4929f8a09244c972841a0cb76680ff060",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAExdrSEkknPNcq0GlDtOO+CCJZW/n6BFki\nPSc1TeokF5uXNAq7Mmr9HrbeXlJaI6rUkp+KCSRMlyhBoMt2aA/wYA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 444,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f2c6643bf373a0812f993cd616993551d7bc7826d3d6bed0918ed4998b74e837d7160a452dd2c8d3e5f4f80a1efbc33793c35d6e243e9dfe9a39e26dfb7a1b9f",
+        "wx": "00f2c6643bf373a0812f993cd616993551d7bc7826d3d6bed0918ed4998b74e837",
+        "wy": "00d7160a452dd2c8d3e5f4f80a1efbc33793c35d6e243e9dfe9a39e26dfb7a1b9f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f2c6643bf373a0812f993cd616993551d7bc7826d3d6bed0918ed4998b74e837d7160a452dd2c8d3e5f4f80a1efbc33793c35d6e243e9dfe9a39e26dfb7a1b9f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE8sZkO/NzoIEvmTzWFpk1Ude8eCbT1r7Q\nkY7UmYt06DfXFgpFLdLI0+X0+Aoe+8M3k8NdbiQ+nf6aOeJt+3obnw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 445,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022100b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043a1bd608d3187c684d8d461a5406e2b86b09eedc5d2dd28fcc341bd2d483a6d85e3ab9d9e79ecb7e43135782ae60b12ff69b3349c1819b4ab27b738c7f803595",
+        "wx": "3a1bd608d3187c684d8d461a5406e2b86b09eedc5d2dd28fcc341bd2d483a6d8",
+        "wy": "5e3ab9d9e79ecb7e43135782ae60b12ff69b3349c1819b4ab27b738c7f803595"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043a1bd608d3187c684d8d461a5406e2b86b09eedc5d2dd28fcc341bd2d483a6d85e3ab9d9e79ecb7e43135782ae60b12ff69b3349c1819b4ab27b738c7f803595",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEOhvWCNMYfGhNjUYaVAbiuGsJ7txdLdKP\nzDQb0tSDptheOrnZ557LfkMTV4KuYLEv9pszScGBm0qye3OMf4A1lQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 446,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179802210099999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04aee2e5aa96d31bde8b0ec1e71d79e721c5fb094eba49d61dfba6e636a77b215aaf3534fa210143ce3cecc5bfe1e0b136ab6811d662376637efe1eddd212b6ff0",
+        "wx": "00aee2e5aa96d31bde8b0ec1e71d79e721c5fb094eba49d61dfba6e636a77b215a",
+        "wy": "00af3534fa210143ce3cecc5bfe1e0b136ab6811d662376637efe1eddd212b6ff0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004aee2e5aa96d31bde8b0ec1e71d79e721c5fb094eba49d61dfba6e636a77b215aaf3534fa210143ce3cecc5bfe1e0b136ab6811d662376637efe1eddd212b6ff0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEruLlqpbTG96LDsHnHXnnIcX7CU66SdYd\n+6bmNqd7IVqvNTT6IQFDzjzsxb/h4LE2q2gR1mI3Zjfv4e3dIStv8A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 447,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022066666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04db0dc63f6dfff9b2564498a2423449cc5d894222ddda86eabd6d2bb2549d28d75b5bc20153ef6a2649dc6f116e6ca5c916740a9a645618003a5a448eee928fcc",
+        "wx": "00db0dc63f6dfff9b2564498a2423449cc5d894222ddda86eabd6d2bb2549d28d7",
+        "wy": "5b5bc20153ef6a2649dc6f116e6ca5c916740a9a645618003a5a448eee928fcc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004db0dc63f6dfff9b2564498a2423449cc5d894222ddda86eabd6d2bb2549d28d75b5bc20153ef6a2649dc6f116e6ca5c916740a9a645618003a5a448eee928fcc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE2w3GP23/+bJWRJiiQjRJzF2JQiLd2obq\nvW0rslSdKNdbW8IBU+9qJkncbxFubKXJFnQKmmRWGAA6WkSO7pKPzA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 448,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022049249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0482a004a2ff4aa7c2fd4c71bc88a4ee16d75c11f5ad8599a6eb41ea73e49f80bcf360abc795b4b21b46584a1bebc41720df51a25044880f287c5e5d83f83c1d20",
+        "wx": "0082a004a2ff4aa7c2fd4c71bc88a4ee16d75c11f5ad8599a6eb41ea73e49f80bc",
+        "wy": "00f360abc795b4b21b46584a1bebc41720df51a25044880f287c5e5d83f83c1d20"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000482a004a2ff4aa7c2fd4c71bc88a4ee16d75c11f5ad8599a6eb41ea73e49f80bcf360abc795b4b21b46584a1bebc41720df51a25044880f287c5e5d83f83c1d20",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEgqAEov9Kp8L9THG8iKTuFtdcEfWthZmm\n60Hqc+SfgLzzYKvHlbSyG0ZYShvrxBcg31GiUESIDyh8Xl2D+DwdIA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 449,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179802200eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 450,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "304402205731b7c4bd04cb9efb836935ff2e547bf2909f86824af4d8df78acf76d7b3d4e02202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 451,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100a8ce483b42fb3461047c96ca00d1ab82c81e3d602cfdab62e059b19562bb03f302202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "00b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5i3xSWI2Vw7mqJbBAPx7vdXAuhLt1l6q+ZjuC9vBO8ndw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 452,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "304402205731b7c4bd04cb9efb836935ff2e547bf2909f86824af4d8df78acf76d7b3d4e02202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 453,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100a8ce483b42fb3461047c96ca00d1ab82c81e3d602cfdab62e059b19562bb03f302202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "01060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv8AAAABBgSS1aVnPg8l2NUPt+WMSdhtRtQhaVXgqj1A4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 454,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450220091bc829be861c20c4bb877f0da205b3911584708ddeef580ae46691b245b99d022100c03bb5e77a8fad94736775f31ae381015a93973954b2f3e541457fcb05bccb5f",
+          "result": "valid"
+        },
+        {
+          "tcId": 455,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100fd6a7eec40d1062b9a4a7af4817b3ea8cd21596d6dc228b287a21b647caab29f022100ab861672dfe3b428c26e08f2f7ca464ad3e966bbf62931408ed1ce2735bab62b",
+          "result": "valid"
+        },
+        {
+          "tcId": 456,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022053ebb6debd028f195c039ef4e04276adfa2d9551a6e02d2c4143907ec889e6d0022100fa01a27240dd63aff235cd9778c90a7c25c993791cda584fdcca1a979f5faf54",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "00fffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv/////++fttKlqYwfDaJyrwSBpztieSuSvelqoeVcK7Tg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 457,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3044022060ec4f23f1b2c0b5acae075bbf09be76ffc978aa4d354d309746047a69c43ddd0220798c3df3ada3c91845272b9573e70e683d4e49d90a51f6ad047e24da19355d3b",
+          "result": "valid"
+        },
+        {
+          "tcId": 458,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502204457c32fe6bf74ee82ff8a38b8076b48323769f3b7970f419352283984dde081022100c6380b3ed90ddba62394c19e02a3b8690d1615dd1120c0fe67b86e7961b8e7d5",
+          "result": "valid"
+        },
+        {
+          "tcId": 459,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022024820a985bc72c8817ffdec275db7406ed5b897fff0b713d98a721a42bb4c6d402210094f1397d1e577fd47cfed7ac01f2aead6888863a3f8ff21f00c34c41e840af99",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+        "wx": "013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0",
+        "wy": "00f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAAAAAT/SIkjWTZX3PCm0irSGMYUL5QP9\nAPhGi18PcOD27nqkO8LG/SWx2CaSQcvdnbsNrJbcliMfQwcF+DhxfQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 460,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402201ed4e5132e4b11268ad55b9a4b7a54ad3e028976bbe85fef2e8cd0a3e4362c7002201d1ce94fd8ffda6df3c307150a98719f276381b0c9d261fba7feba37b402394b",
+          "result": "valid"
+        },
+        {
+          "tcId": 461,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402204f030196e9a558b5af5557c7347d132b1308b3a1ce88a6bc6bf566ed22b5da780220392ddc6e83f995a0030856ecd0822449d8dac2bead6d269ef4b307d535dce238",
+          "result": "valid"
+        },
+        {
+          "tcId": 462,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450221009eaa256762ee3d5d3ed269a2907c4a836c92073918be335469e25743ea9ba0e102202c70e1dbee671e9bbd6b68695ae40d58d11ce82592cf9824914a1d8d9e429fcc",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+        "wx": "25afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dffffffff",
+        "wy": "00fa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJa/WiayrrtZ8Hylt5ZQG+MVQ9XFGoLTs\nLJeHbf/////6RqduUgMi37xJHsTwzBl0IPxOpYg9j23VPDVLxPZ8NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 463,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100db965e2d0d25c84c30ae8a3e31f12b55b8784b90f91d443a70f2c7cb4828f5bf022100aabb284a7715095cb11714ec76779c08ad5496d8870e2109467a21093f0b8bca",
+          "result": "valid"
+        },
+        {
+          "tcId": 464,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3044022058675835add3dd65f25c76b02545176c37a840748fb64a16b8bb113e361cf55d02203b1e25552a5c35732f33735f4dc6f50f947bbecb734599a987f1ffbf86b2842d",
+          "result": "valid"
+        },
+        {
+          "tcId": 465,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30440220786a687776da9c185afa16f90a596f5ddce3c2d3caece0344101be24581b86e1022075b13da23be046d551c68b54e72a990288dd73099800705e1a854366662b950e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+        "wx": "00d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb9",
+        "wy": "3f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0S5sZrZ3NMPITSYBz1013Al+J2N/CspK\nT9t0tqrdO7k/W9/4i9VzbfiY5pkAbtdQ8RzwfFhmzXrXDHEh/////w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 466,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100cfce7188667568bd7d5269a75bef42aa360705db5232d189adcf2323036852bb02205d06871c28d89198870f94264ae11744d254682e06f154332f976b803da8a1a2",
+          "result": "valid"
+        },
+        {
+          "tcId": 467,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100b21cc81843c74779fc5ba9fe1b0d5e7173f696c6e91398cf83a31bc735b6050b0221008945e8711789093c80fe6cec3947cc9c36ffe2505f1ef721bb507e05c9c07bd2",
+          "result": "valid"
+        },
+        {
+          "tcId": 468,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100fbc5087d1e6bbc32dae22a837d03151028ac69ad71e66e5fc841de0548c06dce022100e2dfa5e56de28d72d0e770e7666033c42431bcae1fc6cffd9593d54cbcfcfa7c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+        "wx": "6d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000",
+        "wy": "00e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbUp/YNR3Sk8KqLve25U8fup5CUB+MWR1\nVmS8KAAAAADmWdNOTfONnoyeqt+6NmEsdpGVvobHeqw/NueLU4aA+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 469,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502205ea780b73ce027c03ff81e1b26e61076c8944a835d349cd757ece0c4ddf1da24022100bd9b87db26158d5b9132bb0f3df54a2ab6c9ae9a4e0b8496a539ab4ab588ccba",
+          "result": "valid"
+        },
+        {
+          "tcId": 470,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402204618f1a11cf8cbc1966416785c3149f75a71ae256d445deb31008d51ba6088c20220408087725dd6ce18bfb7493a5460b54022245e5dbd731ed6d35db88a51d2ba6e",
+          "result": "valid"
+        },
+        {
+          "tcId": 471,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450221009d9cdb94e5e9a66bf8eedfdf9f1af43713bb05d880dec89aec21631958970de60220732932649bea35f11dfe0926618e4f091c1b264ca128a9eef14e6d94d7c9f207",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-non-minimal-tag",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-256",
+      "tests": [
+        {
+          "tcId": 472,
+          "comment": "signature with non-minimal SEQUENCE tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "3f1046022100fc0f737a79d525eefe3c940c162173cc6fd9a6d5cc5017754026c4113d0f15cc022100894d6fb59cc79199b89cf12b556ba49f8623b66da8c11a55e267e3318497688c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 473,
+          "comment": "signature with non-minimal INTEGER tag on r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "30471f022100fc0f737a79d525eefe3c940c162173cc6fd9a6d5cc5017754026c4113d0f15cc022100894d6fb59cc79199b89cf12b556ba49f8623b66da8c11a55e267e3318497688c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 474,
+          "comment": "signature with non-minimal INTEGER tag on s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "3047022100fc0f737a79d525eefe3c940c162173cc6fd9a6d5cc5017754026c4113d0f15cc1f022100894d6fb59cc79199b89cf12b556ba49f8623b66da8c11a55e267e3318497688c",
+          "result": "invalid"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/ecc/_data/ecdsa_secp256k1_sha3_512_test.json
+++ b/tests/ecc/_data/ecdsa_secp256k1_sha3_512_test.json
@@ -1,0 +1,7545 @@
+{
+  "algorithm": "ECDSA",
+  "schema": "ecdsa_verify_schema_v1.json",
+  "numberOfTests": 540,
+  "header": [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
+  "notes": {
+    "ArithmeticError": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
+      "cves": [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature": {
+      "bugType": "BER_ENCODING",
+      "description": "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect": "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves": [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero": {
+      "bugType": "LEGACY",
+      "description": "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect": "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves": [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "Untruncatedhash": {
+      "bugType": "MISSING_STEP",
+      "description": "If the size of the digest is longer than the size of the underlying order of the multiplicative subgroup then the hash digest must be truncated during signature generation and verification. This test vector contains a signature where this step has been omitted."
+    },
+    "ValidSignature": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "",
+          "sig": "3044022022bb0000e9648a0ee659f9b6a9ab6513dc90ab968ec49d3953f64c82bddc852002204aa0dfd047b0786e118231eff7e86311487ec9d1bc84aaef1f736f4178c288f9",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "4d7367",
+          "sig": "3046022100855b60549e0d84ed3959ab2800eee0cbc9a2cecae2e510ed51e9f27975cdcc4e022100c60dcc80a3dcce9911cb9cfba123b6a6f85d20ab695a9ee7d46e0bd9eeb337f9",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502205cd73aa58188658ea513f8ecf0d9e2da9eb5d6bcc7cbadcd6a4a8e0cba5176de022100a9f090bb5d3fcf5b7fa7e16d287718773f5f4ba0973b329a3788cd45b4bd3765",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "sig": "304502207f9eebad2a323f8346445d1e2fcde47aba4c96ad4686172bebcffaa604e8dbe3022100ec09d731e58e3a337ea03ab72612b1f801b88eac571bd3a031250ac6f2e34fda",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx": "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy": "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 5,
+          "comment": "signature malleability",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022059f100a7e4a774cf8f04577ebd9ab9ab2f09cfc5a6be10ffd0338524e6c26caa",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "Legacy: ASN encoding of s misses leading 0",
+          "flags": [
+            "MissingZero"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60220a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 7,
+          "comment": "valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "length of sequence [r, s] uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30814502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 9,
+          "comment": "length of sequence [r, s] contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3082004502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "length of sequence [r, s] uses 70 instead of 69",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304602207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 11,
+          "comment": "length of sequence [r, s] uses 68 instead of 69",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 12,
+          "comment": "uint32 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085010000004502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "uint64 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308901000000000000004502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "length of sequence [r, s] = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30847fffffff02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "length of sequence [r, s] = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30848000000002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "length of sequence [r, s] = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3084ffffffff02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "length of sequence [r, s] = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085ffffffffff02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "length of sequence [r, s] = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3088ffffffffffffffff02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "incorrect length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30ff02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "removing sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "lonely sequence tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "appending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "prepending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047000002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "appending unused 0's to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "appending null value to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a498177304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492500304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "appending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "including undefined tags",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304daa00bb00cd00304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d2228aa00bb00cd0002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe62229aa00bb00cd00022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "truncated length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3081",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "including undefined tags to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304baa02aabb304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "using composition with indefinite length for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 36,
+          "comment": "using composition with wrong tag for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080314502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 37,
+          "comment": "Replacing sequence [r, s] with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 38,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2e4502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 39,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2f4502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 40,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "314502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 41,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "324502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 42,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "ff4502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 43,
+          "comment": "dropping value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 44,
+          "comment": "using composition for sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30493001023044207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 45,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4",
+          "result": "invalid"
+        },
+        {
+          "tcId": 46,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 47,
+          "comment": "sequence [r, s] of size 4166 to check for overflows",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3082104602207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 48,
+          "comment": "indefinite length",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 49,
+          "comment": "indefinite length with truncated delimiter",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d49700",
+          "result": "invalid"
+        },
+        {
+          "tcId": 50,
+          "comment": "indefinite length with additional element",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d49705000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 51,
+          "comment": "indefinite length with truncated element",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497060811220000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 52,
+          "comment": "indefinite length with garbage",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000fe02beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 53,
+          "comment": "indefinite length with nonempty EOC",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970002beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 54,
+          "comment": "prepend empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047300002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 55,
+          "comment": "append empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4973000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 56,
+          "comment": "append zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304802207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 57,
+          "comment": "append garbage with high tag number",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304802207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497bf7f00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 58,
+          "comment": "append null with explicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304902207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497a0020500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 59,
+          "comment": "append null with implicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497a000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 60,
+          "comment": "sequence of sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 61,
+          "comment": "truncated sequence: removed last 1 elements",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302202207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 62,
+          "comment": "repeating element in sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "306802207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 63,
+          "comment": "flipped bit 0 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30437d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe7022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 64,
+          "comment": "flipped bit 32 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30437d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccc4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 65,
+          "comment": "flipped bit 48 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30437d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577462ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 66,
+          "comment": "flipped bit 64 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30437d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd477472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 67,
+          "comment": "length of r uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30460281207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 68,
+          "comment": "length of r contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047028200207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 69,
+          "comment": "length of r uses 33 instead of 32",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502217d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 70,
+          "comment": "length of r uses 31 instead of 32",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045021f7d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 71,
+          "comment": "uint32 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a028501000000207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 72,
+          "comment": "uint64 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02890100000000000000207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 73,
+          "comment": "length of r = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902847fffffff7d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 74,
+          "comment": "length of r = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30490284800000007d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 75,
+          "comment": "length of r = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30490284ffffffff7d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 76,
+          "comment": "length of r = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a0285ffffffffff7d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 77,
+          "comment": "length of r = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d0288ffffffffffffffff7d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 78,
+          "comment": "incorrect length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502ff7d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 79,
+          "comment": "replaced r by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502807d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 80,
+          "comment": "removing r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3023022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 81,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 82,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302302207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe602",
+          "result": "invalid"
+        },
+        {
+          "tcId": 83,
+          "comment": "appending 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702227d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60000022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 84,
+          "comment": "prepending 0's to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022200007d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 85,
+          "comment": "appending unused 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60000022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 86,
+          "comment": "appending null value to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702227d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60500022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 87,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a222549817702207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 88,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492224250002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 89,
+          "comment": "appending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d222202207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60004deadbeef022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 90,
+          "comment": "truncated length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250281022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 91,
+          "comment": "including undefined tags to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b2226aa02aabb02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 92,
+          "comment": "using composition with indefinite length for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049228002207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60000022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 93,
+          "comment": "using composition with wrong tag for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049228003207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60000022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 94,
+          "comment": "Replacing r with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30250500022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 95,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304500207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 96,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304501207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 97,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304503207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 98,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304504207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 99,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045ff207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 100,
+          "comment": "dropping value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250200022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 101,
+          "comment": "using composition for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049222402017d021f68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 102,
+          "comment": "modifying first byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207f68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 103,
+          "comment": "modifying last byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32ab66022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 104,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044021f7d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32ab022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 105,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044021f68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 106,
+          "comment": "r of size 4129 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30821048028210217d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 107,
+          "comment": "leading ff in r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff7d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 108,
+          "comment": "replaced r by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026090180022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 109,
+          "comment": "replacing r with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 110,
+          "comment": "flipped bit 0 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe600a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d496",
+          "result": "invalid"
+        },
+        {
+          "tcId": 111,
+          "comment": "flipped bit 32 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe600a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed966e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 112,
+          "comment": "flipped bit 48 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe600a60eff581b588b3070fba881426546538ba50d21088a8f3bef9fd967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 113,
+          "comment": "flipped bit 64 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe600a60eff581b588b3070fba881426546538ba50d21088a8f3aef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 114,
+          "comment": "length of s uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304602207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe602812100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 115,
+          "comment": "length of s contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60282002100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 116,
+          "comment": "length of s uses 34 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022200a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 117,
+          "comment": "length of s uses 32 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022000a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 118,
+          "comment": "uint32 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60285010000002100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 119,
+          "comment": "uint64 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6028901000000000000002100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 120,
+          "comment": "length of s = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe602847fffffff00a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 121,
+          "comment": "length of s = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe602848000000000a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 122,
+          "comment": "length of s = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60284ffffffff00a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 123,
+          "comment": "length of s = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60285ffffffffff00a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 124,
+          "comment": "length of s = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60288ffffffffffffffff00a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 125,
+          "comment": "incorrect length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe602ff00a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 126,
+          "comment": "replaced s by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6028000a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 127,
+          "comment": "appending 0's to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022300a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 128,
+          "comment": "prepending 0's to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304702207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60223000000a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 129,
+          "comment": "appending null value to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022300a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 130,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe62226498177022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 131,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe622252500022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 132,
+          "comment": "appending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe62223022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 133,
+          "comment": "truncated length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60281",
+          "result": "invalid"
+        },
+        {
+          "tcId": 134,
+          "comment": "including undefined tags to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b02207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe62227aa02aabb022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 135,
+          "comment": "using composition with indefinite length for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe62280022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 136,
+          "comment": "using composition with wrong tag for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe62280032100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 137,
+          "comment": "Replacing s with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302402207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 138,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6002100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 139,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6012100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 140,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6032100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 141,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6042100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 142,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6ff2100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 143,
+          "comment": "dropping value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60200",
+          "result": "invalid"
+        },
+        {
+          "tcId": 144,
+          "comment": "using composition for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe622250201000220a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 145,
+          "comment": "modifying first byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022102a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 146,
+          "comment": "modifying last byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d417",
+          "result": "invalid"
+        },
+        {
+          "tcId": 147,
+          "comment": "truncated s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022000a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4",
+          "result": "invalid"
+        },
+        {
+          "tcId": 148,
+          "comment": "s of size 4130 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3082104802207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60282102200a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d4970000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 149,
+          "comment": "leading ff in s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304602207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe60222ff00a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 150,
+          "comment": "replaced s by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6090180",
+          "result": "invalid"
+        },
+        {
+          "tcId": 151,
+          "comment": "replacing s with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302502207d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 152,
+          "comment": "replaced r by r + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221017d68757ac197624ae5c77dfa1b3bdda5c3a93710ad3a9c1137198b5a1f68ed27022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 153,
+          "comment": "replaced r by r - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff7d68757ac197624ae5c77dfa1b3bdda84e4b7d434ea95b99b774ce407efc6aa5022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 154,
+          "comment": "replaced r by r + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022201007d68757ac197624ae5c77dfa1b3bdc61b7d740d94692379549a5b99d8573ece6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 155,
+          "comment": "replaced r by -r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022082978a853e689db51a388205e4c42258f705a5d6020e042a88b8d332b0cd541a022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 156,
+          "comment": "replaced r by n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "304602210082978a853e689db51a388205e4c42257b1b482bcb156a466488b31bf8103955b022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 157,
+          "comment": "replaced r by -n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fe82978a853e689db51a388205e4c4225a3c56c8ef52c563eec8e674a5e09712d9022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 158,
+          "comment": "replaced r by r + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221017d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 159,
+          "comment": "replaced r by r + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02290100000000000000007d68757ac197624ae5c77dfa1b3bdda708fa5a29fdf1fbd577472ccd4f32abe6022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 160,
+          "comment": "replaced s by s + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101a60eff581b588b3070fba881426546524653ea07b7d32f77af7137f4b9aa15d8022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 161,
+          "comment": "replaced s by s - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220a60eff581b588b3070fba88142654654d0f6303a5941ef002fcc7adb193d9356022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 162,
+          "comment": "replaced s by s + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "304702220100a60eff581b588b3070fba8814265450e3a81f3d0512acafbc1fd66381fb51597022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 163,
+          "comment": "replaced s by -s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff59f100a7e4a774cf8f04577ebd9ab9ac745af2def77570c410612698168c2b69022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 164,
+          "comment": "replaced s by -n - s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fe59f100a7e4a774cf8f04577ebd9ab9adb9ac15f8482cd088508ec80b4655ea28022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 165,
+          "comment": "replaced s by s + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 166,
+          "comment": "replaced s by s - 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 167,
+          "comment": "replaced s by s + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e0229010000000000000000a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497022100a60eff581b588b3070fba881426546538ba50d21088a8f3bef9ed967e973d497",
+          "result": "invalid"
+        },
+        {
+          "tcId": 168,
+          "comment": "Signature with special case values r=0 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 169,
+          "comment": "Signature with special case values r=0 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 170,
+          "comment": "Signature with special case values r=0 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 171,
+          "comment": "Signature with special case values r=0 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 172,
+          "comment": "Signature with special case values r=0 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 173,
+          "comment": "Signature with special case values r=0 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 174,
+          "comment": "Signature with special case values r=0 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 175,
+          "comment": "Signature with special case values r=0 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 176,
+          "comment": "Signature with special case values r=1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 177,
+          "comment": "Signature with special case values r=1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 178,
+          "comment": "Signature with special case values r=1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 179,
+          "comment": "Signature with special case values r=1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 180,
+          "comment": "Signature with special case values r=1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 181,
+          "comment": "Signature with special case values r=1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 182,
+          "comment": "Signature with special case values r=1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 183,
+          "comment": "Signature with special case values r=1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 184,
+          "comment": "Signature with special case values r=-1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 185,
+          "comment": "Signature with special case values r=-1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 186,
+          "comment": "Signature with special case values r=-1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 187,
+          "comment": "Signature with special case values r=-1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 188,
+          "comment": "Signature with special case values r=-1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 189,
+          "comment": "Signature with special case values r=-1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 190,
+          "comment": "Signature with special case values r=-1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 191,
+          "comment": "Signature with special case values r=-1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 192,
+          "comment": "Signature with special case values r=n and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 193,
+          "comment": "Signature with special case values r=n and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 194,
+          "comment": "Signature with special case values r=n and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 195,
+          "comment": "Signature with special case values r=n and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 196,
+          "comment": "Signature with special case values r=n and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 197,
+          "comment": "Signature with special case values r=n and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 198,
+          "comment": "Signature with special case values r=n and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 199,
+          "comment": "Signature with special case values r=n and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 200,
+          "comment": "Signature with special case values r=n - 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 201,
+          "comment": "Signature with special case values r=n - 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 202,
+          "comment": "Signature with special case values r=n - 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 203,
+          "comment": "Signature with special case values r=n - 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 204,
+          "comment": "Signature with special case values r=n - 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 205,
+          "comment": "Signature with special case values r=n - 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 206,
+          "comment": "Signature with special case values r=n - 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 207,
+          "comment": "Signature with special case values r=n - 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 208,
+          "comment": "Signature with special case values r=n + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 209,
+          "comment": "Signature with special case values r=n + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 210,
+          "comment": "Signature with special case values r=n + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 211,
+          "comment": "Signature with special case values r=n + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 212,
+          "comment": "Signature with special case values r=n + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 213,
+          "comment": "Signature with special case values r=n + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 214,
+          "comment": "Signature with special case values r=n + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 215,
+          "comment": "Signature with special case values r=n + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 216,
+          "comment": "Signature with special case values r=p and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 217,
+          "comment": "Signature with special case values r=p and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 218,
+          "comment": "Signature with special case values r=p and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 219,
+          "comment": "Signature with special case values r=p and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 220,
+          "comment": "Signature with special case values r=p and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 221,
+          "comment": "Signature with special case values r=p and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 222,
+          "comment": "Signature with special case values r=p and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 223,
+          "comment": "Signature with special case values r=p and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 224,
+          "comment": "Signature with special case values r=p + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 225,
+          "comment": "Signature with special case values r=p + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 226,
+          "comment": "Signature with special case values r=p + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 227,
+          "comment": "Signature with special case values r=p + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 228,
+          "comment": "Signature with special case values r=p + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 229,
+          "comment": "Signature with special case values r=p + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 230,
+          "comment": "Signature with special case values r=p + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 231,
+          "comment": "Signature with special case values r=p + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 232,
+          "comment": "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020100090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 233,
+          "comment": "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 234,
+          "comment": "Signature encoding contains incorrect types: r=0, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 235,
+          "comment": "Signature encoding contains incorrect types: r=0, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 236,
+          "comment": "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 237,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 238,
+          "comment": "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 239,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 240,
+          "comment": "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 241,
+          "comment": "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020101090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 242,
+          "comment": "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 243,
+          "comment": "Signature encoding contains incorrect types: r=1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 244,
+          "comment": "Signature encoding contains incorrect types: r=1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 245,
+          "comment": "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 246,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 247,
+          "comment": "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 248,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201013000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 249,
+          "comment": "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201013003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 250,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 251,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 252,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 253,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 254,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 255,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 256,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 257,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 258,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 259,
+          "comment": "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 260,
+          "comment": "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 261,
+          "comment": "Signature encoding contains incorrect types: r=n, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 262,
+          "comment": "Signature encoding contains incorrect types: r=n, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 263,
+          "comment": "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 264,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 265,
+          "comment": "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 266,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641413000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 267,
+          "comment": "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641413003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 268,
+          "comment": "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 269,
+          "comment": "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 270,
+          "comment": "Signature encoding contains incorrect types: r=p, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 271,
+          "comment": "Signature encoding contains incorrect types: r=p, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 272,
+          "comment": "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 273,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 274,
+          "comment": "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 275,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 276,
+          "comment": "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 277,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a090380fe01090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 278,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 279,
+          "comment": "Signature encoding contains incorrect types: r=True, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 280,
+          "comment": "Signature encoding contains incorrect types: r=False, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 281,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300405000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 282,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30040c000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 283,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c01300c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 284,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300430003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 285,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a30030201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 286,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008090380fe01020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 287,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 288,
+          "comment": "Signature encoding contains incorrect types: r=True, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 289,
+          "comment": "Signature encoding contains incorrect types: r=False, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 290,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050500020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 291,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050c00020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 292,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c0130020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 293,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30053000020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 294,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30083003020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 295,
+          "comment": "Edge case for Shamir multiplication",
+          "flags": [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg": "37363338",
+          "sig": "3046022100dd1b7d09a7bd8218961034a39a87fecf5314f00c4d25eb58a07ac85e85eab516022100f5133b41774a185247720d2aa5d8826b6ec5af4c076936c8eaa52ed6cdf59408",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373239373236343137",
+          "sig": "3046022100904b2bb6e9de8f73243fa7ecc19a5a9fe034acad2b75b97c8cc84a79c5f3577402210081452342987040d43f50c72f2a5246430aa7559bee6c56663fd12029507a915f",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343331343737363137",
+          "sig": "3045022100b08122f027076f924cd1dc877c93659ecf942410772fba58881c9109311bca5302200287a0033df7c069fbfab7faefffddd7121908fdef76c04a1a402d599f04942e",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36363033343338303333",
+          "sig": "3044022048c044b94de8809898184e376a8a0903707679350e37ce290f858c8beef78c6d02206ccd83394e8abf4df2a40afb001ca4284d913d6b9caf6ef225d66bdddf9eb45d",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383239363231343535",
+          "sig": "3044022005535fc39278260eb2b8cfba00226cb3155d75c0cf6b418ac56df63b7c0b1e9b022031aebd43e848874347b38ad64ef172fa315fda09645c8752c0e010152e43418b",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34333131383231373336",
+          "sig": "3044022078957c4f5a000af05fc477cc813cc6dcd9445438215b1c493780b6ccbd39a965022067023127ccde416b92cb3a7560436950ab643bbf08383ec9f4f6862cdb302095",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131373730373734313735",
+          "sig": "3045022100ea1b7fd5ba10eeb70a456c149d494fa3757a209093c4dfcf03730d1cd54829e502203cd204bb84656435e3656fa5e76edc4df3ee79615f7f1adfaf388a7eec4f8172",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353938353135353635",
+          "sig": "3046022100c9611952ab603753d0601e0c97de91a6d2927d38afeb1b2b622ea384968cbbe8022100dc32c42ce627f286f7d14aa4b037588abfc202b916a7bf9051c3d0527c66dca4",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383831313031363138",
+          "sig": "3044022012c960e3fcfee173335123fe15cd7f8c8bc55f6f84a071e440b0e418cc9c0c2c02203f494246c0889b4213150ce77b6f5f2957476d3faf898135d56c145fd3af35ef",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303034373833333332",
+          "sig": "3045022100dc921912a76a225819d4956a7ff0660bcdf695bdf286288858ccd5a26001277102206bc5879138b207c3e4e692d4412c9a3fdff91ac58a669ec830b68b1cd562e556",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39353030323437373837",
+          "sig": "3046022100e31a34cb647ddc65b03f9bd05aa3e5e62a800c6fb56794843b606f1f08890524022100e7f2e4ff291bd309b0617478da0fdba92535376a69dc43061783b3ef928113ad",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323039353030303630",
+          "sig": "3044022047b825bdd67cb5d91f017d52ea77f59b1de1e05be48a469978fc88ca577dba2c022053ee369d5b89bf58b3c76218b7cecf12de68127152917c58ee155ee85dc664f2",
+          "result": "valid"
+        },
+        {
+          "tcId": 307,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38313933373839323237",
+          "sig": "304502210085b2d5faa65cd162e666df35beb535c797e7a2a20836d351ebcff798c343309b0220196a837aabc19fa4522c5fac4c8e63e7cf3a5819c97fcec10e80f33e41f266a2",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33363530363033323938",
+          "sig": "3045022100de538dcaf220334aca9fbc11d1576643662c66585e268bc0eb331608ad9523ed02201b1d32790d46c6925ab909408170839f83e6a03a7632ec8877a0c191fffbee79",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3136333833393533353233",
+          "sig": "3046022100b5d45e7fe1196bf5e076fd76742c1e12eefa7934de826d7395646c94a8013fbc022100f5475abab65d9ef64616fde95b3ca6b75fa864758950015441a4414acdd0c894",
+          "result": "valid"
+        },
+        {
+          "tcId": 310,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303931373638323035",
+          "sig": "3046022100d973f8f20c33772413f214d1b8709cceaad159c9211ccf337e7477da197d49530221008d4c39ee66532e2ceea2f0861ee02781ba0339eefb30bc06218f4a63fd86c11a",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39333634373032383235",
+          "sig": "3046022100c487ab066b8bdac12b5c728586a61e42d0a1bea16fb544d3bd56fede77bb3db9022100d27022a17957dc23bd760d0f00e93f10189c67d32a9ec5489514f140e49272d3",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393236383638373931",
+          "sig": "3045022100f7777648b15af89af40cf9ea0a3c875aa0d9d736eca529af4eb6238f78a562d202203b70d46e1439bc5d941bdae8507625971c1c64dcf4c51bcdb43b1ca3ae0373d4",
+          "result": "valid"
+        },
+        {
+          "tcId": 313,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35313738313334383231",
+          "sig": "304402207bb4646c887062a6c3e680b1491854c4b26a4728e5f2b2c1cc3087c780dab7b3022062900f55b885617f9b3c7ef34c67ecc37bf78e11a04cd6b9052eb80f9756559c",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373335303130373531",
+          "sig": "304502204a96ed67d0950d97a8675c302f6102215ce0ec837ff53fbf06b57b010526b5740221008deb5f7a7c8cbeff01c3443700b8da129088771c8c2bf4ceca2a5fa81138a534",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134333533393131363839",
+          "sig": "3046022100d9c3938a4b91d0660f6ddae8540a7bbeae2b0d717bde1f33e6904280197471930221009b022d6547abf9bef980bf8fd67c366e234eff3aebee58a7ee56d335df807a29",
+          "result": "valid"
+        },
+        {
+          "tcId": 316,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333834353439323034",
+          "sig": "3045022100f855a2d237016b1e0ec307672a793668b611d2b6d4e5acfe2b2088aadd6296a7022013c60acb5e6fa51f03ee8cbe3a220f3ac1ce527daee05e9d7430343030dea7e7",
+          "result": "valid"
+        },
+        {
+          "tcId": 317,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373632313932373839",
+          "sig": "3045022100b8ddb1ed6e80056fb9cea2590b1b63cfd1e8098c27547ec8c6cacd78e6ebfddb02207514ac6644955744946fcb5617f8b067850a3ecf829d821f18435a5e11a4a58b",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383331363534333331",
+          "sig": "3046022100e903b7ead454ff8de871fdf67b6bae4ddc88254c35b333a98ba3a2f6562678a5022100f713e10293aec60e63c2a79b189129e54919a74cda6a204a2727c13bb63a25ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 319,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343336383939303330",
+          "sig": "30450220615208d06b392c418fba55c752fef7b9ab8ed47d98f40776d86ff4bfa3e95464022100f403d5984d446acb203eba58a5468372267f9004f263aaa1eaa208652297db5b",
+          "result": "valid"
+        },
+        {
+          "tcId": 320,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323034303431323232",
+          "sig": "304502200eb65a5bc338cd920a174648dd84ed5443f37417d8d730ceab0dd3fb9a2046f3022100c7a86d7e09f5e142fc6d45a136b4581e081f66a26fe0255f012b812d7cf90189",
+          "result": "valid"
+        },
+        {
+          "tcId": 321,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33333337313139393735",
+          "sig": "30440220226464501f1ccc32f1e1482fff4624f4949343c79a820d4b9df637b493ab5b2302204eb47d0fd14db448cedd611e1dae972bdf27ce0fcfc19d9ec5bda9683081598d",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36363935363230363738",
+          "sig": "3045022100bc0d706b5fdf102805cf83f66ce17a97aebd5e3b6e7d5c008cd51164750af1080220651388d190da29748df343dc61e23c248c753013a5688652ca43d222edd1bfb4",
+          "result": "valid"
+        },
+        {
+          "tcId": 323,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303933303137373437",
+          "sig": "3045022039a1d9927356d6849b7e96cd34a5828bad112687198637e7b84900ed92fad0b70221009b5c753e2e10619e1993b8d8171a7aa4c4813a8721aca1f79bef06c0fa858462",
+          "result": "valid"
+        },
+        {
+          "tcId": 324,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313233343137393136",
+          "sig": "3045022100d57adda8926a6b75a5c994a0b8abc75534e68bd79b02b8eaeb1a7add4c5c423202203b349431e37740c60f92c55dcc8a9f55e70e27b9f73d82e37d728ba7266cddf6",
+          "result": "valid"
+        },
+        {
+          "tcId": 325,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373634333530363837",
+          "sig": "304402207d5b4c29599e97085686534f843d71d25f22b96d89c70b4030abcbe6abd73559022028797ed87120c4bf50e37b0704d2d3b4e0b1b98c27e618eb99568b08123a1be9",
+          "result": "valid"
+        },
+        {
+          "tcId": 326,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131343137323431343431",
+          "sig": "304402200db6c547a1e7bbb715b48b7974104b6d7618f1dfed77019daa29bd59b273c087022057f054587cdd5628772c14dde0a77dc5c1bad06828410c5c63b9c1b35fe04410",
+          "result": "valid"
+        },
+        {
+          "tcId": 327,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323638323436343933",
+          "sig": "30440220094a1e172012d9367852f228f49c382bbdf19a6b354b8511807e585cd46e907f02200e50740da30419a987ccd56746b8737aa74a1292892eef99a34025aebb6dd209",
+          "result": "valid"
+        },
+        {
+          "tcId": 328,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373234373936373737",
+          "sig": "3045022073a5445895e0796686dc28c3e4cd5bc1f85368b3264b455d470a7cbeb7592d910221008a9ffabf9f65921734934d65053a00bfa3c353ac81cc9b6f60271635026cd0e1",
+          "result": "valid"
+        },
+        {
+          "tcId": 329,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393733333935313139",
+          "sig": "304402200630f2c6277e9e0414b7e8da64311850b6f3912193970fd6e2f4df79df720c7c02206ccdaf47a44ee1043b76ef62b3de3aee876c26f4efe492cb3649423e599753d0",
+          "result": "valid"
+        },
+        {
+          "tcId": 330,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353037303032373036",
+          "sig": "304502201e1b75a3495bb5ceb2adb84b80f117672b79c5bc71e953d1a274b11dc4238729022100dcf48d930d89c0d301e97f9083487e63cb39127310b0f5e3c8769e98e5b2605d",
+          "result": "valid"
+        },
+        {
+          "tcId": 331,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33373433353638373832",
+          "sig": "3045022100eb92e1a80ad7f440d8a2e9d88ac765c5cbf724bd367f414c9d91cc1904afe497022074fe0ec7cc0122eea4e63c4d16c89edf6a57823178c3747b01e7aff3df710007",
+          "result": "valid"
+        },
+        {
+          "tcId": 332,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393437363731323438",
+          "sig": "304402207c99e1ae6941f4bcf54ea65491cafca180eee1605a2ed908c476ee67cbdd737302201f94f03ed47cc9674abb294cfe7e7b10ad67101b8cb245a8b5fb883a21a06dd9",
+          "result": "valid"
+        },
+        {
+          "tcId": 333,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373235343434333234",
+          "sig": "3044022029bd14a9dafbe562e0c4c0d4aecb6491bbd37f707133f78fc5cb3313365377b702202ea1d86246d8edad31132f3dbe642cac488690849bdd7438d5c626cf8c973970",
+          "result": "valid"
+        },
+        {
+          "tcId": 334,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35353334303231323139",
+          "sig": "3046022100cf7219dcc18e22bd487b6f59c6494f637c5f0ccb18192e9e60178621220b49fc022100a05d5abbe25a610c8e3615cf7d01c69563ddbfe76d7235fda45f046af03e50ff",
+          "result": "valid"
+        },
+        {
+          "tcId": 335,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3132333031383133373933",
+          "sig": "304402201589de61cd315ba0bf7f0e577f00589d28f72131f4c7af41c6bb31ae8ba271da02202ff82a9a1f52901c4c6f8b8a41c0f6e760f160da266d788da5bdc945084dff8d",
+          "result": "valid"
+        },
+        {
+          "tcId": 336,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39313135333137363130",
+          "sig": "3046022100a8c59942907039886bc374c17ff452b604385c3537b9b6c6113c1b19d72e68a9022100d376bc866cc82d78ca17b461edf16faea44e577659b1fef02cec0f41bd2e747c",
+          "result": "valid"
+        },
+        {
+          "tcId": 337,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383934333937393632",
+          "sig": "304602210099cc652412dcdfc574b6fc2525615e6711caaf7d558cc781a3a11cf371f40f71022100866dd4ab6b58b5d6379f0b431f9a251399defd5516bf6bb5495511e05b24f801",
+          "result": "valid"
+        },
+        {
+          "tcId": 338,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323333353833303333",
+          "sig": "3045022100b47cad5c88161e29620957061e24cdf46f3fff97c266b1635fcf2e9cb4d92879022013549f3b1b639eeb33f40cb338ecd089b9094d9625b76734f3803e9d40a1eb26",
+          "result": "valid"
+        },
+        {
+          "tcId": 339,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323131323639323536",
+          "sig": "3045022100f4f3a043b5bdc56bd471876e2df15ea80ccb189b25486e6ab9007cffe121acfc022078e8e3b3589580dac1ce299a18f5704901104cd21205317608c330adc8d35272",
+          "result": "valid"
+        },
+        {
+          "tcId": 340,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33303035343833383634",
+          "sig": "304502205df45e90f9413908b47f7cbb05d6c43a81eb62375ab961d2b065c6118023c018022100d720a2a23c34ece3acc1a516070bde6bfcad28fd89c482d72b69d8113b1903f6",
+          "result": "valid"
+        },
+        {
+          "tcId": 341,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38333536373632373235",
+          "sig": "30440220780bb93f52d53752a9a877dab0578c7702d1ea889960e1682e84f82740b1be5d022008e366ffe8f72d041426aee57aeffce7822b209c34b28255a5de67190870ce42",
+          "result": "valid"
+        },
+        {
+          "tcId": 342,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38333239353030373630",
+          "sig": "3045022100f743a77c86dce094cc265a87b2e053c8cc773370851dbc7ba1a52c58df24d55402202516e4614dd7ccd36a23cbbb1b58c29f900d4da2113e7b9ac956bf8879907680",
+          "result": "valid"
+        },
+        {
+          "tcId": 343,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393237303834313635",
+          "sig": "304502200b77b2ab21a5c92cb0e3f2f5b8594edcc0dd6c70dbeea9d9d363a3718c64dfb402210091c2d6515ff6f2977fd0a150cb04c600102f0ae07a9061993244783e62f2337a",
+          "result": "valid"
+        },
+        {
+          "tcId": 344,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37333032333538323838",
+          "sig": "3045022041f0a220d11a014dfe43f89ab647abea430cf5a9703088f28c1222abb77e8857022100f811c584c10a25fba6216113698e5a2dc52d8ea340d92ce7a11d356f6d5a1382",
+          "result": "valid"
+        },
+        {
+          "tcId": 345,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3133343733373337333833",
+          "sig": "3045022100ed707e3cac8bd56a4f0a3118558e8402dd477be7dcaa1a7ff448b0bcbfc0fac102203d9933e01d7e9439059973fa499c37b896213b04346bb292f867ff3a58c3d07a",
+          "result": "valid"
+        },
+        {
+          "tcId": 346,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353031353533363839",
+          "sig": "30460221008035d10dfd533e01718fa9d0a1773e55b424770415e570aef766ea2cbe577c27022100815b0f14d6f7f4ca45191428d98c9b414871ffecdac3d0717d285a473e5ddb06",
+          "result": "valid"
+        },
+        {
+          "tcId": 347,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353335303430303239",
+          "sig": "3045022100fbc3576a648ebd633152fc896ae6b4827c55824fb0c96fdd217fb2cfe3bbe63602200b37a95b15589663db322e1f089aa8132965ed6490362d243ef749c6094527f2",
+          "result": "valid"
+        },
+        {
+          "tcId": 348,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343230333537323930",
+          "sig": "3045022100de08cc84004d3fb30521b8e0ade66b6d52734ccd182cace8a34ba0e390fea89302202c1e3deb79d16117ed84c8982276d43709c5963d57bd2b10a530ebf161da1a3d",
+          "result": "valid"
+        },
+        {
+          "tcId": 349,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393035313735303638",
+          "sig": "304502204eef795dc7b17efde95dc52062e3b60ab360d37704800fc915785e7739b834d9022100c68356eacc3509bf4d2b62412b2472f22383d18fa8851527294b1fad194c7bcf",
+          "result": "valid"
+        },
+        {
+          "tcId": 350,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363133373734323935",
+          "sig": "3045022100cb845b9fcfa07e88e9011f0311cae9f3f740516e7d16d9819b7d0f6fc764dac702203d7f3ba5173e130937b02bb7b8da25c506ace6182b8f9ae4ed891f7d216c0378",
+          "result": "valid"
+        },
+        {
+          "tcId": 351,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "383733363733343931",
+          "sig": "304502207d19ff3efc71258f747e74d76f091107b1fa47c87c638720b55178c0655dcbcc022100b8a653e31931dbd2ffc4e957675c68c28719b8118ec3ed3778c57ce3eff1613f",
+          "result": "valid"
+        },
+        {
+          "tcId": 352,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34333535313036343035",
+          "sig": "3045022010d465e03829dad77e8246ad11caf8c6aa8aa918c2bef5a9a9e601c5a919f68f022100f365a7a7540dcb642de90e6d6ccf0c74094a8005deaed4062e394e1cf2bcd8fb",
+          "result": "valid"
+        },
+        {
+          "tcId": 353,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34353339353735383736",
+          "sig": "30450220674330ea5a5d45d71fca1f3ba031494dee9a8623e0d9e9adbb2822794acb4f12022100ae4d3830157c820bc23fa792188b94bb559c3a6212768d7ac59dcf36f74402f6",
+          "result": "valid"
+        },
+        {
+          "tcId": 354,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "383933363633323031",
+          "sig": "3046022100a632c676f667669bda1b0ecf5f33fa67aaaf8aee46bc9e9f2bd5bd10c36cbb95022100a99352cacd6bd42b78a93908008c23eec2d36e5e4fd0aa349d5634fc543199c5",
+          "result": "valid"
+        },
+        {
+          "tcId": 355,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33383036303638303338",
+          "sig": "304502200c9d2e8935f855e69dccd877d95248303e1b6daf8f61da500150185f5565fa97022100e4ce328f00e218aa13d496d85b73b5b891cf0b7c66ebefe5e6b92b1da7f837a9",
+          "result": "valid"
+        },
+        {
+          "tcId": 356,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323332383137343937",
+          "sig": "304402204748c00f44a6b3a8726f604d7b933303d98cd458b850ff2d7cb90c11d5950ac70220766df7aa4c8b3f8b03b0eb8aec653fb70eab7433a84e7ef2d57f368a051b704d",
+          "result": "valid"
+        },
+        {
+          "tcId": 357,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34303734333232353538",
+          "sig": "304402204e4fee37b0b93d7d6dbee89b47dab0c065186ee81caf2227bb26e85149bbf9ef02203eb83850edda9a1b1011118feccd03e47b3e1ec815837bb7f8867288ad8df831",
+          "result": "valid"
+        },
+        {
+          "tcId": 358,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363130363735383237",
+          "sig": "30460221009e8520c5e8296935fe93da2dad55963b9f1f88187f76810fff53c0a6e95b0c07022100d185de4f682a97d28fc3067d56a3d24f743f32d47a6f390068b2ceb71678fadf",
+          "result": "valid"
+        },
+        {
+          "tcId": 359,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3137343138373339323133",
+          "sig": "304402203cacb67364a3fc1a379557f7e6f5d0f501977fd4822666956c9356146b7d922f0220686e27be6217045a5010c88003dd3956a864798c8ae687714fc8b7277f7b520f",
+          "result": "valid"
+        },
+        {
+          "tcId": 360,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35313237383432323837",
+          "sig": "304502205df702c77d4638a4302d21a9fdd70bbe31a4a4a79c7d531d4f4c8283970f664a022100f72d799abce3cd22985c5cfc68f7afc8f96f4e7dce8485ed5c595edc1e1f1d4b",
+          "result": "valid"
+        },
+        {
+          "tcId": 361,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35303338363930383739",
+          "sig": "30450220243a857dfd167b938492c421bd657659d101944736fa79b903cf91ec1c49e8e3022100bab3f04f130d737993ec8f45503376abe816c2b8e5ab3decb0dbca4f5e181d08",
+          "result": "valid"
+        },
+        {
+          "tcId": 362,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33383737303432333937",
+          "sig": "3045022067a7996b7680e958480ac2f97084f2055194b38e0ecf82246dc87918ee1954a8022100de187dfbeefce383dcea1a7fd71362385d09c6d25aacdfa34ea270a91ec97cf5",
+          "result": "valid"
+        },
+        {
+          "tcId": 363,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333231373038313738",
+          "sig": "3045022100ab6cf003aa7865cf8010ea01944fa0d2f825ac6a997a427f8a4e791e797ac6f6022028a7a6c80582ba8f888d2008fbd696799561e92d9a51922cc602aec2135f08aa",
+          "result": "valid"
+        },
+        {
+          "tcId": 364,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37363637303434323730",
+          "sig": "30460221009f9f0be992fdd3e069167599dc55e331c9f189d2c230ae15d1b5b441d3843c74022100f8e5b4ed8ead0352e032f79b5f0475f0975e3738d784d895e9e4002b26762b79",
+          "result": "valid"
+        },
+        {
+          "tcId": 365,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31313034373435303432",
+          "sig": "30440220373b8587777d2b4ff461fddf521abd8fc5d3a1caca847f4a5461dab6ba242d83022051a98da2628724018dff804c26a9671f7df3e24490392a2d1a91fdc7f50deab2",
+          "result": "valid"
+        },
+        {
+          "tcId": 366,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313533383730313534",
+          "sig": "304502210090a6286a271d8ffa72ddb55e8c924793e03b2af73ce10f2deae857961cb07070022028df2b6379501110c12ac167189f9ea8873e1d62ffc76e6ada83f2cf412ea5d3",
+          "result": "valid"
+        },
+        {
+          "tcId": 367,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323631333835303439",
+          "sig": "30450220107434a824ec05568d52219ab3e847046f01493f1db57a82fabe754555838292022100d1c2f7c1ecb5afbc9b0e63e20fcf34cfc16bb260b0748343eb86c44012449b8f",
+          "result": "valid"
+        },
+        {
+          "tcId": 368,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37353538373437363632",
+          "sig": "304502204b737fb724c97348fb67a994e88816b1091951b77234f1904717ec7ef1aa951d022100ff722b669bd4342e6b856232b5a5c03d2cf16f09b3d3842d0a87fc19d910acd4",
+          "result": "valid"
+        },
+        {
+          "tcId": 369,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343939333634313832",
+          "sig": "3046022100abe804f6c76fa3f1470c0f244a7ed96807ddffff4031926cfad9a2c9f73ed773022100e48352653ccc46f5f5a76d7eb3997dfd412001fb1692312788f7c297ef792fa7",
+          "result": "valid"
+        },
+        {
+          "tcId": 370,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333639323733393835",
+          "sig": "304402207d55a5da3201de5343703ff8ee363b7ddbcb3d786afca8f157b25e7c90d09de802203dfcb55acd7def4218abd3f989e901f824cc2d4ed3a37b8794117975103ff004",
+          "result": "valid"
+        },
+        {
+          "tcId": 371,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343933383339353635",
+          "sig": "3044022025d2c88f0b79f2289f92d3ecb6de119fab764fb43ab5286391f9a282c82ac1980220105f44fa27afe4dc9800e6a16528314de01b17737e9741862f93ed0cc33b30f3",
+          "result": "valid"
+        },
+        {
+          "tcId": 372,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353334333739393337",
+          "sig": "3045022100d725c2731a6db8d623027a926a665e9dba0f95e90a5fe6807a84b200111f04ec0220346140bffb84731f0f1cf857193dea25a2f721463dc3b85a8e72c73ff72bda94",
+          "result": "valid"
+        },
+        {
+          "tcId": 373,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "383334383031353938",
+          "sig": "304402204fa9704d3eaa5760da0b97abc0de1f872840e58bfdb1a8f9d8be3f96f950ca7d02206ae15b572c7d1a49c99e1aa54de5fb2bbe055d45686770f579c08ee79924ede9",
+          "result": "valid"
+        },
+        {
+          "tcId": 374,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343131303537343836",
+          "sig": "30450220343353c8be35ca222a38771b19ff3550abe41b91f2ffdea9c9f4887d70b02782022100c285e3761c6645b3db4ff99a7ac40803286f28475ba28b9cd55cacdefb330984",
+          "result": "valid"
+        },
+        {
+          "tcId": 375,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373836343638363335",
+          "sig": "30450220529b121d5b3cccb426189d7343d571adf05cfaee843669da6722f728c192bb8202210086490a7686215fb29b18a166bc22c1b8a982fd7d57ab593318adf8355684b45f",
+          "result": "valid"
+        },
+        {
+          "tcId": 376,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33303534373733373638",
+          "sig": "3045022100ff65707177bb9aa135c5fd774bf72eb3058e80afc7d8bdea8f7fd18040ea995902200d4ed13f9e01bab8aaaa40d7f5c923a78470888375b4690e1164a83fdf136201",
+          "result": "valid"
+        },
+        {
+          "tcId": 377,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393237303137373338",
+          "sig": "30450220471ebfcc45de07bd4118f94b0284f0c5848dd93149a217b56b49e20baf583ced022100ad498b79d6151bf64e003f502fca8fb7b05b2106a96ca1b977ee002c73bc721b",
+          "result": "valid"
+        },
+        {
+          "tcId": 378,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303531333235363334",
+          "sig": "304402201e279add50ce6148dd4a3d311bad896745a169364ef68b94e6360fc48e949b9f02207230fbe4007fb7d6a4274c396081f37a1c9b2559b526db1efe435ead15e4b74e",
+          "result": "valid"
+        },
+        {
+          "tcId": 379,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34303139383636363832",
+          "sig": "3044022052dfbabbcb99651021c025a308530b9cd04732f43463bbc51160cd542d9028df02200ebef4f6870bce1ca302e7120560e5170067c0fb3dc8668448b89dd4821b53fb",
+          "result": "valid"
+        },
+        {
+          "tcId": 380,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130343530323537333530",
+          "sig": "3046022100dabd19aeb87fd56119a3354c468f4429fc14421c54e8be9e9b927941579ae55e022100b10a7396c973e052af2944d37247e9016682d4da7cab2d5428618ce120a21056",
+          "result": "valid"
+        },
+        {
+          "tcId": 381,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333236393538353830",
+          "sig": "304402202b9950c4005dea8e603ffe0fd9b3f66b7c0f07509e50913bb825ef7ddf2e6e77022062c9fcdf79026f60f830e7cae4af814db2cb58b5a948562772da130613bbef94",
+          "result": "valid"
+        },
+        {
+          "tcId": 382,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33303734363533323431",
+          "sig": "3045022009d881e300448b9eac33c67f10c061c2c985c415a414d09c891847e3eec88598022100e75455a508493506f8746074f8bb3698d4362f98a9daa20fa916f6c4023764ae",
+          "result": "valid"
+        },
+        {
+          "tcId": 383,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37373134363833343830",
+          "sig": "304402202db5a6d9b16c61c888a5de064f621e45227ab63efba61ef210fe4ef81c93e00f022004b8e57a7373b3642e58db0cc652d6da541d6d25c7b32c1ed2b408c9e3c39719",
+          "result": "valid"
+        },
+        {
+          "tcId": 384,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373933333831333230",
+          "sig": "304502207bd46dbe132d95aff854bebf1c0dd1e90303328fd84d381e93217723d1a4bc18022100f795a0c68d6c318c038dc37bd22d36bce8083096637e8912c3d01cbabd3feec7",
+          "result": "valid"
+        },
+        {
+          "tcId": 385,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34383830363235353636",
+          "sig": "304502200ca03beb6d348d3d36d2e9f6773e5882ded66fe6026c9c27b847e34523c77c2c0221008770b6f0b6aa7c982e84235f1840a6172386a41ae75fd9affac7916cbd19f8c3",
+          "result": "valid"
+        },
+        {
+          "tcId": 386,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3439343337363438383537",
+          "sig": "304502203f1a74c1dab6bfc319da38cde7a812695b530c60b36d2ae3fa11a7206b2031d5022100f07f8eb5825b2d5642443185d6afd2264e98996dc392519f812883dbe0e247fc",
+          "result": "valid"
+        },
+        {
+          "tcId": 387,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373038363839373836",
+          "sig": "304402201ae1c3ec96f8591a3a235de7c6f739201104381eebeab5fb5ee523f577b6c7fa022007ac1a9348fc8946964fbef0af11dc8b2da6feb3eee8cf475c4926ca9cd571a3",
+          "result": "valid"
+        },
+        {
+          "tcId": 388,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33303239383732393531",
+          "sig": "3046022100c6ef5423c69541caa3bb8f361f4fa9caeca30fb329a0da806ea956270e0a9928022100c045de5205eb8bc861bc159522b41c0d66e62fac0f58730861000cdf9e27bd96",
+          "result": "valid"
+        },
+        {
+          "tcId": 389,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33303137313930333835",
+          "sig": "304402203097d229239b4085e3fb3188106d5da53456752976d2c4ba82dcff6ab96d1909022056f60ab76d33bc94ebae3042a1d56a731429f1bed162bf3ef7269d912aaeea71",
+          "result": "valid"
+        },
+        {
+          "tcId": 390,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393536333633393339",
+          "sig": "304402206c9ecb8dd5b8badd49ea1b26ae3ae2af7236cbe1c626aa6b27029ef1d6d05901022006c9bf356441f84215b006c721a00697cede6941a18fbc0f9c5b3c267eeaa371",
+          "result": "valid"
+        },
+        {
+          "tcId": 391,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35333030373634333530",
+          "sig": "3045022043ae5619f91b711a61be076581f91d382c39fe53d500b136f81be639bea76add022100824594f08185479731ed095367c04def2ff196229c5b136b3835eb8bb819c56d",
+          "result": "valid"
+        },
+        {
+          "tcId": 392,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393334363634383434",
+          "sig": "3045022013e8dc460a0d2af2305a6abfeac834737d4441576b194fe83147b7d7d1247479022100c590a7b7fd6de8c2d658aa2bde97de84505985e2979ab2a527658122cafaf61e",
+          "result": "valid"
+        },
+        {
+          "tcId": 393,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3335353435303535393632",
+          "sig": "3045022027feb06a4c5bb046162467e523b4b62c2c8dabf26ded997eb0737d3eafd16c8a0221009ce87c4cd6b93d1ec3b3c5d29fa415cf918edd24e0febd7b200d6c82c91e5f78",
+          "result": "valid"
+        },
+        {
+          "tcId": 394,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333031373232313038",
+          "sig": "30450221009d76a05d5803a2da17dc2782ec469c8024b1d293a38c23ac4eeb3058595a24a70220226595b192ea8336faa44670fef5e808ff9911ccda85a1765c19ec44671b0505",
+          "result": "valid"
+        },
+        {
+          "tcId": 395,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363137363931363932",
+          "sig": "30440220791088736561f41932cd86f066cca6d63d4473aebb869bcc70c923ef80a7fd95022033402973e7a824602712a5abf7030bad2f183e6b4fa40c66399a14ae48e288e3",
+          "result": "valid"
+        },
+        {
+          "tcId": 396,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353831393332353334",
+          "sig": "3044022052685eef5f2168598c294870188c043dff0496638037170763ef5778b7b6fc1f022079a88d3e7b2c3a44be4b3b3305e4bad5fcfe07d179136f5ac926315ff9d4787a",
+          "result": "valid"
+        },
+        {
+          "tcId": 397,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3135373136363738373434",
+          "sig": "304502205db883b5a3766a2a14ab26a25ec598f7bd1f97585fe0b55341e7da251a62ec1e022100bf63c66e992c91fde513abdbd59b4f9f542881cfdc2be3fbf3e772b97e505b3d",
+          "result": "valid"
+        },
+        {
+          "tcId": 398,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313939373833333630",
+          "sig": "304502207e2f80300a4c81543e324e9c8973bbb6f16599c3d337ee82aed816624843f37002210080a807e920deaebaf3c3247010cb3c91cfce21b0d5ad695177d934ee5a7f7cbe",
+          "result": "valid"
+        },
+        {
+          "tcId": 399,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373430343735303832",
+          "sig": "3046022100de12eb33b717fd887fd684a64af9439a27ee83b28ac5751772249e600856b59e0221008dca367bd7bc83709f25b0fc4e1f4a0e7e747be0b8a2977aabd25750a0ba60c2",
+          "result": "valid"
+        },
+        {
+          "tcId": 400,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343137343336353339",
+          "sig": "3045022100dee112ed7000c0776ba4fab09f439a844addb86c5046223397498ad72d059de402207039b715851e4b386ea15e9bb0899ca21a4e6f4ecbbce4f706d29274806400b6",
+          "result": "valid"
+        },
+        {
+          "tcId": 401,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323335363538383839",
+          "sig": "30450221009d01032d95cac596e7df6c75965c3669f29cb8e58cc9a933bc5d60c1a97e946e02201cf2ce39df73cc734bb4180ef09de883bad7c8d82ab1a5861d265b48aa195bb6",
+          "result": "valid"
+        },
+        {
+          "tcId": 402,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343239323535343034",
+          "sig": "304502206f1513d12e2112ec4f396ef4ea38324102ec3c7fb63ee49f485cb421a07dce57022100a78fbd65b2582a4031c34c7a8c28f03f16ef2ba18e2da41ef173ee5a85af1fe3",
+          "result": "valid"
+        },
+        {
+          "tcId": 403,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3531383033303235343636",
+          "sig": "3046022100c3fb59671cb8c6db48bd51a667060428f75124b5e990af1e997fd636335072d5022100c797e7245cfc8d98bca3ae1f4239b88684cadeda2c628f09ae61053eeb683771",
+          "result": "valid"
+        },
+        {
+          "tcId": 404,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34343736333938323030",
+          "sig": "3046022100e8b5b3f3443d59d7521d093884486e7a6732e275ec13313bd4d178f28128e075022100d299b062928e5f058c705acc3c62f24128ec703c28288b0d294216370cad69b0",
+          "result": "valid"
+        },
+        {
+          "tcId": 405,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39303630303335323132",
+          "sig": "3045022100ce43218d44e113ec38d5cbcf402f3dbfa87d58826a760f0bf2c88f11981f77190220648f3ed0d1b76dec5437cb685dda7a1512ef07f4eb078dc50e418efeb1af8849",
+          "result": "valid"
+        },
+        {
+          "tcId": 406,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373536303533303938",
+          "sig": "3046022100fdc99047865eeffcb69f8b8728a008e31f9f6ba78f698fae62b71cce79501888022100f06612f593873a13459695a5c4cb504acc2a8c56179b68553e60f2319c905b4e",
+          "result": "valid"
+        },
+        {
+          "tcId": 407,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34393830383630303338",
+          "sig": "30450220256e5c4f4cd121e2dee1987be7b241b6e91f90d483210aab9a4b367db5613174022100f75060db4bd6cd52bb8e6aa94f7ab68488a638873515787ec0d7e61bad58ab7f",
+          "result": "valid"
+        },
+        {
+          "tcId": 408,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33363231383735333335",
+          "sig": "3046022100c7a269986b6ad540dd30e620d1606e3267935c7fd5551b3311fd4e840510c2480221008db7c8c464109cf0edb89357e663de6e882b6f5906adde6d58575ce0a2cce257",
+          "result": "valid"
+        },
+        {
+          "tcId": 409,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36363433333334373231",
+          "sig": "304502200bea324758ea80ed4a0a56f7d836fc73bf196e43fbc59d953f0ce34abba57b22022100f04027248e83bd48fb1571291ca1a5f088eb3e89f00904d71b9ea8d6677f7893",
+          "result": "valid"
+        },
+        {
+          "tcId": 410,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34343534393432373832",
+          "sig": "304402205b53c96d7a195f02cfac2d155aa7e132fbc35d59afb080f649dc13056248addf02202b157db2154bd5dc0ef2fc6eecd867fabdc633d2ca683a48f3f9095745351aa6",
+          "result": "valid"
+        },
+        {
+          "tcId": 411,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3230313834343032",
+          "sig": "3044022024174a81d221a4bfd8978f312acec4dacc4f08f8f8cdf29b2024bad2177758df022073fc1bf3388009e3219cf4c7e62e4aeaffc1b9614b2831405a01403c86936452",
+          "result": "valid"
+        },
+        {
+          "tcId": 412,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3538313332313733",
+          "sig": "304502205de7e80ce3137f5705d23397197c86e7749e5e682104f13beb5a6365a63780ea022100f3da2bfd6442638da60201be68fe2ad206365af9e40c4c1531cd3a05db1ad3c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 413,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31313833383631383131",
+          "sig": "3045022100dcdc28f81ff5ed91fa15f15fc4f1d38f9cddfc3df65bb2d3a55582faf7c0910d0220515b7759a130d667eff7ff3167c305cca101be3a07945fd7cb6a1359c16db678",
+          "result": "valid"
+        },
+        {
+          "tcId": 414,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393232363032393036",
+          "sig": "304502207407261c978018cc6e92a340de80edd3044a6e7116eb9fa9b022a2aeb318c65e022100bb5826953e0b85ad69745249f69507765a93f82198bca1e4475fd5de7dfb15ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 415,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393735313433323037",
+          "sig": "304402203962520ea2ef01cba7d5135117a7fcb5ab120b28baf6e31de2e6ec9993d8d5bc02202583659fbdf83399309bddc89ea5f39fe22187671f3149d94f96fa234a6013db",
+          "result": "valid"
+        },
+        {
+          "tcId": 416,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38333135313136333833",
+          "sig": "3046022100bec3ea35844452bb739d92b20882e5b672dc6eff323cd31d1a2db37db93791e80221008ef77b3c709d60b9d5d998f81d3f72c466fd7bb99c681ae8bc9c580db1f7c213",
+          "result": "valid"
+        },
+        {
+          "tcId": 417,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333236333136383132",
+          "sig": "3045022100b8fbdfedee5376cfc9177d96c45e003f90b7367aa40cf37d63e483bfaa4be95102204dcacdfbe41df7899382607489bb75422f3eb67822890ea3bbfd80cd456fc127",
+          "result": "valid"
+        },
+        {
+          "tcId": 418,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34303239363837313336",
+          "sig": "3045022100df228c1a8bb3684b7ffa2e3f777643c369e1bc2299d66a66c8ed27a4ed59b783022047314aaf3629a0de02313df06c0cb363e4e019aafd20ec06be63b7b4c21538ed",
+          "result": "valid"
+        },
+        {
+          "tcId": 419,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36333230383831313931",
+          "sig": "30440220528746b280d8a0e54851cb99894afc01ce24cff7edd60116e3d8dae42adb496102204eb264629e5cf4aba77e05c54774bd0cf20b057142a1ac2103099d664c2c5dee",
+          "result": "valid"
+        },
+        {
+          "tcId": 420,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35323235333930373830",
+          "sig": "3045022044c391f82cf5eeb80f87c347a5bfe461c49fd8779311e237abc05b19f6aed093022100866853619339b716092df4466aa0cc9e6256fb7e18a79854b60ccc534bb6df10",
+          "result": "valid"
+        },
+        {
+          "tcId": 421,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333439333933363934",
+          "sig": "3045022003d127a6f72465bd1c02109f9605202b246763097c756235d8f8a26848eb609c02210083d551427f31b9572b61180cf18bc85c20306c0de2c39d00430b3fc91dc50c6b",
+          "result": "valid"
+        },
+        {
+          "tcId": 422,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130333937393630373631",
+          "sig": "304502205044ef2362c8e6c32fc14584b0751eda8e8e8901d9382354040d2615d9cc07c1022100dd16765911dce7a7ae5f3b64b3ce3a5e12e548784597dc0a379f7bb8f4fca879",
+          "result": "valid"
+        },
+        {
+          "tcId": 423,
+          "comment": "Signature generated without truncating the hash",
+          "flags": [
+            "Untruncatedhash"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100ce645f0f1ccb63844e54bd7603a4280ea065e3c147d26e73cfbe58c6116b0cf1022040ccc23188aa20453d7f95d33868f247b3d77c516b70e4c351b48ca2ebef0027",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040fa36769835d1d215f156d5e82bed2fa76aab134bdb1d3bd40975faf5ac19cc6e67d675a8f0dc4760b3f8fbe0f0853a80b58af8dd2c4a41afbf9cb0c72d016ca",
+        "wx": "0fa36769835d1d215f156d5e82bed2fa76aab134bdb1d3bd40975faf5ac19cc6",
+        "wy": "00e67d675a8f0dc4760b3f8fbe0f0853a80b58af8dd2c4a41afbf9cb0c72d016ca"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040fa36769835d1d215f156d5e82bed2fa76aab134bdb1d3bd40975faf5ac19cc6e67d675a8f0dc4760b3f8fbe0f0853a80b58af8dd2c4a41afbf9cb0c72d016ca",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAED6NnaYNdHSFfFW1egr7S+naqsTS9sdO9\nQJdfr1rBnMbmfWdajw3Edgs/j74PCFOoC1ivjdLEpBr7+csMctAWyg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 424,
+          "comment": "k*G has a large x-coordinate",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30360211014551231950b75fc4402da1722fc9baeb022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        },
+        {
+          "tcId": 425,
+          "comment": "r too large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042f1db0895a8d615779a38ddcbeacad9458f35688b587abeeda1cb5a891e954a5b591478e3b81f5881dd71f93b811130a67ea697f452faccd5c5117fac15f5f93",
+        "wx": "2f1db0895a8d615779a38ddcbeacad9458f35688b587abeeda1cb5a891e954a5",
+        "wy": "00b591478e3b81f5881dd71f93b811130a67ea697f452faccd5c5117fac15f5f93"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042f1db0895a8d615779a38ddcbeacad9458f35688b587abeeda1cb5a891e954a5b591478e3b81f5881dd71f93b811130a67ea697f452faccd5c5117fac15f5f93",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELx2wiVqNYVd5o43cvqytlFjzVoi1h6vu\n2hy1qJHpVKW1kUeOO4H1iB3XH5O4ERMKZ+ppf0UvrM1cURf6wV9fkw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 426,
+          "comment": "r,s are large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04462155174b64dd050601b6d7c2297251815d413e26c9b91d123536e76fd3fb135f0a20f86528dff246ecc71d5d005b2935e4d8e0b076fd6792d4a2b3fd2b7bb9",
+        "wx": "462155174b64dd050601b6d7c2297251815d413e26c9b91d123536e76fd3fb13",
+        "wy": "5f0a20f86528dff246ecc71d5d005b2935e4d8e0b076fd6792d4a2b3fd2b7bb9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004462155174b64dd050601b6d7c2297251815d413e26c9b91d123536e76fd3fb135f0a20f86528dff246ecc71d5d005b2935e4d8e0b076fd6792d4a2b3fd2b7bb9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAERiFVF0tk3QUGAbbXwilyUYFdQT4mybkd\nEjU252/T+xNfCiD4ZSjf8kbsxx1dAFspNeTY4LB2/WeS1KKz/St7uQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 427,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02203e9a7582886089c62fb840cf3b83061cd1cff3ae4341808bb5bdee6191174177",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048e89e0fff2d768c7c139b22b90aa66b24b3b1ced4345c469e439b2c80d6fed084eb9ca1486ff3411db46590f78008d6d6a0a9cf9cf36b2bef833407af5bc883e",
+        "wx": "008e89e0fff2d768c7c139b22b90aa66b24b3b1ced4345c469e439b2c80d6fed08",
+        "wy": "4eb9ca1486ff3411db46590f78008d6d6a0a9cf9cf36b2bef833407af5bc883e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048e89e0fff2d768c7c139b22b90aa66b24b3b1ced4345c469e439b2c80d6fed084eb9ca1486ff3411db46590f78008d6d6a0a9cf9cf36b2bef833407af5bc883e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEjong//LXaMfBObIrkKpmsks7HO1DRcRp\n5DmyyA1v7QhOucoUhv80EdtGWQ94AI1tagqc+c82sr74M0B69byIPg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 428,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022024238e70b431b1a64efdf9032669939d4b77f249503fc6905feb7540dea3e6d2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f4c2d7df7ca616bce49212e47ed112106445f47cf114782626740d37e1c596df1088b19bcaf0d10609a46bbdfd626a83d13e62d405775ae3941755b278a443c0",
+        "wx": "00f4c2d7df7ca616bce49212e47ed112106445f47cf114782626740d37e1c596df",
+        "wy": "1088b19bcaf0d10609a46bbdfd626a83d13e62d405775ae3941755b278a443c0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f4c2d7df7ca616bce49212e47ed112106445f47cf114782626740d37e1c596df1088b19bcaf0d10609a46bbdfd626a83d13e62d405775ae3941755b278a443c0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE9MLX33ymFrzkkhLkftESEGRF9HzxFHgm\nJnQNN+HFlt8QiLGbyvDRBgmka739YmqD0T5i1AV3WuOUF1WyeKRDwA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 429,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0443053fa57436a0b26f0f887b2403ccd9d18f14b7866e1da593835e93cd103a156039d7ccf6c355ac94ed59225aab8a5aa190c89c422f80e71246b998818ecd54",
+        "wx": "43053fa57436a0b26f0f887b2403ccd9d18f14b7866e1da593835e93cd103a15",
+        "wy": "6039d7ccf6c355ac94ed59225aab8a5aa190c89c422f80e71246b998818ecd54"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000443053fa57436a0b26f0f887b2403ccd9d18f14b7866e1da593835e93cd103a156039d7ccf6c355ac94ed59225aab8a5aa190c89c422f80e71246b998818ecd54",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQwU/pXQ2oLJvD4h7JAPM2dGPFLeGbh2l\nk4Nek80QOhVgOdfM9sNVrJTtWSJaq4paoZDInEIvgOcSRrmYgY7NVA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 430,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020102",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049b27e4409c49abe9d8d1b90edc64367daedb43d68a41c501032dba5d73ef10210cd42cc8488eb0588680b94e934ff744f4e6cb079737beb5eeabbe56fd11a7bb",
+        "wx": "009b27e4409c49abe9d8d1b90edc64367daedb43d68a41c501032dba5d73ef1021",
+        "wy": "0cd42cc8488eb0588680b94e934ff744f4e6cb079737beb5eeabbe56fd11a7bb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049b27e4409c49abe9d8d1b90edc64367daedb43d68a41c501032dba5d73ef10210cd42cc8488eb0588680b94e934ff744f4e6cb079737beb5eeabbe56fd11a7bb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEmyfkQJxJq+nY0bkO3GQ2fa7bQ9aKQcUB\nAy26XXPvECEM1CzISI6wWIaAuU6TT/dE9ObLB5c3vrXuq75W/RGnuw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 431,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020103",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ef2c0193d262327fbe06d3a6edeada676b0aeac94f43b5cff5d819e853f637dd7917a8ace976df5ca947daba44607d623d65b7a29a59297723b66cd6fe060345",
+        "wx": "00ef2c0193d262327fbe06d3a6edeada676b0aeac94f43b5cff5d819e853f637dd",
+        "wy": "7917a8ace976df5ca947daba44607d623d65b7a29a59297723b66cd6fe060345"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ef2c0193d262327fbe06d3a6edeada676b0aeac94f43b5cff5d819e853f637dd7917a8ace976df5ca947daba44607d623d65b7a29a59297723b66cd6fe060345",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7ywBk9JiMn++BtOm7eraZ2sK6slPQ7XP\n9dgZ6FP2N915F6is6XbfXKlH2rpEYH1iPWW3oppZKXcjtmzW/gYDRQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 432,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bce72b0e7d13fc61fb298d7e799c31eb7561ca022c00f7cc66848110295055a8526a501171c1007be07d433f9cb4659a26d1cb910aed64e1b2cce73fb3ceee2b",
+        "wx": "00bce72b0e7d13fc61fb298d7e799c31eb7561ca022c00f7cc66848110295055a8",
+        "wy": "526a501171c1007be07d433f9cb4659a26d1cb910aed64e1b2cce73fb3ceee2b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bce72b0e7d13fc61fb298d7e799c31eb7561ca022c00f7cc66848110295055a8526a501171c1007be07d433f9cb4659a26d1cb910aed64e1b2cce73fb3ceee2b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEvOcrDn0T/GH7KY1+eZwx63VhygIsAPfM\nZoSBEClQVahSalARccEAe+B9Qz+ctGWaJtHLkQrtZOGyzOc/s87uKw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 433,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020102",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048afb5d6db0101d97bed729ad568856639c73d39f19353ed60d7c9515c3e33378a0587fb9aca4ffd17787f3ae81cd871218eacf2c32bdd9ed5ee5e4d15cb779f1",
+        "wx": "008afb5d6db0101d97bed729ad568856639c73d39f19353ed60d7c9515c3e33378",
+        "wy": "00a0587fb9aca4ffd17787f3ae81cd871218eacf2c32bdd9ed5ee5e4d15cb779f1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048afb5d6db0101d97bed729ad568856639c73d39f19353ed60d7c9515c3e33378a0587fb9aca4ffd17787f3ae81cd871218eacf2c32bdd9ed5ee5e4d15cb779f1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEivtdbbAQHZe+1ymtVohWY5xz058ZNT7W\nDXyVFcPjM3igWH+5rKT/0XeH866BzYcSGOrPLDK92e1e5eTRXLd58Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 434,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020103",
+          "result": "valid"
+        },
+        {
+          "tcId": 435,
+          "comment": "r is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143020103",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04358a4f5840da0d9344a4f62e090d75870948f57714be0eb331f7fc956e77e9fc84245dcf34ac6ace334c1b6cea82082fe4ccddd2f780b4eb737bc8f4648ef98e",
+        "wx": "358a4f5840da0d9344a4f62e090d75870948f57714be0eb331f7fc956e77e9fc",
+        "wy": "0084245dcf34ac6ace334c1b6cea82082fe4ccddd2f780b4eb737bc8f4648ef98e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004358a4f5840da0d9344a4f62e090d75870948f57714be0eb331f7fc956e77e9fc84245dcf34ac6ace334c1b6cea82082fe4ccddd2f780b4eb737bc8f4648ef98e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAENYpPWEDaDZNEpPYuCQ11hwlI9XcUvg6z\nMff8lW536fyEJF3PNKxqzjNMG2zqgggv5Mzd0veAtOtze8j0ZI75jg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 436,
+          "comment": "s is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020102022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd04917c8",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0406b2c1b72f12846bbcceda68183372d3f05ec591c43569361646f5916a00a7202282d15b70f19db914c6fdd8faf15ab90ced3bd4c3f59a247be41610497594c6",
+        "wx": "06b2c1b72f12846bbcceda68183372d3f05ec591c43569361646f5916a00a720",
+        "wy": "2282d15b70f19db914c6fdd8faf15ab90ced3bd4c3f59a247be41610497594c6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000406b2c1b72f12846bbcceda68183372d3f05ec591c43569361646f5916a00a7202282d15b70f19db914c6fdd8faf15ab90ced3bd4c3f59a247be41610497594c6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEBrLBty8ShGu8ztpoGDNy0/BexZHENWk2\nFkb1kWoApyAigtFbcPGduRTG/dj68Vq5DO071MP1miR75BYQSXWUxg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 437,
+          "comment": "small r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302702020101022100c58b162c58b162c58b162c58b162c58a1b242973853e16db75c8a1a71da4d39d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044e61226e0b1c1e5a40767956c7b530eace83d550038e32bd14c5258c48c939fd57d069215ea210b386820a2d426fc711862bcfb34c7deaaed404d17692892cc4",
+        "wx": "4e61226e0b1c1e5a40767956c7b530eace83d550038e32bd14c5258c48c939fd",
+        "wy": "57d069215ea210b386820a2d426fc711862bcfb34c7deaaed404d17692892cc4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044e61226e0b1c1e5a40767956c7b530eace83d550038e32bd14c5258c48c939fd57d069215ea210b386820a2d426fc711862bcfb34c7deaaed404d17692892cc4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAETmEibgscHlpAdnlWx7Uw6s6D1VADjjK9\nFMUljEjJOf1X0GkhXqIQs4aCCi1Cb8cRhivPs0x96q7UBNF2koksxA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 438,
+          "comment": "smallish r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302c02072d9b4d347952cc022100fcbc5103d0da267477d1791461cf2aa44bf9d43198f79507bd8779d69a13108e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cf259a52f769eecab5071c0b4676bc4cc474474b74675fe8bd1660df5b70ce1b722f774a601a61f2e8e364477b0ccea457b76977ab300139c4ee0e1fbb7fe8f9",
+        "wx": "00cf259a52f769eecab5071c0b4676bc4cc474474b74675fe8bd1660df5b70ce1b",
+        "wy": "722f774a601a61f2e8e364477b0ccea457b76977ab300139c4ee0e1fbb7fe8f9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cf259a52f769eecab5071c0b4676bc4cc474474b74675fe8bd1660df5b70ce1b722f774a601a61f2e8e364477b0ccea457b76977ab300139c4ee0e1fbb7fe8f9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzyWaUvdp7sq1BxwLRna8TMR0R0t0Z1/o\nvRZg31twzhtyL3dKYBph8ujjZEd7DM6kV7dpd6swATnE7g4fu3/o+Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 439,
+          "comment": "100-bit r and small s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3032020d1033e67e37b32b445580bf4efc022100906f906f906f906f906f906f906f906ed8e426f7b1968c35a204236a579723d2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0467ba78328cffa6eb3f7119096adf17e3fca6b2da966c03bc66174c2984a1d5539abdde7989d6f5083187261393a6e162eb508ae62749e41caf55b2be14d9a960",
+        "wx": "67ba78328cffa6eb3f7119096adf17e3fca6b2da966c03bc66174c2984a1d553",
+        "wy": "009abdde7989d6f5083187261393a6e162eb508ae62749e41caf55b2be14d9a960"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000467ba78328cffa6eb3f7119096adf17e3fca6b2da966c03bc66174c2984a1d5539abdde7989d6f5083187261393a6e162eb508ae62749e41caf55b2be14d9a960",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEZ7p4Moz/pus/cRkJat8X4/ymstqWbAO8\nZhdMKYSh1VOavd55idb1CDGHJhOTpuFi61CK5idJ5ByvVbK+FNmpYA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 440,
+          "comment": "small r and 100 bit s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020201010220783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048f8c5fdf711aff7ddc807c4308a132b1099e3e95dabf803ca29283dd41b090558f60c71b4a813e7b4364b0a7260765042d3696a9580548f585be12633ac3b824",
+        "wx": "008f8c5fdf711aff7ddc807c4308a132b1099e3e95dabf803ca29283dd41b09055",
+        "wy": "008f60c71b4a813e7b4364b0a7260765042d3696a9580548f585be12633ac3b824"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048f8c5fdf711aff7ddc807c4308a132b1099e3e95dabf803ca29283dd41b090558f60c71b4a813e7b4364b0a7260765042d3696a9580548f585be12633ac3b824",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEj4xf33Ea/33cgHxDCKEysQmePpXav4A8\nopKD3UGwkFWPYMcbSoE+e0NksKcmB2UELTaWqVgFSPWFvhJjOsO4JA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 441,
+          "comment": "100-bit r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3031020d062522bbd3ecbe7c39e93e7c260220783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fb78c45f16de9b4e098ddc9ef6eb340b055a6a49c438b87bf7969dc24f7967dd2af9ebaba55b6713e06e9df9e42b79ea9364405ebab1199ea230ae38ec83b91a",
+        "wx": "00fb78c45f16de9b4e098ddc9ef6eb340b055a6a49c438b87bf7969dc24f7967dd",
+        "wy": "2af9ebaba55b6713e06e9df9e42b79ea9364405ebab1199ea230ae38ec83b91a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fb78c45f16de9b4e098ddc9ef6eb340b055a6a49c438b87bf7969dc24f7967dd2af9ebaba55b6713e06e9df9e42b79ea9364405ebab1199ea230ae38ec83b91a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+3jEXxbem04Jjdye9us0CwVaaknEOLh7\n95adwk95Z90q+eurpVtnE+BunfnkK3nqk2RAXrqxGZ6iMK447IO5Gg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 442,
+          "comment": "r and s^-1 are close to n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03640c1022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0448d5a8e42195b4e9ccd4dceb80bf1b730777de266b34a3c7e88ef9befe4fac2e261525ba6f1145f51b35936502c421e208d3646ff7b92703afb7663d0c786cb0",
+        "wx": "48d5a8e42195b4e9ccd4dceb80bf1b730777de266b34a3c7e88ef9befe4fac2e",
+        "wy": "261525ba6f1145f51b35936502c421e208d3646ff7b92703afb7663d0c786cb0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000448d5a8e42195b4e9ccd4dceb80bf1b730777de266b34a3c7e88ef9befe4fac2e261525ba6f1145f51b35936502c421e208d3646ff7b92703afb7663d0c786cb0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESNWo5CGVtOnM1NzrgL8bcwd33iZrNKPH\n6I75vv5PrC4mFSW6bxFF9Rs1k2UCxCHiCNNkb/e5JwOvt2Y9DHhssA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 443,
+          "comment": "r and s are 64-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30160209009c44febf31c3594d020900839ed28247c2b06b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04166112b56939449167ae713e3f7dbe4225e82321ee84fbbfea10d4f7b035a7c5b8c96bd3bb190f8bbae83aa4210b315d650b536860e21621dce0d751dfa471a1",
+        "wx": "166112b56939449167ae713e3f7dbe4225e82321ee84fbbfea10d4f7b035a7c5",
+        "wy": "00b8c96bd3bb190f8bbae83aa4210b315d650b536860e21621dce0d751dfa471a1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004166112b56939449167ae713e3f7dbe4225e82321ee84fbbfea10d4f7b035a7c5b8c96bd3bb190f8bbae83aa4210b315d650b536860e21621dce0d751dfa471a1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFmEStWk5RJFnrnE+P32+QiXoIyHuhPu/\n6hDU97A1p8W4yWvTuxkPi7roOqQhCzFdZQtTaGDiFiHc4NdR36RxoQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 444,
+          "comment": "r and s are 100-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "301e020d09df8b682430beef6f5fd7c7cf020d0fd0a62e13778f4222a0d61c8a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cfc9b4068550c2b847fd3f2d993b75161aeda903b156bd5e9a06b9fec14393386a02aad5b6bb8b63b4669c5f8b31ad669ea5461c348f9d2775b537eb43f9175c",
+        "wx": "00cfc9b4068550c2b847fd3f2d993b75161aeda903b156bd5e9a06b9fec1439338",
+        "wy": "6a02aad5b6bb8b63b4669c5f8b31ad669ea5461c348f9d2775b537eb43f9175c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cfc9b4068550c2b847fd3f2d993b75161aeda903b156bd5e9a06b9fec14393386a02aad5b6bb8b63b4669c5f8b31ad669ea5461c348f9d2775b537eb43f9175c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEz8m0BoVQwrhH/T8tmTt1FhrtqQOxVr1e\nmga5/sFDkzhqAqrVtruLY7RmnF+LMa1mnqVGHDSPnSd1tTfrQ/kXXA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 445,
+          "comment": "r and s are 128-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30260211008a598e563a89f526c32ebec8de26367a02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ddf6e65f686360b9487530ae2d6f717f86070fbd5333cbbd8c08576ba976cf5872b1edc23ace294715798912e007d59761b6f63dd29f14a0d65c076bd6aad2cf",
+        "wx": "00ddf6e65f686360b9487530ae2d6f717f86070fbd5333cbbd8c08576ba976cf58",
+        "wy": "72b1edc23ace294715798912e007d59761b6f63dd29f14a0d65c076bd6aad2cf"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ddf6e65f686360b9487530ae2d6f717f86070fbd5333cbbd8c08576ba976cf5872b1edc23ace294715798912e007d59761b6f63dd29f14a0d65c076bd6aad2cf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3fbmX2hjYLlIdTCuLW9xf4YHD71TM8u9\njAhXa6l2z1hyse3COs4pRxV5iRLgB9WXYbb2PdKfFKDWXAdr1qrSzw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 446,
+          "comment": "r and s are 160-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0bdf021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b7b91538786272e70a603cfc80c52f87f057a369149848dbc865a8d2f445ec26bd90ba8844f58db6744b5f31a470e59ebfee1891be36ee65b18ba172e5eaf943",
+        "wx": "00b7b91538786272e70a603cfc80c52f87f057a369149848dbc865a8d2f445ec26",
+        "wy": "00bd90ba8844f58db6744b5f31a470e59ebfee1891be36ee65b18ba172e5eaf943"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b7b91538786272e70a603cfc80c52f87f057a369149848dbc865a8d2f445ec26bd90ba8844f58db6744b5f31a470e59ebfee1891be36ee65b18ba172e5eaf943",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEt7kVOHhicucKYDz8gMUvh/BXo2kUmEjb\nyGWo0vRF7Ca9kLqIRPWNtnRLXzGkcOWev+4Ykb427mWxi6Fy5er5Qw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 447,
+          "comment": "s == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1020101",
+          "result": "valid"
+        },
+        {
+          "tcId": 448,
+          "comment": "s == 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1020100",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ae56d3389670bc30043e0ec892e01842fde6612b32e84fc8b09e013492fd47a9420e10582476634678b200368868730d3b38b4d53a854de259e0431564837e39",
+        "wx": "00ae56d3389670bc30043e0ec892e01842fde6612b32e84fc8b09e013492fd47a9",
+        "wy": "420e10582476634678b200368868730d3b38b4d53a854de259e0431564837e39"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ae56d3389670bc30043e0ec892e01842fde6612b32e84fc8b09e013492fd47a9420e10582476634678b200368868730d3b38b4d53a854de259e0431564837e39",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErlbTOJZwvDAEPg7IkuAYQv3mYSsy6E/I\nsJ4BNJL9R6lCDhBYJHZjRniyADaIaHMNOzi01TqFTeJZ4EMVZIN+OQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 449,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220419d981c515af8cc82545aac0c85e9e308fbb2eab6acd7ed497e0b4145a18fd9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04aaf6fe07d1022e52b605a88f3a7e569571cace4b8c0bb0ab70b4160dc6926c6e20e90e7d0ab15b87d432a293ce039b77f64978f1a7da23c7a1b1129e0ba9a4b4",
+        "wx": "00aaf6fe07d1022e52b605a88f3a7e569571cace4b8c0bb0ab70b4160dc6926c6e",
+        "wy": "20e90e7d0ab15b87d432a293ce039b77f64978f1a7da23c7a1b1129e0ba9a4b4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004aaf6fe07d1022e52b605a88f3a7e569571cace4b8c0bb0ab70b4160dc6926c6e20e90e7d0ab15b87d432a293ce039b77f64978f1a7da23c7a1b1129e0ba9a4b4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEqvb+B9ECLlK2BaiPOn5WlXHKzkuMC7Cr\ncLQWDcaSbG4g6Q59CrFbh9QyopPOA5t39kl48afaI8ehsRKeC6mktA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 450,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102201b21717ad71d23bbac60a9ad0baf75b063c9fdf52a00ebf99d022172910993c9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04810f37f1426b0e59292171e8a493450496733c5114b95b35b185239e58b5b7adff7e4a8fc5ad14a0136075c88ca77659b6bca409e8cf0705b0b8c00d3bef5bfc",
+        "wx": "00810f37f1426b0e59292171e8a493450496733c5114b95b35b185239e58b5b7ad",
+        "wy": "00ff7e4a8fc5ad14a0136075c88ca77659b6bca409e8cf0705b0b8c00d3bef5bfc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004810f37f1426b0e59292171e8a493450496733c5114b95b35b185239e58b5b7adff7e4a8fc5ad14a0136075c88ca77659b6bca409e8cf0705b0b8c00d3bef5bfc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEgQ838UJrDlkpIXHopJNFBJZzPFEUuVs1\nsYUjnli1t63/fkqPxa0UoBNgdciMp3ZZtrykCejPBwWwuMANO+9b/A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 451,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102202f588f66018f3dd14db3e28e77996487e32486b521ed8e5a20f06591951777e9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0493ae05a499eecf676fa6ca2cc4fc0c2bcecabdba28e2a626a10066d3748fa472b543a33c9e7930daed518f5920ef883175a3af764a7eaa57acf988dabf2288b3",
+        "wx": "0093ae05a499eecf676fa6ca2cc4fc0c2bcecabdba28e2a626a10066d3748fa472",
+        "wy": "00b543a33c9e7930daed518f5920ef883175a3af764a7eaa57acf988dabf2288b3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000493ae05a499eecf676fa6ca2cc4fc0c2bcecabdba28e2a626a10066d3748fa472b543a33c9e7930daed518f5920ef883175a3af764a7eaa57acf988dabf2288b3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEk64FpJnuz2dvpsosxPwMK87Kvboo4qYm\noQBm03SPpHK1Q6M8nnkw2u1Rj1kg74gxdaOvdkp+qles+YjavyKIsw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 452,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220091a08870ff4daf9123b30c20e8c4fc8505758dcf4074fcaff2170c9bfcf74f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a4e5a3f71b8de9d50d82cc0020dd73a9d53df41951cf33b97cf655d7d90d95dceadec6f6e1a5bb374b367bc4aa977ea7014c52898754156f8510c990235f184b",
+        "wx": "00a4e5a3f71b8de9d50d82cc0020dd73a9d53df41951cf33b97cf655d7d90d95dc",
+        "wy": "00eadec6f6e1a5bb374b367bc4aa977ea7014c52898754156f8510c990235f184b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a4e5a3f71b8de9d50d82cc0020dd73a9d53df41951cf33b97cf655d7d90d95dceadec6f6e1a5bb374b367bc4aa977ea7014c52898754156f8510c990235f184b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpOWj9xuN6dUNgswAIN1zqdU99BlRzzO5\nfPZV19kNldzq3sb24aW7N0s2e8Sql36nAUxSiYdUFW+FEMmQI18YSw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 453,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102207c370dc0ce8c59a8b273cba44a7c1191fc3186dc03cab96b0567312df0d0b250",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0401645fd8c249d6c1c9a42d49c1bf8ae8c069e415d6c5f01e54dfcc0370e108f92d1e8cef9f160e5272c618e80d6a288f37215f9625e9b65de5090aa10a02d548",
+        "wx": "01645fd8c249d6c1c9a42d49c1bf8ae8c069e415d6c5f01e54dfcc0370e108f9",
+        "wy": "2d1e8cef9f160e5272c618e80d6a288f37215f9625e9b65de5090aa10a02d548"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000401645fd8c249d6c1c9a42d49c1bf8ae8c069e415d6c5f01e54dfcc0370e108f92d1e8cef9f160e5272c618e80d6a288f37215f9625e9b65de5090aa10a02d548",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAWRf2MJJ1sHJpC1Jwb+K6MBp5BXWxfAe\nVN/MA3DhCPktHozvnxYOUnLGGOgNaiiPNyFfliXptl3lCQqhCgLVSA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 454,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022070b59a7d1ee77a2f9e0491c2a7cfcd0ed04df4a35192f6132dcc668c79a6160e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fd1ac8422519c2b37bb07c995e005431740a61fc6b7908e9b029ceac9f4c3a56bf605dc4fd7fa8dc6195ba61ec11278382156ff2394751524e80f3c718553212",
+        "wx": "00fd1ac8422519c2b37bb07c995e005431740a61fc6b7908e9b029ceac9f4c3a56",
+        "wy": "00bf605dc4fd7fa8dc6195ba61ec11278382156ff2394751524e80f3c718553212"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fd1ac8422519c2b37bb07c995e005431740a61fc6b7908e9b029ceac9f4c3a56bf605dc4fd7fa8dc6195ba61ec11278382156ff2394751524e80f3c718553212",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE/RrIQiUZwrN7sHyZXgBUMXQKYfxreQjp\nsCnOrJ9MOla/YF3E/X+o3GGVumHsESeDghVv8jlHUVJOgPPHGFUyEg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 455,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102202736d76e412246e097148e2bf62915614eb7c428913a58eb5e9cd4674a9423de",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044e773d65966770b64d2e0e76b44fe3f75ffe0db6f12c207f382f78afacd52f2bf53bbe2709374374e644a5f35844b82d7a1504134eb82099ea901941566a184a",
+        "wx": "4e773d65966770b64d2e0e76b44fe3f75ffe0db6f12c207f382f78afacd52f2b",
+        "wy": "00f53bbe2709374374e644a5f35844b82d7a1504134eb82099ea901941566a184a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044e773d65966770b64d2e0e76b44fe3f75ffe0db6f12c207f382f78afacd52f2bf53bbe2709374374e644a5f35844b82d7a1504134eb82099ea901941566a184a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAETnc9ZZZncLZNLg52tE/j91/+DbbxLCB/\nOC94r6zVLyv1O74nCTdDdOZEpfNYRLgtehUEE064IJnqkBlBVmoYSg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 456,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102204a1e12831fbe93627b02d6e7f24bccdd6ef4b2d0f46739eaf3b1eaf0ca117770",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044ce8f39f857b80325713262b0816823dea62a5b73aa9d0724e9f750156706147fd7e1688e6b0f6a8ba20a8df5cc8cdf585f2c6cb90e76ca7e10dd54a9f469332",
+        "wx": "4ce8f39f857b80325713262b0816823dea62a5b73aa9d0724e9f750156706147",
+        "wy": "00fd7e1688e6b0f6a8ba20a8df5cc8cdf585f2c6cb90e76ca7e10dd54a9f469332"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044ce8f39f857b80325713262b0816823dea62a5b73aa9d0724e9f750156706147fd7e1688e6b0f6a8ba20a8df5cc8cdf585f2c6cb90e76ca7e10dd54a9f469332",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAETOjzn4V7gDJXEyYrCBaCPepipbc6qdBy\nTp91AVZwYUf9fhaI5rD2qLogqN9cyM31hfLGy5DnbKfhDdVKn0aTMg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 457,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022006c778d4dfff7dee06ed88bc4e0ed34fc553aad67caf796f2a1c6487c1b2e877",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049ad2fdb05c2377d28b1905ad02e2c2a117cd1cdb5bc0db4c1796d27c1ab5b56220ca038df4b0c06f3afc08fa9cf25a2e28ade3da63510ef7405487abbfb96262",
+        "wx": "009ad2fdb05c2377d28b1905ad02e2c2a117cd1cdb5bc0db4c1796d27c1ab5b562",
+        "wy": "20ca038df4b0c06f3afc08fa9cf25a2e28ade3da63510ef7405487abbfb96262"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049ad2fdb05c2377d28b1905ad02e2c2a117cd1cdb5bc0db4c1796d27c1ab5b56220ca038df4b0c06f3afc08fa9cf25a2e28ade3da63510ef7405487abbfb96262",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEmtL9sFwjd9KLGQWtAuLCoRfNHNtbwNtM\nF5bSfBq1tWIgygON9LDAbzr8CPqc8louKK3j2mNRDvdAVIerv7liYg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 458,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102204de459ef9159afa057feb3ec40fef01c45b809f4ab296ea48c206d4249a2b451",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0493db0e5fbfda983ba543821c7bc0a4fd5f98287d18575e8b815bf36f2d18cd3dfdb192a8912b317f95a9f1756aa9e73e12be45e39c764fb23b108197ac3ea8af",
+        "wx": "0093db0e5fbfda983ba543821c7bc0a4fd5f98287d18575e8b815bf36f2d18cd3d",
+        "wy": "00fdb192a8912b317f95a9f1756aa9e73e12be45e39c764fb23b108197ac3ea8af"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000493db0e5fbfda983ba543821c7bc0a4fd5f98287d18575e8b815bf36f2d18cd3dfdb192a8912b317f95a9f1756aa9e73e12be45e39c764fb23b108197ac3ea8af",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEk9sOX7/amDulQ4Ice8Ck/V+YKH0YV16L\ngVvzby0YzT39sZKokSsxf5Wp8XVqqec+Er5F45x2T7I7EIGXrD6orw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 459,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220745d294978007302033502e1acc48b63ae6500be43adbea1b258d6b423dbb416",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049389f01b62417b372ec1f18c61b11cb500af39a9ac94a2c89735deb2b527cc230122435f6058f32b3e5defa25d7fe7c5bc757749da40df426a4fc1e7ef005c17",
+        "wx": "009389f01b62417b372ec1f18c61b11cb500af39a9ac94a2c89735deb2b527cc23",
+        "wy": "0122435f6058f32b3e5defa25d7fe7c5bc757749da40df426a4fc1e7ef005c17"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049389f01b62417b372ec1f18c61b11cb500af39a9ac94a2c89735deb2b527cc230122435f6058f32b3e5defa25d7fe7c5bc757749da40df426a4fc1e7ef005c17",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEk4nwG2JBezcuwfGMYbEctQCvOamslKLI\nlzXesrUnzCMBIkNfYFjzKz5d76Jdf+fFvHV3SdpA30JqT8Hn7wBcFw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 460,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102207b2a785e3896f59b2d69da57648e80ad3c133a750a2847fd2098ccd902042b6c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04339050b9f8039f925f105ca80ef12fbf2480c4a95827395584e59212ec2045338657db3296a8b7629243c149012b5d64f40df5f104c7629f65f51ad25a9dc1d5",
+        "wx": "339050b9f8039f925f105ca80ef12fbf2480c4a95827395584e59212ec204533",
+        "wy": "008657db3296a8b7629243c149012b5d64f40df5f104c7629f65f51ad25a9dc1d5"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004339050b9f8039f925f105ca80ef12fbf2480c4a95827395584e59212ec2045338657db3296a8b7629243c149012b5d64f40df5f104c7629f65f51ad25a9dc1d5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEM5BQufgDn5JfEFyoDvEvvySAxKlYJzlV\nhOWSEuwgRTOGV9sylqi3YpJDwUkBK11k9A318QTHYp9l9RrSWp3B1Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 461,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022071ae94a72ca896875e7aa4a4c3d29afdb4b35b6996273e63c47ac519256c5eb1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0458850b0841339746b06decc9ca47ffda18cb8e5289a97574bb62604ace0dfaf4d0e10766024bb042cb04bd61d282a006b59139a8623c9443652894b2f1255af6",
+        "wx": "58850b0841339746b06decc9ca47ffda18cb8e5289a97574bb62604ace0dfaf4",
+        "wy": "00d0e10766024bb042cb04bd61d282a006b59139a8623c9443652894b2f1255af6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000458850b0841339746b06decc9ca47ffda18cb8e5289a97574bb62604ace0dfaf4d0e10766024bb042cb04bd61d282a006b59139a8623c9443652894b2f1255af6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEWIULCEEzl0awbezJykf/2hjLjlKJqXV0\nu2JgSs4N+vTQ4QdmAkuwQssEvWHSgqAGtZE5qGI8lENlKJSy8SVa9g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 462,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102200fa527fa7343c0bc9ec35a6278bfbff4d83301b154fc4bd14aee7eb93445b5f9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cecffaa16b57999d3fe95627a312a06b0554f2641ff6f781e366283c9fc24a9e5588700c6a4ebea111151d1f5c96265c62d5f905e5b2590c202cfcd3c1848fc3",
+        "wx": "00cecffaa16b57999d3fe95627a312a06b0554f2641ff6f781e366283c9fc24a9e",
+        "wy": "5588700c6a4ebea111151d1f5c96265c62d5f905e5b2590c202cfcd3c1848fc3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cecffaa16b57999d3fe95627a312a06b0554f2641ff6f781e366283c9fc24a9e5588700c6a4ebea111151d1f5c96265c62d5f905e5b2590c202cfcd3c1848fc3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzs/6oWtXmZ0/6VYnoxKgawVU8mQf9veB\n42YoPJ/CSp5ViHAMak6+oREVHR9cliZcYtX5BeWyWQwgLPzTwYSPww==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 463,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102206539c0adadd0525ff42622164ce9314348bd0863b4c80e936b23ca0414264671",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049c0c462658f6493295775ed99348db5895ae8471c819a1ed9ae1b5180397f08ff386d14d6e56758d1dafa50755af4fe079233c139436abf61a9208f8b7f893af",
+        "wx": "009c0c462658f6493295775ed99348db5895ae8471c819a1ed9ae1b5180397f08f",
+        "wy": "00f386d14d6e56758d1dafa50755af4fe079233c139436abf61a9208f8b7f893af"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049c0c462658f6493295775ed99348db5895ae8471c819a1ed9ae1b5180397f08ff386d14d6e56758d1dafa50755af4fe079233c139436abf61a9208f8b7f893af",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEnAxGJlj2STKVd17Zk0jbWJWuhHHIGaHt\nmuG1GAOX8I/zhtFNblZ1jR2vpQdVr0/geSM8E5Q2q/Yakgj4t/iTrw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 464,
+          "comment": "point at infinity during verify",
+          "flags": [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0489e63127c97dd4cb19fb802f22229decd0d852639b3d982b2589817a7e520049e1fd70b15e5e5d3ea4ab748903ca891ab3964ff4d7bf48b17c6007957a5e2021",
+        "wx": "0089e63127c97dd4cb19fb802f22229decd0d852639b3d982b2589817a7e520049",
+        "wy": "00e1fd70b15e5e5d3ea4ab748903ca891ab3964ff4d7bf48b17c6007957a5e2021"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000489e63127c97dd4cb19fb802f22229decd0d852639b3d982b2589817a7e520049e1fd70b15e5e5d3ea4ab748903ca891ab3964ff4d7bf48b17c6007957a5e2021",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEieYxJ8l91MsZ+4AvIiKd7NDYUmObPZgr\nJYmBen5SAEnh/XCxXl5dPqSrdIkDyokas5ZP9Ne/SLF8YAeVel4gIQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 465,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04eb89c838542537c3f530b6e8bc62d1e6284ed4e9b8c6aea96e82970d8abdefff58cae0df61874d30c2afa05c8a703800ac80564397688b19a5149f65054b138f",
+        "wx": "00eb89c838542537c3f530b6e8bc62d1e6284ed4e9b8c6aea96e82970d8abdefff",
+        "wy": "58cae0df61874d30c2afa05c8a703800ac80564397688b19a5149f65054b138f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004eb89c838542537c3f530b6e8bc62d1e6284ed4e9b8c6aea96e82970d8abdefff58cae0df61874d30c2afa05c8a703800ac80564397688b19a5149f65054b138f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE64nIOFQlN8P1MLbovGLR5ihO1Om4xq6p\nboKXDYq97/9YyuDfYYdNMMKvoFyKcDgArIBWQ5doixmlFJ9lBUsTjw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 466,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0472bdb42d379cd807e8dcdd597e5c68c464ecb4211ee885f7210e55ff52e9368834231f3921839c8a3a2cc7ff5964f1f79c77f2c8813e2659684ee1d8bf7125c0",
+        "wx": "72bdb42d379cd807e8dcdd597e5c68c464ecb4211ee885f7210e55ff52e93688",
+        "wy": "34231f3921839c8a3a2cc7ff5964f1f79c77f2c8813e2659684ee1d8bf7125c0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000472bdb42d379cd807e8dcdd597e5c68c464ecb4211ee885f7210e55ff52e9368834231f3921839c8a3a2cc7ff5964f1f79c77f2c8813e2659684ee1d8bf7125c0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEcr20LTec2Afo3N1ZflxoxGTstCEe6IX3\nIQ5V/1LpNog0Ix85IYOcijosx/9ZZPH3nHfyyIE+JlloTuHYv3ElwA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 467,
+          "comment": "u1 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b80220342dae751a63a3ca8189cf342b3b34eaaa2565e2c7e26121c1bfd5435447f1c3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0457cf2c69876d8a9822a6b796492aa889c39fa1371fc730c5a15532ac4aa197b38c936d0041821e1ca81df3f1fd0a495c0c8974a81fb41cec4622cc1bfcccf3d2",
+        "wx": "57cf2c69876d8a9822a6b796492aa889c39fa1371fc730c5a15532ac4aa197b3",
+        "wy": "008c936d0041821e1ca81df3f1fd0a495c0c8974a81fb41cec4622cc1bfcccf3d2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000457cf2c69876d8a9822a6b796492aa889c39fa1371fc730c5a15532ac4aa197b38c936d0041821e1ca81df3f1fd0a495c0c8974a81fb41cec4622cc1bfcccf3d2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEV88saYdtipgipreWSSqoicOfoTcfxzDF\noVUyrEqhl7OMk20AQYIeHKgd8/H9CklcDIl0qB+0HOxGIswb/Mzz0g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 468,
+          "comment": "u1 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022100cbd2518ae59c5c357e7630cbd4c4cb1410897703e7663f19fe1289497bee4f7e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040a7413800a6571b03100d9f327c68a89aaaef2e7ff922b0a0aa95e39a082c4fb37466eb04ed38187bedfd767de7c45416577bca4bd961de3d8890bea3409f697",
+        "wx": "0a7413800a6571b03100d9f327c68a89aaaef2e7ff922b0a0aa95e39a082c4fb",
+        "wy": "37466eb04ed38187bedfd767de7c45416577bca4bd961de3d8890bea3409f697"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040a7413800a6571b03100d9f327c68a89aaaef2e7ff922b0a0aa95e39a082c4fb37466eb04ed38187bedfd767de7c45416577bca4bd961de3d8890bea3409f697",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECnQTgAplcbAxANnzJ8aKiaqu8uf/kisK\nCqleOaCCxPs3Rm6wTtOBh77f12fefEVBZXe8pL2WHePYiQvqNAn2lw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 469,
+          "comment": "u2 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047e27893adb379d40a61668ad660edc256004bbfc12d55889fbd5121eac56a06e9a36f42598db7d643842a72562fe6d86ddc38623830e42a17d444d44a2472b5f",
+        "wx": "7e27893adb379d40a61668ad660edc256004bbfc12d55889fbd5121eac56a06e",
+        "wy": "009a36f42598db7d643842a72562fe6d86ddc38623830e42a17d444d44a2472b5f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047e27893adb379d40a61668ad660edc256004bbfc12d55889fbd5121eac56a06e9a36f42598db7d643842a72562fe6d86ddc38623830e42a17d444d44a2472b5f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEfieJOts3nUCmFmitZg7cJWAEu/wS1ViJ\n+9USHqxWoG6aNvQlmNt9ZDhCpyVi/m2G3cOGI4MOQqF9RE1EokcrXw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 470,
+          "comment": "u2 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9d1c9e899ca306ad27fe1945de0242b89",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043b65f40a248d91a7e6377bfb5989f47d562bdaaf364ea982830f61b71957bda5e42108c5d388f2e173210f867633167eb0f5cbc693aa7bb9223ae8f1aaa26983",
+        "wx": "3b65f40a248d91a7e6377bfb5989f47d562bdaaf364ea982830f61b71957bda5",
+        "wy": "00e42108c5d388f2e173210f867633167eb0f5cbc693aa7bb9223ae8f1aaa26983"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043b65f40a248d91a7e6377bfb5989f47d562bdaaf364ea982830f61b71957bda5e42108c5d388f2e173210f867633167eb0f5cbc693aa7bb9223ae8f1aaa26983",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEO2X0CiSNkafmN3v7WYn0fVYr2q82TqmC\ngw9htxlXvaXkIQjF04jy4XMhD4Z2MxZ+sPXLxpOqe7kiOujxqqJpgw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 471,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100bc0f3a2708cbe1438083451163be66f80a810a900cd135ddc076db7451917c17",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040585249ff4a3acbb996eed6f17a70a7b83a6dfe96e80edc0cd4cc7594e806d59b7576508dbb4eab123e0ed688a9e6625d056c7ad8134776252728dcae375cd84",
+        "wx": "0585249ff4a3acbb996eed6f17a70a7b83a6dfe96e80edc0cd4cc7594e806d59",
+        "wy": "00b7576508dbb4eab123e0ed688a9e6625d056c7ad8134776252728dcae375cd84"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040585249ff4a3acbb996eed6f17a70a7b83a6dfe96e80edc0cd4cc7594e806d59b7576508dbb4eab123e0ed688a9e6625d056c7ad8134776252728dcae375cd84",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEBYUkn/SjrLuZbu1vF6cKe4Om3+lugO3A\nzUzHWU6AbVm3V2UI27TqsSPg7WiKnmYl0FbHrYE0d2JSco3K43XNhA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 472,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022062bf43ba34e73cc3c8922f26d64e3bf882f12dcc06e0b30c8363efa6badcff55",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dd6ba66855e37b7fc91ad160bc4a7c5089f8633ac0e12298a6aba34db680e16b798f5573bd93756e39dd635d9c5f8e876364445a1c9a43f2918beb9137ba3b92",
+        "wx": "00dd6ba66855e37b7fc91ad160bc4a7c5089f8633ac0e12298a6aba34db680e16b",
+        "wy": "798f5573bd93756e39dd635d9c5f8e876364445a1c9a43f2918beb9137ba3b92"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dd6ba66855e37b7fc91ad160bc4a7c5089f8633ac0e12298a6aba34db680e16b798f5573bd93756e39dd635d9c5f8e876364445a1c9a43f2918beb9137ba3b92",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3WumaFXje3/JGtFgvEp8UIn4YzrA4SKY\npqujTbaA4Wt5j1VzvZN1bjndY12cX46HY2REWhyaQ/KRi+uRN7o7kg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 473,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022039422623a4386033ccfa96ad4f8228fb88ac9364ae8b3cd0715ee188c467572c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ce2d8a8432670515b2133689d96e7369decfe994c87e39a28e5636897a360f2aba43f7fa77feba76de9634b6adfde47fb16f70b790bc9a1a5065ef16f6fd2467",
+        "wx": "00ce2d8a8432670515b2133689d96e7369decfe994c87e39a28e5636897a360f2a",
+        "wy": "00ba43f7fa77feba76de9634b6adfde47fb16f70b790bc9a1a5065ef16f6fd2467"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ce2d8a8432670515b2133689d96e7369decfe994c87e39a28e5636897a360f2aba43f7fa77feba76de9634b6adfde47fb16f70b790bc9a1a5065ef16f6fd2467",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzi2KhDJnBRWyEzaJ2W5zad7P6ZTIfjmi\njlY2iXo2Dyq6Q/f6d/66dt6WNLat/eR/sW9wt5C8mhpQZe8W9v0kZw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 474,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02206233bcf8558bae02cbd2518ae59c5c3501ab620efcbd7b40d8dd1f7288ff5dac",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046cefd89c949069c4ef5fefd20512a6fde92e08a2dfc408694a05d2a974bd0284ae4769496c219a59383a7fd6dc1e0690c25506264b0088e0362897e0da59103a",
+        "wx": "6cefd89c949069c4ef5fefd20512a6fde92e08a2dfc408694a05d2a974bd0284",
+        "wy": "00ae4769496c219a59383a7fd6dc1e0690c25506264b0088e0362897e0da59103a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046cefd89c949069c4ef5fefd20512a6fde92e08a2dfc408694a05d2a974bd0284ae4769496c219a59383a7fd6dc1e0690c25506264b0088e0362897e0da59103a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbO/YnJSQacTvX+/SBRKm/ekuCKLfxAhp\nSgXSqXS9AoSuR2lJbCGaWTg6f9bcHgaQwlUGJksAiOA2KJfg2lkQOg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 475,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02203bcf8558bae02cbd2518ae59c5c357e7170b54262d04bee3a9fcee6e38e84e1d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0433a6ee1a121ccab25b00fbecc860be15641a5baa4b4beb35d9a6dad35a1691fa36ba2323e463d684219a1bd15c5eb304878d82d1da113c52c7663cfae3f5751a",
+        "wx": "33a6ee1a121ccab25b00fbecc860be15641a5baa4b4beb35d9a6dad35a1691fa",
+        "wy": "36ba2323e463d684219a1bd15c5eb304878d82d1da113c52c7663cfae3f5751a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000433a6ee1a121ccab25b00fbecc860be15641a5baa4b4beb35d9a6dad35a1691fa36ba2323e463d684219a1bd15c5eb304878d82d1da113c52c7663cfae3f5751a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEM6buGhIcyrJbAPvsyGC+FWQaW6pLS+s1\n2aba01oWkfo2uiMj5GPWhCGaG9FcXrMEh42C0doRPFLHZjz64/V1Gg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 476,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220779f0ab175c0597a4a315cb38b86afce2e16a84c5a097dc753f9dcdc71d09c3a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a2d2e9810bf8f988af6cdf111f2f15062900d2ce06bb72c9c1dd1ca90d69c58c36c24fbc1323359ffc3d7cfdd66451dd3e950ad97cc7f1ddedf30e3aa4425c0f",
+        "wx": "00a2d2e9810bf8f988af6cdf111f2f15062900d2ce06bb72c9c1dd1ca90d69c58c",
+        "wy": "36c24fbc1323359ffc3d7cfdd66451dd3e950ad97cc7f1ddedf30e3aa4425c0f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a2d2e9810bf8f988af6cdf111f2f15062900d2ce06bb72c9c1dd1ca90d69c58c36c24fbc1323359ffc3d7cfdd66451dd3e950ad97cc7f1ddedf30e3aa4425c0f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEotLpgQv4+YivbN8RHy8VBikA0s4Gu3LJ\nwd0cqQ1pxYw2wk+8EyM1n/w9fP3WZFHdPpUK2XzH8d3t8w46pEJcDw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 477,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220558bae02cbd2518ae59c5c357e7630cb680f5a3ee98045977a021c9091920d08",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e93d658ec3a9418daed0ee219d18180d0684fd676ed24f693bcdeb7e358ec44d6914850bd227eeb22bf22a02c3bfd628c769b0f0e50040b50fd3aaa324a1d4ce",
+        "wx": "00e93d658ec3a9418daed0ee219d18180d0684fd676ed24f693bcdeb7e358ec44d",
+        "wy": "6914850bd227eeb22bf22a02c3bfd628c769b0f0e50040b50fd3aaa324a1d4ce"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e93d658ec3a9418daed0ee219d18180d0684fd676ed24f693bcdeb7e358ec44d6914850bd227eeb22bf22a02c3bfd628c769b0f0e50040b50fd3aaa324a1d4ce",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE6T1ljsOpQY2u0O4hnRgYDQaE/Wdu0k9p\nO83rfjWOxE1pFIUL0ifusivyKgLDv9Yox2mw8OUAQLUP06qjJKHUzg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 478,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022019ffa32fd51fb796c6154167347b7773d9058ddb148fdaef8c287fef848f2f7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ebe7e1278636290cb09c7d4554c71c117337d2ed40c77789433c27eaf4d4bc3273025752ca492238b622884c9fe287ce3723ae04ebfaa53505e14b8e86c5dbac",
+        "wx": "00ebe7e1278636290cb09c7d4554c71c117337d2ed40c77789433c27eaf4d4bc32",
+        "wy": "73025752ca492238b622884c9fe287ce3723ae04ebfaa53505e14b8e86c5dbac"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ebe7e1278636290cb09c7d4554c71c117337d2ed40c77789433c27eaf4d4bc3273025752ca492238b622884c9fe287ce3723ae04ebfaa53505e14b8e86c5dbac",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE6+fhJ4Y2KQywnH1FVMccEXM30u1Ax3eJ\nQzwn6vTUvDJzAldSykkiOLYiiEyf4ofONyOuBOv6pTUF4UuOhsXbrA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 479,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02203d180992c1a38ddfd49ecf3d1813b0b195c69b06bbd41cf101fe40dac9c9e6ba",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d1150530bac21e35524ff9e1b7d00731401072d591e696a17bb388b4d7e5ca19bcc66bce3fc176d2da4a2cb954c836bf9b81f1913230ba99ea6e5054073ddf6f",
+        "wx": "00d1150530bac21e35524ff9e1b7d00731401072d591e696a17bb388b4d7e5ca19",
+        "wy": "00bcc66bce3fc176d2da4a2cb954c836bf9b81f1913230ba99ea6e5054073ddf6f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d1150530bac21e35524ff9e1b7d00731401072d591e696a17bb388b4d7e5ca19bcc66bce3fc176d2da4a2cb954c836bf9b81f1913230ba99ea6e5054073ddf6f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0RUFMLrCHjVST/nht9AHMUAQctWR5pah\ne7OItNflyhm8xmvOP8F20tpKLLlUyDa/m4HxkTIwupnqblBUBz3fbw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 480,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100d39813c8e58536460cbfac4b0fa028e60d5d45c13612d79f9964a58cb33be185",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045233a1deddbbdc29c0994fd43ceda3b020b35c465e02d1c12fd29017306be87bc31db5c0e32fbd3f045664acf088014a1116eb3379f24886b3a13f009628df42",
+        "wx": "5233a1deddbbdc29c0994fd43ceda3b020b35c465e02d1c12fd29017306be87b",
+        "wy": "00c31db5c0e32fbd3f045664acf088014a1116eb3379f24886b3a13f009628df42"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045233a1deddbbdc29c0994fd43ceda3b020b35c465e02d1c12fd29017306be87bc31db5c0e32fbd3f045664acf088014a1116eb3379f24886b3a13f009628df42",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUjOh3t273CnAmU/UPO2jsCCzXEZeAtHB\nL9KQFzBr6HvDHbXA4y+9PwRWZKzwiAFKERbrM3nySIazoT8AlijfQg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 481,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100e9fcbcae7e1d744cf6bf4ca0d8573312a131fcb3b90eb26bed6c7f6ba908ab53",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a160ab41fd3fe7d088ee874c8b82d8ae97c8ed99467579d01b97bade23ec46a6ae709a088bcbc72342996efeed0e913f8a5dd8c8878b1caec5c9e057e35d5cfe",
+        "wx": "00a160ab41fd3fe7d088ee874c8b82d8ae97c8ed99467579d01b97bade23ec46a6",
+        "wy": "00ae709a088bcbc72342996efeed0e913f8a5dd8c8878b1caec5c9e057e35d5cfe"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a160ab41fd3fe7d088ee874c8b82d8ae97c8ed99467579d01b97bade23ec46a6ae709a088bcbc72342996efeed0e913f8a5dd8c8878b1caec5c9e057e35d5cfe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEoWCrQf0/59CI7odMi4LYrpfI7ZlGdXnQ\nG5e63iPsRqaucJoIi8vHI0KZbv7tDpE/il3YyIeLHK7FyeBX411c/g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 482,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022021f862ec7b9a0f5e3fbe5d774e20cc835816e92b513bb52effadc18c3f526295",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041d915ecbbf4c25bbc0d2216db6d1a3da8f80058653a24885494aff88fe1599fc8816898d958fa5431bb557d17b6b1b520c3fbdab6bc5984109d1468b6cc141f0",
+        "wx": "1d915ecbbf4c25bbc0d2216db6d1a3da8f80058653a24885494aff88fe1599fc",
+        "wy": "008816898d958fa5431bb557d17b6b1b520c3fbdab6bc5984109d1468b6cc141f0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041d915ecbbf4c25bbc0d2216db6d1a3da8f80058653a24885494aff88fe1599fc8816898d958fa5431bb557d17b6b1b520c3fbdab6bc5984109d1468b6cc141f0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHZFey79MJbvA0iFtttGj2o+ABYZTokiF\nSUr/iP4VmfyIFomNlY+lQxu1V9F7axtSDD+9q2vFmEEJ0UaLbMFB8A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 483,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022043f0c5d8f7341ebc7f7cbaee9c419906b02dd256a2776a5dff5b83187ea4c52a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049598101f8704e2dd0e889ecab9ffe7a5e7536f3ee60d5f05111ce6f5a4ca0405c4c39bbca34c6a687c46a6ddff65e81d0a9a78a8c104f91ea6636a7c8ea6819a",
+        "wx": "009598101f8704e2dd0e889ecab9ffe7a5e7536f3ee60d5f05111ce6f5a4ca0405",
+        "wy": "00c4c39bbca34c6a687c46a6ddff65e81d0a9a78a8c104f91ea6636a7c8ea6819a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049598101f8704e2dd0e889ecab9ffe7a5e7536f3ee60d5f05111ce6f5a4ca0405c4c39bbca34c6a687c46a6ddff65e81d0a9a78a8c104f91ea6636a7c8ea6819a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAElZgQH4cE4t0OiJ7Kuf/npedTbz7mDV8F\nERzm9aTKBAXEw5u8o0xqaHxGpt3/ZegdCpp4qMEE+R6mY2p8jqaBmg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 484,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022065e928c572ce2e1abf3b1865ea62658a0844bb81f3b31f8cff0944a4bdf727bf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0459ee9e0a000baefbe3fb59ea61d7370df77c58dee9d829b6c5e89faae019951bbf61a756c7a30d049bd37010b7b1c25670d4ddb6ceb8f1d7c7d449e393465959",
+        "wx": "59ee9e0a000baefbe3fb59ea61d7370df77c58dee9d829b6c5e89faae019951b",
+        "wy": "00bf61a756c7a30d049bd37010b7b1c25670d4ddb6ceb8f1d7c7d449e393465959"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000459ee9e0a000baefbe3fb59ea61d7370df77c58dee9d829b6c5e89faae019951bbf61a756c7a30d049bd37010b7b1c25670d4ddb6ceb8f1d7c7d449e393465959",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEWe6eCgALrvvj+1nqYdc3Dfd8WN7p2Cm2\nxeifquAZlRu/YadWx6MNBJvTcBC3scJWcNTdts648dfH1Enjk0ZZWQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 485,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02201ca11311d21c3019e67d4b56a7c1147dc45649b257459e6838af70c46233ab96",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d1f1ddd12c710d7c35617a0ed2fc35f4d09888f17034a47fe0a78415858e66a25fcda6abedc3a58ffc55bc5d9f320c60eb6b4c9a22833e13511b2e140ef14057",
+        "wx": "00d1f1ddd12c710d7c35617a0ed2fc35f4d09888f17034a47fe0a78415858e66a2",
+        "wy": "5fcda6abedc3a58ffc55bc5d9f320c60eb6b4c9a22833e13511b2e140ef14057"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d1f1ddd12c710d7c35617a0ed2fc35f4d09888f17034a47fe0a78415858e66a25fcda6abedc3a58ffc55bc5d9f320c60eb6b4c9a22833e13511b2e140ef14057",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0fHd0SxxDXw1YXoO0vw19NCYiPFwNKR/\n4KeEFYWOZqJfzaar7cOlj/xVvF2fMgxg62tMmiKDPhNRGy4UDvFAVw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 486,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100d55555555555555555555555555555547c74934474db157d2a8c3f088aced62a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043c9a5007f19ec624a73ce75fb61ab3e16736d519ee36381497f24bfd3bb691b534b42b0134e17222eff05f3b5477323a3224310b108c4a8fc9b17833128cb822",
+        "wx": "3c9a5007f19ec624a73ce75fb61ab3e16736d519ee36381497f24bfd3bb691b5",
+        "wy": "34b42b0134e17222eff05f3b5477323a3224310b108c4a8fc9b17833128cb822"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043c9a5007f19ec624a73ce75fb61ab3e16736d519ee36381497f24bfd3bb691b534b42b0134e17222eff05f3b5477323a3224310b108c4a8fc9b17833128cb822",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEPJpQB/GexiSnPOdfthqz4Wc21RnuNjgU\nl/JL/Tu2kbU0tCsBNOFyIu/wXztUdzI6MiQxCxCMSo/JsXgzEoy4Ig==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 487,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100c1777c8853938e536213c02464a936000ba1e21c0fc62075d46c624e23b52f31",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f7a2f1027241c8514b2be7097a3eb5b208e8ffd09a700e5d72fc3af6964b3bbf08318a9043d959a8fc8bafa5d403d3490e4e45d9b1e156ff3e2aee38ece66e88",
+        "wx": "00f7a2f1027241c8514b2be7097a3eb5b208e8ffd09a700e5d72fc3af6964b3bbf",
+        "wy": "08318a9043d959a8fc8bafa5d403d3490e4e45d9b1e156ff3e2aee38ece66e88"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f7a2f1027241c8514b2be7097a3eb5b208e8ffd09a700e5d72fc3af6964b3bbf08318a9043d959a8fc8bafa5d403d3490e4e45d9b1e156ff3e2aee38ece66e88",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE96LxAnJByFFLK+cJej61sgjo/9CacA5d\ncvw69pZLO78IMYqQQ9lZqPyLr6XUA9NJDk5F2bHhVv8+Ku447OZuiA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 488,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022030bbb794db588363b40679f6c182a50d3ce9679acdd3ffbe36d7813dacbdc818",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e58d8aba787d54ffcbe530c5ba5955f54e286d31f1a7558dce8924000d7a1b96f5acbdf479b313380325edbbadbc6287e08e98cc86e2ba8339873724437ce813",
+        "wx": "00e58d8aba787d54ffcbe530c5ba5955f54e286d31f1a7558dce8924000d7a1b96",
+        "wy": "00f5acbdf479b313380325edbbadbc6287e08e98cc86e2ba8339873724437ce813"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e58d8aba787d54ffcbe530c5ba5955f54e286d31f1a7558dce8924000d7a1b96f5acbdf479b313380325edbbadbc6287e08e98cc86e2ba8339873724437ce813",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5Y2Kunh9VP/L5TDFullV9U4obTHxp1WN\nzokkAA16G5b1rL30ebMTOAMl7butvGKH4I6YzIbiuoM5hzckQ3zoEw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 489,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202c37fd995622c4fb7fffffffffffffffc7cee745110cb45ab558ed7c90c15a2f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04167df009cec2efd44991a523dc2fd4a13e4de3e76390382d4c1088593f33da65838f62138f2ed73fbc7be316ba5b6a79a4768fd1f4ea07df9eb0eeeef988ab73",
+        "wx": "167df009cec2efd44991a523dc2fd4a13e4de3e76390382d4c1088593f33da65",
+        "wy": "00838f62138f2ed73fbc7be316ba5b6a79a4768fd1f4ea07df9eb0eeeef988ab73"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004167df009cec2efd44991a523dc2fd4a13e4de3e76390382d4c1088593f33da65838f62138f2ed73fbc7be316ba5b6a79a4768fd1f4ea07df9eb0eeeef988ab73",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFn3wCc7C79RJkaUj3C/UoT5N4+djkDgt\nTBCIWT8z2mWDj2ITjy7XP7x74xa6W2p5pHaP0fTqB9+esO7u+Yircw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 490,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02207fd995622c4fb7ffffffffffffffffff5d883ffab5b32652ccdcaa290fccb97d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0401a3a8df8aee278aa306844d60d9c5113e596d66cc92a3566ab0797cd01638250062494573ddc9a21706030fd795708b3fe0d0f224ac01e5957ad0d11d6ee265",
+        "wx": "01a3a8df8aee278aa306844d60d9c5113e596d66cc92a3566ab0797cd0163825",
+        "wy": "62494573ddc9a21706030fd795708b3fe0d0f224ac01e5957ad0d11d6ee265"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000401a3a8df8aee278aa306844d60d9c5113e596d66cc92a3566ab0797cd01638250062494573ddc9a21706030fd795708b3fe0d0f224ac01e5957ad0d11d6ee265",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAaOo34ruJ4qjBoRNYNnFET5ZbWbMkqNW\narB5fNAWOCUAYklFc93JohcGAw/XlXCLP+DQ8iSsAeWVetDRHW7iZQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 491,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100ffb32ac4589f6ffffffffffffffffffebb107ff56b664ca599b954521f9972fa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d6d0f45dbfa12ab4ea5b29a848c71923d1ecb57b148ec1c969b43662a18d00f988c2728d21508a421af6b612a4433c4b7c97f55dc12b24db2cf6cb7fada43f15",
+        "wx": "00d6d0f45dbfa12ab4ea5b29a848c71923d1ecb57b148ec1c969b43662a18d00f9",
+        "wy": "0088c2728d21508a421af6b612a4433c4b7c97f55dc12b24db2cf6cb7fada43f15"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d6d0f45dbfa12ab4ea5b29a848c71923d1ecb57b148ec1c969b43662a18d00f988c2728d21508a421af6b612a4433c4b7c97f55dc12b24db2cf6cb7fada43f15",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE1tD0Xb+hKrTqWymoSMcZI9HstXsUjsHJ\nabQ2YqGNAPmIwnKNIVCKQhr2thKkQzxLfJf1XcErJNss9st/raQ/FQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 492,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02205622c4fb7fffffffffffffffffffffff928a8f1c7ac7bec1808b9f61c01ec327",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0469214198388da2a0d1a0c9464c6eb3731ad44e27287c17cd24bf73c3ada67c2a48dfabbfa5d9127fec9fb7986fb386cb5c7ebe3f609d95e71a70ad7f83334584",
+        "wx": "69214198388da2a0d1a0c9464c6eb3731ad44e27287c17cd24bf73c3ada67c2a",
+        "wy": "48dfabbfa5d9127fec9fb7986fb386cb5c7ebe3f609d95e71a70ad7f83334584"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000469214198388da2a0d1a0c9464c6eb3731ad44e27287c17cd24bf73c3ada67c2a48dfabbfa5d9127fec9fb7986fb386cb5c7ebe3f609d95e71a70ad7f83334584",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEaSFBmDiNoqDRoMlGTG6zcxrUTicofBfN\nJL9zw62mfCpI36u/pdkSf+yft5hvs4bLXH6+P2CdlecacK1/gzNFhA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 493,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022044104104104104104104104104104103b87853fd3b7d3f8e175125b4382f25ed",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0484672e2de042df2668775733c9b0cc716edd7d7534eb859279316ec5186d7733badc81e933abf3d4ce75fae00d1a47b30d69de8754666a294b4c925807dc3ecc",
+        "wx": "0084672e2de042df2668775733c9b0cc716edd7d7534eb859279316ec5186d7733",
+        "wy": "00badc81e933abf3d4ce75fae00d1a47b30d69de8754666a294b4c925807dc3ecc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000484672e2de042df2668775733c9b0cc716edd7d7534eb859279316ec5186d7733badc81e933abf3d4ce75fae00d1a47b30d69de8754666a294b4c925807dc3ecc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEhGcuLeBC3yZod1czybDMcW7dfXU064WS\neTFuxRhtdzO63IHpM6vz1M51+uANGkezDWneh1RmailLTJJYB9w+zA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 494,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202739ce739ce739ce739ce739ce739ce705560298d1f2f08dc419ac273a5b54d9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c9be9c1906a73789a9af1a677f60dd4163c5fa06c7f45c0993a63051aa0c0f303205debee5dc413e4abb3e1f6af550ac64c41b97e425cc2efa2a833c2ee72221",
+        "wx": "00c9be9c1906a73789a9af1a677f60dd4163c5fa06c7f45c0993a63051aa0c0f30",
+        "wy": "3205debee5dc413e4abb3e1f6af550ac64c41b97e425cc2efa2a833c2ee72221"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c9be9c1906a73789a9af1a677f60dd4163c5fa06c7f45c0993a63051aa0c0f303205debee5dc413e4abb3e1f6af550ac64c41b97e425cc2efa2a833c2ee72221",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEyb6cGQanN4mprxpnf2DdQWPF+gbH9FwJ\nk6YwUaoMDzAyBd6+5dxBPkq7Ph9q9VCsZMQbl+QlzC76KoM8LuciIQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 495,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100b777777777777777777777777777777688e6a1fe808a97a348671222ff16b863",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04026794f7b5a84849f41141c68d3248f9c90c4de7edad4fb8f446e3076ffb7962c98e7b67192296efe04379c6a40280b4f113876981b44b73bb676a881f398790",
+        "wx": "026794f7b5a84849f41141c68d3248f9c90c4de7edad4fb8f446e3076ffb7962",
+        "wy": "00c98e7b67192296efe04379c6a40280b4f113876981b44b73bb676a881f398790"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004026794f7b5a84849f41141c68d3248f9c90c4de7edad4fb8f446e3076ffb7962c98e7b67192296efe04379c6a40280b4f113876981b44b73bb676a881f398790",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAmeU97WoSEn0EUHGjTJI+ckMTeftrU+4\n9EbjB2/7eWLJjntnGSKW7+BDecakAoC08ROHaYG0S3O7Z2qIHzmHkA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 496,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02206492492492492492492492492492492406dd3a19b8d5fb875235963c593bd2d3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0418bd65dd46f8c0e326553be55e5e234bb43188ac1fddb37003d12f091aa7a1b9e9c00a03e4d5452ba9a607951d4e4d8a7391a952109d96599266d1e2d9ab2199",
+        "wx": "18bd65dd46f8c0e326553be55e5e234bb43188ac1fddb37003d12f091aa7a1b9",
+        "wy": "00e9c00a03e4d5452ba9a607951d4e4d8a7391a952109d96599266d1e2d9ab2199"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000418bd65dd46f8c0e326553be55e5e234bb43188ac1fddb37003d12f091aa7a1b9e9c00a03e4d5452ba9a607951d4e4d8a7391a952109d96599266d1e2d9ab2199",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGL1l3Ub4wOMmVTvlXl4jS7QxiKwf3bNw\nA9EvCRqnobnpwAoD5NVFK6mmB5UdTk2Kc5GpUhCdllmSZtHi2ashmQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 497,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100955555555555555555555555555555547c74934474db157d2a8c3f088aced62c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b86ae764f2f95eb9331af538fa516fd78435794ebb244c090c6d6b286750f94cf3712f767495a10f2e81350662af3ba09defa2e0e6f27eceea35513032dafb61",
+        "wx": "00b86ae764f2f95eb9331af538fa516fd78435794ebb244c090c6d6b286750f94c",
+        "wy": "00f3712f767495a10f2e81350662af3ba09defa2e0e6f27eceea35513032dafb61"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b86ae764f2f95eb9331af538fa516fd78435794ebb244c090c6d6b286750f94cf3712f767495a10f2e81350662af3ba09defa2e0e6f27eceea35513032dafb61",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuGrnZPL5XrkzGvU4+lFv14Q1eU67JEwJ\nDG1rKGdQ+UzzcS92dJWhDy6BNQZirzugne+i4Obyfs7qNVEwMtr7YQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 498,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3e3a49a23a6d8abe95461f8445676b17",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e045cc5a9414e45e63f1b08648e20e229a9950ab56ec304e1b907989e81af2bf21e52db489853dc470713aaecd6aadc7bfd8504a9c82d0243f6e774600b5ea0a",
+        "wx": "00e045cc5a9414e45e63f1b08648e20e229a9950ab56ec304e1b907989e81af2bf",
+        "wy": "21e52db489853dc470713aaecd6aadc7bfd8504a9c82d0243f6e774600b5ea0a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e045cc5a9414e45e63f1b08648e20e229a9950ab56ec304e1b907989e81af2bf21e52db489853dc470713aaecd6aadc7bfd8504a9c82d0243f6e774600b5ea0a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4EXMWpQU5F5j8bCGSOIOIpqZUKtW7DBO\nG5B5iega8r8h5S20iYU9xHBxOq7Naq3Hv9hQSpyC0CQ/bndGALXqCg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 499,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100bffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0437e377faea8a867f494bb402032c70c12af6fd57feb3866bfc5a5fc1d0a909f008dcbc53fd41b67073a4e71a81f3fe578da4d5add0d698041a9b7f38a9a19bff",
+        "wx": "37e377faea8a867f494bb402032c70c12af6fd57feb3866bfc5a5fc1d0a909f0",
+        "wy": "08dcbc53fd41b67073a4e71a81f3fe578da4d5add0d698041a9b7f38a9a19bff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000437e377faea8a867f494bb402032c70c12af6fd57feb3866bfc5a5fc1d0a909f008dcbc53fd41b67073a4e71a81f3fe578da4d5add0d698041a9b7f38a9a19bff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEN+N3+uqKhn9JS7QCAyxwwSr2/Vf+s4Zr\n/FpfwdCpCfAI3LxT/UG2cHOk5xqB8/5XjaTVrdDWmAQam384qaGb/w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 500,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220185ddbca6dac41b1da033cfb60c152869e74b3cd66e9ffdf1b6bc09ed65ee40c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0409a33110676e4a4f8a977150a7be291e0a269cae9678710b1d87f8068b0fe961043a6f64e86278a656a39e4468b3472597afb2dcd930ccba1b1ea2c988c13450",
+        "wx": "09a33110676e4a4f8a977150a7be291e0a269cae9678710b1d87f8068b0fe961",
+        "wy": "043a6f64e86278a656a39e4468b3472597afb2dcd930ccba1b1ea2c988c13450"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000409a33110676e4a4f8a977150a7be291e0a269cae9678710b1d87f8068b0fe961043a6f64e86278a656a39e4468b3472597afb2dcd930ccba1b1ea2c988c13450",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECaMxEGduSk+Kl3FQp74pHgomnK6WeHEL\nHYf4BosP6WEEOm9k6GJ4plajnkRos0cll6+y3NkwzLobHqLJiME0UA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 501,
+          "comment": "point duplication during verification",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022032b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda022100c55205f423611c7e96615bcc20141945fde24bbce956d49cd43e14ab4cef3659",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0409a33110676e4a4f8a977150a7be291e0a269cae9678710b1d87f8068b0fe961fbc5909b179d8759a95c61bb974cb8da68504d2326cf3345e4e15d35773ec7df",
+        "wx": "09a33110676e4a4f8a977150a7be291e0a269cae9678710b1d87f8068b0fe961",
+        "wy": "00fbc5909b179d8759a95c61bb974cb8da68504d2326cf3345e4e15d35773ec7df"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000409a33110676e4a4f8a977150a7be291e0a269cae9678710b1d87f8068b0fe961fbc5909b179d8759a95c61bb974cb8da68504d2326cf3345e4e15d35773ec7df",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECaMxEGduSk+Kl3FQp74pHgomnK6WeHEL\nHYf4BosP6WH7xZCbF52HWalcYbuXTLjaaFBNIybPM0Xk4V01dz7H3w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 502,
+          "comment": "duplication bug",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022032b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda022100c55205f423611c7e96615bcc20141945fde24bbce956d49cd43e14ab4cef3659",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b7021faebf4081a63094d8ea78ca2004d02a303bbf363470ea4a649b08c1995bde5efba25c9d2f490f181e16795d5c75f83b5c11c81d67ede2ea8df81d970cef",
+        "wx": "00b7021faebf4081a63094d8ea78ca2004d02a303bbf363470ea4a649b08c1995b",
+        "wy": "00de5efba25c9d2f490f181e16795d5c75f83b5c11c81d67ede2ea8df81d970cef"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b7021faebf4081a63094d8ea78ca2004d02a303bbf363470ea4a649b08c1995bde5efba25c9d2f490f181e16795d5c75f83b5c11c81d67ede2ea8df81d970cef",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtwIfrr9AgaYwlNjqeMogBNAqMDu/NjRw\n6kpkmwjBmVveXvuiXJ0vSQ8YHhZ5XVx1+DtcEcgdZ+3i6o34HZcM7w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 503,
+          "comment": "comparison with point at infinity ",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0022033333333333333333333333333333332f222f8faefdb533f265d461c29a47373",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044de024ff2abe7af94fb5e9f53c87d4b4bf1c5447c7c39a9280839f12e52e38d83ce6941fc329978e794abf91a25e83463f8eabcf106d76d4dcd92c0ae05493f3",
+        "wx": "4de024ff2abe7af94fb5e9f53c87d4b4bf1c5447c7c39a9280839f12e52e38d8",
+        "wy": "3ce6941fc329978e794abf91a25e83463f8eabcf106d76d4dcd92c0ae05493f3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044de024ff2abe7af94fb5e9f53c87d4b4bf1c5447c7c39a9280839f12e52e38d83ce6941fc329978e794abf91a25e83463f8eabcf106d76d4dcd92c0ae05493f3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAETeAk/yq+evlPten1PIfUtL8cVEfHw5qS\ngIOfEuUuONg85pQfwymXjnlKv5GiXoNGP46rzxBtdtTc2SwK4FST8w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 504,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04425e137c5fe08e842c3bcc4efbb6c4bca89edda8d6beb130e14899de2f20b74bb1af66ef5baead32e7892160deddcb57f43503104dbc331fa20a8de376e5bd17",
+        "wx": "425e137c5fe08e842c3bcc4efbb6c4bca89edda8d6beb130e14899de2f20b74b",
+        "wy": "00b1af66ef5baead32e7892160deddcb57f43503104dbc331fa20a8de376e5bd17"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004425e137c5fe08e842c3bcc4efbb6c4bca89edda8d6beb130e14899de2f20b74bb1af66ef5baead32e7892160deddcb57f43503104dbc331fa20a8de376e5bd17",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQl4TfF/gjoQsO8xO+7bEvKie3ajWvrEw\n4UiZ3i8gt0uxr2bvW66tMueJIWDe3ctX9DUDEE28Mx+iCo3jduW9Fw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 505,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022100b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046c63d82f22bbeb1bd1c8eba4c680ae17dc2b4d196a0da0e191dc79fefd85e367a883018fb8d160ca01d17234fa0b060a619215ccb9dfea629d6bf92cfd8ed34b",
+        "wx": "6c63d82f22bbeb1bd1c8eba4c680ae17dc2b4d196a0da0e191dc79fefd85e367",
+        "wy": "00a883018fb8d160ca01d17234fa0b060a619215ccb9dfea629d6bf92cfd8ed34b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046c63d82f22bbeb1bd1c8eba4c680ae17dc2b4d196a0da0e191dc79fefd85e367a883018fb8d160ca01d17234fa0b060a619215ccb9dfea629d6bf92cfd8ed34b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbGPYLyK76xvRyOukxoCuF9wrTRlqDaDh\nkdx5/v2F42eogwGPuNFgygHRcjT6CwYKYZIVzLnf6mKda/ks/Y7TSw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 506,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee502210099999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dbf77c566f7483d7407f0095b8b468efdf85b7476e614b8658bcf5e71e6fd588413b50407df0def01b8fcba5621028a6cb0972831c893e3d3c20065b75a8e8e6",
+        "wx": "00dbf77c566f7483d7407f0095b8b468efdf85b7476e614b8658bcf5e71e6fd588",
+        "wy": "413b50407df0def01b8fcba5621028a6cb0972831c893e3d3c20065b75a8e8e6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dbf77c566f7483d7407f0095b8b468efdf85b7476e614b8658bcf5e71e6fd588413b50407df0def01b8fcba5621028a6cb0972831c893e3d3c20065b75a8e8e6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE2/d8Vm90g9dAfwCVuLRo79+Ft0duYUuG\nWLz15x5v1YhBO1BAffDe8BuPy6ViECimywlygxyJPj08IAZbdajo5g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 507,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022066666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a7967bfb54cfbd8d13492b9ac421d967d7c4b0a3b18efb6408a424914789c8ef90969628e6553898c978ba48eb852714f9e220e5e93cada91478ce1af8948fd8",
+        "wx": "00a7967bfb54cfbd8d13492b9ac421d967d7c4b0a3b18efb6408a424914789c8ef",
+        "wy": "0090969628e6553898c978ba48eb852714f9e220e5e93cada91478ce1af8948fd8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a7967bfb54cfbd8d13492b9ac421d967d7c4b0a3b18efb6408a424914789c8ef90969628e6553898c978ba48eb852714f9e220e5e93cada91478ce1af8948fd8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEp5Z7+1TPvY0TSSuaxCHZZ9fEsKOxjvtk\nCKQkkUeJyO+QlpYo5lU4mMl4ukjrhScU+eIg5ek8rakUeM4a+JSP2A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 508,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022049249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04325fd7ab7bc8cd7d859687937a90083f1b46776c2b8fdf4ce2bd9e2e808c68b1bb0d689ca6f542c094c99c71918f5455c7608514149148470494e05aa4ff6110",
+        "wx": "325fd7ab7bc8cd7d859687937a90083f1b46776c2b8fdf4ce2bd9e2e808c68b1",
+        "wy": "00bb0d689ca6f542c094c99c71918f5455c7608514149148470494e05aa4ff6110"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004325fd7ab7bc8cd7d859687937a90083f1b46776c2b8fdf4ce2bd9e2e808c68b1bb0d689ca6f542c094c99c71918f5455c7608514149148470494e05aa4ff6110",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMl/Xq3vIzX2FloeTepAIPxtGd2wrj99M\n4r2eLoCMaLG7DWicpvVCwJTJnHGRj1RVx2CFFBSRSEcElOBapP9hEA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 509,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee502200eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d637dc3c63060a0b21b80d6dc8a97ab6a543c21c18cb5e5c63ad80c3b86050fb1d68bb9b9c36ade49ddd84c7fa3ae5c70f45549592ee03a23a490a891cc70ebb",
+        "wx": "00d637dc3c63060a0b21b80d6dc8a97ab6a543c21c18cb5e5c63ad80c3b86050fb",
+        "wy": "1d68bb9b9c36ade49ddd84c7fa3ae5c70f45549592ee03a23a490a891cc70ebb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d637dc3c63060a0b21b80d6dc8a97ab6a543c21c18cb5e5c63ad80c3b86050fb1d68bb9b9c36ade49ddd84c7fa3ae5c70f45549592ee03a23a490a891cc70ebb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE1jfcPGMGCgshuA1tyKl6tqVDwhwYy15c\nY62Aw7hgUPsdaLubnDat5J3dhMf6OuXHD0VUlZLuA6I6SQqJHMcOuw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 510,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046bc87ce6047a3164be15ad781ef32d12bad8caaef7707ac3e15a53ed75efc90c8eee286e2ac0c8f9f6f0350b8bba94b6c5bfade87ba211adc0cad5f3818091e0",
+        "wx": "6bc87ce6047a3164be15ad781ef32d12bad8caaef7707ac3e15a53ed75efc90c",
+        "wy": "008eee286e2ac0c8f9f6f0350b8bba94b6c5bfade87ba211adc0cad5f3818091e0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046bc87ce6047a3164be15ad781ef32d12bad8caaef7707ac3e15a53ed75efc90c8eee286e2ac0c8f9f6f0350b8bba94b6c5bfade87ba211adc0cad5f3818091e0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEa8h85gR6MWS+Fa14HvMtErrYyq73cHrD\n4VpT7XXvyQyO7ihuKsDI+fbwNQuLupS2xb+t6HuiEa3AytXzgYCR4A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 511,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022100b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dac247040488bec28dc3ec9a81a990701f45c0ba4bb6e22573da400efaa65e2e7de375486e1757b6c7b4269bee423edb84c7f4b333c1557b5ddfba0dd983ccf3",
+        "wx": "00dac247040488bec28dc3ec9a81a990701f45c0ba4bb6e22573da400efaa65e2e",
+        "wy": "7de375486e1757b6c7b4269bee423edb84c7f4b333c1557b5ddfba0dd983ccf3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dac247040488bec28dc3ec9a81a990701f45c0ba4bb6e22573da400efaa65e2e7de375486e1757b6c7b4269bee423edb84c7f4b333c1557b5ddfba0dd983ccf3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE2sJHBASIvsKNw+yagamQcB9FwLpLtuIl\nc9pADvqmXi5943VIbhdXtse0JpvuQj7bhMf0szPBVXtd37oN2YPM8w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 512,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179802210099999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041d4d073190b327ab4e4f5ace8d8c8b68e100fd2565a1a4c4610bca309fe6a9c3e274a19b41e496b0832e9e42f5229fc000706c966d2557f3441d323d8faca129",
+        "wx": "1d4d073190b327ab4e4f5ace8d8c8b68e100fd2565a1a4c4610bca309fe6a9c3",
+        "wy": "00e274a19b41e496b0832e9e42f5229fc000706c966d2557f3441d323d8faca129"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041d4d073190b327ab4e4f5ace8d8c8b68e100fd2565a1a4c4610bca309fe6a9c3e274a19b41e496b0832e9e42f5229fc000706c966d2557f3441d323d8faca129",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHU0HMZCzJ6tOT1rOjYyLaOEA/SVloaTE\nYQvKMJ/mqcPidKGbQeSWsIMunkL1Ip/AAHBslm0lV/NEHTI9j6yhKQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 513,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022066666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04274ba8da21e4ed44e218320daa103f0d4227bb351b67d84ad2628629b82fa8274c90d1dcfe55fe7ee66571ff4526c755cac8c8ed16b01c4db830b7dd9deae749",
+        "wx": "274ba8da21e4ed44e218320daa103f0d4227bb351b67d84ad2628629b82fa827",
+        "wy": "4c90d1dcfe55fe7ee66571ff4526c755cac8c8ed16b01c4db830b7dd9deae749"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004274ba8da21e4ed44e218320daa103f0d4227bb351b67d84ad2628629b82fa8274c90d1dcfe55fe7ee66571ff4526c755cac8c8ed16b01c4db830b7dd9deae749",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJ0uo2iHk7UTiGDINqhA/DUInuzUbZ9hK\n0mKGKbgvqCdMkNHc/lX+fuZlcf9FJsdVysjI7RawHE24MLfdnernSQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 514,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022049249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b45406f951d31975e953ac11c25c238046a7975dd2fbb38d890913c1c8b451cbcae0be688e6e400a9265bd9a59ba1047e164306ef6cd358bc0ff00e9e027e957",
+        "wx": "00b45406f951d31975e953ac11c25c238046a7975dd2fbb38d890913c1c8b451cb",
+        "wy": "00cae0be688e6e400a9265bd9a59ba1047e164306ef6cd358bc0ff00e9e027e957"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b45406f951d31975e953ac11c25c238046a7975dd2fbb38d890913c1c8b451cbcae0be688e6e400a9265bd9a59ba1047e164306ef6cd358bc0ff00e9e027e957",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtFQG+VHTGXXpU6wRwlwjgEanl13S+7ON\niQkTwci0UcvK4L5ojm5ACpJlvZpZuhBH4WQwbvbNNYvA/wDp4CfpVw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 515,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179802200eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 516,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220342dae751a63a3ca8189cf342b3b34eaaa2565e2c7e26121c1bfd5435447f1c302202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 517,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100cbd2518ae59c5c357e7630cbd4c4cb1410897703e7663f19fe1289497bee4f7e02202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "00b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5i3xSWI2Vw7mqJbBAPx7vdXAuhLt1l6q+ZjuC9vBO8ndw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 518,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220342dae751a63a3ca8189cf342b3b34eaaa2565e2c7e26121c1bfd5435447f1c302202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 519,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100cbd2518ae59c5c357e7630cbd4c4cb1410897703e7663f19fe1289497bee4f7e02202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "01060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv8AAAABBgSS1aVnPg8l2NUPt+WMSdhtRtQhaVXgqj1A4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 520,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100c28ad156fe809ed36dc80812ae2f32d84dbbfbb9400123305c332551c4f10d39022100fc5b95b0c7fbc2e7cc4ec1bf01020f8050260ce2ca45c3bf5b64a7b2aeeface9",
+          "result": "valid"
+        },
+        {
+          "tcId": 521,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100a36bfde0f5e23f6e3b3d6cc80ede3d9e4ea1c2cb9337221388f70aa52dec5e53022100c27e1db10d29720a120c2625c7e0756790200b2d9bcceb170a1356e1d5477e3c",
+          "result": "valid"
+        },
+        {
+          "tcId": 522,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100818dee9730f01b3f525daa9cc0d5423b0c4af0414c647b6e0bc88546db9c0d75022061c16a90de1dbb1ab1e3c7917e891632f557f493b4106f225517ef186abc0ff9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "00fffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv/////++fttKlqYwfDaJyrwSBpztieSuSvelqoeVcK7Tg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 523,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3044022053cc0edfc688e3d264ed4755f9cf006418e16e24dc978453a6ef14fbecff617f022024694c00d38c13259973aa6db88adf7cc49b5673e628b3c65e7fe06f2665db86",
+          "result": "valid"
+        },
+        {
+          "tcId": 524,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100cacd14406211ed85d8de1b50e167f59dec688574524c6fc1762c9268214e3bba0220289cf8949f717626c25833a0a159d63d77d022b48e161007464f59f5072df8a7",
+          "result": "valid"
+        },
+        {
+          "tcId": 525,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100c1a4c9d1feef48045813d911f6abb188502e06d26b34194f2deaa356e578a76902204063d3367b2bab52bf9fbc4cd3f670667569ccb1cfb05a7c7c156622ba593d45",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+        "wx": "013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0",
+        "wy": "00f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAAAAAT/SIkjWTZX3PCm0irSGMYUL5QP9\nAPhGi18PcOD27nqkO8LG/SWx2CaSQcvdnbsNrJbcliMfQwcF+DhxfQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 526,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402205af5683467b4cb3d68bd168c5fe229a07b7eb1de2f92b8a9743fb46c3691872a02204cbe35cbe66805729e907462169c13b5c4feb497aab658774bec1ecd7bd8863c",
+          "result": "valid"
+        },
+        {
+          "tcId": 527,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30440220051e5f825a5c29f92a108a3ddcdcbf7ffce37ab32915985978512e89a2a83b0c02206340ac187077a7fb4373537b4595a39299ad0ba351db23bcae9176125c61eded",
+          "result": "valid"
+        },
+        {
+          "tcId": 528,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022034e28decbf74abd30f55155ee2ff96f621066001a853acef916cdb39a7d07b4002210087561a96167016fb7dd6f3c7259f8c563f2144332ebb9a48e93b9512d3bf5392",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+        "wx": "25afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dffffffff",
+        "wy": "00fa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJa/WiayrrtZ8Hylt5ZQG+MVQ9XFGoLTs\nLJeHbf/////6RqduUgMi37xJHsTwzBl0IPxOpYg9j23VPDVLxPZ8NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 529,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100cafded1bc98a4bdfe76e1df9ab75342a7fed16b0c1688a2e744d871b9404be14022100a11fcb57d1212068afed86a37e7291aa02061e75b883e9b9a7af3a52e81f5033",
+          "result": "valid"
+        },
+        {
+          "tcId": 530,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30440220254f9541aebd4fca9ce7136fa8e6ed6367778afedf36201779b0ea6a61a82f3b022038668103eebca5e786e05dfffd8b9f1d87d4a1558b1cdfc0eeb98a606ab654c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 531,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100f998e8322b2a1101bbdf9b8b80bc147e5225632cdb6b1a8c4c4c25c29cd3319d022100ee6b3e7b59621fd62b3253ef646ad7cd4a4d53dd11372038b0b314ced0e2e5a9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+        "wx": "00d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb9",
+        "wy": "3f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0S5sZrZ3NMPITSYBz1013Al+J2N/CspK\nT9t0tqrdO7k/W9/4i9VzbfiY5pkAbtdQ8RzwfFhmzXrXDHEh/////w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 532,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402200c426a3f25f5d0250928ac4e5ea03cf949d34444283ac18a49ec638a2a6ea4c5022009f0df2fe78f8ce301057c734cf3c2505d7219775fb778758461360b168e2c8e",
+          "result": "valid"
+        },
+        {
+          "tcId": 533,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402201309ba742999ad66aef104cc140246bc576bd14acc6bb0be728577e49f4f8ed5022031e29fedcab5999d66b27a4f4ffc950dcc8066fb7cdbad9a6362270c066a500a",
+          "result": "valid"
+        },
+        {
+          "tcId": 534,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100cb565ebfd48044d17d2e241b7cd5fec6089e3d0bee83516b710f68d583ccd1c6022026d6d5a1f12ae063528e7e4b1a6a9c5c760af38f2828db9407c439484f2ae9c1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+        "wx": "6d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000",
+        "wy": "00e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbUp/YNR3Sk8KqLve25U8fup5CUB+MWR1\nVmS8KAAAAADmWdNOTfONnoyeqt+6NmEsdpGVvobHeqw/NueLU4aA+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 535,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100a6c419f478007ce4eb07cd8deb248b8d9d11e16c02364e18391ab934c6f3e91d0220363ab461b8d40c864998a6dfa9c9c77419930b9336f0cd471b74786b09aba27b",
+          "result": "valid"
+        },
+        {
+          "tcId": 536,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100e22ab46f883c6ea58de97f982ffd3ef581749fe5568f8121761566509145b0c8022100fc4a53daf4122aa10b98a4d18c2e4920b37744447f0d843ff9ed1d79d482d73c",
+          "result": "valid"
+        },
+        {
+          "tcId": 537,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100921a16ea241e69c9d4f3bde6ba2cc7e10a27c9dfd8b92076d0a4a6d9f8ae0ab3022039b66ee2afd7db1099fee2cd8c69c9f1ea29047efacc1c6e8ee92e5a2244a40b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-non-minimal-tag",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA3-512",
+      "tests": [
+        {
+          "tcId": 538,
+          "comment": "signature with non-minimal SEQUENCE tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "3f1044022022bb0000e9648a0ee659f9b6a9ab6513dc90ab968ec49d3953f64c82bddc852002204aa0dfd047b0786e118231eff7e86311487ec9d1bc84aaef1f736f4178c288f9",
+          "result": "invalid"
+        },
+        {
+          "tcId": 539,
+          "comment": "signature with non-minimal INTEGER tag on r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "30451f022022bb0000e9648a0ee659f9b6a9ab6513dc90ab968ec49d3953f64c82bddc852002204aa0dfd047b0786e118231eff7e86311487ec9d1bc84aaef1f736f4178c288f9",
+          "result": "invalid"
+        },
+        {
+          "tcId": 540,
+          "comment": "signature with non-minimal INTEGER tag on s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "3045022022bb0000e9648a0ee659f9b6a9ab6513dc90ab968ec49d3953f64c82bddc85201f02204aa0dfd047b0786e118231eff7e86311487ec9d1bc84aaef1f736f4178c288f9",
+          "result": "invalid"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/ecc/_data/ecdsa_secp256k1_sha512_p1363_test.json
+++ b/tests/ecc/_data/ecdsa_secp256k1_sha512_p1363_test.json
@@ -1,0 +1,6204 @@
+{
+  "algorithm": "ECDSA",
+  "schema": "ecdsa_p1363_verify_schema_v1.json",
+  "numberOfTests": 322,
+  "header": [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of IEEE P1363 encoded ECDSA signatures."
+  ],
+  "notes": {
+    "ArithmeticError": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
+      "cves": [
+        "CVE-2017-18146"
+      ]
+    },
+    "EdgeCasePublicKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "ModifiedInteger": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves": [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SignatureSize": {
+      "bugType": "LEGACY",
+      "description": "This test vector contains valid values for r and s. But the values are encoded using a smaller number of bytes. The size of an IEEE P1363 encoded signature should always be twice the number of bytes of the size of the order. Some libraries accept signatures with less bytes. To our knowledge no standard (i.e., IEEE P1363 or RFC 7515) requires any explicit checks of the signature size during signature verification."
+    },
+    "SmallRandS": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "Untruncatedhash": {
+      "bugType": "MISSING_STEP",
+      "description": "If the size of the digest is longer than the size of the underlying order of the multiplicative subgroup then the hash digest must be truncated during signature generation and verification. This test vector contains a signature where this step has been omitted."
+    },
+    "ValidSignature": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx": "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy": "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "signature malleability",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "6cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e934d2f1a567d7e647b178552dec35875a2cc61df3ce8ae2c1357ea8c5ff505561",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "replaced r by r + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "016cb914246e1c92050a03d9b0b4f05dde199ab6bf23cec3a120f56da5843de32a00cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 3,
+          "comment": "replaced r by r + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "01006cb914246e1c92050a03d9b0b4f05c9a0dc8c087bd265f2533819be8ea48e2e90000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 4,
+          "comment": "replaced r by n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "9346ebdb91e36dfaf5fc264f4b0fa21f5bc3030e3ac27cd65eaf4f741c2e9f58cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 5,
+          "comment": "replaced r by r + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "016cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e900cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 6,
+          "comment": "replaced r by r + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "0100000000000000006cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9000000000000000000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 7,
+          "comment": "replaced s by s + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "01cb2d0e5a982819b84e87aad213ca78a348979bd990065db64a261453a11c2d2100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 8,
+          "comment": "replaced s by s + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "0100cb2d0e5a982819b84e87aad213ca775f3cc5a5a2295df93a5cb2429707272ce00000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 9,
+          "comment": "replaced s by s + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "01cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "replaced s by s + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "010000000000000000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0000000000000000000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 11,
+          "comment": "Signature with special case values r=0 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 12,
+          "comment": "Signature with special case values r=0 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "Signature with special case values r=0 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "Signature with special case values r=0 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "Signature with special case values r=0 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "Signature with special case values r=0 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "Signature with special case values r=0 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "Signature with special case values r=1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "Signature with special case values r=1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "Signature with special case values r=1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "Signature with special case values r=1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "Signature with special case values r=1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "Signature with special case values r=1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "Signature with special case values r=1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "Signature with special case values r=n and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "Signature with special case values r=n and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "Signature with special case values r=n and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "Signature with special case values r=n and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "Signature with special case values r=n and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "Signature with special case values r=n and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "Signature with special case values r=n and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "Signature with special case values r=n - 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "Signature with special case values r=n - 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "Signature with special case values r=n - 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "Signature with special case values r=n - 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 36,
+          "comment": "Signature with special case values r=n - 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 37,
+          "comment": "Signature with special case values r=n - 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 38,
+          "comment": "Signature with special case values r=n - 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 39,
+          "comment": "Signature with special case values r=n + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 40,
+          "comment": "Signature with special case values r=n + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 41,
+          "comment": "Signature with special case values r=n + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 42,
+          "comment": "Signature with special case values r=n + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 43,
+          "comment": "Signature with special case values r=n + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 44,
+          "comment": "Signature with special case values r=n + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 45,
+          "comment": "Signature with special case values r=n + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 46,
+          "comment": "Signature with special case values r=p and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 47,
+          "comment": "Signature with special case values r=p and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 48,
+          "comment": "Signature with special case values r=p and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 49,
+          "comment": "Signature with special case values r=p and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 50,
+          "comment": "Signature with special case values r=p and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 51,
+          "comment": "Signature with special case values r=p and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 52,
+          "comment": "Signature with special case values r=p and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 53,
+          "comment": "Signature with special case values r=p + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 54,
+          "comment": "Signature with special case values r=p + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 55,
+          "comment": "Signature with special case values r=p + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 56,
+          "comment": "Signature with special case values r=p + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 57,
+          "comment": "Signature with special case values r=p + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 58,
+          "comment": "Signature with special case values r=p + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 59,
+          "comment": "Signature with special case values r=p + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 60,
+          "comment": "Edge case for Shamir multiplication",
+          "flags": [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg": "313236373939",
+          "sig": "dd1b7d09a7bd8218961034a39a87fecf5314f00c4d25eb58a07ac85e85eab5162c8a79b49cae4ec15d293575a5a1af5b4d6efb74ef5c2c1be34e33cdeb7113cc",
+          "result": "valid"
+        },
+        {
+          "tcId": 61,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393439313934313732",
+          "sig": "d743c5d76e1193a57438f1b43b1b0e33d0d1ab15bd3d57a5cf6aebb370d46ce07df27cb730b33dfe01e34a0067e548a98c56846d9a4cd64a930c96bfd917cf08",
+          "result": "valid"
+        },
+        {
+          "tcId": 62,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35333637363431383737",
+          "sig": "ba30f4ddf3348f26835e9c50f6a2d5023a9a1f5fe2e9cf14b3270015dac283fe1d1616abb204f615fbe99860d89158c3264182d617ac9f1560fa8291b349d579",
+          "result": "valid"
+        },
+        {
+          "tcId": 63,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363731343831303935",
+          "sig": "551d72e63f7b27283c4107f7d851f387b60f3f4713a5d35c21fa332fbeed449480914cc37a3fe13a74db7fcc5226388d95034a50a89a9b2fe9bf42ea29e5714d",
+          "result": "valid"
+        },
+        {
+          "tcId": 64,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131323037313732393039",
+          "sig": "80cead3d165ce05c7cf8469f1c35c5a3a641696c843bef0f022a6c68133dc49eea8409d743a4ad5e136207736c3ad79c8cfc7b57ebd1bd9b8a596670ad12d41c",
+          "result": "valid"
+        },
+        {
+          "tcId": 65,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131323938303334323336",
+          "sig": "bbc0e8b7721065a51bac9c3aad64168998cc0efa23298340d436867cc86ba847ae3baa131a83153cb31de2f758e45139f62fe6cc9ce3941c6b1789dc1010f3e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 66,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39383736303239363833",
+          "sig": "3a5ba93917b954617b40e1d866860d1522b0d310cac2457636e54e2ffdea888e3eac6fe762aee127837c2c65fd9c1f65b404b2c31bb945e75d6166503fb5c8bd",
+          "result": "valid"
+        },
+        {
+          "tcId": 67,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3230323034323936353139",
+          "sig": "647f2b4bef6d1ea7908ac5f3dfd705494c2587456557805fe64a703b2b17503c20e164bbb505c6df56455908008cf9626df320f48aa3fc9d0cc8ad8bcf078cb2",
+          "result": "valid"
+        },
+        {
+          "tcId": 68,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343531363639313830",
+          "sig": "8aa653cfa001798c471eea3199dc975a4dea4f7c1ede47453409e606d05ceb51cab20967a056c0ea7fe9cdf8e1980f55b1597a2dad80c9223a0fab15c314fe6d",
+          "result": "valid"
+        },
+        {
+          "tcId": 69,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303933363835393531",
+          "sig": "842e421f33be241d27f12f875355902a25819f210b3685ad536e23594012d9d04fb894ae0e9c24b6ed280e224ab0811469296a9837d1e95b5d9d661d21a1c255",
+          "result": "valid"
+        },
+        {
+          "tcId": 70,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36323139353630323031",
+          "sig": "0b703fd75bdd8dce4820fe130a0b0af17aad4e4681b0254864d5d6f8931ff573404521acf84e72ff22c2ee05d14a4bc7b70e69adc78caf81350e01379694c3e8",
+          "result": "valid"
+        },
+        {
+          "tcId": 71,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363832343734333033",
+          "sig": "62f0df1650560a5800fa670377a4317a604d6475c490066ce15638f8d1330b63963edf905197096818368a993fbffe32908a57153e6a1612bae6ee9ee8a8a719",
+          "result": "valid"
+        },
+        {
+          "tcId": 72,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33373336353331373836",
+          "sig": "2901ade694d4b9c376b3244018e57bcde7057e8e11dd0f7d07080cdd1a39194bee65a4c2baa70f8e236ceba9eed400d899f75276f94e4b7997b2b01ac008bbbc",
+          "result": "valid"
+        },
+        {
+          "tcId": 73,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373935393033373932",
+          "sig": "aa9c8e5311b232b4ce9db03892f26eb77d655c6ff09a599424abbd4b11e750bec1034c44b02e2fdf05e1ba5eebdf954c5a01794600059e05e5c73d542da3ee38",
+          "result": "valid"
+        },
+        {
+          "tcId": 74,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39333939363131303037",
+          "sig": "2febea016e55059e91e157b988f86048db57c37fd122f5cc60169ff4fcb4863ceb19cbc35b3061e1ac4b59b92d1f732cea3212dcbe943ccad82d32740bc22c33",
+          "result": "valid"
+        },
+        {
+          "tcId": 75,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303837343931313835",
+          "sig": "2be463ff06af2096dd62f0326e1af51c585f18ca8f8aa361dedcf55d543e6b7df56afd59dad42530d94f11c59a6408c54826b7a9ef83f4d020f209d71f9b74c5",
+          "result": "valid"
+        },
+        {
+          "tcId": 76,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323336363738353030",
+          "sig": "f61f64defc45abe284b39161b49585f21edef1e88d06389e5b5aacbb394ce4dca5a27e17df10aedace97eb2c48659f69b58cfe76a1f1ac30fea3043655bde515",
+          "result": "valid"
+        },
+        {
+          "tcId": 77,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343438393937373033",
+          "sig": "052134eae13c1dec5ac5aa46186391786f5b60591cb0dd30bfc61e89486abfe209cdaa279c4f0d3d5ae00e0d74e733a260b8b120a1bda7e5a90194ec442e592d",
+          "result": "valid"
+        },
+        {
+          "tcId": 78,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35373134363332383037",
+          "sig": "24824614686b80f3b738970a27816f58cf103c4a93c2d6b0f5f6de65a65501e3180e5801a593063e75b83cd7ab8e52575a013a1be5cdeeb05b30e3ac9dc4ed82",
+          "result": "valid"
+        },
+        {
+          "tcId": 79,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323236343837343932",
+          "sig": "2ff7a5ab2f1a3323651a0d17c4263672ee4d2c560cda94e7d52ee755138bb045542ce83d8d9d441357e24b618b5695164d4391791cff62eeb01609d1d7cb1c0a",
+          "result": "valid"
+        },
+        {
+          "tcId": 80,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35333533343439343739",
+          "sig": "ae446d1a81766d21dd7fc515d0a956605d0cde26d6086a76f8ffc81a6dfbea464fccef9f75e94abc7eb3f2bdcafdc5d97d61b9d950a06010ab4c54e3da7fd4e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 81,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373837333033383830",
+          "sig": "3957cff4a75fc6039c0b0c2e47eb9b07ff6ec5dc8a3c3316590a7ec9a1d7d9934e578ee6594a00cb80c640cb9589d616dbd1cecda2d15dcc0062f30686d6073b",
+          "result": "valid"
+        },
+        {
+          "tcId": 82,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323332313935383233",
+          "sig": "437c36031737a3140dc30eed281adac8e9074187aad41502a3b9a3bfd4ef252cda13f88f633202b9b9517b93a6c08a7b8e6858734e8894b1a64c6ec08f1d0423",
+          "result": "valid"
+        },
+        {
+          "tcId": 83,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130373339333931393137",
+          "sig": "828c12fd9fe31f91bd8f58aac72ee6485e34ceddf91927cf3a09b63363b9d8e90e889664a8c98619cab572687064edb4f0500f8324a5df0bfb5a431a3cb1ca39",
+          "result": "valid"
+        },
+        {
+          "tcId": 84,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383831303237333135",
+          "sig": "807cb34aa6ea48b175f41f3afdf70a109d2b746ae48e08677cdafc33d916b2da41980e6f7ad19944d278851f98e0a6220ae888964ae81a667a63fec21449334d",
+          "result": "valid"
+        },
+        {
+          "tcId": 85,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36303631363933393037",
+          "sig": "a998f9f0daf02f717f5292142dca447c722d2394dae0c84910433754669716ac826fc37269539cf8a98997f8a0268bfffe888d6c23bc68ad7c759db47f65a925",
+          "result": "valid"
+        },
+        {
+          "tcId": 86,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38383935323237303934",
+          "sig": "f151b614afe5bc9d511d0c34a7eb44283921272e91b3e5d02821cf7a43a92bc5097aa33dc50ebf8fea036cd7e224a4d38aa20773e5a78ddb83a2f3b579b2ef6c",
+          "result": "valid"
+        },
+        {
+          "tcId": 87,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353830323334303934",
+          "sig": "5f21585381f5f42e9f76be3f61f4cfd6476ecc6f06cd4fbcf13e08c27f42614895d5b2deabf19891edd41ac52d9072fadebb2f0145bec9b916f68fd1fbcfb3cf",
+          "result": "valid"
+        },
+        {
+          "tcId": 88,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393635393931353132",
+          "sig": "bdc361e68984482d7b169bc5e6ccf82d2263871be749d67a44f548d32bcaf5f1375614fa4134d5055ac117a6ea948b74269b8063e39259d494a7544afb6291ab",
+          "result": "valid"
+        },
+        {
+          "tcId": 89,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323838373332313938",
+          "sig": "5773b016dffac865ab008abe8a06353d197b4dff32403d7ce98ada4d20ea8a00d60de9c98cf50eff0515b962dffd6aac8a1b72bc9cfaf6bda12b99f63eb976d2",
+          "result": "valid"
+        },
+        {
+          "tcId": 90,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323330383837333139",
+          "sig": "57b747d21fc898472a888b88693a989eabaf143396e4cb2de4af19386fba384f7c99f63904191a4464d0d23ca560d5558895cdcff93af4b00c1c66ca2d974393",
+          "result": "valid"
+        },
+        {
+          "tcId": 91,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313239303536393337",
+          "sig": "854be2bf302a2d6db437eb9e78703673c1c7371399e68caa8625bb13c7aa0fec8fd22607e0169eb2e2e00c4af898fd2a609dc57a9fa94a7f93372098fa675649",
+          "result": "valid"
+        },
+        {
+          "tcId": 92,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373438363536343338",
+          "sig": "ebb3359de3b13a518545a86b7fdd92f4793225b8ca4555a6bd4182922b0452be83faa7dff1aa0eed89a7ddcdaa5d716ba6253c5c21f7122c2755eb78b28884c4",
+          "result": "valid"
+        },
+        {
+          "tcId": 93,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37353833353032363034",
+          "sig": "8bc91cfcfc85ba8aa171b703a330e398df4460d22602e73e327423ebf98bf632ec7569072aa73ff19f183daf433abff142d7d5edceb25b771d853acf0fbd68b6",
+          "result": "valid"
+        },
+        {
+          "tcId": 94,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333237373534323739",
+          "sig": "895b07c0450ed6f4941633a053c978128c46e5225c00eb009c3c6cee5eb2b842c982818b260f1650e03eba8f9db1a2ca79c3f804dbe7d172233260e1a9c10640",
+          "result": "valid"
+        },
+        {
+          "tcId": 95,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373735353038353834",
+          "sig": "d5e152ec304090d764fd7ae61abeeadff2fee8df3dccd8fb44d2af5a8dbee0bc72518dc1ecc993faadffc3426594fe2024c7c84ba101a9274d88009393103ff6",
+          "result": "valid"
+        },
+        {
+          "tcId": 96,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3137393832363438333832",
+          "sig": "1298b131ce97a528e5dae05d92b286e2447b17ec002267b9e8f03784d4074bd1edf223ad9c308aef22e1e0c24a20268f966cc2b9ca4d941945bbca057db92d4c",
+          "result": "valid"
+        },
+        {
+          "tcId": 97,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333936373737333635",
+          "sig": "1e79b3921d23d290a57d08958d3ad8305ec444efe1281c98fda44e8af7648f49f4c7610ad1ba9339178c50e7979b5aa9af07d8143e59d13a2e84f98f37101e3b",
+          "result": "valid"
+        },
+        {
+          "tcId": 98,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35393938313035383031",
+          "sig": "e455f464e0edff9c959f84f081828896149a330361ff2d16d5a2448c9d683684351cfa2f29a1318ebb3a46f0a36df8954043949b8d7cea94eacf99108b4d3fa0",
+          "result": "valid"
+        },
+        {
+          "tcId": 99,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3136363737383237303537",
+          "sig": "a885770c9ffef33f0c11245064936e3dd165ea2633575a6a155368670351f726de31e6a58626a41fd029cf766ef44b8273b88558e2452e893978fbdda1e321d1",
+          "result": "valid"
+        },
+        {
+          "tcId": 100,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323036323134333632",
+          "sig": "4b6b451478ba253ae3c75ca5b18b70ccd3cca408ed245cb2af3369548dd2e507fe479b631a3431b42772925cbfe8e789f9c55fb2fd1d7ab51664cc2fa571ad93",
+          "result": "valid"
+        },
+        {
+          "tcId": 101,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36383432343936303435",
+          "sig": "7ca70376547ad6d18f8e539f09dc269ebaa06854c1adacd58fdc735ed3cf0c16f47654f4c0ac1b0e65b712300e3bb472983b116db5206520eabd886dc706b266",
+          "result": "valid"
+        },
+        {
+          "tcId": 102,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323639383937333231",
+          "sig": "388514d147664fbb37271cb8693e47459c0627d6b1dd52dff1d3947dfc9cabec99d3d40814aa177be99e4819696996bc75073f4518955587cd56b5ad8bbc2c58",
+          "result": "valid"
+        },
+        {
+          "tcId": 103,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333837333234363932",
+          "sig": "44d3ac50d9b65601d79b47d6c5d98394cef155211ff37d4bac15e0d4890809b83ea03829afb0545e088361a8cf952aec17bab7637fddd6db35f039803523c921",
+          "result": "valid"
+        },
+        {
+          "tcId": 104,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313138383837353336",
+          "sig": "a33004a2cd50a4f70447fd382e7fdc9257c4d9be7b16e686c5082a231ee7b010d87b96ed3beea54652607017702cfce5d4e7fcec1fdd28f41681ab80a5c5b63c",
+          "result": "valid"
+        },
+        {
+          "tcId": 105,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393838363036353435",
+          "sig": "668ad18cc22c1d1498cc8e5a11e2bfc4c1e1fcf0a7350a5806c5533ae332f0b1f58b49369771bd20bb08b63d4a9212e2dc71da9257ed3710d9eaef9bee469eb2",
+          "result": "valid"
+        },
+        {
+          "tcId": 106,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343739313135383435",
+          "sig": "f7cdcb0281c70786cc3653820d1756a78395a9eeeab2a4d164e260f64ebfd6a8d966c74499cac97ca8ee67400df01b14793b6d7d07668fc202a9918f3c046e9b",
+          "result": "valid"
+        },
+        {
+          "tcId": 107,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35303736383837333637",
+          "sig": "de0e781d9e3e7f73021458fc1201fc021e5c54f1fe40b1b10db8fcf16ef7e54a7d9db92321b5e5bb105990145390979390d32394116f4e78af34b85105dee8e9",
+          "result": "valid"
+        },
+        {
+          "tcId": 108,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393838353036393637",
+          "sig": "011dac8ea37f7bc6a530a42d0e3bec8c845694f73bec6950081a6f999ccdfbc6153e57ee45e0a379839f3b8f6faf86de7a626b210f4c1007e431f842e39bf7d5",
+          "result": "valid"
+        },
+        {
+          "tcId": 109,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373231333036313331",
+          "sig": "63f9c43a8cab49f518685a120bd73a4e5956f9f167a78d4661fc795d41be2ae16aaf4f3384f1489ef026cb29e97ea1b5562fe8ceb9978d506fb7064f427b9f31",
+          "result": "valid"
+        },
+        {
+          "tcId": 110,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323034313031363535",
+          "sig": "7f0fd3736166195ba810d5a2dfb5e1f03aece2170510c8aa4cc4a0c974a7c5d6370c8772a75d32e8c9cc103004e75e6d30a8ac8611b84b89c41c65542171bc5b",
+          "result": "valid"
+        },
+        {
+          "tcId": 111,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313530363830393530",
+          "sig": "f975196086d10f683f4aa1a3c2d5fe13fd0f52ee72aa3f785006aa024c7587356a66364156ef21b5dfdcee60cce8fb09c12019bc576848ff73db49856af74681",
+          "result": "valid"
+        },
+        {
+          "tcId": 112,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373237343630313033",
+          "sig": "35fe6d9bf9f7d47612c3f5be6a4e9a0fb0c14854d1a377adfb5485d6e3835c6ff96587fc460e7d07396f9f2d060693dae632721259e77c90b8314002a5235dd0",
+          "result": "valid"
+        },
+        {
+          "tcId": 113,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134353731343631323235",
+          "sig": "210c7c9b231293c8ec09b0f610d31724a045f6a33f84423fdd541ac11ff78962e5a40e6b80da99cfc49ce969f1f59146835183e61001b4513f927b71ec3b2a13",
+          "result": "valid"
+        },
+        {
+          "tcId": 114,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313739353136303930",
+          "sig": "09b7dcfad2c84b89825cf3aaaffed51664faccc0d171a43387a6ff98aa128a04272b00e6e0917afe4fbe782604428e09fd91c38125d51c3ba06ce3198e6bf736",
+          "result": "valid"
+        },
+        {
+          "tcId": 115,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35383932373133303534",
+          "sig": "09c7c99681c9159b22c0a467999559a31e279075d37ef872a88ae13565f6149bb0ff953be1940d2cf548663c1b4db7b416521db289467733b9a76629f8ab261f",
+          "result": "valid"
+        },
+        {
+          "tcId": 116,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33383936313832323937",
+          "sig": "2bfaae0ea6d8baab3e02ad7fa3dda3ce0725d11533e3666477f54d697e2ca9bc9289d5da443395bca18fe9d1a4afbe04a32b4ecd258eca6c1772acff2d0b9a89",
+          "result": "valid"
+        },
+        {
+          "tcId": 117,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38323833333436373332",
+          "sig": "368846edc677ae8fc237069cda719af3d7f17cc136fe443b2af614ccfb4844ab5ebe6c1d3e88bc4e291841ea97c836bdcf67d9eabe926346c5f42105f7b38f67",
+          "result": "valid"
+        },
+        {
+          "tcId": 118,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33333636393734383931",
+          "sig": "f336da82bea2a111bddef6a25de4ab87d7c95aa80d21838f3a4efa3d9346555dda5ab612b327aa0fe95d1caf85f3b6698c23a47212006c5667cfa92aa3ef4dad",
+          "result": "valid"
+        },
+        {
+          "tcId": 119,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313939313533323239",
+          "sig": "97c2fb9865f9e76f8d54ce957120b68ccb04cd3183dae7130f73139cd56655cffb63e38176ffac37d0ec1e49c2e2efeff04dffdad5a75f3576f8276cccee9851",
+          "result": "valid"
+        },
+        {
+          "tcId": 120,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363030333136383232",
+          "sig": "7393e0207e07bd73b674d3667dfbc9c30022574d63079a040a23c0cd7e1b6aa62994b3468432fecd0a32134171179d2809244d586bd971129cdba73fd3dc8876",
+          "result": "valid"
+        },
+        {
+          "tcId": 121,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "383639363531363935",
+          "sig": "21e1943d7d396a8c46658bede4ce155c9a06f929cf6ad292d32c91cf8f49388730783c682cebfffec5787d762bd725bafc9c4075ad8eb1582188f4c05dd5169d",
+          "result": "valid"
+        },
+        {
+          "tcId": 122,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36353833393236333732",
+          "sig": "5a269eb44e910bfe8a2656dee47556cb908a417917e2068e20d201721f44f9b1e69d463204dce77c249439f22f77cc4c88134012a286b36a9559f694203766c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 123,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3133323035303135373235",
+          "sig": "cb8c146fb3d58846e5748c48742af2f1b77805f6cd1e4eb98d8c66cbdf5d645517ac992e10251e334467f8e57e2e1c269db8b19469321c74b443972a80f38b2d",
+          "result": "valid"
+        },
+        {
+          "tcId": 124,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35303835333330373931",
+          "sig": "212d84a153db81cea5212fa7dee31d59bdca1307277a01b5936c3aead31bf1e4520305dbef2bda6526fa2cfca789a1c9aca5c2ad4c0027cc8cf3881813da8a72",
+          "result": "valid"
+        },
+        {
+          "tcId": 125,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37383636383133313139",
+          "sig": "310c82892f571134a36725f4a31c5cba8bc46e65002d73b11364084433d8da4a9ca552aca84b96cc9461e2b65a64975118ea78b8b355a0ebcc1a61de37877d13",
+          "result": "valid"
+        },
+        {
+          "tcId": 126,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303832353339343239",
+          "sig": "489deda580c62533783df9fe62de34c2e2cab91d676709beeff13afac8e90db932a85a9c56f308b7a794dcce614a5ed7e0857030b8429fe3b4e07ad533a5a00a",
+          "result": "valid"
+        },
+        {
+          "tcId": 127,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130303635393536363937",
+          "sig": "e8897c1cad1fc870a7d364676a9d7f7cd3ac951f3bc3a9ef1f7231466c3493d7dd2128e876d62da82cfc5fc508d33bf66b71c0a84d0a9b7e47dfc620f5846bc6",
+          "result": "valid"
+        },
+        {
+          "tcId": 128,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33303234313831363034",
+          "sig": "b4d771d19fffb1fe5ead25ef5dbf6b53d4d3dad284641108ad84b2541ad435a4843ecdc2641b33a3ae9ae15d559f6229d7304ee5ecabe00db73bf2b6b5c6c21f",
+          "result": "valid"
+        },
+        {
+          "tcId": 129,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37373637383532383734",
+          "sig": "5ab5fb3136fabdbd22009642df03685935819895d675fc284e8b8112db522d08d87ec88173e823ed70438fb1088b00689352542fabad5e9fd6d4c3c58f722f86",
+          "result": "valid"
+        },
+        {
+          "tcId": 130,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353434313939393734",
+          "sig": "be310120169f8d488c6e5ec5b5e588ab8a65040169d9efd3062e0d05fd7d58df45033f291fa21a85cc08f78fec2dbd94135520de261360728b8743b558ed16f8",
+          "result": "valid"
+        },
+        {
+          "tcId": 131,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35383433343830333931",
+          "sig": "cd7fb3f2c25dfab6f9ee83fcbb08698680e9d1f3d47815bc772d717a764f9997287dd85b976d7f56d23ae7837398c118932aadc982f675f94103036729a47c7c",
+          "result": "valid"
+        },
+        {
+          "tcId": 132,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373138383932363239",
+          "sig": "69f18c064ad2683cc1b6d8b79020aacd186b6ad1999e6e55bf28bb1dac33f339ef66e66001fcc219c9a927d7f0b84863483bfd1ffa6086c06921905310c793e1",
+          "result": "valid"
+        },
+        {
+          "tcId": 133,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373433323233343433",
+          "sig": "00547c6bb40f52d207fff796a29f6dbe62058e50fb73bde6b9c6ca11346fd8e82bc82bd3efc9febe8578acdbc3148bb46c41a39be9ae1994ad52d8bf13195d09",
+          "result": "valid"
+        },
+        {
+          "tcId": 134,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343036303035393336",
+          "sig": "a80496adce42e7971ebe91300710cf4f535fad266668d76d72c95fffe4d425700d4338ca32857e14e0ea8026bc194227b910b98509c8c9307b0d8d93d47b191b",
+          "result": "valid"
+        },
+        {
+          "tcId": 135,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363134303336393838",
+          "sig": "3de40634d11a7a6b67023b84650420673ce6dbadb1159768cc0fd55f3784ec88a455fb08e51b8493177d88fca43aeff306e1490d7f6d24d6a910970a3d8619de",
+          "result": "valid"
+        },
+        {
+          "tcId": 136,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303935343235363835",
+          "sig": "c1f229c0557d4c47962593781bc96cf745f3bd629ad85434dc2eee456ddb30318638f6c01c15d23db24bb851f6c63c763c1f040976f3f2b32c4bb1b9506c1c12",
+          "result": "valid"
+        },
+        {
+          "tcId": 137,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303038303938393833",
+          "sig": "35dd4957b352e8b1bbc80d1deb21f9b0989188ade3fbe46f75106da1684e1d6d8b508e2ed7a51efea0dfaf377f6bd5d4ae133cc4c93650600be545af5d3acd75",
+          "result": "valid"
+        },
+        {
+          "tcId": 138,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353734313437393237",
+          "sig": "410aa9c943e663082c6f76b84469c9845e0d439ba7ffc7cac0418eea0e20e638c873ab5c21c9f0ce0bf78484028796b77451e1187250ee33535dacfb3cee5f61",
+          "result": "valid"
+        },
+        {
+          "tcId": 139,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383636373731353232",
+          "sig": "8191db069b571cd40f2676348433430d3a65155c233c46a42a4299e6f5be806cf3679ef8af0b1b3a3aeaa7bcee51ce960441622e9ff2dcb22a8ec8de724e0a0c",
+          "result": "valid"
+        },
+        {
+          "tcId": 140,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363934323830373837",
+          "sig": "889c44edbf3825b18d933aecd5ef70d12ebb00bf79550451205fd6f5ba7f372becb67194bed2b8176077622d58c9ab4fe4ca34601decc09f9386b8c4445c7224",
+          "result": "valid"
+        },
+        {
+          "tcId": 141,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39393231363932353638",
+          "sig": "aa87113aff2e1ad6461191241f90a23b91242d0066779daaa9506a4188abc42733dbaac5ac443fb4d9529f83247f94c0ad1360d4d0ba8e162a377946c6ab9ae2",
+          "result": "valid"
+        },
+        {
+          "tcId": 142,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131363039343339373938",
+          "sig": "0e13f66a8ffd0da1c4b67f4d805941e90f98ce386540c48019c1ac10540756830cb489e8d5acfca5245d9292f59c6ede52425157af77b8beef38d23b6e6ade13",
+          "result": "valid"
+        },
+        {
+          "tcId": 143,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37313836313632313030",
+          "sig": "6c1813f660c78bda956c1685bc924f69d1bbac5fadf3e4b027ab049bc82ad13420de89ee005d7646f070bdac794ccce24d661b390a78851d35fe6fb5b25b3eba",
+          "result": "valid"
+        },
+        {
+          "tcId": 144,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323934333437313737",
+          "sig": "48dc830b6326ec218144391b658d52045ef86ef918a8d41c59131912b1a46fb1a431916cb7cf79129b90f09842b3f2164a6cf603db88f2d99944142c00b42559",
+          "result": "valid"
+        },
+        {
+          "tcId": 145,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3138353134343535313230",
+          "sig": "4d45782be145a27ae9ecb6cac1b9e30be87c0d13b7d6ada9f795ff051351ac70cf71d1eb15e88446ddb900f20d1e0739da499de9963fe99ded00a62da6462d62",
+          "result": "valid"
+        },
+        {
+          "tcId": 146,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343736303433393330",
+          "sig": "11acd8b8d736e7f00476495803fbd20ad351321e800cfbddbd6a7dd610c5ab8c734027aabcca9487773dc3ab069b802c00f5b6e5520e7761496ac1e7c78ced91",
+          "result": "valid"
+        },
+        {
+          "tcId": 147,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353637333738373431",
+          "sig": "41be8b3bf41a4c507de12f098f7d409a1f941fef84d93794c497f7242a7c382c81f7e7243116f24b84b0321e93eed35e2bdc32b00aa8eb9583be3e9b7a09a4f3",
+          "result": "valid"
+        },
+        {
+          "tcId": 148,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35373339393334393935",
+          "sig": "ea032ff41b061e93e456a5f0a9cdef36c0732df4d55ab4d3867484b0fc49d9ebab298dd811826a6a9319c3632a96253c31c14f75baef536a645420442bab4d43",
+          "result": "valid"
+        },
+        {
+          "tcId": 149,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343738333636313339",
+          "sig": "8b1ff140c65adca22e5596ffb95a5121c356d2d4055f14606445249a5725686fef8c16ff228114a7e33b35ad465f957577dea405fbdf3faf077a878754e58bef",
+          "result": "valid"
+        },
+        {
+          "tcId": 150,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363439303532363032",
+          "sig": "3a40e8dc3ebe9e19dcd0d4d1b698ab2a4934a146def5427b3a6a8fbfbf34784654f65e36088d2d4543011c94b1e5371697202d488b342dd6f77a69944128223d",
+          "result": "valid"
+        },
+        {
+          "tcId": 151,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373633383837343936",
+          "sig": "15fecd439137df74820727f71218405cbe525d403c574471d8a36fa4b1f592ab18ec290971ed0a227ec47f1e2142f3b8fe5b17336350c5515d4a87eb3382fcb6",
+          "result": "valid"
+        },
+        {
+          "tcId": 152,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353739303230303830",
+          "sig": "e676e84a299f481a207cde6a4271c87d73e29d1e49216393292323bcdc238844b8a98c769bf81429644758c8f803ddbedf81634e53099c43ad0ca42f4207ba16",
+          "result": "valid"
+        },
+        {
+          "tcId": 153,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35333434373837383438",
+          "sig": "5116f8f0af12b47bd025aa6eaec5007d4e3c5a3a72cb4c331f569581adb01bfb6962251da7ba9ac951cfbd2051bcb7d953005cb9599ae0ad9c5f5139baacb976",
+          "result": "valid"
+        },
+        {
+          "tcId": 154,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3139323636343130393230",
+          "sig": "b83f3918b6c5506d648ba3dba36762db593ad4b791456babcc3c1a4966317ae68cd0166047cec89963e9c8ca43b556ac17d0d62177a9bda35e61d0bb16dd471d",
+          "result": "valid"
+        },
+        {
+          "tcId": 155,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33373033393135373035",
+          "sig": "077858a840230ca21385c4ab4c36cbd3ffaf85656202fba58f1ea995f52ebc4c543e5e32a6d2f5c08664ed72175adaa25cdb5d6a754b0cb184e6994ede66c5b9",
+          "result": "valid"
+        },
+        {
+          "tcId": 156,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3831353435373730",
+          "sig": "538ad8797a397414ac82287c9216e41915c9e3dadbd493a0bbef5cb0dc7935ec2c94cfdae7bf76f90b3cc7d19feea4005b387e312ad4116654d63cfbecf2ae1a",
+          "result": "valid"
+        },
+        {
+          "tcId": 157,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313935353330333737",
+          "sig": "ff8bbd1b6441388cb8d562c28ce29fbe51de11502fc825773ded3f0df225b2368eccca0148b82fdfb370cdd073aa0634b39cc70d0d5244a7319e4b13791e2c2a",
+          "result": "valid"
+        },
+        {
+          "tcId": 158,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323637383130393033",
+          "sig": "7c179a010f51d66ec82fe5d5d45bd867b4b236a27be882e627506f7286ed7baa5e38c048fb0fbd81c40df3dc16087d9aabeb51a193107499d29d8cf99c388a21",
+          "result": "valid"
+        },
+        {
+          "tcId": 159,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131313830373230383135",
+          "sig": "7e0810885b405d54ceb2eb18cae08de2062f61b7ed94ab67eb15e87b64e730eff511a7919e6e4d70c8d61b831e383f58dea5878a6c8c5f0436ee058dd80a7668",
+          "result": "valid"
+        },
+        {
+          "tcId": 160,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38333831383639323930",
+          "sig": "c665d558dd638ef27a28557c3deb8a2f54abf9bd0bfa032c7ec9a514da9a9e9e65c9efc355981f91778227eefacf1bb2fedb98657e6cd8674fdd42ae00d619ed",
+          "result": "valid"
+        },
+        {
+          "tcId": 161,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313331323837323737",
+          "sig": "4f06b82aa0d070a004a7fd1135bc3a0bc36fcaeeca35e3edf00f5895394d59ab65f71dd7406a17bf19e434a4635479340204dd862a9f2c4653e2fa39b178286c",
+          "result": "valid"
+        },
+        {
+          "tcId": 162,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134333331393236353338",
+          "sig": "539c8fe5715c3dc893815ec2f00e203b4cd4f8fd36cc5742cc81ced266e02e3ba5964b2d5157624cf42b6726ae23a7d5ef83a5d1f1460bd573d5a15316be5bf2",
+          "result": "valid"
+        },
+        {
+          "tcId": 163,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333434393038323336",
+          "sig": "25f337273591f276849cd855b03d07cbcb205924cda4f62a079591602cc10a8cd7b82c8fb38bbd503d92e5ae9303e8673c6dd0e9389f5af53366bbab851f0470",
+          "result": "valid"
+        },
+        {
+          "tcId": 164,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36383239383335393239",
+          "sig": "f36018945d24c89678ce2c8cf3cb4f93c38bdad3589891a5baa293744d4daa2019ef05878dfc636a4662fd5dd127c908d7948991a324840323c8aef4fc2ff8ac",
+          "result": "valid"
+        },
+        {
+          "tcId": 165,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343435313538303233",
+          "sig": "43203c89ad43a2bb1910e70ea104347e84764599535d46dabbe547395b1463f4ed3d29c7c506ecc988614b368b38dd5b4f1e330c1b861efca8152a704b9146e5",
+          "result": "valid"
+        },
+        {
+          "tcId": 166,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3132363937393837363434",
+          "sig": "c2740bfb3f387df1b564e3ff48835b9e380104716f58c5a43e97bb2c2d84d04ae760ee5d0950b512f6c271cd1a87619b830df83fd40d44b9283539b3aa380019",
+          "result": "valid"
+        },
+        {
+          "tcId": 167,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333939323432353533",
+          "sig": "ec07ec5378ed131b2dea7ae9776ba536daef2afc38e2556a70b89b9752eb1f71fea25b9e50b1cfa2cf475dbb2245761d5f4585fbbc438d97226c64ff74bff19e",
+          "result": "valid"
+        },
+        {
+          "tcId": 168,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363031393737393737",
+          "sig": "e438303ccbbee359c865997e46112b0afd7a647c593429291398f0c432dfb9f08487e07a53da18793f8b527069e620e44587e420245d6ec827bb35cccfae7a47",
+          "result": "valid"
+        },
+        {
+          "tcId": 169,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130383738373535313435",
+          "sig": "fc09fa30e89a2ba3d0c4d9d9350e717168c21253371359c0f3cb8c8807bdab565d6c4766bca462cf95b4aeb8f5886b52fc3286642ffee8d0bd7ffd4af7badb4a",
+          "result": "valid"
+        },
+        {
+          "tcId": 170,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37303034323532393939",
+          "sig": "4f184fba2be39078385290acb4cc4b3f39b099c3300c762df205c605c6b30e1a506481d2018b3a4c0ad558f029c82e0625c833cbbee978bee7b589742ee1e377",
+          "result": "valid"
+        },
+        {
+          "tcId": 171,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353635333235323833",
+          "sig": "e9a27533a50eafb09561dc335d67f8e5e53b4fc16b3013f062e581ad027e110e7e4150def368f969ace0fc28cac7a3312d6b9af538c412048be1763ea81f3f44",
+          "result": "valid"
+        },
+        {
+          "tcId": 172,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3233383236333432333530",
+          "sig": "fac24d54387202bff01a91f5504f778c183a0a7930c02af0b618ee64d1b1e438f3a53cb6f96feea45ccadcdf9ac78cd735ec3342163e573d2125caa0d8d507bb",
+          "result": "valid"
+        },
+        {
+          "tcId": 173,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343437383437303635",
+          "sig": "3544590a0f9fa5d43ad4e0a003a8d7db58b8570951657aab3bab732727d1bbc2f257beac10d53e8012ecd236793d280026c5cf1c04aae522019b87e003500ec5",
+          "result": "valid"
+        },
+        {
+          "tcId": 174,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134323630323035353434",
+          "sig": "bc0726386497c85da8f4055a727b1938e96786b009e6847a080a8aae571b075354b1b15fc7886f09b121af6520d0f4336d259d734713fc3e973cf28368830eff",
+          "result": "valid"
+        },
+        {
+          "tcId": 175,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393933383335323835",
+          "sig": "216f8051f9ceed5b5cc1085f83efd871128cb44b260ac12c486c0ea06c71aa55df90346cb028245a72ac7d8094497f0efb83a7c44ba3b258873127355e3b2edf",
+          "result": "valid"
+        },
+        {
+          "tcId": 176,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34323932313533353233",
+          "sig": "cb76652e19d6e7a72c9cac35c2ae46178d8c0ff59b06b0cb97c31aad39ec1b095c47b889a29c781540b8783ca24e2acc340178685d7331017e29b4efe92d9fbd",
+          "result": "valid"
+        },
+        {
+          "tcId": 177,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34343539393031343936",
+          "sig": "edfc03190c839528ba2aa0ba3a23b596fcfec1bf2bbf4467f1fd88398cab8ad245b41fa49e0fa7f060ac1ba38ab4d2d5ab5b9fa54ca59285aee09ceedd9865a3",
+          "result": "valid"
+        },
+        {
+          "tcId": 178,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333933393731313731",
+          "sig": "e7631f03d9dfddc64cfd2a971523def68cb9f8a64e07eb2235c7250adc36480ba004cbac3e04056c7e65fdb48be051e9a52ab427c826c84e2cb2229252983663",
+          "result": "valid"
+        },
+        {
+          "tcId": 179,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333930363936343935",
+          "sig": "15e36a42515118021f6f5372ecbff90755d8ae77f9dd683972d2f26aa67164518d1cd988ba0a1bd919d2f9b5c8a3517eb59ef776caecdf2b5ac2f7a721858315",
+          "result": "valid"
+        },
+        {
+          "tcId": 180,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131343436303536323634",
+          "sig": "6daacbc1125cb3690e43e16b414077c0dd274b96ed61892bad5a519274f01b23d044965811b4050c7a85021e8827635cf9f46260fc33bb7cb56b1b37180c4220",
+          "result": "valid"
+        },
+        {
+          "tcId": 181,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363835303034373530",
+          "sig": "37e50775ee06024d596ed49824b1e6a49efae25c7dce8181de33f93ce34ac3ce616a3e9d1fed086138f6feef6532647c02bd324ba4a8bfea20640d22f5494429",
+          "result": "valid"
+        },
+        {
+          "tcId": 182,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3232323035333630363139",
+          "sig": "d5b64cdf82e354ba6a01772f7d38e8d46a729b808aaed73616ed41a9afc83db7b5c456c91254e57013228c9724bb7f97aaf18e1bfd4c99d3ca9eaa8214382a10",
+          "result": "valid"
+        },
+        {
+          "tcId": 183,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36323135363635313234",
+          "sig": "915779b90ae6f6c1fb82c198c9f0719ce2ea37be0f261e36585ec89adaedd2b67d05e7794ac57578790808c0ac52ca3a51d1399f1a4c7173a7ed19867732b3d9",
+          "result": "valid"
+        },
+        {
+          "tcId": 184,
+          "comment": "Signature generated without truncating the hash",
+          "flags": [
+            "Untruncatedhash"
+          ],
+          "msg": "313233343030",
+          "sig": "097a04ee03a13c511d939e8bbe1471c57a71020e168e2689c69a5625686e24ad40d24d52f3701ac8da959560c36ed0750a1cf031b728a9134e2b71ed3ddef889",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "uDj_ROW8F3vyEYnQdmCC_J2EMiaIf8l2A3EQC37iCm8",
+        "y": "8MnXW_unsxpryhl0SW7rVt41cHGVXYPEsbraoLIYMuk",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0412c90a5debd88d42686b84227dbc755351b78e7c6cb86c0b22536f394603646ed03d965851bc41bb089499c51987b899a8353d997e040fdd35290a2627f0a3ab",
+        "wx": "12c90a5debd88d42686b84227dbc755351b78e7c6cb86c0b22536f394603646e",
+        "wy": "00d03d965851bc41bb089499c51987b899a8353d997e040fdd35290a2627f0a3ab"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000412c90a5debd88d42686b84227dbc755351b78e7c6cb86c0b22536f394603646ed03d965851bc41bb089499c51987b899a8353d997e040fdd35290a2627f0a3ab",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEEskKXevYjUJoa4Qifbx1U1G3jnxsuGwL\nIlNvOUYDZG7QPZZYUbxBuwiUmcUZh7iZqDU9mX4ED901KQomJ/Cjqw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 185,
+          "comment": "k*G has a large x-coordinate",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000014551231950b75fc4402da1722fc9baebfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        },
+        {
+          "tcId": 186,
+          "comment": "r too large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2cfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "EskKXevYjUJoa4Qifbx1U1G3jnxsuGwLIlNvOUYDZG4",
+        "y": "0D2WWFG8QbsIlJnFGYe4mag1PZl-BA_dNSkKJifwo6s",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04913ed043022ee590f59e44f519e5cfd9d6f1b84a50fb417e9ad06683c6afa194b68fb80d6ef261b5a63b57f871d2ea7224319f5fa3ed3dd77f1012dba19d0395",
+        "wx": "00913ed043022ee590f59e44f519e5cfd9d6f1b84a50fb417e9ad06683c6afa194",
+        "wy": "00b68fb80d6ef261b5a63b57f871d2ea7224319f5fa3ed3dd77f1012dba19d0395"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004913ed043022ee590f59e44f519e5cfd9d6f1b84a50fb417e9ad06683c6afa194b68fb80d6ef261b5a63b57f871d2ea7224319f5fa3ed3dd77f1012dba19d0395",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEkT7QQwIu5ZD1nkT1GeXP2dbxuEpQ+0F+\nmtBmg8avoZS2j7gNbvJhtaY7V/hx0upyJDGfX6PtPdd/EBLboZ0DlQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 187,
+          "comment": "r,s are large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "kT7QQwIu5ZD1nkT1GeXP2dbxuEpQ-0F-mtBmg8avoZQ",
+        "y": "to-4DW7yYbWmO1f4cdLqciQxn1-j7T3XfxAS26GdA5U",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04644cc54e84467213fafe2a4451dba550f3ea76ea9970bd6251fc7783a420d8b51cd9439155ec45d5634677c281154bbdf99fe44051dcec322053ca69ea88297c",
+        "wx": "644cc54e84467213fafe2a4451dba550f3ea76ea9970bd6251fc7783a420d8b5",
+        "wy": "1cd9439155ec45d5634677c281154bbdf99fe44051dcec322053ca69ea88297c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004644cc54e84467213fafe2a4451dba550f3ea76ea9970bd6251fc7783a420d8b51cd9439155ec45d5634677c281154bbdf99fe44051dcec322053ca69ea88297c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEZEzFToRGchP6/ipEUdulUPPqduqZcL1i\nUfx3g6Qg2LUc2UORVexF1WNGd8KBFUu9+Z/kQFHc7DIgU8pp6ogpfA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 188,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc3e9a7582886089c62fb840cf3b83061cd1cff3ae4341808bb5bdee6191174177",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ZEzFToRGchP6_ipEUdulUPPqduqZcL1iUfx3g6Qg2LU",
+        "y": "HNlDkVXsRdVjRnfCgRVLvfmf5EBR3OwyIFPKaeqIKXw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040a11d42154bd2de10ca92321fb6b3e638ee8b5a7fb4fb5f501b44515cf60e8c906ccaab8748cd38ece73ddc975bc307e7de172357e14cd96a94bb3461d32d50e",
+        "wx": "0a11d42154bd2de10ca92321fb6b3e638ee8b5a7fb4fb5f501b44515cf60e8c9",
+        "wy": "06ccaab8748cd38ece73ddc975bc307e7de172357e14cd96a94bb3461d32d50e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040a11d42154bd2de10ca92321fb6b3e638ee8b5a7fb4fb5f501b44515cf60e8c906ccaab8748cd38ece73ddc975bc307e7de172357e14cd96a94bb3461d32d50e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEChHUIVS9LeEMqSMh+2s+Y47otaf7T7X1\nAbRFFc9g6MkGzKq4dIzTjs5z3cl1vDB+feFyNX4UzZapS7NGHTLVDg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 189,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc24238e70b431b1a64efdf9032669939d4b77f249503fc6905feb7540dea3e6d2",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ChHUIVS9LeEMqSMh-2s-Y47otaf7T7X1AbRFFc9g6Mk",
+        "y": "BsyquHSM047Oc93Jdbwwfn3hcjV-FM2WqUuzRh0y1Q4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049fa2c32bb349846acb5af14e1c67acfdd8963ed251c4b5783cad4bcdd0fd505d6f724937217d1e5483920405cf1b20200797521c464a2355fdde5306f2a9e448",
+        "wx": "009fa2c32bb349846acb5af14e1c67acfdd8963ed251c4b5783cad4bcdd0fd505d",
+        "wy": "6f724937217d1e5483920405cf1b20200797521c464a2355fdde5306f2a9e448"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049fa2c32bb349846acb5af14e1c67acfdd8963ed251c4b5783cad4bcdd0fd505d6f724937217d1e5483920405cf1b20200797521c464a2355fdde5306f2a9e448",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEn6LDK7NJhGrLWvFOHGes/diWPtJRxLV4\nPK1LzdD9UF1vckk3IX0eVIOSBAXPGyAgB5dSHEZKI1X93lMG8qnkSA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 190,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 191,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0101",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "n6LDK7NJhGrLWvFOHGes_diWPtJRxLV4PK1LzdD9UF0",
+        "y": "b3JJNyF9HlSDkgQFzxsgIAeXUhxGSiNV_d5TBvKp5Eg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0460eace95001201cf4c83b580fb698bb6abf446e5c56ff945eb5769b1a477b55069f5354a77fe2d601528f126c9a6858deeddb9e5ec408356d05ed5c80d62b8e1",
+        "wx": "60eace95001201cf4c83b580fb698bb6abf446e5c56ff945eb5769b1a477b550",
+        "wy": "69f5354a77fe2d601528f126c9a6858deeddb9e5ec408356d05ed5c80d62b8e1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000460eace95001201cf4c83b580fb698bb6abf446e5c56ff945eb5769b1a477b55069f5354a77fe2d601528f126c9a6858deeddb9e5ec408356d05ed5c80d62b8e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYOrOlQASAc9Mg7WA+2mLtqv0RuXFb/lF\n61dpsaR3tVBp9TVKd/4tYBUo8SbJpoWN7t255exAg1bQXtXIDWK44Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 192,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+          "result": "valid"
+        },
+        {
+          "tcId": 193,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0102",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "YOrOlQASAc9Mg7WA-2mLtqv0RuXFb_lF61dpsaR3tVA",
+        "y": "afU1Snf-LWAVKPEmyaaFje7dueXsQINW0F7VyA1iuOE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f1a57d9346842310975ed356672a48a06a70b5efbc0c23287c9b9952ec955b330091aee1224ecd69791856c521b12df172b45a5ce247e6dcaca7349684278f23",
+        "wx": "00f1a57d9346842310975ed356672a48a06a70b5efbc0c23287c9b9952ec955b33",
+        "wy": "0091aee1224ecd69791856c521b12df172b45a5ce247e6dcaca7349684278f23"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f1a57d9346842310975ed356672a48a06a70b5efbc0c23287c9b9952ec955b330091aee1224ecd69791856c521b12df172b45a5ce247e6dcaca7349684278f23",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE8aV9k0aEIxCXXtNWZypIoGpwte+8DCMo\nfJuZUuyVWzMAka7hIk7NaXkYVsUhsS3xcrRaXOJH5tyspzSWhCePIw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 194,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003",
+          "result": "valid"
+        },
+        {
+          "tcId": 195,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0103",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "8aV9k0aEIxCXXtNWZypIoGpwte-8DCMofJuZUuyVWzM",
+        "y": "AJGu4SJOzWl5GFbFIbEt8XK0WlziR-bcrKc0loQnjyM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045f051894500a061da63c3558e1469cdffb8a57e260633d630e16c44149d914732f3881bf8954fffce9308e3792413910614341831f9a35b58d1ad0dde4f90cc4",
+        "wx": "5f051894500a061da63c3558e1469cdffb8a57e260633d630e16c44149d91473",
+        "wy": "2f3881bf8954fffce9308e3792413910614341831f9a35b58d1ad0dde4f90cc4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045f051894500a061da63c3558e1469cdffb8a57e260633d630e16c44149d914732f3881bf8954fffce9308e3792413910614341831f9a35b58d1ad0dde4f90cc4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXwUYlFAKBh2mPDVY4Uac3/uKV+JgYz1j\nDhbEQUnZFHMvOIG/iVT//OkwjjeSQTkQYUNBgx+aNbWNGtDd5PkMxA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 196,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 197,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0201",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "XwUYlFAKBh2mPDVY4Uac3_uKV-JgYz1jDhbEQUnZFHM",
+        "y": "LziBv4lU__zpMI43kkE5EGFDQYMfmjW1jRrQ3eT5DMQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042b934479af23d6b8db0693538e9e15eae8436fe56e3c8c9580955a755103ebb2fd81cdb809b4f839856fa6c051c0df65e4fd8a5d01b297c7797e718c5121b416",
+        "wx": "2b934479af23d6b8db0693538e9e15eae8436fe56e3c8c9580955a755103ebb2",
+        "wy": "00fd81cdb809b4f839856fa6c051c0df65e4fd8a5d01b297c7797e718c5121b416"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042b934479af23d6b8db0693538e9e15eae8436fe56e3c8c9580955a755103ebb2fd81cdb809b4f839856fa6c051c0df65e4fd8a5d01b297c7797e718c5121b416",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEK5NEea8j1rjbBpNTjp4V6uhDb+VuPIyV\ngJVadVED67L9gc24CbT4OYVvpsBRwN9l5P2KXQGyl8d5fnGMUSG0Fg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 198,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002",
+          "result": "valid"
+        },
+        {
+          "tcId": 199,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0202",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "K5NEea8j1rjbBpNTjp4V6uhDb-VuPIyVgJVadVED67I",
+        "y": "_YHNuAm0-DmFb6bAUcDfZeT9il0BspfHeX5xjFEhtBY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0409f5de48a08164e8032f79e4ca19ab5930ae6d85a914b5a000048471fc9f66c21ff3560f3345c9ccbdf49835eb6648c70f5777e41f5a2e010dbc25e1eb0ff1f4",
+        "wx": "09f5de48a08164e8032f79e4ca19ab5930ae6d85a914b5a000048471fc9f66c2",
+        "wy": "1ff3560f3345c9ccbdf49835eb6648c70f5777e41f5a2e010dbc25e1eb0ff1f4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000409f5de48a08164e8032f79e4ca19ab5930ae6d85a914b5a000048471fc9f66c21ff3560f3345c9ccbdf49835eb6648c70f5777e41f5a2e010dbc25e1eb0ff1f4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECfXeSKCBZOgDL3nkyhmrWTCubYWpFLWg\nAASEcfyfZsIf81YPM0XJzL30mDXrZkjHD1d35B9aLgENvCXh6w/x9A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 200,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003",
+          "result": "valid"
+        },
+        {
+          "tcId": 201,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0203",
+          "result": "invalid"
+        },
+        {
+          "tcId": 202,
+          "comment": "r is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641430000000000000000000000000000000000000000000000000000000000000003",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "CfXeSKCBZOgDL3nkyhmrWTCubYWpFLWgAASEcfyfZsI",
+        "y": "H_NWDzNFycy99Jg162ZIxw9Xd-QfWi4BDbwl4esP8fQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0419697f0b44b285f337dfb49eef051e8861097468d9e9e3cff149bb6add90a1dc774eba64f207bdea048381bc48fa7ac64eb8dc49e5cdd6ce007350e7a0e508ae",
+        "wx": "19697f0b44b285f337dfb49eef051e8861097468d9e9e3cff149bb6add90a1dc",
+        "wy": "774eba64f207bdea048381bc48fa7ac64eb8dc49e5cdd6ce007350e7a0e508ae"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000419697f0b44b285f337dfb49eef051e8861097468d9e9e3cff149bb6add90a1dc774eba64f207bdea048381bc48fa7ac64eb8dc49e5cdd6ce007350e7a0e508ae",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGWl/C0SyhfM337Se7wUeiGEJdGjZ6ePP\n8Um7at2Qodx3Trpk8ge96gSDgbxI+nrGTrjcSeXN1s4Ac1DnoOUIrg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 203,
+          "comment": "s is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd04917c8",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "GWl_C0SyhfM337Se7wUeiGEJdGjZ6ePP8Um7at2Qodw",
+        "y": "d066ZPIHveoEg4G8SPp6xk643EnlzdbOAHNQ56DlCK4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b3c7fbdf1d7472f7bd578757762c8ebc922ff063b0ae9c3aa9cd81600abea76c038eeb3852b836c0649fd82fe5d1d02c3d0dbb30fbcd7fe41866ebc3bd927c69",
+        "wx": "00b3c7fbdf1d7472f7bd578757762c8ebc922ff063b0ae9c3aa9cd81600abea76c",
+        "wy": "038eeb3852b836c0649fd82fe5d1d02c3d0dbb30fbcd7fe41866ebc3bd927c69"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b3c7fbdf1d7472f7bd578757762c8ebc922ff063b0ae9c3aa9cd81600abea76c038eeb3852b836c0649fd82fe5d1d02c3d0dbb30fbcd7fe41866ebc3bd927c69",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEs8f73x10cve9V4dXdiyOvJIv8GOwrpw6\nqc2BYAq+p2wDjus4Urg2wGSf2C/l0dAsPQ27MPvNf+QYZuvDvZJ8aQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 204,
+          "comment": "small r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000101c58b162c58b162c58b162c58b162c58a1b242973853e16db75c8a1a71da4d39d",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "s8f73x10cve9V4dXdiyOvJIv8GOwrpw6qc2BYAq-p2w",
+        "y": "A47rOFK4NsBkn9gv5dHQLD0NuzD7zX_kGGbrw72SfGk",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04759fdd1a64c000188b87eb0ddd291a50358fca2b0a5b92f027573845dc40b27a12ec1b2892ef46700f13cff8eb88f40076cc811478b008f5aabee4a74b4546f1",
+        "wx": "759fdd1a64c000188b87eb0ddd291a50358fca2b0a5b92f027573845dc40b27a",
+        "wy": "12ec1b2892ef46700f13cff8eb88f40076cc811478b008f5aabee4a74b4546f1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004759fdd1a64c000188b87eb0ddd291a50358fca2b0a5b92f027573845dc40b27a12ec1b2892ef46700f13cff8eb88f40076cc811478b008f5aabee4a74b4546f1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEdZ/dGmTAABiLh+sN3SkaUDWPyisKW5Lw\nJ1c4RdxAsnoS7Bsoku9GcA8Tz/jriPQAdsyBFHiwCPWqvuSnS0VG8Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 205,
+          "comment": "smallish r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000000000000000000000002d9b4d347952ccfcbc5103d0da267477d1791461cf2aa44bf9d43198f79507bd8779d69a13108e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "dZ_dGmTAABiLh-sN3SkaUDWPyisKW5LwJ1c4RdxAsno",
+        "y": "EuwbKJLvRnAPE8_464j0AHbMgRR4sAj1qr7kp0tFRvE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044882825a892d30267264e300e868ab5d4b0ffc9ef3c2cb6e90d61d238daed856e4c8248a189eb36d83740f5928cb802fb9c50b5a18c9196344a0c2cb74416423",
+        "wx": "4882825a892d30267264e300e868ab5d4b0ffc9ef3c2cb6e90d61d238daed856",
+        "wy": "00e4c8248a189eb36d83740f5928cb802fb9c50b5a18c9196344a0c2cb74416423"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044882825a892d30267264e300e868ab5d4b0ffc9ef3c2cb6e90d61d238daed856e4c8248a189eb36d83740f5928cb802fb9c50b5a18c9196344a0c2cb74416423",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESIKCWoktMCZyZOMA6GirXUsP/J7zwstu\nkNYdI42u2FbkyCSKGJ6zbYN0D1koy4AvucULWhjJGWNEoMLLdEFkIw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 206,
+          "comment": "100-bit r and small s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000000000001033e67e37b32b445580bf4efc906f906f906f906f906f906f906f906ed8e426f7b1968c35a204236a579723d2",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "SIKCWoktMCZyZOMA6GirXUsP_J7zwstukNYdI42u2FY",
+        "y": "5Mgkihies22DdA9ZKMuAL7nFC1oYyRljRKDCy3RBZCM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c4d1b1fdf274cf83f3395a70a36c94f7c51f1a31e99514b4ef10ba1304756caf4eaf435b20dd76d6ef447869503da9b28f0ea08edf287424d44aa04b254c1736",
+        "wx": "00c4d1b1fdf274cf83f3395a70a36c94f7c51f1a31e99514b4ef10ba1304756caf",
+        "wy": "4eaf435b20dd76d6ef447869503da9b28f0ea08edf287424d44aa04b254c1736"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c4d1b1fdf274cf83f3395a70a36c94f7c51f1a31e99514b4ef10ba1304756caf4eaf435b20dd76d6ef447869503da9b28f0ea08edf287424d44aa04b254c1736",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAExNGx/fJ0z4PzOVpwo2yU98UfGjHplRS0\n7xC6EwR1bK9Or0NbIN121u9EeGlQPamyjw6gjt8odCTUSqBLJUwXNg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 207,
+          "comment": "small r and 100 bit s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000101783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "xNGx_fJ0z4PzOVpwo2yU98UfGjHplRS07xC6EwR1bK8",
+        "y": "Tq9DWyDddtbvRHhpUD2pso8OoI7fKHQk1EqgSyVMFzY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043376df7376d5e651d45b8ec2e5ff9d891c6fdd6dbbb52b046e6b5ac4c9facedf76cf27f9fcb65403b1f585a2dafe26b43ebd622baccde699d81c9be98df9f4df",
+        "wx": "3376df7376d5e651d45b8ec2e5ff9d891c6fdd6dbbb52b046e6b5ac4c9facedf",
+        "wy": "76cf27f9fcb65403b1f585a2dafe26b43ebd622baccde699d81c9be98df9f4df"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043376df7376d5e651d45b8ec2e5ff9d891c6fdd6dbbb52b046e6b5ac4c9facedf76cf27f9fcb65403b1f585a2dafe26b43ebd622baccde699d81c9be98df9f4df",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEM3bfc3bV5lHUW47C5f+diRxv3W27tSsE\nbmtaxMn6zt92zyf5/LZUA7H1haLa/ia0Pr1iK6zN5pnYHJvpjfn03w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 208,
+          "comment": "100-bit r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000062522bbd3ecbe7c39e93e7c26783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "M3bfc3bV5lHUW47C5f-diRxv3W27tSsEbmtaxMn6zt8",
+        "y": "ds8n-fy2VAOx9YWi2v4mtD69YiuszeaZ2Byb6Y359N8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045077fdd202fdb4194b05491b6c053fff8760697531fc5227879e9cbec3309585d0b5cffb3e0fdfb1c06e6d11a1182752730cfe439f7a4f8a49b9c2924f49ec14",
+        "wx": "5077fdd202fdb4194b05491b6c053fff8760697531fc5227879e9cbec3309585",
+        "wy": "00d0b5cffb3e0fdfb1c06e6d11a1182752730cfe439f7a4f8a49b9c2924f49ec14"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045077fdd202fdb4194b05491b6c053fff8760697531fc5227879e9cbec3309585d0b5cffb3e0fdfb1c06e6d11a1182752730cfe439f7a4f8a49b9c2924f49ec14",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUHf90gL9tBlLBUkbbAU//4dgaXUx/FIn\nh56cvsMwlYXQtc/7Pg/fscBubRGhGCdScwz+Q596T4pJucKST0nsFA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 209,
+          "comment": "r and s^-1 are close to n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03640c155555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "UHf90gL9tBlLBUkbbAU__4dgaXUx_FInh56cvsMwlYU",
+        "y": "0LXP-z4P37HAbm0RoRgnUnMM_kOfek-KSbnCkk9J7BQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a218a180d55c05040417fa4d6881e8dbcf4952d427e4d5cbaf297e17848c49ae85b4c0e345073b0ad301fc9269d7df1cf328ca245910d9398ebbfa48782a70ff",
+        "wx": "00a218a180d55c05040417fa4d6881e8dbcf4952d427e4d5cbaf297e17848c49ae",
+        "wy": "0085b4c0e345073b0ad301fc9269d7df1cf328ca245910d9398ebbfa48782a70ff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a218a180d55c05040417fa4d6881e8dbcf4952d427e4d5cbaf297e17848c49ae85b4c0e345073b0ad301fc9269d7df1cf328ca245910d9398ebbfa48782a70ff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEohihgNVcBQQEF/pNaIHo289JUtQn5NXL\nryl+F4SMSa6FtMDjRQc7CtMB/JJp198c8yjKJFkQ2TmOu/pIeCpw/w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 210,
+          "comment": "r and s are 64-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000009c44febf31c3594d000000000000000000000000000000000000000000000000839ed28247c2b06b",
+          "result": "valid"
+        },
+        {
+          "tcId": 211,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "9c44febf31c3594d839ed28247c2b06b",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ohihgNVcBQQEF_pNaIHo289JUtQn5NXLryl-F4SMSa4",
+        "y": "hbTA40UHOwrTAfySadffHPMoyiRZENk5jrv6SHgqcP8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049b7e703d3c0224fb5fca71fab833a35fbea230453ae25ce3e3afbb646c587a5a9dd1e4b0c75250fc7845d4013a8f10988ed0875f8cbbdb6ab216bced9b8c3cb7",
+        "wx": "009b7e703d3c0224fb5fca71fab833a35fbea230453ae25ce3e3afbb646c587a5a",
+        "wy": "009dd1e4b0c75250fc7845d4013a8f10988ed0875f8cbbdb6ab216bced9b8c3cb7"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049b7e703d3c0224fb5fca71fab833a35fbea230453ae25ce3e3afbb646c587a5a9dd1e4b0c75250fc7845d4013a8f10988ed0875f8cbbdb6ab216bced9b8c3cb7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEm35wPTwCJPtfynH6uDOjX76iMEU64lzj\n46+7ZGxYelqd0eSwx1JQ/HhF1AE6jxCYjtCHX4y722qyFrztm4w8tw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 212,
+          "comment": "r and s are 100-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000009df8b682430beef6f5fd7c7cf000000000000000000000000000000000000000fd0a62e13778f4222a0d61c8a",
+          "result": "valid"
+        },
+        {
+          "tcId": 213,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "09df8b682430beef6f5fd7c7cf0fd0a62e13778f4222a0d61c8a",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "m35wPTwCJPtfynH6uDOjX76iMEU64lzj46-7ZGxYelo",
+        "y": "ndHksMdSUPx4RdQBOo8QmI7Qh1-Mu9tqsha87ZuMPLc",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0482e6ec5429071f4a4571ff510a5cfea7f493492b7d4dcef0404563eebdf79f7af4d87d7e0da88f73c882dddab8d0b1edf9678a92b08d340a312900df34d860ac",
+        "wx": "0082e6ec5429071f4a4571ff510a5cfea7f493492b7d4dcef0404563eebdf79f7a",
+        "wy": "00f4d87d7e0da88f73c882dddab8d0b1edf9678a92b08d340a312900df34d860ac"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000482e6ec5429071f4a4571ff510a5cfea7f493492b7d4dcef0404563eebdf79f7af4d87d7e0da88f73c882dddab8d0b1edf9678a92b08d340a312900df34d860ac",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEgubsVCkHH0pFcf9RClz+p/STSSt9Tc7w\nQEVj7r33n3r02H1+DaiPc8iC3dq40LHt+WeKkrCNNAoxKQDfNNhgrA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 214,
+          "comment": "r and s are 128-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000008a598e563a89f526c32ebec8de26367a0000000000000000000000000000000084f633e2042630e99dd0f1e16f7a04bf",
+          "result": "valid"
+        },
+        {
+          "tcId": 215,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "8a598e563a89f526c32ebec8de26367a84f633e2042630e99dd0f1e16f7a04bf",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "gubsVCkHH0pFcf9RClz-p_STSSt9Tc7wQEVj7r33n3o",
+        "y": "9Nh9fg2oj3PIgt3auNCx7flnipKwjTQKMSkA3zTYYKw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047937c7f3fbac0301f1e3b73f85cb97bab657c20ec493744c1c3ba692d999038de6b09c5471a987b685b8ff1e5fe9b4e20d59e0ff1299537069897c9ae2bd63ea",
+        "wx": "7937c7f3fbac0301f1e3b73f85cb97bab657c20ec493744c1c3ba692d999038d",
+        "wy": "00e6b09c5471a987b685b8ff1e5fe9b4e20d59e0ff1299537069897c9ae2bd63ea"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047937c7f3fbac0301f1e3b73f85cb97bab657c20ec493744c1c3ba692d999038de6b09c5471a987b685b8ff1e5fe9b4e20d59e0ff1299537069897c9ae2bd63ea",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeTfH8/usAwHx47c/hcuXurZXwg7Ek3RM\nHDumktmZA43msJxUcamHtoW4/x5f6bTiDVng/xKZU3BpiXya4r1j6g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 216,
+          "comment": "r and s are 160-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000aa6eeb5823f7fa31b466bb473797f0d0314c0bdf000000000000000000000000e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "valid"
+        },
+        {
+          "tcId": 217,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "aa6eeb5823f7fa31b466bb473797f0d0314c0bdfe2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eTfH8_usAwHx47c_hcuXurZXwg7Ek3RMHDumktmZA40",
+        "y": "5rCcVHGph7aFuP8eX-m04g1Z4P8SmVNwaYl8muK9Y-o",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041b1f773b472dac5e1adf94e69d865b404d2cc92cff7bb66cf2197978f6c45d08a9725791c5f33787977a9ddfa69296be998a968c51ec7f1c5447793bc56286b3",
+        "wx": "1b1f773b472dac5e1adf94e69d865b404d2cc92cff7bb66cf2197978f6c45d08",
+        "wy": "00a9725791c5f33787977a9ddfa69296be998a968c51ec7f1c5447793bc56286b3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041b1f773b472dac5e1adf94e69d865b404d2cc92cff7bb66cf2197978f6c45d08a9725791c5f33787977a9ddfa69296be998a968c51ec7f1c5447793bc56286b3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGx93O0ctrF4a35TmnYZbQE0sySz/e7Zs\n8hl5ePbEXQipcleRxfM3h5d6nd+mkpa+mYqWjFHsfxxUR3k7xWKGsw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 218,
+          "comment": "s == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 219,
+          "comment": "s == 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Gx93O0ctrF4a35TmnYZbQE0sySz_e7Zs8hl5ePbEXQg",
+        "y": "qXJXkcXzN4eXep3fppKWvpmKloxR7H8cVEd5O8VihrM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fab77f79e004a6890126e793df13464607eca844f29e645f16a0aa1a3ab9f7b39ef2a99df25c2f51cdab3e75810ef5fe36331e36a519ae5ebefefab5a55bfc6a",
+        "wx": "00fab77f79e004a6890126e793df13464607eca844f29e645f16a0aa1a3ab9f7b3",
+        "wy": "009ef2a99df25c2f51cdab3e75810ef5fe36331e36a519ae5ebefefab5a55bfc6a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fab77f79e004a6890126e793df13464607eca844f29e645f16a0aa1a3ab9f7b39ef2a99df25c2f51cdab3e75810ef5fe36331e36a519ae5ebefefab5a55bfc6a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+rd/eeAEpokBJueT3xNGRgfsqETynmRf\nFqCqGjq597Oe8qmd8lwvUc2rPnWBDvX+NjMeNqUZrl6+/vq1pVv8ag==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 220,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1419d981c515af8cc82545aac0c85e9e308fbb2eab6acd7ed497e0b4145a18fd9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "-rd_eeAEpokBJueT3xNGRgfsqETynmRfFqCqGjq597M",
+        "y": "nvKpnfJcL1HNqz51gQ71_jYzHjalGa5evv76taVb_Go",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040afc55541d6cf8bd16289c8954ce899805e39c41ba0d4b83deaef2baed94b2daa5a3a5f79deb3245a51e436c137ea60ddd152d09da5f6e121020ba560eede8b8",
+        "wx": "0afc55541d6cf8bd16289c8954ce899805e39c41ba0d4b83deaef2baed94b2da",
+        "wy": "00a5a3a5f79deb3245a51e436c137ea60ddd152d09da5f6e121020ba560eede8b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040afc55541d6cf8bd16289c8954ce899805e39c41ba0d4b83deaef2baed94b2daa5a3a5f79deb3245a51e436c137ea60ddd152d09da5f6e121020ba560eede8b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECvxVVB1s+L0WKJyJVM6JmAXjnEG6DUuD\n3q7yuu2Ustqlo6X3nesyRaUeQ2wTfqYN3RUtCdpfbhIQILpWDu3ouA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 221,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c11b21717ad71d23bbac60a9ad0baf75b063c9fdf52a00ebf99d022172910993c9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "CvxVVB1s-L0WKJyJVM6JmAXjnEG6DUuD3q7yuu2Usto",
+        "y": "paOl953rMkWlHkNsE36mDd0VLQnaX24SECC6Vg7t6Lg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b50c72e9b03e5ad9f12cd2f69fc442138d3a8917e800fa138795a24ed0aeada51e09f5ef6efa9aa866e763d5a90c62052ea682a217eba654c6b250962308f6de",
+        "wx": "00b50c72e9b03e5ad9f12cd2f69fc442138d3a8917e800fa138795a24ed0aeada5",
+        "wy": "1e09f5ef6efa9aa866e763d5a90c62052ea682a217eba654c6b250962308f6de"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b50c72e9b03e5ad9f12cd2f69fc442138d3a8917e800fa138795a24ed0aeada51e09f5ef6efa9aa866e763d5a90c62052ea682a217eba654c6b250962308f6de",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtQxy6bA+WtnxLNL2n8RCE406iRfoAPoT\nh5WiTtCuraUeCfXvbvqaqGbnY9WpDGIFLqaCohfrplTGslCWIwj23g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c12f588f66018f3dd14db3e28e77996487e32486b521ed8e5a20f06591951777e9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "tQxy6bA-WtnxLNL2n8RCE406iRfoAPoTh5WiTtCuraU",
+        "y": "Hgn17276mqhm52PVqQxiBS6mgqIX66ZUxrJQliMI9t4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046c60df5622465b2c8bd6a22fc20483c450505687e3a832f94545de17c321872a8f6d60c5f3b8e064662562ccd6703cf7418d0f8fbdf55728e4ef69e8a20406a8",
+        "wx": "6c60df5622465b2c8bd6a22fc20483c450505687e3a832f94545de17c321872a",
+        "wy": "008f6d60c5f3b8e064662562ccd6703cf7418d0f8fbdf55728e4ef69e8a20406a8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046c60df5622465b2c8bd6a22fc20483c450505687e3a832f94545de17c321872a8f6d60c5f3b8e064662562ccd6703cf7418d0f8fbdf55728e4ef69e8a20406a8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbGDfViJGWyyL1qIvwgSDxFBQVofjqDL5\nRUXeF8MhhyqPbWDF87jgZGYlYszWcDz3QY0Pj731Vyjk72noogQGqA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 223,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1091a08870ff4daf9123b30c20e8c4fc8505758dcf4074fcaff2170c9bfcf74f4",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "bGDfViJGWyyL1qIvwgSDxFBQVofjqDL5RUXeF8Mhhyo",
+        "y": "j21gxfO44GRmJWLM1nA890GND4-99Vco5O9p6KIEBqg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049326f5033bd0fc2a5108a4ba8872c3ff2d6125db90a0d4af7720d9b7cfe580b7d9d649c6090e76ba1d19ece34b3b3dc7b485df93f888017039eee2e92ebaf64f",
+        "wx": "009326f5033bd0fc2a5108a4ba8872c3ff2d6125db90a0d4af7720d9b7cfe580b7",
+        "wy": "00d9d649c6090e76ba1d19ece34b3b3dc7b485df93f888017039eee2e92ebaf64f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049326f5033bd0fc2a5108a4ba8872c3ff2d6125db90a0d4af7720d9b7cfe580b7d9d649c6090e76ba1d19ece34b3b3dc7b485df93f888017039eee2e92ebaf64f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEkyb1AzvQ/CpRCKS6iHLD/y1hJduQoNSv\ndyDZt8/lgLfZ1knGCQ52uh0Z7ONLOz3HtIXfk/iIAXA57uLpLrr2Tw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 224,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c17c370dc0ce8c59a8b273cba44a7c1191fc3186dc03cab96b0567312df0d0b250",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "kyb1AzvQ_CpRCKS6iHLD_y1hJduQoNSvdyDZt8_lgLc",
+        "y": "2dZJxgkOdrodGezjSzs9x7SF35P4iAFwOe7i6S669k8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048217f17c61e97b578e2586fb03274567099d6b329f4205827b0493d589b6d6cbf5259ef680d96395fde4da8a6a96095bbeb72fc1b616b40de3d91571bd4100a8",
+        "wx": "008217f17c61e97b578e2586fb03274567099d6b329f4205827b0493d589b6d6cb",
+        "wy": "00f5259ef680d96395fde4da8a6a96095bbeb72fc1b616b40de3d91571bd4100a8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048217f17c61e97b578e2586fb03274567099d6b329f4205827b0493d589b6d6cbf5259ef680d96395fde4da8a6a96095bbeb72fc1b616b40de3d91571bd4100a8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEghfxfGHpe1eOJYb7AydFZwmdazKfQgWC\newST1Ym21sv1JZ72gNljlf3k2opqlglbvrcvwbYWtA3j2RVxvUEAqA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 225,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c170b59a7d1ee77a2f9e0491c2a7cfcd0ed04df4a35192f6132dcc668c79a6160e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ghfxfGHpe1eOJYb7AydFZwmdazKfQgWCewST1Ym21ss",
+        "y": "9SWe9oDZY5X95NqKapYJW763L8G2FrQN49kVcb1BAKg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04367b67eb9ece04b532c9925b30595fd733e9f1fa52ca1d05d630c7a877b5162c99219249dc0ec6e92bcbfe6e46b7d500278b01f66397e7d9ce4236b5fb1a70a0",
+        "wx": "367b67eb9ece04b532c9925b30595fd733e9f1fa52ca1d05d630c7a877b5162c",
+        "wy": "0099219249dc0ec6e92bcbfe6e46b7d500278b01f66397e7d9ce4236b5fb1a70a0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004367b67eb9ece04b532c9925b30595fd733e9f1fa52ca1d05d630c7a877b5162c99219249dc0ec6e92bcbfe6e46b7d500278b01f66397e7d9ce4236b5fb1a70a0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAENntn657OBLUyyZJbMFlf1zPp8fpSyh0F\n1jDHqHe1FiyZIZJJ3A7G6SvL/m5Gt9UAJ4sB9mOX59nOQja1+xpwoA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 226,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c12736d76e412246e097148e2bf62915614eb7c428913a58eb5e9cd4674a9423de",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Nntn657OBLUyyZJbMFlf1zPp8fpSyh0F1jDHqHe1Fiw",
+        "y": "mSGSSdwOxukry_5uRrfVACeLAfZjl-fZzkI2tfsacKA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046700d5c4ba0f6fad92f0deb2055b988fec6a427b689cd779b8e4f1606d22f7dff1f3ea8ed23eba61b5c90d66cf4820e4b1c51c9d23b062552f087a162a8c7b0c",
+        "wx": "6700d5c4ba0f6fad92f0deb2055b988fec6a427b689cd779b8e4f1606d22f7df",
+        "wy": "00f1f3ea8ed23eba61b5c90d66cf4820e4b1c51c9d23b062552f087a162a8c7b0c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046700d5c4ba0f6fad92f0deb2055b988fec6a427b689cd779b8e4f1606d22f7dff1f3ea8ed23eba61b5c90d66cf4820e4b1c51c9d23b062552f087a162a8c7b0c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEZwDVxLoPb62S8N6yBVuYj+xqQntonNd5\nuOTxYG0i99/x8+qO0j66YbXJDWbPSCDkscUcnSOwYlUvCHoWKox7DA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 227,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c14a1e12831fbe93627b02d6e7f24bccdd6ef4b2d0f46739eaf3b1eaf0ca117770",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ZwDVxLoPb62S8N6yBVuYj-xqQntonNd5uOTxYG0i998",
+        "y": "8fPqjtI-umG1yQ1mz0gg5LHFHJ0jsGJVLwh6FiqMeww",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b0478cb90c29140cefdfbcb50ca2740c48a97df67ae9672e1e11cb827c1cede51d2824a9265a32d9d2221d453ea40bf64999d2c20e268d0bc061cf6ae2051cf2",
+        "wx": "00b0478cb90c29140cefdfbcb50ca2740c48a97df67ae9672e1e11cb827c1cede5",
+        "wy": "1d2824a9265a32d9d2221d453ea40bf64999d2c20e268d0bc061cf6ae2051cf2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b0478cb90c29140cefdfbcb50ca2740c48a97df67ae9672e1e11cb827c1cede51d2824a9265a32d9d2221d453ea40bf64999d2c20e268d0bc061cf6ae2051cf2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsEeMuQwpFAzv37y1DKJ0DEipffZ66Wcu\nHhHLgnwc7eUdKCSpJloy2dIiHUU+pAv2SZnSwg4mjQvAYc9q4gUc8g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 228,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c106c778d4dfff7dee06ed88bc4e0ed34fc553aad67caf796f2a1c6487c1b2e877",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "sEeMuQwpFAzv37y1DKJ0DEipffZ66WcuHhHLgnwc7eU",
+        "y": "HSgkqSZaMtnSIh1FPqQL9kmZ0sIOJo0LwGHPauIFHPI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04940e51450409cd15529adc38e730a662916bc93ae10c0facf41580a75a0c598655c6b4c9b8fdc7d932fb4a0a6847e0d878a8bdbe9390567f0b8ed92eb86267fa",
+        "wx": "00940e51450409cd15529adc38e730a662916bc93ae10c0facf41580a75a0c5986",
+        "wy": "55c6b4c9b8fdc7d932fb4a0a6847e0d878a8bdbe9390567f0b8ed92eb86267fa"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004940e51450409cd15529adc38e730a662916bc93ae10c0facf41580a75a0c598655c6b4c9b8fdc7d932fb4a0a6847e0d878a8bdbe9390567f0b8ed92eb86267fa",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAElA5RRQQJzRVSmtw45zCmYpFryTrhDA+s\n9BWAp1oMWYZVxrTJuP3H2TL7SgpoR+DYeKi9vpOQVn8LjtkuuGJn+g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 229,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c14de459ef9159afa057feb3ec40fef01c45b809f4ab296ea48c206d4249a2b451",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "lA5RRQQJzRVSmtw45zCmYpFryTrhDA-s9BWAp1oMWYY",
+        "y": "Vca0ybj9x9ky-0oKaEfg2Hiovb6TkFZ_C47ZLrhiZ_o",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040b0beeaed3b2586106e814824a0803b19fe7085ec923e0865a3c803bd46760d1e2741cd27b03f78381957bf81d42f5d61124c001418e591d14480bb8e789d1e5",
+        "wx": "0b0beeaed3b2586106e814824a0803b19fe7085ec923e0865a3c803bd46760d1",
+        "wy": "00e2741cd27b03f78381957bf81d42f5d61124c001418e591d14480bb8e789d1e5"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040b0beeaed3b2586106e814824a0803b19fe7085ec923e0865a3c803bd46760d1e2741cd27b03f78381957bf81d42f5d61124c001418e591d14480bb8e789d1e5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECwvurtOyWGEG6BSCSggDsZ/nCF7JI+CG\nWjyAO9RnYNHidBzSewP3g4GVe/gdQvXWESTAAUGOWR0USAu454nR5Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 230,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1745d294978007302033502e1acc48b63ae6500be43adbea1b258d6b423dbb416",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "CwvurtOyWGEG6BSCSggDsZ_nCF7JI-CGWjyAO9RnYNE",
+        "y": "4nQc0nsD94OBlXv4HUL11hEkwAFBjlkdFEgLuOeJ0eU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d56bb0e13f31470316914085214ee218039df7a2ea062878e1d769e47f7e39295a122a009a17683f079c2da61cff3032e88347c525592edf0877bb5338bcedd",
+        "wx": "6d56bb0e13f31470316914085214ee218039df7a2ea062878e1d769e47f7e392",
+        "wy": "0095a122a009a17683f079c2da61cff3032e88347c525592edf0877bb5338bcedd"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d56bb0e13f31470316914085214ee218039df7a2ea062878e1d769e47f7e39295a122a009a17683f079c2da61cff3032e88347c525592edf0877bb5338bcedd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbVa7DhPzFHAxaRQIUhTuIYA533ouoGKH\njh12nkf345KVoSKgCaF2g/B5wtphz/MDLog0fFJVku3wh3u1M4vO3Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 231,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c17b2a785e3896f59b2d69da57648e80ad3c133a750a2847fd2098ccd902042b6c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "bVa7DhPzFHAxaRQIUhTuIYA533ouoGKHjh12nkf345I",
+        "y": "laEioAmhdoPwecLaYc_zAy6INHxSVZLt8Id7tTOLzt0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049e38cd7f3aefb648b90dc9e3562737bda57cf73113cb110568af698392992d53bdaf4fe8760647abdbd91f14b4b32a21de6737629dd62e9f38f76e12bb4649ae",
+        "wx": "009e38cd7f3aefb648b90dc9e3562737bda57cf73113cb110568af698392992d53",
+        "wy": "00bdaf4fe8760647abdbd91f14b4b32a21de6737629dd62e9f38f76e12bb4649ae"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049e38cd7f3aefb648b90dc9e3562737bda57cf73113cb110568af698392992d53bdaf4fe8760647abdbd91f14b4b32a21de6737629dd62e9f38f76e12bb4649ae",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEnjjNfzrvtki5DcnjVic3vaV89zETyxEF\naK9pg5KZLVO9r0/odgZHq9vZHxS0syoh3mc3Yp3WLp84924Su0ZJrg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 232,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c171ae94a72ca896875e7aa4a4c3d29afdb4b35b6996273e63c47ac519256c5eb1",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "njjNfzrvtki5DcnjVic3vaV89zETyxEFaK9pg5KZLVM",
+        "y": "va9P6HYGR6vb2R8UtLMqId5nN2Kd1i6fOPduErtGSa4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e1c989fd3b9e87020a508b72b6cd8da14f15b9c12125b4b2ed402e1257abed82aa6074e0a4ea09ffc24a36d61bd37e0ea642a06d4d58ebd51b2d172bacd5e525",
+        "wx": "00e1c989fd3b9e87020a508b72b6cd8da14f15b9c12125b4b2ed402e1257abed82",
+        "wy": "00aa6074e0a4ea09ffc24a36d61bd37e0ea642a06d4d58ebd51b2d172bacd5e525"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e1c989fd3b9e87020a508b72b6cd8da14f15b9c12125b4b2ed402e1257abed82aa6074e0a4ea09ffc24a36d61bd37e0ea642a06d4d58ebd51b2d172bacd5e525",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4cmJ/TuehwIKUItyts2NoU8VucEhJbSy\n7UAuEler7YKqYHTgpOoJ/8JKNtYb034OpkKgbU1Y69UbLRcrrNXlJQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 233,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10fa527fa7343c0bc9ec35a6278bfbff4d83301b154fc4bd14aee7eb93445b5f9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "4cmJ_TuehwIKUItyts2NoU8VucEhJbSy7UAuEler7YI",
+        "y": "qmB04KTqCf_CSjbWG9N-DqZCoG1NWOvVGy0XK6zV5SU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0411119d9ac0b4e2adf1bb1db84324fff3c93c76f46999a453b5492151677b8dcebf16cb2f94bae17949c17714a6b0d87fe3cce99d9c149562df76ab035cf0c671",
+        "wx": "11119d9ac0b4e2adf1bb1db84324fff3c93c76f46999a453b5492151677b8dce",
+        "wy": "00bf16cb2f94bae17949c17714a6b0d87fe3cce99d9c149562df76ab035cf0c671"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000411119d9ac0b4e2adf1bb1db84324fff3c93c76f46999a453b5492151677b8dcebf16cb2f94bae17949c17714a6b0d87fe3cce99d9c149562df76ab035cf0c671",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEERGdmsC04q3xux24QyT/88k8dvRpmaRT\ntUkhUWd7jc6/FssvlLrheUnBdxSmsNh/48zpnZwUlWLfdqsDXPDGcQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 234,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c16539c0adadd0525ff42622164ce9314348bd0863b4c80e936b23ca0414264671",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ERGdmsC04q3xux24QyT_88k8dvRpmaRTtUkhUWd7jc4",
+        "y": "vxbLL5S64XlJwXcUprDYf-PM6Z2cFJVi33arA1zwxnE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042f20bc2232b4ba9d75fea6a92bc827d91c5a8f5c887f4e304d76656ba15999ea5f83242efbd57dd16dbd3de0915bdb2ddec201d2f749b13fc22c223a2644dcdc",
+        "wx": "2f20bc2232b4ba9d75fea6a92bc827d91c5a8f5c887f4e304d76656ba15999ea",
+        "wy": "5f83242efbd57dd16dbd3de0915bdb2ddec201d2f749b13fc22c223a2644dcdc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042f20bc2232b4ba9d75fea6a92bc827d91c5a8f5c887f4e304d76656ba15999ea5f83242efbd57dd16dbd3de0915bdb2ddec201d2f749b13fc22c223a2644dcdc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELyC8IjK0up11/qapK8gn2Rxaj1yIf04w\nTXZla6FZmepfgyQu+9V90W29PeCRW9st3sIB0vdJsT/CLCI6JkTc3A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 235,
+          "comment": "point at infinity during verify",
+          "flags": [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "LyC8IjK0up11_qapK8gn2Rxaj1yIf04wTXZla6FZmeo",
+        "y": "X4MkLvvVfdFtvT3gkVvbLd7CAdL3SbE_wiwiOiZE3Nw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049e009cd0a1a7d0c51765169c468e62e56fc4f3ff02e8666c55483419a2560032cd36d713acd504598ff3b4f58046a4690f550bd60ef4c823c5c581c6b899315e",
+        "wx": "009e009cd0a1a7d0c51765169c468e62e56fc4f3ff02e8666c55483419a2560032",
+        "wy": "00cd36d713acd504598ff3b4f58046a4690f550bd60ef4c823c5c581c6b899315e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049e009cd0a1a7d0c51765169c468e62e56fc4f3ff02e8666c55483419a2560032cd36d713acd504598ff3b4f58046a4690f550bd60ef4c823c5c581c6b899315e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEngCc0KGn0MUXZRacRo5i5W/E8/8C6GZs\nVUg0GaJWADLNNtcTrNUEWY/ztPWARqRpD1UL1g70yCPFxYHGuJkxXg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 236,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a07fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ngCc0KGn0MUXZRacRo5i5W_E8_8C6GZsVUg0GaJWADI",
+        "y": "zTbXE6zVBFmP87T1gEakaQ9VC9YO9MgjxcWBxriZMV4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04af58a6ecc8254b9b831ae0441c13990802c3d68c301d43634c71f1974c09e704d920612d82f32fca436c5c5097505271494875402731d03dba942b355306c783",
+        "wx": "00af58a6ecc8254b9b831ae0441c13990802c3d68c301d43634c71f1974c09e704",
+        "wy": "00d920612d82f32fca436c5c5097505271494875402731d03dba942b355306c783"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004af58a6ecc8254b9b831ae0441c13990802c3d68c301d43634c71f1974c09e704d920612d82f32fca436c5c5097505271494875402731d03dba942b355306c783",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEr1im7MglS5uDGuBEHBOZCALD1owwHUNj\nTHHxl0wJ5wTZIGEtgvMvykNsXFCXUFJxSUh1QCcx0D26lCs1UwbHgw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 237,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a07fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a1",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "r1im7MglS5uDGuBEHBOZCALD1owwHUNjTHHxl0wJ5wQ",
+        "y": "2SBhLYLzL8pDbFxQl1BScUlIdUAnMdA9upQrNVMGx4M",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044a7217cabc95b496f3f4e12d54e9def7651b866be69d3695cd77ad2e3a3f13d1d0fa71bf21d2c00b1ff4cc76b53a9c5c2a8a8b6b4c2ec88b99ee537ac6262b3d",
+        "wx": "4a7217cabc95b496f3f4e12d54e9def7651b866be69d3695cd77ad2e3a3f13d1",
+        "wy": "00d0fa71bf21d2c00b1ff4cc76b53a9c5c2a8a8b6b4c2ec88b99ee537ac6262b3d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044a7217cabc95b496f3f4e12d54e9def7651b866be69d3695cd77ad2e3a3f13d1d0fa71bf21d2c00b1ff4cc76b53a9c5c2a8a8b6b4c2ec88b99ee537ac6262b3d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESnIXyryVtJbz9OEtVOne92UbhmvmnTaV\nzXetLjo/E9HQ+nG/IdLACx/0zHa1OpxcKoqLa0wuyIuZ7lN6xiYrPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 238,
+          "comment": "u1 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b843f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b023210281",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "SnIXyryVtJbz9OEtVOne92UbhmvmnTaVzXetLjo_E9E",
+        "y": "0PpxvyHSwAsf9Mx2tTqcXCqKi2tMLsiLme5TesYmKz0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0400a42e277ce657fb3dd07e135a3cb9b0a75a30bd8b64911606ee68371e56124467cf22e26a7009045b73ff19cd79851cceaad9ae72ef2d043d75365245befa06",
+        "wx": "00a42e277ce657fb3dd07e135a3cb9b0a75a30bd8b64911606ee68371e561244",
+        "wy": "67cf22e26a7009045b73ff19cd79851cceaad9ae72ef2d043d75365245befa06"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000400a42e277ce657fb3dd07e135a3cb9b0a75a30bd8b64911606ee68371e56124467cf22e26a7009045b73ff19cd79851cceaad9ae72ef2d043d75365245befa06",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAKQuJ3zmV/s90H4TWjy5sKdaML2LZJEW\nBu5oNx5WEkRnzyLianAJBFtz/xnNeYUczqrZrnLvLQQ9dTZSRb76Bg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 239,
+          "comment": "u1 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8bc07ff041506dc73a75086a43252fb4270e157da75fb6cb92a9f07dcad153ec0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AKQuJ3zmV_s90H4TWjy5sKdaML2LZJEWBu5oNx5WEkQ",
+        "y": "Z88i4mpwCQRbc_8ZzXmFHM6q2a5y7y0EPXU2UkW--gY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048520b9502f9a5ed753f09a5282cad721f5ebfb3db4142d667c6279869e76bcf1678e9bbd04a51460afc40a3e0cb7b0f8b8add89b2979758a5a1ffeb4584ee49e",
+        "wx": "008520b9502f9a5ed753f09a5282cad721f5ebfb3db4142d667c6279869e76bcf1",
+        "wy": "678e9bbd04a51460afc40a3e0cb7b0f8b8add89b2979758a5a1ffeb4584ee49e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048520b9502f9a5ed753f09a5282cad721f5ebfb3db4142d667c6279869e76bcf1678e9bbd04a51460afc40a3e0cb7b0f8b8add89b2979758a5a1ffeb4584ee49e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEhSC5UC+aXtdT8JpSgsrXIfXr+z20FC1m\nfGJ5hp52vPFnjpu9BKUUYK/ECj4Mt7D4uK3Ymyl5dYpaH/60WE7kng==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 240,
+          "comment": "u2 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b855555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "hSC5UC-aXtdT8JpSgsrXIfXr-z20FC1mfGJ5hp52vPE",
+        "y": "Z46bvQSlFGCvxAo-DLew-Lit2JspeXWKWh_-tFhO5J4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b5deca0fe0296905aac27e3604a95a0a2ecbee9fc453d2e1164632964454d0c94f9e4e85a143ee677d40919c71014e8cabf4d9db7442fe4b96298f99f90ca67f",
+        "wx": "00b5deca0fe0296905aac27e3604a95a0a2ecbee9fc453d2e1164632964454d0c9",
+        "wy": "4f9e4e85a143ee677d40919c71014e8cabf4d9db7442fe4b96298f99f90ca67f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b5deca0fe0296905aac27e3604a95a0a2ecbee9fc453d2e1164632964454d0c94f9e4e85a143ee677d40919c71014e8cabf4d9db7442fe4b96298f99f90ca67f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtd7KD+ApaQWqwn42BKlaCi7L7p/EU9Lh\nFkYylkRU0MlPnk6FoUPuZ31AkZxxAU6Mq/TZ23RC/kuWKY+Z+Qymfw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 241,
+          "comment": "u2 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9d1c9e899ca306ad27fe1945de0242b89",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "td7KD-ApaQWqwn42BKlaCi7L7p_EU9LhFkYylkRU0Mk",
+        "y": "T55OhaFD7md9QJGccQFOjKv02dt0Qv5LlimPmfkMpn8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045dcb2767dc851e20911ed7be39dd87ba81c7a6d10255dfb825f241486f98ae10f8a9ef736b3e11d7d54a0e086902fb477246ec8c57de65d336570b65f65e0d83",
+        "wx": "5dcb2767dc851e20911ed7be39dd87ba81c7a6d10255dfb825f241486f98ae10",
+        "wy": "00f8a9ef736b3e11d7d54a0e086902fb477246ec8c57de65d336570b65f65e0d83"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045dcb2767dc851e20911ed7be39dd87ba81c7a6d10255dfb825f241486f98ae10f8a9ef736b3e11d7d54a0e086902fb477246ec8c57de65d336570b65f65e0d83",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXcsnZ9yFHiCRHte+Od2HuoHHptECVd+4\nJfJBSG+YrhD4qe9zaz4R19VKDghpAvtHckbsjFfeZdM2Vwtl9l4Ngw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 242,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc6bfd55a94e530bd972e52873ef39ac3e56d420a64d874694c701e714511d1696",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "XcsnZ9yFHiCRHte-Od2HuoHHptECVd-4JfJBSG-YrhA",
+        "y": "-Knvc2s-EdfVSg4IaQL7R3JG7IxX3mXTNlcLZfZeDYM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c8e144c853a7e1a6f5bbabe7ef91ef5b152113210d44fd58d3cb6185184e168aac40fb3618882193fc6d113760e476465df49067480a0a7cffe686515b3391a8",
+        "wx": "00c8e144c853a7e1a6f5bbabe7ef91ef5b152113210d44fd58d3cb6185184e168a",
+        "wy": "00ac40fb3618882193fc6d113760e476465df49067480a0a7cffe686515b3391a8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c8e144c853a7e1a6f5bbabe7ef91ef5b152113210d44fd58d3cb6185184e168aac40fb3618882193fc6d113760e476465df49067480a0a7cffe686515b3391a8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEyOFEyFOn4ab1u6vn75HvWxUhEyENRP1Y\n08thhRhOFoqsQPs2GIghk/xtETdg5HZGXfSQZ0gKCnz/5oZRWzORqA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 243,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcb494bd67c209a5adb1c9a09337e2629b03f8a924be53c542478e5864ed2622ad",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "yOFEyFOn4ab1u6vn75HvWxUhEyENRP1Y08thhRhOFoo",
+        "y": "rED7NhiIIZP8bRE3YOR2Rl30kGdICgp8_-aGUVszkag",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047ffe185a23eb5b736704387e6357628a65984985773b4473cf9ef560b3fa50514740cb1217f1ad2b5910d7f74906602b1f9550b3d11cff705b358c3bcbf72c3d",
+        "wx": "7ffe185a23eb5b736704387e6357628a65984985773b4473cf9ef560b3fa5051",
+        "wy": "4740cb1217f1ad2b5910d7f74906602b1f9550b3d11cff705b358c3bcbf72c3d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047ffe185a23eb5b736704387e6357628a65984985773b4473cf9ef560b3fa50514740cb1217f1ad2b5910d7f74906602b1f9550b3d11cff705b358c3bcbf72c3d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEf/4YWiPrW3NnBDh+Y1diimWYSYV3O0Rz\nz571YLP6UFFHQMsSF/GtK1kQ1/dJBmArH5VQs9Ec/3BbNYw7y/csPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 244,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcaad4e2b69a9f378dae7873b40f7c15cb4565fcc8cbc0ec55b0bd3fe9d8626b2c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "f_4YWiPrW3NnBDh-Y1diimWYSYV3O0Rzz571YLP6UFE",
+        "y": "R0DLEhfxrStZENf3SQZgKx-VULPRHP9wWzWMO8v3LD0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048a858226155e34dbb7e5dac7f13127c81c6ce8c9d891918c67c8738d7e4b46e96c1386e84c612312de53e9e4af34d9bd57f93d9a06b855b6e0b06ad4137ff57c",
+        "wx": "008a858226155e34dbb7e5dac7f13127c81c6ce8c9d891918c67c8738d7e4b46e9",
+        "wy": "6c1386e84c612312de53e9e4af34d9bd57f93d9a06b855b6e0b06ad4137ff57c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048a858226155e34dbb7e5dac7f13127c81c6ce8c9d891918c67c8738d7e4b46e96c1386e84c612312de53e9e4af34d9bd57f93d9a06b855b6e0b06ad4137ff57c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEioWCJhVeNNu35drH8TEnyBxs6MnYkZGM\nZ8hzjX5LRulsE4boTGEjEt5T6eSvNNm9V/k9mga4VbbgsGrUE3/1fA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 245,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc73fec4995e9d3140bc07ff041506dc7313e95389fb599d22f24039392a4014d3",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ioWCJhVeNNu35drH8TEnyBxs6MnYkZGMZ8hzjX5LRuk",
+        "y": "bBOG6ExhIxLeU-nkrzTZvVf5PZoGuFW24LBq1BN_9Xw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04aec0be729b02f266c542d139a3e04110c933e8eca1008e8dba38d75e7f8fab532cd688d924b456848bd5c651444c67a9399fdfb5b5b9693162c1728bfadc1046",
+        "wx": "00aec0be729b02f266c542d139a3e04110c933e8eca1008e8dba38d75e7f8fab53",
+        "wy": "2cd688d924b456848bd5c651444c67a9399fdfb5b5b9693162c1728bfadc1046"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004aec0be729b02f266c542d139a3e04110c933e8eca1008e8dba38d75e7f8fab532cd688d924b456848bd5c651444c67a9399fdfb5b5b9693162c1728bfadc1046",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErsC+cpsC8mbFQtE5o+BBEMkz6OyhAI6N\nujjXXn+Pq1Ms1ojZJLRWhIvVxlFETGepOZ/ftbW5aTFiwXKL+twQRg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 246,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcec4995e9d3140bc07ff041506dc73a73dc25f4257a911e310e38744b482a5a01",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "rsC-cpsC8mbFQtE5o-BBEMkz6OyhAI6NujjXXn-Pq1M",
+        "y": "LNaI2SS0VoSL1cZRRExnqTmf37W1uWkxYsFyi_rcEEY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0401ed4b5f941f443b31a7e2583ea165551d1815b54740deb12e9fdeff32e2306184385ca448cc5dd71139bda3ab42d0b6e44d719e52fff64d971876efa9109fb2",
+        "wx": "01ed4b5f941f443b31a7e2583ea165551d1815b54740deb12e9fdeff32e23061",
+        "wy": "0084385ca448cc5dd71139bda3ab42d0b6e44d719e52fff64d971876efa9109fb2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000401ed4b5f941f443b31a7e2583ea165551d1815b54740deb12e9fdeff32e2306184385ca448cc5dd71139bda3ab42d0b6e44d719e52fff64d971876efa9109fb2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAe1LX5QfRDsxp+JYPqFlVR0YFbVHQN6x\nLp/e/zLiMGGEOFykSMxd1xE5vaOrQtC25E1xnlL/9k2XGHbvqRCfsg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 247,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcd8932bd3a6281780ffe082a0db8e74e8fd9d0b6445d99c265c9e8a09c01e72c1",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Ae1LX5QfRDsxp-JYPqFlVR0YFbVHQN6xLp_e_zLiMGE",
+        "y": "hDhcpEjMXdcROb2jq0LQtuRNcZ5S__ZNlxh276kQn7I",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0459c427cb6525eab511a06e03e00cf2aab4abc587c2601534338a50bc25701a703e4eb388b453cbaea594d6b5c14a519ac3fda770c53580beefc68f09200d55ff",
+        "wx": "59c427cb6525eab511a06e03e00cf2aab4abc587c2601534338a50bc25701a70",
+        "wy": "3e4eb388b453cbaea594d6b5c14a519ac3fda770c53580beefc68f09200d55ff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000459c427cb6525eab511a06e03e00cf2aab4abc587c2601534338a50bc25701a703e4eb388b453cbaea594d6b5c14a519ac3fda770c53580beefc68f09200d55ff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEWcQny2Ul6rURoG4D4AzyqrSrxYfCYBU0\nM4pQvCVwGnA+TrOItFPLrqWU1rXBSlGaw/2ncMU1gL7vxo8JIA1V/w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 248,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc5e9d3140bc07ff041506dc73a75086a3ba176f06c2b6e37363e2ce1c141f3c27",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "WcQny2Ul6rURoG4D4AzyqrSrxYfCYBU0M4pQvCVwGnA",
+        "y": "Pk6ziLRTy66llNa1wUpRmsP9p3DFNYC-78aPCSANVf8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0404acbbcd23cf2ec819fd297ab2cb5407ede6319518651a391e941cc8003568331206dd00df23bc8ce0b85a018c4b34e9c3b41b4ef59c71492fa62d134772f97e",
+        "wx": "04acbbcd23cf2ec819fd297ab2cb5407ede6319518651a391e941cc800356833",
+        "wy": "1206dd00df23bc8ce0b85a018c4b34e9c3b41b4ef59c71492fa62d134772f97e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000404acbbcd23cf2ec819fd297ab2cb5407ede6319518651a391e941cc8003568331206dd00df23bc8ce0b85a018c4b34e9c3b41b4ef59c71492fa62d134772f97e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEBKy7zSPPLsgZ/Sl6sstUB+3mMZUYZRo5\nHpQcyAA1aDMSBt0A3yO8jOC4WgGMSzTpw7QbTvWccUkvpi0TR3L5fg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 249,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcfd6dc71a71f1d50d1bbd976af4357be4dd2fe850707c431fd376e53d176c6b62",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "BKy7zSPPLsgZ_Sl6sstUB-3mMZUYZRo5HpQcyAA1aDM",
+        "y": "EgbdAN8jvIzguFoBjEs06cO0G071nHFJL6YtE0dy-X4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ccacbc626fd6ea31175815cff958ca1637323877d3bdf09896b527bf4e255e8571f8a27e6309bd9b9b15d78d5270012ad2ed15a7fffe024fc0eca63fb6ac2f8d",
+        "wx": "00ccacbc626fd6ea31175815cff958ca1637323877d3bdf09896b527bf4e255e85",
+        "wy": "71f8a27e6309bd9b9b15d78d5270012ad2ed15a7fffe024fc0eca63fb6ac2f8d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ccacbc626fd6ea31175815cff958ca1637323877d3bdf09896b527bf4e255e8571f8a27e6309bd9b9b15d78d5270012ad2ed15a7fffe024fc0eca63fb6ac2f8d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzKy8Ym/W6jEXWBXP+VjKFjcyOHfTvfCY\nlrUnv04lXoVx+KJ+Ywm9m5sV141ScAEq0u0Vp//+Ak/A7KY/tqwvjQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 250,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc7ee75ad2a5801c54722eb7d95ba67febcfc399b956b7b682fe89638de3690bf1",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "zKy8Ym_W6jEXWBXP-VjKFjcyOHfTvfCYlrUnv04lXoU",
+        "y": "cfiifmMJvZubFdeNUnABKtLtFaf__gJPwOymP7asL40",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ccc30b65cad3dd1d793b6db80f57b2e1237973e4264c3d9bbc2551ec68a0b7be75ff6d1f4f535a131aa573f6e2d6912c397154933750417d28e46524392592de",
+        "wx": "00ccc30b65cad3dd1d793b6db80f57b2e1237973e4264c3d9bbc2551ec68a0b7be",
+        "wy": "75ff6d1f4f535a131aa573f6e2d6912c397154933750417d28e46524392592de"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ccc30b65cad3dd1d793b6db80f57b2e1237973e4264c3d9bbc2551ec68a0b7be75ff6d1f4f535a131aa573f6e2d6912c397154933750417d28e46524392592de",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzMMLZcrT3R15O224D1ey4SN5c+QmTD2b\nvCVR7Gigt751/20fT1NaExqlc/bi1pEsOXFUkzdQQX0o5GUkOSWS3g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 251,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcf533776f11c47ed0a7b5e25ace7a3b921866733c7454b2c678b8943dfb4cf232",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "zMMLZcrT3R15O224D1ey4SN5c-QmTD2bvCVR7Gigt74",
+        "y": "df9tH09TWhMapXP24taRLDlxVJM3UEF9KORlJDklkt4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cc9349aca0cbd0b2df0deecd88ed39e6d8c7c3d7b422fd5d92431baf7225fcc0ed494be698d6f3850be277c268792400f396025cfa95cf56018bcbc243e512eb",
+        "wx": "00cc9349aca0cbd0b2df0deecd88ed39e6d8c7c3d7b422fd5d92431baf7225fcc0",
+        "wy": "00ed494be698d6f3850be277c268792400f396025cfa95cf56018bcbc243e512eb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cc9349aca0cbd0b2df0deecd88ed39e6d8c7c3d7b422fd5d92431baf7225fcc0ed494be698d6f3850be277c268792400f396025cfa95cf56018bcbc243e512eb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzJNJrKDL0LLfDe7NiO055tjHw9e0Iv1d\nkkMbr3Il/MDtSUvmmNbzhQvid8JoeSQA85YCXPqVz1YBi8vCQ+US6w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 252,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffce8dbffee01807d75f9aa52c295e15b15f138439e7a195a40709b1abf511dbc6a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "zJNJrKDL0LLfDe7NiO055tjHw9e0Iv1dkkMbr3Il_MA",
+        "y": "7UlL5pjW84UL4nfCaHkkAPOWAlz6lc9WAYvLwkPlEus",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04000e7c30d2f259f7c13f194320e43905d0ead7277e283e8918437c10f9d052b02b39b66dbba2b1cf5dac1b41d2dec6f1fb08bdd14d420d703986f63aedeb5c47",
+        "wx": "0e7c30d2f259f7c13f194320e43905d0ead7277e283e8918437c10f9d052b0",
+        "wy": "2b39b66dbba2b1cf5dac1b41d2dec6f1fb08bdd14d420d703986f63aedeb5c47"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004000e7c30d2f259f7c13f194320e43905d0ead7277e283e8918437c10f9d052b02b39b66dbba2b1cf5dac1b41d2dec6f1fb08bdd14d420d703986f63aedeb5c47",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAA58MNLyWffBPxlDIOQ5BdDq1yd+KD6J\nGEN8EPnQUrArObZtu6Kxz12sG0HS3sbx+wi90U1CDXA5hvY67etcRw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 253,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcca01552b58d67a13468d6bc6086329df8f44cc938884fcf15c516b02a7a7b5f6",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AA58MNLyWffBPxlDIOQ5BdDq1yd-KD6JGEN8EPnQUrA",
+        "y": "Kzm2bbuisc9drBtB0t7G8fsIvdFNQg1wOYb2Ou3rXEc",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048fa298c00ac93f7c36892c5299005a0f6843f9cf0669fdbb7d6d81e0341803ed4cab33cc2821b2da849f90ef20dc1eb896fc67161440b3c52c0b1e88627e508c",
+        "wx": "008fa298c00ac93f7c36892c5299005a0f6843f9cf0669fdbb7d6d81e0341803ed",
+        "wy": "4cab33cc2821b2da849f90ef20dc1eb896fc67161440b3c52c0b1e88627e508c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048fa298c00ac93f7c36892c5299005a0f6843f9cf0669fdbb7d6d81e0341803ed4cab33cc2821b2da849f90ef20dc1eb896fc67161440b3c52c0b1e88627e508c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEj6KYwArJP3w2iSxSmQBaD2hD+c8Gaf27\nfW2B4DQYA+1MqzPMKCGy2oSfkO8g3B64lvxnFhRAs8UsCx6IYn5QjA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 254,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc9402aa56b1acf4268d1ad78c10c653c063dabc4061c159a6f8d077787f192aab",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "j6KYwArJP3w2iSxSmQBaD2hD-c8Gaf27fW2B4DQYA-0",
+        "y": "TKszzCghstqEn5DvINweuJb8ZxYUQLPFLAseiGJ-UIw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046fbf608a83e37ec26b37da033e069816680b770ba766fb8c44fce003960562f1045f268ccc5e0949213f7f2f1fa57cfead04625ec3ccfc9c333596e487b2056f",
+        "wx": "6fbf608a83e37ec26b37da033e069816680b770ba766fb8c44fce003960562f1",
+        "wy": "045f268ccc5e0949213f7f2f1fa57cfead04625ec3ccfc9c333596e487b2056f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046fbf608a83e37ec26b37da033e069816680b770ba766fb8c44fce003960562f1045f268ccc5e0949213f7f2f1fa57cfead04625ec3ccfc9c333596e487b2056f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEb79gioPjfsJrN9oDPgaYFmgLdwunZvuM\nRPzgA5YFYvEEXyaMzF4JSSE/fy8fpXz+rQRiXsPM/JwzNZbkh7IFbw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 255,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc5e03ff820a836e39d3a8435219297da13870abed3afdb65c954f83ee568a9f60",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "b79gioPjfsJrN9oDPgaYFmgLdwunZvuMRPzgA5YFYvE",
+        "y": "BF8mjMxeCUkhP38vH6V8_q0EYl7DzPycMzWW5IeyBW8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c4dd547ad750174179bac8b8ce27481c58b81347776220a1b52ada13d65c8124f9c2ef3b5b4957cf69d3a139891682363c040610f200f4c318e59aa68f298af0",
+        "wx": "00c4dd547ad750174179bac8b8ce27481c58b81347776220a1b52ada13d65c8124",
+        "wy": "00f9c2ef3b5b4957cf69d3a139891682363c040610f200f4c318e59aa68f298af0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c4dd547ad750174179bac8b8ce27481c58b81347776220a1b52ada13d65c8124f9c2ef3b5b4957cf69d3a139891682363c040610f200f4c318e59aa68f298af0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAExN1UetdQF0F5usi4zidIHFi4E0d3YiCh\ntSraE9ZcgST5wu87W0lXz2nToTmJFoI2PAQGEPIA9MMY5ZqmjymK8A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 256,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc556a715b4d4f9bc6d73c39da07be0ae5a2b2fe6465e0762ad85e9ff4ec313596",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "xN1UetdQF0F5usi4zidIHFi4E0d3YiChtSraE9ZcgSQ",
+        "y": "-cLvO1tJV89p06E5iRaCNjwEBhDyAPTDGOWapo8pivA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0400055d79fb26286bb6289a7983a2b23bf5c30cc3d70363b559adf5548af991f8cae8b1b0ace32fd74a86ee1a671cc36c052a4796eae323be32e02ce9a0fb6227",
+        "wx": "055d79fb26286bb6289a7983a2b23bf5c30cc3d70363b559adf5548af991f8",
+        "wy": "00cae8b1b0ace32fd74a86ee1a671cc36c052a4796eae323be32e02ce9a0fb6227"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000400055d79fb26286bb6289a7983a2b23bf5c30cc3d70363b559adf5548af991f8cae8b1b0ace32fd74a86ee1a671cc36c052a4796eae323be32e02ce9a0fb6227",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAAVdefsmKGu2KJp5g6KyO/XDDMPXA2O1\nWa31VIr5kfjK6LGwrOMv10qG7hpnHMNsBSpHlurjI74y4CzpoPtiJw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 257,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcd55555555555555555555555555555547c74934474db157d2a8c3f088aced62a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AAVdefsmKGu2KJp5g6KyO_XDDMPXA2O1Wa31VIr5kfg",
+        "y": "yuixsKzjL9dKhu4aZxzDbAUqR5bq4yO-MuAs6aD7Yic",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040db51c74d34e41baba67c13a60af404ee82d8f1b0386b09696ee1e6ea1327b86413886c4623fc222a6950c3c3a09f3fd867a566bfd345e06b09ec6c5c2e4a192",
+        "wx": "0db51c74d34e41baba67c13a60af404ee82d8f1b0386b09696ee1e6ea1327b86",
+        "wy": "413886c4623fc222a6950c3c3a09f3fd867a566bfd345e06b09ec6c5c2e4a192"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040db51c74d34e41baba67c13a60af404ee82d8f1b0386b09696ee1e6ea1327b86413886c4623fc222a6950c3c3a09f3fd867a566bfd345e06b09ec6c5c2e4a192",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEDbUcdNNOQbq6Z8E6YK9ATugtjxsDhrCW\nlu4ebqEye4ZBOIbEYj/CIqaVDDw6CfP9hnpWa/00XgawnsbFwuShkg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 258,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcc1777c8853938e536213c02464a936000ba1e21c0fc62075d46c624e23b52f31",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "DbUcdNNOQbq6Z8E6YK9ATugtjxsDhrCWlu4ebqEye4Y",
+        "y": "QTiGxGI_wiKmlQw8Ognz_YZ6Vmv9NF4GsJ7GxcLkoZI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bc2f7bc74cb3bc7e797b06cc3e649bf3407d1a55b4eaaddd28d3dcfaff2c3737a23bb364e16ac79398c013ce29a22e762c0d6067aaefda958474aad194a92e8a",
+        "wx": "00bc2f7bc74cb3bc7e797b06cc3e649bf3407d1a55b4eaaddd28d3dcfaff2c3737",
+        "wy": "00a23bb364e16ac79398c013ce29a22e762c0d6067aaefda958474aad194a92e8a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bc2f7bc74cb3bc7e797b06cc3e649bf3407d1a55b4eaaddd28d3dcfaff2c3737a23bb364e16ac79398c013ce29a22e762c0d6067aaefda958474aad194a92e8a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEvC97x0yzvH55ewbMPmSb80B9GlW06q3d\nKNPc+v8sNzeiO7Nk4WrHk5jAE84poi52LA1gZ6rv2pWEdKrRlKkuig==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 259,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc30bbb794db588363b40679f6c182a50d3ce9679acdd3ffbe36d7813dacbdc818",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "vC97x0yzvH55ewbMPmSb80B9GlW06q3dKNPc-v8sNzc",
+        "y": "ojuzZOFqx5OYwBPOKaIudiwNYGeq79qVhHSq0ZSpLoo",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d7edc7c645efff6af8821aea5b7f969f56ef6e615862b08fba3eaf0111c06f67e47fd0da61682adcc405f329148bf1c35b89cb5ec5a9ed0d98a410e261a6b41a",
+        "wx": "00d7edc7c645efff6af8821aea5b7f969f56ef6e615862b08fba3eaf0111c06f67",
+        "wy": "00e47fd0da61682adcc405f329148bf1c35b89cb5ec5a9ed0d98a410e261a6b41a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d7edc7c645efff6af8821aea5b7f969f56ef6e615862b08fba3eaf0111c06f67e47fd0da61682adcc405f329148bf1c35b89cb5ec5a9ed0d98a410e261a6b41a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE1+3HxkXv/2r4ghrqW3+Wn1bvbmFYYrCP\nuj6vARHAb2fkf9DaYWgq3MQF8ykUi/HDW4nLXsWp7Q2YpBDiYaa0Gg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 260,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2c37fd995622c4fb7fffffffffffffffc7cee745110cb45ab558ed7c90c15a2f",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "1-3HxkXv_2r4ghrqW3-Wn1bvbmFYYrCPuj6vARHAb2c",
+        "y": "5H_Q2mFoKtzEBfMpFIvxw1uJy17Fqe0NmKQQ4mGmtBo",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046bfd7ad01b5dcfb04de464083d3ca7ef5054506111df92ef02ff7690d9a6ec9306c469fe4c5a1e04f114e193b4bb197de2c8e35089037e5a20275bcf67d9bf73",
+        "wx": "6bfd7ad01b5dcfb04de464083d3ca7ef5054506111df92ef02ff7690d9a6ec93",
+        "wy": "06c469fe4c5a1e04f114e193b4bb197de2c8e35089037e5a20275bcf67d9bf73"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046bfd7ad01b5dcfb04de464083d3ca7ef5054506111df92ef02ff7690d9a6ec9306c469fe4c5a1e04f114e193b4bb197de2c8e35089037e5a20275bcf67d9bf73",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEa/160Btdz7BN5GQIPTyn71BUUGER35Lv\nAv92kNmm7JMGxGn+TFoeBPEU4ZO0uxl94sjjUIkDflogJ1vPZ9m/cw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 261,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc7fd995622c4fb7ffffffffffffffffff5d883ffab5b32652ccdcaa290fccb97d",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "a_160Btdz7BN5GQIPTyn71BUUGER35LvAv92kNmm7JM",
+        "y": "BsRp_kxaHgTxFOGTtLsZfeLI41CJA35aICdbz2fZv3M",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048a9076c923021d5c5ef85894176ebb5c3a74aba75b3944c96f17debc2173ba99e5601d115bf08d37ae115c4d186bc21127bbfb21d0629bde27a16e9ed721b740",
+        "wx": "008a9076c923021d5c5ef85894176ebb5c3a74aba75b3944c96f17debc2173ba99",
+        "wy": "00e5601d115bf08d37ae115c4d186bc21127bbfb21d0629bde27a16e9ed721b740"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048a9076c923021d5c5ef85894176ebb5c3a74aba75b3944c96f17debc2173ba99e5601d115bf08d37ae115c4d186bc21127bbfb21d0629bde27a16e9ed721b740",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEipB2ySMCHVxe+FiUF267XDp0q6dbOUTJ\nbxfevCFzupnlYB0RW/CNN64RXE0Ya8IRJ7v7IdBim94noW6e1yG3QA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 262,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcffb32ac4589f6ffffffffffffffffffebb107ff56b664ca599b954521f9972fa",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ipB2ySMCHVxe-FiUF267XDp0q6dbOUTJbxfevCFzupk",
+        "y": "5WAdEVvwjTeuEVxNGGvCESe7-yHQYpveJ6Funtcht0A",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040fec6a85e077ef4240b98c62ab3b93e2cebcad0ae9617f7b0471504db1f45a65245a5fd0ad7a6d854125ed76d4787f77cc1983eca8c6ba8c019523a088c4d0f3",
+        "wx": "0fec6a85e077ef4240b98c62ab3b93e2cebcad0ae9617f7b0471504db1f45a65",
+        "wy": "245a5fd0ad7a6d854125ed76d4787f77cc1983eca8c6ba8c019523a088c4d0f3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040fec6a85e077ef4240b98c62ab3b93e2cebcad0ae9617f7b0471504db1f45a65245a5fd0ad7a6d854125ed76d4787f77cc1983eca8c6ba8c019523a088c4d0f3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAED+xqheB370JAuYxiqzuT4s68rQrpYX97\nBHFQTbH0WmUkWl/QrXpthUEl7XbUeH93zBmD7KjGuowBlSOgiMTQ8w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 263,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc5622c4fb7fffffffffffffffffffffff928a8f1c7ac7bec1808b9f61c01ec327",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "D-xqheB370JAuYxiqzuT4s68rQrpYX97BHFQTbH0WmU",
+        "y": "JFpf0K16bYVBJe121Hh_d8wZg-yoxrqMAZUjoIjE0PM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d3ab94d8704fb51774dcc3838ad9703071e0851de9b2d6ca74ccd79b855581914e4979b67f377419e5a9d4f03012b7e75656556f23756d4dbee145834c8279ef",
+        "wx": "00d3ab94d8704fb51774dcc3838ad9703071e0851de9b2d6ca74ccd79b85558191",
+        "wy": "4e4979b67f377419e5a9d4f03012b7e75656556f23756d4dbee145834c8279ef"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d3ab94d8704fb51774dcc3838ad9703071e0851de9b2d6ca74ccd79b855581914e4979b67f377419e5a9d4f03012b7e75656556f23756d4dbee145834c8279ef",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE06uU2HBPtRd03MODitlwMHHghR3pstbK\ndMzXm4VVgZFOSXm2fzd0GeWp1PAwErfnVlZVbyN1bU2+4UWDTIJ57w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 264,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc44104104104104104104104104104103b87853fd3b7d3f8e175125b4382f25ed",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "06uU2HBPtRd03MODitlwMHHghR3pstbKdMzXm4VVgZE",
+        "y": "Tkl5tn83dBnlqdTwMBK351ZWVW8jdW1NvuFFg0yCee8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0449e13cd44c8b8350a5eaca2181bf96db120b768bde8800f379f43e9198333c75030ad9fb4b0b233bdc10ca0dc4c2134b18b691e46c7151e3573aa2b62891e69d",
+        "wx": "49e13cd44c8b8350a5eaca2181bf96db120b768bde8800f379f43e9198333c75",
+        "wy": "030ad9fb4b0b233bdc10ca0dc4c2134b18b691e46c7151e3573aa2b62891e69d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000449e13cd44c8b8350a5eaca2181bf96db120b768bde8800f379f43e9198333c75030ad9fb4b0b233bdc10ca0dc4c2134b18b691e46c7151e3573aa2b62891e69d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESeE81EyLg1Cl6sohgb+W2xILdoveiADz\nefQ+kZgzPHUDCtn7SwsjO9wQyg3EwhNLGLaR5GxxUeNXOqK2KJHmnQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 265,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2739ce739ce739ce739ce739ce739ce705560298d1f2f08dc419ac273a5b54d9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "SeE81EyLg1Cl6sohgb-W2xILdoveiADzefQ-kZgzPHU",
+        "y": "AwrZ-0sLIzvcEMoNxMITSxi2keRscVHjVzqitiiR5p0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044574fd94ad03828588cb0bc2d434842ee093efe639015cc107d1ea3710f2112d1786d6ef1d411cbd1af5b5ee8845993e738fb64519b4329d04be21f7902a1c1d",
+        "wx": "4574fd94ad03828588cb0bc2d434842ee093efe639015cc107d1ea3710f2112d",
+        "wy": "1786d6ef1d411cbd1af5b5ee8845993e738fb64519b4329d04be21f7902a1c1d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044574fd94ad03828588cb0bc2d434842ee093efe639015cc107d1ea3710f2112d1786d6ef1d411cbd1af5b5ee8845993e738fb64519b4329d04be21f7902a1c1d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAERXT9lK0DgoWIywvC1DSELuCT7+Y5AVzB\nB9HqNxDyES0XhtbvHUEcvRr1te6IRZk+c4+2RRm0Mp0EviH3kCocHQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 266,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcb777777777777777777777777777777688e6a1fe808a97a348671222ff16b863",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "RXT9lK0DgoWIywvC1DSELuCT7-Y5AVzBB9HqNxDyES0",
+        "y": "F4bW7x1BHL0a9bXuiEWZPnOPtkUZtDKdBL4h95AqHB0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ee824d818768f13fa0eb908e396ea1c56b11774ce69d01e563aa36bb41d6371c990291ce2abc55bb6682d502ae0129e7c57e146e96d44757daaa1f94c93e0b17",
+        "wx": "00ee824d818768f13fa0eb908e396ea1c56b11774ce69d01e563aa36bb41d6371c",
+        "wy": "00990291ce2abc55bb6682d502ae0129e7c57e146e96d44757daaa1f94c93e0b17"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ee824d818768f13fa0eb908e396ea1c56b11774ce69d01e563aa36bb41d6371c990291ce2abc55bb6682d502ae0129e7c57e146e96d44757daaa1f94c93e0b17",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7oJNgYdo8T+g65COOW6hxWsRd0zmnQHl\nY6o2u0HWNxyZApHOKrxVu2aC1QKuASnnxX4UbpbUR1faqh+UyT4LFw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 267,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc6492492492492492492492492492492406dd3a19b8d5fb875235963c593bd2d3",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "7oJNgYdo8T-g65COOW6hxWsRd0zmnQHlY6o2u0HWNxw",
+        "y": "mQKRziq8VbtmgtUCrgEp58V-FG6W1EdX2qoflMk-Cxc",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044825ee46b2d21564726a32a922f5e3f2da6098f780e1f15c6bf1640669c41fe7292c066a24f0f450c2603f1837210898f8e80fa384aaf077eb5c7e87c6b26976",
+        "wx": "4825ee46b2d21564726a32a922f5e3f2da6098f780e1f15c6bf1640669c41fe7",
+        "wy": "292c066a24f0f450c2603f1837210898f8e80fa384aaf077eb5c7e87c6b26976"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044825ee46b2d21564726a32a922f5e3f2da6098f780e1f15c6bf1640669c41fe7292c066a24f0f450c2603f1837210898f8e80fa384aaf077eb5c7e87c6b26976",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESCXuRrLSFWRyajKpIvXj8tpgmPeA4fFc\na/FkBmnEH+cpLAZqJPD0UMJgPxg3IQiY+OgPo4Sq8HfrXH6HxrJpdg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 268,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc955555555555555555555555555555547c74934474db157d2a8c3f088aced62c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "SCXuRrLSFWRyajKpIvXj8tpgmPeA4fFca_FkBmnEH-c",
+        "y": "KSwGaiTw9FDCYD8YNyEImPjoD6OEqvB361x-h8ayaXY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0441348e7ac18eb1f4852801467bb0a0e36209321a8af4b410fd06f070a81f5de603b5594f1a5a79d23089e49e3e379f2a6cb14f92301c6999e510b8c8dc37fb4b",
+        "wx": "41348e7ac18eb1f4852801467bb0a0e36209321a8af4b410fd06f070a81f5de6",
+        "wy": "03b5594f1a5a79d23089e49e3e379f2a6cb14f92301c6999e510b8c8dc37fb4b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000441348e7ac18eb1f4852801467bb0a0e36209321a8af4b410fd06f070a81f5de603b5594f1a5a79d23089e49e3e379f2a6cb14f92301c6999e510b8c8dc37fb4b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQTSOesGOsfSFKAFGe7Cg42IJMhqK9LQQ\n/QbwcKgfXeYDtVlPGlp50jCJ5J4+N58qbLFPkjAcaZnlELjI3Df7Sw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 269,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3e3a49a23a6d8abe95461f8445676b17",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "QTSOesGOsfSFKAFGe7Cg42IJMhqK9LQQ_QbwcKgfXeY",
+        "y": "A7VZTxpaedIwieSePjefKmyxT5IwHGmZ5RC4yNw3-0s",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04753c74e5a36e1a4b61be7787202c98e05841fea2b0392b6ab69ee2e8a747e2b618971da1c85825c1d8141886115d27cb2add86545e6971bb835a2f452cde1e52",
+        "wx": "753c74e5a36e1a4b61be7787202c98e05841fea2b0392b6ab69ee2e8a747e2b6",
+        "wy": "18971da1c85825c1d8141886115d27cb2add86545e6971bb835a2f452cde1e52"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004753c74e5a36e1a4b61be7787202c98e05841fea2b0392b6ab69ee2e8a747e2b618971da1c85825c1d8141886115d27cb2add86545e6971bb835a2f452cde1e52",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEdTx05aNuGkthvneHICyY4FhB/qKwOStq\ntp7i6KdH4rYYlx2hyFglwdgUGIYRXSfLKt2GVF5pcbuDWi9FLN4eUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 270,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcbffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "dTx05aNuGkthvneHICyY4FhB_qKwOStqtp7i6KdH4rY",
+        "y": "GJcdochYJcHYFBiGEV0nyyrdhlReaXG7g1ovRSzeHlI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0449c0254724576b0949827ce46240d90cb4075cd1978a416495a455f06a895504df7d64c35853353bd4d905da6adb88f26e62a5f20b3cd6382adf2c5a42d85053",
+        "wx": "49c0254724576b0949827ce46240d90cb4075cd1978a416495a455f06a895504",
+        "wy": "00df7d64c35853353bd4d905da6adb88f26e62a5f20b3cd6382adf2c5a42d85053"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000449c0254724576b0949827ce46240d90cb4075cd1978a416495a455f06a895504df7d64c35853353bd4d905da6adb88f26e62a5f20b3cd6382adf2c5a42d85053",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEScAlRyRXawlJgnzkYkDZDLQHXNGXikFk\nlaRV8GqJVQTffWTDWFM1O9TZBdpq24jybmKl8gs81jgq3yxaQthQUw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 271,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc185ddbca6dac41b1da033cfb60c152869e74b3cd66e9ffdf1b6bc09ed65ee40c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ScAlRyRXawlJgnzkYkDZDLQHXNGXikFklaRV8GqJVQQ",
+        "y": "331kw1hTNTvU2QXaatuI8m5ipfILPNY4Kt8sWkLYUFM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb1871d7415d5f6c57c840678f7e1a1c1e323519a4647fb3f6f52abb4647b9b6d70",
+        "wx": "00b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb1",
+        "wy": "00871d7415d5f6c57c840678f7e1a1c1e323519a4647fb3f6f52abb4647b9b6d70"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb1871d7415d5f6c57c840678f7e1a1c1e323519a4647fb3f6f52abb4647b9b6d70",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsF6Y6E4sGXQ8Hc9ODd8LsfMoVAM95j/P\nPmBfuy7ZTLGHHXQV1fbFfIQGePfhocHjI1GaRkf7P29Sq7Rke5ttcA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 272,
+          "comment": "point duplication during verification",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "32b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda6fd848306e968e3ac1f6e443577c47a3c20bf0d01a5dc39c78c2c69d681850f4",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "sF6Y6E4sGXQ8Hc9ODd8LsfMoVAM95j_PPmBfuy7ZTLE",
+        "y": "hx10FdX2xXyEBnj34aHB4yNRmkZH-z9vUqu0ZHubbXA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb178e28bea2a093a837bf987081e5e3e1cdcae65b9b804c090ad544b9a84648ebf",
+        "wx": "00b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb1",
+        "wy": "78e28bea2a093a837bf987081e5e3e1cdcae65b9b804c090ad544b9a84648ebf"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb178e28bea2a093a837bf987081e5e3e1cdcae65b9b804c090ad544b9a84648ebf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsF6Y6E4sGXQ8Hc9ODd8LsfMoVAM95j/P\nPmBfuy7ZTLF44ovqKgk6g3v5hwgeXj4c3K5lubgEwJCtVEuahGSOvw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 273,
+          "comment": "duplication bug",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "32b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda6fd848306e968e3ac1f6e443577c47a3c20bf0d01a5dc39c78c2c69d681850f4",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "sF6Y6E4sGXQ8Hc9ODd8LsfMoVAM95j_PPmBfuy7ZTLE",
+        "y": "eOKL6ioJOoN7-YcIHl4-HNyuZbm4BMCQrVRLmoRkjr8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a49f9ebc082c064d61c0eab5f8bf23207b06e3a689dfc4fa2896ed114d1a88ab55783a6baf9401977d117ccb748c0d5c24a5d3bd2133d62c74de2be7cc7d9d40",
+        "wx": "00a49f9ebc082c064d61c0eab5f8bf23207b06e3a689dfc4fa2896ed114d1a88ab",
+        "wy": "55783a6baf9401977d117ccb748c0d5c24a5d3bd2133d62c74de2be7cc7d9d40"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a49f9ebc082c064d61c0eab5f8bf23207b06e3a689dfc4fa2896ed114d1a88ab55783a6baf9401977d117ccb748c0d5c24a5d3bd2133d62c74de2be7cc7d9d40",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpJ+evAgsBk1hwOq1+L8jIHsG46aJ38T6\nKJbtEU0aiKtVeDprr5QBl30RfMt0jA1cJKXTvSEz1ix03ivnzH2dQA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 274,
+          "comment": "comparison with point at infinity ",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c033333333333333333333333333333332f222f8faefdb533f265d461c29a47373",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "pJ-evAgsBk1hwOq1-L8jIHsG46aJ38T6KJbtEU0aiKs",
+        "y": "VXg6a6-UAZd9EXzLdIwNXCSl070hM9YsdN4r58x9nUA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f9567a431b716388428510393b37feefd3afcfc6dc3881f623c0a0995e461ec3fba2f910ced19f8e789b158390a295e636c588c622d54f8feffbd2852e2911a9",
+        "wx": "00f9567a431b716388428510393b37feefd3afcfc6dc3881f623c0a0995e461ec3",
+        "wy": "00fba2f910ced19f8e789b158390a295e636c588c622d54f8feffbd2852e2911a9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f9567a431b716388428510393b37feefd3afcfc6dc3881f623c0a0995e461ec3fba2f910ced19f8e789b158390a295e636c588c622d54f8feffbd2852e2911a9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+VZ6QxtxY4hChRA5Ozf+79Ovz8bcOIH2\nI8CgmV5GHsP7ovkQztGfjnibFYOQopXmNsWIxiLVT4/v+9KFLikRqQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 275,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee555555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "-VZ6QxtxY4hChRA5Ozf-79Ovz8bcOIH2I8CgmV5GHsM",
+        "y": "-6L5EM7Rn454mxWDkKKV5jbFiMYi1U-P7_vShS4pEak",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0426095ef93b10bf50fe283f4c99136fb81fa297814f09977e8e38a3bfb837f61baf8d7cfc46c1928624f201ed14a70701bc5531bff4e2e578d5c92dabddbc7580",
+        "wx": "26095ef93b10bf50fe283f4c99136fb81fa297814f09977e8e38a3bfb837f61b",
+        "wy": "00af8d7cfc46c1928624f201ed14a70701bc5531bff4e2e578d5c92dabddbc7580"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000426095ef93b10bf50fe283f4c99136fb81fa297814f09977e8e38a3bfb837f61baf8d7cfc46c1928624f201ed14a70701bc5531bff4e2e578d5c92dabddbc7580",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJgle+TsQv1D+KD9MmRNvuB+il4FPCZd+\njjijv7g39huvjXz8RsGShiTyAe0UpwcBvFUxv/Ti5XjVyS2r3bx1gA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 276,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Jgle-TsQv1D-KD9MmRNvuB-il4FPCZd-jjijv7g39hs",
+        "y": "r418_EbBkoYk8gHtFKcHAbxVMb_04uV41cktq928dYA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047a4b58ee76d461a1c3cde68400a0bbeeab346ee69315bed63f1700c66cf5e6cca642ae4078bb6bbbb76028977882e9c8374f267a2ced131029ae89560ce29825",
+        "wx": "7a4b58ee76d461a1c3cde68400a0bbeeab346ee69315bed63f1700c66cf5e6cc",
+        "wy": "00a642ae4078bb6bbbb76028977882e9c8374f267a2ced131029ae89560ce29825"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047a4b58ee76d461a1c3cde68400a0bbeeab346ee69315bed63f1700c66cf5e6cca642ae4078bb6bbbb76028977882e9c8374f267a2ced131029ae89560ce29825",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEektY7nbUYaHDzeaEAKC77qs0buaTFb7W\nPxcAxmz15symQq5AeLtru7dgKJd4gunIN08meiztExAprolWDOKYJQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 277,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee599999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ektY7nbUYaHDzeaEAKC77qs0buaTFb7WPxcAxmz15sw",
+        "y": "pkKuQHi7a7u3YCiXeILpyDdPJnos7RMQKa6JVgzimCU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f2a111eb24c9d280d9a66e4ff18681d222dd6a1828ebc4528f2bebe3e25228a1a0699bcec507fd0ec83da541a5a6143e2e68e4af72fcdcc8a2aea2b17478cc8a",
+        "wx": "00f2a111eb24c9d280d9a66e4ff18681d222dd6a1828ebc4528f2bebe3e25228a1",
+        "wy": "00a0699bcec507fd0ec83da541a5a6143e2e68e4af72fcdcc8a2aea2b17478cc8a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f2a111eb24c9d280d9a66e4ff18681d222dd6a1828ebc4528f2bebe3e25228a1a0699bcec507fd0ec83da541a5a6143e2e68e4af72fcdcc8a2aea2b17478cc8a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE8qER6yTJ0oDZpm5P8YaB0iLdahgo68RS\njyvr4+JSKKGgaZvOxQf9Dsg9pUGlphQ+Lmjkr3L83MiirqKxdHjMig==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 278,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee566666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "8qER6yTJ0oDZpm5P8YaB0iLdahgo68RSjyvr4-JSKKE",
+        "y": "oGmbzsUH_Q7IPaVBpaYUPi5o5K9y_NzIoq6isXR4zIo",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e50054b3e4a4d1fef988e5a5e830155abc293fea3598af4c5ddaa10acd111274eb710d1834568cb379a1d1f3d691a8c0dc19f901fe3225c2b6691df5ef5333fe",
+        "wx": "00e50054b3e4a4d1fef988e5a5e830155abc293fea3598af4c5ddaa10acd111274",
+        "wy": "00eb710d1834568cb379a1d1f3d691a8c0dc19f901fe3225c2b6691df5ef5333fe"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e50054b3e4a4d1fef988e5a5e830155abc293fea3598af4c5ddaa10acd111274eb710d1834568cb379a1d1f3d691a8c0dc19f901fe3225c2b6691df5ef5333fe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5QBUs+Sk0f75iOWl6DAVWrwpP+o1mK9M\nXdqhCs0REnTrcQ0YNFaMs3mh0fPWkajA3Bn5Af4yJcK2aR3171Mz/g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 279,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee549249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "5QBUs-Sk0f75iOWl6DAVWrwpP-o1mK9MXdqhCs0REnQ",
+        "y": "63ENGDRWjLN5odHz1pGowNwZ-QH-MiXCtmkd9e9TM_4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04edc17cd4ca6f9988fda5af4042e3f9eb42d0f7b6a1c0156e1a2af566b78103548a5d357777b306e96405f12e2617c1b29e8d574e5f6d66d1bc8ff7ea7c4b683c",
+        "wx": "00edc17cd4ca6f9988fda5af4042e3f9eb42d0f7b6a1c0156e1a2af566b7810354",
+        "wy": "008a5d357777b306e96405f12e2617c1b29e8d574e5f6d66d1bc8ff7ea7c4b683c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004edc17cd4ca6f9988fda5af4042e3f9eb42d0f7b6a1c0156e1a2af566b78103548a5d357777b306e96405f12e2617c1b29e8d574e5f6d66d1bc8ff7ea7c4b683c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7cF81MpvmYj9pa9AQuP560LQ97ahwBVu\nGir1ZreBA1SKXTV3d7MG6WQF8S4mF8Gyno1XTl9tZtG8j/fqfEtoPA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 280,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee50eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "7cF81MpvmYj9pa9AQuP560LQ97ahwBVuGir1ZreBA1Q",
+        "y": "il01d3ezBulkBfEuJhfBsp6NV05fbWbRvI_36nxLaDw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d267c10d2315b42dbaf34c97c3c0d331fabacaf6021df4dc85b3e9e63dc0798ed154b11fa3a5ed952c14d8a2dd242de2b6cce3c22df42cd97de30054a19555e",
+        "wx": "6d267c10d2315b42dbaf34c97c3c0d331fabacaf6021df4dc85b3e9e63dc0798",
+        "wy": "00ed154b11fa3a5ed952c14d8a2dd242de2b6cce3c22df42cd97de30054a19555e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d267c10d2315b42dbaf34c97c3c0d331fabacaf6021df4dc85b3e9e63dc0798ed154b11fa3a5ed952c14d8a2dd242de2b6cce3c22df42cd97de30054a19555e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbSZ8ENIxW0LbrzTJfDwNMx+rrK9gId9N\nyFs+nmPcB5jtFUsR+jpe2VLBTYot0kLeK2zOPCLfQs2X3jAFShlVXg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 281,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179855555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "bSZ8ENIxW0LbrzTJfDwNMx-rrK9gId9NyFs-nmPcB5g",
+        "y": "7RVLEfo6XtlSwU2KLdJC3itszjwi30LNl94wBUoZVV4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c24bf7a984c96ece10077a9def38cbd0d898abd555f1668e06c27cabc00f6f679f69b238e1f95e99e5b558e0036273ebd6c36d12b4515348b85a21f6283f5016",
+        "wx": "00c24bf7a984c96ece10077a9def38cbd0d898abd555f1668e06c27cabc00f6f67",
+        "wy": "009f69b238e1f95e99e5b558e0036273ebd6c36d12b4515348b85a21f6283f5016"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c24bf7a984c96ece10077a9def38cbd0d898abd555f1668e06c27cabc00f6f679f69b238e1f95e99e5b558e0036273ebd6c36d12b4515348b85a21f6283f5016",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEwkv3qYTJbs4QB3qd7zjL0NiYq9VV8WaO\nBsJ8q8APb2efabI44flemeW1WOADYnPr1sNtErRRU0i4WiH2KD9QFg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 282,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "wkv3qYTJbs4QB3qd7zjL0NiYq9VV8WaOBsJ8q8APb2c",
+        "y": "n2myOOH5XpnltVjgA2Jz69bDbRK0UVNIuFoh9ig_UBY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041cd26d668807c815ed3f532c1db81ac473fb368f0f7ef1aff2592ea6fa6c4624a229b9ab5746cfbc47280c019a4248545354ca20880ff41cac2e252bc9b49704",
+        "wx": "1cd26d668807c815ed3f532c1db81ac473fb368f0f7ef1aff2592ea6fa6c4624",
+        "wy": "00a229b9ab5746cfbc47280c019a4248545354ca20880ff41cac2e252bc9b49704"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041cd26d668807c815ed3f532c1db81ac473fb368f0f7ef1aff2592ea6fa6c4624a229b9ab5746cfbc47280c019a4248545354ca20880ff41cac2e252bc9b49704",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHNJtZogHyBXtP1MsHbgaxHP7No8PfvGv\n8lkupvpsRiSiKbmrV0bPvEcoDAGaQkhUU1TKIIgP9BysLiUrybSXBA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 283,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179899999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "HNJtZogHyBXtP1MsHbgaxHP7No8PfvGv8lkupvpsRiQ",
+        "y": "oim5q1dGz7xHKAwBmkJIVFNUyiCID_QcrC4lK8m0lwQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fc780777a3289af663fa02b1c262a8373b84614e659c1ab46942f1e058926ff82196c6bcae0b2798298d463be5c87924343d7f103a27131e0c7f4d60d2b5da8c",
+        "wx": "00fc780777a3289af663fa02b1c262a8373b84614e659c1ab46942f1e058926ff8",
+        "wy": "2196c6bcae0b2798298d463be5c87924343d7f103a27131e0c7f4d60d2b5da8c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fc780777a3289af663fa02b1c262a8373b84614e659c1ab46942f1e058926ff82196c6bcae0b2798298d463be5c87924343d7f103a27131e0c7f4d60d2b5da8c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE/HgHd6MomvZj+gKxwmKoNzuEYU5lnBq0\naULx4FiSb/ghlsa8rgsnmCmNRjvlyHkkND1/EDonEx4Mf01g0rXajA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 284,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179866666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "_HgHd6MomvZj-gKxwmKoNzuEYU5lnBq0aULx4FiSb_g",
+        "y": "IZbGvK4LJ5gpjUY75ch5JDQ9fxA6JxMeDH9NYNK12ow",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045e25e2ee8af5ef8a3e0908341f9884501fb58a2fd234b1db6f22d561025524f4491d97a7793c9d9a1f35bb35f12121b9dbe075d8501cbd4db6697e3e0ad98bc0",
+        "wx": "5e25e2ee8af5ef8a3e0908341f9884501fb58a2fd234b1db6f22d561025524f4",
+        "wy": "491d97a7793c9d9a1f35bb35f12121b9dbe075d8501cbd4db6697e3e0ad98bc0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045e25e2ee8af5ef8a3e0908341f9884501fb58a2fd234b1db6f22d561025524f4491d97a7793c9d9a1f35bb35f12121b9dbe075d8501cbd4db6697e3e0ad98bc0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXiXi7or174o+CQg0H5iEUB+1ii/SNLHb\nbyLVYQJVJPRJHZeneTydmh81uzXxISG52+B12FAcvU22aX4+CtmLwA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 285,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179849249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "XiXi7or174o-CQg0H5iEUB-1ii_SNLHbbyLVYQJVJPQ",
+        "y": "SR2Xp3k8nZofNbs18SEhudvgddhQHL1Ntml-PgrZi8A",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043ddf2920607df596da90123ea5674958054c8ed7758661b813f1aa30f19778b0707243e1a7bcc264b54289832e950c27563856241b79c243d0fc54f7ad24bc25",
+        "wx": "3ddf2920607df596da90123ea5674958054c8ed7758661b813f1aa30f19778b0",
+        "wy": "707243e1a7bcc264b54289832e950c27563856241b79c243d0fc54f7ad24bc25"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043ddf2920607df596da90123ea5674958054c8ed7758661b813f1aa30f19778b0707243e1a7bcc264b54289832e950c27563856241b79c243d0fc54f7ad24bc25",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEPd8pIGB99ZbakBI+pWdJWAVMjtd1hmG4\nE/GqMPGXeLBwckPhp7zCZLVCiYMulQwnVjhWJBt5wkPQ/FT3rSS8JQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 286,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f817980eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Pd8pIGB99ZbakBI-pWdJWAVMjtd1hmG4E_GqMPGXeLA",
+        "y": "cHJD4ae8wmS1QomDLpUMJ1Y4ViQbecJD0PxU960kvCU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 287,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "43f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b0232102812492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 288,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "bc07ff041506dc73a75086a43252fb4270e157da75fb6cb92a9f07dcad153ec02492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+        "y": "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "00b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5i3xSWI2Vw7mqJbBAPx7vdXAuhLt1l6q+ZjuC9vBO8ndw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 289,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "43f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b0232102812492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 290,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "bc07ff041506dc73a75086a43252fb4270e157da75fb6cb92a9f07dcad153ec02492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+        "y": "t8UliNlcO5qiWwQD8e73VwLoS7dZeqvmY7gvbwTvJ3c",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 291,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "",
+          "sig": "6632473c909425b6fa37095398e2538daab8552440320f9fe190dba8f672796ba8c3aacce9ffe4bc17c0530738f1386f9d9579f029ff3a7791b16e98422265e3",
+          "result": "valid"
+        },
+        {
+          "tcId": 292,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "4d7367",
+          "sig": "465b0fb05c14cd4ddef23e13acbe5f2337c45ea3816536670cfa7f2ab9090619005e525e837c406cf8944383e20bcee32112d8da5b42b40f88415098f722aa89",
+          "result": "valid"
+        },
+        {
+          "tcId": 293,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "7b1553e4d650c71fd49aa36ceed56f0438b0065e1b234445134bf7c83231ca9de369a20fa6434bd138b092885a89e53a3f0b6bdcc5d2653e136c54070081dc5a",
+          "result": "valid"
+        },
+        {
+          "tcId": 294,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "sig": "c7ba1c73bdc4364f6c7c61ab1fecc0547f8d6fcbeb251f734964407536353f327b3a6fb2fe60f8861e9e0955663f5703a17f5ecc3a5b5140eb87eaf35a3a5090",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eCyO0X47Kng7VGTzOwllKnHGeOBexR6E4rz8Zjo96WM",
+        "y": "r5rLQoC4x_fEL075q6YkXsHsFxL9OKD6lkGNjNaqYVI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "01060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv8AAAABBgSS1aVnPg8l2NUPt+WMSdhtRtQhaVXgqj1A4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 295,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "2b9c9f85596fed708b3af80393b27edfd0b5ae2f0074270a56362f5f9f62b4e12fae837503ba2c1d4c945e0913949ef094ce0b8086359bbb5dba4a12707c5600",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "5cd765209021d8c1a8aef4ff61d6fa6e7993bf9fea0b93609eea130de536fccc4f10c7989587fe3019e36d85aa024bf20db6737c4f28900c1c9662f2782143e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "4c1a59b1e578d76f1595e13b557057559f26ab559ec1df3f45ec98b90fa526cec6872f094bdb3f82e31f93ad65357e2daafe66f304af197089ef0dc94ff90624",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "boI1VUUpFAmRgsaywdbwtdKNUMzQBa8s4bulQapAyv8",
+        "y": "AAAAAQYEktWlZz4PJdjVD7fljEnYbUbUIWlV4Ko9QOE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "00fffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv/////++fttKlqYwfDaJyrwSBpztieSuSvelqoeVcK7Tg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 298,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "a35d1400d4cc7a8f617b721faee7118a74103c4630dec5aa47e097951dafc1a7958221023024e97ef6df35a22e820c7bc5e16299f3f12e9d9b1b727c46d795e6",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "7fb733ed73c72fc4f4cf065e370c730301316ff4e9c6a8a701170f604c2d70b77ca9ca985d3df48978b3a2f9c0bb8a58b216c795e687f74623a3321448bfa73c",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "95ae4df2fba8524e1151cb9a9c5c1ec1357a663722a18329303d86a58e704754591ea644b1dc6f4c7cd5d7d939397f84d9e077100760f0816ae5b22ae6a74203",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "boI1VUUpFAmRgsaywdbwtdKNUMzQBa8s4bulQapAyv8",
+        "y": "_____vn7bSpamMHw2icq8Egac7Ynkrkr3paqHlXCu04",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+        "wx": "013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0",
+        "wy": "00f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAAAAAT/SIkjWTZX3PCm0irSGMYUL5QP9\nAPhGi18PcOD27nqkO8LG/SWx2CaSQcvdnbsNrJbcliMfQwcF+DhxfQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 301,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "717925f0dd5cf45e746e87f79c9ea97d11eb01444052c270aeccef56c2e95828785787b664137080383d2fc500459fa713258205fdae97b3240fb64bb638a657",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "8adfdeae3b586315d06183610d271fc423cc789908b8f5dc563253a3c782510a8137bedbb4e60da26041b351f72a6bc3b7741f745743f0733b40b7fc56febd04",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "92ded14e19b94d17c79b063a034b122ce3b93a2502f2f223fad3461abf63163252ff8ad14ba3657242e29440d01cab36ebb6033ee36021dc8d9b38f0808a90bc",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AAAAAT_SIkjWTZX3PCm0irSGMYUL5QP9APhGi18PcOA",
+        "y": "9u56pDvCxv0lsdgmkkHL3Z27DayW3JYjH0MHBfg4cX0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+        "wx": "25afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dffffffff",
+        "wy": "00fa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJa/WiayrrtZ8Hylt5ZQG+MVQ9XFGoLTs\nLJeHbf/////6RqduUgMi37xJHsTwzBl0IPxOpYg9j23VPDVLxPZ8NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 304,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "d48373483e0fa2f11cfdfaea6f1de59e6861e9e87c4f6446602ba0125ab7de469d753bba3a7be08aab456e93a6500d4781795ed59af8bd6d6133129abef1ad98",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "f11473117b66e5d84a2ecd0f8b7ec4a2cc2aee89ae022020235777305142f498fe5ce43ced28f3f69f65e810678afefd2bdeefb051280ad2880157fda28b2ab1",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3c9f5bdde7310b5696c93c86203fc97e11a70739e20c71c9e722308d45a59e6cc09efb9a045a47cce799b768890bb17833a0210d869a36be1da33f2585477c32",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Ja_WiayrrtZ8Hylt5ZQG-MVQ9XFGoLTsLJeHbf____8",
+        "y": "-kanblIDIt-8SR7E8MwZdCD8TqWIPY9t1Tw1S8T2fDU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+        "wx": "00d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb9",
+        "wy": "3f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0S5sZrZ3NMPITSYBz1013Al+J2N/CspK\nT9t0tqrdO7k/W9/4i9VzbfiY5pkAbtdQ8RzwfFhmzXrXDHEh/////w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 307,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "6953442c487f240487d2af81f9825c894b1fc2534321fa012db8248be20a4b0656927395d64ce4d690caa98944c2ddebc312f57f439d37236ea63cc1de098718",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "fb39aa5f36ceca6e68d1932e811598c412892734dade389fd9e8ba94c5c7a251fdddf0c3db66c7c46608ac98431f0ee8ebb1e27ba501937789ebcd0f7ac26ecc",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "44fef6017638fd5bda17dfce346b0311b5e369bfb68aa85d5e970786b8e6644b720b3a52fe44be6028759f0f1a6fd7020ff6792cd4ece98dffd0d97d3b726091",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "0S5sZrZ3NMPITSYBz1013Al-J2N_CspKT9t0tqrdO7k",
+        "y": "P1vf-IvVc234mOaZAG7XUPEc8HxYZs161wxxIf____8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+        "wx": "6d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000",
+        "wy": "00e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbUp/YNR3Sk8KqLve25U8fup5CUB+MWR1\nVmS8KAAAAADmWdNOTfONnoyeqt+6NmEsdpGVvobHeqw/NueLU4aA+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 310,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304babc41346e6205cf03e2d0b26e4b222dce8227402d001ba233efa69c912340065add3279f51b2417fb0a13b0f06404199caac3430385513ee49f67d8e8cdf",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "23868700b71fbafcaa73960faf922ee0458ef69e01fb060b2f9a80d992fe114c6ec1526bd56f6eebf10463bd9210d62510b95166365e10a7b7abfc4d584ca338",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "dd60d7cf83a08208637212b65d079fb658d8ef1b8438d9c58f4122b0cd14ac49f1d762516f4d6c3e6a98dd31dc3869dc7cf35944f33b35c6a17fe632d2b18cd5",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "bUp_YNR3Sk8KqLve25U8fup5CUB-MWR1VmS8KAAAAAA",
+        "y": "5lnTTk3zjZ6MnqrfujZhLHaRlb6Gx3qsPzbni1OGgPs",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+        "wx": "2df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5b",
+        "wy": "aa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELfOElG+CrhPOJTCU9AYOSV/JfUjpTSxs\nHw0SLgcWG1uqNna+Bp5er1Vs8FLmpp5DD0ut7Iz7qMJ35Wl/aQb79g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 313,
+          "comment": "r = 1, x = 1 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0497047b3db38d6866eb16f42e6da13a235353c6b6d55fff54f2f84f84db19830546618f8cf778e11dca09549e397f2f054d4098b28c437e73eb29902f038a3066",
+        "wx": "97047b3db38d6866eb16f42e6da13a235353c6b6d55fff54f2f84f84db198305",
+        "wy": "46618f8cf778e11dca09549e397f2f054d4098b28c437e73eb29902f038a3066"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000497047b3db38d6866eb16f42e6da13a235353c6b6d55fff54f2f84f84db19830546618f8cf778e11dca09549e397f2f054d4098b28c437e73eb29902f038a3066",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAElwR7PbONaGbrFvQubaE6I1NTxrbVX/9U\n8vhPhNsZgwVGYY+M93jhHcoJVJ45fy8FTUCYsoxDfnPrKZAvA4owZg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 314,
+          "comment": "r = 2, x = 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+        "wx": "2df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5b",
+        "wy": "aa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELfOElG+CrhPOJTCU9AYOSV/JfUjpTSxs\nHw0SLgcWG1uqNna+Bp5er1Vs8FLmpp5DD0ut7Iz7qMJ35Wl/aQb79g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 315,
+          "comment": "r = 1 + n, x = 1 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bbd24d14fe5a2a324c61c69845a8dea22a61c1a47b1d8a4c017144b8ac507a9941c7e7c3de74a65afa7d2d4d10892f67cf784d406a587e6cb9f95821bbbeeba1",
+        "wx": "bbd24d14fe5a2a324c61c69845a8dea22a61c1a47b1d8a4c017144b8ac507a99",
+        "wy": "41c7e7c3de74a65afa7d2d4d10892f67cf784d406a587e6cb9f95821bbbeeba1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bbd24d14fe5a2a324c61c69845a8dea22a61c1a47b1d8a4c017144b8ac507a9941c7e7c3de74a65afa7d2d4d10892f67cf784d406a587e6cb9f95821bbbeeba1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEu9JNFP5aKjJMYcaYRajeoiphwaR7HYpM\nAXFEuKxQeplBx+fD3nSmWvp9LU0QiS9nz3hNQGpYfmy5+Vghu77roQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 316,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413efffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d7c42bdab5d38d6439fe64459745b4fb172d6e6a0e4618439aeeab489ff6532db3d14b5650b9b1e823d18bfde89b55d07b5cfe166815a3e4da8bb34f405545ae",
+        "wx": "d7c42bdab5d38d6439fe64459745b4fb172d6e6a0e4618439aeeab489ff6532d",
+        "wy": "b3d14b5650b9b1e823d18bfde89b55d07b5cfe166815a3e4da8bb34f405545ae"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d7c42bdab5d38d6439fe64459745b4fb172d6e6a0e4618439aeeab489ff6532db3d14b5650b9b1e823d18bfde89b55d07b5cfe166815a3e4da8bb34f405545ae",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE18Qr2rXTjWQ5/mRFl0W0+xctbmoORhhD\nmu6rSJ/2Uy2z0UtWULmx6CPRi/3om1XQe1z+FmgVo+Tai7NPQFVFrg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 317,
+          "comment": "r = 2, x = n + 2 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044fe4cc98d665a49cfda32bea8de8bd3e6ad863911cd077c072be2b35b487946a256f9cb614fa9bcb345ae8726a9f618a737d45cce96a766bf0fb610c202d56da",
+        "wx": "4fe4cc98d665a49cfda32bea8de8bd3e6ad863911cd077c072be2b35b487946a",
+        "wy": "256f9cb614fa9bcb345ae8726a9f618a737d45cce96a766bf0fb610c202d56da"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044fe4cc98d665a49cfda32bea8de8bd3e6ad863911cd077c072be2b35b487946a256f9cb614fa9bcb345ae8726a9f618a737d45cce96a766bf0fb610c202d56da",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAET+TMmNZlpJz9oyvqjei9PmrYY5Ec0HfA\ncr4rNbSHlGolb5y2FPqbyzRa6HJqn2GKc31FzOlqdmvw+2EMIC1W2g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 318,
+          "comment": "r = 3, x = n + 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f3d010cc99320cbc39bee9101aa7ba7e8edf4e32ea8110e9f2442d6a49aeb78c0ae144cb8146541555043872922dfa14e8ff6b4f9983cdae79b2bce958ef8862",
+        "wx": "f3d010cc99320cbc39bee9101aa7ba7e8edf4e32ea8110e9f2442d6a49aeb78c",
+        "wy": "0ae144cb8146541555043872922dfa14e8ff6b4f9983cdae79b2bce958ef8862"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f3d010cc99320cbc39bee9101aa7ba7e8edf4e32ea8110e9f2442d6a49aeb78c0ae144cb8146541555043872922dfa14e8ff6b4f9983cdae79b2bce958ef8862",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE89AQzJkyDLw5vukQGqe6fo7fTjLqgRDp\n8kQtakmut4wK4UTLgUZUFVUEOHKSLfoU6P9rT5mDza55srzpWO+IYg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 319,
+          "comment": "r = p - n + 1, x = 1 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000014551231950b75fc4402da1722fc9baeffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a6245583e13d23c9cc0089c99e2e202766ea3379645c14762cf029873b099dfc74e9942da9f18327d5b1fbccaa958992d3062ae4602d0ed736aa4b87291ef10d",
+        "wx": "a6245583e13d23c9cc0089c99e2e202766ea3379645c14762cf029873b099dfc",
+        "wy": "74e9942da9f18327d5b1fbccaa958992d3062ae4602d0ed736aa4b87291ef10d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a6245583e13d23c9cc0089c99e2e202766ea3379645c14762cf029873b099dfc74e9942da9f18327d5b1fbccaa958992d3062ae4602d0ed736aa4b87291ef10d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpiRVg+E9I8nMAInJni4gJ2bqM3lkXBR2\nLPAphzsJnfx06ZQtqfGDJ9Wx+8yqlYmS0wYq5GAtDtc2qkuHKR7xDQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 320,
+          "comment": "r = 2^256 - n + 1, x = 1 is invalid; r + n is too large to compare r + n with x, and overflows 2^256 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "000000000000000000000000000000014551231950b75fc4402da1732fc9bec0fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9",
+        "wx": "935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e",
+        "wy": "3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEk1q37bwhy0zLOv1rY9N0D2LZikGXXl5u\ng218mQ0Xen4+w9Y3fN0wIbYXbSbD0ZmdbY/o+5vXBRtJCNFgi5qxqQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 321,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "2b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef220000000000000000000000000000000100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "2b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef22fffffffffffffffffffffffffffffffdbaaedce6af48a03bbfd25e8cd0364141",
+          "result": "valid"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/ecc/_data/ecdsa_secp256k1_sha512_test.json
+++ b/tests/ecc/_data/ecdsa_secp256k1_sha512_test.json
@@ -1,0 +1,7785 @@
+{
+  "algorithm": "ECDSA",
+  "schema": "ecdsa_verify_schema_v1.json",
+  "numberOfTests": 546,
+  "header": [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
+  "notes": {
+    "ArithmeticError": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
+      "cves": [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature": {
+      "bugType": "BER_ENCODING",
+      "description": "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect": "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves": [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero": {
+      "bugType": "LEGACY",
+      "description": "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect": "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves": [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "Untruncatedhash": {
+      "bugType": "MISSING_STEP",
+      "description": "If the size of the digest is longer than the size of the underlying order of the multiplicative subgroup then the hash digest must be truncated during signature generation and verification. This test vector contains a signature where this step has been omitted."
+    },
+    "ValidSignature": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "",
+          "sig": "304502206632473c909425b6fa37095398e2538daab8552440320f9fe190dba8f672796b022100a8c3aacce9ffe4bc17c0530738f1386f9d9579f029ff3a7791b16e98422265e3",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "4d7367",
+          "sig": "30430220465b0fb05c14cd4ddef23e13acbe5f2337c45ea3816536670cfa7f2ab9090619021f5e525e837c406cf8944383e20bcee32112d8da5b42b40f88415098f722aa89",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207b1553e4d650c71fd49aa36ceed56f0438b0065e1b234445134bf7c83231ca9d022100e369a20fa6434bd138b092885a89e53a3f0b6bdcc5d2653e136c54070081dc5a",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "sig": "3045022100c7ba1c73bdc4364f6c7c61ab1fecc0547f8d6fcbeb251f734964407536353f3202207b3a6fb2fe60f8861e9e0955663f5703a17f5ecc3a5b5140eb87eaf35a3a5090",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx": "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy": "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 5,
+          "comment": "signature malleability",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022034d2f1a567d7e647b178552dec35875a2cc61df3ce8ae2c1357ea8c5ff505561",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "Legacy: ASN encoding of s misses leading 0",
+          "flags": [
+            "MissingZero"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90220cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 7,
+          "comment": "valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "valid"
+        },
+        {
+          "tcId": 8,
+          "comment": "length of sequence [r, s] uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30814502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 9,
+          "comment": "length of sequence [r, s] contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3082004502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "length of sequence [r, s] uses 70 instead of 69",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304602206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 11,
+          "comment": "length of sequence [r, s] uses 68 instead of 69",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 12,
+          "comment": "uint32 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085010000004502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "uint64 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308901000000000000004502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "length of sequence [r, s] = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30847fffffff02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "length of sequence [r, s] = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30848000000002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "length of sequence [r, s] = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3084ffffffff02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "length of sequence [r, s] = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085ffffffffff02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "length of sequence [r, s] = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3088ffffffffffffffff02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "incorrect length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30ff02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "removing sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "lonely sequence tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "appending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "prepending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047000002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "appending unused 0's to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "appending null value to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a498177304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492500304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "appending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "including undefined tags",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304daa00bb00cd00304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d2228aa00bb00cd0002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e92229aa00bb00cd00022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "truncated length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3081",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "including undefined tags to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304baa02aabb304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "using composition with indefinite length for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 36,
+          "comment": "using composition with wrong tag for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080314502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 37,
+          "comment": "Replacing sequence [r, s] with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 38,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2e4502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 39,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2f4502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 40,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "314502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 41,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "324502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 42,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "ff4502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 43,
+          "comment": "dropping value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 44,
+          "comment": "using composition for sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30493001023044206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 45,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5eb",
+          "result": "invalid"
+        },
+        {
+          "tcId": 46,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 47,
+          "comment": "sequence [r, s] of size 4166 to check for overflows",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3082104602206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 48,
+          "comment": "indefinite length",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 49,
+          "comment": "indefinite length with truncated delimiter",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 50,
+          "comment": "indefinite length with additional element",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe005000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 51,
+          "comment": "indefinite length with truncated element",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0060811220000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 52,
+          "comment": "indefinite length with garbage",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000fe02beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 53,
+          "comment": "indefinite length with nonempty EOC",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00002beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 54,
+          "comment": "prepend empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047300002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 55,
+          "comment": "append empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe03000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 56,
+          "comment": "append zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304802206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 57,
+          "comment": "append garbage with high tag number",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304802206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0bf7f00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 58,
+          "comment": "append null with explicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304902206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0a0020500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 59,
+          "comment": "append null with implicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0a000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 60,
+          "comment": "sequence of sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 61,
+          "comment": "truncated sequence: removed last 1 elements",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302202206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9",
+          "result": "invalid"
+        },
+        {
+          "tcId": 62,
+          "comment": "repeating element in sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "306802206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 63,
+          "comment": "flipped bit 0 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30436cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e8022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 64,
+          "comment": "flipped bit 32 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30436cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f19b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 65,
+          "comment": "flipped bit 48 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30436cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561220f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 66,
+          "comment": "flipped bit 64 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30436cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236461230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 67,
+          "comment": "length of r uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30460281206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 68,
+          "comment": "length of r contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047028200206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 69,
+          "comment": "length of r uses 33 instead of 32",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502216cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 70,
+          "comment": "length of r uses 31 instead of 32",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045021f6cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 71,
+          "comment": "uint32 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a028501000000206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 72,
+          "comment": "uint64 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02890100000000000000206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 73,
+          "comment": "length of r = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902847fffffff6cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 74,
+          "comment": "length of r = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30490284800000006cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 75,
+          "comment": "length of r = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30490284ffffffff6cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 76,
+          "comment": "length of r = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a0285ffffffffff6cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 77,
+          "comment": "length of r = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d0288ffffffffffffffff6cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 78,
+          "comment": "incorrect length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502ff6cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 79,
+          "comment": "replaced r by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502806cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 80,
+          "comment": "removing r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3023022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 81,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 82,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302302206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e902",
+          "result": "invalid"
+        },
+        {
+          "tcId": 83,
+          "comment": "appending 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702226cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90000022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 84,
+          "comment": "prepending 0's to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022200006cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 85,
+          "comment": "appending unused 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90000022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 86,
+          "comment": "appending null value to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702226cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90500022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 87,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a222549817702206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 88,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30492224250002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 89,
+          "comment": "appending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d222202206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90004deadbeef022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 90,
+          "comment": "truncated length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250281022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 91,
+          "comment": "including undefined tags to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b2226aa02aabb02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 92,
+          "comment": "using composition with indefinite length for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049228002206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90000022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 93,
+          "comment": "using composition with wrong tag for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049228003206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90000022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 94,
+          "comment": "Replacing r with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30250500022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 95,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304500206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 96,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304501206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 97,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304503206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 98,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304504206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 99,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045ff206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 100,
+          "comment": "dropping value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250200022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 101,
+          "comment": "using composition for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3049222402016c021fb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 102,
+          "comment": "modifying first byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206eb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 103,
+          "comment": "modifying last byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a169022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 104,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044021f6cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 105,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3044021fb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 106,
+          "comment": "r of size 4129 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30821048028210216cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 107,
+          "comment": "leading ff in r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff6cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 108,
+          "comment": "replaced r by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026090180022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 109,
+          "comment": "replacing r with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 110,
+          "comment": "flipped bit 0 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e900cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe1",
+          "result": "invalid"
+        },
+        {
+          "tcId": 111,
+          "comment": "flipped bit 32 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e900cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c7d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 112,
+          "comment": "flipped bit 48 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e900cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a52b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 113,
+          "comment": "flipped bit 64 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304302206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e900cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7b8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 114,
+          "comment": "length of s uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304602206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e902812100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 115,
+          "comment": "length of s contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90282002100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 116,
+          "comment": "length of s uses 34 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022200cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 117,
+          "comment": "length of s uses 32 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 118,
+          "comment": "uint32 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90285010000002100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 119,
+          "comment": "uint64 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9028901000000000000002100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 120,
+          "comment": "length of s = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e902847fffffff00cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 121,
+          "comment": "length of s = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e902848000000000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 122,
+          "comment": "length of s = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90284ffffffff00cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 123,
+          "comment": "length of s = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90285ffffffffff00cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 124,
+          "comment": "length of s = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90288ffffffffffffffff00cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 125,
+          "comment": "incorrect length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e902ff00cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 126,
+          "comment": "replaced s by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9028000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 127,
+          "comment": "appending 0's to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022300cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 128,
+          "comment": "prepending 0's to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304702206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90223000000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 129,
+          "comment": "appending null value to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022300cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 130,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e92226498177022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 131,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e922252500022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 132,
+          "comment": "appending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304d02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e92223022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 133,
+          "comment": "truncated length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90281",
+          "result": "invalid"
+        },
+        {
+          "tcId": 134,
+          "comment": "including undefined tags to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b02206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e92227aa02aabb022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 135,
+          "comment": "using composition with indefinite length for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e92280022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 136,
+          "comment": "using composition with wrong tag for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e92280032100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 137,
+          "comment": "Replacing s with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302402206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 138,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9002100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 139,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9012100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 140,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9032100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 141,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9042100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 142,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9ff2100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 143,
+          "comment": "dropping value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90200",
+          "result": "invalid"
+        },
+        {
+          "tcId": 144,
+          "comment": "using composition for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304902206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e922250201000220cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 145,
+          "comment": "modifying first byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022102cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 146,
+          "comment": "modifying last byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5eb60",
+          "result": "invalid"
+        },
+        {
+          "tcId": 147,
+          "comment": "truncated s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304402206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5eb",
+          "result": "invalid"
+        },
+        {
+          "tcId": 148,
+          "comment": "s of size 4130 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3082104802206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90282102200cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 149,
+          "comment": "leading ff in s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304602206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e90222ff00cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 150,
+          "comment": "replaced s by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9090180",
+          "result": "invalid"
+        },
+        {
+          "tcId": 151,
+          "comment": "replacing s with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "302502206cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 152,
+          "comment": "replaced r by r + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221016cb914246e1c92050a03d9b0b4f05dde199ab6bf23cec3a120f56da5843de32a022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 153,
+          "comment": "replaced r by r - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff6cb914246e1c92050a03d9b0b4f05de0a43cfcf1c53d8329a150b08be3d160a8022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 154,
+          "comment": "replaced r by r + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022201006cb914246e1c92050a03d9b0b4f05c9a0dc8c087bd265f2533819be8ea48e2e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 155,
+          "comment": "replaced r by -r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "304502209346ebdb91e36dfaf5fc264f4b0fa220a11426278b79dc9a9edcf0e74bf85e17022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 156,
+          "comment": "replaced r by n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221009346ebdb91e36dfaf5fc264f4b0fa21f5bc3030e3ac27cd65eaf4f741c2e9f58022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 157,
+          "comment": "replaced r by -n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fe9346ebdb91e36dfaf5fc264f4b0fa221e6654940dc313c5edf0a925a7bc21cd6022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 158,
+          "comment": "replaced r by r + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221016cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 159,
+          "comment": "replaced r by r + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e02290100000000000000006cb914246e1c92050a03d9b0b4f05ddf5eebd9d87486236561230f18b407a1e9022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 160,
+          "comment": "replaced s by s + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101cb2d0e5a982819b84e87aad213ca78a348979bd990065db64a261453a11c2d21022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 161,
+          "comment": "replaced s by s - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220cb2d0e5a982819b84e87aad213ca78a5d339e20c31751d3eca81573a00afaa9f022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 162,
+          "comment": "replaced s by s + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "304702220100cb2d0e5a982819b84e87aad213ca775f3cc5a5a2295df93a5cb2429707272ce0022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 163,
+          "comment": "replaced s by -s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff34d2f1a567d7e647b178552dec35875b7217410d1f42428575ac4a392f1a1420022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 164,
+          "comment": "replaced s by -n - s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fe34d2f1a567d7e647b178552dec35875cb76864266ff9a249b5d9ebac5ee3d2df022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 165,
+          "comment": "replaced s by s + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 166,
+          "comment": "replaced s by s - 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 167,
+          "comment": "replaced s by s + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e0229010000000000000000cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0022100cb2d0e5a982819b84e87aad213ca78a48de8bef2e0bdbd7a8a53b5c6d0e5ebe0",
+          "result": "invalid"
+        },
+        {
+          "tcId": 168,
+          "comment": "Signature with special case values r=0 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 169,
+          "comment": "Signature with special case values r=0 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 170,
+          "comment": "Signature with special case values r=0 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 171,
+          "comment": "Signature with special case values r=0 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 172,
+          "comment": "Signature with special case values r=0 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 173,
+          "comment": "Signature with special case values r=0 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 174,
+          "comment": "Signature with special case values r=0 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 175,
+          "comment": "Signature with special case values r=0 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 176,
+          "comment": "Signature with special case values r=1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 177,
+          "comment": "Signature with special case values r=1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 178,
+          "comment": "Signature with special case values r=1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 179,
+          "comment": "Signature with special case values r=1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 180,
+          "comment": "Signature with special case values r=1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 181,
+          "comment": "Signature with special case values r=1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 182,
+          "comment": "Signature with special case values r=1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 183,
+          "comment": "Signature with special case values r=1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 184,
+          "comment": "Signature with special case values r=-1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 185,
+          "comment": "Signature with special case values r=-1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 186,
+          "comment": "Signature with special case values r=-1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 187,
+          "comment": "Signature with special case values r=-1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 188,
+          "comment": "Signature with special case values r=-1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 189,
+          "comment": "Signature with special case values r=-1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 190,
+          "comment": "Signature with special case values r=-1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 191,
+          "comment": "Signature with special case values r=-1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 192,
+          "comment": "Signature with special case values r=n and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 193,
+          "comment": "Signature with special case values r=n and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 194,
+          "comment": "Signature with special case values r=n and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 195,
+          "comment": "Signature with special case values r=n and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 196,
+          "comment": "Signature with special case values r=n and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 197,
+          "comment": "Signature with special case values r=n and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 198,
+          "comment": "Signature with special case values r=n and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 199,
+          "comment": "Signature with special case values r=n and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 200,
+          "comment": "Signature with special case values r=n - 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 201,
+          "comment": "Signature with special case values r=n - 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 202,
+          "comment": "Signature with special case values r=n - 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 203,
+          "comment": "Signature with special case values r=n - 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 204,
+          "comment": "Signature with special case values r=n - 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 205,
+          "comment": "Signature with special case values r=n - 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 206,
+          "comment": "Signature with special case values r=n - 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 207,
+          "comment": "Signature with special case values r=n - 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 208,
+          "comment": "Signature with special case values r=n + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 209,
+          "comment": "Signature with special case values r=n + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 210,
+          "comment": "Signature with special case values r=n + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 211,
+          "comment": "Signature with special case values r=n + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 212,
+          "comment": "Signature with special case values r=n + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 213,
+          "comment": "Signature with special case values r=n + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 214,
+          "comment": "Signature with special case values r=n + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 215,
+          "comment": "Signature with special case values r=n + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 216,
+          "comment": "Signature with special case values r=p and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 217,
+          "comment": "Signature with special case values r=p and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 218,
+          "comment": "Signature with special case values r=p and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 219,
+          "comment": "Signature with special case values r=p and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 220,
+          "comment": "Signature with special case values r=p and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 221,
+          "comment": "Signature with special case values r=p and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 222,
+          "comment": "Signature with special case values r=p and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 223,
+          "comment": "Signature with special case values r=p and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 224,
+          "comment": "Signature with special case values r=p + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 225,
+          "comment": "Signature with special case values r=p + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 226,
+          "comment": "Signature with special case values r=p + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 227,
+          "comment": "Signature with special case values r=p + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 228,
+          "comment": "Signature with special case values r=p + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 229,
+          "comment": "Signature with special case values r=p + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 230,
+          "comment": "Signature with special case values r=p + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 231,
+          "comment": "Signature with special case values r=p + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 232,
+          "comment": "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020100090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 233,
+          "comment": "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 234,
+          "comment": "Signature encoding contains incorrect types: r=0, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 235,
+          "comment": "Signature encoding contains incorrect types: r=0, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 236,
+          "comment": "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 237,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 238,
+          "comment": "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 239,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 240,
+          "comment": "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 241,
+          "comment": "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020101090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 242,
+          "comment": "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 243,
+          "comment": "Signature encoding contains incorrect types: r=1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 244,
+          "comment": "Signature encoding contains incorrect types: r=1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 245,
+          "comment": "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 246,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 247,
+          "comment": "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 248,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201013000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 249,
+          "comment": "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201013003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 250,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 251,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 252,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 253,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 254,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 255,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 256,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 257,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 258,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 259,
+          "comment": "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 260,
+          "comment": "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 261,
+          "comment": "Signature encoding contains incorrect types: r=n, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 262,
+          "comment": "Signature encoding contains incorrect types: r=n, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 263,
+          "comment": "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 264,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 265,
+          "comment": "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 266,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641413000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 267,
+          "comment": "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641413003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 268,
+          "comment": "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 269,
+          "comment": "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 270,
+          "comment": "Signature encoding contains incorrect types: r=p, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 271,
+          "comment": "Signature encoding contains incorrect types: r=p, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 272,
+          "comment": "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 273,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 274,
+          "comment": "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 275,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 276,
+          "comment": "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 277,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a090380fe01090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 278,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 279,
+          "comment": "Signature encoding contains incorrect types: r=True, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 280,
+          "comment": "Signature encoding contains incorrect types: r=False, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 281,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300405000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 282,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30040c000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 283,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c01300c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 284,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300430003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 285,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a30030201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 286,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008090380fe01020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 287,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 288,
+          "comment": "Signature encoding contains incorrect types: r=True, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 289,
+          "comment": "Signature encoding contains incorrect types: r=False, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 290,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050500020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 291,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050c00020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 292,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c0130020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 293,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30053000020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 294,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30083003020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 295,
+          "comment": "Edge case for Shamir multiplication",
+          "flags": [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg": "313236373939",
+          "sig": "3045022100dd1b7d09a7bd8218961034a39a87fecf5314f00c4d25eb58a07ac85e85eab51602202c8a79b49cae4ec15d293575a5a1af5b4d6efb74ef5c2c1be34e33cdeb7113cc",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393439313934313732",
+          "sig": "3045022100d743c5d76e1193a57438f1b43b1b0e33d0d1ab15bd3d57a5cf6aebb370d46ce002207df27cb730b33dfe01e34a0067e548a98c56846d9a4cd64a930c96bfd917cf08",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35333637363431383737",
+          "sig": "3045022100ba30f4ddf3348f26835e9c50f6a2d5023a9a1f5fe2e9cf14b3270015dac283fe02201d1616abb204f615fbe99860d89158c3264182d617ac9f1560fa8291b349d579",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363731343831303935",
+          "sig": "30450220551d72e63f7b27283c4107f7d851f387b60f3f4713a5d35c21fa332fbeed449402210080914cc37a3fe13a74db7fcc5226388d95034a50a89a9b2fe9bf42ea29e5714d",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131323037313732393039",
+          "sig": "304602210080cead3d165ce05c7cf8469f1c35c5a3a641696c843bef0f022a6c68133dc49e022100ea8409d743a4ad5e136207736c3ad79c8cfc7b57ebd1bd9b8a596670ad12d41c",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131323938303334323336",
+          "sig": "3046022100bbc0e8b7721065a51bac9c3aad64168998cc0efa23298340d436867cc86ba847022100ae3baa131a83153cb31de2f758e45139f62fe6cc9ce3941c6b1789dc1010f3e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39383736303239363833",
+          "sig": "304402203a5ba93917b954617b40e1d866860d1522b0d310cac2457636e54e2ffdea888e02203eac6fe762aee127837c2c65fd9c1f65b404b2c31bb945e75d6166503fb5c8bd",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3230323034323936353139",
+          "sig": "30440220647f2b4bef6d1ea7908ac5f3dfd705494c2587456557805fe64a703b2b17503c022020e164bbb505c6df56455908008cf9626df320f48aa3fc9d0cc8ad8bcf078cb2",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343531363639313830",
+          "sig": "30460221008aa653cfa001798c471eea3199dc975a4dea4f7c1ede47453409e606d05ceb51022100cab20967a056c0ea7fe9cdf8e1980f55b1597a2dad80c9223a0fab15c314fe6d",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303933363835393531",
+          "sig": "3045022100842e421f33be241d27f12f875355902a25819f210b3685ad536e23594012d9d002204fb894ae0e9c24b6ed280e224ab0811469296a9837d1e95b5d9d661d21a1c255",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36323139353630323031",
+          "sig": "304402200b703fd75bdd8dce4820fe130a0b0af17aad4e4681b0254864d5d6f8931ff5730220404521acf84e72ff22c2ee05d14a4bc7b70e69adc78caf81350e01379694c3e8",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363832343734333033",
+          "sig": "3045022062f0df1650560a5800fa670377a4317a604d6475c490066ce15638f8d1330b63022100963edf905197096818368a993fbffe32908a57153e6a1612bae6ee9ee8a8a719",
+          "result": "valid"
+        },
+        {
+          "tcId": 307,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33373336353331373836",
+          "sig": "304502202901ade694d4b9c376b3244018e57bcde7057e8e11dd0f7d07080cdd1a39194b022100ee65a4c2baa70f8e236ceba9eed400d899f75276f94e4b7997b2b01ac008bbbc",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373935393033373932",
+          "sig": "3046022100aa9c8e5311b232b4ce9db03892f26eb77d655c6ff09a599424abbd4b11e750be022100c1034c44b02e2fdf05e1ba5eebdf954c5a01794600059e05e5c73d542da3ee38",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39333939363131303037",
+          "sig": "304502202febea016e55059e91e157b988f86048db57c37fd122f5cc60169ff4fcb4863c022100eb19cbc35b3061e1ac4b59b92d1f732cea3212dcbe943ccad82d32740bc22c33",
+          "result": "valid"
+        },
+        {
+          "tcId": 310,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303837343931313835",
+          "sig": "304502202be463ff06af2096dd62f0326e1af51c585f18ca8f8aa361dedcf55d543e6b7d022100f56afd59dad42530d94f11c59a6408c54826b7a9ef83f4d020f209d71f9b74c5",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323336363738353030",
+          "sig": "3046022100f61f64defc45abe284b39161b49585f21edef1e88d06389e5b5aacbb394ce4dc022100a5a27e17df10aedace97eb2c48659f69b58cfe76a1f1ac30fea3043655bde515",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343438393937373033",
+          "sig": "30440220052134eae13c1dec5ac5aa46186391786f5b60591cb0dd30bfc61e89486abfe2022009cdaa279c4f0d3d5ae00e0d74e733a260b8b120a1bda7e5a90194ec442e592d",
+          "result": "valid"
+        },
+        {
+          "tcId": 313,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35373134363332383037",
+          "sig": "3044022024824614686b80f3b738970a27816f58cf103c4a93c2d6b0f5f6de65a65501e30220180e5801a593063e75b83cd7ab8e52575a013a1be5cdeeb05b30e3ac9dc4ed82",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323236343837343932",
+          "sig": "304402202ff7a5ab2f1a3323651a0d17c4263672ee4d2c560cda94e7d52ee755138bb0450220542ce83d8d9d441357e24b618b5695164d4391791cff62eeb01609d1d7cb1c0a",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35333533343439343739",
+          "sig": "3045022100ae446d1a81766d21dd7fc515d0a956605d0cde26d6086a76f8ffc81a6dfbea4602204fccef9f75e94abc7eb3f2bdcafdc5d97d61b9d950a06010ab4c54e3da7fd4e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 316,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373837333033383830",
+          "sig": "304402203957cff4a75fc6039c0b0c2e47eb9b07ff6ec5dc8a3c3316590a7ec9a1d7d99302204e578ee6594a00cb80c640cb9589d616dbd1cecda2d15dcc0062f30686d6073b",
+          "result": "valid"
+        },
+        {
+          "tcId": 317,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323332313935383233",
+          "sig": "30450220437c36031737a3140dc30eed281adac8e9074187aad41502a3b9a3bfd4ef252c022100da13f88f633202b9b9517b93a6c08a7b8e6858734e8894b1a64c6ec08f1d0423",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130373339333931393137",
+          "sig": "3045022100828c12fd9fe31f91bd8f58aac72ee6485e34ceddf91927cf3a09b63363b9d8e902200e889664a8c98619cab572687064edb4f0500f8324a5df0bfb5a431a3cb1ca39",
+          "result": "valid"
+        },
+        {
+          "tcId": 319,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383831303237333135",
+          "sig": "3045022100807cb34aa6ea48b175f41f3afdf70a109d2b746ae48e08677cdafc33d916b2da022041980e6f7ad19944d278851f98e0a6220ae888964ae81a667a63fec21449334d",
+          "result": "valid"
+        },
+        {
+          "tcId": 320,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36303631363933393037",
+          "sig": "3046022100a998f9f0daf02f717f5292142dca447c722d2394dae0c84910433754669716ac022100826fc37269539cf8a98997f8a0268bfffe888d6c23bc68ad7c759db47f65a925",
+          "result": "valid"
+        },
+        {
+          "tcId": 321,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38383935323237303934",
+          "sig": "3045022100f151b614afe5bc9d511d0c34a7eb44283921272e91b3e5d02821cf7a43a92bc50220097aa33dc50ebf8fea036cd7e224a4d38aa20773e5a78ddb83a2f3b579b2ef6c",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353830323334303934",
+          "sig": "304502205f21585381f5f42e9f76be3f61f4cfd6476ecc6f06cd4fbcf13e08c27f42614802210095d5b2deabf19891edd41ac52d9072fadebb2f0145bec9b916f68fd1fbcfb3cf",
+          "result": "valid"
+        },
+        {
+          "tcId": 323,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393635393931353132",
+          "sig": "3045022100bdc361e68984482d7b169bc5e6ccf82d2263871be749d67a44f548d32bcaf5f10220375614fa4134d5055ac117a6ea948b74269b8063e39259d494a7544afb6291ab",
+          "result": "valid"
+        },
+        {
+          "tcId": 324,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323838373332313938",
+          "sig": "304502205773b016dffac865ab008abe8a06353d197b4dff32403d7ce98ada4d20ea8a00022100d60de9c98cf50eff0515b962dffd6aac8a1b72bc9cfaf6bda12b99f63eb976d2",
+          "result": "valid"
+        },
+        {
+          "tcId": 325,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323330383837333139",
+          "sig": "3044022057b747d21fc898472a888b88693a989eabaf143396e4cb2de4af19386fba384f02207c99f63904191a4464d0d23ca560d5558895cdcff93af4b00c1c66ca2d974393",
+          "result": "valid"
+        },
+        {
+          "tcId": 326,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313239303536393337",
+          "sig": "3046022100854be2bf302a2d6db437eb9e78703673c1c7371399e68caa8625bb13c7aa0fec0221008fd22607e0169eb2e2e00c4af898fd2a609dc57a9fa94a7f93372098fa675649",
+          "result": "valid"
+        },
+        {
+          "tcId": 327,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373438363536343338",
+          "sig": "3046022100ebb3359de3b13a518545a86b7fdd92f4793225b8ca4555a6bd4182922b0452be02210083faa7dff1aa0eed89a7ddcdaa5d716ba6253c5c21f7122c2755eb78b28884c4",
+          "result": "valid"
+        },
+        {
+          "tcId": 328,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37353833353032363034",
+          "sig": "30460221008bc91cfcfc85ba8aa171b703a330e398df4460d22602e73e327423ebf98bf632022100ec7569072aa73ff19f183daf433abff142d7d5edceb25b771d853acf0fbd68b6",
+          "result": "valid"
+        },
+        {
+          "tcId": 329,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333237373534323739",
+          "sig": "3046022100895b07c0450ed6f4941633a053c978128c46e5225c00eb009c3c6cee5eb2b842022100c982818b260f1650e03eba8f9db1a2ca79c3f804dbe7d172233260e1a9c10640",
+          "result": "valid"
+        },
+        {
+          "tcId": 330,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373735353038353834",
+          "sig": "3045022100d5e152ec304090d764fd7ae61abeeadff2fee8df3dccd8fb44d2af5a8dbee0bc022072518dc1ecc993faadffc3426594fe2024c7c84ba101a9274d88009393103ff6",
+          "result": "valid"
+        },
+        {
+          "tcId": 331,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3137393832363438333832",
+          "sig": "304502201298b131ce97a528e5dae05d92b286e2447b17ec002267b9e8f03784d4074bd1022100edf223ad9c308aef22e1e0c24a20268f966cc2b9ca4d941945bbca057db92d4c",
+          "result": "valid"
+        },
+        {
+          "tcId": 332,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333936373737333635",
+          "sig": "304502201e79b3921d23d290a57d08958d3ad8305ec444efe1281c98fda44e8af7648f49022100f4c7610ad1ba9339178c50e7979b5aa9af07d8143e59d13a2e84f98f37101e3b",
+          "result": "valid"
+        },
+        {
+          "tcId": 333,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35393938313035383031",
+          "sig": "3045022100e455f464e0edff9c959f84f081828896149a330361ff2d16d5a2448c9d6836840220351cfa2f29a1318ebb3a46f0a36df8954043949b8d7cea94eacf99108b4d3fa0",
+          "result": "valid"
+        },
+        {
+          "tcId": 334,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3136363737383237303537",
+          "sig": "3046022100a885770c9ffef33f0c11245064936e3dd165ea2633575a6a155368670351f726022100de31e6a58626a41fd029cf766ef44b8273b88558e2452e893978fbdda1e321d1",
+          "result": "valid"
+        },
+        {
+          "tcId": 335,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323036323134333632",
+          "sig": "304502204b6b451478ba253ae3c75ca5b18b70ccd3cca408ed245cb2af3369548dd2e507022100fe479b631a3431b42772925cbfe8e789f9c55fb2fd1d7ab51664cc2fa571ad93",
+          "result": "valid"
+        },
+        {
+          "tcId": 336,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36383432343936303435",
+          "sig": "304502207ca70376547ad6d18f8e539f09dc269ebaa06854c1adacd58fdc735ed3cf0c16022100f47654f4c0ac1b0e65b712300e3bb472983b116db5206520eabd886dc706b266",
+          "result": "valid"
+        },
+        {
+          "tcId": 337,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323639383937333231",
+          "sig": "30450220388514d147664fbb37271cb8693e47459c0627d6b1dd52dff1d3947dfc9cabec02210099d3d40814aa177be99e4819696996bc75073f4518955587cd56b5ad8bbc2c58",
+          "result": "valid"
+        },
+        {
+          "tcId": 338,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333837333234363932",
+          "sig": "3044022044d3ac50d9b65601d79b47d6c5d98394cef155211ff37d4bac15e0d4890809b802203ea03829afb0545e088361a8cf952aec17bab7637fddd6db35f039803523c921",
+          "result": "valid"
+        },
+        {
+          "tcId": 339,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313138383837353336",
+          "sig": "3046022100a33004a2cd50a4f70447fd382e7fdc9257c4d9be7b16e686c5082a231ee7b010022100d87b96ed3beea54652607017702cfce5d4e7fcec1fdd28f41681ab80a5c5b63c",
+          "result": "valid"
+        },
+        {
+          "tcId": 340,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393838363036353435",
+          "sig": "30450220668ad18cc22c1d1498cc8e5a11e2bfc4c1e1fcf0a7350a5806c5533ae332f0b1022100f58b49369771bd20bb08b63d4a9212e2dc71da9257ed3710d9eaef9bee469eb2",
+          "result": "valid"
+        },
+        {
+          "tcId": 341,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343739313135383435",
+          "sig": "3046022100f7cdcb0281c70786cc3653820d1756a78395a9eeeab2a4d164e260f64ebfd6a8022100d966c74499cac97ca8ee67400df01b14793b6d7d07668fc202a9918f3c046e9b",
+          "result": "valid"
+        },
+        {
+          "tcId": 342,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35303736383837333637",
+          "sig": "3045022100de0e781d9e3e7f73021458fc1201fc021e5c54f1fe40b1b10db8fcf16ef7e54a02207d9db92321b5e5bb105990145390979390d32394116f4e78af34b85105dee8e9",
+          "result": "valid"
+        },
+        {
+          "tcId": 343,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393838353036393637",
+          "sig": "30440220011dac8ea37f7bc6a530a42d0e3bec8c845694f73bec6950081a6f999ccdfbc60220153e57ee45e0a379839f3b8f6faf86de7a626b210f4c1007e431f842e39bf7d5",
+          "result": "valid"
+        },
+        {
+          "tcId": 344,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373231333036313331",
+          "sig": "3044022063f9c43a8cab49f518685a120bd73a4e5956f9f167a78d4661fc795d41be2ae102206aaf4f3384f1489ef026cb29e97ea1b5562fe8ceb9978d506fb7064f427b9f31",
+          "result": "valid"
+        },
+        {
+          "tcId": 345,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323034313031363535",
+          "sig": "304402207f0fd3736166195ba810d5a2dfb5e1f03aece2170510c8aa4cc4a0c974a7c5d60220370c8772a75d32e8c9cc103004e75e6d30a8ac8611b84b89c41c65542171bc5b",
+          "result": "valid"
+        },
+        {
+          "tcId": 346,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313530363830393530",
+          "sig": "3045022100f975196086d10f683f4aa1a3c2d5fe13fd0f52ee72aa3f785006aa024c75873502206a66364156ef21b5dfdcee60cce8fb09c12019bc576848ff73db49856af74681",
+          "result": "valid"
+        },
+        {
+          "tcId": 347,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373237343630313033",
+          "sig": "3045022035fe6d9bf9f7d47612c3f5be6a4e9a0fb0c14854d1a377adfb5485d6e3835c6f022100f96587fc460e7d07396f9f2d060693dae632721259e77c90b8314002a5235dd0",
+          "result": "valid"
+        },
+        {
+          "tcId": 348,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134353731343631323235",
+          "sig": "30450220210c7c9b231293c8ec09b0f610d31724a045f6a33f84423fdd541ac11ff78962022100e5a40e6b80da99cfc49ce969f1f59146835183e61001b4513f927b71ec3b2a13",
+          "result": "valid"
+        },
+        {
+          "tcId": 349,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313739353136303930",
+          "sig": "3044022009b7dcfad2c84b89825cf3aaaffed51664faccc0d171a43387a6ff98aa128a040220272b00e6e0917afe4fbe782604428e09fd91c38125d51c3ba06ce3198e6bf736",
+          "result": "valid"
+        },
+        {
+          "tcId": 350,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35383932373133303534",
+          "sig": "3045022009c7c99681c9159b22c0a467999559a31e279075d37ef872a88ae13565f6149b022100b0ff953be1940d2cf548663c1b4db7b416521db289467733b9a76629f8ab261f",
+          "result": "valid"
+        },
+        {
+          "tcId": 351,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33383936313832323937",
+          "sig": "304502202bfaae0ea6d8baab3e02ad7fa3dda3ce0725d11533e3666477f54d697e2ca9bc0221009289d5da443395bca18fe9d1a4afbe04a32b4ecd258eca6c1772acff2d0b9a89",
+          "result": "valid"
+        },
+        {
+          "tcId": 352,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38323833333436373332",
+          "sig": "30440220368846edc677ae8fc237069cda719af3d7f17cc136fe443b2af614ccfb4844ab02205ebe6c1d3e88bc4e291841ea97c836bdcf67d9eabe926346c5f42105f7b38f67",
+          "result": "valid"
+        },
+        {
+          "tcId": 353,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33333636393734383931",
+          "sig": "3046022100f336da82bea2a111bddef6a25de4ab87d7c95aa80d21838f3a4efa3d9346555d022100da5ab612b327aa0fe95d1caf85f3b6698c23a47212006c5667cfa92aa3ef4dad",
+          "result": "valid"
+        },
+        {
+          "tcId": 354,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313939313533323239",
+          "sig": "304602210097c2fb9865f9e76f8d54ce957120b68ccb04cd3183dae7130f73139cd56655cf022100fb63e38176ffac37d0ec1e49c2e2efeff04dffdad5a75f3576f8276cccee9851",
+          "result": "valid"
+        },
+        {
+          "tcId": 355,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363030333136383232",
+          "sig": "304402207393e0207e07bd73b674d3667dfbc9c30022574d63079a040a23c0cd7e1b6aa602202994b3468432fecd0a32134171179d2809244d586bd971129cdba73fd3dc8876",
+          "result": "valid"
+        },
+        {
+          "tcId": 356,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "383639363531363935",
+          "sig": "3044022021e1943d7d396a8c46658bede4ce155c9a06f929cf6ad292d32c91cf8f493887022030783c682cebfffec5787d762bd725bafc9c4075ad8eb1582188f4c05dd5169d",
+          "result": "valid"
+        },
+        {
+          "tcId": 357,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36353833393236333732",
+          "sig": "304502205a269eb44e910bfe8a2656dee47556cb908a417917e2068e20d201721f44f9b1022100e69d463204dce77c249439f22f77cc4c88134012a286b36a9559f694203766c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 358,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3133323035303135373235",
+          "sig": "3045022100cb8c146fb3d58846e5748c48742af2f1b77805f6cd1e4eb98d8c66cbdf5d6455022017ac992e10251e334467f8e57e2e1c269db8b19469321c74b443972a80f38b2d",
+          "result": "valid"
+        },
+        {
+          "tcId": 359,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35303835333330373931",
+          "sig": "30440220212d84a153db81cea5212fa7dee31d59bdca1307277a01b5936c3aead31bf1e40220520305dbef2bda6526fa2cfca789a1c9aca5c2ad4c0027cc8cf3881813da8a72",
+          "result": "valid"
+        },
+        {
+          "tcId": 360,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37383636383133313139",
+          "sig": "30450220310c82892f571134a36725f4a31c5cba8bc46e65002d73b11364084433d8da4a0221009ca552aca84b96cc9461e2b65a64975118ea78b8b355a0ebcc1a61de37877d13",
+          "result": "valid"
+        },
+        {
+          "tcId": 361,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303832353339343239",
+          "sig": "30440220489deda580c62533783df9fe62de34c2e2cab91d676709beeff13afac8e90db9022032a85a9c56f308b7a794dcce614a5ed7e0857030b8429fe3b4e07ad533a5a00a",
+          "result": "valid"
+        },
+        {
+          "tcId": 362,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130303635393536363937",
+          "sig": "3046022100e8897c1cad1fc870a7d364676a9d7f7cd3ac951f3bc3a9ef1f7231466c3493d7022100dd2128e876d62da82cfc5fc508d33bf66b71c0a84d0a9b7e47dfc620f5846bc6",
+          "result": "valid"
+        },
+        {
+          "tcId": 363,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33303234313831363034",
+          "sig": "3046022100b4d771d19fffb1fe5ead25ef5dbf6b53d4d3dad284641108ad84b2541ad435a4022100843ecdc2641b33a3ae9ae15d559f6229d7304ee5ecabe00db73bf2b6b5c6c21f",
+          "result": "valid"
+        },
+        {
+          "tcId": 364,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37373637383532383734",
+          "sig": "304502205ab5fb3136fabdbd22009642df03685935819895d675fc284e8b8112db522d08022100d87ec88173e823ed70438fb1088b00689352542fabad5e9fd6d4c3c58f722f86",
+          "result": "valid"
+        },
+        {
+          "tcId": 365,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353434313939393734",
+          "sig": "3045022100be310120169f8d488c6e5ec5b5e588ab8a65040169d9efd3062e0d05fd7d58df022045033f291fa21a85cc08f78fec2dbd94135520de261360728b8743b558ed16f8",
+          "result": "valid"
+        },
+        {
+          "tcId": 366,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35383433343830333931",
+          "sig": "3045022100cd7fb3f2c25dfab6f9ee83fcbb08698680e9d1f3d47815bc772d717a764f99970220287dd85b976d7f56d23ae7837398c118932aadc982f675f94103036729a47c7c",
+          "result": "valid"
+        },
+        {
+          "tcId": 367,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373138383932363239",
+          "sig": "3045022069f18c064ad2683cc1b6d8b79020aacd186b6ad1999e6e55bf28bb1dac33f339022100ef66e66001fcc219c9a927d7f0b84863483bfd1ffa6086c06921905310c793e1",
+          "result": "valid"
+        },
+        {
+          "tcId": 368,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373433323233343433",
+          "sig": "3043021f547c6bb40f52d207fff796a29f6dbe62058e50fb73bde6b9c6ca11346fd8e802202bc82bd3efc9febe8578acdbc3148bb46c41a39be9ae1994ad52d8bf13195d09",
+          "result": "valid"
+        },
+        {
+          "tcId": 369,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343036303035393336",
+          "sig": "3045022100a80496adce42e7971ebe91300710cf4f535fad266668d76d72c95fffe4d4257002200d4338ca32857e14e0ea8026bc194227b910b98509c8c9307b0d8d93d47b191b",
+          "result": "valid"
+        },
+        {
+          "tcId": 370,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363134303336393838",
+          "sig": "304502203de40634d11a7a6b67023b84650420673ce6dbadb1159768cc0fd55f3784ec88022100a455fb08e51b8493177d88fca43aeff306e1490d7f6d24d6a910970a3d8619de",
+          "result": "valid"
+        },
+        {
+          "tcId": 371,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303935343235363835",
+          "sig": "3046022100c1f229c0557d4c47962593781bc96cf745f3bd629ad85434dc2eee456ddb30310221008638f6c01c15d23db24bb851f6c63c763c1f040976f3f2b32c4bb1b9506c1c12",
+          "result": "valid"
+        },
+        {
+          "tcId": 372,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303038303938393833",
+          "sig": "3045022035dd4957b352e8b1bbc80d1deb21f9b0989188ade3fbe46f75106da1684e1d6d0221008b508e2ed7a51efea0dfaf377f6bd5d4ae133cc4c93650600be545af5d3acd75",
+          "result": "valid"
+        },
+        {
+          "tcId": 373,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353734313437393237",
+          "sig": "30450220410aa9c943e663082c6f76b84469c9845e0d439ba7ffc7cac0418eea0e20e638022100c873ab5c21c9f0ce0bf78484028796b77451e1187250ee33535dacfb3cee5f61",
+          "result": "valid"
+        },
+        {
+          "tcId": 374,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383636373731353232",
+          "sig": "30460221008191db069b571cd40f2676348433430d3a65155c233c46a42a4299e6f5be806c022100f3679ef8af0b1b3a3aeaa7bcee51ce960441622e9ff2dcb22a8ec8de724e0a0c",
+          "result": "valid"
+        },
+        {
+          "tcId": 375,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363934323830373837",
+          "sig": "3046022100889c44edbf3825b18d933aecd5ef70d12ebb00bf79550451205fd6f5ba7f372b022100ecb67194bed2b8176077622d58c9ab4fe4ca34601decc09f9386b8c4445c7224",
+          "result": "valid"
+        },
+        {
+          "tcId": 376,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39393231363932353638",
+          "sig": "3045022100aa87113aff2e1ad6461191241f90a23b91242d0066779daaa9506a4188abc427022033dbaac5ac443fb4d9529f83247f94c0ad1360d4d0ba8e162a377946c6ab9ae2",
+          "result": "valid"
+        },
+        {
+          "tcId": 377,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131363039343339373938",
+          "sig": "304402200e13f66a8ffd0da1c4b67f4d805941e90f98ce386540c48019c1ac105407568302200cb489e8d5acfca5245d9292f59c6ede52425157af77b8beef38d23b6e6ade13",
+          "result": "valid"
+        },
+        {
+          "tcId": 378,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37313836313632313030",
+          "sig": "304402206c1813f660c78bda956c1685bc924f69d1bbac5fadf3e4b027ab049bc82ad134022020de89ee005d7646f070bdac794ccce24d661b390a78851d35fe6fb5b25b3eba",
+          "result": "valid"
+        },
+        {
+          "tcId": 379,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323934333437313737",
+          "sig": "3045022048dc830b6326ec218144391b658d52045ef86ef918a8d41c59131912b1a46fb1022100a431916cb7cf79129b90f09842b3f2164a6cf603db88f2d99944142c00b42559",
+          "result": "valid"
+        },
+        {
+          "tcId": 380,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3138353134343535313230",
+          "sig": "304502204d45782be145a27ae9ecb6cac1b9e30be87c0d13b7d6ada9f795ff051351ac70022100cf71d1eb15e88446ddb900f20d1e0739da499de9963fe99ded00a62da6462d62",
+          "result": "valid"
+        },
+        {
+          "tcId": 381,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343736303433393330",
+          "sig": "3044022011acd8b8d736e7f00476495803fbd20ad351321e800cfbddbd6a7dd610c5ab8c0220734027aabcca9487773dc3ab069b802c00f5b6e5520e7761496ac1e7c78ced91",
+          "result": "valid"
+        },
+        {
+          "tcId": 382,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353637333738373431",
+          "sig": "3045022041be8b3bf41a4c507de12f098f7d409a1f941fef84d93794c497f7242a7c382c02210081f7e7243116f24b84b0321e93eed35e2bdc32b00aa8eb9583be3e9b7a09a4f3",
+          "result": "valid"
+        },
+        {
+          "tcId": 383,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35373339393334393935",
+          "sig": "3046022100ea032ff41b061e93e456a5f0a9cdef36c0732df4d55ab4d3867484b0fc49d9eb022100ab298dd811826a6a9319c3632a96253c31c14f75baef536a645420442bab4d43",
+          "result": "valid"
+        },
+        {
+          "tcId": 384,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343738333636313339",
+          "sig": "30460221008b1ff140c65adca22e5596ffb95a5121c356d2d4055f14606445249a5725686f022100ef8c16ff228114a7e33b35ad465f957577dea405fbdf3faf077a878754e58bef",
+          "result": "valid"
+        },
+        {
+          "tcId": 385,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363439303532363032",
+          "sig": "304402203a40e8dc3ebe9e19dcd0d4d1b698ab2a4934a146def5427b3a6a8fbfbf347846022054f65e36088d2d4543011c94b1e5371697202d488b342dd6f77a69944128223d",
+          "result": "valid"
+        },
+        {
+          "tcId": 386,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373633383837343936",
+          "sig": "3044022015fecd439137df74820727f71218405cbe525d403c574471d8a36fa4b1f592ab022018ec290971ed0a227ec47f1e2142f3b8fe5b17336350c5515d4a87eb3382fcb6",
+          "result": "valid"
+        },
+        {
+          "tcId": 387,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353739303230303830",
+          "sig": "3046022100e676e84a299f481a207cde6a4271c87d73e29d1e49216393292323bcdc238844022100b8a98c769bf81429644758c8f803ddbedf81634e53099c43ad0ca42f4207ba16",
+          "result": "valid"
+        },
+        {
+          "tcId": 388,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35333434373837383438",
+          "sig": "304402205116f8f0af12b47bd025aa6eaec5007d4e3c5a3a72cb4c331f569581adb01bfb02206962251da7ba9ac951cfbd2051bcb7d953005cb9599ae0ad9c5f5139baacb976",
+          "result": "valid"
+        },
+        {
+          "tcId": 389,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3139323636343130393230",
+          "sig": "3046022100b83f3918b6c5506d648ba3dba36762db593ad4b791456babcc3c1a4966317ae60221008cd0166047cec89963e9c8ca43b556ac17d0d62177a9bda35e61d0bb16dd471d",
+          "result": "valid"
+        },
+        {
+          "tcId": 390,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33373033393135373035",
+          "sig": "30440220077858a840230ca21385c4ab4c36cbd3ffaf85656202fba58f1ea995f52ebc4c0220543e5e32a6d2f5c08664ed72175adaa25cdb5d6a754b0cb184e6994ede66c5b9",
+          "result": "valid"
+        },
+        {
+          "tcId": 391,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3831353435373730",
+          "sig": "30440220538ad8797a397414ac82287c9216e41915c9e3dadbd493a0bbef5cb0dc7935ec02202c94cfdae7bf76f90b3cc7d19feea4005b387e312ad4116654d63cfbecf2ae1a",
+          "result": "valid"
+        },
+        {
+          "tcId": 392,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313935353330333737",
+          "sig": "3046022100ff8bbd1b6441388cb8d562c28ce29fbe51de11502fc825773ded3f0df225b2360221008eccca0148b82fdfb370cdd073aa0634b39cc70d0d5244a7319e4b13791e2c2a",
+          "result": "valid"
+        },
+        {
+          "tcId": 393,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323637383130393033",
+          "sig": "304402207c179a010f51d66ec82fe5d5d45bd867b4b236a27be882e627506f7286ed7baa02205e38c048fb0fbd81c40df3dc16087d9aabeb51a193107499d29d8cf99c388a21",
+          "result": "valid"
+        },
+        {
+          "tcId": 394,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131313830373230383135",
+          "sig": "304502207e0810885b405d54ceb2eb18cae08de2062f61b7ed94ab67eb15e87b64e730ef022100f511a7919e6e4d70c8d61b831e383f58dea5878a6c8c5f0436ee058dd80a7668",
+          "result": "valid"
+        },
+        {
+          "tcId": 395,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38333831383639323930",
+          "sig": "3045022100c665d558dd638ef27a28557c3deb8a2f54abf9bd0bfa032c7ec9a514da9a9e9e022065c9efc355981f91778227eefacf1bb2fedb98657e6cd8674fdd42ae00d619ed",
+          "result": "valid"
+        },
+        {
+          "tcId": 396,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313331323837323737",
+          "sig": "304402204f06b82aa0d070a004a7fd1135bc3a0bc36fcaeeca35e3edf00f5895394d59ab022065f71dd7406a17bf19e434a4635479340204dd862a9f2c4653e2fa39b178286c",
+          "result": "valid"
+        },
+        {
+          "tcId": 397,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134333331393236353338",
+          "sig": "30450220539c8fe5715c3dc893815ec2f00e203b4cd4f8fd36cc5742cc81ced266e02e3b022100a5964b2d5157624cf42b6726ae23a7d5ef83a5d1f1460bd573d5a15316be5bf2",
+          "result": "valid"
+        },
+        {
+          "tcId": 398,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333434393038323336",
+          "sig": "3045022025f337273591f276849cd855b03d07cbcb205924cda4f62a079591602cc10a8c022100d7b82c8fb38bbd503d92e5ae9303e8673c6dd0e9389f5af53366bbab851f0470",
+          "result": "valid"
+        },
+        {
+          "tcId": 399,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36383239383335393239",
+          "sig": "3045022100f36018945d24c89678ce2c8cf3cb4f93c38bdad3589891a5baa293744d4daa20022019ef05878dfc636a4662fd5dd127c908d7948991a324840323c8aef4fc2ff8ac",
+          "result": "valid"
+        },
+        {
+          "tcId": 400,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343435313538303233",
+          "sig": "3045022043203c89ad43a2bb1910e70ea104347e84764599535d46dabbe547395b1463f4022100ed3d29c7c506ecc988614b368b38dd5b4f1e330c1b861efca8152a704b9146e5",
+          "result": "valid"
+        },
+        {
+          "tcId": 401,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3132363937393837363434",
+          "sig": "3046022100c2740bfb3f387df1b564e3ff48835b9e380104716f58c5a43e97bb2c2d84d04a022100e760ee5d0950b512f6c271cd1a87619b830df83fd40d44b9283539b3aa380019",
+          "result": "valid"
+        },
+        {
+          "tcId": 402,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "333939323432353533",
+          "sig": "3046022100ec07ec5378ed131b2dea7ae9776ba536daef2afc38e2556a70b89b9752eb1f71022100fea25b9e50b1cfa2cf475dbb2245761d5f4585fbbc438d97226c64ff74bff19e",
+          "result": "valid"
+        },
+        {
+          "tcId": 403,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363031393737393737",
+          "sig": "3046022100e438303ccbbee359c865997e46112b0afd7a647c593429291398f0c432dfb9f00221008487e07a53da18793f8b527069e620e44587e420245d6ec827bb35cccfae7a47",
+          "result": "valid"
+        },
+        {
+          "tcId": 404,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130383738373535313435",
+          "sig": "3045022100fc09fa30e89a2ba3d0c4d9d9350e717168c21253371359c0f3cb8c8807bdab5602205d6c4766bca462cf95b4aeb8f5886b52fc3286642ffee8d0bd7ffd4af7badb4a",
+          "result": "valid"
+        },
+        {
+          "tcId": 405,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37303034323532393939",
+          "sig": "304402204f184fba2be39078385290acb4cc4b3f39b099c3300c762df205c605c6b30e1a0220506481d2018b3a4c0ad558f029c82e0625c833cbbee978bee7b589742ee1e377",
+          "result": "valid"
+        },
+        {
+          "tcId": 406,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353635333235323833",
+          "sig": "3045022100e9a27533a50eafb09561dc335d67f8e5e53b4fc16b3013f062e581ad027e110e02207e4150def368f969ace0fc28cac7a3312d6b9af538c412048be1763ea81f3f44",
+          "result": "valid"
+        },
+        {
+          "tcId": 407,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3233383236333432333530",
+          "sig": "3046022100fac24d54387202bff01a91f5504f778c183a0a7930c02af0b618ee64d1b1e438022100f3a53cb6f96feea45ccadcdf9ac78cd735ec3342163e573d2125caa0d8d507bb",
+          "result": "valid"
+        },
+        {
+          "tcId": 408,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343437383437303635",
+          "sig": "304502203544590a0f9fa5d43ad4e0a003a8d7db58b8570951657aab3bab732727d1bbc2022100f257beac10d53e8012ecd236793d280026c5cf1c04aae522019b87e003500ec5",
+          "result": "valid"
+        },
+        {
+          "tcId": 409,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134323630323035353434",
+          "sig": "3045022100bc0726386497c85da8f4055a727b1938e96786b009e6847a080a8aae571b0753022054b1b15fc7886f09b121af6520d0f4336d259d734713fc3e973cf28368830eff",
+          "result": "valid"
+        },
+        {
+          "tcId": 410,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393933383335323835",
+          "sig": "30450220216f8051f9ceed5b5cc1085f83efd871128cb44b260ac12c486c0ea06c71aa55022100df90346cb028245a72ac7d8094497f0efb83a7c44ba3b258873127355e3b2edf",
+          "result": "valid"
+        },
+        {
+          "tcId": 411,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34323932313533353233",
+          "sig": "3045022100cb76652e19d6e7a72c9cac35c2ae46178d8c0ff59b06b0cb97c31aad39ec1b0902205c47b889a29c781540b8783ca24e2acc340178685d7331017e29b4efe92d9fbd",
+          "result": "valid"
+        },
+        {
+          "tcId": 412,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34343539393031343936",
+          "sig": "3045022100edfc03190c839528ba2aa0ba3a23b596fcfec1bf2bbf4467f1fd88398cab8ad2022045b41fa49e0fa7f060ac1ba38ab4d2d5ab5b9fa54ca59285aee09ceedd9865a3",
+          "result": "valid"
+        },
+        {
+          "tcId": 413,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333933393731313731",
+          "sig": "3046022100e7631f03d9dfddc64cfd2a971523def68cb9f8a64e07eb2235c7250adc36480b022100a004cbac3e04056c7e65fdb48be051e9a52ab427c826c84e2cb2229252983663",
+          "result": "valid"
+        },
+        {
+          "tcId": 414,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333930363936343935",
+          "sig": "3045022015e36a42515118021f6f5372ecbff90755d8ae77f9dd683972d2f26aa67164510221008d1cd988ba0a1bd919d2f9b5c8a3517eb59ef776caecdf2b5ac2f7a721858315",
+          "result": "valid"
+        },
+        {
+          "tcId": 415,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131343436303536323634",
+          "sig": "304502206daacbc1125cb3690e43e16b414077c0dd274b96ed61892bad5a519274f01b23022100d044965811b4050c7a85021e8827635cf9f46260fc33bb7cb56b1b37180c4220",
+          "result": "valid"
+        },
+        {
+          "tcId": 416,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363835303034373530",
+          "sig": "3044022037e50775ee06024d596ed49824b1e6a49efae25c7dce8181de33f93ce34ac3ce0220616a3e9d1fed086138f6feef6532647c02bd324ba4a8bfea20640d22f5494429",
+          "result": "valid"
+        },
+        {
+          "tcId": 417,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3232323035333630363139",
+          "sig": "3046022100d5b64cdf82e354ba6a01772f7d38e8d46a729b808aaed73616ed41a9afc83db7022100b5c456c91254e57013228c9724bb7f97aaf18e1bfd4c99d3ca9eaa8214382a10",
+          "result": "valid"
+        },
+        {
+          "tcId": 418,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36323135363635313234",
+          "sig": "3045022100915779b90ae6f6c1fb82c198c9f0719ce2ea37be0f261e36585ec89adaedd2b602207d05e7794ac57578790808c0ac52ca3a51d1399f1a4c7173a7ed19867732b3d9",
+          "result": "valid"
+        },
+        {
+          "tcId": 419,
+          "comment": "Signature generated without truncating the hash",
+          "flags": [
+            "Untruncatedhash"
+          ],
+          "msg": "313233343030",
+          "sig": "30440220097a04ee03a13c511d939e8bbe1471c57a71020e168e2689c69a5625686e24ad022040d24d52f3701ac8da959560c36ed0750a1cf031b728a9134e2b71ed3ddef889",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0412c90a5debd88d42686b84227dbc755351b78e7c6cb86c0b22536f394603646ed03d965851bc41bb089499c51987b899a8353d997e040fdd35290a2627f0a3ab",
+        "wx": "12c90a5debd88d42686b84227dbc755351b78e7c6cb86c0b22536f394603646e",
+        "wy": "00d03d965851bc41bb089499c51987b899a8353d997e040fdd35290a2627f0a3ab"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000412c90a5debd88d42686b84227dbc755351b78e7c6cb86c0b22536f394603646ed03d965851bc41bb089499c51987b899a8353d997e040fdd35290a2627f0a3ab",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEEskKXevYjUJoa4Qifbx1U1G3jnxsuGwL\nIlNvOUYDZG7QPZZYUbxBuwiUmcUZh7iZqDU9mX4ED901KQomJ/Cjqw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 420,
+          "comment": "k*G has a large x-coordinate",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30360211014551231950b75fc4402da1722fc9baeb022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        },
+        {
+          "tcId": 421,
+          "comment": "r too large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04913ed043022ee590f59e44f519e5cfd9d6f1b84a50fb417e9ad06683c6afa194b68fb80d6ef261b5a63b57f871d2ea7224319f5fa3ed3dd77f1012dba19d0395",
+        "wx": "00913ed043022ee590f59e44f519e5cfd9d6f1b84a50fb417e9ad06683c6afa194",
+        "wy": "00b68fb80d6ef261b5a63b57f871d2ea7224319f5fa3ed3dd77f1012dba19d0395"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004913ed043022ee590f59e44f519e5cfd9d6f1b84a50fb417e9ad06683c6afa194b68fb80d6ef261b5a63b57f871d2ea7224319f5fa3ed3dd77f1012dba19d0395",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEkT7QQwIu5ZD1nkT1GeXP2dbxuEpQ+0F+\nmtBmg8avoZS2j7gNbvJhtaY7V/hx0upyJDGfX6PtPdd/EBLboZ0DlQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 422,
+          "comment": "r,s are large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04644cc54e84467213fafe2a4451dba550f3ea76ea9970bd6251fc7783a420d8b51cd9439155ec45d5634677c281154bbdf99fe44051dcec322053ca69ea88297c",
+        "wx": "644cc54e84467213fafe2a4451dba550f3ea76ea9970bd6251fc7783a420d8b5",
+        "wy": "1cd9439155ec45d5634677c281154bbdf99fe44051dcec322053ca69ea88297c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004644cc54e84467213fafe2a4451dba550f3ea76ea9970bd6251fc7783a420d8b51cd9439155ec45d5634677c281154bbdf99fe44051dcec322053ca69ea88297c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEZEzFToRGchP6/ipEUdulUPPqduqZcL1i\nUfx3g6Qg2LUc2UORVexF1WNGd8KBFUu9+Z/kQFHc7DIgU8pp6ogpfA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 423,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02203e9a7582886089c62fb840cf3b83061cd1cff3ae4341808bb5bdee6191174177",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040a11d42154bd2de10ca92321fb6b3e638ee8b5a7fb4fb5f501b44515cf60e8c906ccaab8748cd38ece73ddc975bc307e7de172357e14cd96a94bb3461d32d50e",
+        "wx": "0a11d42154bd2de10ca92321fb6b3e638ee8b5a7fb4fb5f501b44515cf60e8c9",
+        "wy": "06ccaab8748cd38ece73ddc975bc307e7de172357e14cd96a94bb3461d32d50e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040a11d42154bd2de10ca92321fb6b3e638ee8b5a7fb4fb5f501b44515cf60e8c906ccaab8748cd38ece73ddc975bc307e7de172357e14cd96a94bb3461d32d50e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEChHUIVS9LeEMqSMh+2s+Y47otaf7T7X1\nAbRFFc9g6MkGzKq4dIzTjs5z3cl1vDB+feFyNX4UzZapS7NGHTLVDg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 424,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022024238e70b431b1a64efdf9032669939d4b77f249503fc6905feb7540dea3e6d2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049fa2c32bb349846acb5af14e1c67acfdd8963ed251c4b5783cad4bcdd0fd505d6f724937217d1e5483920405cf1b20200797521c464a2355fdde5306f2a9e448",
+        "wx": "009fa2c32bb349846acb5af14e1c67acfdd8963ed251c4b5783cad4bcdd0fd505d",
+        "wy": "6f724937217d1e5483920405cf1b20200797521c464a2355fdde5306f2a9e448"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049fa2c32bb349846acb5af14e1c67acfdd8963ed251c4b5783cad4bcdd0fd505d6f724937217d1e5483920405cf1b20200797521c464a2355fdde5306f2a9e448",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEn6LDK7NJhGrLWvFOHGes/diWPtJRxLV4\nPK1LzdD9UF1vckk3IX0eVIOSBAXPGyAgB5dSHEZKI1X93lMG8qnkSA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 425,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0460eace95001201cf4c83b580fb698bb6abf446e5c56ff945eb5769b1a477b55069f5354a77fe2d601528f126c9a6858deeddb9e5ec408356d05ed5c80d62b8e1",
+        "wx": "60eace95001201cf4c83b580fb698bb6abf446e5c56ff945eb5769b1a477b550",
+        "wy": "69f5354a77fe2d601528f126c9a6858deeddb9e5ec408356d05ed5c80d62b8e1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000460eace95001201cf4c83b580fb698bb6abf446e5c56ff945eb5769b1a477b55069f5354a77fe2d601528f126c9a6858deeddb9e5ec408356d05ed5c80d62b8e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYOrOlQASAc9Mg7WA+2mLtqv0RuXFb/lF\n61dpsaR3tVBp9TVKd/4tYBUo8SbJpoWN7t255exAg1bQXtXIDWK44Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 426,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020102",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f1a57d9346842310975ed356672a48a06a70b5efbc0c23287c9b9952ec955b330091aee1224ecd69791856c521b12df172b45a5ce247e6dcaca7349684278f23",
+        "wx": "00f1a57d9346842310975ed356672a48a06a70b5efbc0c23287c9b9952ec955b33",
+        "wy": "0091aee1224ecd69791856c521b12df172b45a5ce247e6dcaca7349684278f23"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f1a57d9346842310975ed356672a48a06a70b5efbc0c23287c9b9952ec955b330091aee1224ecd69791856c521b12df172b45a5ce247e6dcaca7349684278f23",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE8aV9k0aEIxCXXtNWZypIoGpwte+8DCMo\nfJuZUuyVWzMAka7hIk7NaXkYVsUhsS3xcrRaXOJH5tyspzSWhCePIw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 427,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020103",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045f051894500a061da63c3558e1469cdffb8a57e260633d630e16c44149d914732f3881bf8954fffce9308e3792413910614341831f9a35b58d1ad0dde4f90cc4",
+        "wx": "5f051894500a061da63c3558e1469cdffb8a57e260633d630e16c44149d91473",
+        "wy": "2f3881bf8954fffce9308e3792413910614341831f9a35b58d1ad0dde4f90cc4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045f051894500a061da63c3558e1469cdffb8a57e260633d630e16c44149d914732f3881bf8954fffce9308e3792413910614341831f9a35b58d1ad0dde4f90cc4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXwUYlFAKBh2mPDVY4Uac3/uKV+JgYz1j\nDhbEQUnZFHMvOIG/iVT//OkwjjeSQTkQYUNBgx+aNbWNGtDd5PkMxA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 428,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042b934479af23d6b8db0693538e9e15eae8436fe56e3c8c9580955a755103ebb2fd81cdb809b4f839856fa6c051c0df65e4fd8a5d01b297c7797e718c5121b416",
+        "wx": "2b934479af23d6b8db0693538e9e15eae8436fe56e3c8c9580955a755103ebb2",
+        "wy": "00fd81cdb809b4f839856fa6c051c0df65e4fd8a5d01b297c7797e718c5121b416"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042b934479af23d6b8db0693538e9e15eae8436fe56e3c8c9580955a755103ebb2fd81cdb809b4f839856fa6c051c0df65e4fd8a5d01b297c7797e718c5121b416",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEK5NEea8j1rjbBpNTjp4V6uhDb+VuPIyV\ngJVadVED67L9gc24CbT4OYVvpsBRwN9l5P2KXQGyl8d5fnGMUSG0Fg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 429,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020102",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0409f5de48a08164e8032f79e4ca19ab5930ae6d85a914b5a000048471fc9f66c21ff3560f3345c9ccbdf49835eb6648c70f5777e41f5a2e010dbc25e1eb0ff1f4",
+        "wx": "09f5de48a08164e8032f79e4ca19ab5930ae6d85a914b5a000048471fc9f66c2",
+        "wy": "1ff3560f3345c9ccbdf49835eb6648c70f5777e41f5a2e010dbc25e1eb0ff1f4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000409f5de48a08164e8032f79e4ca19ab5930ae6d85a914b5a000048471fc9f66c21ff3560f3345c9ccbdf49835eb6648c70f5777e41f5a2e010dbc25e1eb0ff1f4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECfXeSKCBZOgDL3nkyhmrWTCubYWpFLWg\nAASEcfyfZsIf81YPM0XJzL30mDXrZkjHD1d35B9aLgENvCXh6w/x9A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 430,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020103",
+          "result": "valid"
+        },
+        {
+          "tcId": 431,
+          "comment": "r is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143020103",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0419697f0b44b285f337dfb49eef051e8861097468d9e9e3cff149bb6add90a1dc774eba64f207bdea048381bc48fa7ac64eb8dc49e5cdd6ce007350e7a0e508ae",
+        "wx": "19697f0b44b285f337dfb49eef051e8861097468d9e9e3cff149bb6add90a1dc",
+        "wy": "774eba64f207bdea048381bc48fa7ac64eb8dc49e5cdd6ce007350e7a0e508ae"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000419697f0b44b285f337dfb49eef051e8861097468d9e9e3cff149bb6add90a1dc774eba64f207bdea048381bc48fa7ac64eb8dc49e5cdd6ce007350e7a0e508ae",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGWl/C0SyhfM337Se7wUeiGEJdGjZ6ePP\n8Um7at2Qodx3Trpk8ge96gSDgbxI+nrGTrjcSeXN1s4Ac1DnoOUIrg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 432,
+          "comment": "s is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020102022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd04917c8",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b3c7fbdf1d7472f7bd578757762c8ebc922ff063b0ae9c3aa9cd81600abea76c038eeb3852b836c0649fd82fe5d1d02c3d0dbb30fbcd7fe41866ebc3bd927c69",
+        "wx": "00b3c7fbdf1d7472f7bd578757762c8ebc922ff063b0ae9c3aa9cd81600abea76c",
+        "wy": "038eeb3852b836c0649fd82fe5d1d02c3d0dbb30fbcd7fe41866ebc3bd927c69"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b3c7fbdf1d7472f7bd578757762c8ebc922ff063b0ae9c3aa9cd81600abea76c038eeb3852b836c0649fd82fe5d1d02c3d0dbb30fbcd7fe41866ebc3bd927c69",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEs8f73x10cve9V4dXdiyOvJIv8GOwrpw6\nqc2BYAq+p2wDjus4Urg2wGSf2C/l0dAsPQ27MPvNf+QYZuvDvZJ8aQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 433,
+          "comment": "small r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302702020101022100c58b162c58b162c58b162c58b162c58a1b242973853e16db75c8a1a71da4d39d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04759fdd1a64c000188b87eb0ddd291a50358fca2b0a5b92f027573845dc40b27a12ec1b2892ef46700f13cff8eb88f40076cc811478b008f5aabee4a74b4546f1",
+        "wx": "759fdd1a64c000188b87eb0ddd291a50358fca2b0a5b92f027573845dc40b27a",
+        "wy": "12ec1b2892ef46700f13cff8eb88f40076cc811478b008f5aabee4a74b4546f1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004759fdd1a64c000188b87eb0ddd291a50358fca2b0a5b92f027573845dc40b27a12ec1b2892ef46700f13cff8eb88f40076cc811478b008f5aabee4a74b4546f1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEdZ/dGmTAABiLh+sN3SkaUDWPyisKW5Lw\nJ1c4RdxAsnoS7Bsoku9GcA8Tz/jriPQAdsyBFHiwCPWqvuSnS0VG8Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 434,
+          "comment": "smallish r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302c02072d9b4d347952cc022100fcbc5103d0da267477d1791461cf2aa44bf9d43198f79507bd8779d69a13108e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044882825a892d30267264e300e868ab5d4b0ffc9ef3c2cb6e90d61d238daed856e4c8248a189eb36d83740f5928cb802fb9c50b5a18c9196344a0c2cb74416423",
+        "wx": "4882825a892d30267264e300e868ab5d4b0ffc9ef3c2cb6e90d61d238daed856",
+        "wy": "00e4c8248a189eb36d83740f5928cb802fb9c50b5a18c9196344a0c2cb74416423"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044882825a892d30267264e300e868ab5d4b0ffc9ef3c2cb6e90d61d238daed856e4c8248a189eb36d83740f5928cb802fb9c50b5a18c9196344a0c2cb74416423",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESIKCWoktMCZyZOMA6GirXUsP/J7zwstu\nkNYdI42u2FbkyCSKGJ6zbYN0D1koy4AvucULWhjJGWNEoMLLdEFkIw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 435,
+          "comment": "100-bit r and small s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3032020d1033e67e37b32b445580bf4efc022100906f906f906f906f906f906f906f906ed8e426f7b1968c35a204236a579723d2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c4d1b1fdf274cf83f3395a70a36c94f7c51f1a31e99514b4ef10ba1304756caf4eaf435b20dd76d6ef447869503da9b28f0ea08edf287424d44aa04b254c1736",
+        "wx": "00c4d1b1fdf274cf83f3395a70a36c94f7c51f1a31e99514b4ef10ba1304756caf",
+        "wy": "4eaf435b20dd76d6ef447869503da9b28f0ea08edf287424d44aa04b254c1736"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c4d1b1fdf274cf83f3395a70a36c94f7c51f1a31e99514b4ef10ba1304756caf4eaf435b20dd76d6ef447869503da9b28f0ea08edf287424d44aa04b254c1736",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAExNGx/fJ0z4PzOVpwo2yU98UfGjHplRS0\n7xC6EwR1bK9Or0NbIN121u9EeGlQPamyjw6gjt8odCTUSqBLJUwXNg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 436,
+          "comment": "small r and 100 bit s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020201010220783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043376df7376d5e651d45b8ec2e5ff9d891c6fdd6dbbb52b046e6b5ac4c9facedf76cf27f9fcb65403b1f585a2dafe26b43ebd622baccde699d81c9be98df9f4df",
+        "wx": "3376df7376d5e651d45b8ec2e5ff9d891c6fdd6dbbb52b046e6b5ac4c9facedf",
+        "wy": "76cf27f9fcb65403b1f585a2dafe26b43ebd622baccde699d81c9be98df9f4df"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043376df7376d5e651d45b8ec2e5ff9d891c6fdd6dbbb52b046e6b5ac4c9facedf76cf27f9fcb65403b1f585a2dafe26b43ebd622baccde699d81c9be98df9f4df",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEM3bfc3bV5lHUW47C5f+diRxv3W27tSsE\nbmtaxMn6zt92zyf5/LZUA7H1haLa/ia0Pr1iK6zN5pnYHJvpjfn03w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 437,
+          "comment": "100-bit r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3031020d062522bbd3ecbe7c39e93e7c260220783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045077fdd202fdb4194b05491b6c053fff8760697531fc5227879e9cbec3309585d0b5cffb3e0fdfb1c06e6d11a1182752730cfe439f7a4f8a49b9c2924f49ec14",
+        "wx": "5077fdd202fdb4194b05491b6c053fff8760697531fc5227879e9cbec3309585",
+        "wy": "00d0b5cffb3e0fdfb1c06e6d11a1182752730cfe439f7a4f8a49b9c2924f49ec14"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045077fdd202fdb4194b05491b6c053fff8760697531fc5227879e9cbec3309585d0b5cffb3e0fdfb1c06e6d11a1182752730cfe439f7a4f8a49b9c2924f49ec14",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUHf90gL9tBlLBUkbbAU//4dgaXUx/FIn\nh56cvsMwlYXQtc/7Pg/fscBubRGhGCdScwz+Q596T4pJucKST0nsFA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 438,
+          "comment": "r and s^-1 are close to n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03640c1022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a218a180d55c05040417fa4d6881e8dbcf4952d427e4d5cbaf297e17848c49ae85b4c0e345073b0ad301fc9269d7df1cf328ca245910d9398ebbfa48782a70ff",
+        "wx": "00a218a180d55c05040417fa4d6881e8dbcf4952d427e4d5cbaf297e17848c49ae",
+        "wy": "0085b4c0e345073b0ad301fc9269d7df1cf328ca245910d9398ebbfa48782a70ff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a218a180d55c05040417fa4d6881e8dbcf4952d427e4d5cbaf297e17848c49ae85b4c0e345073b0ad301fc9269d7df1cf328ca245910d9398ebbfa48782a70ff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEohihgNVcBQQEF/pNaIHo289JUtQn5NXL\nryl+F4SMSa6FtMDjRQc7CtMB/JJp198c8yjKJFkQ2TmOu/pIeCpw/w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 439,
+          "comment": "r and s are 64-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30160209009c44febf31c3594d020900839ed28247c2b06b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049b7e703d3c0224fb5fca71fab833a35fbea230453ae25ce3e3afbb646c587a5a9dd1e4b0c75250fc7845d4013a8f10988ed0875f8cbbdb6ab216bced9b8c3cb7",
+        "wx": "009b7e703d3c0224fb5fca71fab833a35fbea230453ae25ce3e3afbb646c587a5a",
+        "wy": "009dd1e4b0c75250fc7845d4013a8f10988ed0875f8cbbdb6ab216bced9b8c3cb7"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049b7e703d3c0224fb5fca71fab833a35fbea230453ae25ce3e3afbb646c587a5a9dd1e4b0c75250fc7845d4013a8f10988ed0875f8cbbdb6ab216bced9b8c3cb7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEm35wPTwCJPtfynH6uDOjX76iMEU64lzj\n46+7ZGxYelqd0eSwx1JQ/HhF1AE6jxCYjtCHX4y722qyFrztm4w8tw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 440,
+          "comment": "r and s are 100-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "301e020d09df8b682430beef6f5fd7c7cf020d0fd0a62e13778f4222a0d61c8a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0482e6ec5429071f4a4571ff510a5cfea7f493492b7d4dcef0404563eebdf79f7af4d87d7e0da88f73c882dddab8d0b1edf9678a92b08d340a312900df34d860ac",
+        "wx": "0082e6ec5429071f4a4571ff510a5cfea7f493492b7d4dcef0404563eebdf79f7a",
+        "wy": "00f4d87d7e0da88f73c882dddab8d0b1edf9678a92b08d340a312900df34d860ac"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000482e6ec5429071f4a4571ff510a5cfea7f493492b7d4dcef0404563eebdf79f7af4d87d7e0da88f73c882dddab8d0b1edf9678a92b08d340a312900df34d860ac",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEgubsVCkHH0pFcf9RClz+p/STSSt9Tc7w\nQEVj7r33n3r02H1+DaiPc8iC3dq40LHt+WeKkrCNNAoxKQDfNNhgrA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 441,
+          "comment": "r and s are 128-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30260211008a598e563a89f526c32ebec8de26367a02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047937c7f3fbac0301f1e3b73f85cb97bab657c20ec493744c1c3ba692d999038de6b09c5471a987b685b8ff1e5fe9b4e20d59e0ff1299537069897c9ae2bd63ea",
+        "wx": "7937c7f3fbac0301f1e3b73f85cb97bab657c20ec493744c1c3ba692d999038d",
+        "wy": "00e6b09c5471a987b685b8ff1e5fe9b4e20d59e0ff1299537069897c9ae2bd63ea"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047937c7f3fbac0301f1e3b73f85cb97bab657c20ec493744c1c3ba692d999038de6b09c5471a987b685b8ff1e5fe9b4e20d59e0ff1299537069897c9ae2bd63ea",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeTfH8/usAwHx47c/hcuXurZXwg7Ek3RM\nHDumktmZA43msJxUcamHtoW4/x5f6bTiDVng/xKZU3BpiXya4r1j6g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 442,
+          "comment": "r and s are 160-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0bdf021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041b1f773b472dac5e1adf94e69d865b404d2cc92cff7bb66cf2197978f6c45d08a9725791c5f33787977a9ddfa69296be998a968c51ec7f1c5447793bc56286b3",
+        "wx": "1b1f773b472dac5e1adf94e69d865b404d2cc92cff7bb66cf2197978f6c45d08",
+        "wy": "00a9725791c5f33787977a9ddfa69296be998a968c51ec7f1c5447793bc56286b3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041b1f773b472dac5e1adf94e69d865b404d2cc92cff7bb66cf2197978f6c45d08a9725791c5f33787977a9ddfa69296be998a968c51ec7f1c5447793bc56286b3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGx93O0ctrF4a35TmnYZbQE0sySz/e7Zs\n8hl5ePbEXQipcleRxfM3h5d6nd+mkpa+mYqWjFHsfxxUR3k7xWKGsw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 443,
+          "comment": "s == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1020101",
+          "result": "valid"
+        },
+        {
+          "tcId": 444,
+          "comment": "s == 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1020100",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fab77f79e004a6890126e793df13464607eca844f29e645f16a0aa1a3ab9f7b39ef2a99df25c2f51cdab3e75810ef5fe36331e36a519ae5ebefefab5a55bfc6a",
+        "wx": "00fab77f79e004a6890126e793df13464607eca844f29e645f16a0aa1a3ab9f7b3",
+        "wy": "009ef2a99df25c2f51cdab3e75810ef5fe36331e36a519ae5ebefefab5a55bfc6a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fab77f79e004a6890126e793df13464607eca844f29e645f16a0aa1a3ab9f7b39ef2a99df25c2f51cdab3e75810ef5fe36331e36a519ae5ebefefab5a55bfc6a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+rd/eeAEpokBJueT3xNGRgfsqETynmRf\nFqCqGjq597Oe8qmd8lwvUc2rPnWBDvX+NjMeNqUZrl6+/vq1pVv8ag==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 445,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220419d981c515af8cc82545aac0c85e9e308fbb2eab6acd7ed497e0b4145a18fd9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040afc55541d6cf8bd16289c8954ce899805e39c41ba0d4b83deaef2baed94b2daa5a3a5f79deb3245a51e436c137ea60ddd152d09da5f6e121020ba560eede8b8",
+        "wx": "0afc55541d6cf8bd16289c8954ce899805e39c41ba0d4b83deaef2baed94b2da",
+        "wy": "00a5a3a5f79deb3245a51e436c137ea60ddd152d09da5f6e121020ba560eede8b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040afc55541d6cf8bd16289c8954ce899805e39c41ba0d4b83deaef2baed94b2daa5a3a5f79deb3245a51e436c137ea60ddd152d09da5f6e121020ba560eede8b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECvxVVB1s+L0WKJyJVM6JmAXjnEG6DUuD\n3q7yuu2Ustqlo6X3nesyRaUeQ2wTfqYN3RUtCdpfbhIQILpWDu3ouA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 446,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102201b21717ad71d23bbac60a9ad0baf75b063c9fdf52a00ebf99d022172910993c9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b50c72e9b03e5ad9f12cd2f69fc442138d3a8917e800fa138795a24ed0aeada51e09f5ef6efa9aa866e763d5a90c62052ea682a217eba654c6b250962308f6de",
+        "wx": "00b50c72e9b03e5ad9f12cd2f69fc442138d3a8917e800fa138795a24ed0aeada5",
+        "wy": "1e09f5ef6efa9aa866e763d5a90c62052ea682a217eba654c6b250962308f6de"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b50c72e9b03e5ad9f12cd2f69fc442138d3a8917e800fa138795a24ed0aeada51e09f5ef6efa9aa866e763d5a90c62052ea682a217eba654c6b250962308f6de",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtQxy6bA+WtnxLNL2n8RCE406iRfoAPoT\nh5WiTtCuraUeCfXvbvqaqGbnY9WpDGIFLqaCohfrplTGslCWIwj23g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 447,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102202f588f66018f3dd14db3e28e77996487e32486b521ed8e5a20f06591951777e9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046c60df5622465b2c8bd6a22fc20483c450505687e3a832f94545de17c321872a8f6d60c5f3b8e064662562ccd6703cf7418d0f8fbdf55728e4ef69e8a20406a8",
+        "wx": "6c60df5622465b2c8bd6a22fc20483c450505687e3a832f94545de17c321872a",
+        "wy": "008f6d60c5f3b8e064662562ccd6703cf7418d0f8fbdf55728e4ef69e8a20406a8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046c60df5622465b2c8bd6a22fc20483c450505687e3a832f94545de17c321872a8f6d60c5f3b8e064662562ccd6703cf7418d0f8fbdf55728e4ef69e8a20406a8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbGDfViJGWyyL1qIvwgSDxFBQVofjqDL5\nRUXeF8MhhyqPbWDF87jgZGYlYszWcDz3QY0Pj731Vyjk72noogQGqA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 448,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220091a08870ff4daf9123b30c20e8c4fc8505758dcf4074fcaff2170c9bfcf74f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049326f5033bd0fc2a5108a4ba8872c3ff2d6125db90a0d4af7720d9b7cfe580b7d9d649c6090e76ba1d19ece34b3b3dc7b485df93f888017039eee2e92ebaf64f",
+        "wx": "009326f5033bd0fc2a5108a4ba8872c3ff2d6125db90a0d4af7720d9b7cfe580b7",
+        "wy": "00d9d649c6090e76ba1d19ece34b3b3dc7b485df93f888017039eee2e92ebaf64f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049326f5033bd0fc2a5108a4ba8872c3ff2d6125db90a0d4af7720d9b7cfe580b7d9d649c6090e76ba1d19ece34b3b3dc7b485df93f888017039eee2e92ebaf64f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEkyb1AzvQ/CpRCKS6iHLD/y1hJduQoNSv\ndyDZt8/lgLfZ1knGCQ52uh0Z7ONLOz3HtIXfk/iIAXA57uLpLrr2Tw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 449,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102207c370dc0ce8c59a8b273cba44a7c1191fc3186dc03cab96b0567312df0d0b250",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048217f17c61e97b578e2586fb03274567099d6b329f4205827b0493d589b6d6cbf5259ef680d96395fde4da8a6a96095bbeb72fc1b616b40de3d91571bd4100a8",
+        "wx": "008217f17c61e97b578e2586fb03274567099d6b329f4205827b0493d589b6d6cb",
+        "wy": "00f5259ef680d96395fde4da8a6a96095bbeb72fc1b616b40de3d91571bd4100a8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048217f17c61e97b578e2586fb03274567099d6b329f4205827b0493d589b6d6cbf5259ef680d96395fde4da8a6a96095bbeb72fc1b616b40de3d91571bd4100a8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEghfxfGHpe1eOJYb7AydFZwmdazKfQgWC\newST1Ym21sv1JZ72gNljlf3k2opqlglbvrcvwbYWtA3j2RVxvUEAqA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 450,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022070b59a7d1ee77a2f9e0491c2a7cfcd0ed04df4a35192f6132dcc668c79a6160e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04367b67eb9ece04b532c9925b30595fd733e9f1fa52ca1d05d630c7a877b5162c99219249dc0ec6e92bcbfe6e46b7d500278b01f66397e7d9ce4236b5fb1a70a0",
+        "wx": "367b67eb9ece04b532c9925b30595fd733e9f1fa52ca1d05d630c7a877b5162c",
+        "wy": "0099219249dc0ec6e92bcbfe6e46b7d500278b01f66397e7d9ce4236b5fb1a70a0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004367b67eb9ece04b532c9925b30595fd733e9f1fa52ca1d05d630c7a877b5162c99219249dc0ec6e92bcbfe6e46b7d500278b01f66397e7d9ce4236b5fb1a70a0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAENntn657OBLUyyZJbMFlf1zPp8fpSyh0F\n1jDHqHe1FiyZIZJJ3A7G6SvL/m5Gt9UAJ4sB9mOX59nOQja1+xpwoA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 451,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102202736d76e412246e097148e2bf62915614eb7c428913a58eb5e9cd4674a9423de",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046700d5c4ba0f6fad92f0deb2055b988fec6a427b689cd779b8e4f1606d22f7dff1f3ea8ed23eba61b5c90d66cf4820e4b1c51c9d23b062552f087a162a8c7b0c",
+        "wx": "6700d5c4ba0f6fad92f0deb2055b988fec6a427b689cd779b8e4f1606d22f7df",
+        "wy": "00f1f3ea8ed23eba61b5c90d66cf4820e4b1c51c9d23b062552f087a162a8c7b0c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046700d5c4ba0f6fad92f0deb2055b988fec6a427b689cd779b8e4f1606d22f7dff1f3ea8ed23eba61b5c90d66cf4820e4b1c51c9d23b062552f087a162a8c7b0c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEZwDVxLoPb62S8N6yBVuYj+xqQntonNd5\nuOTxYG0i99/x8+qO0j66YbXJDWbPSCDkscUcnSOwYlUvCHoWKox7DA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 452,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102204a1e12831fbe93627b02d6e7f24bccdd6ef4b2d0f46739eaf3b1eaf0ca117770",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b0478cb90c29140cefdfbcb50ca2740c48a97df67ae9672e1e11cb827c1cede51d2824a9265a32d9d2221d453ea40bf64999d2c20e268d0bc061cf6ae2051cf2",
+        "wx": "00b0478cb90c29140cefdfbcb50ca2740c48a97df67ae9672e1e11cb827c1cede5",
+        "wy": "1d2824a9265a32d9d2221d453ea40bf64999d2c20e268d0bc061cf6ae2051cf2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b0478cb90c29140cefdfbcb50ca2740c48a97df67ae9672e1e11cb827c1cede51d2824a9265a32d9d2221d453ea40bf64999d2c20e268d0bc061cf6ae2051cf2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsEeMuQwpFAzv37y1DKJ0DEipffZ66Wcu\nHhHLgnwc7eUdKCSpJloy2dIiHUU+pAv2SZnSwg4mjQvAYc9q4gUc8g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 453,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022006c778d4dfff7dee06ed88bc4e0ed34fc553aad67caf796f2a1c6487c1b2e877",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04940e51450409cd15529adc38e730a662916bc93ae10c0facf41580a75a0c598655c6b4c9b8fdc7d932fb4a0a6847e0d878a8bdbe9390567f0b8ed92eb86267fa",
+        "wx": "00940e51450409cd15529adc38e730a662916bc93ae10c0facf41580a75a0c5986",
+        "wy": "55c6b4c9b8fdc7d932fb4a0a6847e0d878a8bdbe9390567f0b8ed92eb86267fa"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004940e51450409cd15529adc38e730a662916bc93ae10c0facf41580a75a0c598655c6b4c9b8fdc7d932fb4a0a6847e0d878a8bdbe9390567f0b8ed92eb86267fa",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAElA5RRQQJzRVSmtw45zCmYpFryTrhDA+s\n9BWAp1oMWYZVxrTJuP3H2TL7SgpoR+DYeKi9vpOQVn8LjtkuuGJn+g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 454,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102204de459ef9159afa057feb3ec40fef01c45b809f4ab296ea48c206d4249a2b451",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040b0beeaed3b2586106e814824a0803b19fe7085ec923e0865a3c803bd46760d1e2741cd27b03f78381957bf81d42f5d61124c001418e591d14480bb8e789d1e5",
+        "wx": "0b0beeaed3b2586106e814824a0803b19fe7085ec923e0865a3c803bd46760d1",
+        "wy": "00e2741cd27b03f78381957bf81d42f5d61124c001418e591d14480bb8e789d1e5"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040b0beeaed3b2586106e814824a0803b19fe7085ec923e0865a3c803bd46760d1e2741cd27b03f78381957bf81d42f5d61124c001418e591d14480bb8e789d1e5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECwvurtOyWGEG6BSCSggDsZ/nCF7JI+CG\nWjyAO9RnYNHidBzSewP3g4GVe/gdQvXWESTAAUGOWR0USAu454nR5Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 455,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220745d294978007302033502e1acc48b63ae6500be43adbea1b258d6b423dbb416",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d56bb0e13f31470316914085214ee218039df7a2ea062878e1d769e47f7e39295a122a009a17683f079c2da61cff3032e88347c525592edf0877bb5338bcedd",
+        "wx": "6d56bb0e13f31470316914085214ee218039df7a2ea062878e1d769e47f7e392",
+        "wy": "0095a122a009a17683f079c2da61cff3032e88347c525592edf0877bb5338bcedd"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d56bb0e13f31470316914085214ee218039df7a2ea062878e1d769e47f7e39295a122a009a17683f079c2da61cff3032e88347c525592edf0877bb5338bcedd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbVa7DhPzFHAxaRQIUhTuIYA533ouoGKH\njh12nkf345KVoSKgCaF2g/B5wtphz/MDLog0fFJVku3wh3u1M4vO3Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 456,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102207b2a785e3896f59b2d69da57648e80ad3c133a750a2847fd2098ccd902042b6c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049e38cd7f3aefb648b90dc9e3562737bda57cf73113cb110568af698392992d53bdaf4fe8760647abdbd91f14b4b32a21de6737629dd62e9f38f76e12bb4649ae",
+        "wx": "009e38cd7f3aefb648b90dc9e3562737bda57cf73113cb110568af698392992d53",
+        "wy": "00bdaf4fe8760647abdbd91f14b4b32a21de6737629dd62e9f38f76e12bb4649ae"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049e38cd7f3aefb648b90dc9e3562737bda57cf73113cb110568af698392992d53bdaf4fe8760647abdbd91f14b4b32a21de6737629dd62e9f38f76e12bb4649ae",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEnjjNfzrvtki5DcnjVic3vaV89zETyxEF\naK9pg5KZLVO9r0/odgZHq9vZHxS0syoh3mc3Yp3WLp84924Su0ZJrg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 457,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022071ae94a72ca896875e7aa4a4c3d29afdb4b35b6996273e63c47ac519256c5eb1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e1c989fd3b9e87020a508b72b6cd8da14f15b9c12125b4b2ed402e1257abed82aa6074e0a4ea09ffc24a36d61bd37e0ea642a06d4d58ebd51b2d172bacd5e525",
+        "wx": "00e1c989fd3b9e87020a508b72b6cd8da14f15b9c12125b4b2ed402e1257abed82",
+        "wy": "00aa6074e0a4ea09ffc24a36d61bd37e0ea642a06d4d58ebd51b2d172bacd5e525"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e1c989fd3b9e87020a508b72b6cd8da14f15b9c12125b4b2ed402e1257abed82aa6074e0a4ea09ffc24a36d61bd37e0ea642a06d4d58ebd51b2d172bacd5e525",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4cmJ/TuehwIKUItyts2NoU8VucEhJbSy\n7UAuEler7YKqYHTgpOoJ/8JKNtYb034OpkKgbU1Y69UbLRcrrNXlJQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 458,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102200fa527fa7343c0bc9ec35a6278bfbff4d83301b154fc4bd14aee7eb93445b5f9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0411119d9ac0b4e2adf1bb1db84324fff3c93c76f46999a453b5492151677b8dcebf16cb2f94bae17949c17714a6b0d87fe3cce99d9c149562df76ab035cf0c671",
+        "wx": "11119d9ac0b4e2adf1bb1db84324fff3c93c76f46999a453b5492151677b8dce",
+        "wy": "00bf16cb2f94bae17949c17714a6b0d87fe3cce99d9c149562df76ab035cf0c671"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000411119d9ac0b4e2adf1bb1db84324fff3c93c76f46999a453b5492151677b8dcebf16cb2f94bae17949c17714a6b0d87fe3cce99d9c149562df76ab035cf0c671",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEERGdmsC04q3xux24QyT/88k8dvRpmaRT\ntUkhUWd7jc6/FssvlLrheUnBdxSmsNh/48zpnZwUlWLfdqsDXPDGcQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 459,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102206539c0adadd0525ff42622164ce9314348bd0863b4c80e936b23ca0414264671",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042f20bc2232b4ba9d75fea6a92bc827d91c5a8f5c887f4e304d76656ba15999ea5f83242efbd57dd16dbd3de0915bdb2ddec201d2f749b13fc22c223a2644dcdc",
+        "wx": "2f20bc2232b4ba9d75fea6a92bc827d91c5a8f5c887f4e304d76656ba15999ea",
+        "wy": "5f83242efbd57dd16dbd3de0915bdb2ddec201d2f749b13fc22c223a2644dcdc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042f20bc2232b4ba9d75fea6a92bc827d91c5a8f5c887f4e304d76656ba15999ea5f83242efbd57dd16dbd3de0915bdb2ddec201d2f749b13fc22c223a2644dcdc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELyC8IjK0up11/qapK8gn2Rxaj1yIf04w\nTXZla6FZmepfgyQu+9V90W29PeCRW9st3sIB0vdJsT/CLCI6JkTc3A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 460,
+          "comment": "point at infinity during verify",
+          "flags": [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049e009cd0a1a7d0c51765169c468e62e56fc4f3ff02e8666c55483419a2560032cd36d713acd504598ff3b4f58046a4690f550bd60ef4c823c5c581c6b899315e",
+        "wx": "009e009cd0a1a7d0c51765169c468e62e56fc4f3ff02e8666c55483419a2560032",
+        "wy": "00cd36d713acd504598ff3b4f58046a4690f550bd60ef4c823c5c581c6b899315e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049e009cd0a1a7d0c51765169c468e62e56fc4f3ff02e8666c55483419a2560032cd36d713acd504598ff3b4f58046a4690f550bd60ef4c823c5c581c6b899315e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEngCc0KGn0MUXZRacRo5i5W/E8/8C6GZs\nVUg0GaJWADLNNtcTrNUEWY/ztPWARqRpD1UL1g70yCPFxYHGuJkxXg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 461,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04af58a6ecc8254b9b831ae0441c13990802c3d68c301d43634c71f1974c09e704d920612d82f32fca436c5c5097505271494875402731d03dba942b355306c783",
+        "wx": "00af58a6ecc8254b9b831ae0441c13990802c3d68c301d43634c71f1974c09e704",
+        "wy": "00d920612d82f32fca436c5c5097505271494875402731d03dba942b355306c783"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004af58a6ecc8254b9b831ae0441c13990802c3d68c301d43634c71f1974c09e704d920612d82f32fca436c5c5097505271494875402731d03dba942b355306c783",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEr1im7MglS5uDGuBEHBOZCALD1owwHUNj\nTHHxl0wJ5wTZIGEtgvMvykNsXFCXUFJxSUh1QCcx0D26lCs1UwbHgw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 462,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044a7217cabc95b496f3f4e12d54e9def7651b866be69d3695cd77ad2e3a3f13d1d0fa71bf21d2c00b1ff4cc76b53a9c5c2a8a8b6b4c2ec88b99ee537ac6262b3d",
+        "wx": "4a7217cabc95b496f3f4e12d54e9def7651b866be69d3695cd77ad2e3a3f13d1",
+        "wy": "00d0fa71bf21d2c00b1ff4cc76b53a9c5c2a8a8b6b4c2ec88b99ee537ac6262b3d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044a7217cabc95b496f3f4e12d54e9def7651b866be69d3695cd77ad2e3a3f13d1d0fa71bf21d2c00b1ff4cc76b53a9c5c2a8a8b6b4c2ec88b99ee537ac6262b3d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESnIXyryVtJbz9OEtVOne92UbhmvmnTaV\nzXetLjo/E9HQ+nG/IdLACx/0zHa1OpxcKoqLa0wuyIuZ7lN6xiYrPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 463,
+          "comment": "u1 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b023210281",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0400a42e277ce657fb3dd07e135a3cb9b0a75a30bd8b64911606ee68371e56124467cf22e26a7009045b73ff19cd79851cceaad9ae72ef2d043d75365245befa06",
+        "wx": "00a42e277ce657fb3dd07e135a3cb9b0a75a30bd8b64911606ee68371e561244",
+        "wy": "67cf22e26a7009045b73ff19cd79851cceaad9ae72ef2d043d75365245befa06"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000400a42e277ce657fb3dd07e135a3cb9b0a75a30bd8b64911606ee68371e56124467cf22e26a7009045b73ff19cd79851cceaad9ae72ef2d043d75365245befa06",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAKQuJ3zmV/s90H4TWjy5sKdaML2LZJEW\nBu5oNx5WEkRnzyLianAJBFtz/xnNeYUczqrZrnLvLQQ9dTZSRb76Bg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 464,
+          "comment": "u1 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022100bc07ff041506dc73a75086a43252fb4270e157da75fb6cb92a9f07dcad153ec0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048520b9502f9a5ed753f09a5282cad721f5ebfb3db4142d667c6279869e76bcf1678e9bbd04a51460afc40a3e0cb7b0f8b8add89b2979758a5a1ffeb4584ee49e",
+        "wx": "008520b9502f9a5ed753f09a5282cad721f5ebfb3db4142d667c6279869e76bcf1",
+        "wy": "678e9bbd04a51460afc40a3e0cb7b0f8b8add89b2979758a5a1ffeb4584ee49e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048520b9502f9a5ed753f09a5282cad721f5ebfb3db4142d667c6279869e76bcf1678e9bbd04a51460afc40a3e0cb7b0f8b8add89b2979758a5a1ffeb4584ee49e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEhSC5UC+aXtdT8JpSgsrXIfXr+z20FC1m\nfGJ5hp52vPFnjpu9BKUUYK/ECj4Mt7D4uK3Ymyl5dYpaH/60WE7kng==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 465,
+          "comment": "u2 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b5deca0fe0296905aac27e3604a95a0a2ecbee9fc453d2e1164632964454d0c94f9e4e85a143ee677d40919c71014e8cabf4d9db7442fe4b96298f99f90ca67f",
+        "wx": "00b5deca0fe0296905aac27e3604a95a0a2ecbee9fc453d2e1164632964454d0c9",
+        "wy": "4f9e4e85a143ee677d40919c71014e8cabf4d9db7442fe4b96298f99f90ca67f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b5deca0fe0296905aac27e3604a95a0a2ecbee9fc453d2e1164632964454d0c94f9e4e85a143ee677d40919c71014e8cabf4d9db7442fe4b96298f99f90ca67f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtd7KD+ApaQWqwn42BKlaCi7L7p/EU9Lh\nFkYylkRU0MlPnk6FoUPuZ31AkZxxAU6Mq/TZ23RC/kuWKY+Z+Qymfw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 466,
+          "comment": "u2 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9d1c9e899ca306ad27fe1945de0242b89",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045dcb2767dc851e20911ed7be39dd87ba81c7a6d10255dfb825f241486f98ae10f8a9ef736b3e11d7d54a0e086902fb477246ec8c57de65d336570b65f65e0d83",
+        "wx": "5dcb2767dc851e20911ed7be39dd87ba81c7a6d10255dfb825f241486f98ae10",
+        "wy": "00f8a9ef736b3e11d7d54a0e086902fb477246ec8c57de65d336570b65f65e0d83"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045dcb2767dc851e20911ed7be39dd87ba81c7a6d10255dfb825f241486f98ae10f8a9ef736b3e11d7d54a0e086902fb477246ec8c57de65d336570b65f65e0d83",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXcsnZ9yFHiCRHte+Od2HuoHHptECVd+4\nJfJBSG+YrhD4qe9zaz4R19VKDghpAvtHckbsjFfeZdM2Vwtl9l4Ngw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 467,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02206bfd55a94e530bd972e52873ef39ac3e56d420a64d874694c701e714511d1696",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c8e144c853a7e1a6f5bbabe7ef91ef5b152113210d44fd58d3cb6185184e168aac40fb3618882193fc6d113760e476465df49067480a0a7cffe686515b3391a8",
+        "wx": "00c8e144c853a7e1a6f5bbabe7ef91ef5b152113210d44fd58d3cb6185184e168a",
+        "wy": "00ac40fb3618882193fc6d113760e476465df49067480a0a7cffe686515b3391a8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c8e144c853a7e1a6f5bbabe7ef91ef5b152113210d44fd58d3cb6185184e168aac40fb3618882193fc6d113760e476465df49067480a0a7cffe686515b3391a8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEyOFEyFOn4ab1u6vn75HvWxUhEyENRP1Y\n08thhRhOFoqsQPs2GIghk/xtETdg5HZGXfSQZ0gKCnz/5oZRWzORqA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 468,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100b494bd67c209a5adb1c9a09337e2629b03f8a924be53c542478e5864ed2622ad",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047ffe185a23eb5b736704387e6357628a65984985773b4473cf9ef560b3fa50514740cb1217f1ad2b5910d7f74906602b1f9550b3d11cff705b358c3bcbf72c3d",
+        "wx": "7ffe185a23eb5b736704387e6357628a65984985773b4473cf9ef560b3fa5051",
+        "wy": "4740cb1217f1ad2b5910d7f74906602b1f9550b3d11cff705b358c3bcbf72c3d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047ffe185a23eb5b736704387e6357628a65984985773b4473cf9ef560b3fa50514740cb1217f1ad2b5910d7f74906602b1f9550b3d11cff705b358c3bcbf72c3d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEf/4YWiPrW3NnBDh+Y1diimWYSYV3O0Rz\nz571YLP6UFFHQMsSF/GtK1kQ1/dJBmArH5VQs9Ec/3BbNYw7y/csPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 469,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100aad4e2b69a9f378dae7873b40f7c15cb4565fcc8cbc0ec55b0bd3fe9d8626b2c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048a858226155e34dbb7e5dac7f13127c81c6ce8c9d891918c67c8738d7e4b46e96c1386e84c612312de53e9e4af34d9bd57f93d9a06b855b6e0b06ad4137ff57c",
+        "wx": "008a858226155e34dbb7e5dac7f13127c81c6ce8c9d891918c67c8738d7e4b46e9",
+        "wy": "6c1386e84c612312de53e9e4af34d9bd57f93d9a06b855b6e0b06ad4137ff57c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048a858226155e34dbb7e5dac7f13127c81c6ce8c9d891918c67c8738d7e4b46e96c1386e84c612312de53e9e4af34d9bd57f93d9a06b855b6e0b06ad4137ff57c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEioWCJhVeNNu35drH8TEnyBxs6MnYkZGM\nZ8hzjX5LRulsE4boTGEjEt5T6eSvNNm9V/k9mga4VbbgsGrUE3/1fA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 470,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022073fec4995e9d3140bc07ff041506dc7313e95389fb599d22f24039392a4014d3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04aec0be729b02f266c542d139a3e04110c933e8eca1008e8dba38d75e7f8fab532cd688d924b456848bd5c651444c67a9399fdfb5b5b9693162c1728bfadc1046",
+        "wx": "00aec0be729b02f266c542d139a3e04110c933e8eca1008e8dba38d75e7f8fab53",
+        "wy": "2cd688d924b456848bd5c651444c67a9399fdfb5b5b9693162c1728bfadc1046"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004aec0be729b02f266c542d139a3e04110c933e8eca1008e8dba38d75e7f8fab532cd688d924b456848bd5c651444c67a9399fdfb5b5b9693162c1728bfadc1046",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErsC+cpsC8mbFQtE5o+BBEMkz6OyhAI6N\nujjXXn+Pq1Ms1ojZJLRWhIvVxlFETGepOZ/ftbW5aTFiwXKL+twQRg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 471,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100ec4995e9d3140bc07ff041506dc73a73dc25f4257a911e310e38744b482a5a01",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0401ed4b5f941f443b31a7e2583ea165551d1815b54740deb12e9fdeff32e2306184385ca448cc5dd71139bda3ab42d0b6e44d719e52fff64d971876efa9109fb2",
+        "wx": "01ed4b5f941f443b31a7e2583ea165551d1815b54740deb12e9fdeff32e23061",
+        "wy": "0084385ca448cc5dd71139bda3ab42d0b6e44d719e52fff64d971876efa9109fb2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000401ed4b5f941f443b31a7e2583ea165551d1815b54740deb12e9fdeff32e2306184385ca448cc5dd71139bda3ab42d0b6e44d719e52fff64d971876efa9109fb2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAe1LX5QfRDsxp+JYPqFlVR0YFbVHQN6x\nLp/e/zLiMGGEOFykSMxd1xE5vaOrQtC25E1xnlL/9k2XGHbvqRCfsg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 472,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100d8932bd3a6281780ffe082a0db8e74e8fd9d0b6445d99c265c9e8a09c01e72c1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0459c427cb6525eab511a06e03e00cf2aab4abc587c2601534338a50bc25701a703e4eb388b453cbaea594d6b5c14a519ac3fda770c53580beefc68f09200d55ff",
+        "wx": "59c427cb6525eab511a06e03e00cf2aab4abc587c2601534338a50bc25701a70",
+        "wy": "3e4eb388b453cbaea594d6b5c14a519ac3fda770c53580beefc68f09200d55ff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000459c427cb6525eab511a06e03e00cf2aab4abc587c2601534338a50bc25701a703e4eb388b453cbaea594d6b5c14a519ac3fda770c53580beefc68f09200d55ff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEWcQny2Ul6rURoG4D4AzyqrSrxYfCYBU0\nM4pQvCVwGnA+TrOItFPLrqWU1rXBSlGaw/2ncMU1gL7vxo8JIA1V/w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 473,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02205e9d3140bc07ff041506dc73a75086a3ba176f06c2b6e37363e2ce1c141f3c27",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0404acbbcd23cf2ec819fd297ab2cb5407ede6319518651a391e941cc8003568331206dd00df23bc8ce0b85a018c4b34e9c3b41b4ef59c71492fa62d134772f97e",
+        "wx": "04acbbcd23cf2ec819fd297ab2cb5407ede6319518651a391e941cc800356833",
+        "wy": "1206dd00df23bc8ce0b85a018c4b34e9c3b41b4ef59c71492fa62d134772f97e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000404acbbcd23cf2ec819fd297ab2cb5407ede6319518651a391e941cc8003568331206dd00df23bc8ce0b85a018c4b34e9c3b41b4ef59c71492fa62d134772f97e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEBKy7zSPPLsgZ/Sl6sstUB+3mMZUYZRo5\nHpQcyAA1aDMSBt0A3yO8jOC4WgGMSzTpw7QbTvWccUkvpi0TR3L5fg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 474,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100fd6dc71a71f1d50d1bbd976af4357be4dd2fe850707c431fd376e53d176c6b62",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ccacbc626fd6ea31175815cff958ca1637323877d3bdf09896b527bf4e255e8571f8a27e6309bd9b9b15d78d5270012ad2ed15a7fffe024fc0eca63fb6ac2f8d",
+        "wx": "00ccacbc626fd6ea31175815cff958ca1637323877d3bdf09896b527bf4e255e85",
+        "wy": "71f8a27e6309bd9b9b15d78d5270012ad2ed15a7fffe024fc0eca63fb6ac2f8d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ccacbc626fd6ea31175815cff958ca1637323877d3bdf09896b527bf4e255e8571f8a27e6309bd9b9b15d78d5270012ad2ed15a7fffe024fc0eca63fb6ac2f8d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzKy8Ym/W6jEXWBXP+VjKFjcyOHfTvfCY\nlrUnv04lXoVx+KJ+Ywm9m5sV141ScAEq0u0Vp//+Ak/A7KY/tqwvjQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 475,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02207ee75ad2a5801c54722eb7d95ba67febcfc399b956b7b682fe89638de3690bf1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ccc30b65cad3dd1d793b6db80f57b2e1237973e4264c3d9bbc2551ec68a0b7be75ff6d1f4f535a131aa573f6e2d6912c397154933750417d28e46524392592de",
+        "wx": "00ccc30b65cad3dd1d793b6db80f57b2e1237973e4264c3d9bbc2551ec68a0b7be",
+        "wy": "75ff6d1f4f535a131aa573f6e2d6912c397154933750417d28e46524392592de"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ccc30b65cad3dd1d793b6db80f57b2e1237973e4264c3d9bbc2551ec68a0b7be75ff6d1f4f535a131aa573f6e2d6912c397154933750417d28e46524392592de",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzMMLZcrT3R15O224D1ey4SN5c+QmTD2b\nvCVR7Gigt751/20fT1NaExqlc/bi1pEsOXFUkzdQQX0o5GUkOSWS3g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 476,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100f533776f11c47ed0a7b5e25ace7a3b921866733c7454b2c678b8943dfb4cf232",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cc9349aca0cbd0b2df0deecd88ed39e6d8c7c3d7b422fd5d92431baf7225fcc0ed494be698d6f3850be277c268792400f396025cfa95cf56018bcbc243e512eb",
+        "wx": "00cc9349aca0cbd0b2df0deecd88ed39e6d8c7c3d7b422fd5d92431baf7225fcc0",
+        "wy": "00ed494be698d6f3850be277c268792400f396025cfa95cf56018bcbc243e512eb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cc9349aca0cbd0b2df0deecd88ed39e6d8c7c3d7b422fd5d92431baf7225fcc0ed494be698d6f3850be277c268792400f396025cfa95cf56018bcbc243e512eb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzJNJrKDL0LLfDe7NiO055tjHw9e0Iv1d\nkkMbr3Il/MDtSUvmmNbzhQvid8JoeSQA85YCXPqVz1YBi8vCQ+US6w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 477,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100e8dbffee01807d75f9aa52c295e15b15f138439e7a195a40709b1abf511dbc6a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04000e7c30d2f259f7c13f194320e43905d0ead7277e283e8918437c10f9d052b02b39b66dbba2b1cf5dac1b41d2dec6f1fb08bdd14d420d703986f63aedeb5c47",
+        "wx": "0e7c30d2f259f7c13f194320e43905d0ead7277e283e8918437c10f9d052b0",
+        "wy": "2b39b66dbba2b1cf5dac1b41d2dec6f1fb08bdd14d420d703986f63aedeb5c47"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004000e7c30d2f259f7c13f194320e43905d0ead7277e283e8918437c10f9d052b02b39b66dbba2b1cf5dac1b41d2dec6f1fb08bdd14d420d703986f63aedeb5c47",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAA58MNLyWffBPxlDIOQ5BdDq1yd+KD6J\nGEN8EPnQUrArObZtu6Kxz12sG0HS3sbx+wi90U1CDXA5hvY67etcRw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 478,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100ca01552b58d67a13468d6bc6086329df8f44cc938884fcf15c516b02a7a7b5f6",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048fa298c00ac93f7c36892c5299005a0f6843f9cf0669fdbb7d6d81e0341803ed4cab33cc2821b2da849f90ef20dc1eb896fc67161440b3c52c0b1e88627e508c",
+        "wx": "008fa298c00ac93f7c36892c5299005a0f6843f9cf0669fdbb7d6d81e0341803ed",
+        "wy": "4cab33cc2821b2da849f90ef20dc1eb896fc67161440b3c52c0b1e88627e508c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048fa298c00ac93f7c36892c5299005a0f6843f9cf0669fdbb7d6d81e0341803ed4cab33cc2821b2da849f90ef20dc1eb896fc67161440b3c52c0b1e88627e508c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEj6KYwArJP3w2iSxSmQBaD2hD+c8Gaf27\nfW2B4DQYA+1MqzPMKCGy2oSfkO8g3B64lvxnFhRAs8UsCx6IYn5QjA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 479,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0221009402aa56b1acf4268d1ad78c10c653c063dabc4061c159a6f8d077787f192aab",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046fbf608a83e37ec26b37da033e069816680b770ba766fb8c44fce003960562f1045f268ccc5e0949213f7f2f1fa57cfead04625ec3ccfc9c333596e487b2056f",
+        "wx": "6fbf608a83e37ec26b37da033e069816680b770ba766fb8c44fce003960562f1",
+        "wy": "045f268ccc5e0949213f7f2f1fa57cfead04625ec3ccfc9c333596e487b2056f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046fbf608a83e37ec26b37da033e069816680b770ba766fb8c44fce003960562f1045f268ccc5e0949213f7f2f1fa57cfead04625ec3ccfc9c333596e487b2056f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEb79gioPjfsJrN9oDPgaYFmgLdwunZvuM\nRPzgA5YFYvEEXyaMzF4JSSE/fy8fpXz+rQRiXsPM/JwzNZbkh7IFbw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 480,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02205e03ff820a836e39d3a8435219297da13870abed3afdb65c954f83ee568a9f60",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c4dd547ad750174179bac8b8ce27481c58b81347776220a1b52ada13d65c8124f9c2ef3b5b4957cf69d3a139891682363c040610f200f4c318e59aa68f298af0",
+        "wx": "00c4dd547ad750174179bac8b8ce27481c58b81347776220a1b52ada13d65c8124",
+        "wy": "00f9c2ef3b5b4957cf69d3a139891682363c040610f200f4c318e59aa68f298af0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c4dd547ad750174179bac8b8ce27481c58b81347776220a1b52ada13d65c8124f9c2ef3b5b4957cf69d3a139891682363c040610f200f4c318e59aa68f298af0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAExN1UetdQF0F5usi4zidIHFi4E0d3YiCh\ntSraE9ZcgST5wu87W0lXz2nToTmJFoI2PAQGEPIA9MMY5ZqmjymK8A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 481,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220556a715b4d4f9bc6d73c39da07be0ae5a2b2fe6465e0762ad85e9ff4ec313596",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0400055d79fb26286bb6289a7983a2b23bf5c30cc3d70363b559adf5548af991f8cae8b1b0ace32fd74a86ee1a671cc36c052a4796eae323be32e02ce9a0fb6227",
+        "wx": "055d79fb26286bb6289a7983a2b23bf5c30cc3d70363b559adf5548af991f8",
+        "wy": "00cae8b1b0ace32fd74a86ee1a671cc36c052a4796eae323be32e02ce9a0fb6227"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000400055d79fb26286bb6289a7983a2b23bf5c30cc3d70363b559adf5548af991f8cae8b1b0ace32fd74a86ee1a671cc36c052a4796eae323be32e02ce9a0fb6227",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAAVdefsmKGu2KJp5g6KyO/XDDMPXA2O1\nWa31VIr5kfjK6LGwrOMv10qG7hpnHMNsBSpHlurjI74y4CzpoPtiJw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 482,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100d55555555555555555555555555555547c74934474db157d2a8c3f088aced62a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040db51c74d34e41baba67c13a60af404ee82d8f1b0386b09696ee1e6ea1327b86413886c4623fc222a6950c3c3a09f3fd867a566bfd345e06b09ec6c5c2e4a192",
+        "wx": "0db51c74d34e41baba67c13a60af404ee82d8f1b0386b09696ee1e6ea1327b86",
+        "wy": "413886c4623fc222a6950c3c3a09f3fd867a566bfd345e06b09ec6c5c2e4a192"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040db51c74d34e41baba67c13a60af404ee82d8f1b0386b09696ee1e6ea1327b86413886c4623fc222a6950c3c3a09f3fd867a566bfd345e06b09ec6c5c2e4a192",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEDbUcdNNOQbq6Z8E6YK9ATugtjxsDhrCW\nlu4ebqEye4ZBOIbEYj/CIqaVDDw6CfP9hnpWa/00XgawnsbFwuShkg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 483,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100c1777c8853938e536213c02464a936000ba1e21c0fc62075d46c624e23b52f31",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bc2f7bc74cb3bc7e797b06cc3e649bf3407d1a55b4eaaddd28d3dcfaff2c3737a23bb364e16ac79398c013ce29a22e762c0d6067aaefda958474aad194a92e8a",
+        "wx": "00bc2f7bc74cb3bc7e797b06cc3e649bf3407d1a55b4eaaddd28d3dcfaff2c3737",
+        "wy": "00a23bb364e16ac79398c013ce29a22e762c0d6067aaefda958474aad194a92e8a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bc2f7bc74cb3bc7e797b06cc3e649bf3407d1a55b4eaaddd28d3dcfaff2c3737a23bb364e16ac79398c013ce29a22e762c0d6067aaefda958474aad194a92e8a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEvC97x0yzvH55ewbMPmSb80B9GlW06q3d\nKNPc+v8sNzeiO7Nk4WrHk5jAE84poi52LA1gZ6rv2pWEdKrRlKkuig==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 484,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022030bbb794db588363b40679f6c182a50d3ce9679acdd3ffbe36d7813dacbdc818",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d7edc7c645efff6af8821aea5b7f969f56ef6e615862b08fba3eaf0111c06f67e47fd0da61682adcc405f329148bf1c35b89cb5ec5a9ed0d98a410e261a6b41a",
+        "wx": "00d7edc7c645efff6af8821aea5b7f969f56ef6e615862b08fba3eaf0111c06f67",
+        "wy": "00e47fd0da61682adcc405f329148bf1c35b89cb5ec5a9ed0d98a410e261a6b41a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d7edc7c645efff6af8821aea5b7f969f56ef6e615862b08fba3eaf0111c06f67e47fd0da61682adcc405f329148bf1c35b89cb5ec5a9ed0d98a410e261a6b41a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE1+3HxkXv/2r4ghrqW3+Wn1bvbmFYYrCP\nuj6vARHAb2fkf9DaYWgq3MQF8ykUi/HDW4nLXsWp7Q2YpBDiYaa0Gg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 485,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202c37fd995622c4fb7fffffffffffffffc7cee745110cb45ab558ed7c90c15a2f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046bfd7ad01b5dcfb04de464083d3ca7ef5054506111df92ef02ff7690d9a6ec9306c469fe4c5a1e04f114e193b4bb197de2c8e35089037e5a20275bcf67d9bf73",
+        "wx": "6bfd7ad01b5dcfb04de464083d3ca7ef5054506111df92ef02ff7690d9a6ec93",
+        "wy": "06c469fe4c5a1e04f114e193b4bb197de2c8e35089037e5a20275bcf67d9bf73"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046bfd7ad01b5dcfb04de464083d3ca7ef5054506111df92ef02ff7690d9a6ec9306c469fe4c5a1e04f114e193b4bb197de2c8e35089037e5a20275bcf67d9bf73",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEa/160Btdz7BN5GQIPTyn71BUUGER35Lv\nAv92kNmm7JMGxGn+TFoeBPEU4ZO0uxl94sjjUIkDflogJ1vPZ9m/cw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 486,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02207fd995622c4fb7ffffffffffffffffff5d883ffab5b32652ccdcaa290fccb97d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048a9076c923021d5c5ef85894176ebb5c3a74aba75b3944c96f17debc2173ba99e5601d115bf08d37ae115c4d186bc21127bbfb21d0629bde27a16e9ed721b740",
+        "wx": "008a9076c923021d5c5ef85894176ebb5c3a74aba75b3944c96f17debc2173ba99",
+        "wy": "00e5601d115bf08d37ae115c4d186bc21127bbfb21d0629bde27a16e9ed721b740"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048a9076c923021d5c5ef85894176ebb5c3a74aba75b3944c96f17debc2173ba99e5601d115bf08d37ae115c4d186bc21127bbfb21d0629bde27a16e9ed721b740",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEipB2ySMCHVxe+FiUF267XDp0q6dbOUTJ\nbxfevCFzupnlYB0RW/CNN64RXE0Ya8IRJ7v7IdBim94noW6e1yG3QA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 487,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100ffb32ac4589f6ffffffffffffffffffebb107ff56b664ca599b954521f9972fa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040fec6a85e077ef4240b98c62ab3b93e2cebcad0ae9617f7b0471504db1f45a65245a5fd0ad7a6d854125ed76d4787f77cc1983eca8c6ba8c019523a088c4d0f3",
+        "wx": "0fec6a85e077ef4240b98c62ab3b93e2cebcad0ae9617f7b0471504db1f45a65",
+        "wy": "245a5fd0ad7a6d854125ed76d4787f77cc1983eca8c6ba8c019523a088c4d0f3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040fec6a85e077ef4240b98c62ab3b93e2cebcad0ae9617f7b0471504db1f45a65245a5fd0ad7a6d854125ed76d4787f77cc1983eca8c6ba8c019523a088c4d0f3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAED+xqheB370JAuYxiqzuT4s68rQrpYX97\nBHFQTbH0WmUkWl/QrXpthUEl7XbUeH93zBmD7KjGuowBlSOgiMTQ8w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 488,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02205622c4fb7fffffffffffffffffffffff928a8f1c7ac7bec1808b9f61c01ec327",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d3ab94d8704fb51774dcc3838ad9703071e0851de9b2d6ca74ccd79b855581914e4979b67f377419e5a9d4f03012b7e75656556f23756d4dbee145834c8279ef",
+        "wx": "00d3ab94d8704fb51774dcc3838ad9703071e0851de9b2d6ca74ccd79b85558191",
+        "wy": "4e4979b67f377419e5a9d4f03012b7e75656556f23756d4dbee145834c8279ef"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d3ab94d8704fb51774dcc3838ad9703071e0851de9b2d6ca74ccd79b855581914e4979b67f377419e5a9d4f03012b7e75656556f23756d4dbee145834c8279ef",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE06uU2HBPtRd03MODitlwMHHghR3pstbK\ndMzXm4VVgZFOSXm2fzd0GeWp1PAwErfnVlZVbyN1bU2+4UWDTIJ57w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 489,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022044104104104104104104104104104103b87853fd3b7d3f8e175125b4382f25ed",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0449e13cd44c8b8350a5eaca2181bf96db120b768bde8800f379f43e9198333c75030ad9fb4b0b233bdc10ca0dc4c2134b18b691e46c7151e3573aa2b62891e69d",
+        "wx": "49e13cd44c8b8350a5eaca2181bf96db120b768bde8800f379f43e9198333c75",
+        "wy": "030ad9fb4b0b233bdc10ca0dc4c2134b18b691e46c7151e3573aa2b62891e69d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000449e13cd44c8b8350a5eaca2181bf96db120b768bde8800f379f43e9198333c75030ad9fb4b0b233bdc10ca0dc4c2134b18b691e46c7151e3573aa2b62891e69d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESeE81EyLg1Cl6sohgb+W2xILdoveiADz\nefQ+kZgzPHUDCtn7SwsjO9wQyg3EwhNLGLaR5GxxUeNXOqK2KJHmnQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 490,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202739ce739ce739ce739ce739ce739ce705560298d1f2f08dc419ac273a5b54d9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044574fd94ad03828588cb0bc2d434842ee093efe639015cc107d1ea3710f2112d1786d6ef1d411cbd1af5b5ee8845993e738fb64519b4329d04be21f7902a1c1d",
+        "wx": "4574fd94ad03828588cb0bc2d434842ee093efe639015cc107d1ea3710f2112d",
+        "wy": "1786d6ef1d411cbd1af5b5ee8845993e738fb64519b4329d04be21f7902a1c1d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044574fd94ad03828588cb0bc2d434842ee093efe639015cc107d1ea3710f2112d1786d6ef1d411cbd1af5b5ee8845993e738fb64519b4329d04be21f7902a1c1d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAERXT9lK0DgoWIywvC1DSELuCT7+Y5AVzB\nB9HqNxDyES0XhtbvHUEcvRr1te6IRZk+c4+2RRm0Mp0EviH3kCocHQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 491,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100b777777777777777777777777777777688e6a1fe808a97a348671222ff16b863",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ee824d818768f13fa0eb908e396ea1c56b11774ce69d01e563aa36bb41d6371c990291ce2abc55bb6682d502ae0129e7c57e146e96d44757daaa1f94c93e0b17",
+        "wx": "00ee824d818768f13fa0eb908e396ea1c56b11774ce69d01e563aa36bb41d6371c",
+        "wy": "00990291ce2abc55bb6682d502ae0129e7c57e146e96d44757daaa1f94c93e0b17"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ee824d818768f13fa0eb908e396ea1c56b11774ce69d01e563aa36bb41d6371c990291ce2abc55bb6682d502ae0129e7c57e146e96d44757daaa1f94c93e0b17",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7oJNgYdo8T+g65COOW6hxWsRd0zmnQHl\nY6o2u0HWNxyZApHOKrxVu2aC1QKuASnnxX4UbpbUR1faqh+UyT4LFw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 492,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02206492492492492492492492492492492406dd3a19b8d5fb875235963c593bd2d3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044825ee46b2d21564726a32a922f5e3f2da6098f780e1f15c6bf1640669c41fe7292c066a24f0f450c2603f1837210898f8e80fa384aaf077eb5c7e87c6b26976",
+        "wx": "4825ee46b2d21564726a32a922f5e3f2da6098f780e1f15c6bf1640669c41fe7",
+        "wy": "292c066a24f0f450c2603f1837210898f8e80fa384aaf077eb5c7e87c6b26976"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044825ee46b2d21564726a32a922f5e3f2da6098f780e1f15c6bf1640669c41fe7292c066a24f0f450c2603f1837210898f8e80fa384aaf077eb5c7e87c6b26976",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESCXuRrLSFWRyajKpIvXj8tpgmPeA4fFc\na/FkBmnEH+cpLAZqJPD0UMJgPxg3IQiY+OgPo4Sq8HfrXH6HxrJpdg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 493,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100955555555555555555555555555555547c74934474db157d2a8c3f088aced62c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0441348e7ac18eb1f4852801467bb0a0e36209321a8af4b410fd06f070a81f5de603b5594f1a5a79d23089e49e3e379f2a6cb14f92301c6999e510b8c8dc37fb4b",
+        "wx": "41348e7ac18eb1f4852801467bb0a0e36209321a8af4b410fd06f070a81f5de6",
+        "wy": "03b5594f1a5a79d23089e49e3e379f2a6cb14f92301c6999e510b8c8dc37fb4b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000441348e7ac18eb1f4852801467bb0a0e36209321a8af4b410fd06f070a81f5de603b5594f1a5a79d23089e49e3e379f2a6cb14f92301c6999e510b8c8dc37fb4b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQTSOesGOsfSFKAFGe7Cg42IJMhqK9LQQ\n/QbwcKgfXeYDtVlPGlp50jCJ5J4+N58qbLFPkjAcaZnlELjI3Df7Sw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 494,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3e3a49a23a6d8abe95461f8445676b17",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04753c74e5a36e1a4b61be7787202c98e05841fea2b0392b6ab69ee2e8a747e2b618971da1c85825c1d8141886115d27cb2add86545e6971bb835a2f452cde1e52",
+        "wx": "753c74e5a36e1a4b61be7787202c98e05841fea2b0392b6ab69ee2e8a747e2b6",
+        "wy": "18971da1c85825c1d8141886115d27cb2add86545e6971bb835a2f452cde1e52"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004753c74e5a36e1a4b61be7787202c98e05841fea2b0392b6ab69ee2e8a747e2b618971da1c85825c1d8141886115d27cb2add86545e6971bb835a2f452cde1e52",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEdTx05aNuGkthvneHICyY4FhB/qKwOStq\ntp7i6KdH4rYYlx2hyFglwdgUGIYRXSfLKt2GVF5pcbuDWi9FLN4eUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 495,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100bffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0449c0254724576b0949827ce46240d90cb4075cd1978a416495a455f06a895504df7d64c35853353bd4d905da6adb88f26e62a5f20b3cd6382adf2c5a42d85053",
+        "wx": "49c0254724576b0949827ce46240d90cb4075cd1978a416495a455f06a895504",
+        "wy": "00df7d64c35853353bd4d905da6adb88f26e62a5f20b3cd6382adf2c5a42d85053"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000449c0254724576b0949827ce46240d90cb4075cd1978a416495a455f06a895504df7d64c35853353bd4d905da6adb88f26e62a5f20b3cd6382adf2c5a42d85053",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEScAlRyRXawlJgnzkYkDZDLQHXNGXikFk\nlaRV8GqJVQTffWTDWFM1O9TZBdpq24jybmKl8gs81jgq3yxaQthQUw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 496,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220185ddbca6dac41b1da033cfb60c152869e74b3cd66e9ffdf1b6bc09ed65ee40c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb1871d7415d5f6c57c840678f7e1a1c1e323519a4647fb3f6f52abb4647b9b6d70",
+        "wx": "00b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb1",
+        "wy": "00871d7415d5f6c57c840678f7e1a1c1e323519a4647fb3f6f52abb4647b9b6d70"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb1871d7415d5f6c57c840678f7e1a1c1e323519a4647fb3f6f52abb4647b9b6d70",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsF6Y6E4sGXQ8Hc9ODd8LsfMoVAM95j/P\nPmBfuy7ZTLGHHXQV1fbFfIQGePfhocHjI1GaRkf7P29Sq7Rke5ttcA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 497,
+          "comment": "point duplication during verification",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022032b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda02206fd848306e968e3ac1f6e443577c47a3c20bf0d01a5dc39c78c2c69d681850f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb178e28bea2a093a837bf987081e5e3e1cdcae65b9b804c090ad544b9a84648ebf",
+        "wx": "00b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb1",
+        "wy": "78e28bea2a093a837bf987081e5e3e1cdcae65b9b804c090ad544b9a84648ebf"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b05e98e84e2c19743c1dcf4e0ddf0bb1f32854033de63fcf3e605fbb2ed94cb178e28bea2a093a837bf987081e5e3e1cdcae65b9b804c090ad544b9a84648ebf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsF6Y6E4sGXQ8Hc9ODd8LsfMoVAM95j/P\nPmBfuy7ZTLF44ovqKgk6g3v5hwgeXj4c3K5lubgEwJCtVEuahGSOvw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 498,
+          "comment": "duplication bug",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022032b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda02206fd848306e968e3ac1f6e443577c47a3c20bf0d01a5dc39c78c2c69d681850f4",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a49f9ebc082c064d61c0eab5f8bf23207b06e3a689dfc4fa2896ed114d1a88ab55783a6baf9401977d117ccb748c0d5c24a5d3bd2133d62c74de2be7cc7d9d40",
+        "wx": "00a49f9ebc082c064d61c0eab5f8bf23207b06e3a689dfc4fa2896ed114d1a88ab",
+        "wy": "55783a6baf9401977d117ccb748c0d5c24a5d3bd2133d62c74de2be7cc7d9d40"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a49f9ebc082c064d61c0eab5f8bf23207b06e3a689dfc4fa2896ed114d1a88ab55783a6baf9401977d117ccb748c0d5c24a5d3bd2133d62c74de2be7cc7d9d40",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpJ+evAgsBk1hwOq1+L8jIHsG46aJ38T6\nKJbtEU0aiKtVeDprr5QBl30RfMt0jA1cJKXTvSEz1ix03ivnzH2dQA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 499,
+          "comment": "comparison with point at infinity ",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0022033333333333333333333333333333332f222f8faefdb533f265d461c29a47373",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f9567a431b716388428510393b37feefd3afcfc6dc3881f623c0a0995e461ec3fba2f910ced19f8e789b158390a295e636c588c622d54f8feffbd2852e2911a9",
+        "wx": "00f9567a431b716388428510393b37feefd3afcfc6dc3881f623c0a0995e461ec3",
+        "wy": "00fba2f910ced19f8e789b158390a295e636c588c622d54f8feffbd2852e2911a9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f9567a431b716388428510393b37feefd3afcfc6dc3881f623c0a0995e461ec3fba2f910ced19f8e789b158390a295e636c588c622d54f8feffbd2852e2911a9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+VZ6QxtxY4hChRA5Ozf+79Ovz8bcOIH2\nI8CgmV5GHsP7ovkQztGfjnibFYOQopXmNsWIxiLVT4/v+9KFLikRqQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 500,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0426095ef93b10bf50fe283f4c99136fb81fa297814f09977e8e38a3bfb837f61baf8d7cfc46c1928624f201ed14a70701bc5531bff4e2e578d5c92dabddbc7580",
+        "wx": "26095ef93b10bf50fe283f4c99136fb81fa297814f09977e8e38a3bfb837f61b",
+        "wy": "00af8d7cfc46c1928624f201ed14a70701bc5531bff4e2e578d5c92dabddbc7580"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000426095ef93b10bf50fe283f4c99136fb81fa297814f09977e8e38a3bfb837f61baf8d7cfc46c1928624f201ed14a70701bc5531bff4e2e578d5c92dabddbc7580",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJgle+TsQv1D+KD9MmRNvuB+il4FPCZd+\njjijv7g39huvjXz8RsGShiTyAe0UpwcBvFUxv/Ti5XjVyS2r3bx1gA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 501,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022100b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047a4b58ee76d461a1c3cde68400a0bbeeab346ee69315bed63f1700c66cf5e6cca642ae4078bb6bbbb76028977882e9c8374f267a2ced131029ae89560ce29825",
+        "wx": "7a4b58ee76d461a1c3cde68400a0bbeeab346ee69315bed63f1700c66cf5e6cc",
+        "wy": "00a642ae4078bb6bbbb76028977882e9c8374f267a2ced131029ae89560ce29825"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047a4b58ee76d461a1c3cde68400a0bbeeab346ee69315bed63f1700c66cf5e6cca642ae4078bb6bbbb76028977882e9c8374f267a2ced131029ae89560ce29825",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEektY7nbUYaHDzeaEAKC77qs0buaTFb7W\nPxcAxmz15symQq5AeLtru7dgKJd4gunIN08meiztExAprolWDOKYJQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 502,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee502210099999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f2a111eb24c9d280d9a66e4ff18681d222dd6a1828ebc4528f2bebe3e25228a1a0699bcec507fd0ec83da541a5a6143e2e68e4af72fcdcc8a2aea2b17478cc8a",
+        "wx": "00f2a111eb24c9d280d9a66e4ff18681d222dd6a1828ebc4528f2bebe3e25228a1",
+        "wy": "00a0699bcec507fd0ec83da541a5a6143e2e68e4af72fcdcc8a2aea2b17478cc8a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f2a111eb24c9d280d9a66e4ff18681d222dd6a1828ebc4528f2bebe3e25228a1a0699bcec507fd0ec83da541a5a6143e2e68e4af72fcdcc8a2aea2b17478cc8a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE8qER6yTJ0oDZpm5P8YaB0iLdahgo68RS\njyvr4+JSKKGgaZvOxQf9Dsg9pUGlphQ+Lmjkr3L83MiirqKxdHjMig==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 503,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022066666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e50054b3e4a4d1fef988e5a5e830155abc293fea3598af4c5ddaa10acd111274eb710d1834568cb379a1d1f3d691a8c0dc19f901fe3225c2b6691df5ef5333fe",
+        "wx": "00e50054b3e4a4d1fef988e5a5e830155abc293fea3598af4c5ddaa10acd111274",
+        "wy": "00eb710d1834568cb379a1d1f3d691a8c0dc19f901fe3225c2b6691df5ef5333fe"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e50054b3e4a4d1fef988e5a5e830155abc293fea3598af4c5ddaa10acd111274eb710d1834568cb379a1d1f3d691a8c0dc19f901fe3225c2b6691df5ef5333fe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5QBUs+Sk0f75iOWl6DAVWrwpP+o1mK9M\nXdqhCs0REnTrcQ0YNFaMs3mh0fPWkajA3Bn5Af4yJcK2aR3171Mz/g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 504,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022049249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04edc17cd4ca6f9988fda5af4042e3f9eb42d0f7b6a1c0156e1a2af566b78103548a5d357777b306e96405f12e2617c1b29e8d574e5f6d66d1bc8ff7ea7c4b683c",
+        "wx": "00edc17cd4ca6f9988fda5af4042e3f9eb42d0f7b6a1c0156e1a2af566b7810354",
+        "wy": "008a5d357777b306e96405f12e2617c1b29e8d574e5f6d66d1bc8ff7ea7c4b683c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004edc17cd4ca6f9988fda5af4042e3f9eb42d0f7b6a1c0156e1a2af566b78103548a5d357777b306e96405f12e2617c1b29e8d574e5f6d66d1bc8ff7ea7c4b683c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7cF81MpvmYj9pa9AQuP560LQ97ahwBVu\nGir1ZreBA1SKXTV3d7MG6WQF8S4mF8Gyno1XTl9tZtG8j/fqfEtoPA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 505,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee502200eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d267c10d2315b42dbaf34c97c3c0d331fabacaf6021df4dc85b3e9e63dc0798ed154b11fa3a5ed952c14d8a2dd242de2b6cce3c22df42cd97de30054a19555e",
+        "wx": "6d267c10d2315b42dbaf34c97c3c0d331fabacaf6021df4dc85b3e9e63dc0798",
+        "wy": "00ed154b11fa3a5ed952c14d8a2dd242de2b6cce3c22df42cd97de30054a19555e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d267c10d2315b42dbaf34c97c3c0d331fabacaf6021df4dc85b3e9e63dc0798ed154b11fa3a5ed952c14d8a2dd242de2b6cce3c22df42cd97de30054a19555e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbSZ8ENIxW0LbrzTJfDwNMx+rrK9gId9N\nyFs+nmPcB5jtFUsR+jpe2VLBTYot0kLeK2zOPCLfQs2X3jAFShlVXg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 506,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c24bf7a984c96ece10077a9def38cbd0d898abd555f1668e06c27cabc00f6f679f69b238e1f95e99e5b558e0036273ebd6c36d12b4515348b85a21f6283f5016",
+        "wx": "00c24bf7a984c96ece10077a9def38cbd0d898abd555f1668e06c27cabc00f6f67",
+        "wy": "009f69b238e1f95e99e5b558e0036273ebd6c36d12b4515348b85a21f6283f5016"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c24bf7a984c96ece10077a9def38cbd0d898abd555f1668e06c27cabc00f6f679f69b238e1f95e99e5b558e0036273ebd6c36d12b4515348b85a21f6283f5016",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEwkv3qYTJbs4QB3qd7zjL0NiYq9VV8WaO\nBsJ8q8APb2efabI44flemeW1WOADYnPr1sNtErRRU0i4WiH2KD9QFg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 507,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022100b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041cd26d668807c815ed3f532c1db81ac473fb368f0f7ef1aff2592ea6fa6c4624a229b9ab5746cfbc47280c019a4248545354ca20880ff41cac2e252bc9b49704",
+        "wx": "1cd26d668807c815ed3f532c1db81ac473fb368f0f7ef1aff2592ea6fa6c4624",
+        "wy": "00a229b9ab5746cfbc47280c019a4248545354ca20880ff41cac2e252bc9b49704"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041cd26d668807c815ed3f532c1db81ac473fb368f0f7ef1aff2592ea6fa6c4624a229b9ab5746cfbc47280c019a4248545354ca20880ff41cac2e252bc9b49704",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHNJtZogHyBXtP1MsHbgaxHP7No8PfvGv\n8lkupvpsRiSiKbmrV0bPvEcoDAGaQkhUU1TKIIgP9BysLiUrybSXBA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 508,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179802210099999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fc780777a3289af663fa02b1c262a8373b84614e659c1ab46942f1e058926ff82196c6bcae0b2798298d463be5c87924343d7f103a27131e0c7f4d60d2b5da8c",
+        "wx": "00fc780777a3289af663fa02b1c262a8373b84614e659c1ab46942f1e058926ff8",
+        "wy": "2196c6bcae0b2798298d463be5c87924343d7f103a27131e0c7f4d60d2b5da8c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fc780777a3289af663fa02b1c262a8373b84614e659c1ab46942f1e058926ff82196c6bcae0b2798298d463be5c87924343d7f103a27131e0c7f4d60d2b5da8c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE/HgHd6MomvZj+gKxwmKoNzuEYU5lnBq0\naULx4FiSb/ghlsa8rgsnmCmNRjvlyHkkND1/EDonEx4Mf01g0rXajA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 509,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022066666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045e25e2ee8af5ef8a3e0908341f9884501fb58a2fd234b1db6f22d561025524f4491d97a7793c9d9a1f35bb35f12121b9dbe075d8501cbd4db6697e3e0ad98bc0",
+        "wx": "5e25e2ee8af5ef8a3e0908341f9884501fb58a2fd234b1db6f22d561025524f4",
+        "wy": "491d97a7793c9d9a1f35bb35f12121b9dbe075d8501cbd4db6697e3e0ad98bc0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045e25e2ee8af5ef8a3e0908341f9884501fb58a2fd234b1db6f22d561025524f4491d97a7793c9d9a1f35bb35f12121b9dbe075d8501cbd4db6697e3e0ad98bc0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXiXi7or174o+CQg0H5iEUB+1ii/SNLHb\nbyLVYQJVJPRJHZeneTydmh81uzXxISG52+B12FAcvU22aX4+CtmLwA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 510,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022049249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043ddf2920607df596da90123ea5674958054c8ed7758661b813f1aa30f19778b0707243e1a7bcc264b54289832e950c27563856241b79c243d0fc54f7ad24bc25",
+        "wx": "3ddf2920607df596da90123ea5674958054c8ed7758661b813f1aa30f19778b0",
+        "wy": "707243e1a7bcc264b54289832e950c27563856241b79c243d0fc54f7ad24bc25"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043ddf2920607df596da90123ea5674958054c8ed7758661b813f1aa30f19778b0707243e1a7bcc264b54289832e950c27563856241b79c243d0fc54f7ad24bc25",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEPd8pIGB99ZbakBI+pWdJWAVMjtd1hmG4\nE/GqMPGXeLBwckPhp7zCZLVCiYMulQwnVjhWJBt5wkPQ/FT3rSS8JQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 511,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179802200eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 512,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b02321028102202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 513,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100bc07ff041506dc73a75086a43252fb4270e157da75fb6cb92a9f07dcad153ec002202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "00b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5i3xSWI2Vw7mqJbBAPx7vdXAuhLt1l6q+ZjuC9vBO8ndw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 514,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b02321028102202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 515,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100bc07ff041506dc73a75086a43252fb4270e157da75fb6cb92a9f07dcad153ec002202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "01060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv8AAAABBgSS1aVnPg8l2NUPt+WMSdhtRtQhaVXgqj1A4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 516,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402202b9c9f85596fed708b3af80393b27edfd0b5ae2f0074270a56362f5f9f62b4e102202fae837503ba2c1d4c945e0913949ef094ce0b8086359bbb5dba4a12707c5600",
+          "result": "valid"
+        },
+        {
+          "tcId": 517,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402205cd765209021d8c1a8aef4ff61d6fa6e7993bf9fea0b93609eea130de536fccc02204f10c7989587fe3019e36d85aa024bf20db6737c4f28900c1c9662f2782143e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 518,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502204c1a59b1e578d76f1595e13b557057559f26ab559ec1df3f45ec98b90fa526ce022100c6872f094bdb3f82e31f93ad65357e2daafe66f304af197089ef0dc94ff90624",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "00fffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv/////++fttKlqYwfDaJyrwSBpztieSuSvelqoeVcK7Tg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 519,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100a35d1400d4cc7a8f617b721faee7118a74103c4630dec5aa47e097951dafc1a7022100958221023024e97ef6df35a22e820c7bc5e16299f3f12e9d9b1b727c46d795e6",
+          "result": "valid"
+        },
+        {
+          "tcId": 520,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402207fb733ed73c72fc4f4cf065e370c730301316ff4e9c6a8a701170f604c2d70b702207ca9ca985d3df48978b3a2f9c0bb8a58b216c795e687f74623a3321448bfa73c",
+          "result": "valid"
+        },
+        {
+          "tcId": 521,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502210095ae4df2fba8524e1151cb9a9c5c1ec1357a663722a18329303d86a58e7047540220591ea644b1dc6f4c7cd5d7d939397f84d9e077100760f0816ae5b22ae6a74203",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+        "wx": "013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0",
+        "wy": "00f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAAAAAT/SIkjWTZX3PCm0irSGMYUL5QP9\nAPhGi18PcOD27nqkO8LG/SWx2CaSQcvdnbsNrJbcliMfQwcF+DhxfQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 522,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30440220717925f0dd5cf45e746e87f79c9ea97d11eb01444052c270aeccef56c2e958280220785787b664137080383d2fc500459fa713258205fdae97b3240fb64bb638a657",
+          "result": "valid"
+        },
+        {
+          "tcId": 523,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30460221008adfdeae3b586315d06183610d271fc423cc789908b8f5dc563253a3c782510a0221008137bedbb4e60da26041b351f72a6bc3b7741f745743f0733b40b7fc56febd04",
+          "result": "valid"
+        },
+        {
+          "tcId": 524,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502210092ded14e19b94d17c79b063a034b122ce3b93a2502f2f223fad3461abf631632022052ff8ad14ba3657242e29440d01cab36ebb6033ee36021dc8d9b38f0808a90bc",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+        "wx": "25afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dffffffff",
+        "wy": "00fa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJa/WiayrrtZ8Hylt5ZQG+MVQ9XFGoLTs\nLJeHbf/////6RqduUgMi37xJHsTwzBl0IPxOpYg9j23VPDVLxPZ8NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 525,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100d48373483e0fa2f11cfdfaea6f1de59e6861e9e87c4f6446602ba0125ab7de460221009d753bba3a7be08aab456e93a6500d4781795ed59af8bd6d6133129abef1ad98",
+          "result": "valid"
+        },
+        {
+          "tcId": 526,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100f11473117b66e5d84a2ecd0f8b7ec4a2cc2aee89ae022020235777305142f498022100fe5ce43ced28f3f69f65e810678afefd2bdeefb051280ad2880157fda28b2ab1",
+          "result": "valid"
+        },
+        {
+          "tcId": 527,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502203c9f5bdde7310b5696c93c86203fc97e11a70739e20c71c9e722308d45a59e6c022100c09efb9a045a47cce799b768890bb17833a0210d869a36be1da33f2585477c32",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+        "wx": "00d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb9",
+        "wy": "3f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0S5sZrZ3NMPITSYBz1013Al+J2N/CspK\nT9t0tqrdO7k/W9/4i9VzbfiY5pkAbtdQ8RzwfFhmzXrXDHEh/////w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 528,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402206953442c487f240487d2af81f9825c894b1fc2534321fa012db8248be20a4b06022056927395d64ce4d690caa98944c2ddebc312f57f439d37236ea63cc1de098718",
+          "result": "valid"
+        },
+        {
+          "tcId": 529,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100fb39aa5f36ceca6e68d1932e811598c412892734dade389fd9e8ba94c5c7a251022100fdddf0c3db66c7c46608ac98431f0ee8ebb1e27ba501937789ebcd0f7ac26ecc",
+          "result": "valid"
+        },
+        {
+          "tcId": 530,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3044022044fef6017638fd5bda17dfce346b0311b5e369bfb68aa85d5e970786b8e6644b0220720b3a52fe44be6028759f0f1a6fd7020ff6792cd4ece98dffd0d97d3b726091",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9rc5"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+        "wx": "6d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000",
+        "wy": "00e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbUp/YNR3Sk8KqLve25U8fup5CUB+MWR1\nVmS8KAAAAADmWdNOTfONnoyeqt+6NmEsdpGVvobHeqw/NueLU4aA+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 531,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30430220304babc41346e6205cf03e2d0b26e4b222dce8227402d001ba233efa69c91234021f65add3279f51b2417fb0a13b0f06404199caac3430385513ee49f67d8e8cdf",
+          "result": "valid"
+        },
+        {
+          "tcId": 532,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3044022023868700b71fbafcaa73960faf922ee0458ef69e01fb060b2f9a80d992fe114c02206ec1526bd56f6eebf10463bd9210d62510b95166365e10a7b7abfc4d584ca338",
+          "result": "valid"
+        },
+        {
+          "tcId": 533,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100dd60d7cf83a08208637212b65d079fb658d8ef1b8438d9c58f4122b0cd14ac49022100f1d762516f4d6c3e6a98dd31dc3869dc7cf35944f33b35c6a17fe632d2b18cd5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-non-minimal-tag",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 534,
+          "comment": "signature with non-minimal SEQUENCE tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "3f104502206632473c909425b6fa37095398e2538daab8552440320f9fe190dba8f672796b022100a8c3aacce9ffe4bc17c0530738f1386f9d9579f029ff3a7791b16e98422265e3",
+          "result": "invalid"
+        },
+        {
+          "tcId": 535,
+          "comment": "signature with non-minimal INTEGER tag on r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "30461f02206632473c909425b6fa37095398e2538daab8552440320f9fe190dba8f672796b022100a8c3aacce9ffe4bc17c0530738f1386f9d9579f029ff3a7791b16e98422265e3",
+          "result": "invalid"
+        },
+        {
+          "tcId": 536,
+          "comment": "signature with non-minimal INTEGER tag on s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "304602206632473c909425b6fa37095398e2538daab8552440320f9fe190dba8f672796b1f022100a8c3aacce9ffe4bc17c0530738f1386f9d9579f029ff3a7791b16e98422265e3",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+        "wx": "2df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5b",
+        "wy": "aa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELfOElG+CrhPOJTCU9AYOSV/JfUjpTSxs\nHw0SLgcWG1uqNna+Bp5er1Vs8FLmpp5DD0ut7Iz7qMJ35Wl/aQb79g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 537,
+          "comment": "r = 1, x = 1 is valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0497047b3db38d6866eb16f42e6da13a235353c6b6d55fff54f2f84f84db19830546618f8cf778e11dca09549e397f2f054d4098b28c437e73eb29902f038a3066",
+        "wx": "97047b3db38d6866eb16f42e6da13a235353c6b6d55fff54f2f84f84db198305",
+        "wy": "46618f8cf778e11dca09549e397f2f054d4098b28c437e73eb29902f038a3066"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000497047b3db38d6866eb16f42e6da13a235353c6b6d55fff54f2f84f84db19830546618f8cf778e11dca09549e397f2f054d4098b28c437e73eb29902f038a3066",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAElwR7PbONaGbrFvQubaE6I1NTxrbVX/9U\n8vhPhNsZgwVGYY+M93jhHcoJVJ45fy8FTUCYsoxDfnPrKZAvA4owZg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 538,
+          "comment": "r = 2, x = 1 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020102022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+        "wx": "2df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5b",
+        "wy": "aa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042df384946f82ae13ce253094f4060e495fc97d48e94d2c6c1f0d122e07161b5baa3676be069e5eaf556cf052e6a69e430f4badec8cfba8c277e5697f6906fbf6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELfOElG+CrhPOJTCU9AYOSV/JfUjpTSxs\nHw0SLgcWG1uqNna+Bp5er1Vs8FLmpp5DD0ut7Iz7qMJ35Wl/aQb79g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 539,
+          "comment": "r = 1 + n, x = 1 is invalid; r was not reduced mod n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bbd24d14fe5a2a324c61c69845a8dea22a61c1a47b1d8a4c017144b8ac507a9941c7e7c3de74a65afa7d2d4d10892f67cf784d406a587e6cb9f95821bbbeeba1",
+        "wx": "bbd24d14fe5a2a324c61c69845a8dea22a61c1a47b1d8a4c017144b8ac507a99",
+        "wy": "41c7e7c3de74a65afa7d2d4d10892f67cf784d406a587e6cb9f95821bbbeeba1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bbd24d14fe5a2a324c61c69845a8dea22a61c1a47b1d8a4c017144b8ac507a9941c7e7c3de74a65afa7d2d4d10892f67cf784d406a587e6cb9f95821bbbeeba1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEu9JNFP5aKjJMYcaYRajeoiphwaR7HYpM\nAXFEuKxQeplBx+fD3nSmWvp9LU0QiS9nz3hNQGpYfmy5+Vghu77roQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 540,
+          "comment": "r = n - 3, x = n - 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d7c42bdab5d38d6439fe64459745b4fb172d6e6a0e4618439aeeab489ff6532db3d14b5650b9b1e823d18bfde89b55d07b5cfe166815a3e4da8bb34f405545ae",
+        "wx": "d7c42bdab5d38d6439fe64459745b4fb172d6e6a0e4618439aeeab489ff6532d",
+        "wy": "b3d14b5650b9b1e823d18bfde89b55d07b5cfe166815a3e4da8bb34f405545ae"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d7c42bdab5d38d6439fe64459745b4fb172d6e6a0e4618439aeeab489ff6532db3d14b5650b9b1e823d18bfde89b55d07b5cfe166815a3e4da8bb34f405545ae",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE18Qr2rXTjWQ5/mRFl0W0+xctbmoORhhD\nmu6rSJ/2Uy2z0UtWULmx6CPRi/3om1XQe1z+FmgVo+Tai7NPQFVFrg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 541,
+          "comment": "r = 2, x = n + 2 is the smallest possible x with a reduction",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020102022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044fe4cc98d665a49cfda32bea8de8bd3e6ad863911cd077c072be2b35b487946a256f9cb614fa9bcb345ae8726a9f618a737d45cce96a766bf0fb610c202d56da",
+        "wx": "4fe4cc98d665a49cfda32bea8de8bd3e6ad863911cd077c072be2b35b487946a",
+        "wy": "256f9cb614fa9bcb345ae8726a9f618a737d45cce96a766bf0fb610c202d56da"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044fe4cc98d665a49cfda32bea8de8bd3e6ad863911cd077c072be2b35b487946a256f9cb614fa9bcb345ae8726a9f618a737d45cce96a766bf0fb610c202d56da",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAET+TMmNZlpJz9oyvqjei9PmrYY5Ec0HfA\ncr4rNbSHlGolb5y2FPqbyzRa6HJqn2GKc31FzOlqdmvw+2EMIC1W2g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 542,
+          "comment": "r = 3, x = n + 2 is invalid",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "3026020103022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f3d010cc99320cbc39bee9101aa7ba7e8edf4e32ea8110e9f2442d6a49aeb78c0ae144cb8146541555043872922dfa14e8ff6b4f9983cdae79b2bce958ef8862",
+        "wx": "f3d010cc99320cbc39bee9101aa7ba7e8edf4e32ea8110e9f2442d6a49aeb78c",
+        "wy": "0ae144cb8146541555043872922dfa14e8ff6b4f9983cdae79b2bce958ef8862"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f3d010cc99320cbc39bee9101aa7ba7e8edf4e32ea8110e9f2442d6a49aeb78c0ae144cb8146541555043872922dfa14e8ff6b4f9983cdae79b2bce958ef8862",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE89AQzJkyDLw5vukQGqe6fo7fTjLqgRDp\n8kQtakmut4wK4UTLgUZUFVUEOHKSLfoU6P9rT5mDza55srzpWO+IYg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 543,
+          "comment": "r = p - n + 1, x = 1 is invalid; r is too large to compare r + n with x",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "30360211014551231950b75fc4402da1722fc9baef022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-r-s-edge-cases",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a6245583e13d23c9cc0089c99e2e202766ea3379645c14762cf029873b099dfc74e9942da9f18327d5b1fbccaa958992d3062ae4602d0ed736aa4b87291ef10d",
+        "wx": "a6245583e13d23c9cc0089c99e2e202766ea3379645c14762cf029873b099dfc",
+        "wy": "74e9942da9f18327d5b1fbccaa958992d3062ae4602d0ed736aa4b87291ef10d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a6245583e13d23c9cc0089c99e2e202766ea3379645c14762cf029873b099dfc74e9942da9f18327d5b1fbccaa958992d3062ae4602d0ed736aa4b87291ef10d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpiRVg+E9I8nMAInJni4gJ2bqM3lkXBR2\nLPAphzsJnfx06ZQtqfGDJ9Wx+8yqlYmS0wYq5GAtDtc2qkuHKR7xDQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 544,
+          "comment": "r = 2^256 - n + 1, x = 1 is invalid; r + n is too large to compare r + n with x, and overflows 2^256 bits",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "30360211014551231950b75fc4402da1732fc9bec0022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-s-pow2",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9",
+        "wx": "935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e",
+        "wy": "3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004935ab7edbc21cb4ccb3afd6b63d3740f62d98a41975e5e6e836d7c990d177a7e3ec3d6377cdd3021b6176d26c3d1999d6d8fe8fb9bd7051b4908d1608b9ab1a9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEk1q37bwhy0zLOv1rY9N0D2LZikGXXl5u\ng218mQ0Xen4+w9Y3fN0wIbYXbSbD0ZmdbY/o+5vXBRtJCNFgi5qxqQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHA-512",
+      "tests": [
+        {
+          "tcId": 545,
+          "comment": "s = 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "303502202b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef2202110100000000000000000000000000000000",
+          "result": "valid"
+        },
+        {
+          "tcId": 546,
+          "comment": "s = n - 2^128",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "68656c6c6f2c20776f726c64",
+          "sig": "304502202b698a0f0a4041b77e63488ad48c23e8e8838dd1fb7520408b121697b782ef22022100fffffffffffffffffffffffffffffffdbaaedce6af48a03bbfd25e8cd0364141",
+          "result": "valid"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/ecc/wycheproof_test.py
+++ b/tests/ecc/wycheproof_test.py
@@ -6,8 +6,9 @@
 
 https://github.com/C2SP/wycheproof, which is where bitcoin-core/secp256k1
 takes the same two algorithms' vectors from; `tests/_data/README.md` pins
-the revision of each of the four files, and `WYCHEPROOF_COPYING` beside
-them is the Apache-2.0 licence they arrive under.
+the revision of every file read here, names the ones deliberately left
+out and why, and `WYCHEPROOF_COPYING` beside them is the Apache-2.0
+licence they arrive under.
 
 What they add to the BIP and RFC vectors already here is the adversarial
 half. Those are what a correct signer produces; these are what an
@@ -26,7 +27,7 @@ one of the other two: which way an `acceptable` case falls is a property
 of how strict a parser is, and pinning it here would make a legitimate
 loosening or tightening of one look like a regression.
 
-Two profiles of ECDSA, which is why two of the four files are the same
+Two profiles of ECDSA, which is why two of the files are the same
 algorithm over the same curve and hash. `EcdsaBitcoinVerify` is btclib's
 `lower_s=True` default and refuses the malleable high-s twin;
 `EcdsaVerify` is `lower_s=False` and accepts it. Their tcId 5 is the same
@@ -35,24 +36,33 @@ key and the same signature under both, `invalid` in the first file and
 of the two files whichever way it is wired -- which neither file could
 report on its own.
 
-Every vector runs twice, against the bindings and against the Python
-arithmetic underneath them. The bindings are the authority on the answer,
-Wycheproof is the authority on what the answer should be, and the second
-run is what puts the Python path -- which serves every other curve, hash
-and caller-supplied nonce, and which no ordinary secp256k1 call reaches
-any more -- in front of the same adversary.
+Four hash functions, for the same reason in a second direction. Bitcoin
+signs with sha256 and nothing else, so the sha512 and SHA3 files are not
+bitcoin signatures and are not here pretending to be: what they hold to
+account is the *generic* ECDSA `dsa.verify_` promises, and they are the
+only adversarial vectors that reach it. `_libsecp256k1_applicable`
+declines every hash but sha256, so those files land on the Python path
+by construction rather than by a patch -- the path `SECURITY.md`
+publishes as not constant-time, under an adversary for the first time.
+
+Which implementations answer is therefore read off the hash rather than
+asserted: `_paths` below. Under sha256 a vector runs twice, against the
+bindings and against the Python arithmetic underneath them -- the
+bindings being the authority on the answer, Wycheproof on what the
+answer should be. Under any other hash the bindings never answer at all,
+so it runs once.
 """
 
 from __future__ import annotations
 
-from hashlib import sha256
+from hashlib import sha3_256, sha3_512, sha256, sha512
 from io import BytesIO
 from types import ModuleType
 from typing import Any
 
 import pytest
 
-from btclib.alias import Point
+from btclib.alias import HashF, Point
 from btclib.curves import mult, point_from_octets, secp256k1
 from btclib.ecc import dh, dsa
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
@@ -61,7 +71,11 @@ from tests.curves.curve_test import no_bindings
 
 _ECDSA_BITCOIN = "ecdsa_secp256k1_sha256_bitcoin_test.json"
 _ECDSA = "ecdsa_secp256k1_sha256_test.json"
+_ECDSA_SHA512 = "ecdsa_secp256k1_sha512_test.json"
+_ECDSA_SHA3_256 = "ecdsa_secp256k1_sha3_256_test.json"
+_ECDSA_SHA3_512 = "ecdsa_secp256k1_sha3_512_test.json"
 _ECDSA_P1363 = "ecdsa_secp256k1_sha256_p1363_test.json"
+_ECDSA_SHA512_P1363 = "ecdsa_secp256k1_sha512_p1363_test.json"
 _ECDH = "ecdh_secp256k1_test.json"
 
 # the DER tags the SubjectPublicKeyInfo below is made of
@@ -174,37 +188,83 @@ def _point_from_spki(der: bytes) -> Point:
     return point_from_octets(key[1:], secp256k1)
 
 
-def _signature_vectors(fname: str, prefix: str, *extra: Any) -> list[Any]:
+def _digest(hf: HashF, data: bytes) -> bytes:
+    """Hash `data` once, through the two calls a `HashF` actually offers.
+
+    Not `hf(data)`, which is what hashlib allows and what the alias does
+    not: `HashF` is `Callable[[], HashObject]` on purpose, so that a
+    one-shot digest function cannot be passed where an updatable one is
+    meant. `hashlib.sha256` accepts the argument anyway, which is what
+    makes the distinction invisible until mypy is asked -- and a test
+    module reaching around a type the library states is a test of
+    something else.
+    """
+    hash_object = hf()
+    hash_object.update(data)
+    return hash_object.digest()
+
+
+def _paths(hf: HashF) -> list[bool]:
+    """Say which implementations answer a vector: both, or Python alone.
+
+    `_libsecp256k1_applicable` compares the hash function by identity and
+    admits sha256 alone, so under sha512 or SHA3 the bindings decline
+    before the dispatch is even reached. Running such a vector a second
+    time with the dispatch patched off would be the same Python
+    arithmetic twice, the first of the two named `bindings` and saying
+    what did not happen -- and a report whose ids are not true is worse
+    than a shorter one.
+    """
+    return [True, False] if hf is sha256 else [False]
+
+
+def _vector_id(prefix: str, test: dict[str, Any], *, bindings: bool) -> str:
+    """Name a case: which file, upstream's own numbering, which path.
+
+    `tcId` is unique within a file and is what a reader greps for in it;
+    the prefix is what keeps two files' tcId 5 apart. The path is part of
+    the name rather than a second `parametrize` because it is not a free
+    axis: `_paths` decides it per file.
+    """
+    path = "bindings" if bindings else "python"
+    return f"{prefix}-{vector_id(test['tcId'], test['comment'])}-{path}"
+
+
+def _signature_vectors(fname: str, prefix: str, hf: HashF, *extra: Any) -> list[Any]:
     """Flatten the groups of a verification file: a key, then a case.
 
     A Wycheproof group is a public key and the cases made against it, so
     the key is repeated into each parameter rather than the group being
     the unit of the test: what a failure has to name is the case.
-    `tcId` is upstream's own numbering of them, unique within the file
-    and what a reader greps for in it.
     """
     return [
         pytest.param(
             group["publicKey"]["uncompressed"],
             test,
             *extra,
-            id=f"{prefix}-{vector_id(test['tcId'], test['comment'])}",
+            hf,
+            bindings,
+            id=_vector_id(prefix, test, bindings=bindings),
         )
         for group in load("ecc", "_data", fname)["testGroups"]
         for test in group["tests"]
+        for bindings in _paths(hf)
     ]
 
 
-@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
 @pytest.mark.parametrize(
-    "key, vector, lower_s",
-    _signature_vectors(_ECDSA_BITCOIN, "bitcoin", True)
-    + _signature_vectors(_ECDSA, "ecdsa", False),
+    "key, vector, lower_s, hf, bindings",
+    _signature_vectors(_ECDSA_BITCOIN, "bitcoin", sha256, True)
+    + _signature_vectors(_ECDSA, "ecdsa", sha256, False)
+    + _signature_vectors(_ECDSA_SHA512, "sha512", sha512, False)
+    + _signature_vectors(_ECDSA_SHA3_256, "sha3-256", sha3_256, False)
+    + _signature_vectors(_ECDSA_SHA3_512, "sha3-512", sha3_512, False),
 )
 def test_ecdsa_der(
     key: str,
     vector: dict[str, Any],
     lower_s: bool,
+    hf: HashF,
     bindings: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -219,20 +279,30 @@ def test_ecdsa_der(
     is malformed is invalid, and the file's `InvalidEncoding`,
     `BerEncodedSignature` and `MissingZero` cases are all of them cases
     where nothing but the encoding is wrong.
+
+    `hf` is the file's own, and it reaches `challenge_` as well as the
+    message: a digest wider than the order is truncated to the leftmost
+    `nlen` bits there, which is what the sha512 and SHA3-512 files
+    exercise and what the sha256 ones cannot.
     """
     if not bindings:
         _python_path(monkeypatch, dsa)
 
-    msg_hash = sha256(bytes.fromhex(vector["msg"])).digest()
-    verified = dsa.verify_(msg_hash, key, bytes.fromhex(vector["sig"]), lower_s)
+    msg_hash = _digest(hf, bytes.fromhex(vector["msg"]))
+    sig = bytes.fromhex(vector["sig"])
+    verified = dsa.verify_(msg_hash, key, sig, lower_s, hf)
     assert verified == (vector["result"] == "valid")
 
 
-@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
-@pytest.mark.parametrize("key, vector", _signature_vectors(_ECDSA_P1363, "p1363"))
+@pytest.mark.parametrize(
+    "key, vector, hf, bindings",
+    _signature_vectors(_ECDSA_P1363, "p1363", sha256)
+    + _signature_vectors(_ECDSA_SHA512_P1363, "p1363-sha512", sha512),
+)
 def test_ecdsa_p1363(
     key: str,
     vector: dict[str, Any],
+    hf: HashF,
     bindings: bool,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -246,8 +316,12 @@ def test_ecdsa_p1363(
     `RangeCheck` and `InvalidSignature` cases are r and s at 0, at n, and
     at n plus a valid value, none of which any DER framing can hide.
 
-    `lower_s=False`, this file having no bitcoin profile: its tcId 1 is
-    the malleable high-s signature and is `valid`.
+    `lower_s=False` for both files, neither having a bitcoin profile: the
+    sha256 one's tcId 1 is the malleable high-s signature and is `valid`.
+
+    The size rule is the encoding's and not the hash's, so it is `n_size`
+    twice over under sha512 as under sha256: P1363 pads each of r and s
+    to the width of the order, which no wider digest changes.
     """
     if not bindings:
         _python_path(monkeypatch, dsa)
@@ -266,19 +340,19 @@ def test_ecdsa_p1363(
         assert vector["result"] != "valid"
         return
 
-    msg_hash = sha256(bytes.fromhex(vector["msg"])).digest()
-    assert dsa.verify_(msg_hash, key, sig, lower_s=False) == (
-        vector["result"] == "valid"
-    )
+    msg_hash = _digest(hf, bytes.fromhex(vector["msg"]))
+    assert dsa.verify_(msg_hash, key, sig, False, hf) == (vector["result"] == "valid")
 
 
-@pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
 @pytest.mark.parametrize(
-    "vector",
+    "vector, bindings",
     [
-        pytest.param(test, id=vector_id(test["tcId"], test["comment"]))
+        pytest.param(test, bindings, id=_vector_id("ecdh", test, bindings=bindings))
         for group in load("ecc", "_data", _ECDH)["testGroups"]
         for test in group["tests"]
+        # sha256, so both: the KDF below is SEC 1's over sha256 and the
+        # agreement itself is a multiplication the bindings do answer
+        for bindings in _paths(sha256)
     ],
 )
 def test_ecdh(


### PR DESCRIPTION
Implements group 1 of https://github.com/btclib-org/btclib/issues/706 and
documents group 3. Group 2 (SHAKE) stays open in the issue, deliberately
— see below.

Built on top of https://github.com/btclib-org/btclib/pull/704, which
merged while this was being written; rebased onto `main`, so this is one
commit and the diff is this change alone.

## What is added

Four more files from C2SP/wycheproof, same pin `5722833c`, all four
byte-identical to upstream. 1882 cases, all passing, no library change:

| file | tests | hash |
| --- | --- | --- |
| `ecdsa_secp256k1_sha512_test.json` | 546 | sha512, DER |
| `ecdsa_secp256k1_sha3_512_test.json` | 540 | SHA3-512, DER |
| `ecdsa_secp256k1_sha3_256_test.json` | 474 | SHA3-256, DER |
| `ecdsa_secp256k1_sha512_p1363_test.json` | 322 | sha512, P1363 |

They are the same `dsa.verify_` call with a different `hf`. None is a
bitcoin signature — bitcoin signs with sha256 and nothing else — and that
is what makes them worth taking: what they hold to account is the
*generic* ECDSA the API promises, and they are the only adversarial
vectors that reach it.

## Two things they buy that the sha256 files cannot

**The Python path without a patch.** `_libsecp256k1_applicable` compares
the hash by identity and admits `sha256` alone, so every one of these
1882 lands on the Python arithmetic by construction — the path
`SECURITY.md` publishes as not constant-time, under an adversary for the
first time rather than under vectors a correct signer produced.

**`challenge_`'s truncation.** sha512 and SHA3-512 are wider than the
order, so the leftmost-`nlen`-bits step is exercised; no sha256 vector
can reach it.

## `_paths`, and why the count goes up by exactly 1882

The path is no longer a free `parametrize` axis — it is read off the
hash:

```python
return [True, False] if hf is sha256 else [False]
```

Running a sha512 vector a second time with the dispatch patched off would
be the same Python arithmetic twice, the first of the two labelled
`bindings` in the report and saying what did not happen. A report whose
ids are not true is worse than a shorter one. So the suite goes from
22484 to 24366: +1882, one run each, no duplication.

## `_digest`

mypy caught a real thing while this was being written: `hf(data)` does
not type check. `HashF` is `Callable[[], HashObject]` deliberately —
`btclib/alias.py` says so, and says why — and `hashlib.sha256` accepting
the argument anyway is what made it invisible. `_digest` goes through
`hf()` and `update()` instead. The sha256 call sites that #704 added were
reaching around the library's own type; they no longer do.

## Group 3, documented rather than silently skipped

Two `tests/_data/README.md` entries, because "not taken" and "not
noticed" look the same in a directory listing:

- **`ecdh_secp256k1_webcrypto_test.json`** — the ECDH file #704 vendored,
  re-encoded as JWK. Measured: its valid cases yield **468 distinct
  shared secrets, and all 468 are that file's**; its invalid classes are
  a strict subset (no `InvalidAsn`, JWK having no ASN.1 to attack). It
  would add a base64url reader and no arithmetic.
- **the four SHAKE files** — blocked on a type, not on their data. An XOF
  has no fixed output, so `hashlib.shake_128` fails `alias.HashObject`
  under mypy (`digest()` takes a length; the Protocol declares none) and
  at run time makes `challenge_` demand a zero-length message hash.
  Measured, and this is the part worth knowing: `verify_` catches that
  `ValueError` and answers `False`, so a naive import would show every
  `valid` vector failing and every `invalid` one "passing" — a half-green
  suite reporting an unsupported hash as a bad signature. Whether `HashF`
  should admit an XOF is a public-surface question and is left to the
  issue.

## Gates

`uv run pytest` (24366 passed, 100% ratchet met), `uv run pre-commit run
--all-files`, and the sphinx `-W` build, all green locally, and re-run
after the rebase. The four new blobs re-checked against upstream after
the hooks ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Integrate additional Wycheproof ECDSA test vectors for non‑sha256 hashes and update testing to dispatch between bindings and Python implementations based on the hash function, ensuring the generic ECDSA path and hash truncation logic are exercised without patching secp256k1 bindings.

New Features:
- Add four new Wycheproof ECDSA secp256k1 test vector files for sha512, SHA3-256, SHA3-512, and sha512 P1363 encodings.

Enhancements:
- Drive ECDSA and ECDH tests via a hash-function-aware `_paths` mechanism so only sha256 uses both bindings and Python while other hashes exercise the Python path alone.
- Introduce a typed `_digest` helper that respects the `HashF` protocol and passes the selected hash function through to `dsa.verify_`, covering wide-digest truncation behaviour.
- Refine Wycheproof documentation and README entries to record all vendored files, explicitly document non-vendored ECDH WebCrypto and SHAKE vectors, and explain their rationale.
- Note the new Wycheproof coverage and hash-path behaviour in the changelog, including the deliberate exclusion of SHAKE-based vectors pending a `HashF` decision.

Tests:
- Expand ECDSA DER and P1363 test parametrization to cover sha512 and SHA3 variants, increasing coverage of the generic ECDSA implementation and its challenge truncation logic.
- Adjust ECDH tests to use the same hash-based path selection, ensuring both bindings and Python arithmetic are exercised only where applicable.