### PR TITLE
Say why HashF takes no argument, rather than that it takes none

### DIFF
--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -311,12 +311,25 @@ KeyOrder = Literal["none", "account", "derived"]
 # What a HashF returns: as much of the hashlib object as this library uses,
 # and no more. A Protocol rather than Any: under Any, hf().digest() and
 # hf().digest_size go unchecked, and with them every expression downstream
-# of a hash function. Eleven sites read digest_size and nine build a digest
-# through update(); with Any, a typo in either is a runtime AttributeError
-# in a mypy-strict code base.
+# of a hash function -- in a mypy-strict code base a typo in either would
+# be a runtime AttributeError.
 #
-# Not hashlib._Hash, which is what typeshed calls it: a private name, and
-# structural typing is the right tool for "whatever hashlib.new returns"
+# Not hashlib._Hash, which is what typeshed calls the class: a private
+# name, and structural typing is the right tool for "whatever hashlib.new
+# returns". typeshed writes this same Protocol beside it, under this very
+# class's name, and marks it type_check_only, so importing that one is no
+# option either.
+#
+# An extendable-output function is not one of these, and here is where it
+# is refused: hashlib.shake_128 fails this Protocol statically, its
+# digest() requiring the output length that digest() -> bytes does not
+# declare, and its digest_size reading 0. Not a btclib restriction --
+# typeshed derives HASHXOF from HASH through a type: ignore[override], and
+# hmac.new rejects an XOF as a digestmod for the same reason, which is
+# dsa.sign's answer too: rfc6979 hands hf to hmac.new, and HMAC over an
+# XOF is not defined (NIST specifies KMAC instead). An XOF is a function
+# of data *and* length, and the length has nowhere to live here, so what
+# reads SHAKE vectors is an adapter pinning one, not a wider Protocol
 class HashObject(Protocol):
     """The slice of a hashlib object this library reads, as a Protocol.
 
@@ -343,10 +356,9 @@ class HashObject(Protocol):
     # takes a digestmod whose update() accepts typeshed's ReadableBuffer,
     # a union this library cannot spell before 3.12, collections.abc.Buffer
     # being 3.12 and the floor 3.10, and a narrower parameter here makes
-    # the whole Protocol unassignable to hmac's -- rfc6979 passes hf to
-    # hmac.new eight times. The two members that are actually read,
-    # digest() and digest_size, stay exact, which is the point of the
-    # Protocol
+    # the whole Protocol unassignable to hmac's -- rfc6979 hands hf to
+    # hmac.new. The two members that are actually read, digest() and
+    # digest_size, stay exact, which is the point of the Protocol
     def update(self, data: Any, /) -> None:
         """Absorb more data, as hashlib's update does."""
         ...
@@ -366,9 +378,20 @@ class HashObject(Protocol):
 
 # Hash digest constructor: it may be any name suitable to hashlib.new().
 # Called with no argument and then fed through update(), which is how every
-# hf parameter in the package is used: hf(data) does not type check here,
-# and hashlib.sha256 accepting it anyway is what makes the distinction
-# below invisible at run time
+# hf parameter in the package is used -- digest() and digest_size are the
+# whole of what it reads off the result, so no argument is the whole of the
+# capability it needs. Typing a callback at the capability actually used is
+# what leaves the widest set of callables able to be one: a lambda and a
+# functools.partial are a HashF here, and typeshed types the same object
+# the same way, hmac's digestmod being Callable[[], _HashObject].
+#
+# The price is that hf(data) does not type check, though hashlib.sha256
+# accepts it and that is what makes the distinction below invisible at run
+# time. A Protocol declaring __call__ with an optional positional parameter
+# would take both spellings, and would take with the other hand: a
+# zero-argument constructor would no longer be a HashF, which is
+# contravariance and not an oversight. btclib.hashes.reduce_to_hlen is the
+# one-shot digest, for whoever wants one
 HashF = Callable[[], HashObject]
 
 # A one-shot digest: hf(data) returns the digest, where a HashF returns an

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -49,9 +49,6 @@ def _hash(m: bytes, R: bytes, i: int, j: int, hf: HashF) -> bytes:
     temp = b"".join(
         [m, R, i.to_bytes(4, "big", signed=False), j.to_bytes(4, "big", signed=False)]
     )
