### PR TITLE
Fix NETWORKS at import, and let the node's identity live with the node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1066,6 +1066,62 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`NETWORKS` is fixed at import, and read-only** (issue #683). A
+  `MappingProxyType` over the dict the five json files fill, so
+  `NETWORKS["custom"] = ...` is a `TypeError` where it used to be a
+  registration nothing else here would honour: `XPRV_VERSIONS_ALL` and
+  `XPUB_VERSIONS_ALL` were built at import from the same data, so a
+  network registered afterwards was named by `network_from_xkeyversion`
+  and refused by `bip32._assert_valid_key` -- one of the two being wrong
+  about what the catalogue meant. What settles it is that a `Network` is
+  an encoding table: every field of one is the same for every deployment
+  of that network, so there is nothing left for a caller to register.
+- **`Network.magic_bytes` is gone**, with it. The p2p message start
+  identifies a *node*, is a function of the challenge for a signet
+  therefore not a constant per name, and had exactly one reader in this
+  library -- `BitcoinCoreFetcher.assert_network`, inside the rpc adapter.
+  It now comes from the package that speaks that protocol and already
+  owns the ports, the datadir subdirectories and the chain names from the
+  same file of Core's: `bitcoin_core_rpc.magic_from_chain` and
+  `magic_from_signet_challenge`. The five `_data/*.json` files lose the
+  field, `to_dict` and `from_dict` with them, and `alias.NetworkField` is
+  seventeen names.
+- **`BitcoinCoreFetcher` takes `signet_challenge`**, which is how a
+  custom signet is now spelled: no entry in `NETWORKS` and no `Network`
+  built by hand, the addresses of one being signet's. Hex or the bytes it
+  spells, as `-signetchallenge` takes it. Refused with a network that is
+  no signet, and refused with `verify_network=False`, either being a
+  check the caller expects and would not get; a challenge that is no
+  script is refused at construction rather than at the first fetch.
+  `assert_network` is now the client's `assert_chain` plus the
+  translation into btclib's vocabulary and exceptions --
+  `chain_from_network` in, `client_errors` out -- so the comparison lives
+  beside the protocol it reads. `_signet_magic` is gone from this tree.
+- **`XPRV_VERSIONS_ALL` and `XPUB_VERSIONS_ALL` are frozensets**, not
+  lists: they answer one question -- is this a private version, is it a
+  public one -- and four of the five networks carry testnet's versions,
+  so a list of them was four fifths repetition in an order that meant
+  nothing. Code indexing them, or reading `.index()`, has
+  `xpubversion_from_xprvversion` for the one thing the parallel positions
+  were used for.
+- **`xpubversion_from_xprvversion`** is that pairing, published: same
+  network, same script type, xprv to xpub and Zprv to Zpub. What
+  `bip32._xpub_from_xprv` re-labels a key with, where it read
+  `XPUB_VERSIONS_ALL[XPRV_VERSIONS_ALL.index(version)]` -- a scan of
+  twenty-five entries per neuter, and a pair of parallel lists a caller
+  had to know were parallel. `BTClibValueError` for anything that is not
+  an xprv version, an xpub version included.
+- **the reverse lookups by xkey version are a table** (issue #683), built
+  in one pass over `NETWORKS` beside the two sets above and the pairing:
+  `networks_from_xkeyversion` was asking every network in turn whether it
+  carried the version, and each question rebuilt two five-element lists,
+  which the issue measured at 21 calls into the builders per address
+  derived and encoded (1.40 us to 0.03 us for the lookup, about 5% off an
+  address end to end). `networks_from_key_value` stays a scan, and not
+  for want of a key: `prefix` is whatever a caller passes, so a dict
+  would answer an unhashable one with a `TypeError` where the comparison
+  answers "no network carries this".
+
 - **Taproot takes no curve** (#618). `output_pubkey`,
   `output_pubkey_from_merkle_root`, `output_prvkey`,
   `output_prvkey_from_merkle_root` and `check_output_pubkey` ended in

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -54,6 +54,35 @@ full year, short month, short day (YYYY-M-D)
   `dsa.sign_recoverable` and with it `bms.sign` are unaffected, a compact
   signature having no DER pad to save, and so is `bip322.sign`, which asks
   for the plain signature to keep reproducing the BIP's own vectors.
+- **an ECDSA signature is low-R now.** `dsa.sign` and `dsa.sign_` grind
+  for it wherever the nonce is theirs to derive, as Core has done since
+  its 0.17, so the signature of a given key and message is a different one
+  for about half of all messages -- and one DER byte shorter. `grind=False`
+  is the plain RFC6979 signature, which is what a caller pinning btclib's
+  bytes has to pass now. `dsa.sign_recoverable` and with it `bms.sign` are
+  unaffected, a compact signature having no DER pad to save, and so is
+  `bip322.sign`, which asks for the plain signature to keep reproducing
+  the BIP's own vectors.
+- **`NETWORKS` is read-only, and `Network.magic_bytes` is gone.**
+  `NETWORKS["mynet"] = Network(...)` now raises `TypeError`. It was never
+  honoured throughout: the extended-key version lists are built at import,
+  so keys of a network registered afterwards were refused by `bip32` while
+  `network_from_xkeyversion` named it. A `Network` is an encoding table and
+  every field of one is the same for every deployment of that network, so
+  the only thing a caller had to register a network *for* was a custom
+  signet's p2p magic -- and that identifies a node, not an encoding.
+  `bitcoin_core_rpc.magic_from_chain(chain)` and
+  `magic_from_signet_challenge(challenge)` are where it is now;
+  `NETWORKS[net].magic_bytes` has no replacement here, and note the byte
+  order is Core's `pchMessageStart` where this field was its reverse.
+  A custom signet is `BitcoinCoreFetcher(client, "signet",
+  signet_challenge=...)`, which is the check that magic was read for.
+- **`XPRV_VERSIONS_ALL` and `XPUB_VERSIONS_ALL` are frozensets.**
+  `version in XPRV_VERSIONS_ALL` is unchanged and is what nearly every use
+  was; indexing, slicing and `.index()` are not. The one use of the
+  parallel positions -- the xpub version paired with an xprv version -- is
+  `network.xpubversion_from_xprvversion(version)`.
+
 - **a MOV-weak curve is refused with `BTClibValueError`, not
   `UserWarning`.** `Curve(p, a, b, G, n, cofactor)` with the default
   `weakness_check=True` used to raise `UserWarning("weak curve")` for a

--- a/btclib/_data/mainnet.json
+++ b/btclib/_data/mainnet.json
@@ -1,7 +1,6 @@
 {
     "curve": "secp256k1",
     "network_type": "main",
-    "magic_bytes": "d9b4bef9",
     "genesis_block": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
     "wif": "80",
     "p2pkh": "00",

--- a/btclib/_data/regtest.json
+++ b/btclib/_data/regtest.json
@@ -1,7 +1,6 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
-    "magic_bytes": "dab5bffa",
     "genesis_block": "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
     "wif": "ef",
     "p2pkh": "6f",

--- a/btclib/_data/signet.json
+++ b/btclib/_data/signet.json
@@ -1,7 +1,6 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
-    "magic_bytes": "40cf030a",
     "genesis_block": "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
     "wif": "ef",
     "p2pkh": "6f",

--- a/btclib/_data/testnet.json
+++ b/btclib/_data/testnet.json
@@ -1,7 +1,6 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
-    "magic_bytes": "0709110b",
     "genesis_block": "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
     "wif": "ef",
     "p2pkh": "6f",

--- a/btclib/_data/testnet4.json
+++ b/btclib/_data/testnet4.json
@@ -1,7 +1,6 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
-    "magic_bytes": "283f161c",
     "genesis_block": "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043",
     "wif": "ef",
     "p2pkh": "6f",

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -188,7 +188,6 @@ ScriptType = Literal[
 NetworkField = Literal[
     "curve",
     "network_type",
-    "magic_bytes",
     "genesis_block",
     "wif",
     "p2pkh",
@@ -206,14 +205,18 @@ NetworkField = Literal[
     "slip132_p2wsh_pub",
 ]
 
-# The networks btclib ships, i.e. the keys of network.NETWORKS as loaded.
-# Not a parameter type, and that is the honest half of issue #216:
-# NETWORKS is a dict a caller adds a custom signet to, so a `network:
-# NetworkName` would refuse a name the library itself accepts and every
-# such caller would have to cast. It names the five for a caller who
-# uses only those and wants mypy to hold them to it; network.py
-# annotates with it the tuple of names it loads, which is what keeps
-# this list equal to the data
+# The networks btclib ships, which is every network there is here:
+# network.NETWORKS is fixed at import and read-only, so this list is the
+# whole of the vocabulary and not a sample of it.
+#
+# Still not a parameter type, and issue #216 is where that is decided: the
+# `network: str` parameters accept a name with spaces around it and in any
+# case -- `network.strip().lower()` is what they run it through -- so the
+# set they take is wider than these five spellings, and narrowing the
+# annotation without dropping that tolerance would reject calls that work.
+# It names the five for a caller who wants mypy to hold them to it;
+# network.py annotates with it the tuple of names it loads, which is what
+# keeps this list equal to the data
 NetworkName = Literal["mainnet", "testnet", "regtest", "signet", "testnet4"]
 
 # The word-lists btclib ships: BIP39's twelve languages, and SLIP-0039's

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -43,7 +43,12 @@ from btclib.curves import (
 from btclib.curves.curve import _is_x_coordinate
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
-from btclib.network import NETWORKS, XPRV_VERSIONS_ALL, XPUB_VERSIONS_ALL
+from btclib.network import (
+    NETWORKS,
+    XPRV_VERSIONS_ALL,
+    XPUB_VERSIONS_ALL,
+    xpubversion_from_xprvversion,
+)
 from btclib.utils import (
     assert_no_trailing,
     bytes_from_octets,
@@ -391,7 +396,7 @@ def _xpub_from_xprv(xprv: BIP32KeyData) -> BIP32KeyData:
     # `prv_key_int` into an object whose key is public, the one scalar
     # this function exists to drop
     return BIP32KeyData(
-        version=XPUB_VERSIONS_ALL[XPRV_VERSIONS_ALL.index(xprv.version)],
+        version=xpubversion_from_xprvversion(xprv.version),
         depth=xprv.depth,
         parent_fingerprint=xprv.parent_fingerprint,
         index=xprv.index,

--- a/btclib/fetch/bitcoin_core.py
+++ b/btclib/fetch/bitcoin_core.py
@@ -22,16 +22,15 @@ true.
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-import bitcoin_core_rpc as rpc
 from bitcoin_core_rpc import (
     COOKIE_USER,
     DEFAULT_DATADIR,
     BitcoinCoreRpcClient,
     chain_from_network,
     cookie_auth,
+    magic_from_signet_challenge,
 )
 
-from btclib import var_bytes
 from btclib.alias import Octets
 from btclib.exceptions import BTClibValueError
 from btclib.fetch.fetcher import (
@@ -41,8 +40,6 @@ from btclib.fetch.fetcher import (
     tx_from_raw,
     tx_id_hex,
 )
-from btclib.hashes import hash256
-from btclib.network import NETWORKS
 from btclib.tx import Tx
 from btclib.utils import bytes_from_octets
 
@@ -59,19 +56,6 @@ __all__ = [
 # value of a few dozen octets. `getrawtransaction` is the one answer here that
 # is not small, and it keeps the client's default.
 _MAX_SMALL_REPLY = 1024
-
-
-def _signet_magic(challenge: str) -> bytes:
-    """Return the p2p magic a signet's block challenge determines.
-
-    Core: the message start is the first four bytes of the sha256d of the
-    block script, serialized with its CompactSize length, taken in the
-    order the digest produces them -- which is the reverse of how this
-    library writes `magic_bytes`, hence the slice reversed here.
-    `tests/network_test.py` checks the default signet's own magic against
-    this same computation, from the challenge in Core's chainparams.
-    """
-    return hash256(var_bytes.serialize(challenge))[:4][::-1]
 
 
 class BitcoinCoreFetcher(Fetcher):
@@ -93,8 +77,17 @@ class BitcoinCoreFetcher(Fetcher):
     built and never used, and a node that is merely down should not be a
     failure to *construct* anything. The answer is then kept -- a node
     does not change chain under a client that goes on pointing at it --
-    and a caller that would rather not ask says `verify_network=False`,
-    which is what this class did before the option existed.
+    and a caller that would rather not ask says `verify_network=False`.
+
+    `signet_challenge` is which signet, for the one label that names more
+    than one chain: Core answers `signet` for the default signet and for
+    every custom one alike, so a fetcher on a signet of its own passes the
+    challenge and `assert_network` holds the node to it. Hex or the bytes
+    it spells, as `-signetchallenge` takes it. It is what a custom signet
+    needs from this class and the whole of it -- the addresses of one are
+    signet's, `NETWORKS` describing the encoding and not the chain -- so it
+    is refused with a network that is no signet, and refused with
+    `verify_network` off, either being a check that would not be made.
     """
 
     def __init__(
@@ -103,10 +96,27 @@ class BitcoinCoreFetcher(Fetcher):
         network: str = "mainnet",
         *,
         verify_network: bool = True,
+        signet_challenge: str | bytes | None = None,
     ) -> None:
         super().__init__(network)
+        if signet_challenge is not None:
+            if chain_from_network(self.network) != "signet":
+                err_msg = f"a signet_challenge for {self.network},"
+                err_msg += " which is no signet"
+                raise BTClibValueError(err_msg)
+            if not verify_network:
+                err_msg = "a signet_challenge is what verify_network"
+                err_msg += " compares, and checks nothing with it off"
+                raise BTClibValueError(err_msg)
+            # derived here and thrown away, so that a challenge that is no
+            # script fails at the line that wrote it rather than at the
+            # first fetch: what the check itself uses is the challenge, the
+            # comparison being of the node's derived magic against this one
+            with client_errors():
+                magic_from_signet_challenge(signet_challenge)
         self.client = client
         self.verify_network = verify_network
+        self.signet_challenge = signet_challenge
         self._agreed = False
         self._disagreement = ""
 
@@ -208,68 +218,26 @@ class BitcoinCoreFetcher(Fetcher):
         Signet is the case a name cannot settle: Core reports `signet` for
         the default one and for every custom one alike, so two nodes
         sharing nothing but the shape of a challenge answer the same
-        string. `signet_challenge` is what tells them apart, and the p2p
-        magic derived from it is compared with the network's own -- which
-        also checks a caller-registered custom signet, `NETWORKS` being a
-        dict a caller adds to, and issue #207 the reason they do.
+        string. The challenge is what tells them apart, and this fetcher's
+        is the constructor's `signet_challenge`, or the default signet with
+        none given.
 
-        A malformed reply is a `FetchError` naming the method. A
-        disagreement is a `BTClibValueError`: the node is the authority on
-        which chain it serves, so the fetcher's label is the thing to fix.
+        Both comparisons are the client's `assert_chain`, this method being
+        the translation into btclib's vocabulary and btclib's exceptions:
+        `chain_from_network` on the way in, `client_errors` on the way out.
+        The check itself belongs beside the protocol it reads, and lived
+        here only while `bitcoin_core_rpc` did not have it.
+
+        A malformed reply is a `FetchError`. A disagreement is a
+        `BTClibValueError`: the node is the authority on which chain it
+        serves, so the fetcher's label is the thing to fix.
         """
-        with fetch_errors("getblockchaininfo"):
-            info: Any = self._call("getblockchaininfo", None, max_body_size=None)
-            if not isinstance(info, Mapping):
-                err_msg = f"not a JSON object: {type(info).__name__}"
-                raise BTClibValueError(err_msg)
-            chain = info.get("chain")
-            if not isinstance(chain, str):
-                err_msg = f"no chain name in the reply: {chain!r}"
-                raise BTClibValueError(err_msg)
-            # None off signet, and the reason the comparison below is
-            # written against it rather than against the name a second
-            # time: what the node answered is read here, in one place,
-            # and what it is worth is decided there
-            node_magic: bytes | None = None
-            if chain == "signet":
-                challenge = info.get("signet_challenge")
-                if not isinstance(challenge, str):
-                    err_msg = f"no signet_challenge in the reply: {challenge!r}"
-                    raise BTClibValueError(err_msg)
-                node_magic = _signet_magic(challenge)
-
-        # outside the block above, so that a node that answered a
-        # well-formed disagreement is not reported as a failure to fetch
-        if node_magic is not None:
-            expected_magic = NETWORKS[self.network].magic_bytes
-            if node_magic != expected_magic:
-                # worded for both mismatches it catches: another signet,
-                # and a fetcher that is on no signet at all
-                err_msg = "the node is on a signet this fetcher is not:"
-                err_msg += f" its challenge derives magic {node_magic.hex()},"
-                err_msg += f" where {self.network} has {expected_magic.hex()}"
-                raise BTClibValueError(err_msg)
-            return
-        try:
-            expected_chain = chain_from_network(self.network)
-        except rpc.BtcRpcValueError as e:
-            # `BtcRpcValueError` and not btclib's `BTClibValueError`:
-            # `chain_from_network` is the package's function and raises
-            # the package's class, so catching btclib's here would let a
-            # name it does not know escape as something no caller of
-            # `assert_network` is told to expect. The two were spelled
-            # alike until the package renamed its own, and this line is
-            # why -- it read correct and was wrong.
-            #
-            # A Network the caller registered: its name is btclib's alone,
-            # so there is nothing to compare a chain name with, and only a
-            # signet carries an identity a node can be asked for
-            err_msg = f"the node is on {chain}, and {self.network} is no"
-            err_msg += " chain of Core's to compare that with: a custom"
-            err_msg += " network is identified by its challenge, so only a"
-            err_msg += " signet node can answer for one"
-            raise BTClibValueError(err_msg) from e
-        if chain != expected_chain:
-            err_msg = f"the node is on {chain}, this fetcher on"
-            err_msg += f" {self.network}, which is Core's {expected_chain}"
-            raise BTClibValueError(err_msg)
+        # every network of NETWORKS is a chain of Core's -- the catalogue is
+        # fixed at import and `tests/fetch/bitcoin_core_test.py` holds the
+        # two vocabularies to covering each other -- so the translation
+        # cannot fail for a name this fetcher was allowed to carry
+        with client_errors():
+            self.client.assert_chain(
+                chain_from_network(self.network),
+                signet_challenge=self.signet_challenge,
+            )

--- a/btclib/fetch/fetcher.py
+++ b/btclib/fetch/fetcher.py
@@ -78,6 +78,12 @@ def client_errors() -> Iterator[None]:
         raise HttpError(e.args[0], e.status) from e
     except rpc.FetchError as e:
         raise FetchError(str(e)) from e
+    except rpc.BtcRpcValueError as e:
+        # what `assert_chain` raises for a node serving another chain: a
+        # refusal on valid inputs, so `BTClibValueError` and not a
+        # `FetchError`. Its message names the node's chain and the client's,
+        # which is the whole of what a caller has to act on
+        raise BTClibValueError(str(e)) from e
 
 
 @contextmanager

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -6,7 +6,20 @@
 
 What this module exports is the dataclass, the catalogue, the three
 questions asked of a key-value pair and the three asked of an extended-key
-version, plus the two version lists a caller matches against.
+version, plus the two version sets a caller matches against.
+
+**A Network is an encoding table, and NETWORKS is fixed at import.** The
+fields are the prefixes and version bytes a network spells its keys and
+addresses with, plus the genesis block; every one of them is the same for
+every deployment of that network, so there is nothing here for a caller to
+register and the catalogue is a read-only mapping. What *is* per
+deployment -- a custom signet's p2p magic, which its challenge determines
+-- is a fact about a node rather than about an encoding, and lives where
+the node is spoken to: `bitcoin_core_rpc.magic_from_signet_challenge`, and
+`BitcoinCoreFetcher(..., signet_challenge=...)` for the check it feeds.
+Fixed at import is what lets the reverse lookups below be tables built
+once: a network registered afterwards would be found by a scan and missed
+by a precomputed index, which is the disagreement issue 683 recorded.
 
 `datadir` stays out, and this is where that decision is recorded: it is
 where this package keeps the five json files loaded at the bottom of this
@@ -22,6 +35,7 @@ import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 from btclib.alias import NetworkField, NetworkName, NetworkType, Octets
@@ -44,11 +58,11 @@ __all__ = [
     "networks_from_key_value",
     "networks_from_xkeyversion",
     "xprvversions_from_network",
+    "xpubversion_from_xprvversion",
     "xpubversions_from_network",
 ]
 
 _KEY_SIZE: list[tuple[NetworkField, int]] = [
-    ("magic_bytes", 4),
     ("genesis_block", 32),
     ("wif", 1),
     ("p2pkh", 1),
@@ -68,12 +82,15 @@ _KEY_SIZE: list[tuple[NetworkField, int]] = [
 
 @dataclass(frozen=True)
 class Network:
-    """The encoding table of one network: prefixes, versions, magic.
+    """The encoding table of one network: prefixes, versions, genesis.
 
     What tells a mainnet spelling from a test one -- wif and address
     prefixes, the bech32 hrp, the BIP32 and SLIP132 version bytes --
-    plus the wire magic and the genesis block hash. No consensus
-    parameter lives here; NETWORKS holds the built-in instances, and
+    plus the genesis block hash. No consensus parameter lives here, and
+    no p2p one: the message start belongs to the code that speaks to a
+    node, `bitcoin_core_rpc.magic_from_chain` being where it is, because
+    a custom signet's is a function of its challenge and therefore not a
+    field any table can hold. NETWORKS holds the built-in instances, and
     the ``*_from_network`` and ``*_from_xkeyversion`` functions below
     are the lookups.
     """
@@ -85,7 +102,6 @@ class Network:
     # network_type_from_* functions below for the answering
     network_type: NetworkType
 
-    magic_bytes: bytes
     genesis_block: bytes
 
     # base58 wif starts with 'K' or 'L' if compressed else '5'
@@ -122,7 +138,6 @@ class Network:
     def __init__(
         self,
         curve: Curve,
-        magic_bytes: Octets,
         genesis_block: Octets,
         wif: Octets,
         p2pkh: Octets,
@@ -138,19 +153,16 @@ class Network:
         slip132_p2wsh_pub: Octets,
         slip132_p2wsh_p2sh_prv: Octets,
         slip132_p2wsh_p2sh_pub: Octets,
-        # last and defaulted, where the field is declared second: a
-        # caller building a Network by hand -- a custom signet, which is
-        # what issue #207 says callers do today -- keeps every existing
-        # call valid, and "test" is the safe direction for the default.
-        # Defaulting to "main" would let a forgotten argument claim a
-        # made-up chain is the real one
+        # last and defaulted, where the field is declared second: it is
+        # the one field that is not bytes to be spelled out, and "test" is
+        # the safe direction for a default. Defaulting to "main" would let
+        # a forgotten argument claim a made-up chain is the real one
         network_type: NetworkType = "test",
         *,
         check_validity: bool = True,
     ) -> None:
         object.__setattr__(self, "curve", curve)
         object.__setattr__(self, "network_type", network_type)
-        object.__setattr__(self, "magic_bytes", bytes_from_octets(magic_bytes))
         object.__setattr__(self, "genesis_block", bytes_from_octets(genesis_block))
 
         object.__setattr__(self, "wif", bytes_from_octets(wif))
@@ -202,7 +214,6 @@ class Network:
         return {
             "curve": self.curve.name,
             "network_type": self.network_type,
-            "magic_bytes": self.magic_bytes.hex(),
             "genesis_block": self.genesis_block.hex(),
             "wif": self.wif.hex(),
             "p2pkh": self.p2pkh.hex(),
@@ -227,7 +238,6 @@ class Network:
         """Build a Network from the dict shape to_dict writes."""
         return cls(
             CURVES[dict_["curve"]],
-            dict_["magic_bytes"],
             dict_["genesis_block"],
             dict_["wif"],
             dict_["p2pkh"],
@@ -279,21 +289,18 @@ class Network:
                 raise BTClibValueError(err_msg)
 
 
-NETWORKS: dict[str, Network] = {}
 datadir = Path(__file__).parent / "_data"
 # order matters, and it is the order of the reverse lookups below: the
 # first network holding a version prefix is the one they answer with, so
 # testnet, the oldest, answers for the four networks that share its
 # prefixes, and appending a newer network cannot change any answer.
 # mainnet first, then the test networks oldest to newest -- signet.json
-# and testnet4.json differ from testnet.json in the genesis block and
-# the p2p magic, and in nothing else.
+# and testnet4.json differ from testnet.json in the genesis block, and in
+# nothing else.
 #
 # Annotated, where inference would widen it to tuple[str, ...]: this is
 # what ties NetworkName to the data it names, a sixth file loaded here
-# without a sixth member there being a mypy error. The dict it fills
-# stays dict[str, Network], a caller's custom signet being as much a
-# network as these -- issue #216 for why no parameter below narrows
+# without a sixth member there being a mypy error
 _network_names: tuple[NetworkName, ...] = (
     "mainnet",
     "testnet",
@@ -304,14 +311,80 @@ _network_names: tuple[NetworkName, ...] = (
 # the loop's own names are underscored: a for target and a with target are
 # module globals like any other, so `net`, `filename` and the open file
 # would be three names of this module that no caller has any use for
+_networks: dict[str, Network] = {}
 for _net in _network_names:
     _filename = datadir / f"{_net}.json"
     with _filename.open(encoding="ascii") as _network_file:
-        NETWORKS[_net] = Network.from_dict(json.load(_network_file))
+        _networks[_net] = Network.from_dict(json.load(_network_file))
+
+# the networks btclib ships, by name. A mapping and not a dict, because the
+# tables below are built from it once and an entry added afterwards would be
+# in the catalogue and in none of them. `NETWORKS[name]`, `name in
+# NETWORKS`, `.items()` and `.values()` are what this library and its
+# callers do with it, and all four are what a mapping is
+NETWORKS: Mapping[str, Network] = MappingProxyType(_networks)
 
 
-# Three questions, three functions, and one scan -- the plural one --
-# because "which networks carry this prefix" is the only fact here and it
+# Everything below is derived from NETWORKS, in one pass over it, because
+# every one of these questions is "which network carries these bytes" asked
+# from a different side -- and a second pass is a second thing to go stale.
+# Insertion order is the order above, so the first candidate of a shared
+# prefix is the oldest network holding it.
+_XPRV_VERSIONS: dict[str, tuple[bytes, ...]] = {}
+_XPUB_VERSIONS: dict[str, tuple[bytes, ...]] = {}
+_NETWORKS_FROM_XKEYVERSION: dict[bytes, tuple[str, ...]] = {}
+# the sibling of an xprv version: what neutering re-labels a key with,
+# looked up rather than found by position in the two sets below
+_XPUB_VERSION_FROM_XPRV_VERSION: dict[bytes, bytes] = {}
+
+for _name, _network in _networks.items():
+    # the five kinds of xkey -- BIP32's and SLIP132's four -- in one order
+    # for both halves: what pairs a prv version with its pub is this
+    # pairing, and nothing about where either lands in the sets below
+    _prv_versions = (
+        _network.bip32_prv,
+        _network.slip132_p2wsh_p2sh_prv,
+        _network.slip132_p2wpkh_p2sh_prv,
+        _network.slip132_p2wpkh_prv,
+        _network.slip132_p2wsh_prv,
+    )
+    _pub_versions = (
+        _network.bip32_pub,
+        _network.slip132_p2wsh_p2sh_pub,
+        _network.slip132_p2wpkh_p2sh_pub,
+        _network.slip132_p2wpkh_pub,
+        _network.slip132_p2wsh_pub,
+    )
+    _XPRV_VERSIONS[_name] = _prv_versions
+    _XPUB_VERSIONS[_name] = _pub_versions
+    for _prv, _pub in zip(_prv_versions, _pub_versions, strict=True):
+        # setdefault, not assignment: the four test networks carry one set
+        # of versions between them, so testnet -- first of the four -- is
+        # what a shared version keeps answering
+        _XPUB_VERSION_FROM_XPRV_VERSION.setdefault(_prv, _pub)
+    # dict.fromkeys and not the concatenation itself: a network naming
+    # itself twice for one version is what a prv version equal to a pub
+    # one would produce, and this is exact without a condition that the
+    # shipped data never takes
+    for _version in dict.fromkeys(_prv_versions + _pub_versions):
+        _NETWORKS_FROM_XKEYVERSION[_version] = (
+            *_NETWORKS_FROM_XKEYVERSION.get(_version, ()),
+            _name,
+        )
+
+# every xkey version this library knows, private and public. Sets, because
+# each answers one question -- is this a private version, is this a public
+# one -- and the four test networks carry one set of versions between them,
+# so a list of them was four fifths repetition in an order that meant
+# nothing. `xpubversion_from_xprvversion` is the pairing the parallel lists
+# were also used for, and `xprvversions_from_network` the versions of one
+# network
+XPRV_VERSIONS_ALL = frozenset(_XPUB_VERSION_FROM_XPRV_VERSION)
+XPUB_VERSIONS_ALL = frozenset(_XPUB_VERSION_FROM_XPRV_VERSION.values())
+
+
+# Three questions, three functions, and one answer underneath each trio --
+# because "which networks carry these bytes" is the only fact here and it
 # belongs in one place. Which of the three to reach for:
 #
 # - networks_from_*: every candidate, oldest first. The whole truth, for
@@ -340,6 +413,12 @@ def networks_from_key_value(
     never say. Mostly it holds the four test networks (one set of
     prefixes between them) or exactly one (mainnet's bytes, and
     regtest's bcrt hrp, are unique).
+
+    A scan where the xkey-version trio is a table, and not for want of a
+    key: `prefix` is whatever a caller passes, so a dict would answer an
+    unhashable one with a TypeError where the comparison answers "no
+    network carries this". Five networks and one `getattr` each is what
+    that costs.
     """
     return [
         network_str
@@ -356,8 +435,8 @@ def network_from_key_value(
     Oldest, i.e. 'testnet' for the prefixes testnet, regtest, signet and
     testnet4 share, 'regtest' for the bcrt hrp that is regtest's alone,
     'mainnet' for mainnet's. That is the network to encode *with*: the
-    candidates differ in genesis block and p2p magic, which no encoding
-    here reads, so the bytes it yields are right for all of them.
+    candidates differ in the genesis block, which no encoding here reads,
+    so the bytes it yields are right for all of them.
     It is not an answer to "which chain is this": use
     network_type_from_key_value for what the prefix does say, or
     networks_from_key_value for the candidates.
@@ -386,50 +465,43 @@ def network_type_from_network(network: str = "mainnet") -> NetworkType:
 
 
 def xpubversions_from_network(network: str = "mainnet") -> list[bytes]:
-    """Return every xpub version of the network, BIP32 and SLIP132."""
-    network = network.strip().lower()
-    return [
-        NETWORKS[network].bip32_pub,
-        NETWORKS[network].slip132_p2wsh_p2sh_pub,
-        NETWORKS[network].slip132_p2wpkh_p2sh_pub,
-        NETWORKS[network].slip132_p2wpkh_pub,
-        NETWORKS[network].slip132_p2wsh_pub,
-    ]
+    """Return every xpub version of the network, BIP32 and SLIP132.
+
+    A fresh list off the table built at import, so that a caller sorting
+    or trimming the answer is not editing the table every other lookup
+    reads.
+    """
+    return list(_XPUB_VERSIONS[network.strip().lower()])
 
 
 def xprvversions_from_network(network: str = "mainnet") -> list[bytes]:
     """Return every xprv version of the network, BIP32 and SLIP132."""
-    network = network.strip().lower()
-    return [
-        NETWORKS[network].bip32_prv,
-        NETWORKS[network].slip132_p2wsh_p2sh_prv,
-        NETWORKS[network].slip132_p2wpkh_p2sh_prv,
-        NETWORKS[network].slip132_p2wpkh_prv,
-        NETWORKS[network].slip132_p2wsh_prv,
-    ]
+    return list(_XPRV_VERSIONS[network.strip().lower()])
 
 
-# every xkey version this library knows, one block per network in
-# NETWORKS order. Four of the five networks carry testnet's, so each of
-# those appears four times over -- which is why the lookups below ask
-# each network whether it holds the version, rather than indexing a
-# parallel list of names: the position of a repeated entry means nothing
-XPRV_VERSIONS_ALL = [
-    version for network in NETWORKS for version in xprvversions_from_network(network)
-]
-XPUB_VERSIONS_ALL = [
-    version for network in NETWORKS for version in xpubversions_from_network(network)
-]
+def xpubversion_from_xprvversion(xprvversion: bytes) -> bytes:
+    """Return the xpub version paired with an xprv version.
+
+    The same network and the same script type: xprv to xpub, yprv to ypub,
+    Zprv to Zpub. What neutering re-labels a key with, and the one
+    question here a version *pair* answers rather than a version alone --
+    which is why it is a table and not two positions in the sets above.
+    """
+    if xprvversion not in _XPUB_VERSION_FROM_XPRV_VERSION:
+        err_msg = f"unknown xprv version: 0x{xprvversion.hex()}"
+        raise BTClibValueError(err_msg)
+    return _XPUB_VERSION_FROM_XPRV_VERSION[xprvversion]
 
 
 def networks_from_xkeyversion(xkeyversion: bytes) -> list[str]:
-    """Return every network with the xkey version prefix, oldest first."""
-    return [
-        network
-        for network in NETWORKS
-        if xkeyversion in xprvversions_from_network(network)
-        or xkeyversion in xpubversions_from_network(network)
-    ]
+    """Return every network with the xkey version prefix, oldest first.
+
+    One lookup, where asking each network in turn rebuilt two version
+    lists per network asked -- issue 683 measured what that cost the
+    address path, and the table it answers from is why NETWORKS is fixed
+    at import.
+    """
+    return list(_NETWORKS_FROM_XKEYVERSION.get(xkeyversion, ()))
 
 
 def network_from_xkeyversion(xkeyversion: bytes) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,13 @@ authors = [{ name = "The btclib developers", email = "devs@btclib.org" }]
 requires-python = ">=3.10"
 dependencies = [
     "btclib_secp256k1>=0.8.0",
-    "bitcoin-core-rpc>=2026.8.12",
+    # main, not a release: `assert_chain` and the two magic lookups are
+    # there first, and this tree stops carrying the check and the p2p
+    # constant it was made of. A direct reference is what PyPI refuses to
+    # publish, so the next release of that package replaces this line with
+    # a floor -- `bitcoin-core-rpc>=<that version>` -- and nothing else
+    # here changes. The lock pins the commit, and moves when main does
+    "bitcoin-core-rpc @ git+https://github.com/btclib-org/bitcoin-core-rpc.git@main",
 ]
 keywords = [
     # The GitHub repository topics, in the same order, and the order is by

--- a/tests/_generated_files/mainnet.json
+++ b/tests/_generated_files/mainnet.json
@@ -1,7 +1,6 @@
 {
     "curve": "secp256k1",
     "network_type": "main",
-    "magic_bytes": "d9b4bef9",
     "genesis_block": "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
     "wif": "80",
     "p2pkh": "00",

--- a/tests/_generated_files/regtest.json
+++ b/tests/_generated_files/regtest.json
@@ -1,7 +1,6 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
-    "magic_bytes": "dab5bffa",
     "genesis_block": "06226e46111a0b59caaf126043eb5bbf28c34f3a5e332a1fc7b2b73cf188910f",
     "wif": "ef",
     "p2pkh": "6f",

--- a/tests/_generated_files/signet.json
+++ b/tests/_generated_files/signet.json
@@ -1,7 +1,6 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
-    "magic_bytes": "40cf030a",
     "genesis_block": "00000008819873e925422c1ff0f99f7cc9bbb232af63a077a480a3633bee1ef6",
     "wif": "ef",
     "p2pkh": "6f",

--- a/tests/_generated_files/testnet.json
+++ b/tests/_generated_files/testnet.json
@@ -1,7 +1,6 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
-    "magic_bytes": "0709110b",
     "genesis_block": "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
     "wif": "ef",
     "p2pkh": "6f",

--- a/tests/_generated_files/testnet4.json
+++ b/tests/_generated_files/testnet4.json
@@ -1,7 +1,6 @@
 {
     "curve": "secp256k1",
     "network_type": "test",
-    "magic_bytes": "283f161c",
     "genesis_block": "00000000da84f2bafbbc53dee25a72ae507ff4914b867c565be350b0da8bf043",
     "wif": "ef",
     "p2pkh": "6f",

--- a/tests/fetch/bitcoin_core_test.py
+++ b/tests/fetch/bitcoin_core_test.py
@@ -29,18 +29,18 @@ from urllib.request import Request
 import bitcoin_core_rpc as rpc
 import pytest
 from bitcoin_core_rpc import (
+    DEFAULT_SIGNET_CHALLENGE,
     BitcoinCoreRpcClient,
     chain_from_network,
     network_from_chain,
 )
 
 from btclib.exceptions import BTClibValueError, FetchError, HttpError, RpcError
-from btclib.fetch.bitcoin_core import BitcoinCoreFetcher, _signet_magic
+from btclib.fetch.bitcoin_core import BitcoinCoreFetcher
 from btclib.fetch.transport import DEFAULT_MAX_BODY_SIZE
-from btclib.network import NETWORKS, Network
+from btclib.network import NETWORKS
 from btclib.tx import OutPoint
 from tests.fetch import TIP_HEIGHT, TIP_ID, TX_ID, Recorded, recorded_body
-from tests.network_test import SIGNET_CHALLENGE
 
 # the rpc credentials every test here passes. Named once rather than
 # written at each call, which is what keeps the string out of a
@@ -115,8 +115,13 @@ def fetcher(
     assert isinstance(network, str)
     verify_network = kwargs.pop("verify_network", False)
     assert isinstance(verify_network, bool)
+    challenge = kwargs.pop("signet_challenge", None)
+    assert challenge is None or isinstance(challenge, (str, bytes))
     return BitcoinCoreFetcher(
-        client(*answers, **kwargs), network, verify_network=verify_network
+        client(*answers, **kwargs),
+        network,
+        verify_network=verify_network,
+        signet_challenge=challenge,
     )
 
 
@@ -201,35 +206,6 @@ def blockchaininfo(**members: object) -> tuple[int, bytes]:
     return 200, body
 
 
-def custom_signet(challenge: str) -> Network:
-    """Return a Network like the default signet, with this challenge's magic.
-
-    What a caller registers for a signet of their own -- issue #207 -- and
-    the magic is derived by the function the check itself uses. What that
-    derivation is worth is settled elsewhere, in
-    `tests/network_test.py`, against the magic Core publishes for its own
-    signet; here it is the pairing of a challenge with a Network that
-    matters.
-    """
-    return Network.from_dict(
-        {**NETWORKS["signet"].to_dict(), "magic_bytes": _signet_magic(challenge).hex()}
-    )
-
-
-def test_signet_magic_is_the_reverse_of_the_digest_and_not_the_digest() -> None:
-    """`_signet_magic` itself, not the independent computation beside it.
-
-    `tests/network_test.py` computes the default signet's magic by its own
-    route and pins it to `0a03cf40` reversed; that is a fact about the
-    constant, not a call into this function, so a mutant of the slice this
-    function ends on -- dropped, or read forwards -- is not what that test
-    would notice. `custom_signet`'s docstring says the derivation is
-    "settled elsewhere", which is only true once this test exists.
-    """
-    assert _signet_magic(SIGNET_CHALLENGE).hex() == "40cf030a"
-    assert _signet_magic(SIGNET_CHALLENGE) == NETWORKS["signet"].magic_bytes
-
-
 def test_every_network_btclib_ships_has_a_chain_name() -> None:
     """The coupling between two vocabularies kept in two repositories.
 
@@ -240,8 +216,9 @@ def test_every_network_btclib_ships_has_a_chain_name() -> None:
     round trip is what says the two tables agree in both directions rather
     than merely having an entry each.
 
-    `NETWORKS` is a dict a caller adds to, so this reads the shipped
-    registry: the four names of `_data/`, not whatever a test registered.
+    `assert_network` relies on this: `NETWORKS` is fixed at import, so a
+    name a fetcher is allowed to carry is one `chain_from_network` can
+    translate, and there is no branch there for a name it cannot.
     """
     for network in NETWORKS:
         assert network_from_chain(chain_from_network(network)) == network
@@ -263,9 +240,7 @@ def test_assert_network_refuses_a_node_on_another_chain() -> None:
     returns is then a mainnet address for coins that are not there.
     Nothing else in the exchange says so.
     """
-    with pytest.raises(
-        BTClibValueError, match="node is on test, this fetcher on mainnet"
-    ):
+    with pytest.raises(BTClibValueError, match="reports chain 'test', not the 'main'"):
         fetcher(blockchaininfo(chain="test"), network="mainnet").assert_network()
 
 
@@ -277,9 +252,7 @@ def test_assert_network_refuses_a_chain_that_sorts_before_the_label() -> None:
     still refuse that one. Asking for testnet and getting `main`, which
     sorts before it, is the half only a real inequality catches.
     """
-    with pytest.raises(
-        BTClibValueError, match="node is on main, this fetcher on testnet"
-    ):
+    with pytest.raises(BTClibValueError, match="reports chain 'main', not the 'test'"):
         fetcher(blockchaininfo(chain="main"), network="testnet").assert_network()
 
 
@@ -292,62 +265,100 @@ def test_assert_network_tells_two_signets_apart() -> None:
     signet does not share with a node on someone else's.
     """
     answer = blockchaininfo(chain="signet", signet_challenge=CUSTOM_CHALLENGE)
-    with pytest.raises(BTClibValueError, match="signet this fetcher is not"):
+    with pytest.raises(BTClibValueError, match="signet this client is not"):
         fetcher(answer, network="signet").assert_network()
 
+    default = blockchaininfo(chain="signet", signet_challenge=DEFAULT_SIGNET_CHALLENGE)
+    fetcher(default, network="signet").assert_network()
 
-def test_assert_network_checks_a_caller_registered_signet(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A Network a caller built is checkable, which is what the magic buys.
 
-    Its name is btclib's alone and means nothing to a node, so the name is
-    not what is compared. `NETWORKS` is a dict a caller adds to, and
-    `monkeypatch.setitem` is how this one is taken back out.
+def test_assert_network_checks_the_signet_the_fetcher_was_given() -> None:
+    """A signet of the caller's own, which is what `signet_challenge` is for.
+
+    No entry in `NETWORKS` and no `Network` built by hand: a custom signet
+    differs from the default one in its p2p magic alone, which is a fact
+    about the node and not about how an address is spelled -- so the
+    challenge is an argument to this class, and the encoding table stays
+    signet's.
     """
-    monkeypatch.setitem(NETWORKS, "custom-signet", custom_signet(CUSTOM_CHALLENGE))
-
     answer = blockchaininfo(chain="signet", signet_challenge=CUSTOM_CHALLENGE)
-    fetcher(answer, network="custom-signet").assert_network()
+    endpoint = fetcher(
+        answer, network="signet", verify_network=True, signet_challenge=CUSTOM_CHALLENGE
+    )
+    endpoint.assert_network()
 
     other = blockchaininfo(chain="signet", signet_challenge=OTHER_CHALLENGE)
-    with pytest.raises(BTClibValueError, match="signet this fetcher is not"):
-        fetcher(other, network="custom-signet").assert_network()
+    with pytest.raises(BTClibValueError, match="signet this client is not"):
+        fetcher(
+            other,
+            network="signet",
+            verify_network=True,
+            signet_challenge=CUSTOM_CHALLENGE,
+        ).assert_network()
 
 
-def test_assert_network_has_nothing_to_compare_for_a_custom_name_off_signet(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A caller's own network against a node on main: a refusal, not a pass.
+def test_a_challenge_is_refused_where_it_would_check_nothing() -> None:
+    """Two combinations that are a check the caller expects and would not get.
 
-    Only a signet answers with an identity, so a name Core never heard of
-    has nothing to be held against -- and passing silently is the failure
-    this method exists to catch.
+    A network that is no signet has no challenge to be held to, and
+    `verify_network` off is the comparison not being made -- so both are
+    refused at construction, where the mistake was written, rather than at
+    a fetch that would pass.
     """
-    monkeypatch.setitem(NETWORKS, "custom-signet", custom_signet(CUSTOM_CHALLENGE))
-    with pytest.raises(BTClibValueError, match="no chain of Core's"):
-        fetcher(blockchaininfo(chain="main"), network="custom-signet").assert_network()
+    with pytest.raises(BTClibValueError, match="challenge for mainnet"):
+        fetcher(
+            network="mainnet", verify_network=True, signet_challenge=CUSTOM_CHALLENGE
+        )
+    with pytest.raises(BTClibValueError, match="checks nothing with it off"):
+        fetcher(network="signet", signet_challenge=CUSTOM_CHALLENGE)
+
+
+def test_a_challenge_that_is_no_script_is_refused_at_construction() -> None:
+    """Derived once here, so that the failure is at the line that wrote it.
+
+    A challenge is hex or the bytes it spells; anything else would
+    otherwise reach the node's reply and be reported as the *node*
+    answering something unreadable.
+    """
+    with pytest.raises(BTClibValueError, match="no hex"):
+        fetcher(network="signet", verify_network=True, signet_challenge="not hex")
 
 
 @pytest.mark.parametrize(
-    "result, message",
+    "result, message, network",
     [
-        pytest.param(3, "not a JSON object: int", id="not-an-object"),
-        pytest.param({}, "no chain name in the reply: None", id="no-chain"),
         pytest.param(
-            {"chain": 5}, "no chain name in the reply: 5", id="chain-not-a-string"
+            3, "no string chain in the int result", "mainnet", id="not-an-object"
         ),
         pytest.param(
-            {"chain": "signet"}, "no signet_challenge", id="signet-with-no-challenge"
+            {}, "no string chain in the dict result", "mainnet", id="no-chain"
+        ),
+        pytest.param(
+            {"chain": 5},
+            "no string chain in the dict result",
+            "mainnet",
+            id="chain-not-a-string",
+        ),
+        # a signet fetcher for the two below: the chain name is compared
+        # first, so a mainnet one would disagree about the name and never
+        # read the member these are about
+        pytest.param(
+            {"chain": "signet"},
+            "no string signet_challenge",
+            "signet",
+            id="signet-no-challenge",
         ),
         pytest.param(
             {"chain": "signet", "signet_challenge": "not hex"},
-            "getblockchaininfo",
+            "unreadable signet_challenge",
+            "signet",
             id="challenge-that-is-not-hex",
         ),
     ],
 )
-def test_assert_network_refuses_a_malformed_reply(result: object, message: str) -> None:
+def test_assert_network_refuses_a_malformed_reply(
+    result: object, message: str, network: str
+) -> None:
     """A reply that is not an answer is a FetchError naming the method.
 
     The same treatment every other answer here gets, and what tells it
@@ -357,7 +368,7 @@ def test_assert_network_refuses_a_malformed_reply(result: object, message: str) 
     """
     body = json.dumps({"jsonrpc": "2.0", "result": result, "id": "x"}).encode()
     with pytest.raises(FetchError, match=message):
-        fetcher((200, body), network="mainnet").assert_network()
+        fetcher((200, body), network=network).assert_network()
 
 
 def test_the_first_fetch_asks_the_node_which_chain_it_serves() -> None:
@@ -393,7 +404,7 @@ def test_a_node_on_another_chain_answers_no_fetch_at_all() -> None:
     endpoint = client(blockchaininfo(chain="test"))
     core = BitcoinCoreFetcher(endpoint, "mainnet")
     for _ in range(2):
-        with pytest.raises(BTClibValueError, match="node is on test"):
+        with pytest.raises(BTClibValueError, match="reports chain 'test'"):
             core.get_tx(TX_ID)
     assert asked(endpoint) == ["getblockchaininfo"]
 

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -5,15 +5,13 @@
 """Tests for the `btclib.network` module."""
 
 from dataclasses import fields
-from typing import get_args
+from typing import Any, get_args
 
 import pytest
 
-from btclib import var_bytes
 from btclib.alias import NetworkField, NetworkName
 from btclib.curves.curve import CURVES
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.hashes import hash256
 from btclib.network import (
     NETWORKS,
     Network,
@@ -26,6 +24,7 @@ from btclib.network import (
     networks_from_key_value,
     networks_from_xkeyversion,
     xprvversions_from_network,
+    xpubversion_from_xprvversion,
     xpubversions_from_network,
 )
 from tests.conftest import JsonGolden
@@ -36,7 +35,6 @@ def test_bad_network() -> None:
     with pytest.raises(BTClibValueError, match="invalid genesis_block length: "):
         Network(
             curve=CURVES["secp256k1"],
-            magic_bytes="d9b4bef9",
             genesis_block="000000000019d6689c08",  # too short
             wif=b"\x80",
             p2pkh=b"\x00",
@@ -73,6 +71,36 @@ def test_curve_from_xkeyversion() -> None:
             assert net.network_type == network_type_from_xkeyversion(version)
 
 
+def test_the_xpub_version_paired_with_an_xprv_one() -> None:
+    """What neutering re-labels a key with: same network, same script type.
+
+    The pairing is by position within a network -- bip32_prv with
+    bip32_pub, and so on for the four SLIP132 pairs -- which is what
+    `xprvversions_from_network` and `xpubversions_from_network` spell out,
+    one network at a time. Four networks share testnet's versions, so a
+    shared xprv version answers with the shared xpub version, the same
+    bytes for all four.
+    """
+    for name in NETWORKS:
+        prv_versions = xprvversions_from_network(name)
+        pub_versions = xpubversions_from_network(name)
+        for prv, pub in zip(prv_versions, pub_versions, strict=True):
+            assert xpubversion_from_xprvversion(prv) == pub
+
+
+def test_only_an_xprv_version_has_a_paired_xpub_one() -> None:
+    """Keyed by the private versions, so a public one is not a key at all.
+
+    Which is the refusal that matters: `xpubversion_from_xprvversion` of
+    an xpub version would otherwise have to invent an answer for a key
+    that is already public, where neutering is what this serves.
+    """
+    with pytest.raises(BTClibValueError, match="unknown xprv version: 0x0488b21e"):
+        xpubversion_from_xprvversion(NETWORKS["mainnet"].bip32_pub)
+    with pytest.raises(BTClibValueError, match="unknown xprv version: 0xdeadbeef"):
+        xpubversion_from_xprvversion(bytes.fromhex("deadbeef"))
+
+
 def test_space_and_caps() -> None:
     """Verify network names are stripped and lowercased before lookup."""
     net = " MainNet "
@@ -88,6 +116,30 @@ def test_numbers_of_networks() -> None:
     assert len(NETWORKS) == 5
 
 
+def test_the_catalogue_is_read_only() -> None:
+    """Adding a network is refused, which is what the tables below rest on.
+
+    `networks_from_xkeyversion` and the two version sets are built once
+    from `NETWORKS`, so an entry added afterwards would be in the
+    catalogue and in none of them -- the disagreement issue 683 recorded,
+    where the scan found a registered network and the frozen lists did
+    not. A `Network` is an encoding table and every field of one is the
+    same for every deployment of that network, so there is nothing left
+    for a caller to register: a custom signet differs in its p2p magic,
+    which identifies a node and is `bitcoin_core_rpc`'s.
+    """
+    mutable: Any = NETWORKS
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        mutable["custom-signet"] = NETWORKS["signet"]
+    with pytest.raises(AttributeError):
+        mutable.pop("signet")
+
+    # a mapping is what the library asks of it, and all of it
+    assert NETWORKS["mainnet"].hrp == "bc"
+    assert "mainnet" in NETWORKS
+    assert set(NETWORKS) == set(get_args(NetworkName))
+
+
 def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
     """Round-trip every Network through its dict and golden json."""
     for network_name, net in NETWORKS.items():
@@ -96,43 +148,14 @@ def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
         json_golden(f"{network_name}.json", net.to_dict())
 
 
-# Bitcoin Core's default signet challenge, kernel/chainparams.cpp: a
-# 1-of-2 multisig, and the only input to the p2p magic below
-SIGNET_CHALLENGE = (
-    "512103ad5e0edad18cb1f0fc0d28a3d4f1f3e445640337489abb10404f2d1e086be430"
-    "210359ef5021964fe22d6f8e05b2463c9540ce96883fe3b278760f048f5189f2e6c452ae"
-)
-
-
-def test_the_signet_magic_is_derived_and_not_copied() -> None:
-    """Signet's p2p magic is a function of its challenge, so compute it.
-
-    Core: "message start is defined as the first 4 bytes of the sha256d
-    of the block script", the script being serialized with its
-    CompactSize length, and the four bytes taken in the order the digest
-    produces them -- which is the reverse of how this library writes
-    magic_bytes, as the other four networks show.
-
-    Which is also the limitation to record: a *custom* signet has a
-    different challenge and therefore a different magic, so
-    NETWORKS["signet"] describes the default signet alone. Anything else
-    is a Network built by the caller, with this computation for the one
-    field that changes.
-    """
-    challenge = bytes.fromhex(SIGNET_CHALLENGE)
-    assert len(challenge) == 71
-    core_message_start = hash256(var_bytes.serialize(challenge))[:4]
-    assert core_message_start.hex() == "0a03cf40"
-    assert NETWORKS["signet"].magic_bytes == core_message_start[::-1]
-
-
-def test_the_test_networks_differ_from_testnet_in_two_fields() -> None:
-    """Signet and testnet4 reuse everything of testnet but chain identity.
+def test_the_test_networks_differ_from_testnet_in_the_genesis_block() -> None:
+    """Signet and testnet4 reuse everything of testnet but the chain.
 
     The wif, p2pkh, p2sh, hrp and bip32 version bytes are testnet's,
     which is the whole reason the reverse lookups have an ambiguity to
-    answer for; what a network of its own buys them is a genesis block
-    and a p2p magic.
+    answer for; what a network of its own buys them is a genesis block --
+    and, outside this table, a p2p magic, which identifies a *node* and
+    lives in `bitcoin_core_rpc` with the rest of what Core reports.
     """
     testnet = NETWORKS["testnet"].to_dict()
     for name in ("signet", "testnet4", "regtest"):
@@ -141,7 +164,7 @@ def test_the_test_networks_differ_from_testnet_in_two_fields() -> None:
             for key, value in NETWORKS[name].to_dict().items()
             if testnet[key] != value
         }
-        expected = {"magic_bytes", "genesis_block"}
+        expected = {"genesis_block"}
         if name == "regtest":
             expected.add("hrp")  # bcrt, where signet and testnet4 are tb
         assert differing == expected, name
@@ -157,8 +180,6 @@ def test_the_test_networks_differ_from_testnet_in_two_fields() -> None:
     # every network is a distinct chain, and the genesis block says so
     genesis = {net.genesis_block for net in NETWORKS.values()}
     assert len(genesis) == len(NETWORKS)
-    magics = {net.magic_bytes for net in NETWORKS.values()}
-    assert len(magics) == len(NETWORKS)
 
 
 # the prefix fields, i.e. every field a reverse lookup is asked about:
@@ -285,9 +306,10 @@ def test_network_type_from_network() -> None:
 def test_the_network_type_default_is_test() -> None:
     """A Network built without one is a test network, not the real chain.
 
-    Issue #207 filed this as the case that matters: a caller who needs a
-    custom signet builds a Network by hand, and a forgotten argument
-    must not let it claim to be mainnet.
+    `from_dict` is where it matters, a dict serialized before the field
+    existed having no `network_type` to read: the safe direction for what
+    is missing is "test", a forgotten field being no reason to claim the
+    real chain.
     """
     mainnet = NETWORKS["mainnet"].to_dict()
     del mainnet["network_type"]

--- a/uv.lock
+++ b/uv.lock
@@ -301,12 +301,8 @@ wheels = [
 
 [[package]]
 name = "bitcoin-core-rpc"
-version = "2026.8.12"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/6f/c059af17a556fd0840649fcb00a6aa053ab0ddc196ac1068f12ba0b0f4d5/bitcoin_core_rpc-2026.8.12.tar.gz", hash = "sha256:15677a3b11c959a31d2a63ba580093dcebb9b85534d18927afa7da59e1ebf184", size = 356774, upload-time = "2026-08-12T11:30:17.148Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/40/071a063c1d7d5b75afbe19b7d124eca260d2c9d45dace0952baa2a23c937/bitcoin_core_rpc-2026.8.12-py3-none-any.whl", hash = "sha256:0757f2290bc7b7bd6d7e99fd9ffb6b64a1f52492c4508d1af00f19faf42df6d0", size = 41395, upload-time = "2026-08-12T11:30:15.763Z" },
-]
+version = "2026.9"
+source = { git = "https://github.com/btclib-org/bitcoin-core-rpc.git?rev=main#f6899c92d3638651f49b91b6a4ca1ec878853aa9" }
 
 [[package]]
 name = "btclib"
@@ -373,7 +369,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bitcoin-core-rpc", specifier = ">=2026.8.12" },
+    { name = "bitcoin-core-rpc", git = "https://github.com/btclib-org/bitcoin-core-rpc.git?rev=main" },
     { name = "btclib-secp256k1", specifier = ">=0.8.0" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -302,7 +302,7 @@ wheels = [
 [[package]]
 name = "bitcoin-core-rpc"
 version = "2026.9"
-source = { git = "https://github.com/btclib-org/bitcoin-core-rpc.git?rev=main#f6899c92d3638651f49b91b6a4ca1ec878853aa9" }
+source = { git = "https://github.com/btclib-org/bitcoin-core-rpc.git?rev=main#299334b2dd4b6b5a15903dd78bfc266e13318044" }
 
 [[package]]
 name = "btclib"


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/683.

Builds on
[bitcoin-core-rpc#112](https://github.com/btclib-org/bitcoin-core-rpc/pull/112),
**merged**: `pyproject.toml` names `bitcoin-core-rpc @ git+…@main` and the
lock pins the commit that carries it. A direct reference cannot be published
to PyPI, so the next release of that package replaces the line with a floor
(`bitcoin-core-rpc>=<version>`) and nothing else here changes.

## The decision the issue asked for

`NETWORKS` is fixed at import, as a `MappingProxyType`. What settles it is
what a `Network` *is*: an encoding table whose every field is the same for
every deployment of the network it describes — so there is nothing left for
a caller to register.

`magic_bytes` was the one field that was not. Verified against Core's
`SigNetParams` (src/kernel/chainparams.cpp): `pchMessageStart` is derived
from the challenge (lines 513-515) while the genesis block is not (line
520), so a custom signet differs from the default one in the magic **and in
nothing else** — which is why the field could not be a constant per name.
It also had exactly one reader in this library, inside the rpc adapter, and
`genesis_block` has none.

So the split is by what the fact is about:

- **the chain as an encoding** — prefixes, version bytes, hrp, genesis:
  stays here, frozen;
- **the node** — p2p magic, chain names, ports, datadir subdirectories: is
  `bitcoin_core_rpc`'s, which already owned three of the four from the same
  file of Core's.

## What changes

- `NETWORKS["x"] = ...` is a `TypeError`. The disagreement the issue found
  is gone by construction: one pass over the catalogue builds the version
  sets, the version→networks index and the xprv→xpub pairing.
- `Network.magic_bytes` is gone, from the dataclass, `to_dict`/`from_dict`,
  the five `_data/*.json` and `alias.NetworkField`. `magic_from_chain` and
  `magic_from_signet_challenge` replace it — note the byte order there is
  Core's, where this field was its reverse.
- `BitcoinCoreFetcher(client, "signet", signet_challenge=…)` is how a
  custom signet is spelled: no registry entry, no `Network` built by hand.
  Refused with a non-signet network, with `verify_network=False`, and at
  construction if it is no script — each being a check the caller expects
  and would not get.
- `assert_network` is the client's `assert_chain` plus the translation:
  `chain_from_network` in, `client_errors` out. `_signet_magic` is gone, and
  so is the "no chain of Core's" branch — with the catalogue frozen, every
  name a fetcher can carry translates, and
  `test_every_network_btclib_ships_has_a_chain_name` is the guard.
- `XPRV_VERSIONS_ALL`/`XPUB_VERSIONS_ALL` are frozensets: membership is what
  nearly every use was, and four of the five networks carry testnet's
  versions, so the lists were four fifths repetition in an order that meant
  nothing.
- `xpubversion_from_xprvversion` publishes the pairing that
  `XPUB_VERSIONS_ALL[XPRV_VERSIONS_ALL.index(v)]` was doing — a
  twenty-five-entry scan on every neuter.
- `networks_from_key_value` stays a scan, and not for want of a key:
  `prefix` is whatever a caller passes, so a dict would answer an
  unhashable one with a `TypeError` where the comparison answers "no
  network carries this".

`alias.NetworkName` is now exact — the vocabulary is closed — but still
types nothing: the `network: str` parameters accept a name with spaces and
in any case, so narrowing them is
[#216](https://github.com/btclib-org/btclib/issues/216)'s decision and not
this change's.

## Breaking

HISTORY.md carries the two: the read-only catalogue with `magic_bytes`
gone, and the frozensets. Both are in CHANGELOG.md with the reasoning.

## Gates

Run locally as CONTRIBUTING.md documents them, against the merged
`bitcoin_core_rpc` the lock pins: `pre-commit run --all-files` exit 0,
`pytest` 24379 passed at 100.00% coverage, sphinx `-W` build succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)