-    # hf() then update(), which is how HashF is spelled everywhere else in
-    # the package: the alias is Callable[[], Any], a constructor, so hf(temp)
-    # does not type check even though hashlib.sha256 accepts it
     hasher = hf()
     hasher.update(temp)
     return bytes(hasher.digest())


### PR DESCRIPTION
`btclib/alias.py` described `HashF`'s arity as something that gets in the
way -- "hf(data) does not type check here" -- where it is a decision. It
now states the decision and the reason, and states the one thing the file
did not say at all: an XOF is not a `HashObject`.

## Why zero arguments is right

`digest()` and `digest_size` are the whole of what this package reads off
a hash object, so no argument is the whole of the capability an `hf`
needs. Typing a callback at the capability actually used is what leaves
the widest set of callables able to be one. Measured against this tree,
mypy strict:

```python
a: HashF = lambda: hashlib.sha256()                    # ok today
b: HashF = functools.partial(hashlib.new, "ripemd160") # ok today
```

Both stop being a `HashF` under a `Protocol` whose `__call__` takes the
one-shot spelling as well -- contravariance, not an oversight:

```text
error: Incompatible types in assignment (expression has type
"Callable[[], HASH]", variable has type "HashF")
```

The standard library types the same object the same way: `hmac`'s
`_DigestMod` is `str | Callable[[], _HashObject] | ModuleType`, zero
arguments, because `hmac` calls `digestmod()` and then `update()`. And
`btclib.hashes.reduce_to_hlen` is already the one-shot digest for whoever
wants one.

## Where an XOF is refused

The open decision of https://github.com/btclib-org/btclib/issues/706 --
may a `HashF` be an XOF -- had no answer written anywhere in the source.
`hashlib.shake_128` fails `HashObject` statically: its `digest()`
requires the output length that `digest() -> bytes` does not declare, and
its `digest_size` reads 0. That is not a btclib restriction. typeshed
derives `HASHXOF` from `HASH` only through a `type: ignore[override]`,
and `hmac.new` rejects an XOF as a digestmod for the same structural
reason:

```text
error: Argument 3 to "new" has incompatible type
"def openssl_shake_128(...) -> HASHXOF";
expected "str | Callable[[], _HashObject] | Module"
```

which is `dsa.sign`'s answer too: `rfc6979_nonce` hands `hf` to
`hmac.new`, and HMAC over an XOF is not defined -- NIST specifies KMAC
instead. So the comment now says that reading SHAKE vectors needs an
adapter pinning an output length, not a wider Protocol. This does not
close https://github.com/btclib-org/btclib/issues/706: whether those four
files are read, and by what adapter, is still a decision.

## Also

- The stated counts go, as `CLAUDE.md` asks: "eleven sites", "nine",
  "eight times" are what drifts, and none of the three arguments needs a
  number.
- `borromean.py` carried its own copy of the rule, stating the alias as
  `Callable[[], Any]`, which it has not been since `HashObject` exists.
  Deleted: `alias.py` carries it once.

Comments only, no CHANGELOG entry: nothing a user notices. Gates green
locally -- `pre-commit run --all-files`, `pytest` (24377 passed, coverage
ratchet included), and `sphinx-build -W`.

## Summary by Sourcery

Clarify the HashF callback contract and document the exclusion of extendable-output hash functions (XOFs) from the hash protocol.

Enhancements:
- Tighten and expand HashObject/HashF comments to explain the zero-argument constructor design and its relationship to digest() and digest_size.
- Document that XOFs (e.g., hashlib.shake_128) do not satisfy HashObject and require an adapter with a fixed output length rather than a broader protocol.
- Align wording around rfc6979’s use of HashF with hmac.new and reference typeshed’s corresponding protocol typing.

Chores:
- Remove a duplicated local explanation of HashF usage in borromean.py, relying on the central alias.py documentation instead.