### PR TITLE
Pin a length onto a SHAKE, rather than widen HashF to admit one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1573,20 +1573,45 @@ documented at release-notes length in the first place, and are still in
   wide digests are the other half: `challenge_` truncates to the
   leftmost `nlen` bits, which sha256 vectors cannot exercise at all.
 
-  Two sets were measured and deliberately left out, each with an entry in
+  One set was measured and deliberately left out, with an entry in
   `tests/_data/README.md` saying so -- "not taken" and "not noticed" look
   the same in a directory listing otherwise.
   `ecdh_secp256k1_webcrypto_test.json` is the ECDH file already vendored,
   re-encoded as JWK: its valid cases yield 468 distinct shared secrets and
   all 468 are that file's, its invalid classes a strict subset, so it
-  would add a base64url reader and no arithmetic. The four SHAKE files are
-  blocked on a type rather than on their data: an XOF has no fixed output,
-  so `hashlib.shake_128` fails `alias.HashObject` under mypy and, at run
-  time, makes `challenge_` demand a zero-length message hash -- which
-  `verify_` catches and reports as `False`, so every valid vector would
-  read as a bad signature rather than as an unsupported hash. Whether
-  `HashF` should admit an XOF is a public-surface question and is left
-  open.
+  would add a base64url reader and no arithmetic. The four SHAKE files
+  needed a decision about `HashF` rather than a reader, and the entry
+  below is that decision.
+- **Wycheproof's four SHAKE files, through an adapter that pins an output
+  length** (#706). 1580 more adversarial cases, all of them on the Python
+  path: `_libsecp256k1_applicable` admits sha256 alone, so a SHAKE never
+  reaches the bindings at all.
+
+  They needed a decision first, and it is written where the type is.
+  `hashlib.shake_128` is not a `HashF` and `btclib/alias.py` now says why
+  it is not: an extendable-output function has no output length of its
+  own -- `digest()` takes one as an argument and `digest_size` reads 0 --
+  so it fails `alias.HashObject` under mypy, and at run time makes
+  `challenge_` demand a zero-length message hash, which `verify_` catches
+  and reports as `False`. Every valid vector would have read as a bad
+  signature rather than as an unsupported hash.
+
+  The length is pinned by `_PinnedXof` in the test module, and the
+  library does not grow an XOF type. `HashF` admitting one would admit it
+  to `dsa.sign` as well, whose nonce is RFC6979 -- HMAC, which over an
+  XOF is not defined, NIST specifying KMAC instead. The standard library
+  refuses the same substitution in the same place: typeshed's `hmac.new`
+  rejects a SHAKE as a digestmod, and derives `HASHXOF` from `HASH` only
+  through a `type: ignore[override]`.
+
+  `n_size` is the pinned length, and any length above it is the same
+  test: `challenge_` reads the leftmost `nlen` bits, and a SHAKE's output
+  is a stream whose longer forms carry these very bytes as their prefix.
+  Measured, all four files verify identically at 32 bytes and at 64.
+  Nothing was found -- they pass as they are -- and the two SHAKE256
+  files carry a case the others cannot, upstream's `Untruncatedhash`: a
+  signature made over the whole digest instead of its leftmost `nlen`
+  bits, which is `invalid` and stays so.
 
 ## v2026.8.9
 

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -121,8 +121,8 @@ what their `pulled` says: the eight BIP327 files, the three Core files
 and the two python-bitcoinlib block files added here; Core's
 `blockfilters.json`, the psbts of BIP370 and BIP373 and the two BIP324
 csv files followed on 2026-08-03, at the tip of their paths too, the
-two BIP322 files on 2026-08-08, and the seven Wycheproof files with the
-licence beside them on 2026-08-13.
+two BIP322 files on 2026-08-08, and the Wycheproof files with the licence
+beside them on 2026-08-13.
 
 A vector btclib fails is vendored anyway and marked `xfail`, never left
 out: an absent vector hides the defect it would have shown, and
@@ -1324,7 +1324,7 @@ regenerates each of the four mnemonics word for word from the master
 secret. The other 11 are recovery only, a 2-of-3 share being random by
 construction.
 
-### C2SP/wycheproof: eight files under `tests/ecc/_data/`
+### C2SP/wycheproof: the ECDSA and ECDH files under `tests/ecc/_data/`
 
 The adversarial vectors, and the one upstream here published under a
 licence that is not MIT: Apache-2.0, whose condition on redistribution
@@ -1336,10 +1336,19 @@ All are pinned to the same commit, `5722833c` of 2026-08-11, and all
 live in `testvectors_v1/`. Not `testvectors/`, which upstream removed
 on 2025-09-02 and which no refresh can reach again. They are read by
 `tests/ecc/wycheproof_test.py`, which is also where the split between
-the two ECDSA profiles is explained, and where the sha512 and SHA3
-files' one difference from the rest is: `_libsecp256k1_applicable`
+the two ECDSA profiles is explained, and where the difference the files
+under a hash other than sha256 make is: `_libsecp256k1_applicable`
 admits sha256 alone, so those reach the Python arithmetic without the
 dispatch being patched off, and are run once rather than twice.
+
+The SHAKE files need one thing the others do not, and it is a type
+rather than a reader: `hashlib.shake_128` is not a `HashF`, an
+extendable-output function having no output length of its own, so
+`_PinnedXof` in that module pins one and `btclib/alias.py` says why the
+library does not. The pinned length is `n_size` and any length above it
+is the same test, `challenge_` reading the leftmost `nlen` bits of a
+digest whose longer forms have these very bytes as their prefix --
+measured, all four files verify identically at 32 and at 64.
 
 `ecdsa_secp256k1_sha256_bitcoin_test.json` is the one file of the four
 with no schema in upstream's `schemas/`, its own README listing it among
@@ -1450,6 +1459,70 @@ Verdict: **identical**. The wide digest without DER around it, which is
 what says the P1363 size rule is the encoding's and not the hash's: r
 and s stay `n_size` each while the message hash doubles.
 
+### `tests/ecc/_data/ecdsa_secp256k1_shake128_test.json`
+
+```text
+repo    C2SP/wycheproof
+path    testvectors_v1/ecdsa_secp256k1_shake128_test.json
+commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
+blob    bffa63ed0097e4910a5d99381f88a4b1c12db757
+pulled  2026-08-13
+behind  0 revisions; last changed at e0df04e0, 2025-10-07
+```
+
+Verdict: **identical**. An extendable-output function read as a hash of
+fixed size, which is the one thing here that needed something built for
+it: `_PinnedXof` in the test module, because `HashF` is a constructor of
+digests that report their own length and a SHAKE's is 0.
+
+### `tests/ecc/_data/ecdsa_secp256k1_shake256_test.json`
+
+```text
+repo    C2SP/wycheproof
+path    testvectors_v1/ecdsa_secp256k1_shake256_test.json
+commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
+blob    5bfb394cf971b3c9a68862f23b1251f3d3e7b1c0
+pulled  2026-08-13
+behind  0 revisions; last changed at e0df04e0, 2025-10-07
+```
+
+Verdict: **identical**. The same stream read at the same `n_size`, over
+a sponge of a different rate. Its tcId 425 is upstream's
+`Untruncatedhash` case, a signature made over the whole digest instead
+of its leftmost `nlen` bits and therefore `invalid` -- which is also the
+evidence that upstream generated this file at a length wider than the
+order, and that reading the stream at `n_size` reads the leftmost bits
+it read.
+
+### `tests/ecc/_data/ecdsa_secp256k1_shake128_p1363_test.json`
+
+```text
+repo    C2SP/wycheproof
+path    testvectors_v1/ecdsa_secp256k1_shake128_p1363_test.json
+commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
+blob    3f63208d4cbeaed6a8c46c430678199bd52d0e50
+pulled  2026-08-13
+behind  0 revisions; last changed at e0df04e0, 2025-10-07
+```
+
+Verdict: **identical**. The XOF with no DER around it: `Sig` answers for
+r and s alone, as under sha256 and sha512, the adapter changing what the
+message hashes to and nothing about the encoding.
+
+### `tests/ecc/_data/ecdsa_secp256k1_shake256_p1363_test.json`
+
+```text
+repo    C2SP/wycheproof
+path    testvectors_v1/ecdsa_secp256k1_shake256_p1363_test.json
+commit  5722833ca004983abd1a91bcb6c24596d50ac0f9  2026-08-11
+blob    c2b431b5d76016a8da19fdc1aab1ecaa5cfe12f1
+pulled  2026-08-13
+behind  0 revisions; last changed at e0df04e0, 2025-10-07
+```
+
+Verdict: **identical**. The fourth corner, and it carries the
+`Untruncatedhash` case of the pair as tcId 190.
+
 ### `tests/ecc/_data/ecdh_secp256k1_test.json`
 
 ```text
@@ -1514,27 +1587,6 @@ no arithmetic btclib does not already answer for. Recorded here rather
 than left silent because "we did not take it" and "we did not notice
 it" look the same in a directory listing, and a later refresh would
 otherwise have to measure this again.
-
-### Not vendored: the four SHAKE files
-
-`ecdsa_secp256k1_shake128_test.json`,
-`ecdsa_secp256k1_shake128_p1363_test.json`,
-`ecdsa_secp256k1_shake256_test.json` and
-`ecdsa_secp256k1_shake256_p1363_test.json`, at the same pin.
-
-Verdict: **not vendored, blocked on the type rather than on the data**.
-`hashlib.shake_128` is not a `HashF`: an XOF has no fixed output, so
-`digest_size` reads 0 and `digest()` takes the length as an argument,
-which `alias.HashObject.digest()` does not declare -- mypy refuses the
-assignment, and at run time `challenge_` asks
-`bytes_from_octets(msg_hash, 0)` and rejects every message hash. The
-failure is quiet where it matters most: `verify_` catches that
-`ValueError` and answers `False`, so every `valid` vector of those files
-would read as a bad signature rather than as an unsupported hash.
-
-Whether `HashF` should admit an XOF is a public-surface question, and
-answering it inside a test module would answer it in the one place
-`btclib/alias.py` cannot see. Left to the issue that raised it.
 
 ## Chain data, not a repository
 
@@ -1850,7 +1902,7 @@ Against a pinned upstream blob:
   `base58_encode_decode.json`, `blockfilters.json`,
   `checkblock_valid.json`, `checkblock_invalid.json`,
   `bip39_test_vectors.json`, the eight BIP327 vector files, and the
-  seven Wycheproof vector files.
+  Wycheproof vector files.
 - identical but for a trailing newline:
   `script_assets_test.json`, `vectors.json`, `WYCHEPROOF_COPYING`.
 - identical but for CRLF against LF: `bip340_test_vectors.csv` and the
@@ -1874,9 +1926,8 @@ No upstream blob exists for the rest:
 - response bodies under `tests/fetch/_data/`, whose envelopes are
   composed from Core's and Esplora's own source and whose payload is
   chain data two of the entries above already hold.
-- deliberately not vendored, each with an entry saying why it was
-  measured and left: Wycheproof's `ecdh_secp256k1_webcrypto_test.json`
-  and its four SHAKE files.
+- deliberately not vendored, with an entry saying why it was measured
+  and left: Wycheproof's `ecdh_secp256k1_webcrypto_test.json`.
 - not vendored: `rfc6979.json` (an RFC), `electrum_test_vectors.json`,
   `electrum_language_vectors.json`, `fakeenglish.txt` and
   `btclib_test_vectors.json` (btclib's own). The last is the only one

--- a/tests/ecc/_data/ecdsa_secp256k1_shake128_p1363_test.json
+++ b/tests/ecc/_data/ecdsa_secp256k1_shake128_p1363_test.json
@@ -1,0 +1,5280 @@
+{
+  "algorithm": "ECDSA",
+  "schema": "ecdsa_p1363_verify_schema_v1.json",
+  "numberOfTests": 248,
+  "header": [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of IEEE P1363 encoded ECDSA signatures."
+  ],
+  "notes": {
+    "ArithmeticError": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
+      "cves": [
+        "CVE-2017-18146"
+      ]
+    },
+    "EdgeCasePublicKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "ModifiedInteger": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves": [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SignatureSize": {
+      "bugType": "LEGACY",
+      "description": "This test vector contains valid values for r and s. But the values are encoded using a smaller number of bytes. The size of an IEEE P1363 encoded signature should always be twice the number of bytes of the size of the order. Some libraries accept signatures with less bytes. To our knowledge no standard (i.e., IEEE P1363 or RFC 7515) requires any explicit checks of the signature size during signature verification."
+    },
+    "SmallRandS": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "ValidSignature": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx": "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy": "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "signature malleability",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e4710612ebbe0145a469f29a195700b55c5ad2fc1df818eac017099bcb1bbef15",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "replaced r by r + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "01b67909c3703a5115a72263124050fd0eb5e4c7c2d988654ca7914b52295c106f00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 3,
+          "comment": "replaced r by r + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "0100b67909c3703a5115a72263124050fbcaaa12d18b72e000d0ba1d79958f67102e0000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 4,
+          "comment": "replaced r by n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "4986f63c8fc5aeea58dd9cedbfaf02eebf78f20a8508db2ad81371c777107213b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 5,
+          "comment": "replaced r by r + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "01b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 6,
+          "comment": "replaced r by r + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "010000000000000000b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e000000000000000000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 7,
+          "comment": "replaced s by s + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "01b8ef9ed1441feba5b960d65e6a8ff4a7afb08a0b7f0fb1cb7e34235ceeb0936d00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 8,
+          "comment": "replaced s by s + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "0100b8ef9ed1441feba5b960d65e6a8ff363a3de93d418674d4f90c051a054bb932c0000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 9,
+          "comment": "replaced s by s + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "01b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "replaced s by s + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "010000000000000000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c000000000000000000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 11,
+          "comment": "Signature with special case values r=0 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 12,
+          "comment": "Signature with special case values r=0 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "Signature with special case values r=0 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "Signature with special case values r=0 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "Signature with special case values r=0 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "Signature with special case values r=0 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "Signature with special case values r=0 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "Signature with special case values r=1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "Signature with special case values r=1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "Signature with special case values r=1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "Signature with special case values r=1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "Signature with special case values r=1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "Signature with special case values r=1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "Signature with special case values r=1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "Signature with special case values r=n and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "Signature with special case values r=n and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "Signature with special case values r=n and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "Signature with special case values r=n and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "Signature with special case values r=n and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "Signature with special case values r=n and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "Signature with special case values r=n and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "Signature with special case values r=n - 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "Signature with special case values r=n - 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "Signature with special case values r=n - 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "Signature with special case values r=n - 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 36,
+          "comment": "Signature with special case values r=n - 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 37,
+          "comment": "Signature with special case values r=n - 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 38,
+          "comment": "Signature with special case values r=n - 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 39,
+          "comment": "Signature with special case values r=n + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 40,
+          "comment": "Signature with special case values r=n + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 41,
+          "comment": "Signature with special case values r=n + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 42,
+          "comment": "Signature with special case values r=n + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 43,
+          "comment": "Signature with special case values r=n + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 44,
+          "comment": "Signature with special case values r=n + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 45,
+          "comment": "Signature with special case values r=n + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 46,
+          "comment": "Signature with special case values r=p and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 47,
+          "comment": "Signature with special case values r=p and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 48,
+          "comment": "Signature with special case values r=p and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 49,
+          "comment": "Signature with special case values r=p and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 50,
+          "comment": "Signature with special case values r=p and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 51,
+          "comment": "Signature with special case values r=p and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 52,
+          "comment": "Signature with special case values r=p and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 53,
+          "comment": "Signature with special case values r=p + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 54,
+          "comment": "Signature with special case values r=p + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 55,
+          "comment": "Signature with special case values r=p + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 56,
+          "comment": "Signature with special case values r=p + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 57,
+          "comment": "Signature with special case values r=p + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 58,
+          "comment": "Signature with special case values r=p + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 59,
+          "comment": "Signature with special case values r=p + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 60,
+          "comment": "Edge case for Shamir multiplication",
+          "flags": [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg": "3639313331",
+          "sig": "dd1b7d09a7bd8218961034a39a87fecf5314f00c4d25eb58a07ac85e85eab516942b93d2552410ae06d6f651659174a77c3701c1d1320d032d6a01a5a330c041",
+          "result": "valid"
+        },
+        {
+          "tcId": 61,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363530303637353631",
+          "sig": "512edaee1ab1c77564fc52cb549b78425c56953237fa5aec783b5a81b11e22bfa5573fbcf6ff4faf8a4c5f782906bcf9d5059ae086db252d7682174a8ee4232e",
+          "result": "valid"
+        },
+        {
+          "tcId": 62,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383039333631353931",
+          "sig": "281ca95097599e8331e7b002d16cdae136cfb279c1900a5d0e52320ac28f8355a63da77fdf93ceb643dabf2656b2f4b2b7c1e2cbb5a7c5c2189e53a7c73e4ae2",
+          "result": "valid"
+        },
+        {
+          "tcId": 63,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313231333636353837",
+          "sig": "ea496271d334150ceb6b29c1ce1d5aaafb8ff6619ebc1aa8d9e8f68e9e94d9144b2350d9f4afca5f7d1595ce6cb5d7ffcd4ac5a767c7bc5c014fe8ea66309512",
+          "result": "valid"
+        },
+        {
+          "tcId": 64,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393635323435333939",
+          "sig": "45a95e29999caca1b06a27f5dd9dfb01a9b7196edafdc8375486c2ebdc9713cec9e1dfc621ceac522146d2235439c3b191513caa01fa3fcef37b2977456f3ed4",
+          "result": "valid"
+        },
+        {
+          "tcId": 65,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323035343733333935",
+          "sig": "a681bf2da732cde1405e3958ad8fe795650936824c846856650fbfe053194fe344435ef6218b2805e7603bbd1cf550f916e30231f4a62acc43b55a853e7d234f",
+          "result": "valid"
+        },
+        {
+          "tcId": 66,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323236333030353738",
+          "sig": "9696582199ed95e1f9a83935f20d7cb014fd12b4a929cda0b46678ddafb99140ad0625e45afc7e2f16968cebe5f415c77b8e922641c5fa94ce0d3bbc4f5916d2",
+          "result": "valid"
+        },
+        {
+          "tcId": 67,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35353736313930313833",
+          "sig": "6d1f5edf9f118678cef172d5bfdfb62169944c799895eae908eae92fdee785bf6d8d689faa873f2f4cc854bc8375e12321c31dcf51d708cc781e228846c646cb",
+          "result": "valid"
+        },
+        {
+          "tcId": 68,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36393239393934393737",
+          "sig": "a3e862869eb0723ce9b89f6ebc200a2e98bc025529b35004f5a87c4f61b1d669c53866fb237c155215e340a6cdd5c4613220dae081b73537ed9c470adddc380a",
+          "result": "valid"
+        },
+        {
+          "tcId": 69,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343139303333343334",
+          "sig": "5ca10aa93f22b30d6990551d641c05fdbd91093b8a2c8a6346db6d73fd0afc62f56aaf3a6becb5020ac26999a5eeba10f77fabe0451bd117c1b00e52f70e2fcc",
+          "result": "valid"
+        },
+        {
+          "tcId": 70,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38343034303136323630",
+          "sig": "0cab3be2d173329a6848eb02fc7233e9a3266aac8ad3968fc3c816cb2c7ab26bc039cee82f7904090b7bd82b2752c03095536284d212e067b2643a14aeab11c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 71,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323939383433333936",
+          "sig": "0fec3b9a9b4bfe28a8659482558a13b245e5f18e9ad189ba798137fb1d2fa3a5c9340abfba096f3715e73a459c90ef92572bdcc4ef212edcad6fc07e6f35a6aa",
+          "result": "valid"
+        },
+        {
+          "tcId": 72,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313834333734343135",
+          "sig": "9a8d68e482d54e3abf25ef0c936bba854127355504919352b97a3be66a73e5c92a1a3b547014baca64090d26da67e737cf7dec42be4cef584b80d768c12d6464",
+          "result": "valid"
+        },
+        {
+          "tcId": 73,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130383632313035383639",
+          "sig": "e6a527a6e04fdf6fc80d6f4d0b6fec846938536143993f0ca172404cd98525614dd33d9a7432e89c17fd8357db487b1ded3e2c781dc426456684e6c5508b89bf",
+          "result": "valid"
+        },
+        {
+          "tcId": 74,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353030303333393137",
+          "sig": "e0b8fd2f4fd424d1686b59dc233e6de82b5eff4a3fc9feadd2330a14bc4843c61a530270440b71c80c6099288d87627e77175ef39cedde74da37f7425f2a46ac",
+          "result": "valid"
+        },
+        {
+          "tcId": 75,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130323039383532343831",
+          "sig": "adc55436cb93eeaaf851bcf505458b36d8a0e9036af87030cfa5369e497416d1e0a6cc64d89a8e70fab849cb3b15f271f461274fc0e823973ffb976315db9900",
+          "result": "valid"
+        },
+        {
+          "tcId": 76,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353432383438333133",
+          "sig": "24df16632e42fa2f05ae4d55356781fc58945128315c046d6225d33afc7ea70aa5a9d16ceb809d57b12748aad029af7914a237f5b6ca0526de86649a8cdd2960",
+          "result": "valid"
+        },
+        {
+          "tcId": 77,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323535363938303935",
+          "sig": "6f808e7ff5394daf91b1c93b4bdf8edb83dde6bd93443adeebd60c785e24b1f23d8d87ecebcb7b8f51440fbeb5637fe0c6794a99fab45d5d5051cacfd55cc5c1",
+          "result": "valid"
+        },
+        {
+          "tcId": 78,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373334363931363630",
+          "sig": "45e91631ef8cdbd0f919c0afc439c1ac1f7ad9a0729684f2e07d95fe6d74d3fe0dcb4dbc55cca634968fd0c6157f5649c624b27f5c18d4845973ffe0f8438259",
+          "result": "valid"
+        },
+        {
+          "tcId": 79,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37393633383036363138",
+          "sig": "db310a1f6a1640221145b65f95d703ecc0ae84fdd5b14f78a5f7bf749d4e4b36e660a55ab50c761d72e0c729b6068644f9eb05209f43d72392bfcd7015197943",
+          "result": "valid"
+        },
+        {
+          "tcId": 80,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363334333037323131",
+          "sig": "e40849775b4b333bba557de96c45033f15e20d1e315a4e4494b8ffc7d30820dfb6ef7550bd1db54464ae07eae8732ceaacd1151d6106fd5badb5e5045e3a95ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 81,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353039393431353232",
+          "sig": "c42a94145084e023768ec283d461b85b01133a03c78e5bb3cd3a8f3252f011e761a90325338f02878ae4998edb3563b392448cd303578b3cd3899955db1d32e6",
+          "result": "valid"
+        },
+        {
+          "tcId": 82,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373932323430313639",
+          "sig": "ba01f5e1a9aa16fa8d74be994edc745b3783d901ea9c834f1d1522376cd812af00c6b0c0c0a7b6ab3de2df52ca6c9aa41c6be94f71925c6e73cbe75094517d16",
+          "result": "valid"
+        },
+        {
+          "tcId": 83,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36343835373332363232",
+          "sig": "218c618cfc01aa7519e5f106c57a206864fb02dae1ccc8928076b8fef801cc5d0d636547bdd3e833eeced26e56e38ed10895219fcc171a29405c1efd41ea7b02",
+          "result": "valid"
+        },
+        {
+          "tcId": 84,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34323030333139303235",
+          "sig": "1809137a4c81666e82d8b10372951d8cac40deb7ee5156d859cd9498fe344398f22cd60ed48ca3f4e71919b9bb2f67eefb5e43f5c0120242c1014a743602b9d5",
+          "result": "valid"
+        },
+        {
+          "tcId": 85,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31313031323032313732",
+          "sig": "0dee22bfc32ebab0bf630365188f5362278cc1b83bb1ff14dd732e9ffa6aed6a50f4c5c50fc5e520a1d3b16401150a348803e1b9660bb9af2f149d6446b2885f",
+          "result": "valid"
+        },
+        {
+          "tcId": 86,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363830343631373331",
+          "sig": "a8e9eaefff83c5237cdce17f29c0de49fd3fdfcf09945abc9b80358ebb631e1e97ce1eda7c5da180de13c030e7ac9588e637b55bdc92ac6acb5ee0355560f290",
+          "result": "valid"
+        },
+        {
+          "tcId": 87,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3433333030373131",
+          "sig": "766c9079a3ddd8421a7506611c4317e1375f20ef6a2f97458f5f06a85de6a48e71c05d521d67f38d9d230cbbe14832e3490dee1b83633a72c30368d24448d94d",
+          "result": "valid"
+        },
+        {
+          "tcId": 88,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35343130383731383131",
+          "sig": "a24a6bfdb18fd549021fb3f5781ac5bbd5cd04886476b2dbc543663ba0fe8002ce2307d2330f8ffa57cab705627c222ddca3bd4c65782667899417388d64be79",
+          "result": "valid"
+        },
+        {
+          "tcId": 89,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34393935363839393432",
+          "sig": "a166858bc0de34f642b8243af2c9b5de7d932780d0c577293d3841434bc6d3681344da59d582ce3e6bd459deedcc15195e9923f9a09e5e33b6cc22347b4efdb3",
+          "result": "valid"
+        },
+        {
+          "tcId": 90,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333535303737393735",
+          "sig": "7d245bbd8852f477aab5f66e763ba80af436c676883254e0e0677594dd777f0ffb0980a77ebc02354412ed76b491369e87098d44d4e5629f4aac2e0df38f739d",
+          "result": "valid"
+        },
+        {
+          "tcId": 91,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3637383237343235353934",
+          "sig": "cac23081f1b638caea584fe0feb6fed7da1b15474305c8a23f7b6df1f2e10db4917ed6d28013052e6448f011377d51bc108baf9b8e7b5e64c43509f3d3101bdf",
+          "result": "valid"
+        },
+        {
+          "tcId": 92,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333230353830363930",
+          "sig": "6cfb9dabf738725a952085f74f31b15c9da48b52a8a45667f6098c7c5df115ab804c1c65db15e52f4093828f7743294969da4c1a71b927de8bd0e1bffdfb7024",
+          "result": "valid"
+        },
+        {
+          "tcId": 93,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383536333035303638",
+          "sig": "5b32944ee796cd9b997a673214c587701f7882239d29f6b834cc26c18e9638dec39547b682e6a2de446ae2c70e507692acf4d3c898a20f4aaf2379bcec114a6a",
+          "result": "valid"
+        },
+        {
+          "tcId": 94,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37303836313032363437",
+          "sig": "a2ad0277149153d7b4d01d600cbf5b9c75e3e89c58862078d9ec06850caadc63348e06b90da5f6dd3cabd3a339c08b2ffc89bfa5902b4b7bfc69892163ba0e8c",
+          "result": "valid"
+        },
+        {
+          "tcId": 95,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383133383135343839",
+          "sig": "d6dc8278d912a92e44e7c5a06718c93d0cd3f621f2101f55888235bf74e680a665e87883e04a699e926fd864a81b3f3d83136e20ae82d91682b0808567e866c0",
+          "result": "valid"
+        },
+        {
+          "tcId": 96,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353133303032323331",
+          "sig": "f0382ca2736e6ab2adb71aa43e29d95214ec48d61b3f84b0543c16c0f25716d07d50ebf35cf732381bcf6b75f8a49df18dbbf967828f6d1ce98840bd0c366070",
+          "result": "valid"
+        },
+        {
+          "tcId": 97,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393333383130313533",
+          "sig": "45403dbed83e7ccd359c209ae692f3c9b54df7a15b049b468de8a0d5e8b58b1c5eebf48b9d40586d05ede8abafecf21e91266f607c007ae3ed0b8cedf03cbdc5",
+          "result": "valid"
+        },
+        {
+          "tcId": 98,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333035363037343230",
+          "sig": "39cf2c7f8a554e6674195ba7d54d5face5c4539e8765a9f791a8f43b2205759b03c736dc8b0281a8cf1834d0c194499b5caf5fdd459e4453e86915c91b60be39",
+          "result": "valid"
+        },
+        {
+          "tcId": 99,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3633373635373930323234",
+          "sig": "a4f4399e8963439774e120b1412e01ca7fc4e298edce3c034521565196c8f42e01cd175d2a8718127949b2b5153019846bec47364d549d22c2671b1a2f459a16",
+          "result": "valid"
+        },
+        {
+          "tcId": 100,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393139303435363730",
+          "sig": "520d886a2027b7b980ea7b6ffc5f90ad10297dd8b21679d69c40d5f40f416a5a358398ea11fc66a54b8bb7d848888acca88b5ca18fc05f276deb5f66c5cbc53e",
+          "result": "valid"
+        },
+        {
+          "tcId": 101,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343536303739363233",
+          "sig": "8b180e44f592fa84b49b19e0d413a96f130a6a9ce62b529535ac053d86c8123d4b865d92413a9c5fe8e718e3491103751d40254fd6f30918e59ab81d24fed474",
+          "result": "valid"
+        },
+        {
+          "tcId": 102,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373837373735323437",
+          "sig": "96336c7319d70accdf613d5db165a967d9229ba3771f38d323e450ddaf0f755a3f386fdfb6ec686027ae45ce71060832f5dea4b2bbc55ad5ac92da3601233059",
+          "result": "valid"
+        },
+        {
+          "tcId": 103,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33333031393735303837",
+          "sig": "2260f86a44bc6d28d642190ea5ac409689b7556e2a042be1b5a39fd265fbe80e734564b7d0575907ab18ef683d5e4da490f6b9df4a347147679ae4c235d67495",
+          "result": "valid"
+        },
+        {
+          "tcId": 104,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353138323633323336",
+          "sig": "e6f11102223a007db4ebeb897e8baec78d178eee9ace4339de93dda2d97797667a8b12e5684da7a0dac02b151e1fd15a2c9aa8f26e92ad281876ef6a5be5f357",
+          "result": "valid"
+        },
+        {
+          "tcId": 105,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363637363730363435",
+          "sig": "ff46a3bc8530db22de7ab9d0fdc2925c711696b58b0720e30822eb883a980bacf02f72976361c7c61b707fc6415c6277eac77704da5aac851633c1c7f8b22363",
+          "result": "valid"
+        },
+        {
+          "tcId": 106,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31313733313630343337",
+          "sig": "d2b944c292991bf07b04e3251c72deadadc7703533a8d38c283eca747ff2ea0b8fdc265f9476ed7ddab57648902c8a0c70662e94b2e12c2de8553f97fadc81ee",
+          "result": "valid"
+        },
+        {
+          "tcId": 107,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36313831353839313035",
+          "sig": "aa41d869490e00703174f700c3cf059f2e0b6687634eb043525811211a6b83524041a086c2b1a794bc540aa98afc599c0b904971a1a3d55bea0046042e4a2cc6",
+          "result": "valid"
+        },
+        {
+          "tcId": 108,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313233363236363536",
+          "sig": "1635edeb95f7f19ac9ff925ef558f8e88a84ce690bfdda025b37dcef7fbea2caf6622f57c16c3689e579c21eeb5d3b5b0cd5f1568e435bf31c9e88a08e5a012d",
+          "result": "valid"
+        },
+        {
+          "tcId": 109,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303134343435353535",
+          "sig": "264a610125078e2fb8ee915c6bf75b0922eb2c98959cd7485f48a2a23435631eabb202b102476093c4ed36fc5196e54a679c47f19ac1073fc0f63d80885ca1f5",
+          "result": "valid"
+        },
+        {
+          "tcId": 110,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383030393034353338",
+          "sig": "1f074c47123d5c79472089de6bfe35f3f28bd3d15125722c410b39682072e325164d85563be93911de5dd6003f6beb8daa370e47713e096e5d750f809cc49468",
+          "result": "valid"
+        },
+        {
+          "tcId": 111,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353034313630343138",
+          "sig": "e1a5dd2395e62047d3a900b0c78aa6bb0f344140f664d21f7a5fa93e3660efc65386e2d5789206ff278e9c833d11780b4471f2325e1ed843bd44bf281c965955",
+          "result": "valid"
+        },
+        {
+          "tcId": 112,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363834303939333836",
+          "sig": "ccf7c57ee2d8090058aedbe31a1eafd90c5ea4338edcb54445ffbb130b7d6339a121b1ceb05b46b60d6754747e67a114efe9d3b0971fafd26aea6f84446a71b2",
+          "result": "valid"
+        },
+        {
+          "tcId": 113,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37303931393134373137",
+          "sig": "217f4b7f49ec9098cc674fbbbef4c1426cf5fb4f53157757eae081069f204387db07d9d84e1ec80921fa62b562a52762f193d6cb007bab13df619981fc51e92b",
+          "result": "valid"
+        },
+        {
+          "tcId": 114,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36383730353736323136",
+          "sig": "6e44444851ff0b16f815e85047ff89b4d130a4a9f962f1f9abe2f582b7d79adcdbd446884e2cf11ef21bf8d489b361fc6c67eba81cdd4d4c74098690159ac990",
+          "result": "valid"
+        },
+        {
+          "tcId": 115,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353130383339363937",
+          "sig": "bc2957b83ec0ce04238e86258cdc573313ae171ad52ffa84ac88f10e3e411ed7d718daa144d74e1efe9768afb54fb7006a1c05217bc885f109b4cc1e2485cc37",
+          "result": "valid"
+        },
+        {
+          "tcId": 116,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343937383635313830",
+          "sig": "fff680cc7551b65b284c8a478e62f643e80c75ba942f6f6537c33c6154076b4e562635a5e53d02128458184bab32acbcc29eb7b0a2cd174f7e923d3f7142619f",
+          "result": "valid"
+        },
+        {
+          "tcId": 117,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3135323237383238323639",
+          "sig": "62daace3787591218f7e4c7373b2db408c52c9c01405e5f6ce0c037c9b2b1854c0b6f11a5fba1f710fd43ea6ad3b20aee65f5c0e1b0ec7ba40a98a9f77416cb7",
+          "result": "valid"
+        },
+        {
+          "tcId": 118,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33363437363930313730",
+          "sig": "882dcf364ab5840d6d10be9ab0293bbb126b44f97eb9de4fd1e93c4b2e2952e96215d699e9484afafd3a4e546eadc7841c4c8aba38323ca5f7b692c9f19ac09d",
+          "result": "valid"
+        },
+        {
+          "tcId": 119,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130323131353335373237",
+          "sig": "d0e2f0a3a4b4f5f193c6d4aa865fca9e421a009863d3cf0c2664a4cbffb8d59ad201d86dc869455396cb17f53c1058d0334058ffe2306c03143ed029a76a5492",
+          "result": "valid"
+        },
+        {
+          "tcId": 120,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373430353737333639",
+          "sig": "22b7a717ffb1dbae9dcb80ecd08d0651bee1cb77df9bddccff1eaf52d3ae6c020fc7f279d33f0a9769775deb93ed378bddbbeace831e84074b0317d69945d3ca",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "uDj_ROW8F3vyEYnQdmCC_J2EMiaIf8l2A3EQC37iCm8",
+        "y": "8MnXW_unsxpryhl0SW7rVt41cHGVXYPEsbraoLIYMuk",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047df5977eeb9b4e8a530e3ff4ded003cf900e1fd5b5e86dc39ef2899437ade0d2e38e4d0af342fbbcd40cc613cf2e7234405bee3c89fb84f26969446895c05ede",
+        "wx": "7df5977eeb9b4e8a530e3ff4ded003cf900e1fd5b5e86dc39ef2899437ade0d2",
+        "wy": "00e38e4d0af342fbbcd40cc613cf2e7234405bee3c89fb84f26969446895c05ede"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047df5977eeb9b4e8a530e3ff4ded003cf900e1fd5b5e86dc39ef2899437ade0d2e38e4d0af342fbbcd40cc613cf2e7234405bee3c89fb84f26969446895c05ede",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEffWXfuubTopTDj/03tADz5AOH9W16G3D\nnvKJlDet4NLjjk0K80L7vNQMxhPPLnI0QFvuPIn7hPJpaURolcBe3g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 121,
+          "comment": "k*G has a large x-coordinate",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000014551231950b75fc4402da1722fc9baebfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        },
+        {
+          "tcId": 122,
+          "comment": "r too large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2cfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ffWXfuubTopTDj_03tADz5AOH9W16G3DnvKJlDet4NI",
+        "y": "445NCvNC-7zUDMYTzy5yNEBb7jyJ-4TyaWlEaJXAXt4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049b2f0d042ceeae39be642b142cb57a8ea38ceae0505dff76f2fa3f5d87ba31f00129e1485752464145443ae713119a5c4604bbec98262d45c4257aa3cb8f5d9f",
+        "wx": "009b2f0d042ceeae39be642b142cb57a8ea38ceae0505dff76f2fa3f5d87ba31f0",
+        "wy": "0129e1485752464145443ae713119a5c4604bbec98262d45c4257aa3cb8f5d9f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049b2f0d042ceeae39be642b142cb57a8ea38ceae0505dff76f2fa3f5d87ba31f00129e1485752464145443ae713119a5c4604bbec98262d45c4257aa3cb8f5d9f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEmy8NBCzurjm+ZCsULLV6jqOM6uBQXf92\n8vo/XYe6MfABKeFIV1JGQUVEOucTEZpcRgS77JgmLUXEJXqjy49dnw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 123,
+          "comment": "r,s are large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "my8NBCzurjm-ZCsULLV6jqOM6uBQXf928vo_XYe6MfA",
+        "y": "ASnhSFdSRkFFRDrnExGaXEYEu-yYJi1FxCV6o8uPXZ8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0443c82fbeb0c94c84fb2f94662eb10a8e028cb80095deff46a6980850c6dfbf359f72182bd0cb5dc438c29f9ce828f9e5c1a1ba01f95be26da4024e39f11f663f",
+        "wx": "43c82fbeb0c94c84fb2f94662eb10a8e028cb80095deff46a6980850c6dfbf35",
+        "wy": "009f72182bd0cb5dc438c29f9ce828f9e5c1a1ba01f95be26da4024e39f11f663f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000443c82fbeb0c94c84fb2f94662eb10a8e028cb80095deff46a6980850c6dfbf359f72182bd0cb5dc438c29f9ce828f9e5c1a1ba01f95be26da4024e39f11f663f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQ8gvvrDJTIT7L5RmLrEKjgKMuACV3v9G\nppgIUMbfvzWfchgr0MtdxDjCn5zoKPnlwaG6Aflb4m2kAk458R9mPw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 124,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc3e9a7582886089c62fb840cf3b83061cd1cff3ae4341808bb5bdee6191174177",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Q8gvvrDJTIT7L5RmLrEKjgKMuACV3v9GppgIUMbfvzU",
+        "y": "n3IYK9DLXcQ4wp-c6Cj55cGhugH5W-JtpAJOOfEfZj8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045d8fc5fa2ae8a19877c87eb94d8494741c07298386af0794559bad328cdffbf4c59623522979c175f70ef4b61a165af1c9862447360ad440dcc15586042de7f8",
+        "wx": "5d8fc5fa2ae8a19877c87eb94d8494741c07298386af0794559bad328cdffbf4",
+        "wy": "00c59623522979c175f70ef4b61a165af1c9862447360ad440dcc15586042de7f8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045d8fc5fa2ae8a19877c87eb94d8494741c07298386af0794559bad328cdffbf4c59623522979c175f70ef4b61a165af1c9862447360ad440dcc15586042de7f8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXY/F+irooZh3yH65TYSUdBwHKYOGrweU\nVZutMozf+/TFliNSKXnBdfcO9LYaFlrxyYYkRzYK1EDcwVWGBC3n+A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 125,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc24238e70b431b1a64efdf9032669939d4b77f249503fc6905feb7540dea3e6d2",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "XY_F-irooZh3yH65TYSUdBwHKYOGrweUVZutMozf-_Q",
+        "y": "xZYjUil5wXX3DvS2GhZa8cmGJEc2CtRA3MFVhgQt5_g",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044ecfb55c21451e2158fec7371df2897630f352a75b0748746bde2ba6a2decedb9bdaf193eaaa3f819a57ccde4eeb8e1483c1461be1e451ad959159f288851989",
+        "wx": "4ecfb55c21451e2158fec7371df2897630f352a75b0748746bde2ba6a2decedb",
+        "wy": "009bdaf193eaaa3f819a57ccde4eeb8e1483c1461be1e451ad959159f288851989"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044ecfb55c21451e2158fec7371df2897630f352a75b0748746bde2ba6a2decedb9bdaf193eaaa3f819a57ccde4eeb8e1483c1461be1e451ad959159f288851989",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAETs+1XCFFHiFY/sc3HfKJdjDzUqdbB0h0\na94rpqLeztub2vGT6qo/gZpXzN5O644Ug8FGG+HkUa2VkVnyiIUZiQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 126,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 127,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0101",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Ts-1XCFFHiFY_sc3HfKJdjDzUqdbB0h0a94rpqLezts",
+        "y": "m9rxk-qqP4GaV8zeTuuOFIPBRhvh5FGtlZFZ8oiFGYk",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049e9bf525b52ad0b1f32a8b1787c1de5e3c435a65551cc7a68d24beb975bf0b5c0ebdbb39d8cf4e1ee7c10b95c7764a299796e69890ba24f69af1c6c0318e455a",
+        "wx": "009e9bf525b52ad0b1f32a8b1787c1de5e3c435a65551cc7a68d24beb975bf0b5c",
+        "wy": "0ebdbb39d8cf4e1ee7c10b95c7764a299796e69890ba24f69af1c6c0318e455a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049e9bf525b52ad0b1f32a8b1787c1de5e3c435a65551cc7a68d24beb975bf0b5c0ebdbb39d8cf4e1ee7c10b95c7764a299796e69890ba24f69af1c6c0318e455a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEnpv1JbUq0LHzKosXh8HeXjxDWmVVHMem\njSS+uXW/C1wOvbs52M9OHufBC5XHdkopl5bmmJC6JPaa8cbAMY5FWg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 128,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+          "result": "valid"
+        },
+        {
+          "tcId": 129,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0102",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "npv1JbUq0LHzKosXh8HeXjxDWmVVHMemjSS-uXW_C1w",
+        "y": "Dr27OdjPTh7nwQuVx3ZKKZeW5piQuiT2mvHGwDGORVo",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04238a1b25d18f6e50d4e66ec617cec5caf8915cdb3f068898f01d9d478ac86da1c4ccb59b26abeafb8d63b46c81812cebf1b3e1a00e7dac550689dab16eb382e3",
+        "wx": "238a1b25d18f6e50d4e66ec617cec5caf8915cdb3f068898f01d9d478ac86da1",
+        "wy": "00c4ccb59b26abeafb8d63b46c81812cebf1b3e1a00e7dac550689dab16eb382e3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004238a1b25d18f6e50d4e66ec617cec5caf8915cdb3f068898f01d9d478ac86da1c4ccb59b26abeafb8d63b46c81812cebf1b3e1a00e7dac550689dab16eb382e3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEI4obJdGPblDU5m7GF87FyviRXNs/BoiY\n8B2dR4rIbaHEzLWbJqvq+41jtGyBgSzr8bPhoA59rFUGidqxbrOC4w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 130,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003",
+          "result": "valid"
+        },
+        {
+          "tcId": 131,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0103",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "I4obJdGPblDU5m7GF87FyviRXNs_BoiY8B2dR4rIbaE",
+        "y": "xMy1myar6vuNY7RsgYEs6_Gz4aAOfaxVBonasW6zguM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0453af90c4805fc6970759be2fbbcd9b8830a9005d308e01e29a8d3ece82cc208d76277c445337294b63de38de8b1ea9272c33c95d2cf94463e6502d77295332a1",
+        "wx": "53af90c4805fc6970759be2fbbcd9b8830a9005d308e01e29a8d3ece82cc208d",
+        "wy": "76277c445337294b63de38de8b1ea9272c33c95d2cf94463e6502d77295332a1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000453af90c4805fc6970759be2fbbcd9b8830a9005d308e01e29a8d3ece82cc208d76277c445337294b63de38de8b1ea9272c33c95d2cf94463e6502d77295332a1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEU6+QxIBfxpcHWb4vu82biDCpAF0wjgHi\nmo0+zoLMII12J3xEUzcpS2PeON6LHqknLDPJXSz5RGPmUC13KVMyoQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 132,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 133,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0201",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "U6-QxIBfxpcHWb4vu82biDCpAF0wjgHimo0-zoLMII0",
+        "y": "did8RFM3KUtj3jjeix6pJywzyV0s-URj5lAtdylTMqE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049cfe252b251749d52bc1fdbcb5d0e3e8dfe3239c172380facc63590f85520c79532ee36e68792ebe69867a042a61cd99d7d8c5ece834f36b5b01f26589c13649",
+        "wx": "009cfe252b251749d52bc1fdbcb5d0e3e8dfe3239c172380facc63590f85520c79",
+        "wy": "532ee36e68792ebe69867a042a61cd99d7d8c5ece834f36b5b01f26589c13649"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049cfe252b251749d52bc1fdbcb5d0e3e8dfe3239c172380facc63590f85520c79532ee36e68792ebe69867a042a61cd99d7d8c5ece834f36b5b01f26589c13649",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEnP4lKyUXSdUrwf28tdDj6N/jI5wXI4D6\nzGNZD4VSDHlTLuNuaHkuvmmGegQqYc2Z19jF7Og082tbAfJlicE2SQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 134,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002",
+          "result": "valid"
+        },
+        {
+          "tcId": 135,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0202",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "nP4lKyUXSdUrwf28tdDj6N_jI5wXI4D6zGNZD4VSDHk",
+        "y": "Uy7jbmh5Lr5phnoEKmHNmdfYxezoNPNrWwHyZYnBNkk",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ef105def30266133e1488f127056642f30f6033f035be186f6185e8d7e34745ebe65d70d75959058195f71068d12c30f3301335e8bc54b39fd5bb2eb5220a22a",
+        "wx": "00ef105def30266133e1488f127056642f30f6033f035be186f6185e8d7e34745e",
+        "wy": "00be65d70d75959058195f71068d12c30f3301335e8bc54b39fd5bb2eb5220a22a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ef105def30266133e1488f127056642f30f6033f035be186f6185e8d7e34745ebe65d70d75959058195f71068d12c30f3301335e8bc54b39fd5bb2eb5220a22a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7xBd7zAmYTPhSI8ScFZkLzD2Az8DW+GG\n9hhejX40dF6+ZdcNdZWQWBlfcQaNEsMPMwEzXovFSzn9W7LrUiCiKg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 136,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003",
+          "result": "valid"
+        },
+        {
+          "tcId": 137,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0203",
+          "result": "invalid"
+        },
+        {
+          "tcId": 138,
+          "comment": "r is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641430000000000000000000000000000000000000000000000000000000000000003",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "7xBd7zAmYTPhSI8ScFZkLzD2Az8DW-GG9hhejX40dF4",
+        "y": "vmXXDXWVkFgZX3EGjRLDDzMBM16LxUs5_Vuy61Igoio",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0443f43ad13fd4198b2810f20d00f306c365a64f4621784da4280e452c0b53993bb2f7fbadf3a661203894df4013ea6759e45aa9009a07d6ed84624fdce01526a6",
+        "wx": "43f43ad13fd4198b2810f20d00f306c365a64f4621784da4280e452c0b53993b",
+        "wy": "00b2f7fbadf3a661203894df4013ea6759e45aa9009a07d6ed84624fdce01526a6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000443f43ad13fd4198b2810f20d00f306c365a64f4621784da4280e452c0b53993bb2f7fbadf3a661203894df4013ea6759e45aa9009a07d6ed84624fdce01526a6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQ/Q60T/UGYsoEPINAPMGw2WmT0YheE2k\nKA5FLAtTmTuy9/ut86ZhIDiU30AT6mdZ5FqpAJoH1u2EYk/c4BUmpg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 139,
+          "comment": "s is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd04917c8",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Q_Q60T_UGYsoEPINAPMGw2WmT0YheE2kKA5FLAtTmTs",
+        "y": "svf7rfOmYSA4lN9AE-pnWeRaqQCaB9bthGJP3OAVJqY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047d32a05199975a2f5d473b879af0f75d577402f528757fa3a92928652b4d817db8000cc7d3f91680180a66f397e2e0345da5a815da3a263e8438467144af1b69",
+        "wx": "7d32a05199975a2f5d473b879af0f75d577402f528757fa3a92928652b4d817d",
+        "wy": "00b8000cc7d3f91680180a66f397e2e0345da5a815da3a263e8438467144af1b69"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047d32a05199975a2f5d473b879af0f75d577402f528757fa3a92928652b4d817db8000cc7d3f91680180a66f397e2e0345da5a815da3a263e8438467144af1b69",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEfTKgUZmXWi9dRzuHmvD3XVd0AvUodX+j\nqSkoZStNgX24AAzH0/kWgBgKZvOX4uA0XaWoFdo6Jj6EOEZxRK8baQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 140,
+          "comment": "small r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000101c58b162c58b162c58b162c58b162c58a1b242973853e16db75c8a1a71da4d39d",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "fTKgUZmXWi9dRzuHmvD3XVd0AvUodX-jqSkoZStNgX0",
+        "y": "uAAMx9P5FoAYCmbzl-LgNF2lqBXaOiY-hDhGcUSvG2k",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04eeeea2cb300c44bcc0817aa83138b5f6ea591e11f5aefb3dc1be09484f8844a80fc86e7eab9f4dde612d0aa7e123f36bac7dc95287e34a22daf4a114db47b333",
+        "wx": "00eeeea2cb300c44bcc0817aa83138b5f6ea591e11f5aefb3dc1be09484f8844a8",
+        "wy": "0fc86e7eab9f4dde612d0aa7e123f36bac7dc95287e34a22daf4a114db47b333"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004eeeea2cb300c44bcc0817aa83138b5f6ea591e11f5aefb3dc1be09484f8844a80fc86e7eab9f4dde612d0aa7e123f36bac7dc95287e34a22daf4a114db47b333",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7u6iyzAMRLzAgXqoMTi19upZHhH1rvs9\nwb4JSE+IRKgPyG5+q59N3mEtCqfhI/NrrH3JUofjSiLa9KEU20ezMw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 141,
+          "comment": "smallish r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000000000000000000000002d9b4d347952ccfcbc5103d0da267477d1791461cf2aa44bf9d43198f79507bd8779d69a13108e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "7u6iyzAMRLzAgXqoMTi19upZHhH1rvs9wb4JSE-IRKg",
+        "y": "D8hufqufTd5hLQqn4SPza6x9yVKH40oi2vShFNtHszM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dfba55134a9570020c097af4b60a2fbeabbe21998a2f30c35afce9b2f712d0b75d3d79e68248a21961256a0b542741fe181e6a7f7fc4187c16dcce39316a7a8d",
+        "wx": "00dfba55134a9570020c097af4b60a2fbeabbe21998a2f30c35afce9b2f712d0b7",
+        "wy": "5d3d79e68248a21961256a0b542741fe181e6a7f7fc4187c16dcce39316a7a8d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dfba55134a9570020c097af4b60a2fbeabbe21998a2f30c35afce9b2f712d0b75d3d79e68248a21961256a0b542741fe181e6a7f7fc4187c16dcce39316a7a8d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE37pVE0qVcAIMCXr0tgovvqu+IZmKLzDD\nWvzpsvcS0LddPXnmgkiiGWElagtUJ0H+GB5qf3/EGHwW3M45MWp6jQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 142,
+          "comment": "100-bit r and small s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000000000001033e67e37b32b445580bf4efc906f906f906f906f906f906f906f906ed8e426f7b1968c35a204236a579723d2",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "37pVE0qVcAIMCXr0tgovvqu-IZmKLzDDWvzpsvcS0Lc",
+        "y": "XT155oJIohlhJWoLVCdB_hgean9_xBh8FtzOOTFqeo0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047e7474d27df26ce4fadd81c950c3bd2827d7e73d2f4be93d55e99cbf1754070309acac087399ecd1afd3dce0355fb4a76f969f5d46ed68f70fc2d920ae63ce80",
+        "wx": "7e7474d27df26ce4fadd81c950c3bd2827d7e73d2f4be93d55e99cbf17540703",
+        "wy": "09acac087399ecd1afd3dce0355fb4a76f969f5d46ed68f70fc2d920ae63ce80"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047e7474d27df26ce4fadd81c950c3bd2827d7e73d2f4be93d55e99cbf1754070309acac087399ecd1afd3dce0355fb4a76f969f5d46ed68f70fc2d920ae63ce80",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEfnR00n3ybOT63YHJUMO9KCfX5z0vS+k9\nVemcvxdUBwMJrKwIc5ns0a/T3OA1X7Snb5afXUbtaPcPwtkgrmPOgA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 143,
+          "comment": "small r and 100 bit s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000101783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "fnR00n3ybOT63YHJUMO9KCfX5z0vS-k9VemcvxdUBwM",
+        "y": "CaysCHOZ7NGv09zgNV-0p2-Wn11G7Wj3D8LZIK5jzoA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0436ab43c27ac8bae06ccd37c2135fb5d1959311aa206b8ff911066a7fba55a806307355cabf2af7d22e8d49bbfafc6e724f64cbb2fa5153a048344e323a809391",
+        "wx": "36ab43c27ac8bae06ccd37c2135fb5d1959311aa206b8ff911066a7fba55a806",
+        "wy": "307355cabf2af7d22e8d49bbfafc6e724f64cbb2fa5153a048344e323a809391"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000436ab43c27ac8bae06ccd37c2135fb5d1959311aa206b8ff911066a7fba55a806307355cabf2af7d22e8d49bbfafc6e724f64cbb2fa5153a048344e323a809391",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAENqtDwnrIuuBszTfCE1+10ZWTEaoga4/5\nEQZqf7pVqAYwc1XKvyr30i6NSbv6/G5yT2TLsvpRU6BINE4yOoCTkQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 144,
+          "comment": "100-bit r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000062522bbd3ecbe7c39e93e7c26783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "NqtDwnrIuuBszTfCE1-10ZWTEaoga4_5EQZqf7pVqAY",
+        "y": "MHNVyr8q99IujUm7-vxuck9ky7L6UVOgSDROMjqAk5E",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049b9e76adb9164075e661c4462ee3ab841c60f6820efb970822b0e54f8333c41a9704f9937ae8fedf55fc03405941e66ded639d536ff725ff8abf0d889fcec0cb",
+        "wx": "009b9e76adb9164075e661c4462ee3ab841c60f6820efb970822b0e54f8333c41a",
+        "wy": "009704f9937ae8fedf55fc03405941e66ded639d536ff725ff8abf0d889fcec0cb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049b9e76adb9164075e661c4462ee3ab841c60f6820efb970822b0e54f8333c41a9704f9937ae8fedf55fc03405941e66ded639d536ff725ff8abf0d889fcec0cb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEm552rbkWQHXmYcRGLuOrhBxg9oIO+5cI\nIrDlT4MzxBqXBPmTeuj+31X8A0BZQeZt7WOdU2/3Jf+Kvw2In87Ayw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 145,
+          "comment": "r and s^-1 are close to n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03640c155555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "m552rbkWQHXmYcRGLuOrhBxg9oIO-5cIIrDlT4MzxBo",
+        "y": "lwT5k3ro_t9V_ANAWUHmbe1jnVNv9yX_ir8NiJ_OwMs",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0462e9bcb187c62b86f755e4cc9200a6818d7de643278acabc66d3b0d60beb7f8abe839dbd89b4935883c08fa0dd7e5b21740d4c27d1d778c3e33fbbc6ec1d2a7a",
+        "wx": "62e9bcb187c62b86f755e4cc9200a6818d7de643278acabc66d3b0d60beb7f8a",
+        "wy": "00be839dbd89b4935883c08fa0dd7e5b21740d4c27d1d778c3e33fbbc6ec1d2a7a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000462e9bcb187c62b86f755e4cc9200a6818d7de643278acabc66d3b0d60beb7f8abe839dbd89b4935883c08fa0dd7e5b21740d4c27d1d778c3e33fbbc6ec1d2a7a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYum8sYfGK4b3VeTMkgCmgY195kMnisq8\nZtOw1gvrf4q+g529ibSTWIPAj6DdflshdA1MJ9HXeMPjP7vG7B0qeg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 146,
+          "comment": "r and s are 64-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000009c44febf31c3594d000000000000000000000000000000000000000000000000839ed28247c2b06b",
+          "result": "valid"
+        },
+        {
+          "tcId": 147,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "9c44febf31c3594d839ed28247c2b06b",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Yum8sYfGK4b3VeTMkgCmgY195kMnisq8ZtOw1gvrf4o",
+        "y": "voOdvYm0k1iDwI-g3X5bIXQNTCfR13jD4z-7xuwdKno",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ac50a3a818f4c94a40bdf2f5236a4e17c674a6bc59278da694a57d8968acbd53ae77d279a38c3a277dc70c7caf5624f358649968c8c375a7b9846535cf6b29b8",
+        "wx": "00ac50a3a818f4c94a40bdf2f5236a4e17c674a6bc59278da694a57d8968acbd53",
+        "wy": "00ae77d279a38c3a277dc70c7caf5624f358649968c8c375a7b9846535cf6b29b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ac50a3a818f4c94a40bdf2f5236a4e17c674a6bc59278da694a57d8968acbd53ae77d279a38c3a277dc70c7caf5624f358649968c8c375a7b9846535cf6b29b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErFCjqBj0yUpAvfL1I2pOF8Z0prxZJ42m\nlKV9iWisvVOud9J5o4w6J33HDHyvViTzWGSZaMjDdae5hGU1z2spuA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 148,
+          "comment": "r and s are 100-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000009df8b682430beef6f5fd7c7cf000000000000000000000000000000000000000fd0a62e13778f4222a0d61c8a",
+          "result": "valid"
+        },
+        {
+          "tcId": 149,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "09df8b682430beef6f5fd7c7cf0fd0a62e13778f4222a0d61c8a",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "rFCjqBj0yUpAvfL1I2pOF8Z0prxZJ42mlKV9iWisvVM",
+        "y": "rnfSeaOMOid9xwx8r1Yk81hkmWjIw3WnuYRlNc9rKbg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044d913e392004f6a3bc68de5800f022f3399b10192d50cdb4d8159a20b322765439a999e57fcad59f6152ec4b644cdd6cfe8db85452cdcf591e27d64a8ea1c272",
+        "wx": "4d913e392004f6a3bc68de5800f022f3399b10192d50cdb4d8159a20b3227654",
+        "wy": "39a999e57fcad59f6152ec4b644cdd6cfe8db85452cdcf591e27d64a8ea1c272"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044d913e392004f6a3bc68de5800f022f3399b10192d50cdb4d8159a20b322765439a999e57fcad59f6152ec4b644cdd6cfe8db85452cdcf591e27d64a8ea1c272",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAETZE+OSAE9qO8aN5YAPAi8zmbEBktUM20\n2BWaILMidlQ5qZnlf8rVn2FS7EtkTN1s/o24VFLNz1keJ9ZKjqHCcg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 150,
+          "comment": "r and s are 128-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000008a598e563a89f526c32ebec8de26367a0000000000000000000000000000000084f633e2042630e99dd0f1e16f7a04bf",
+          "result": "valid"
+        },
+        {
+          "tcId": 151,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "8a598e563a89f526c32ebec8de26367a84f633e2042630e99dd0f1e16f7a04bf",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "TZE-OSAE9qO8aN5YAPAi8zmbEBktUM202BWaILMidlQ",
+        "y": "OamZ5X_K1Z9hUuxLZEzdbP6NuFRSzc9ZHifWSo6hwnI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dd7faf8855a2593a5dbe970ad7abbab3e4e2031a1f1b683e2a982393197d30756483257650c599ff82753dea3d3051f45e5d3f080b5f763bed77a3c4b4799034",
+        "wx": "00dd7faf8855a2593a5dbe970ad7abbab3e4e2031a1f1b683e2a982393197d3075",
+        "wy": "6483257650c599ff82753dea3d3051f45e5d3f080b5f763bed77a3c4b4799034"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dd7faf8855a2593a5dbe970ad7abbab3e4e2031a1f1b683e2a982393197d30756483257650c599ff82753dea3d3051f45e5d3f080b5f763bed77a3c4b4799034",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3X+viFWiWTpdvpcK16u6s+TiAxofG2g+\nKpgjkxl9MHVkgyV2UMWZ/4J1Peo9MFH0Xl0/CAtfdjvtd6PEtHmQNA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 152,
+          "comment": "r and s are 160-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000aa6eeb5823f7fa31b466bb473797f0d0314c0bdf000000000000000000000000e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "valid"
+        },
+        {
+          "tcId": 153,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "aa6eeb5823f7fa31b466bb473797f0d0314c0bdfe2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "3X-viFWiWTpdvpcK16u6s-TiAxofG2g-Kpgjkxl9MHU",
+        "y": "ZIMldlDFmf-CdT3qPTBR9F5dPwgLX3Y77XejxLR5kDQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044100635e830522797ac10d2ea8275694b99c1f862a885a9d2d45185303bfd0800183ffcffb6fdb15954367a1641e6e9b65695ffc887946ba0d51e64f08f753da",
+        "wx": "4100635e830522797ac10d2ea8275694b99c1f862a885a9d2d45185303bfd080",
+        "wy": "0183ffcffb6fdb15954367a1641e6e9b65695ffc887946ba0d51e64f08f753da"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044100635e830522797ac10d2ea8275694b99c1f862a885a9d2d45185303bfd0800183ffcffb6fdb15954367a1641e6e9b65695ffc887946ba0d51e64f08f753da",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQQBjXoMFInl6wQ0uqCdWlLmcH4YqiFqd\nLUUYUwO/0IABg//P+2/bFZVDZ6FkHm6bZWlf/Ih5RroNUeZPCPdT2g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 154,
+          "comment": "s == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 155,
+          "comment": "s == 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "QQBjXoMFInl6wQ0uqCdWlLmcH4YqiFqdLUUYUwO_0IA",
+        "y": "AYP_z_tv2xWVQ2ehZB5um2VpX_yIeUa6DVHmTwj3U9o",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b4363909e1e962bbe67552ecdb536885409add71a967462ff838e997dbeeaa40d01eea8265137ceb419d7b84044bf09b06c08974660f19d1723bfbb780723f0a",
+        "wx": "00b4363909e1e962bbe67552ecdb536885409add71a967462ff838e997dbeeaa40",
+        "wy": "00d01eea8265137ceb419d7b84044bf09b06c08974660f19d1723bfbb780723f0a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b4363909e1e962bbe67552ecdb536885409add71a967462ff838e997dbeeaa40d01eea8265137ceb419d7b84044bf09b06c08974660f19d1723bfbb780723f0a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtDY5CeHpYrvmdVLs21NohUCa3XGpZ0Yv\n+Djpl9vuqkDQHuqCZRN860Gde4QES/CbBsCJdGYPGdFyO/u3gHI/Cg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 156,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1419d981c515af8cc82545aac0c85e9e308fbb2eab6acd7ed497e0b4145a18fd9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "tDY5CeHpYrvmdVLs21NohUCa3XGpZ0Yv-Djpl9vuqkA",
+        "y": "0B7qgmUTfOtBnXuEBEvwmwbAiXRmDxnRcjv7t4ByPwo",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047dc7901bc8308ce836edfbd9d3a1324c3d04b29be6a31450de3d79905a76704120ac850524b9eb239c8e57de5d91f0158e59705f64d6b741205070ab1748924c",
+        "wx": "7dc7901bc8308ce836edfbd9d3a1324c3d04b29be6a31450de3d79905a767041",
+        "wy": "20ac850524b9eb239c8e57de5d91f0158e59705f64d6b741205070ab1748924c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047dc7901bc8308ce836edfbd9d3a1324c3d04b29be6a31450de3d79905a76704120ac850524b9eb239c8e57de5d91f0158e59705f64d6b741205070ab1748924c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEfceQG8gwjOg27fvZ06EyTD0EspvmoxRQ\n3j15kFp2cEEgrIUFJLnrI5yOV95dkfAVjllwX2TWt0EgUHCrF0iSTA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 157,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c11b21717ad71d23bbac60a9ad0baf75b063c9fdf52a00ebf99d022172910993c9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "fceQG8gwjOg27fvZ06EyTD0EspvmoxRQ3j15kFp2cEE",
+        "y": "IKyFBSS56yOcjlfeXZHwFY5ZcF9k1rdBIFBwqxdIkkw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0456dad3a5ad3be19e358b3a6d6f20c8f888812b7c77aae353db4731e9061dec8fe03740ee7d05adcc7e9a2cd8fb076c4377daa07b3d7dd4187a63ee641ee302df",
+        "wx": "56dad3a5ad3be19e358b3a6d6f20c8f888812b7c77aae353db4731e9061dec8f",
+        "wy": "00e03740ee7d05adcc7e9a2cd8fb076c4377daa07b3d7dd4187a63ee641ee302df"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000456dad3a5ad3be19e358b3a6d6f20c8f888812b7c77aae353db4731e9061dec8fe03740ee7d05adcc7e9a2cd8fb076c4377daa07b3d7dd4187a63ee641ee302df",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEVtrTpa074Z41izptbyDI+IiBK3x3quNT\n20cx6QYd7I/gN0DufQWtzH6aLNj7B2xDd9qgez191Bh6Y+5kHuMC3w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 158,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c12f588f66018f3dd14db3e28e77996487e32486b521ed8e5a20f06591951777e9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "VtrTpa074Z41izptbyDI-IiBK3x3quNT20cx6QYd7I8",
+        "y": "4DdA7n0Frcx-mizY-wdsQ3faoHs9fdQYemPuZB7jAt8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0424c3b0d417522a2b755a7d9cd9b3e7195d5c6edad701bb33c3b923719955d7de9d1723775d4985a0afef06b996bac89302fa9b15509acc31acdda61cb556d0ff",
+        "wx": "24c3b0d417522a2b755a7d9cd9b3e7195d5c6edad701bb33c3b923719955d7de",
+        "wy": "009d1723775d4985a0afef06b996bac89302fa9b15509acc31acdda61cb556d0ff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000424c3b0d417522a2b755a7d9cd9b3e7195d5c6edad701bb33c3b923719955d7de9d1723775d4985a0afef06b996bac89302fa9b15509acc31acdda61cb556d0ff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJMOw1BdSKit1Wn2c2bPnGV1cbtrXAbsz\nw7kjcZlV196dFyN3XUmFoK/vBrmWusiTAvqbFVCazDGs3aYctVbQ/w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 159,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1091a08870ff4daf9123b30c20e8c4fc8505758dcf4074fcaff2170c9bfcf74f4",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "JMOw1BdSKit1Wn2c2bPnGV1cbtrXAbszw7kjcZlV194",
+        "y": "nRcjd11JhaCv7wa5lrrIkwL6mxVQmswxrN2mHLVW0P8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044a6f47dd683ac2721b3d3120f9dc756a415f1ac0a0b6c9bdff741e2d45a12b17fc59515ecd3f39c3f0912bc80d1643344b1db50d9a2f354f7c98ffadeec65597",
+        "wx": "4a6f47dd683ac2721b3d3120f9dc756a415f1ac0a0b6c9bdff741e2d45a12b17",
+        "wy": "00fc59515ecd3f39c3f0912bc80d1643344b1db50d9a2f354f7c98ffadeec65597"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044a6f47dd683ac2721b3d3120f9dc756a415f1ac0a0b6c9bdff741e2d45a12b17fc59515ecd3f39c3f0912bc80d1643344b1db50d9a2f354f7c98ffadeec65597",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESm9H3Wg6wnIbPTEg+dx1akFfGsCgtsm9\n/3QeLUWhKxf8WVFezT85w/CRK8gNFkM0Sx21DZovNU98mP+t7sZVlw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 160,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c17c370dc0ce8c59a8b273cba44a7c1191fc3186dc03cab96b0567312df0d0b250",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Sm9H3Wg6wnIbPTEg-dx1akFfGsCgtsm9_3QeLUWhKxc",
+        "y": "_FlRXs0_OcPwkSvIDRZDNEsdtQ2aLzVPfJj_re7GVZc",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0450fafcdf2cc4e4e9eeec7a48bf54ee6be8a79263ce7008b380fdb8e56b3dd85f974e8efe7ff7360289891cc7576cd5c1769cb104f57283d5ccfb31e3149e36b4",
+        "wx": "50fafcdf2cc4e4e9eeec7a48bf54ee6be8a79263ce7008b380fdb8e56b3dd85f",
+        "wy": "00974e8efe7ff7360289891cc7576cd5c1769cb104f57283d5ccfb31e3149e36b4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000450fafcdf2cc4e4e9eeec7a48bf54ee6be8a79263ce7008b380fdb8e56b3dd85f974e8efe7ff7360289891cc7576cd5c1769cb104f57283d5ccfb31e3149e36b4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUPr83yzE5Onu7HpIv1Tua+inkmPOcAiz\ngP245Ws92F+XTo7+f/c2AomJHMdXbNXBdpyxBPVyg9XM+zHjFJ42tA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 161,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c170b59a7d1ee77a2f9e0491c2a7cfcd0ed04df4a35192f6132dcc668c79a6160e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "UPr83yzE5Onu7HpIv1Tua-inkmPOcAizgP245Ws92F8",
+        "y": "l06O_n_3NgKJiRzHV2zVwXacsQT1coPVzPsx4xSeNrQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ad297d34f9948a22b5dbb29eb63b509456976b78fe5239314161dede7e944622614daf40d80bff1e9d8cbb7504ea0dbb1bf918400049372bec5947cf58710013",
+        "wx": "00ad297d34f9948a22b5dbb29eb63b509456976b78fe5239314161dede7e944622",
+        "wy": "614daf40d80bff1e9d8cbb7504ea0dbb1bf918400049372bec5947cf58710013"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ad297d34f9948a22b5dbb29eb63b509456976b78fe5239314161dede7e944622614daf40d80bff1e9d8cbb7504ea0dbb1bf918400049372bec5947cf58710013",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErSl9NPmUiiK127KetjtQlFaXa3j+Ujkx\nQWHe3n6URiJhTa9A2Av/Hp2Mu3UE6g27G/kYQABJNyvsWUfPWHEAEw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 162,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c12736d76e412246e097148e2bf62915614eb7c428913a58eb5e9cd4674a9423de",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "rSl9NPmUiiK127KetjtQlFaXa3j-UjkxQWHe3n6URiI",
+        "y": "YU2vQNgL_x6djLt1BOoNuxv5GEAASTcr7FlHz1hxABM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0442c3a5a08f26cbe662cef0df4efa74766180b3ff9a52352083b2223f3f819d8c9734ff777272f9d5aee9cc6718aee8b48acde93d46db5ac1ecd9bee20da8a71e",
+        "wx": "42c3a5a08f26cbe662cef0df4efa74766180b3ff9a52352083b2223f3f819d8c",
+        "wy": "009734ff777272f9d5aee9cc6718aee8b48acde93d46db5ac1ecd9bee20da8a71e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000442c3a5a08f26cbe662cef0df4efa74766180b3ff9a52352083b2223f3f819d8c9734ff777272f9d5aee9cc6718aee8b48acde93d46db5ac1ecd9bee20da8a71e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQsOloI8my+ZizvDfTvp0dmGAs/+aUjUg\ng7IiPz+BnYyXNP93cnL51a7pzGcYrui0is3pPUbbWsHs2b7iDainHg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 163,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c14a1e12831fbe93627b02d6e7f24bccdd6ef4b2d0f46739eaf3b1eaf0ca117770",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "QsOloI8my-ZizvDfTvp0dmGAs_-aUjUgg7IiPz-BnYw",
+        "y": "lzT_d3Jy-dWu6cxnGK7otIrN6T1G21rB7Nm-4g2opx4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042781ed4b950bc8637b2e1ed175073ca805f4ee0841b81d4e4526ab97508b8d3662d71c351e27cbd7a3425a9a5eaf73889a6e35d886af15f7c5e8356b4ccd5698",
+        "wx": "2781ed4b950bc8637b2e1ed175073ca805f4ee0841b81d4e4526ab97508b8d36",
+        "wy": "62d71c351e27cbd7a3425a9a5eaf73889a6e35d886af15f7c5e8356b4ccd5698"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042781ed4b950bc8637b2e1ed175073ca805f4ee0841b81d4e4526ab97508b8d3662d71c351e27cbd7a3425a9a5eaf73889a6e35d886af15f7c5e8356b4ccd5698",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJ4HtS5ULyGN7Lh7RdQc8qAX07ghBuB1O\nRSarl1CLjTZi1xw1HifL16NCWpper3OImm412IavFffF6DVrTM1WmA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 164,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c106c778d4dfff7dee06ed88bc4e0ed34fc553aad67caf796f2a1c6487c1b2e877",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "J4HtS5ULyGN7Lh7RdQc8qAX07ghBuB1ORSarl1CLjTY",
+        "y": "YtccNR4ny9ejQlqaXq9ziJpuNdiGrxX3xeg1a0zNVpg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04aedc9a490c28d9b82360da16b988795f8ffd392e109142304468b008ffae4dc5bb9864173d258b243eb633794181838366826ac42229b1906d5f089add9a60ba",
+        "wx": "00aedc9a490c28d9b82360da16b988795f8ffd392e109142304468b008ffae4dc5",
+        "wy": "00bb9864173d258b243eb633794181838366826ac42229b1906d5f089add9a60ba"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004aedc9a490c28d9b82360da16b988795f8ffd392e109142304468b008ffae4dc5bb9864173d258b243eb633794181838366826ac42229b1906d5f089add9a60ba",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErtyaSQwo2bgjYNoWuYh5X4/9OS4QkUIw\nRGiwCP+uTcW7mGQXPSWLJD62M3lBgYODZoJqxCIpsZBtXwia3Zpgug==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 165,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c14de459ef9159afa057feb3ec40fef01c45b809f4ab296ea48c206d4249a2b451",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "rtyaSQwo2bgjYNoWuYh5X4_9OS4QkUIwRGiwCP-uTcU",
+        "y": "u5hkFz0liyQ-tjN5QYGDg2aCasQiKbGQbV8Imt2aYLo",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040094bb568a8b2503af9510148a031a8c87ffa6273ee32e94ffc09417bff06dc8b7b07744c7e9d430669b3ef564381b17f522c0e79854e76685e59a409ab32bac",
+        "wx": "0094bb568a8b2503af9510148a031a8c87ffa6273ee32e94ffc09417bff06dc8",
+        "wy": "00b7b07744c7e9d430669b3ef564381b17f522c0e79854e76685e59a409ab32bac"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040094bb568a8b2503af9510148a031a8c87ffa6273ee32e94ffc09417bff06dc8b7b07744c7e9d430669b3ef564381b17f522c0e79854e76685e59a409ab32bac",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAJS7VoqLJQOvlRAUigMajIf/pic+4y6U\n/8CUF7/wbci3sHdEx+nUMGabPvVkOBsX9SLA55hU52aF5ZpAmrMrrA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 166,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1745d294978007302033502e1acc48b63ae6500be43adbea1b258d6b423dbb416",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AJS7VoqLJQOvlRAUigMajIf_pic-4y6U_8CUF7_wbcg",
+        "y": "t7B3RMfp1DBmmz71ZDgbF_UiwOeYVOdmheWaQJqzK6w",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0402d10f15c8be7aa2626a513b6576812b0e4c9c883d473492df0e4c6290b4e999c769c9c7bacc2e22b198a4791838a93fb21ff4f074819b379056935822045a2d",
+        "wx": "02d10f15c8be7aa2626a513b6576812b0e4c9c883d473492df0e4c6290b4e999",
+        "wy": "00c769c9c7bacc2e22b198a4791838a93fb21ff4f074819b379056935822045a2d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000402d10f15c8be7aa2626a513b6576812b0e4c9c883d473492df0e4c6290b4e999c769c9c7bacc2e22b198a4791838a93fb21ff4f074819b379056935822045a2d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAtEPFci+eqJialE7ZXaBKw5MnIg9RzSS\n3w5MYpC06ZnHacnHuswuIrGYpHkYOKk/sh/08HSBmzeQVpNYIgRaLQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 167,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c17b2a785e3896f59b2d69da57648e80ad3c133a750a2847fd2098ccd902042b6c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AtEPFci-eqJialE7ZXaBKw5MnIg9RzSS3w5MYpC06Zk",
+        "y": "x2nJx7rMLiKxmKR5GDipP7If9PB0gZs3kFaTWCIEWi0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d89e4028c751e7602ff5b741916c951a1d79713787324663787a2d54f686c0798af86cb644647beaebd782ce47b1ece564b4d01e29b2ca16d8362c90b9c3ade5",
+        "wx": "00d89e4028c751e7602ff5b741916c951a1d79713787324663787a2d54f686c079",
+        "wy": "008af86cb644647beaebd782ce47b1ece564b4d01e29b2ca16d8362c90b9c3ade5"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d89e4028c751e7602ff5b741916c951a1d79713787324663787a2d54f686c0798af86cb644647beaebd782ce47b1ece564b4d01e29b2ca16d8362c90b9c3ade5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE2J5AKMdR52Av9bdBkWyVGh15cTeHMkZj\neHotVPaGwHmK+Gy2RGR76uvXgs5HsezlZLTQHimyyhbYNiyQucOt5Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 168,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c171ae94a72ca896875e7aa4a4c3d29afdb4b35b6996273e63c47ac519256c5eb1",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "2J5AKMdR52Av9bdBkWyVGh15cTeHMkZjeHotVPaGwHk",
+        "y": "ivhstkRke-rr14LOR7Hs5WS00B4pssoW2DYskLnDreU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044b600b61cd33aa10be6ceccba325185d4bebbfd0894e01da26edf07441148a04f218539dcf44401fec04117a1492a3466144c7de5852b106185e6d7cd8cee18b",
+        "wx": "4b600b61cd33aa10be6ceccba325185d4bebbfd0894e01da26edf07441148a04",
+        "wy": "00f218539dcf44401fec04117a1492a3466144c7de5852b106185e6d7cd8cee18b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044b600b61cd33aa10be6ceccba325185d4bebbfd0894e01da26edf07441148a04f218539dcf44401fec04117a1492a3466144c7de5852b106185e6d7cd8cee18b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAES2ALYc0zqhC+bOzLoyUYXUvrv9CJTgHa\nJu3wdEEUigTyGFOdz0RAH+wEEXoUkqNGYUTH3lhSsQYYXm182M7hiw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 169,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10fa527fa7343c0bc9ec35a6278bfbff4d83301b154fc4bd14aee7eb93445b5f9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "S2ALYc0zqhC-bOzLoyUYXUvrv9CJTgHaJu3wdEEUigQ",
+        "y": "8hhTnc9EQB_sBBF6FJKjRmFEx95YUrEGGF5tfNjO4Ys",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ed6b2238c0b17532cf7df5561669dd13c81a1bc685405deacaef4372fb1676cea3e09b1ee362051c12edf4d44f91564d6ae8a5da65b8a1344cfdbd00162ea943",
+        "wx": "00ed6b2238c0b17532cf7df5561669dd13c81a1bc685405deacaef4372fb1676ce",
+        "wy": "00a3e09b1ee362051c12edf4d44f91564d6ae8a5da65b8a1344cfdbd00162ea943"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ed6b2238c0b17532cf7df5561669dd13c81a1bc685405deacaef4372fb1676cea3e09b1ee362051c12edf4d44f91564d6ae8a5da65b8a1344cfdbd00162ea943",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7WsiOMCxdTLPffVWFmndE8gaG8aFQF3q\nyu9DcvsWds6j4Jse42IFHBLt9NRPkVZNauil2mW4oTRM/b0AFi6pQw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 170,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c16539c0adadd0525ff42622164ce9314348bd0863b4c80e936b23ca0414264671",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "7WsiOMCxdTLPffVWFmndE8gaG8aFQF3qyu9DcvsWds4",
+        "y": "o-CbHuNiBRwS7fTUT5FWTWropdpluKE0TP29ABYuqUM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0401453f1e605e780faa44d5839a9921ff44465fbccf6df1ec91c77a1e4ed533bd73f834f0749cbb7939ea7fa8c5607a6f2d4c9137a8240f502536ce1f9fd70f4e",
+        "wx": "01453f1e605e780faa44d5839a9921ff44465fbccf6df1ec91c77a1e4ed533bd",
+        "wy": "73f834f0749cbb7939ea7fa8c5607a6f2d4c9137a8240f502536ce1f9fd70f4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000401453f1e605e780faa44d5839a9921ff44465fbccf6df1ec91c77a1e4ed533bd73f834f0749cbb7939ea7fa8c5607a6f2d4c9137a8240f502536ce1f9fd70f4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAUU/HmBeeA+qRNWDmpkh/0RGX7zPbfHs\nkcd6Hk7VM71z+DTwdJy7eTnqf6jFYHpvLUyRN6gkD1AlNs4fn9cPTg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 171,
+          "comment": "point at infinity during verify",
+          "flags": [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AUU_HmBeeA-qRNWDmpkh_0RGX7zPbfHskcd6Hk7VM70",
+        "y": "c_g08HScu3k56n-oxWB6by1MkTeoJA9QJTbOH5_XD04",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041475141a66444a621e2dad47c356f9c7128a72bdd199a08932651044ee14021691be28607690d4404802e4c0c9201d0955231baed395ccfa433a404086aa5937",
+        "wx": "1475141a66444a621e2dad47c356f9c7128a72bdd199a08932651044ee140216",
+        "wy": "0091be28607690d4404802e4c0c9201d0955231baed395ccfa433a404086aa5937"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041475141a66444a621e2dad47c356f9c7128a72bdd199a08932651044ee14021691be28607690d4404802e4c0c9201d0955231baed395ccfa433a404086aa5937",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFHUUGmZESmIeLa1Hw1b5xxKKcr3RmaCJ\nMmUQRO4UAhaRvihgdpDUQEgC5MDJIB0JVSMbrtOVzPpDOkBAhqpZNw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 172,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a07fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "FHUUGmZESmIeLa1Hw1b5xxKKcr3RmaCJMmUQRO4UAhY",
+        "y": "kb4oYHaQ1EBIAuTAySAdCVUjG67Tlcz6QzpAQIaqWTc",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e88beb5bc33a5a03a2dc9b13dfa76972ab97c50ea3cd41c2d50699a163d8bc1cc70052f6563a04ebdb0c6131206e1ceb7c233b5b562bc605bbf71a3b9bbed9f1",
+        "wx": "00e88beb5bc33a5a03a2dc9b13dfa76972ab97c50ea3cd41c2d50699a163d8bc1c",
+        "wy": "00c70052f6563a04ebdb0c6131206e1ceb7c233b5b562bc605bbf71a3b9bbed9f1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e88beb5bc33a5a03a2dc9b13dfa76972ab97c50ea3cd41c2d50699a163d8bc1cc70052f6563a04ebdb0c6131206e1ceb7c233b5b562bc605bbf71a3b9bbed9f1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE6IvrW8M6WgOi3JsT36dpcquXxQ6jzUHC\n1QaZoWPYvBzHAFL2VjoE69sMYTEgbhzrfCM7W1YrxgW79xo7m77Z8Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 173,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a07fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a1",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "6IvrW8M6WgOi3JsT36dpcquXxQ6jzUHC1QaZoWPYvBw",
+        "y": "xwBS9lY6BOvbDGExIG4c63wjO1tWK8YFu_caO5u-2fE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044615410b5a898db0019843b89493f8fb67417b534833b434b5bbe2174cd368797a98eb7c1e94b1ba077e6234faa80cced7bf98425e6ac1fa793198b6f2d9c2ee",
+        "wx": "4615410b5a898db0019843b89493f8fb67417b534833b434b5bbe2174cd36879",
+        "wy": "7a98eb7c1e94b1ba077e6234faa80cced7bf98425e6ac1fa793198b6f2d9c2ee"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044615410b5a898db0019843b89493f8fb67417b534833b434b5bbe2174cd368797a98eb7c1e94b1ba077e6234faa80cced7bf98425e6ac1fa793198b6f2d9c2ee",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAERhVBC1qJjbABmEO4lJP4+2dBe1NIM7Q0\ntbviF0zTaHl6mOt8HpSxugd+YjT6qAzO17+YQl5qwfp5MZi28tnC7g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 174,
+          "comment": "u1 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8c492aebe9f1b702c6747fbd016604d49ad6beb2c57a29c0587bb76a07c988b1a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "RhVBC1qJjbABmEO4lJP4-2dBe1NIM7Q0tbviF0zTaHk",
+        "y": "epjrfB6UsboHfmI0-qgMzte_mEJeasH6eTGYtvLZwu4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040f98a9b3dc01ddfb38129c112d80422ad5ad5d71c4b1baddbe351b71b93998c0630a60be467dcd022cfabcdd20d9eca85542219460b7c3e5e06352af8785ec1d",
+        "wx": "0f98a9b3dc01ddfb38129c112d80422ad5ad5d71c4b1baddbe351b71b93998c0",
+        "wy": "630a60be467dcd022cfabcdd20d9eca85542219460b7c3e5e06352af8785ec1d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040f98a9b3dc01ddfb38129c112d80422ad5ad5d71c4b1baddbe351b71b93998c0630a60be467dcd022cfabcdd20d9eca85542219460b7c3e5e06352af8785ec1d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAED5ips9wB3fs4EpwRLYBCKtWtXXHEsbrd\nvjUbcbk5mMBjCmC+Rn3NAiz6vN0g2eyoVUIhlGC3w+XgY1Kvh4XsHQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 175,
+          "comment": "u1 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b83b6d514160e48fd398b8042fe99fb2b50d42f1ba57a604363816e7ec539db627",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "D5ips9wB3fs4EpwRLYBCKtWtXXHEsbrdvjUbcbk5mMA",
+        "y": "YwpgvkZ9zQIs-rzdINnsqFVCIZRgt8Pl4GNSr4eF7B0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0407c3f8a58910b348910113b8306f810e8ef4245b09de62b96754ac54f8ef24c5d4bece34aba6160c758d1c90561089e02af94e7c38a3f77c7d432010e2d59297",
+        "wx": "07c3f8a58910b348910113b8306f810e8ef4245b09de62b96754ac54f8ef24c5",
+        "wy": "00d4bece34aba6160c758d1c90561089e02af94e7c38a3f77c7d432010e2d59297"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000407c3f8a58910b348910113b8306f810e8ef4245b09de62b96754ac54f8ef24c5d4bece34aba6160c758d1c90561089e02af94e7c38a3f77c7d432010e2d59297",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEB8P4pYkQs0iRARO4MG+BDo70JFsJ3mK5\nZ1SsVPjvJMXUvs40q6YWDHWNHJBWEIngKvlOfDij93x9QyAQ4tWSlw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 176,
+          "comment": "u2 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b855555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "B8P4pYkQs0iRARO4MG-BDo70JFsJ3mK5Z1SsVPjvJMU",
+        "y": "1L7ONKumFgx1jRyQVhCJ4Cr5Tnw4o_d8fUMgEOLVkpc",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048e1ad03a1afb457576703eca8db21db7c19e38f43822b1de029790cb33ca95fe5078b7056f61584edd1dc0d0aa3173787e224551ec6fce2c9c26df7d73460ecd",
+        "wx": "008e1ad03a1afb457576703eca8db21db7c19e38f43822b1de029790cb33ca95fe",
+        "wy": "5078b7056f61584edd1dc0d0aa3173787e224551ec6fce2c9c26df7d73460ecd"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048e1ad03a1afb457576703eca8db21db7c19e38f43822b1de029790cb33ca95fe5078b7056f61584edd1dc0d0aa3173787e224551ec6fce2c9c26df7d73460ecd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEjhrQOhr7RXV2cD7KjbIdt8GeOPQ4IrHe\nApeQyzPKlf5QeLcFb2FYTt0dwNCqMXN4fiJFUexvziycJt99c0YOzQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 177,
+          "comment": "u2 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9d1c9e899ca306ad27fe1945de0242b89",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "jhrQOhr7RXV2cD7KjbIdt8GeOPQ4IrHeApeQyzPKlf4",
+        "y": "UHi3BW9hWE7dHcDQqjFzeH4iRVHsb84snCbffXNGDs0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b254cb64dc9886d258c77d2f22245e9240385c375ecf58b3f3c47addca98637d87897a37bedd27856363e99ef88a1f4780f40d51dbf2b673a33d455080a79056",
+        "wx": "00b254cb64dc9886d258c77d2f22245e9240385c375ecf58b3f3c47addca98637d",
+        "wy": "0087897a37bedd27856363e99ef88a1f4780f40d51dbf2b673a33d455080a79056"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b254cb64dc9886d258c77d2f22245e9240385c375ecf58b3f3c47addca98637d87897a37bedd27856363e99ef88a1f4780f40d51dbf2b673a33d455080a79056",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEslTLZNyYhtJYx30vIiRekkA4XDdez1iz\n88R63cqYY32HiXo3vt0nhWNj6Z74ih9HgPQNUdvytnOjPUVQgKeQVg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 178,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc96db8f94dfb3d00ecd17fe9ab22019c2cd5e42b1024e696b17d9f1b9c444eec9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "slTLZNyYhtJYx30vIiRekkA4XDdez1iz88R63cqYY30",
+        "y": "h4l6N77dJ4VjY-me-IofR4D0DVHb8rZzoz1FUICnkFY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046a3e00ea396499ea1b2445c8138528ea5465da376fc0185b41acc7423fcf301ad912ae4aad92eff7433222b185442739d43e0634ee5b0b59ec545f0bd21ab921",
+        "wx": "6a3e00ea396499ea1b2445c8138528ea5465da376fc0185b41acc7423fcf301a",
+        "wy": "00d912ae4aad92eff7433222b185442739d43e0634ee5b0b59ec545f0bd21ab921"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046a3e00ea396499ea1b2445c8138528ea5465da376fc0185b41acc7423fcf301ad912ae4aad92eff7433222b185442739d43e0634ee5b0b59ec545f0bd21ab921",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEaj4A6jlkmeobJEXIE4Uo6lRl2jdvwBhb\nQazHQj/PMBrZEq5KrZLv90MyIrGFRCc51D4GNO5bC1nsVF8L0hq5IQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 179,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2fe5caa8b5ba8fbf9fbffd9b874c3826004a38d2ea1af2060e744ce16deb275e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "aj4A6jlkmeobJEXIE4Uo6lRl2jdvwBhbQazHQj_PMBo",
+        "y": "2RKuSq2S7_dDMiKxhUQnOdQ-BjTuWwtZ7FRfC9IauSE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0458314ecd80245960a53ec7ffacae63745c465474e02a46f6c6f13388a784fe45e4ae69717db5492bb4c9584717655710c7a1c51ebef67a8554988e92dd59d67f",
+        "wx": "58314ecd80245960a53ec7ffacae63745c465474e02a46f6c6f13388a784fe45",
+        "wy": "00e4ae69717db5492bb4c9584717655710c7a1c51ebef67a8554988e92dd59d67f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000458314ecd80245960a53ec7ffacae63745c465474e02a46f6c6f13388a784fe45e4ae69717db5492bb4c9584717655710c7a1c51ebef67a8554988e92dd59d67f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEWDFOzYAkWWClPsf/rK5jdFxGVHTgKkb2\nxvEziKeE/kXkrmlxfbVJK7TJWEcXZVcQx6HFHr72eoVUmI6S3VnWfw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 180,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcebc70148775c0588c86343020844f8714aa2b44b1e59c96364683def955bacea",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "WDFOzYAkWWClPsf_rK5jdFxGVHTgKkb2xvEziKeE_kU",
+        "y": "5K5pcX21SSu0yVhHF2VXEMehxR6-9nqFVJiOkt1Z1n8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0461dcd030c448a718b72aea6dd6d2d976935ac3dc19015c12c49240c495cc7be26fe8a5bada1e942c67bcfdd726bfb0e137f666a479a9366eea5ada79fe440250",
+        "wx": "61dcd030c448a718b72aea6dd6d2d976935ac3dc19015c12c49240c495cc7be2",
+        "wy": "6fe8a5bada1e942c67bcfdd726bfb0e137f666a479a9366eea5ada79fe440250"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000461dcd030c448a718b72aea6dd6d2d976935ac3dc19015c12c49240c495cc7be26fe8a5bada1e942c67bcfdd726bfb0e137f666a479a9366eea5ada79fe440250",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYdzQMMRIpxi3Kupt1tLZdpNaw9wZAVwS\nxJJAxJXMe+Jv6KW62h6ULGe8/dcmv7DhN/ZmpHmpNm7qWtp5/kQCUA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 181,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc678faec65678ca993b6d514160e48fd3151dc8a4ee82b9061fb9e2ec68567ca5",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "YdzQMMRIpxi3Kupt1tLZdpNaw9wZAVwSxJJAxJXMe-I",
+        "y": "b-ilutoelCxnvP3XJr-w4Tf2ZqR5qTZu6lraef5EAlA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04103e2bfe5515dc3f7e7f58fad53722e57654268e7f4a80543ab50faba0ae6c4fe57729b60e604ef8ec64833ec2c31e64cfa94e929a3c2efbbe249f37e1b44e2b",
+        "wx": "103e2bfe5515dc3f7e7f58fad53722e57654268e7f4a80543ab50faba0ae6c4f",
+        "wy": "00e57729b60e604ef8ec64833ec2c31e64cfa94e929a3c2efbbe249f37e1b44e2b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004103e2bfe5515dc3f7e7f58fad53722e57654268e7f4a80543ab50faba0ae6c4fe57729b60e604ef8ec64833ec2c31e64cfa94e929a3c2efbbe249f37e1b44e2b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEED4r/lUV3D9+f1j61Tci5XZUJo5/SoBU\nOrUPq6CubE/ldym2DmBO+Oxkgz7Cwx5kz6lOkpo8Lvu+JJ834bROKw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 182,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcfaec65678ca993b6d514160e48fd398a41655aaa4dc3df7ac55b27a288d43388",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ED4r_lUV3D9-f1j61Tci5XZUJo5_SoBUOrUPq6CubE8",
+        "y": "5Xcptg5gTvjsZIM-wsMeZM-pTpKaPC77viSfN-G0Tis",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fdeaf5f60c791aaa116327296264c84f6ee569fd2288c95e7abd23a613533c9dafbfec7d9351dedf01cac0412d502e6b4c7531300faa0805551b89a21a296f60",
+        "wx": "00fdeaf5f60c791aaa116327296264c84f6ee569fd2288c95e7abd23a613533c9d",
+        "wy": "00afbfec7d9351dedf01cac0412d502e6b4c7531300faa0805551b89a21a296f60"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fdeaf5f60c791aaa116327296264c84f6ee569fd2288c95e7abd23a613533c9dafbfec7d9351dedf01cac0412d502e6b4c7531300faa0805551b89a21a296f60",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE/er19gx5GqoRYycpYmTIT27laf0iiMle\ner0jphNTPJ2vv+x9k1He3wHKwEEtUC5rTHUxMA+qCAVVG4miGilvYA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 183,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcf5d8cacf1953276daa282c1c91fa7315c81bd86dec3f1eb9cae3f0b8417225cf",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "_er19gx5GqoRYycpYmTIT27laf0iiMleer0jphNTPJ0",
+        "y": "r7_sfZNR3t8BysBBLVAua0x1MTAPqggFVRuJohopb2A",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043f75814e8cdb09ec839973f41f5701e4361033792cc24cadafbc94f594389944ca8463cf5b12e1d88f23918b1a35cf597531a12cd722abf4edc9f8f07890fa7b",
+        "wx": "3f75814e8cdb09ec839973f41f5701e4361033792cc24cadafbc94f594389944",
+        "wy": "00ca8463cf5b12e1d88f23918b1a35cf597531a12cd722abf4edc9f8f07890fa7b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043f75814e8cdb09ec839973f41f5701e4361033792cc24cadafbc94f594389944ca8463cf5b12e1d88f23918b1a35cf597531a12cd722abf4edc9f8f07890fa7b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEP3WBTozbCeyDmXP0H1cB5DYQM3kswkyt\nr7yU9ZQ4mUTKhGPPWxLh2I8jkYsaNc9ZdTGhLNciq/TtyfjweJD6ew==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 184,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc5678ca993b6d514160e48fd398b8042f7bbcf16da5178dc796ef83a77b6059ba",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "P3WBTozbCeyDmXP0H1cB5DYQM3kswkytr7yU9ZQ4mUQ",
+        "y": "yoRjz1sS4diPI5GLGjXPWXUxoSzXIqv07cn48HiQ-ns",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e67ce84bb63666d0c6fe6a8b04e6257aa4049d2820b33daacbd99a3336a9a3a297d28fdf67ea1e921380f323f9a2827b9659b79a9c867dc8363547197bb51283",
+        "wx": "00e67ce84bb63666d0c6fe6a8b04e6257aa4049d2820b33daacbd99a3336a9a3a2",
+        "wy": "0097d28fdf67ea1e921380f323f9a2827b9659b79a9c867dc8363547197bb51283"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e67ce84bb63666d0c6fe6a8b04e6257aa4049d2820b33daacbd99a3336a9a3a297d28fdf67ea1e921380f323f9a2827b9659b79a9c867dc8363547197bb51283",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5nzoS7Y2ZtDG/mqLBOYleqQEnSggsz2q\ny9maMzapo6KX0o/fZ+oekhOA8yP5ooJ7llm3mpyGfcg2NUcZe7USgw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 185,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcb95c4bd1c9e96edb137f6dbf5d4860e823605850b82da484fabaa7a68ee9739f",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "5nzoS7Y2ZtDG_mqLBOYleqQEnSggsz2qy9maMzapo6I",
+        "y": "l9KP32fqHpITgPMj-aKCe5ZZt5qchn3INjVHGXu1EoM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043747a8c41c79d96874d1023fe5915d8af75c9b207c2be84536735acf7c29b7f1305c3f1681e2a26ae19c9f7e52e4cba3c1a3c2eb1f3a564662242a0aabf1919f",
+        "wx": "3747a8c41c79d96874d1023fe5915d8af75c9b207c2be84536735acf7c29b7f1",
+        "wy": "305c3f1681e2a26ae19c9f7e52e4cba3c1a3c2eb1f3a564662242a0aabf1919f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043747a8c41c79d96874d1023fe5915d8af75c9b207c2be84536735acf7c29b7f1305c3f1681e2a26ae19c9f7e52e4cba3c1a3c2eb1f3a564662242a0aabf1919f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEN0eoxBx52Wh00QI/5ZFdivdcmyB8K+hF\nNnNaz3wpt/EwXD8WgeKiauGcn35S5MujwaPC6x86VkZiJCoKq/GRnw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 186,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc051668895003afbd3824001149f6304d38e6ff342545e9e0ce5236d067cdbdcc",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "N0eoxBx52Wh00QI_5ZFdivdcmyB8K-hFNnNaz3wpt_E",
+        "y": "MFw_FoHiomrhnJ9-UuTLo8GjwusfOlZGYiQqCqvxkZ8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04039914231dacaa7c6cda74293933151ce4000ed51ffadc291777a252e8bdb4f9476915da31f22b7647b9f8ddc407e5cd75003e95ad402eff542cec2a2915a260",
+        "wx": "039914231dacaa7c6cda74293933151ce4000ed51ffadc291777a252e8bdb4f9",
+        "wy": "476915da31f22b7647b9f8ddc407e5cd75003e95ad402eff542cec2a2915a260"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004039914231dacaa7c6cda74293933151ce4000ed51ffadc291777a252e8bdb4f9476915da31f22b7647b9f8ddc407e5cd75003e95ad402eff542cec2a2915a260",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEA5kUIx2sqnxs2nQpOTMVHOQADtUf+twp\nF3eiUui9tPlHaRXaMfIrdke5+N3EB+XNdQA+la1ALv9ULOwqKRWiYA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 187,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0a83a4d7833ad1981eb0ccf087c99705fe21a9055e19057b43ff3e151acb550c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "A5kUIx2sqnxs2nQpOTMVHOQADtUf-twpF3eiUui9tPk",
+        "y": "R2kV2jHyK3ZHufjdxAflzXUAPpWtQC7_VCzsKikVomA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a7115d9be02a635a2b6fb286146b9d179a7761e5a83bab5967609933816e2f627e189ef7814f51e177ff4d75cc15a4d7cd7616c60ed217a7aada70f3eaca019c",
+        "wx": "00a7115d9be02a635a2b6fb286146b9d179a7761e5a83bab5967609933816e2f62",
+        "wy": "7e189ef7814f51e177ff4d75cc15a4d7cd7616c60ed217a7aada70f3eaca019c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a7115d9be02a635a2b6fb286146b9d179a7761e5a83bab5967609933816e2f627e189ef7814f51e177ff4d75cc15a4d7cd7616c60ed217a7aada70f3eaca019c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpxFdm+AqY1orb7KGFGudF5p3YeWoO6tZ\nZ2CZM4FuL2J+GJ73gU9R4Xf/TXXMFaTXzXYWxg7SF6eq2nDz6soBnA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 188,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc843eaa601934e5b3af7adbba478b6830de49ed6e5de7074651a1ad8e24ef8911",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "pxFdm-AqY1orb7KGFGudF5p3YeWoO6tZZ2CZM4FuL2I",
+        "y": "fhie94FPUeF3_011zBWk1812FsYO0henqtpw8-rKAZw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040dffe3c248f260c0f8fbc721561bae785c464e1e17011b10b60169b8e992a5ede1cf121285f5c5e95fa8516d174c9fa0e88f27c0bba582b6866c492980c997e7",
+        "wx": "0dffe3c248f260c0f8fbc721561bae785c464e1e17011b10b60169b8e992a5ed",
+        "wy": "00e1cf121285f5c5e95fa8516d174c9fa0e88f27c0bba582b6866c492980c997e7"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040dffe3c248f260c0f8fbc721561bae785c464e1e17011b10b60169b8e992a5ede1cf121285f5c5e95fa8516d174c9fa0e88f27c0bba582b6866c492980c997e7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEDf/jwkjyYMD4+8chVhuueFxGTh4XARsQ\ntgFpuOmSpe3hzxIShfXF6V+oUW0XTJ+g6I8nwLulgraGbEkpgMmX5w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 189,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc34923835902617f8997400b2a6eff31df6a84d1ad67d1b6853fc366985f8a93c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Df_jwkjyYMD4-8chVhuueFxGTh4XARsQtgFpuOmSpe0",
+        "y": "4c8SEoX1xelfqFFtF0yfoOiPJ8C7pYK2hmxJKYDJl-c",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e3235a0167137f153c56b2ec5c642539c31d86027b7faa4f75707b9e7b1c09d0eda7e7e408abb2513771d36b71f04b5d67065b2270db053a4d988ddda8e2ca0f",
+        "wx": "00e3235a0167137f153c56b2ec5c642539c31d86027b7faa4f75707b9e7b1c09d0",
+        "wy": "00eda7e7e408abb2513771d36b71f04b5d67065b2270db053a4d988ddda8e2ca0f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e3235a0167137f153c56b2ec5c642539c31d86027b7faa4f75707b9e7b1c09d0eda7e7e408abb2513771d36b71f04b5d67065b2270db053a4d988ddda8e2ca0f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4yNaAWcTfxU8VrLsXGQlOcMdhgJ7f6pP\ndXB7nnscCdDtp+fkCKuyUTdx02tx8EtdZwZbInDbBTpNmI3dqOLKDw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 190,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc6924706b204c2ff132e801654ddfe63bed509a35acfa36d0a7f86cd30bf15278",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "4yNaAWcTfxU8VrLsXGQlOcMdhgJ7f6pPdXB7nnscCdA",
+        "y": "7afn5AirslE3cdNrcfBLXWcGWyJw2wU6TZiN3ajiyg8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041cc3e31519a415a09f5d1cce39ecc742071af056b40f4ab2c2411d5e4e81c1f30b78c126cc6da95a93aadf7152bdd2e6318dcfbe79ac1e0f62134c33465c7e0e",
+        "wx": "1cc3e31519a415a09f5d1cce39ecc742071af056b40f4ab2c2411d5e4e81c1f3",
+        "wy": "0b78c126cc6da95a93aadf7152bdd2e6318dcfbe79ac1e0f62134c33465c7e0e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041cc3e31519a415a09f5d1cce39ecc742071af056b40f4ab2c2411d5e4e81c1f30b78c126cc6da95a93aadf7152bdd2e6318dcfbe79ac1e0f62134c33465c7e0e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHMPjFRmkFaCfXRzOOezHQgca8Fa0D0qy\nwkEdXk6BwfMLeMEmzG2pWpOq33FSvdLmMY3PvnmsHg9iE0wzRlx+Dg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 191,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc9db6a8a0b07247e9cc5c0217f4cfd959e3f8e75083775238fbf4a33c91e9fbb4",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "HMPjFRmkFaCfXRzOOezHQgca8Fa0D0qywkEdXk6BwfM",
+        "y": "C3jBJsxtqVqTqt9xUr3S5jGNz755rB4PYhNMM0Zcfg4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c678da720a74e55e804e8fd4aecd17721e9665a9579c7a51131c0ec355b718ade7b9710b10454cc86823115c5b4940e8cec130368519e28c2fc69e1e6095ec06",
+        "wx": "00c678da720a74e55e804e8fd4aecd17721e9665a9579c7a51131c0ec355b718ad",
+        "wy": "00e7b9710b10454cc86823115c5b4940e8cec130368519e28c2fc69e1e6095ec06"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c678da720a74e55e804e8fd4aecd17721e9665a9579c7a51131c0ec355b718ade7b9710b10454cc86823115c5b4940e8cec130368519e28c2fc69e1e6095ec06",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAExnjacgp05V6ATo/Urs0Xch6WZalXnHpR\nExwOw1W3GK3nuXELEEVMyGgjEVxbSUDozsEwNoUZ4owvxp4eYJXsBg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 192,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc75e380a43bae02c46431a18104227c38a5515a258f2ce4b1b2341ef7caadd675",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "xnjacgp05V6ATo_Urs0Xch6WZalXnHpRExwOw1W3GK0",
+        "y": "57lxCxBFTMhoIxFcW0lA6M7BMDaFGeKML8aeHmCV7AY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04694a86dd0dcb0af89b5769f3c6686fe7016a4565b1538f0327693a1d77e50d2024b347593d4dc9038308198dfb09f55a310bac8dd029c9adeed014e1244bf0ea",
+        "wx": "694a86dd0dcb0af89b5769f3c6686fe7016a4565b1538f0327693a1d77e50d20",
+        "wy": "24b347593d4dc9038308198dfb09f55a310bac8dd029c9adeed014e1244bf0ea"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004694a86dd0dcb0af89b5769f3c6686fe7016a4565b1538f0327693a1d77e50d2024b347593d4dc9038308198dfb09f55a310bac8dd029c9adeed014e1244bf0ea",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEaUqG3Q3LCvibV2nzxmhv5wFqRWWxU48D\nJ2k6HXflDSAks0dZPU3JA4MIGY37CfVaMQusjdApya3u0BThJEvw6g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 193,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcd55555555555555555555555555555547c74934474db157d2a8c3f088aced62a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "aUqG3Q3LCvibV2nzxmhv5wFqRWWxU48DJ2k6HXflDSA",
+        "y": "JLNHWT1NyQODCBmN-wn1WjELrI3QKcmt7tAU4SRL8Oo",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0478031915fc9f0c725ac6e0001978d82544567c6fdac6068637ab8f87a4fc8fc39291e97620aaa2dc5528bb69ba48f12d4448fff2ddb72fa96f84d4d7515d5354",
+        "wx": "78031915fc9f0c725ac6e0001978d82544567c6fdac6068637ab8f87a4fc8fc3",
+        "wy": "009291e97620aaa2dc5528bb69ba48f12d4448fff2ddb72fa96f84d4d7515d5354"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000478031915fc9f0c725ac6e0001978d82544567c6fdac6068637ab8f87a4fc8fc39291e97620aaa2dc5528bb69ba48f12d4448fff2ddb72fa96f84d4d7515d5354",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeAMZFfyfDHJaxuAAGXjYJURWfG/axgaG\nN6uPh6T8j8OSkel2IKqi3FUou2m6SPEtREj/8t23L6lvhNTXUV1TVA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 194,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcc1777c8853938e536213c02464a936000ba1e21c0fc62075d46c624e23b52f31",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eAMZFfyfDHJaxuAAGXjYJURWfG_axgaGN6uPh6T8j8M",
+        "y": "kpHpdiCqotxVKLtpukjxLURI__Ldty-pb4TU11FdU1Q",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e2ef37a5b327ba15ad0ba3a913e34e10f16b4313de90fc647d81e1347810ba86dfeb3ceef841b1164532094c1c248da7d1d019c4ca88836801cdf38f1c9ea484",
+        "wx": "00e2ef37a5b327ba15ad0ba3a913e34e10f16b4313de90fc647d81e1347810ba86",
+        "wy": "00dfeb3ceef841b1164532094c1c248da7d1d019c4ca88836801cdf38f1c9ea484"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e2ef37a5b327ba15ad0ba3a913e34e10f16b4313de90fc647d81e1347810ba86dfeb3ceef841b1164532094c1c248da7d1d019c4ca88836801cdf38f1c9ea484",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4u83pbMnuhWtC6OpE+NOEPFrQxPekPxk\nfYHhNHgQuobf6zzu+EGxFkUyCUwcJI2n0dAZxMqIg2gBzfOPHJ6khA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 195,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc30bbb794db588363b40679f6c182a50d3ce9679acdd3ffbe36d7813dacbdc818",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "4u83pbMnuhWtC6OpE-NOEPFrQxPekPxkfYHhNHgQuoY",
+        "y": "3-s87vhBsRZFMglMHCSNp9HQGcTKiINoAc3zjxyepIQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b72af48bc8d3cccf646bf4d248e59bfb3f4be05a65c6e137dfd33f89ae0538bda5245ea537238f91347a9fa911f93e8d69550cae815b5e6d340f0f5ab28e0fa0",
+        "wx": "00b72af48bc8d3cccf646bf4d248e59bfb3f4be05a65c6e137dfd33f89ae0538bd",
+        "wy": "00a5245ea537238f91347a9fa911f93e8d69550cae815b5e6d340f0f5ab28e0fa0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b72af48bc8d3cccf646bf4d248e59bfb3f4be05a65c6e137dfd33f89ae0538bda5245ea537238f91347a9fa911f93e8d69550cae815b5e6d340f0f5ab28e0fa0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtyr0i8jTzM9ka/TSSOWb+z9L4FplxuE3\n39M/ia4FOL2lJF6lNyOPkTR6n6kR+T6NaVUMroFbXm00Dw9aso4PoA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 196,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2c37fd995622c4fb7fffffffffffffffc7cee745110cb45ab558ed7c90c15a2f",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "tyr0i8jTzM9ka_TSSOWb-z9L4FplxuE339M_ia4FOL0",
+        "y": "pSRepTcjj5E0ep-pEfk-jWlVDK6BW15tNA8PWrKOD6A",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041c286c9b478065202336356e83f1887b052efbf637aca65bcafd033ba6df697d4c7fb641aa83f96579be9db51c555ecdbb7a5637311db2efab94b08afa01dae8",
+        "wx": "1c286c9b478065202336356e83f1887b052efbf637aca65bcafd033ba6df697d",
+        "wy": "4c7fb641aa83f96579be9db51c555ecdbb7a5637311db2efab94b08afa01dae8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041c286c9b478065202336356e83f1887b052efbf637aca65bcafd033ba6df697d4c7fb641aa83f96579be9db51c555ecdbb7a5637311db2efab94b08afa01dae8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHChsm0eAZSAjNjVug/GIewUu+/Y3rKZb\nyv0DO6bfaX1Mf7ZBqoP5ZXm+nbUcVV7Nu3pWNzEdsu+rlLCK+gHa6A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 197,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc7fd995622c4fb7ffffffffffffffffff5d883ffab5b32652ccdcaa290fccb97d",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "HChsm0eAZSAjNjVug_GIewUu-_Y3rKZbyv0DO6bfaX0",
+        "y": "TH-2QaqD-WV5vp21HFVezbt6VjcxHbLvq5SwivoB2ug",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041008faa2a4177b7341135ca54dcac622ab3168f1261454d6ecd0a3063ed1165652750f2c7a4b4b11393e125240c701841e754c32f8e0340361595ae7677d5688",
+        "wx": "1008faa2a4177b7341135ca54dcac622ab3168f1261454d6ecd0a3063ed11656",
+        "wy": "52750f2c7a4b4b11393e125240c701841e754c32f8e0340361595ae7677d5688"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041008faa2a4177b7341135ca54dcac622ab3168f1261454d6ecd0a3063ed1165652750f2c7a4b4b11393e125240c701841e754c32f8e0340361595ae7677d5688",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEEAj6oqQXe3NBE1ylTcrGIqsxaPEmFFTW\n7NCjBj7RFlZSdQ8sektLETk+ElJAxwGEHnVMMvjgNANhWVrnZ31WiA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 198,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcffb32ac4589f6ffffffffffffffffffebb107ff56b664ca599b954521f9972fa",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "EAj6oqQXe3NBE1ylTcrGIqsxaPEmFFTW7NCjBj7RFlY",
+        "y": "UnUPLHpLSxE5PhJSQMcBhB51TDL44DQDYVla52d9Vog",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b173f818f572ed7cb0deb165f4173f65f0f48bd49fb4d0b04f4e2ee81c8ed9d67af7091dc3474aeeceb4ed2097118c4262c978f06dda44fde8e5c60f222580a6",
+        "wx": "00b173f818f572ed7cb0deb165f4173f65f0f48bd49fb4d0b04f4e2ee81c8ed9d6",
+        "wy": "7af7091dc3474aeeceb4ed2097118c4262c978f06dda44fde8e5c60f222580a6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b173f818f572ed7cb0deb165f4173f65f0f48bd49fb4d0b04f4e2ee81c8ed9d67af7091dc3474aeeceb4ed2097118c4262c978f06dda44fde8e5c60f222580a6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsXP4GPVy7Xyw3rFl9Bc/ZfD0i9SftNCw\nT04u6ByO2dZ69wkdw0dK7s607SCXEYxCYsl48G3aRP3o5cYPIiWApg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 199,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc5622c4fb7fffffffffffffffffffffff928a8f1c7ac7bec1808b9f61c01ec327",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "sXP4GPVy7Xyw3rFl9Bc_ZfD0i9SftNCwT04u6ByO2dY",
+        "y": "evcJHcNHSu7OtO0glxGMQmLJePBt2kT96OXGDyIlgKY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e49f6fa148d964041b5c6175d8e0db6626aa653afde03e1c6d804193778a615f69ecc0e5f8e22a49de05fea7ef8cd0c8ec9fb0cf28d8d8e05900abcd8d3874b0",
+        "wx": "00e49f6fa148d964041b5c6175d8e0db6626aa653afde03e1c6d804193778a615f",
+        "wy": "69ecc0e5f8e22a49de05fea7ef8cd0c8ec9fb0cf28d8d8e05900abcd8d3874b0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e49f6fa148d964041b5c6175d8e0db6626aa653afde03e1c6d804193778a615f69ecc0e5f8e22a49de05fea7ef8cd0c8ec9fb0cf28d8d8e05900abcd8d3874b0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5J9voUjZZAQbXGF12ODbZiaqZTr94D4c\nbYBBk3eKYV9p7MDl+OIqSd4F/qfvjNDI7J+wzyjY2OBZAKvNjTh0sA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 200,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc44104104104104104104104104104103b87853fd3b7d3f8e175125b4382f25ed",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "5J9voUjZZAQbXGF12ODbZiaqZTr94D4cbYBBk3eKYV8",
+        "y": "aezA5fjiKkneBf6n74zQyOyfsM8o2NjgWQCrzY04dLA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0484db9801948d816235b76fbce2d41a8ee317565411daef97a8c3975f70df13f095dac7b1cbb82a2719c6c3fee23ef982725ca81f13551e129a20299e54ee4e83",
+        "wx": "0084db9801948d816235b76fbce2d41a8ee317565411daef97a8c3975f70df13f0",
+        "wy": "0095dac7b1cbb82a2719c6c3fee23ef982725ca81f13551e129a20299e54ee4e83"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000484db9801948d816235b76fbce2d41a8ee317565411daef97a8c3975f70df13f095dac7b1cbb82a2719c6c3fee23ef982725ca81f13551e129a20299e54ee4e83",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEhNuYAZSNgWI1t2+84tQajuMXVlQR2u+X\nqMOXX3DfE/CV2sexy7gqJxnGw/7iPvmCclyoHxNVHhKaICmeVO5Ogw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 201,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2739ce739ce739ce739ce739ce739ce705560298d1f2f08dc419ac273a5b54d9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "hNuYAZSNgWI1t2-84tQajuMXVlQR2u-XqMOXX3DfE_A",
+        "y": "ldrHscu4KicZxsP-4j75gnJcqB8TVR4SmiApnlTuToM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044789e4dc7c8d32aa842701a8e14a9667ee9a1620f764a8ebac822fa46bce3356572a8abb89e27a5d8d740ff6d3482d7c998dcd1a35ccf50bb07116fe3675eb7c",
+        "wx": "4789e4dc7c8d32aa842701a8e14a9667ee9a1620f764a8ebac822fa46bce3356",
+        "wy": "572a8abb89e27a5d8d740ff6d3482d7c998dcd1a35ccf50bb07116fe3675eb7c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044789e4dc7c8d32aa842701a8e14a9667ee9a1620f764a8ebac822fa46bce3356572a8abb89e27a5d8d740ff6d3482d7c998dcd1a35ccf50bb07116fe3675eb7c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAER4nk3HyNMqqEJwGo4UqWZ+6aFiD3ZKjr\nrIIvpGvOM1ZXKoq7ieJ6XY10D/bTSC18mY3NGjXM9QuwcRb+NnXrfA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 202,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcb777777777777777777777777777777688e6a1fe808a97a348671222ff16b863",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "R4nk3HyNMqqEJwGo4UqWZ-6aFiD3ZKjrrIIvpGvOM1Y",
+        "y": "VyqKu4niel2NdA_200gtfJmNzRo1zPULsHEW_jZ163w",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0476677705ce4dee1ca8c7fa2444754938a01bd7216210a4b4d79a9054d4f97bf4aa18e93f6019119feb60fb64d180ff60e43e744cb928786cc8904f3b5879180d",
+        "wx": "76677705ce4dee1ca8c7fa2444754938a01bd7216210a4b4d79a9054d4f97bf4",
+        "wy": "00aa18e93f6019119feb60fb64d180ff60e43e744cb928786cc8904f3b5879180d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000476677705ce4dee1ca8c7fa2444754938a01bd7216210a4b4d79a9054d4f97bf4aa18e93f6019119feb60fb64d180ff60e43e744cb928786cc8904f3b5879180d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEdmd3Bc5N7hyox/okRHVJOKAb1yFiEKS0\n15qQVNT5e/SqGOk/YBkRn+tg+2TRgP9g5D50TLkoeGzIkE87WHkYDQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 203,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc6492492492492492492492492492492406dd3a19b8d5fb875235963c593bd2d3",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "dmd3Bc5N7hyox_okRHVJOKAb1yFiEKS015qQVNT5e_Q",
+        "y": "qhjpP2AZEZ_rYPtk0YD_YOQ-dEy5KHhsyJBPO1h5GA0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04024377dbfad10b73555517c81f3b5a1ab1ffc2059d080070c0622b89d56209aa892de4161423ab7eff48d204a83783e769974cd67b4bd6ddefc86132a18d4abf",
+        "wx": "024377dbfad10b73555517c81f3b5a1ab1ffc2059d080070c0622b89d56209aa",
+        "wy": "00892de4161423ab7eff48d204a83783e769974cd67b4bd6ddefc86132a18d4abf"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004024377dbfad10b73555517c81f3b5a1ab1ffc2059d080070c0622b89d56209aa892de4161423ab7eff48d204a83783e769974cd67b4bd6ddefc86132a18d4abf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAkN32/rRC3NVVRfIHztaGrH/wgWdCABw\nwGIridViCaqJLeQWFCOrfv9I0gSoN4PnaZdM1ntL1t3vyGEyoY1Kvw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 204,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc955555555555555555555555555555547c74934474db157d2a8c3f088aced62c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AkN32_rRC3NVVRfIHztaGrH_wgWdCABwwGIridViCao",
+        "y": "iS3kFhQjq37_SNIEqDeD52mXTNZ7S9bd78hhMqGNSr8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04113150f49ada74a14dd2c383ec03f53ec1e27e957990e9033da50be6ee412fd8ddca40ad06596555f662133f587afc8c76f2ff5a086ceae5f88e0c2c1c3035d6",
+        "wx": "113150f49ada74a14dd2c383ec03f53ec1e27e957990e9033da50be6ee412fd8",
+        "wy": "00ddca40ad06596555f662133f587afc8c76f2ff5a086ceae5f88e0c2c1c3035d6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004113150f49ada74a14dd2c383ec03f53ec1e27e957990e9033da50be6ee412fd8ddca40ad06596555f662133f587afc8c76f2ff5a086ceae5f88e0c2c1c3035d6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEETFQ9JradKFN0sOD7AP1PsHifpV5kOkD\nPaUL5u5BL9jdykCtBlllVfZiEz9YevyMdvL/Wghs6uX4jgwsHDA11g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 205,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3e3a49a23a6d8abe95461f8445676b17",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ETFQ9JradKFN0sOD7AP1PsHifpV5kOkDPaUL5u5BL9g",
+        "y": "3cpArQZZZVX2YhM_WHr8jHby_1oIbOrl-I4MLBwwNdY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043c5b0f99db1e52ce0f9376de29102d1f1bcc343a39f0cf0a665afd3669fa0a627ef25431ecafe6b876f2ba181f721fb7e06d71aa756a575574a181aa26a779eb",
+        "wx": "3c5b0f99db1e52ce0f9376de29102d1f1bcc343a39f0cf0a665afd3669fa0a62",
+        "wy": "7ef25431ecafe6b876f2ba181f721fb7e06d71aa756a575574a181aa26a779eb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043c5b0f99db1e52ce0f9376de29102d1f1bcc343a39f0cf0a665afd3669fa0a627ef25431ecafe6b876f2ba181f721fb7e06d71aa756a575574a181aa26a779eb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEPFsPmdseUs4Pk3beKRAtHxvMNDo58M8K\nZlr9Nmn6CmJ+8lQx7K/muHbyuhgfch+34G1xqnVqV1V0oYGqJqd56w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 206,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcbffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "PFsPmdseUs4Pk3beKRAtHxvMNDo58M8KZlr9Nmn6CmI",
+        "y": "fvJUMeyv5rh28roYH3Ift-Btcap1aldVdKGBqianees",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047f9bc1f653895da490829846836106cde3e8cd89bcd3aa66892c3e6db5e9f9ba6f344f323d5b0a4e75117ed634f3a4ed0cabd4e2d87c9be844c7d562ac4d9b90",
+        "wx": "7f9bc1f653895da490829846836106cde3e8cd89bcd3aa66892c3e6db5e9f9ba",
+        "wy": "6f344f323d5b0a4e75117ed634f3a4ed0cabd4e2d87c9be844c7d562ac4d9b90"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047f9bc1f653895da490829846836106cde3e8cd89bcd3aa66892c3e6db5e9f9ba6f344f323d5b0a4e75117ed634f3a4ed0cabd4e2d87c9be844c7d562ac4d9b90",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEf5vB9lOJXaSQgphGg2EGzePozYm806pm\niSw+bbXp+bpvNE8yPVsKTnURftY086TtDKvU4th8m+hEx9VirE2bkA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 207,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc185ddbca6dac41b1da033cfb60c152869e74b3cd66e9ffdf1b6bc09ed65ee40c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "f5vB9lOJXaSQgphGg2EGzePozYm806pmiSw-bbXp-bo",
+        "y": "bzRPMj1bCk51EX7WNPOk7Qyr1OLYfJvoRMfVYqxNm5A",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c8212982bde0e2b0e7dab30f3eed9820260641fa76a5221e5d086c9ac16d83f28aaf69",
+        "wx": "5f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c82129",
+        "wy": "0082bde0e2b0e7dab30f3eed9820260641fa76a5221e5d086c9ac16d83f28aaf69"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c8212982bde0e2b0e7dab30f3eed9820260641fa76a5221e5d086c9ac16d83f28aaf69",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEX0hVMAxyOWYAvyIMu2jKO6YQdzDX6QzK\n9UZUl2PIISmCveDisOfasw8+7ZggJgZB+nalIh5dCGyawW2D8oqvaQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 208,
+          "comment": "point duplication during verification",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "32b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcdae8b6b0e5c1202774c31c0deb26db0fd15b080a0ac87c016af93236bde9f078f9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "X0hVMAxyOWYAvyIMu2jKO6YQdzDX6QzK9UZUl2PIISk",
+        "y": "gr3g4rDn2rMPPu2YICYGQfp2pSIeXQhsmsFtg_KKr2k",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c821297d421f1d4f18254cf0c11267dfd9f9be05895adde1a2f793653e927b0d754cc6",
+        "wx": "5f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c82129",
+        "wy": "7d421f1d4f18254cf0c11267dfd9f9be05895adde1a2f793653e927b0d754cc6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c821297d421f1d4f18254cf0c11267dfd9f9be05895adde1a2f793653e927b0d754cc6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEX0hVMAxyOWYAvyIMu2jKO6YQdzDX6QzK\n9UZUl2PIISl9Qh8dTxglTPDBEmff2fm+BYla3eGi95NlPpJ7DXVMxg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 209,
+          "comment": "duplication bug",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "32b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcdae8b6b0e5c1202774c31c0deb26db0fd15b080a0ac87c016af93236bde9f078f9",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "X0hVMAxyOWYAvyIMu2jKO6YQdzDX6QzK9UZUl2PIISk",
+        "y": "fUIfHU8YJUzwwRJn39n5vgWJWt3hoveTZT6Sew11TMY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041070baba3f326768d7693b1daf238737e91b7e6b3ac750b497e0480c2dae4c4d950ab9368086a7fa8b972270f8238d4791b8f9082cf67ba75dff7b347b209986",
+        "wx": "1070baba3f326768d7693b1daf238737e91b7e6b3ac750b497e0480c2dae4c4d",
+        "wy": "00950ab9368086a7fa8b972270f8238d4791b8f9082cf67ba75dff7b347b209986"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041070baba3f326768d7693b1daf238737e91b7e6b3ac750b497e0480c2dae4c4d950ab9368086a7fa8b972270f8238d4791b8f9082cf67ba75dff7b347b209986",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEEHC6uj8yZ2jXaTsdryOHN+kbfms6x1C0\nl+BIDC2uTE2VCrk2gIan+ouXInD4I41Hkbj5CCz2e6dd/3s0eyCZhg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 210,
+          "comment": "comparison with point at infinity ",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c033333333333333333333333333333332f222f8faefdb533f265d461c29a47373",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "EHC6uj8yZ2jXaTsdryOHN-kbfms6x1C0l-BIDC2uTE0",
+        "y": "lQq5NoCGp_qLlyJw-CONR5G4-Qgs9nunXf97NHsgmYY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04934e4daf8b9b05dd5de34bcf83dcc2f1b5ba67d63b5e5a2fbed1a71f186b4dd91d89cb32ceba5162e317558ca86bc3aedec7356e115c7e9468da7d12fb10ce05",
+        "wx": "00934e4daf8b9b05dd5de34bcf83dcc2f1b5ba67d63b5e5a2fbed1a71f186b4dd9",
+        "wy": "1d89cb32ceba5162e317558ca86bc3aedec7356e115c7e9468da7d12fb10ce05"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004934e4daf8b9b05dd5de34bcf83dcc2f1b5ba67d63b5e5a2fbed1a71f186b4dd91d89cb32ceba5162e317558ca86bc3aedec7356e115c7e9468da7d12fb10ce05",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEk05Nr4ubBd1d40vPg9zC8bW6Z9Y7Xlov\nvtGnHxhrTdkdicsyzrpRYuMXVYyoa8Ou3sc1bhFcfpRo2n0S+xDOBQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 211,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee555555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "k05Nr4ubBd1d40vPg9zC8bW6Z9Y7XlovvtGnHxhrTdk",
+        "y": "HYnLMs66UWLjF1WMqGvDrt7HNW4RXH6UaNp9EvsQzgU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042326edd3cdaece8c2ffab414190644b79d898fa9e347ca05f959827adff6916b336982ee7c35942f4af53b9b5a79e91dcc6e7ab4c6ced372b96824d8e1e2133c",
+        "wx": "2326edd3cdaece8c2ffab414190644b79d898fa9e347ca05f959827adff6916b",
+        "wy": "336982ee7c35942f4af53b9b5a79e91dcc6e7ab4c6ced372b96824d8e1e2133c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042326edd3cdaece8c2ffab414190644b79d898fa9e347ca05f959827adff6916b336982ee7c35942f4af53b9b5a79e91dcc6e7ab4c6ced372b96824d8e1e2133c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEIybt082uzowv+rQUGQZEt52Jj6njR8oF\n+VmCet/2kWszaYLufDWUL0r1O5taeekdzG56tMbO03K5aCTY4eITPA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 212,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Iybt082uzowv-rQUGQZEt52Jj6njR8oF-VmCet_2kWs",
+        "y": "M2mC7nw1lC9K9TubWnnpHcxuerTGztNyuWgk2OHiEzw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ccfdb7f86de824470828ba57600382f20999e3e231a327c767c2d0e6d7286aaf72be7a9a8f45502e3134cc0ade853e149023395ed061649a3372957c2c90cf13",
+        "wx": "00ccfdb7f86de824470828ba57600382f20999e3e231a327c767c2d0e6d7286aaf",
+        "wy": "72be7a9a8f45502e3134cc0ade853e149023395ed061649a3372957c2c90cf13"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ccfdb7f86de824470828ba57600382f20999e3e231a327c767c2d0e6d7286aaf72be7a9a8f45502e3134cc0ade853e149023395ed061649a3372957c2c90cf13",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzP23+G3oJEcIKLpXYAOC8gmZ4+IxoyfH\nZ8LQ5tcoaq9yvnqaj0VQLjE0zArehT4UkCM5XtBhZJozcpV8LJDPEw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 213,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee599999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "zP23-G3oJEcIKLpXYAOC8gmZ4-IxoyfHZ8LQ5tcoaq8",
+        "y": "cr56mo9FUC4xNMwK3oU-FJAjOV7QYWSaM3KVfCyQzxM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040355ab3652890e4871a8f597a71c499b3a78c68a229e6890fddb02922868cffde58bdfdbc55c59da91e6bb3cbbfe92b413cccd672e9624115c4b1badffd96ef2",
+        "wx": "0355ab3652890e4871a8f597a71c499b3a78c68a229e6890fddb02922868cffd",
+        "wy": "00e58bdfdbc55c59da91e6bb3cbbfe92b413cccd672e9624115c4b1badffd96ef2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040355ab3652890e4871a8f597a71c499b3a78c68a229e6890fddb02922868cffde58bdfdbc55c59da91e6bb3cbbfe92b413cccd672e9624115c4b1badffd96ef2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEA1WrNlKJDkhxqPWXpxxJmzp4xooinmiQ\n/dsCkihoz/3li9/bxVxZ2pHmuzy7/pK0E8zNZy6WJBFcSxut/9lu8g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 214,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee566666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "A1WrNlKJDkhxqPWXpxxJmzp4xooinmiQ_dsCkihoz_0",
+        "y": "5Yvf28VcWdqR5rs8u_6StBPMzWculiQRXEsbrf_ZbvI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042e2969ff37317dc22f50d7b80462f077eaf8c3789790b462a5ea66c0557a7e179caec6be59fcf1193ee5bfcd33007af97066f01989e746221dd26b71d9e4bccc",
+        "wx": "2e2969ff37317dc22f50d7b80462f077eaf8c3789790b462a5ea66c0557a7e17",
+        "wy": "009caec6be59fcf1193ee5bfcd33007af97066f01989e746221dd26b71d9e4bccc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042e2969ff37317dc22f50d7b80462f077eaf8c3789790b462a5ea66c0557a7e179caec6be59fcf1193ee5bfcd33007af97066f01989e746221dd26b71d9e4bccc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELilp/zcxfcIvUNe4BGLwd+r4w3iXkLRi\npepmwFV6fhecrsa+WfzxGT7lv80zAHr5cGbwGYnnRiId0mtx2eS8zA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 215,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee549249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Lilp_zcxfcIvUNe4BGLwd-r4w3iXkLRipepmwFV6fhc",
+        "y": "nK7Gvln88Rk-5b_NMwB6-XBm8BmJ50YiHdJrcdnkvMw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04751eab708173dcf2cb265424f9d6646c63865b89a46cc545169f8a227e72989668205e16739d2e9efece8343cf8c6115ae22b48d2ef8d478a1535c76311f9d10",
+        "wx": "751eab708173dcf2cb265424f9d6646c63865b89a46cc545169f8a227e729896",
+        "wy": "68205e16739d2e9efece8343cf8c6115ae22b48d2ef8d478a1535c76311f9d10"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004751eab708173dcf2cb265424f9d6646c63865b89a46cc545169f8a227e72989668205e16739d2e9efece8343cf8c6115ae22b48d2ef8d478a1535c76311f9d10",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEdR6rcIFz3PLLJlQk+dZkbGOGW4mkbMVF\nFp+KIn5ymJZoIF4Wc50unv7Og0PPjGEVriK0jS741HihU1x2MR+dEA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 216,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee50eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "dR6rcIFz3PLLJlQk-dZkbGOGW4mkbMVFFp-KIn5ymJY",
+        "y": "aCBeFnOdLp7-zoNDz4xhFa4itI0u-NR4oVNcdjEfnRA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0448b155ab6603c57a2a9184a0193d882f18e6bde72a24c11d9e2db4caabdcf25221d180a4aa53548a878b16fa5d7de0ce37d50717bfb2960a937fb358a07799b6",
+        "wx": "48b155ab6603c57a2a9184a0193d882f18e6bde72a24c11d9e2db4caabdcf252",
+        "wy": "21d180a4aa53548a878b16fa5d7de0ce37d50717bfb2960a937fb358a07799b6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000448b155ab6603c57a2a9184a0193d882f18e6bde72a24c11d9e2db4caabdcf25221d180a4aa53548a878b16fa5d7de0ce37d50717bfb2960a937fb358a07799b6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESLFVq2YDxXoqkYSgGT2ILxjmvecqJMEd\nni20yqvc8lIh0YCkqlNUioeLFvpdfeDON9UHF7+ylgqTf7NYoHeZtg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 217,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179855555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "SLFVq2YDxXoqkYSgGT2ILxjmvecqJMEdni20yqvc8lI",
+        "y": "IdGApKpTVIqHixb6XX3gzjfVBxe_spYKk3-zWKB3mbY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d55558e86b9151a9cca8bf3f95c3095b6dd46fd59cd97fbfe81cc1012f1c9368344f003527679e991f9f4fe8e63d104d0d46798ed074b52416b73b62d2198e8c",
+        "wx": "00d55558e86b9151a9cca8bf3f95c3095b6dd46fd59cd97fbfe81cc1012f1c9368",
+        "wy": "344f003527679e991f9f4fe8e63d104d0d46798ed074b52416b73b62d2198e8c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d55558e86b9151a9cca8bf3f95c3095b6dd46fd59cd97fbfe81cc1012f1c9368344f003527679e991f9f4fe8e63d104d0d46798ed074b52416b73b62d2198e8c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE1VVY6GuRUanMqL8/lcMJW23Ub9Wc2X+/\n6BzBAS8ck2g0TwA1J2eemR+fT+jmPRBNDUZ5jtB0tSQWtzti0hmOjA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 218,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "1VVY6GuRUanMqL8_lcMJW23Ub9Wc2X-_6BzBAS8ck2g",
+        "y": "NE8ANSdnnpkfn0_o5j0QTQ1GeY7QdLUkFrc7YtIZjow",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04659940ed14c45baba750ac48dd67af0bbe46d5a5d710558650ddcdb45bde3e1de2d921a2eb0ec8690a38a05c82f627bd9c4065d26ebbe38b55a1e68f564b4459",
+        "wx": "659940ed14c45baba750ac48dd67af0bbe46d5a5d710558650ddcdb45bde3e1d",
+        "wy": "00e2d921a2eb0ec8690a38a05c82f627bd9c4065d26ebbe38b55a1e68f564b4459"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004659940ed14c45baba750ac48dd67af0bbe46d5a5d710558650ddcdb45bde3e1de2d921a2eb0ec8690a38a05c82f627bd9c4065d26ebbe38b55a1e68f564b4459",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEZZlA7RTEW6unUKxI3WevC75G1aXXEFWG\nUN3NtFvePh3i2SGi6w7IaQo4oFyC9ie9nEBl0m6744tVoeaPVktEWQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 219,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179899999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ZZlA7RTEW6unUKxI3WevC75G1aXXEFWGUN3NtFvePh0",
+        "y": "4tkhousOyGkKOKBcgvYnvZxAZdJuu-OLVaHmj1ZLRFk",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047271061600121d1c88b6097f64bb68c4960f55c20b8feedca426a2b1f375eebe0a258bf99824ff3c8330cd8cf6e6973d5c3ccccaddfee8686c79bcc68253aa46",
+        "wx": "7271061600121d1c88b6097f64bb68c4960f55c20b8feedca426a2b1f375eebe",
+        "wy": "0a258bf99824ff3c8330cd8cf6e6973d5c3ccccaddfee8686c79bcc68253aa46"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047271061600121d1c88b6097f64bb68c4960f55c20b8feedca426a2b1f375eebe0a258bf99824ff3c8330cd8cf6e6973d5c3ccccaddfee8686c79bcc68253aa46",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEcnEGFgASHRyItgl/ZLtoxJYPVcILj+7c\npCaisfN17r4KJYv5mCT/PIMwzYz25pc9XDzMyt3+6GhsebzGglOqRg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 220,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179866666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "cnEGFgASHRyItgl_ZLtoxJYPVcILj-7cpCaisfN17r4",
+        "y": "CiWL-Zgk_zyDMM2M9uaXPVw8zMrd_uhobHm8xoJTqkY",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047b939c4fba5a8ff3611afaddb37c4719b19c6a6a8fbd92589d84fb1ef8337aaf3bd3dc4c184fe7adee1a7193ed30a6cae3992e5b3bdebc26f100133e6d04be61",
+        "wx": "7b939c4fba5a8ff3611afaddb37c4719b19c6a6a8fbd92589d84fb1ef8337aaf",
+        "wy": "3bd3dc4c184fe7adee1a7193ed30a6cae3992e5b3bdebc26f100133e6d04be61"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047b939c4fba5a8ff3611afaddb37c4719b19c6a6a8fbd92589d84fb1ef8337aaf3bd3dc4c184fe7adee1a7193ed30a6cae3992e5b3bdebc26f100133e6d04be61",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEe5OcT7paj/NhGvrds3xHGbGcamqPvZJY\nnYT7Hvgzeq8709xMGE/nre4acZPtMKbK45kuWzvevCbxABM+bQS+YQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 221,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179849249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "e5OcT7paj_NhGvrds3xHGbGcamqPvZJYnYT7Hvgzeq8",
+        "y": "O9PcTBhP563uGnGT7TCmyuOZLls73rwm8QATPm0EvmE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04645a699226e2dbabb31d76e06d5cdb9bb9c0c20da7ce87955ea93c82d22c236bbd49fbe2250e00622314cab4a29eef91e4524ab6238086147e73c01eda9fc244",
+        "wx": "645a699226e2dbabb31d76e06d5cdb9bb9c0c20da7ce87955ea93c82d22c236b",
+        "wy": "00bd49fbe2250e00622314cab4a29eef91e4524ab6238086147e73c01eda9fc244"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004645a699226e2dbabb31d76e06d5cdb9bb9c0c20da7ce87955ea93c82d22c236bbd49fbe2250e00622314cab4a29eef91e4524ab6238086147e73c01eda9fc244",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEZFppkibi26uzHXbgbVzbm7nAwg2nzoeV\nXqk8gtIsI2u9SfviJQ4AYiMUyrSinu+R5FJKtiOAhhR+c8Ae2p/CRA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f817980eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ZFppkibi26uzHXbgbVzbm7nAwg2nzoeVXqk8gtIsI2s",
+        "y": "vUn74iUOAGIjFMq0op7vkeRSSrYjgIYUfnPAHtqfwkQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 223,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "c492aebe9f1b702c6747fbd016604d49ad6beb2c57a29c0587bb76a07c988b1a2492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 224,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3b6d514160e48fd398b8042fe99fb2b50d42f1ba57a604363816e7ec539db6272492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+        "y": "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "00b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5i3xSWI2Vw7mqJbBAPx7vdXAuhLt1l6q+ZjuC9vBO8ndw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 225,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "c492aebe9f1b702c6747fbd016604d49ad6beb2c57a29c0587bb76a07c988b1a2492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 226,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3b6d514160e48fd398b8042fe99fb2b50d42f1ba57a604363816e7ec539db6272492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+        "y": "t8UliNlcO5qiWwQD8e73VwLoS7dZeqvmY7gvbwTvJ3c",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 227,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "",
+          "sig": "606e2e02683631c5fb803e8c92a594e4c444ffe2b83066029f62d637330dfc1fea9f5b6c399a99bdbbc5a6ddc3cffde178f08f52774e47cc83a9d7bd19ec16ef",
+          "result": "valid"
+        },
+        {
+          "tcId": 228,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "4d7367",
+          "sig": "fc36e66fa4681984a3eb534d4f14b829410b1ccbcd107b857a80b0864b5c763adc006c02ba9c5973c0c70e5fd289225af83392d31e15ddbcbb82cc215f7d91c3",
+          "result": "valid"
+        },
+        {
+          "tcId": 229,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "9e7ddd1a7916e921bc2efe0f538f29233368f8dfa55f5922bcfe224a2e703dd7f2d61b8142c4f5d60abf62dd6c8f16eb8a4a2d05cdefaf57d48b55bcdba75ce7",
+          "result": "valid"
+        },
+        {
+          "tcId": 230,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "sig": "0169daa2ef3b2f0424608df5de627f832d7b99cefa4787ddd7389fc7f1eefdadf1d5d81cd3d7507da294de45cc50549bb6442751b39b1a3c1f32584e9594ebbf",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eCyO0X47Kng7VGTzOwllKnHGeOBexR6E4rz8Zjo96WM",
+        "y": "r5rLQoC4x_fEL075q6YkXsHsFxL9OKD6lkGNjNaqYVI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "01060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv8AAAABBgSS1aVnPg8l2NUPt+WMSdhtRtQhaVXgqj1A4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 231,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "13f7c539626f89a954dbe09c8cb68cf691fb808789139c70192d831752e8a6a94b7a5beaa9e455940597b666a2a006caa6f58e7e8d35b189f0705d9243c0aa7b",
+          "result": "valid"
+        },
+        {
+          "tcId": 232,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "59f020bd01827233ebc883add6f2243235a2880b7dd7cfb6fde00b1be0871a44d64e496bc7937d954e6b5bef6b9390b2517af0f52efb026faa074777ed725015",
+          "result": "valid"
+        },
+        {
+          "tcId": 233,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "47bb77178d250fc3ffe251f0d0caa34cde1550c9f3433dd76c1a7571776b22d9670cecf9838b07d360c742528e8640c75d02a1e92b291fafff70678f76ba31e1",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "boI1VUUpFAmRgsaywdbwtdKNUMzQBa8s4bulQapAyv8",
+        "y": "AAAAAQYEktWlZz4PJdjVD7fljEnYbUbUIWlV4Ko9QOE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "00fffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv/////++fttKlqYwfDaJyrwSBpztieSuSvelqoeVcK7Tg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 234,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "8cd4f2977044c51dd8805aa28304c54fdabd722462c0f3aab492f0b338bc5c97fbb0bf8d8f5b3735236f6d616fddec1ec27d69cb5ab14df460cec0fc813d3ec0",
+          "result": "valid"
+        },
+        {
+          "tcId": 235,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "b44a3977d35d577b52106ea2bece72ec5202cc6dcbf5f0e2df4195c6215cfc84794754a83f6b4dd90b28418c37106177449b172487030f9e3c7430e0a213b708",
+          "result": "valid"
+        },
+        {
+          "tcId": 236,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "c4af8155dab795b096f7039dca9c38307d0935e50f1dc548d4dcb356620f7bd2e791b8d05a4fe1aa5cf03a1687460d0dc1938e5270fb49e6ec22538893740cd6",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "boI1VUUpFAmRgsaywdbwtdKNUMzQBa8s4bulQapAyv8",
+        "y": "_____vn7bSpamMHw2icq8Egac7Ynkrkr3paqHlXCu04",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+        "wx": "013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0",
+        "wy": "00f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAAAAAT/SIkjWTZX3PCm0irSGMYUL5QP9\nAPhGi18PcOD27nqkO8LG/SWx2CaSQcvdnbsNrJbcliMfQwcF+DhxfQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 237,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "21757478b5257b9afa77f0b984270e7e659c50450473dddcf7cbf9debdcdaebfe42d6fd80e720f8eac286d87620dd616d17202451d5c198c7ddf63ad4a0a8460",
+          "result": "valid"
+        },
+        {
+          "tcId": 238,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "4e3400b9d73d3e52c461c0b2257d694b057ca2278e44c290fbf62a13cfee6b647b04553c61d2ad7178aa15261bebaa3f70855ff21c6c9495d3a5c92750572f16",
+          "result": "valid"
+        },
+        {
+          "tcId": 239,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "20960e67a2bb64aae5109251eef514144f1b4d532a196ff3667b23a8f0426d25c83703e173afc7489e2a3a3dded23ee1a9e321c421c1ed31ba78d43cbe1d0dd4",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AAAAAT_SIkjWTZX3PCm0irSGMYUL5QP9APhGi18PcOA",
+        "y": "9u56pDvCxv0lsdgmkkHL3Z27DayW3JYjH0MHBfg4cX0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+        "wx": "25afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dffffffff",
+        "wy": "00fa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJa/WiayrrtZ8Hylt5ZQG+MVQ9XFGoLTs\nLJeHbf/////6RqduUgMi37xJHsTwzBl0IPxOpYg9j23VPDVLxPZ8NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 240,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "133ff714d612532cdc2142868cc9efb1e59fbfd1277ad9240488c1c547c2b7e3b4c6c1a8a32e6f0015a9b0a3c802e9f3ccba7ebb1bf50d2427b30d0d808f0ce2",
+          "result": "valid"
+        },
+        {
+          "tcId": 241,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "4e7f995e2bafb2ea3759160234184d63e99f9f29cd91299c93309ff3e4c081836e474385b295c7f9752f6c56c485813770192eaa8c06f57bbbdd8dff2cf69406",
+          "result": "valid"
+        },
+        {
+          "tcId": 242,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "5b226b26922de1dcf1b2ff2950a1926a3bfa1b47b0d3c0224d3d74cfd8a383a6a723f5420da8fa10a007e1cc0cd9314473ef32ae628683cb5779c8e451544053",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Ja_WiayrrtZ8Hylt5ZQG-MVQ9XFGoLTsLJeHbf____8",
+        "y": "-kanblIDIt-8SR7E8MwZdCD8TqWIPY9t1Tw1S8T2fDU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+        "wx": "00d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb9",
+        "wy": "3f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0S5sZrZ3NMPITSYBz1013Al+J2N/CspK\nT9t0tqrdO7k/W9/4i9VzbfiY5pkAbtdQ8RzwfFhmzXrXDHEh/////w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 243,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "4111c525606fa194f16dbd57f7338784173c4fa06a66bf44cfababc5458aaf22f53d185caa1020e7304dd2424986dab3a8f93c47135e0c0caaa825a175ac68c2",
+          "result": "valid"
+        },
+        {
+          "tcId": 244,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "7e482dee38b853850c8a3bad568b1e6fcf3ee0c00ba22bf3a799a352c3c61b41de6dfeac0902f82c61b20955bcea89260a41c5e220160705614e7397fbbec69f",
+          "result": "valid"
+        },
+        {
+          "tcId": 245,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "4f0736fc03a8d7e82130168136dcb9ff423d3d26a721d225422844af33c7bdc8c3e163974aa872b76fa0e6511c53f8ea2f39b117045e45adbd17a0ffbe4e2549",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "0S5sZrZ3NMPITSYBz1013Al-J2N_CspKT9t0tqrdO7k",
+        "y": "P1vf-IvVc234mOaZAG7XUPEc8HxYZs161wxxIf____8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+        "wx": "6d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000",
+        "wy": "00e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbUp/YNR3Sk8KqLve25U8fup5CUB+MWR1\nVmS8KAAAAADmWdNOTfONnoyeqt+6NmEsdpGVvobHeqw/NueLU4aA+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 246,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "81baafa92031d4d9be8083b2c93a5319faa507f88cc4e3db9dee9539d042d418f83234e54336c2ebf68230ab6015ced7176bd4164aea66ce828e7fab3f523261",
+          "result": "valid"
+        },
+        {
+          "tcId": 247,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "8acd6383aea9c70038538f30e4bb18ead6907e3a9245fa22f93cd1ad28dc4e85bb2ae2ac3d9bd94de4a3df80cee8499485e923c97b2e6a108c1f7299114cb99e",
+          "result": "valid"
+        },
+        {
+          "tcId": 248,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "50d5cd3ba1be23ad74f4eef7213024678999c2e0f2953c193c90f14615b620cdbf89d4a87902f306cb4a8b7c5fc0cb65c4593eab0d7df88d557cbbb4d764d3cc",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "bUp_YNR3Sk8KqLve25U8fup5CUB-MWR1VmS8KAAAAAA",
+        "y": "5lnTTk3zjZ6MnqrfujZhLHaRlb6Gx3qsPzbni1OGgPs",
+        "kid": "none"
+      }
+    }
+  ]
+}

--- a/tests/ecc/_data/ecdsa_secp256k1_shake128_test.json
+++ b/tests/ecc/_data/ecdsa_secp256k1_shake128_test.json
@@ -1,0 +1,6861 @@
+{
+  "algorithm": "ECDSA",
+  "schema": "ecdsa_verify_schema_v1.json",
+  "numberOfTests": 472,
+  "header": [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
+  "notes": {
+    "ArithmeticError": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
+      "cves": [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature": {
+      "bugType": "BER_ENCODING",
+      "description": "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect": "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves": [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero": {
+      "bugType": "LEGACY",
+      "description": "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect": "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves": [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "ValidSignature": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "",
+          "sig": "30450220606e2e02683631c5fb803e8c92a594e4c444ffe2b83066029f62d637330dfc1f022100ea9f5b6c399a99bdbbc5a6ddc3cffde178f08f52774e47cc83a9d7bd19ec16ef",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "4d7367",
+          "sig": "3046022100fc36e66fa4681984a3eb534d4f14b829410b1ccbcd107b857a80b0864b5c763a022100dc006c02ba9c5973c0c70e5fd289225af83392d31e15ddbcbb82cc215f7d91c3",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221009e7ddd1a7916e921bc2efe0f538f29233368f8dfa55f5922bcfe224a2e703dd7022100f2d61b8142c4f5d60abf62dd6c8f16eb8a4a2d05cdefaf57d48b55bcdba75ce7",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "sig": "304502200169daa2ef3b2f0424608df5de627f832d7b99cefa4787ddd7389fc7f1eefdad022100f1d5d81cd3d7507da294de45cc50549bb6442751b39b1a3c1f32584e9594ebbf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx": "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy": "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 5,
+          "comment": "signature malleability",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e02204710612ebbe0145a469f29a195700b55c5ad2fc1df818eac017099bcb1bbef15",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "Legacy: ASN encoding of r misses leading 0",
+          "flags": [
+            "MissingZero"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 7,
+          "comment": "Legacy: ASN encoding of s misses leading 0",
+          "flags": [
+            "MissingZero"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0220b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 8,
+          "comment": "valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "valid"
+        },
+        {
+          "tcId": 9,
+          "comment": "length of sequence [r, s] uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308146022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "length of sequence [r, s] contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30820046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 11,
+          "comment": "length of sequence [r, s] uses 71 instead of 70",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 12,
+          "comment": "length of sequence [r, s] uses 69 instead of 70",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "uint32 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30850100000046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "uint64 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3089010000000000000046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "length of sequence [r, s] = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30847fffffff022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "length of sequence [r, s] = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308480000000022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "length of sequence [r, s] = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3084ffffffff022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "length of sequence [r, s] = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085ffffffffff022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "length of sequence [r, s] = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3088ffffffffffffffff022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "incorrect length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30ff022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "removing sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "lonely sequence tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "appending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "prepending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30480000022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "appending unused 0's to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "appending null value to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b4981773046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a25003046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "appending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30483046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "including undefined tags",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304eaa00bb00cd003046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e2229aa00bb00cd00022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e2229aa00bb00cd00022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "truncated length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3081",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "including undefined tags to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304caa02aabb3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 36,
+          "comment": "using composition with indefinite length for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30803046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 37,
+          "comment": "using composition with wrong tag for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30803146022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 38,
+          "comment": "Replacing sequence [r, s] with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 39,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2e46022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 40,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2f46022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 41,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3146022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 42,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3246022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 43,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "ff46022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 44,
+          "comment": "dropping value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 45,
+          "comment": "using composition for sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a30010230452100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 46,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a52",
+          "result": "invalid"
+        },
+        {
+          "tcId": 47,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30452100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 48,
+          "comment": "sequence [r, s] of size 4167 to check for overflows",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30821047022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 49,
+          "comment": "indefinite length",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 50,
+          "comment": "indefinite length with truncated delimiter",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 51,
+          "comment": "indefinite length with additional element",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c05000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 52,
+          "comment": "indefinite length with truncated element",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c060811220000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 53,
+          "comment": "indefinite length with garbage",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000fe02beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 54,
+          "comment": "indefinite length with nonempty EOC",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0002beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 55,
+          "comment": "prepend empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30483000022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 56,
+          "comment": "append empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 57,
+          "comment": "append zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 58,
+          "comment": "append garbage with high tag number",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522cbf7f00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 59,
+          "comment": "append null with explicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522ca0020500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 60,
+          "comment": "append null with implicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522ca000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 61,
+          "comment": "sequence of sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30483046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 62,
+          "comment": "truncated sequence: removed last 1 elements",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3023022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e",
+          "result": "invalid"
+        },
+        {
+          "tcId": 63,
+          "comment": "repeating element in sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3069022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 64,
+          "comment": "flipped bit 0 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304400b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2f022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 65,
+          "comment": "flipped bit 32 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304400b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc45925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 66,
+          "comment": "flipped bit 48 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304400b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7bfecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 67,
+          "comment": "flipped bit 64 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304400b67909c3703a5115a72263124050fd0ffb35eadc2a3fc511e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 68,
+          "comment": "length of r uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702812100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 69,
+          "comment": "length of r contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30480282002100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 70,
+          "comment": "length of r uses 34 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022200b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 71,
+          "comment": "length of r uses 32 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022000b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 72,
+          "comment": "uint32 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b0285010000002100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 73,
+          "comment": "uint64 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304f028901000000000000002100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 74,
+          "comment": "length of r = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02847fffffff00b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 75,
+          "comment": "length of r = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02848000000000b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 76,
+          "comment": "length of r = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a0284ffffffff00b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 77,
+          "comment": "length of r = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b0285ffffffffff00b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 78,
+          "comment": "length of r = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e0288ffffffffffffffff00b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 79,
+          "comment": "incorrect length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304602ff00b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 80,
+          "comment": "replaced r by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046028000b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 81,
+          "comment": "removing r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3023022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 82,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 83,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3024022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e02",
+          "result": "invalid"
+        },
+        {
+          "tcId": 84,
+          "comment": "appending 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022300b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0000022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 85,
+          "comment": "prepending 0's to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30480223000000b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 86,
+          "comment": "appending unused 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0000022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 87,
+          "comment": "appending null value to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022300b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0500022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 88,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b2226498177022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 89,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a22252500022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 90,
+          "comment": "appending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e2223022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0004deadbeef022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 91,
+          "comment": "truncated length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250281022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 92,
+          "comment": "including undefined tags to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304c2227aa02aabb022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 93,
+          "comment": "using composition with indefinite length for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a2280022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0000022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 94,
+          "comment": "using composition with wrong tag for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a2280032100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0000022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 95,
+          "comment": "Replacing r with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30250500022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 96,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046002100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 97,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046012100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 98,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046032100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 99,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046042100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 100,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046ff2100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 101,
+          "comment": "dropping value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250200022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 102,
+          "comment": "using composition for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a22250201000220b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 103,
+          "comment": "modifying first byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022102b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 104,
+          "comment": "modifying last byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cfae022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 105,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022000b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 106,
+          "comment": "r of size 4130 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308210490282102200b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 107,
+          "comment": "leading ff in r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30470222ff00b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 108,
+          "comment": "replaced r by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026090180022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 109,
+          "comment": "replacing r with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 110,
+          "comment": "flipped bit 0 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522d",
+          "result": "invalid"
+        },
+        {
+          "tcId": 111,
+          "comment": "flipped bit 32 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d11e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 112,
+          "comment": "flipped bit 48 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe60c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 113,
+          "comment": "flipped bit 64 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118ebe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 114,
+          "comment": "length of s uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e02812100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 115,
+          "comment": "length of s contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0282002100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 116,
+          "comment": "length of s uses 34 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022200b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 117,
+          "comment": "length of s uses 32 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 118,
+          "comment": "uint32 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0285010000002100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 119,
+          "comment": "uint64 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304f022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e028901000000000000002100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 120,
+          "comment": "length of s = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e02847fffffff00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 121,
+          "comment": "length of s = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e02848000000000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 122,
+          "comment": "length of s = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0284ffffffff00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 123,
+          "comment": "length of s = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0285ffffffffff00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 124,
+          "comment": "length of s = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0288ffffffffffffffff00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 125,
+          "comment": "incorrect length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e02ff00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 126,
+          "comment": "replaced s by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e028000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 127,
+          "comment": "appending 0's to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022300b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 128,
+          "comment": "prepending 0's to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0223000000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 129,
+          "comment": "appending null value to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022300b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 130,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e2226498177022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 131,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e22252500022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 132,
+          "comment": "appending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e2223022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 133,
+          "comment": "truncated length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0281",
+          "result": "invalid"
+        },
+        {
+          "tcId": 134,
+          "comment": "including undefined tags to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304c022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e2227aa02aabb022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 135,
+          "comment": "using composition with indefinite length for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e2280022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 136,
+          "comment": "using composition with wrong tag for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e2280032100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 137,
+          "comment": "Replacing s with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 138,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e002100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 139,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e012100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 140,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e032100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 141,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e042100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 142,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2eff2100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 143,
+          "comment": "dropping value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0200",
+          "result": "invalid"
+        },
+        {
+          "tcId": 144,
+          "comment": "using composition for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e22250201000220b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 145,
+          "comment": "modifying first byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022102b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 146,
+          "comment": "modifying last byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a52ac",
+          "result": "invalid"
+        },
+        {
+          "tcId": 147,
+          "comment": "truncated s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a52",
+          "result": "invalid"
+        },
+        {
+          "tcId": 148,
+          "comment": "s of size 4130 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30821049022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0282102200b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 149,
+          "comment": "leading ff in s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e0222ff00b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 150,
+          "comment": "replaced s by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e090180",
+          "result": "invalid"
+        },
+        {
+          "tcId": 151,
+          "comment": "replacing s with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 152,
+          "comment": "replaced r by r + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101b67909c3703a5115a72263124050fd0eb5e4c7c2d988654ca7914b52295c106f022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 153,
+          "comment": "replaced r by r - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220b67909c3703a5115a72263124050fd1140870df57af724d527ec8e3888ef8ded022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 154,
+          "comment": "replaced r by r + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "304702220100b67909c3703a5115a72263124050fbcaaa12d18b72e000d0ba1d79958f67102e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 155,
+          "comment": "replaced r by -r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff4986f63c8fc5aeea58dd9cedbfaf02f004ca1523d5c03aef1841133aa6da30d2022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 156,
+          "comment": "replaced r by n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "304502204986f63c8fc5aeea58dd9cedbfaf02eebf78f20a8508db2ad81371c777107213022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 157,
+          "comment": "replaced r by -n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fe4986f63c8fc5aeea58dd9cedbfaf02f14a1b383d26779ab3586eb4add6a3ef91022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 158,
+          "comment": "replaced r by r + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 159,
+          "comment": "replaced r by r + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e0229010000000000000000b67909c3703a5115a72263124050fd0ffb35eadc2a3fc510e7beecc55925cf2e022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 160,
+          "comment": "replaced s by s + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101b8ef9ed1441feba5b960d65e6a8ff4a7afb08a0b7f0fb1cb7e34235ceeb0936d022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 161,
+          "comment": "replaced s by s - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220b8ef9ed1441feba5b960d65e6a8ff4aa3a52d03e207e7153fe8f66434e4410eb022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 162,
+          "comment": "replaced s by s + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "304702220100b8ef9ed1441feba5b960d65e6a8ff363a3de93d418674d4f90c051a054bb932c022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 163,
+          "comment": "replaced s by -s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff4710612ebbe0145a469f29a195700b570afe52db3038ee70419e3b2fe185add4022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 164,
+          "comment": "replaced s by -n - s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fe4710612ebbe0145a469f29a195700b58504f75f480f04e3481cbdca3114f6c93022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 165,
+          "comment": "replaced s by s + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 166,
+          "comment": "replaced s by s - 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 167,
+          "comment": "replaced s by s + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e0229010000000000000000b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c022100b8ef9ed1441feba5b960d65e6a8ff4a8f501ad24cfc7118fbe61c4d01e7a522c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 168,
+          "comment": "Signature with special case values r=0 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 169,
+          "comment": "Signature with special case values r=0 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 170,
+          "comment": "Signature with special case values r=0 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 171,
+          "comment": "Signature with special case values r=0 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 172,
+          "comment": "Signature with special case values r=0 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 173,
+          "comment": "Signature with special case values r=0 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 174,
+          "comment": "Signature with special case values r=0 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 175,
+          "comment": "Signature with special case values r=0 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 176,
+          "comment": "Signature with special case values r=1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 177,
+          "comment": "Signature with special case values r=1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 178,
+          "comment": "Signature with special case values r=1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 179,
+          "comment": "Signature with special case values r=1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 180,
+          "comment": "Signature with special case values r=1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 181,
+          "comment": "Signature with special case values r=1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 182,
+          "comment": "Signature with special case values r=1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 183,
+          "comment": "Signature with special case values r=1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 184,
+          "comment": "Signature with special case values r=-1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 185,
+          "comment": "Signature with special case values r=-1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 186,
+          "comment": "Signature with special case values r=-1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 187,
+          "comment": "Signature with special case values r=-1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 188,
+          "comment": "Signature with special case values r=-1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 189,
+          "comment": "Signature with special case values r=-1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 190,
+          "comment": "Signature with special case values r=-1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 191,
+          "comment": "Signature with special case values r=-1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 192,
+          "comment": "Signature with special case values r=n and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 193,
+          "comment": "Signature with special case values r=n and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 194,
+          "comment": "Signature with special case values r=n and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 195,
+          "comment": "Signature with special case values r=n and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 196,
+          "comment": "Signature with special case values r=n and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 197,
+          "comment": "Signature with special case values r=n and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 198,
+          "comment": "Signature with special case values r=n and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 199,
+          "comment": "Signature with special case values r=n and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 200,
+          "comment": "Signature with special case values r=n - 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 201,
+          "comment": "Signature with special case values r=n - 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 202,
+          "comment": "Signature with special case values r=n - 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 203,
+          "comment": "Signature with special case values r=n - 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 204,
+          "comment": "Signature with special case values r=n - 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 205,
+          "comment": "Signature with special case values r=n - 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 206,
+          "comment": "Signature with special case values r=n - 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 207,
+          "comment": "Signature with special case values r=n - 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 208,
+          "comment": "Signature with special case values r=n + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 209,
+          "comment": "Signature with special case values r=n + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 210,
+          "comment": "Signature with special case values r=n + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 211,
+          "comment": "Signature with special case values r=n + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 212,
+          "comment": "Signature with special case values r=n + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 213,
+          "comment": "Signature with special case values r=n + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 214,
+          "comment": "Signature with special case values r=n + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 215,
+          "comment": "Signature with special case values r=n + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 216,
+          "comment": "Signature with special case values r=p and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 217,
+          "comment": "Signature with special case values r=p and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 218,
+          "comment": "Signature with special case values r=p and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 219,
+          "comment": "Signature with special case values r=p and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 220,
+          "comment": "Signature with special case values r=p and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 221,
+          "comment": "Signature with special case values r=p and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 222,
+          "comment": "Signature with special case values r=p and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 223,
+          "comment": "Signature with special case values r=p and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 224,
+          "comment": "Signature with special case values r=p + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 225,
+          "comment": "Signature with special case values r=p + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 226,
+          "comment": "Signature with special case values r=p + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 227,
+          "comment": "Signature with special case values r=p + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 228,
+          "comment": "Signature with special case values r=p + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 229,
+          "comment": "Signature with special case values r=p + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 230,
+          "comment": "Signature with special case values r=p + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 231,
+          "comment": "Signature with special case values r=p + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 232,
+          "comment": "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020100090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 233,
+          "comment": "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 234,
+          "comment": "Signature encoding contains incorrect types: r=0, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 235,
+          "comment": "Signature encoding contains incorrect types: r=0, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 236,
+          "comment": "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 237,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 238,
+          "comment": "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 239,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 240,
+          "comment": "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 241,
+          "comment": "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020101090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 242,
+          "comment": "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 243,
+          "comment": "Signature encoding contains incorrect types: r=1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 244,
+          "comment": "Signature encoding contains incorrect types: r=1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 245,
+          "comment": "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 246,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 247,
+          "comment": "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 248,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201013000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 249,
+          "comment": "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201013003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 250,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 251,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 252,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 253,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 254,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 255,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 256,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 257,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 258,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 259,
+          "comment": "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 260,
+          "comment": "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 261,
+          "comment": "Signature encoding contains incorrect types: r=n, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 262,
+          "comment": "Signature encoding contains incorrect types: r=n, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 263,
+          "comment": "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 264,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 265,
+          "comment": "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 266,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641413000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 267,
+          "comment": "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641413003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 268,
+          "comment": "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 269,
+          "comment": "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 270,
+          "comment": "Signature encoding contains incorrect types: r=p, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 271,
+          "comment": "Signature encoding contains incorrect types: r=p, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 272,
+          "comment": "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 273,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 274,
+          "comment": "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 275,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 276,
+          "comment": "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 277,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a090380fe01090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 278,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 279,
+          "comment": "Signature encoding contains incorrect types: r=True, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 280,
+          "comment": "Signature encoding contains incorrect types: r=False, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 281,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300405000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 282,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30040c000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 283,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c01300c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 284,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300430003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 285,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a30030201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 286,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008090380fe01020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 287,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 288,
+          "comment": "Signature encoding contains incorrect types: r=True, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 289,
+          "comment": "Signature encoding contains incorrect types: r=False, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 290,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050500020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 291,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050c00020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 292,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c0130020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 293,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30053000020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 294,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30083003020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 295,
+          "comment": "Edge case for Shamir multiplication",
+          "flags": [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg": "3639313331",
+          "sig": "3046022100dd1b7d09a7bd8218961034a39a87fecf5314f00c4d25eb58a07ac85e85eab516022100942b93d2552410ae06d6f651659174a77c3701c1d1320d032d6a01a5a330c041",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363530303637353631",
+          "sig": "30450220512edaee1ab1c77564fc52cb549b78425c56953237fa5aec783b5a81b11e22bf022100a5573fbcf6ff4faf8a4c5f782906bcf9d5059ae086db252d7682174a8ee4232e",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383039333631353931",
+          "sig": "30450220281ca95097599e8331e7b002d16cdae136cfb279c1900a5d0e52320ac28f8355022100a63da77fdf93ceb643dabf2656b2f4b2b7c1e2cbb5a7c5c2189e53a7c73e4ae2",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313231333636353837",
+          "sig": "3045022100ea496271d334150ceb6b29c1ce1d5aaafb8ff6619ebc1aa8d9e8f68e9e94d91402204b2350d9f4afca5f7d1595ce6cb5d7ffcd4ac5a767c7bc5c014fe8ea66309512",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393635323435333939",
+          "sig": "3045022045a95e29999caca1b06a27f5dd9dfb01a9b7196edafdc8375486c2ebdc9713ce022100c9e1dfc621ceac522146d2235439c3b191513caa01fa3fcef37b2977456f3ed4",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323035343733333935",
+          "sig": "3045022100a681bf2da732cde1405e3958ad8fe795650936824c846856650fbfe053194fe3022044435ef6218b2805e7603bbd1cf550f916e30231f4a62acc43b55a853e7d234f",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323236333030353738",
+          "sig": "30460221009696582199ed95e1f9a83935f20d7cb014fd12b4a929cda0b46678ddafb99140022100ad0625e45afc7e2f16968cebe5f415c77b8e922641c5fa94ce0d3bbc4f5916d2",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35353736313930313833",
+          "sig": "304402206d1f5edf9f118678cef172d5bfdfb62169944c799895eae908eae92fdee785bf02206d8d689faa873f2f4cc854bc8375e12321c31dcf51d708cc781e228846c646cb",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36393239393934393737",
+          "sig": "3046022100a3e862869eb0723ce9b89f6ebc200a2e98bc025529b35004f5a87c4f61b1d669022100c53866fb237c155215e340a6cdd5c4613220dae081b73537ed9c470adddc380a",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343139303333343334",
+          "sig": "304502205ca10aa93f22b30d6990551d641c05fdbd91093b8a2c8a6346db6d73fd0afc62022100f56aaf3a6becb5020ac26999a5eeba10f77fabe0451bd117c1b00e52f70e2fcc",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38343034303136323630",
+          "sig": "304502200cab3be2d173329a6848eb02fc7233e9a3266aac8ad3968fc3c816cb2c7ab26b022100c039cee82f7904090b7bd82b2752c03095536284d212e067b2643a14aeab11c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323939383433333936",
+          "sig": "304502200fec3b9a9b4bfe28a8659482558a13b245e5f18e9ad189ba798137fb1d2fa3a5022100c9340abfba096f3715e73a459c90ef92572bdcc4ef212edcad6fc07e6f35a6aa",
+          "result": "valid"
+        },
+        {
+          "tcId": 307,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33313834333734343135",
+          "sig": "30450221009a8d68e482d54e3abf25ef0c936bba854127355504919352b97a3be66a73e5c902202a1a3b547014baca64090d26da67e737cf7dec42be4cef584b80d768c12d6464",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130383632313035383639",
+          "sig": "3045022100e6a527a6e04fdf6fc80d6f4d0b6fec846938536143993f0ca172404cd985256102204dd33d9a7432e89c17fd8357db487b1ded3e2c781dc426456684e6c5508b89bf",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353030303333393137",
+          "sig": "3045022100e0b8fd2f4fd424d1686b59dc233e6de82b5eff4a3fc9feadd2330a14bc4843c602201a530270440b71c80c6099288d87627e77175ef39cedde74da37f7425f2a46ac",
+          "result": "valid"
+        },
+        {
+          "tcId": 310,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130323039383532343831",
+          "sig": "3046022100adc55436cb93eeaaf851bcf505458b36d8a0e9036af87030cfa5369e497416d1022100e0a6cc64d89a8e70fab849cb3b15f271f461274fc0e823973ffb976315db9900",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353432383438333133",
+          "sig": "3045022024df16632e42fa2f05ae4d55356781fc58945128315c046d6225d33afc7ea70a022100a5a9d16ceb809d57b12748aad029af7914a237f5b6ca0526de86649a8cdd2960",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323535363938303935",
+          "sig": "304402206f808e7ff5394daf91b1c93b4bdf8edb83dde6bd93443adeebd60c785e24b1f202203d8d87ecebcb7b8f51440fbeb5637fe0c6794a99fab45d5d5051cacfd55cc5c1",
+          "result": "valid"
+        },
+        {
+          "tcId": 313,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373334363931363630",
+          "sig": "3044022045e91631ef8cdbd0f919c0afc439c1ac1f7ad9a0729684f2e07d95fe6d74d3fe02200dcb4dbc55cca634968fd0c6157f5649c624b27f5c18d4845973ffe0f8438259",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37393633383036363138",
+          "sig": "3046022100db310a1f6a1640221145b65f95d703ecc0ae84fdd5b14f78a5f7bf749d4e4b36022100e660a55ab50c761d72e0c729b6068644f9eb05209f43d72392bfcd7015197943",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363334333037323131",
+          "sig": "3046022100e40849775b4b333bba557de96c45033f15e20d1e315a4e4494b8ffc7d30820df022100b6ef7550bd1db54464ae07eae8732ceaacd1151d6106fd5badb5e5045e3a95ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 316,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353039393431353232",
+          "sig": "3045022100c42a94145084e023768ec283d461b85b01133a03c78e5bb3cd3a8f3252f011e7022061a90325338f02878ae4998edb3563b392448cd303578b3cd3899955db1d32e6",
+          "result": "valid"
+        },
+        {
+          "tcId": 317,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373932323430313639",
+          "sig": "3045022100ba01f5e1a9aa16fa8d74be994edc745b3783d901ea9c834f1d1522376cd812af022000c6b0c0c0a7b6ab3de2df52ca6c9aa41c6be94f71925c6e73cbe75094517d16",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36343835373332363232",
+          "sig": "30440220218c618cfc01aa7519e5f106c57a206864fb02dae1ccc8928076b8fef801cc5d02200d636547bdd3e833eeced26e56e38ed10895219fcc171a29405c1efd41ea7b02",
+          "result": "valid"
+        },
+        {
+          "tcId": 319,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34323030333139303235",
+          "sig": "304502201809137a4c81666e82d8b10372951d8cac40deb7ee5156d859cd9498fe344398022100f22cd60ed48ca3f4e71919b9bb2f67eefb5e43f5c0120242c1014a743602b9d5",
+          "result": "valid"
+        },
+        {
+          "tcId": 320,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31313031323032313732",
+          "sig": "304402200dee22bfc32ebab0bf630365188f5362278cc1b83bb1ff14dd732e9ffa6aed6a022050f4c5c50fc5e520a1d3b16401150a348803e1b9660bb9af2f149d6446b2885f",
+          "result": "valid"
+        },
+        {
+          "tcId": 321,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363830343631373331",
+          "sig": "3046022100a8e9eaefff83c5237cdce17f29c0de49fd3fdfcf09945abc9b80358ebb631e1e02210097ce1eda7c5da180de13c030e7ac9588e637b55bdc92ac6acb5ee0355560f290",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3433333030373131",
+          "sig": "30440220766c9079a3ddd8421a7506611c4317e1375f20ef6a2f97458f5f06a85de6a48e022071c05d521d67f38d9d230cbbe14832e3490dee1b83633a72c30368d24448d94d",
+          "result": "valid"
+        },
+        {
+          "tcId": 323,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35343130383731383131",
+          "sig": "3046022100a24a6bfdb18fd549021fb3f5781ac5bbd5cd04886476b2dbc543663ba0fe8002022100ce2307d2330f8ffa57cab705627c222ddca3bd4c65782667899417388d64be79",
+          "result": "valid"
+        },
+        {
+          "tcId": 324,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34393935363839393432",
+          "sig": "3045022100a166858bc0de34f642b8243af2c9b5de7d932780d0c577293d3841434bc6d36802201344da59d582ce3e6bd459deedcc15195e9923f9a09e5e33b6cc22347b4efdb3",
+          "result": "valid"
+        },
+        {
+          "tcId": 325,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333535303737393735",
+          "sig": "304502207d245bbd8852f477aab5f66e763ba80af436c676883254e0e0677594dd777f0f022100fb0980a77ebc02354412ed76b491369e87098d44d4e5629f4aac2e0df38f739d",
+          "result": "valid"
+        },
+        {
+          "tcId": 326,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3637383237343235353934",
+          "sig": "3046022100cac23081f1b638caea584fe0feb6fed7da1b15474305c8a23f7b6df1f2e10db4022100917ed6d28013052e6448f011377d51bc108baf9b8e7b5e64c43509f3d3101bdf",
+          "result": "valid"
+        },
+        {
+          "tcId": 327,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333230353830363930",
+          "sig": "304502206cfb9dabf738725a952085f74f31b15c9da48b52a8a45667f6098c7c5df115ab022100804c1c65db15e52f4093828f7743294969da4c1a71b927de8bd0e1bffdfb7024",
+          "result": "valid"
+        },
+        {
+          "tcId": 328,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383536333035303638",
+          "sig": "304502205b32944ee796cd9b997a673214c587701f7882239d29f6b834cc26c18e9638de022100c39547b682e6a2de446ae2c70e507692acf4d3c898a20f4aaf2379bcec114a6a",
+          "result": "valid"
+        },
+        {
+          "tcId": 329,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37303836313032363437",
+          "sig": "3045022100a2ad0277149153d7b4d01d600cbf5b9c75e3e89c58862078d9ec06850caadc630220348e06b90da5f6dd3cabd3a339c08b2ffc89bfa5902b4b7bfc69892163ba0e8c",
+          "result": "valid"
+        },
+        {
+          "tcId": 330,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383133383135343839",
+          "sig": "3045022100d6dc8278d912a92e44e7c5a06718c93d0cd3f621f2101f55888235bf74e680a6022065e87883e04a699e926fd864a81b3f3d83136e20ae82d91682b0808567e866c0",
+          "result": "valid"
+        },
+        {
+          "tcId": 331,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31353133303032323331",
+          "sig": "3045022100f0382ca2736e6ab2adb71aa43e29d95214ec48d61b3f84b0543c16c0f25716d002207d50ebf35cf732381bcf6b75f8a49df18dbbf967828f6d1ce98840bd0c366070",
+          "result": "valid"
+        },
+        {
+          "tcId": 332,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393333383130313533",
+          "sig": "3044022045403dbed83e7ccd359c209ae692f3c9b54df7a15b049b468de8a0d5e8b58b1c02205eebf48b9d40586d05ede8abafecf21e91266f607c007ae3ed0b8cedf03cbdc5",
+          "result": "valid"
+        },
+        {
+          "tcId": 333,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333035363037343230",
+          "sig": "3044022039cf2c7f8a554e6674195ba7d54d5face5c4539e8765a9f791a8f43b2205759b022003c736dc8b0281a8cf1834d0c194499b5caf5fdd459e4453e86915c91b60be39",
+          "result": "valid"
+        },
+        {
+          "tcId": 334,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3633373635373930323234",
+          "sig": "3045022100a4f4399e8963439774e120b1412e01ca7fc4e298edce3c034521565196c8f42e022001cd175d2a8718127949b2b5153019846bec47364d549d22c2671b1a2f459a16",
+          "result": "valid"
+        },
+        {
+          "tcId": 335,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393139303435363730",
+          "sig": "30440220520d886a2027b7b980ea7b6ffc5f90ad10297dd8b21679d69c40d5f40f416a5a0220358398ea11fc66a54b8bb7d848888acca88b5ca18fc05f276deb5f66c5cbc53e",
+          "result": "valid"
+        },
+        {
+          "tcId": 336,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343536303739363233",
+          "sig": "30450221008b180e44f592fa84b49b19e0d413a96f130a6a9ce62b529535ac053d86c8123d02204b865d92413a9c5fe8e718e3491103751d40254fd6f30918e59ab81d24fed474",
+          "result": "valid"
+        },
+        {
+          "tcId": 337,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373837373735323437",
+          "sig": "304502210096336c7319d70accdf613d5db165a967d9229ba3771f38d323e450ddaf0f755a02203f386fdfb6ec686027ae45ce71060832f5dea4b2bbc55ad5ac92da3601233059",
+          "result": "valid"
+        },
+        {
+          "tcId": 338,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33333031393735303837",
+          "sig": "304402202260f86a44bc6d28d642190ea5ac409689b7556e2a042be1b5a39fd265fbe80e0220734564b7d0575907ab18ef683d5e4da490f6b9df4a347147679ae4c235d67495",
+          "result": "valid"
+        },
+        {
+          "tcId": 339,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353138323633323336",
+          "sig": "3045022100e6f11102223a007db4ebeb897e8baec78d178eee9ace4339de93dda2d977976602207a8b12e5684da7a0dac02b151e1fd15a2c9aa8f26e92ad281876ef6a5be5f357",
+          "result": "valid"
+        },
+        {
+          "tcId": 340,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363637363730363435",
+          "sig": "3046022100ff46a3bc8530db22de7ab9d0fdc2925c711696b58b0720e30822eb883a980bac022100f02f72976361c7c61b707fc6415c6277eac77704da5aac851633c1c7f8b22363",
+          "result": "valid"
+        },
+        {
+          "tcId": 341,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31313733313630343337",
+          "sig": "3046022100d2b944c292991bf07b04e3251c72deadadc7703533a8d38c283eca747ff2ea0b0221008fdc265f9476ed7ddab57648902c8a0c70662e94b2e12c2de8553f97fadc81ee",
+          "result": "valid"
+        },
+        {
+          "tcId": 342,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36313831353839313035",
+          "sig": "3045022100aa41d869490e00703174f700c3cf059f2e0b6687634eb043525811211a6b835202204041a086c2b1a794bc540aa98afc599c0b904971a1a3d55bea0046042e4a2cc6",
+          "result": "valid"
+        },
+        {
+          "tcId": 343,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313233363236363536",
+          "sig": "304502201635edeb95f7f19ac9ff925ef558f8e88a84ce690bfdda025b37dcef7fbea2ca022100f6622f57c16c3689e579c21eeb5d3b5b0cd5f1568e435bf31c9e88a08e5a012d",
+          "result": "valid"
+        },
+        {
+          "tcId": 344,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303134343435353535",
+          "sig": "30450220264a610125078e2fb8ee915c6bf75b0922eb2c98959cd7485f48a2a23435631e022100abb202b102476093c4ed36fc5196e54a679c47f19ac1073fc0f63d80885ca1f5",
+          "result": "valid"
+        },
+        {
+          "tcId": 345,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383030393034353338",
+          "sig": "304402201f074c47123d5c79472089de6bfe35f3f28bd3d15125722c410b39682072e3250220164d85563be93911de5dd6003f6beb8daa370e47713e096e5d750f809cc49468",
+          "result": "valid"
+        },
+        {
+          "tcId": 346,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "353034313630343138",
+          "sig": "3045022100e1a5dd2395e62047d3a900b0c78aa6bb0f344140f664d21f7a5fa93e3660efc602205386e2d5789206ff278e9c833d11780b4471f2325e1ed843bd44bf281c965955",
+          "result": "valid"
+        },
+        {
+          "tcId": 347,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35363834303939333836",
+          "sig": "3046022100ccf7c57ee2d8090058aedbe31a1eafd90c5ea4338edcb54445ffbb130b7d6339022100a121b1ceb05b46b60d6754747e67a114efe9d3b0971fafd26aea6f84446a71b2",
+          "result": "valid"
+        },
+        {
+          "tcId": 348,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37303931393134373137",
+          "sig": "30450220217f4b7f49ec9098cc674fbbbef4c1426cf5fb4f53157757eae081069f204387022100db07d9d84e1ec80921fa62b562a52762f193d6cb007bab13df619981fc51e92b",
+          "result": "valid"
+        },
+        {
+          "tcId": 349,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36383730353736323136",
+          "sig": "304502206e44444851ff0b16f815e85047ff89b4d130a4a9f962f1f9abe2f582b7d79adc022100dbd446884e2cf11ef21bf8d489b361fc6c67eba81cdd4d4c74098690159ac990",
+          "result": "valid"
+        },
+        {
+          "tcId": 350,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353130383339363937",
+          "sig": "3046022100bc2957b83ec0ce04238e86258cdc573313ae171ad52ffa84ac88f10e3e411ed7022100d718daa144d74e1efe9768afb54fb7006a1c05217bc885f109b4cc1e2485cc37",
+          "result": "valid"
+        },
+        {
+          "tcId": 351,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343937383635313830",
+          "sig": "3045022100fff680cc7551b65b284c8a478e62f643e80c75ba942f6f6537c33c6154076b4e0220562635a5e53d02128458184bab32acbcc29eb7b0a2cd174f7e923d3f7142619f",
+          "result": "valid"
+        },
+        {
+          "tcId": 352,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3135323237383238323639",
+          "sig": "3045022062daace3787591218f7e4c7373b2db408c52c9c01405e5f6ce0c037c9b2b1854022100c0b6f11a5fba1f710fd43ea6ad3b20aee65f5c0e1b0ec7ba40a98a9f77416cb7",
+          "result": "valid"
+        },
+        {
+          "tcId": 353,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33363437363930313730",
+          "sig": "3045022100882dcf364ab5840d6d10be9ab0293bbb126b44f97eb9de4fd1e93c4b2e2952e902206215d699e9484afafd3a4e546eadc7841c4c8aba38323ca5f7b692c9f19ac09d",
+          "result": "valid"
+        },
+        {
+          "tcId": 354,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130323131353335373237",
+          "sig": "3046022100d0e2f0a3a4b4f5f193c6d4aa865fca9e421a009863d3cf0c2664a4cbffb8d59a022100d201d86dc869455396cb17f53c1058d0334058ffe2306c03143ed029a76a5492",
+          "result": "valid"
+        },
+        {
+          "tcId": 355,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373430353737333639",
+          "sig": "3044022022b7a717ffb1dbae9dcb80ecd08d0651bee1cb77df9bddccff1eaf52d3ae6c0202200fc7f279d33f0a9769775deb93ed378bddbbeace831e84074b0317d69945d3ca",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047df5977eeb9b4e8a530e3ff4ded003cf900e1fd5b5e86dc39ef2899437ade0d2e38e4d0af342fbbcd40cc613cf2e7234405bee3c89fb84f26969446895c05ede",
+        "wx": "7df5977eeb9b4e8a530e3ff4ded003cf900e1fd5b5e86dc39ef2899437ade0d2",
+        "wy": "00e38e4d0af342fbbcd40cc613cf2e7234405bee3c89fb84f26969446895c05ede"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047df5977eeb9b4e8a530e3ff4ded003cf900e1fd5b5e86dc39ef2899437ade0d2e38e4d0af342fbbcd40cc613cf2e7234405bee3c89fb84f26969446895c05ede",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEffWXfuubTopTDj/03tADz5AOH9W16G3D\nnvKJlDet4NLjjk0K80L7vNQMxhPPLnI0QFvuPIn7hPJpaURolcBe3g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 356,
+          "comment": "k*G has a large x-coordinate",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30360211014551231950b75fc4402da1722fc9baeb022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        },
+        {
+          "tcId": 357,
+          "comment": "r too large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049b2f0d042ceeae39be642b142cb57a8ea38ceae0505dff76f2fa3f5d87ba31f00129e1485752464145443ae713119a5c4604bbec98262d45c4257aa3cb8f5d9f",
+        "wx": "009b2f0d042ceeae39be642b142cb57a8ea38ceae0505dff76f2fa3f5d87ba31f0",
+        "wy": "0129e1485752464145443ae713119a5c4604bbec98262d45c4257aa3cb8f5d9f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049b2f0d042ceeae39be642b142cb57a8ea38ceae0505dff76f2fa3f5d87ba31f00129e1485752464145443ae713119a5c4604bbec98262d45c4257aa3cb8f5d9f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEmy8NBCzurjm+ZCsULLV6jqOM6uBQXf92\n8vo/XYe6MfABKeFIV1JGQUVEOucTEZpcRgS77JgmLUXEJXqjy49dnw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 358,
+          "comment": "r,s are large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0443c82fbeb0c94c84fb2f94662eb10a8e028cb80095deff46a6980850c6dfbf359f72182bd0cb5dc438c29f9ce828f9e5c1a1ba01f95be26da4024e39f11f663f",
+        "wx": "43c82fbeb0c94c84fb2f94662eb10a8e028cb80095deff46a6980850c6dfbf35",
+        "wy": "009f72182bd0cb5dc438c29f9ce828f9e5c1a1ba01f95be26da4024e39f11f663f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000443c82fbeb0c94c84fb2f94662eb10a8e028cb80095deff46a6980850c6dfbf359f72182bd0cb5dc438c29f9ce828f9e5c1a1ba01f95be26da4024e39f11f663f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQ8gvvrDJTIT7L5RmLrEKjgKMuACV3v9G\nppgIUMbfvzWfchgr0MtdxDjCn5zoKPnlwaG6Aflb4m2kAk458R9mPw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 359,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02203e9a7582886089c62fb840cf3b83061cd1cff3ae4341808bb5bdee6191174177",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045d8fc5fa2ae8a19877c87eb94d8494741c07298386af0794559bad328cdffbf4c59623522979c175f70ef4b61a165af1c9862447360ad440dcc15586042de7f8",
+        "wx": "5d8fc5fa2ae8a19877c87eb94d8494741c07298386af0794559bad328cdffbf4",
+        "wy": "00c59623522979c175f70ef4b61a165af1c9862447360ad440dcc15586042de7f8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045d8fc5fa2ae8a19877c87eb94d8494741c07298386af0794559bad328cdffbf4c59623522979c175f70ef4b61a165af1c9862447360ad440dcc15586042de7f8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXY/F+irooZh3yH65TYSUdBwHKYOGrweU\nVZutMozf+/TFliNSKXnBdfcO9LYaFlrxyYYkRzYK1EDcwVWGBC3n+A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 360,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022024238e70b431b1a64efdf9032669939d4b77f249503fc6905feb7540dea3e6d2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044ecfb55c21451e2158fec7371df2897630f352a75b0748746bde2ba6a2decedb9bdaf193eaaa3f819a57ccde4eeb8e1483c1461be1e451ad959159f288851989",
+        "wx": "4ecfb55c21451e2158fec7371df2897630f352a75b0748746bde2ba6a2decedb",
+        "wy": "009bdaf193eaaa3f819a57ccde4eeb8e1483c1461be1e451ad959159f288851989"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044ecfb55c21451e2158fec7371df2897630f352a75b0748746bde2ba6a2decedb9bdaf193eaaa3f819a57ccde4eeb8e1483c1461be1e451ad959159f288851989",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAETs+1XCFFHiFY/sc3HfKJdjDzUqdbB0h0\na94rpqLeztub2vGT6qo/gZpXzN5O644Ug8FGG+HkUa2VkVnyiIUZiQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 361,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049e9bf525b52ad0b1f32a8b1787c1de5e3c435a65551cc7a68d24beb975bf0b5c0ebdbb39d8cf4e1ee7c10b95c7764a299796e69890ba24f69af1c6c0318e455a",
+        "wx": "009e9bf525b52ad0b1f32a8b1787c1de5e3c435a65551cc7a68d24beb975bf0b5c",
+        "wy": "0ebdbb39d8cf4e1ee7c10b95c7764a299796e69890ba24f69af1c6c0318e455a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049e9bf525b52ad0b1f32a8b1787c1de5e3c435a65551cc7a68d24beb975bf0b5c0ebdbb39d8cf4e1ee7c10b95c7764a299796e69890ba24f69af1c6c0318e455a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEnpv1JbUq0LHzKosXh8HeXjxDWmVVHMem\njSS+uXW/C1wOvbs52M9OHufBC5XHdkopl5bmmJC6JPaa8cbAMY5FWg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 362,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020102",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04238a1b25d18f6e50d4e66ec617cec5caf8915cdb3f068898f01d9d478ac86da1c4ccb59b26abeafb8d63b46c81812cebf1b3e1a00e7dac550689dab16eb382e3",
+        "wx": "238a1b25d18f6e50d4e66ec617cec5caf8915cdb3f068898f01d9d478ac86da1",
+        "wy": "00c4ccb59b26abeafb8d63b46c81812cebf1b3e1a00e7dac550689dab16eb382e3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004238a1b25d18f6e50d4e66ec617cec5caf8915cdb3f068898f01d9d478ac86da1c4ccb59b26abeafb8d63b46c81812cebf1b3e1a00e7dac550689dab16eb382e3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEI4obJdGPblDU5m7GF87FyviRXNs/BoiY\n8B2dR4rIbaHEzLWbJqvq+41jtGyBgSzr8bPhoA59rFUGidqxbrOC4w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 363,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020103",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0453af90c4805fc6970759be2fbbcd9b8830a9005d308e01e29a8d3ece82cc208d76277c445337294b63de38de8b1ea9272c33c95d2cf94463e6502d77295332a1",
+        "wx": "53af90c4805fc6970759be2fbbcd9b8830a9005d308e01e29a8d3ece82cc208d",
+        "wy": "76277c445337294b63de38de8b1ea9272c33c95d2cf94463e6502d77295332a1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000453af90c4805fc6970759be2fbbcd9b8830a9005d308e01e29a8d3ece82cc208d76277c445337294b63de38de8b1ea9272c33c95d2cf94463e6502d77295332a1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEU6+QxIBfxpcHWb4vu82biDCpAF0wjgHi\nmo0+zoLMII12J3xEUzcpS2PeON6LHqknLDPJXSz5RGPmUC13KVMyoQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 364,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049cfe252b251749d52bc1fdbcb5d0e3e8dfe3239c172380facc63590f85520c79532ee36e68792ebe69867a042a61cd99d7d8c5ece834f36b5b01f26589c13649",
+        "wx": "009cfe252b251749d52bc1fdbcb5d0e3e8dfe3239c172380facc63590f85520c79",
+        "wy": "532ee36e68792ebe69867a042a61cd99d7d8c5ece834f36b5b01f26589c13649"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049cfe252b251749d52bc1fdbcb5d0e3e8dfe3239c172380facc63590f85520c79532ee36e68792ebe69867a042a61cd99d7d8c5ece834f36b5b01f26589c13649",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEnP4lKyUXSdUrwf28tdDj6N/jI5wXI4D6\nzGNZD4VSDHlTLuNuaHkuvmmGegQqYc2Z19jF7Og082tbAfJlicE2SQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 365,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020102",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ef105def30266133e1488f127056642f30f6033f035be186f6185e8d7e34745ebe65d70d75959058195f71068d12c30f3301335e8bc54b39fd5bb2eb5220a22a",
+        "wx": "00ef105def30266133e1488f127056642f30f6033f035be186f6185e8d7e34745e",
+        "wy": "00be65d70d75959058195f71068d12c30f3301335e8bc54b39fd5bb2eb5220a22a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ef105def30266133e1488f127056642f30f6033f035be186f6185e8d7e34745ebe65d70d75959058195f71068d12c30f3301335e8bc54b39fd5bb2eb5220a22a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7xBd7zAmYTPhSI8ScFZkLzD2Az8DW+GG\n9hhejX40dF6+ZdcNdZWQWBlfcQaNEsMPMwEzXovFSzn9W7LrUiCiKg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 366,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020103",
+          "result": "valid"
+        },
+        {
+          "tcId": 367,
+          "comment": "r is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143020103",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0443f43ad13fd4198b2810f20d00f306c365a64f4621784da4280e452c0b53993bb2f7fbadf3a661203894df4013ea6759e45aa9009a07d6ed84624fdce01526a6",
+        "wx": "43f43ad13fd4198b2810f20d00f306c365a64f4621784da4280e452c0b53993b",
+        "wy": "00b2f7fbadf3a661203894df4013ea6759e45aa9009a07d6ed84624fdce01526a6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000443f43ad13fd4198b2810f20d00f306c365a64f4621784da4280e452c0b53993bb2f7fbadf3a661203894df4013ea6759e45aa9009a07d6ed84624fdce01526a6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQ/Q60T/UGYsoEPINAPMGw2WmT0YheE2k\nKA5FLAtTmTuy9/ut86ZhIDiU30AT6mdZ5FqpAJoH1u2EYk/c4BUmpg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 368,
+          "comment": "s is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020102022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd04917c8",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047d32a05199975a2f5d473b879af0f75d577402f528757fa3a92928652b4d817db8000cc7d3f91680180a66f397e2e0345da5a815da3a263e8438467144af1b69",
+        "wx": "7d32a05199975a2f5d473b879af0f75d577402f528757fa3a92928652b4d817d",
+        "wy": "00b8000cc7d3f91680180a66f397e2e0345da5a815da3a263e8438467144af1b69"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047d32a05199975a2f5d473b879af0f75d577402f528757fa3a92928652b4d817db8000cc7d3f91680180a66f397e2e0345da5a815da3a263e8438467144af1b69",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEfTKgUZmXWi9dRzuHmvD3XVd0AvUodX+j\nqSkoZStNgX24AAzH0/kWgBgKZvOX4uA0XaWoFdo6Jj6EOEZxRK8baQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 369,
+          "comment": "small r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302702020101022100c58b162c58b162c58b162c58b162c58a1b242973853e16db75c8a1a71da4d39d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04eeeea2cb300c44bcc0817aa83138b5f6ea591e11f5aefb3dc1be09484f8844a80fc86e7eab9f4dde612d0aa7e123f36bac7dc95287e34a22daf4a114db47b333",
+        "wx": "00eeeea2cb300c44bcc0817aa83138b5f6ea591e11f5aefb3dc1be09484f8844a8",
+        "wy": "0fc86e7eab9f4dde612d0aa7e123f36bac7dc95287e34a22daf4a114db47b333"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004eeeea2cb300c44bcc0817aa83138b5f6ea591e11f5aefb3dc1be09484f8844a80fc86e7eab9f4dde612d0aa7e123f36bac7dc95287e34a22daf4a114db47b333",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7u6iyzAMRLzAgXqoMTi19upZHhH1rvs9\nwb4JSE+IRKgPyG5+q59N3mEtCqfhI/NrrH3JUofjSiLa9KEU20ezMw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 370,
+          "comment": "smallish r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302c02072d9b4d347952cc022100fcbc5103d0da267477d1791461cf2aa44bf9d43198f79507bd8779d69a13108e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dfba55134a9570020c097af4b60a2fbeabbe21998a2f30c35afce9b2f712d0b75d3d79e68248a21961256a0b542741fe181e6a7f7fc4187c16dcce39316a7a8d",
+        "wx": "00dfba55134a9570020c097af4b60a2fbeabbe21998a2f30c35afce9b2f712d0b7",
+        "wy": "5d3d79e68248a21961256a0b542741fe181e6a7f7fc4187c16dcce39316a7a8d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dfba55134a9570020c097af4b60a2fbeabbe21998a2f30c35afce9b2f712d0b75d3d79e68248a21961256a0b542741fe181e6a7f7fc4187c16dcce39316a7a8d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE37pVE0qVcAIMCXr0tgovvqu+IZmKLzDD\nWvzpsvcS0LddPXnmgkiiGWElagtUJ0H+GB5qf3/EGHwW3M45MWp6jQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 371,
+          "comment": "100-bit r and small s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3032020d1033e67e37b32b445580bf4efc022100906f906f906f906f906f906f906f906ed8e426f7b1968c35a204236a579723d2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047e7474d27df26ce4fadd81c950c3bd2827d7e73d2f4be93d55e99cbf1754070309acac087399ecd1afd3dce0355fb4a76f969f5d46ed68f70fc2d920ae63ce80",
+        "wx": "7e7474d27df26ce4fadd81c950c3bd2827d7e73d2f4be93d55e99cbf17540703",
+        "wy": "09acac087399ecd1afd3dce0355fb4a76f969f5d46ed68f70fc2d920ae63ce80"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047e7474d27df26ce4fadd81c950c3bd2827d7e73d2f4be93d55e99cbf1754070309acac087399ecd1afd3dce0355fb4a76f969f5d46ed68f70fc2d920ae63ce80",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEfnR00n3ybOT63YHJUMO9KCfX5z0vS+k9\nVemcvxdUBwMJrKwIc5ns0a/T3OA1X7Snb5afXUbtaPcPwtkgrmPOgA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 372,
+          "comment": "small r and 100 bit s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020201010220783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0436ab43c27ac8bae06ccd37c2135fb5d1959311aa206b8ff911066a7fba55a806307355cabf2af7d22e8d49bbfafc6e724f64cbb2fa5153a048344e323a809391",
+        "wx": "36ab43c27ac8bae06ccd37c2135fb5d1959311aa206b8ff911066a7fba55a806",
+        "wy": "307355cabf2af7d22e8d49bbfafc6e724f64cbb2fa5153a048344e323a809391"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000436ab43c27ac8bae06ccd37c2135fb5d1959311aa206b8ff911066a7fba55a806307355cabf2af7d22e8d49bbfafc6e724f64cbb2fa5153a048344e323a809391",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAENqtDwnrIuuBszTfCE1+10ZWTEaoga4/5\nEQZqf7pVqAYwc1XKvyr30i6NSbv6/G5yT2TLsvpRU6BINE4yOoCTkQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 373,
+          "comment": "100-bit r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3031020d062522bbd3ecbe7c39e93e7c260220783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049b9e76adb9164075e661c4462ee3ab841c60f6820efb970822b0e54f8333c41a9704f9937ae8fedf55fc03405941e66ded639d536ff725ff8abf0d889fcec0cb",
+        "wx": "009b9e76adb9164075e661c4462ee3ab841c60f6820efb970822b0e54f8333c41a",
+        "wy": "009704f9937ae8fedf55fc03405941e66ded639d536ff725ff8abf0d889fcec0cb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049b9e76adb9164075e661c4462ee3ab841c60f6820efb970822b0e54f8333c41a9704f9937ae8fedf55fc03405941e66ded639d536ff725ff8abf0d889fcec0cb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEm552rbkWQHXmYcRGLuOrhBxg9oIO+5cI\nIrDlT4MzxBqXBPmTeuj+31X8A0BZQeZt7WOdU2/3Jf+Kvw2In87Ayw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 374,
+          "comment": "r and s^-1 are close to n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03640c1022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0462e9bcb187c62b86f755e4cc9200a6818d7de643278acabc66d3b0d60beb7f8abe839dbd89b4935883c08fa0dd7e5b21740d4c27d1d778c3e33fbbc6ec1d2a7a",
+        "wx": "62e9bcb187c62b86f755e4cc9200a6818d7de643278acabc66d3b0d60beb7f8a",
+        "wy": "00be839dbd89b4935883c08fa0dd7e5b21740d4c27d1d778c3e33fbbc6ec1d2a7a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000462e9bcb187c62b86f755e4cc9200a6818d7de643278acabc66d3b0d60beb7f8abe839dbd89b4935883c08fa0dd7e5b21740d4c27d1d778c3e33fbbc6ec1d2a7a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYum8sYfGK4b3VeTMkgCmgY195kMnisq8\nZtOw1gvrf4q+g529ibSTWIPAj6DdflshdA1MJ9HXeMPjP7vG7B0qeg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 375,
+          "comment": "r and s are 64-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30160209009c44febf31c3594d020900839ed28247c2b06b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ac50a3a818f4c94a40bdf2f5236a4e17c674a6bc59278da694a57d8968acbd53ae77d279a38c3a277dc70c7caf5624f358649968c8c375a7b9846535cf6b29b8",
+        "wx": "00ac50a3a818f4c94a40bdf2f5236a4e17c674a6bc59278da694a57d8968acbd53",
+        "wy": "00ae77d279a38c3a277dc70c7caf5624f358649968c8c375a7b9846535cf6b29b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ac50a3a818f4c94a40bdf2f5236a4e17c674a6bc59278da694a57d8968acbd53ae77d279a38c3a277dc70c7caf5624f358649968c8c375a7b9846535cf6b29b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErFCjqBj0yUpAvfL1I2pOF8Z0prxZJ42m\nlKV9iWisvVOud9J5o4w6J33HDHyvViTzWGSZaMjDdae5hGU1z2spuA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 376,
+          "comment": "r and s are 100-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "301e020d09df8b682430beef6f5fd7c7cf020d0fd0a62e13778f4222a0d61c8a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044d913e392004f6a3bc68de5800f022f3399b10192d50cdb4d8159a20b322765439a999e57fcad59f6152ec4b644cdd6cfe8db85452cdcf591e27d64a8ea1c272",
+        "wx": "4d913e392004f6a3bc68de5800f022f3399b10192d50cdb4d8159a20b3227654",
+        "wy": "39a999e57fcad59f6152ec4b644cdd6cfe8db85452cdcf591e27d64a8ea1c272"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044d913e392004f6a3bc68de5800f022f3399b10192d50cdb4d8159a20b322765439a999e57fcad59f6152ec4b644cdd6cfe8db85452cdcf591e27d64a8ea1c272",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAETZE+OSAE9qO8aN5YAPAi8zmbEBktUM20\n2BWaILMidlQ5qZnlf8rVn2FS7EtkTN1s/o24VFLNz1keJ9ZKjqHCcg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 377,
+          "comment": "r and s are 128-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30260211008a598e563a89f526c32ebec8de26367a02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dd7faf8855a2593a5dbe970ad7abbab3e4e2031a1f1b683e2a982393197d30756483257650c599ff82753dea3d3051f45e5d3f080b5f763bed77a3c4b4799034",
+        "wx": "00dd7faf8855a2593a5dbe970ad7abbab3e4e2031a1f1b683e2a982393197d3075",
+        "wy": "6483257650c599ff82753dea3d3051f45e5d3f080b5f763bed77a3c4b4799034"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dd7faf8855a2593a5dbe970ad7abbab3e4e2031a1f1b683e2a982393197d30756483257650c599ff82753dea3d3051f45e5d3f080b5f763bed77a3c4b4799034",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3X+viFWiWTpdvpcK16u6s+TiAxofG2g+\nKpgjkxl9MHVkgyV2UMWZ/4J1Peo9MFH0Xl0/CAtfdjvtd6PEtHmQNA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 378,
+          "comment": "r and s are 160-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0bdf021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044100635e830522797ac10d2ea8275694b99c1f862a885a9d2d45185303bfd0800183ffcffb6fdb15954367a1641e6e9b65695ffc887946ba0d51e64f08f753da",
+        "wx": "4100635e830522797ac10d2ea8275694b99c1f862a885a9d2d45185303bfd080",
+        "wy": "0183ffcffb6fdb15954367a1641e6e9b65695ffc887946ba0d51e64f08f753da"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044100635e830522797ac10d2ea8275694b99c1f862a885a9d2d45185303bfd0800183ffcffb6fdb15954367a1641e6e9b65695ffc887946ba0d51e64f08f753da",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQQBjXoMFInl6wQ0uqCdWlLmcH4YqiFqd\nLUUYUwO/0IABg//P+2/bFZVDZ6FkHm6bZWlf/Ih5RroNUeZPCPdT2g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 379,
+          "comment": "s == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1020101",
+          "result": "valid"
+        },
+        {
+          "tcId": 380,
+          "comment": "s == 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1020100",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b4363909e1e962bbe67552ecdb536885409add71a967462ff838e997dbeeaa40d01eea8265137ceb419d7b84044bf09b06c08974660f19d1723bfbb780723f0a",
+        "wx": "00b4363909e1e962bbe67552ecdb536885409add71a967462ff838e997dbeeaa40",
+        "wy": "00d01eea8265137ceb419d7b84044bf09b06c08974660f19d1723bfbb780723f0a"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b4363909e1e962bbe67552ecdb536885409add71a967462ff838e997dbeeaa40d01eea8265137ceb419d7b84044bf09b06c08974660f19d1723bfbb780723f0a",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtDY5CeHpYrvmdVLs21NohUCa3XGpZ0Yv\n+Djpl9vuqkDQHuqCZRN860Gde4QES/CbBsCJdGYPGdFyO/u3gHI/Cg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 381,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220419d981c515af8cc82545aac0c85e9e308fbb2eab6acd7ed497e0b4145a18fd9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047dc7901bc8308ce836edfbd9d3a1324c3d04b29be6a31450de3d79905a76704120ac850524b9eb239c8e57de5d91f0158e59705f64d6b741205070ab1748924c",
+        "wx": "7dc7901bc8308ce836edfbd9d3a1324c3d04b29be6a31450de3d79905a767041",
+        "wy": "20ac850524b9eb239c8e57de5d91f0158e59705f64d6b741205070ab1748924c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047dc7901bc8308ce836edfbd9d3a1324c3d04b29be6a31450de3d79905a76704120ac850524b9eb239c8e57de5d91f0158e59705f64d6b741205070ab1748924c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEfceQG8gwjOg27fvZ06EyTD0EspvmoxRQ\n3j15kFp2cEEgrIUFJLnrI5yOV95dkfAVjllwX2TWt0EgUHCrF0iSTA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 382,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102201b21717ad71d23bbac60a9ad0baf75b063c9fdf52a00ebf99d022172910993c9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0456dad3a5ad3be19e358b3a6d6f20c8f888812b7c77aae353db4731e9061dec8fe03740ee7d05adcc7e9a2cd8fb076c4377daa07b3d7dd4187a63ee641ee302df",
+        "wx": "56dad3a5ad3be19e358b3a6d6f20c8f888812b7c77aae353db4731e9061dec8f",
+        "wy": "00e03740ee7d05adcc7e9a2cd8fb076c4377daa07b3d7dd4187a63ee641ee302df"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000456dad3a5ad3be19e358b3a6d6f20c8f888812b7c77aae353db4731e9061dec8fe03740ee7d05adcc7e9a2cd8fb076c4377daa07b3d7dd4187a63ee641ee302df",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEVtrTpa074Z41izptbyDI+IiBK3x3quNT\n20cx6QYd7I/gN0DufQWtzH6aLNj7B2xDd9qgez191Bh6Y+5kHuMC3w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 383,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102202f588f66018f3dd14db3e28e77996487e32486b521ed8e5a20f06591951777e9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0424c3b0d417522a2b755a7d9cd9b3e7195d5c6edad701bb33c3b923719955d7de9d1723775d4985a0afef06b996bac89302fa9b15509acc31acdda61cb556d0ff",
+        "wx": "24c3b0d417522a2b755a7d9cd9b3e7195d5c6edad701bb33c3b923719955d7de",
+        "wy": "009d1723775d4985a0afef06b996bac89302fa9b15509acc31acdda61cb556d0ff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000424c3b0d417522a2b755a7d9cd9b3e7195d5c6edad701bb33c3b923719955d7de9d1723775d4985a0afef06b996bac89302fa9b15509acc31acdda61cb556d0ff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJMOw1BdSKit1Wn2c2bPnGV1cbtrXAbsz\nw7kjcZlV196dFyN3XUmFoK/vBrmWusiTAvqbFVCazDGs3aYctVbQ/w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 384,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220091a08870ff4daf9123b30c20e8c4fc8505758dcf4074fcaff2170c9bfcf74f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044a6f47dd683ac2721b3d3120f9dc756a415f1ac0a0b6c9bdff741e2d45a12b17fc59515ecd3f39c3f0912bc80d1643344b1db50d9a2f354f7c98ffadeec65597",
+        "wx": "4a6f47dd683ac2721b3d3120f9dc756a415f1ac0a0b6c9bdff741e2d45a12b17",
+        "wy": "00fc59515ecd3f39c3f0912bc80d1643344b1db50d9a2f354f7c98ffadeec65597"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044a6f47dd683ac2721b3d3120f9dc756a415f1ac0a0b6c9bdff741e2d45a12b17fc59515ecd3f39c3f0912bc80d1643344b1db50d9a2f354f7c98ffadeec65597",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESm9H3Wg6wnIbPTEg+dx1akFfGsCgtsm9\n/3QeLUWhKxf8WVFezT85w/CRK8gNFkM0Sx21DZovNU98mP+t7sZVlw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 385,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102207c370dc0ce8c59a8b273cba44a7c1191fc3186dc03cab96b0567312df0d0b250",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0450fafcdf2cc4e4e9eeec7a48bf54ee6be8a79263ce7008b380fdb8e56b3dd85f974e8efe7ff7360289891cc7576cd5c1769cb104f57283d5ccfb31e3149e36b4",
+        "wx": "50fafcdf2cc4e4e9eeec7a48bf54ee6be8a79263ce7008b380fdb8e56b3dd85f",
+        "wy": "00974e8efe7ff7360289891cc7576cd5c1769cb104f57283d5ccfb31e3149e36b4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000450fafcdf2cc4e4e9eeec7a48bf54ee6be8a79263ce7008b380fdb8e56b3dd85f974e8efe7ff7360289891cc7576cd5c1769cb104f57283d5ccfb31e3149e36b4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUPr83yzE5Onu7HpIv1Tua+inkmPOcAiz\ngP245Ws92F+XTo7+f/c2AomJHMdXbNXBdpyxBPVyg9XM+zHjFJ42tA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 386,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022070b59a7d1ee77a2f9e0491c2a7cfcd0ed04df4a35192f6132dcc668c79a6160e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ad297d34f9948a22b5dbb29eb63b509456976b78fe5239314161dede7e944622614daf40d80bff1e9d8cbb7504ea0dbb1bf918400049372bec5947cf58710013",
+        "wx": "00ad297d34f9948a22b5dbb29eb63b509456976b78fe5239314161dede7e944622",
+        "wy": "614daf40d80bff1e9d8cbb7504ea0dbb1bf918400049372bec5947cf58710013"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ad297d34f9948a22b5dbb29eb63b509456976b78fe5239314161dede7e944622614daf40d80bff1e9d8cbb7504ea0dbb1bf918400049372bec5947cf58710013",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErSl9NPmUiiK127KetjtQlFaXa3j+Ujkx\nQWHe3n6URiJhTa9A2Av/Hp2Mu3UE6g27G/kYQABJNyvsWUfPWHEAEw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 387,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102202736d76e412246e097148e2bf62915614eb7c428913a58eb5e9cd4674a9423de",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0442c3a5a08f26cbe662cef0df4efa74766180b3ff9a52352083b2223f3f819d8c9734ff777272f9d5aee9cc6718aee8b48acde93d46db5ac1ecd9bee20da8a71e",
+        "wx": "42c3a5a08f26cbe662cef0df4efa74766180b3ff9a52352083b2223f3f819d8c",
+        "wy": "009734ff777272f9d5aee9cc6718aee8b48acde93d46db5ac1ecd9bee20da8a71e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000442c3a5a08f26cbe662cef0df4efa74766180b3ff9a52352083b2223f3f819d8c9734ff777272f9d5aee9cc6718aee8b48acde93d46db5ac1ecd9bee20da8a71e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQsOloI8my+ZizvDfTvp0dmGAs/+aUjUg\ng7IiPz+BnYyXNP93cnL51a7pzGcYrui0is3pPUbbWsHs2b7iDainHg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 388,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102204a1e12831fbe93627b02d6e7f24bccdd6ef4b2d0f46739eaf3b1eaf0ca117770",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042781ed4b950bc8637b2e1ed175073ca805f4ee0841b81d4e4526ab97508b8d3662d71c351e27cbd7a3425a9a5eaf73889a6e35d886af15f7c5e8356b4ccd5698",
+        "wx": "2781ed4b950bc8637b2e1ed175073ca805f4ee0841b81d4e4526ab97508b8d36",
+        "wy": "62d71c351e27cbd7a3425a9a5eaf73889a6e35d886af15f7c5e8356b4ccd5698"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042781ed4b950bc8637b2e1ed175073ca805f4ee0841b81d4e4526ab97508b8d3662d71c351e27cbd7a3425a9a5eaf73889a6e35d886af15f7c5e8356b4ccd5698",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJ4HtS5ULyGN7Lh7RdQc8qAX07ghBuB1O\nRSarl1CLjTZi1xw1HifL16NCWpper3OImm412IavFffF6DVrTM1WmA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 389,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022006c778d4dfff7dee06ed88bc4e0ed34fc553aad67caf796f2a1c6487c1b2e877",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04aedc9a490c28d9b82360da16b988795f8ffd392e109142304468b008ffae4dc5bb9864173d258b243eb633794181838366826ac42229b1906d5f089add9a60ba",
+        "wx": "00aedc9a490c28d9b82360da16b988795f8ffd392e109142304468b008ffae4dc5",
+        "wy": "00bb9864173d258b243eb633794181838366826ac42229b1906d5f089add9a60ba"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004aedc9a490c28d9b82360da16b988795f8ffd392e109142304468b008ffae4dc5bb9864173d258b243eb633794181838366826ac42229b1906d5f089add9a60ba",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErtyaSQwo2bgjYNoWuYh5X4/9OS4QkUIw\nRGiwCP+uTcW7mGQXPSWLJD62M3lBgYODZoJqxCIpsZBtXwia3Zpgug==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 390,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102204de459ef9159afa057feb3ec40fef01c45b809f4ab296ea48c206d4249a2b451",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040094bb568a8b2503af9510148a031a8c87ffa6273ee32e94ffc09417bff06dc8b7b07744c7e9d430669b3ef564381b17f522c0e79854e76685e59a409ab32bac",
+        "wx": "0094bb568a8b2503af9510148a031a8c87ffa6273ee32e94ffc09417bff06dc8",
+        "wy": "00b7b07744c7e9d430669b3ef564381b17f522c0e79854e76685e59a409ab32bac"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040094bb568a8b2503af9510148a031a8c87ffa6273ee32e94ffc09417bff06dc8b7b07744c7e9d430669b3ef564381b17f522c0e79854e76685e59a409ab32bac",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAJS7VoqLJQOvlRAUigMajIf/pic+4y6U\n/8CUF7/wbci3sHdEx+nUMGabPvVkOBsX9SLA55hU52aF5ZpAmrMrrA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 391,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220745d294978007302033502e1acc48b63ae6500be43adbea1b258d6b423dbb416",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0402d10f15c8be7aa2626a513b6576812b0e4c9c883d473492df0e4c6290b4e999c769c9c7bacc2e22b198a4791838a93fb21ff4f074819b379056935822045a2d",
+        "wx": "02d10f15c8be7aa2626a513b6576812b0e4c9c883d473492df0e4c6290b4e999",
+        "wy": "00c769c9c7bacc2e22b198a4791838a93fb21ff4f074819b379056935822045a2d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000402d10f15c8be7aa2626a513b6576812b0e4c9c883d473492df0e4c6290b4e999c769c9c7bacc2e22b198a4791838a93fb21ff4f074819b379056935822045a2d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAtEPFci+eqJialE7ZXaBKw5MnIg9RzSS\n3w5MYpC06ZnHacnHuswuIrGYpHkYOKk/sh/08HSBmzeQVpNYIgRaLQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 392,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102207b2a785e3896f59b2d69da57648e80ad3c133a750a2847fd2098ccd902042b6c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d89e4028c751e7602ff5b741916c951a1d79713787324663787a2d54f686c0798af86cb644647beaebd782ce47b1ece564b4d01e29b2ca16d8362c90b9c3ade5",
+        "wx": "00d89e4028c751e7602ff5b741916c951a1d79713787324663787a2d54f686c079",
+        "wy": "008af86cb644647beaebd782ce47b1ece564b4d01e29b2ca16d8362c90b9c3ade5"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d89e4028c751e7602ff5b741916c951a1d79713787324663787a2d54f686c0798af86cb644647beaebd782ce47b1ece564b4d01e29b2ca16d8362c90b9c3ade5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE2J5AKMdR52Av9bdBkWyVGh15cTeHMkZj\neHotVPaGwHmK+Gy2RGR76uvXgs5HsezlZLTQHimyyhbYNiyQucOt5Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 393,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022071ae94a72ca896875e7aa4a4c3d29afdb4b35b6996273e63c47ac519256c5eb1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044b600b61cd33aa10be6ceccba325185d4bebbfd0894e01da26edf07441148a04f218539dcf44401fec04117a1492a3466144c7de5852b106185e6d7cd8cee18b",
+        "wx": "4b600b61cd33aa10be6ceccba325185d4bebbfd0894e01da26edf07441148a04",
+        "wy": "00f218539dcf44401fec04117a1492a3466144c7de5852b106185e6d7cd8cee18b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044b600b61cd33aa10be6ceccba325185d4bebbfd0894e01da26edf07441148a04f218539dcf44401fec04117a1492a3466144c7de5852b106185e6d7cd8cee18b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAES2ALYc0zqhC+bOzLoyUYXUvrv9CJTgHa\nJu3wdEEUigTyGFOdz0RAH+wEEXoUkqNGYUTH3lhSsQYYXm182M7hiw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 394,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102200fa527fa7343c0bc9ec35a6278bfbff4d83301b154fc4bd14aee7eb93445b5f9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ed6b2238c0b17532cf7df5561669dd13c81a1bc685405deacaef4372fb1676cea3e09b1ee362051c12edf4d44f91564d6ae8a5da65b8a1344cfdbd00162ea943",
+        "wx": "00ed6b2238c0b17532cf7df5561669dd13c81a1bc685405deacaef4372fb1676ce",
+        "wy": "00a3e09b1ee362051c12edf4d44f91564d6ae8a5da65b8a1344cfdbd00162ea943"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ed6b2238c0b17532cf7df5561669dd13c81a1bc685405deacaef4372fb1676cea3e09b1ee362051c12edf4d44f91564d6ae8a5da65b8a1344cfdbd00162ea943",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7WsiOMCxdTLPffVWFmndE8gaG8aFQF3q\nyu9DcvsWds6j4Jse42IFHBLt9NRPkVZNauil2mW4oTRM/b0AFi6pQw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 395,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102206539c0adadd0525ff42622164ce9314348bd0863b4c80e936b23ca0414264671",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0401453f1e605e780faa44d5839a9921ff44465fbccf6df1ec91c77a1e4ed533bd73f834f0749cbb7939ea7fa8c5607a6f2d4c9137a8240f502536ce1f9fd70f4e",
+        "wx": "01453f1e605e780faa44d5839a9921ff44465fbccf6df1ec91c77a1e4ed533bd",
+        "wy": "73f834f0749cbb7939ea7fa8c5607a6f2d4c9137a8240f502536ce1f9fd70f4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000401453f1e605e780faa44d5839a9921ff44465fbccf6df1ec91c77a1e4ed533bd73f834f0749cbb7939ea7fa8c5607a6f2d4c9137a8240f502536ce1f9fd70f4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAUU/HmBeeA+qRNWDmpkh/0RGX7zPbfHs\nkcd6Hk7VM71z+DTwdJy7eTnqf6jFYHpvLUyRN6gkD1AlNs4fn9cPTg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 396,
+          "comment": "point at infinity during verify",
+          "flags": [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041475141a66444a621e2dad47c356f9c7128a72bdd199a08932651044ee14021691be28607690d4404802e4c0c9201d0955231baed395ccfa433a404086aa5937",
+        "wx": "1475141a66444a621e2dad47c356f9c7128a72bdd199a08932651044ee140216",
+        "wy": "0091be28607690d4404802e4c0c9201d0955231baed395ccfa433a404086aa5937"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041475141a66444a621e2dad47c356f9c7128a72bdd199a08932651044ee14021691be28607690d4404802e4c0c9201d0955231baed395ccfa433a404086aa5937",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFHUUGmZESmIeLa1Hw1b5xxKKcr3RmaCJ\nMmUQRO4UAhaRvihgdpDUQEgC5MDJIB0JVSMbrtOVzPpDOkBAhqpZNw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 397,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e88beb5bc33a5a03a2dc9b13dfa76972ab97c50ea3cd41c2d50699a163d8bc1cc70052f6563a04ebdb0c6131206e1ceb7c233b5b562bc605bbf71a3b9bbed9f1",
+        "wx": "00e88beb5bc33a5a03a2dc9b13dfa76972ab97c50ea3cd41c2d50699a163d8bc1c",
+        "wy": "00c70052f6563a04ebdb0c6131206e1ceb7c233b5b562bc605bbf71a3b9bbed9f1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e88beb5bc33a5a03a2dc9b13dfa76972ab97c50ea3cd41c2d50699a163d8bc1cc70052f6563a04ebdb0c6131206e1ceb7c233b5b562bc605bbf71a3b9bbed9f1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE6IvrW8M6WgOi3JsT36dpcquXxQ6jzUHC\n1QaZoWPYvBzHAFL2VjoE69sMYTEgbhzrfCM7W1YrxgW79xo7m77Z8Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 398,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044615410b5a898db0019843b89493f8fb67417b534833b434b5bbe2174cd368797a98eb7c1e94b1ba077e6234faa80cced7bf98425e6ac1fa793198b6f2d9c2ee",
+        "wx": "4615410b5a898db0019843b89493f8fb67417b534833b434b5bbe2174cd36879",
+        "wy": "7a98eb7c1e94b1ba077e6234faa80cced7bf98425e6ac1fa793198b6f2d9c2ee"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044615410b5a898db0019843b89493f8fb67417b534833b434b5bbe2174cd368797a98eb7c1e94b1ba077e6234faa80cced7bf98425e6ac1fa793198b6f2d9c2ee",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAERhVBC1qJjbABmEO4lJP4+2dBe1NIM7Q0\ntbviF0zTaHl6mOt8HpSxugd+YjT6qAzO17+YQl5qwfp5MZi28tnC7g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 399,
+          "comment": "u1 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022100c492aebe9f1b702c6747fbd016604d49ad6beb2c57a29c0587bb76a07c988b1a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040f98a9b3dc01ddfb38129c112d80422ad5ad5d71c4b1baddbe351b71b93998c0630a60be467dcd022cfabcdd20d9eca85542219460b7c3e5e06352af8785ec1d",
+        "wx": "0f98a9b3dc01ddfb38129c112d80422ad5ad5d71c4b1baddbe351b71b93998c0",
+        "wy": "630a60be467dcd022cfabcdd20d9eca85542219460b7c3e5e06352af8785ec1d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040f98a9b3dc01ddfb38129c112d80422ad5ad5d71c4b1baddbe351b71b93998c0630a60be467dcd022cfabcdd20d9eca85542219460b7c3e5e06352af8785ec1d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAED5ips9wB3fs4EpwRLYBCKtWtXXHEsbrd\nvjUbcbk5mMBjCmC+Rn3NAiz6vN0g2eyoVUIhlGC3w+XgY1Kvh4XsHQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 400,
+          "comment": "u1 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b802203b6d514160e48fd398b8042fe99fb2b50d42f1ba57a604363816e7ec539db627",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0407c3f8a58910b348910113b8306f810e8ef4245b09de62b96754ac54f8ef24c5d4bece34aba6160c758d1c90561089e02af94e7c38a3f77c7d432010e2d59297",
+        "wx": "07c3f8a58910b348910113b8306f810e8ef4245b09de62b96754ac54f8ef24c5",
+        "wy": "00d4bece34aba6160c758d1c90561089e02af94e7c38a3f77c7d432010e2d59297"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000407c3f8a58910b348910113b8306f810e8ef4245b09de62b96754ac54f8ef24c5d4bece34aba6160c758d1c90561089e02af94e7c38a3f77c7d432010e2d59297",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEB8P4pYkQs0iRARO4MG+BDo70JFsJ3mK5\nZ1SsVPjvJMXUvs40q6YWDHWNHJBWEIngKvlOfDij93x9QyAQ4tWSlw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 401,
+          "comment": "u2 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048e1ad03a1afb457576703eca8db21db7c19e38f43822b1de029790cb33ca95fe5078b7056f61584edd1dc0d0aa3173787e224551ec6fce2c9c26df7d73460ecd",
+        "wx": "008e1ad03a1afb457576703eca8db21db7c19e38f43822b1de029790cb33ca95fe",
+        "wy": "5078b7056f61584edd1dc0d0aa3173787e224551ec6fce2c9c26df7d73460ecd"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048e1ad03a1afb457576703eca8db21db7c19e38f43822b1de029790cb33ca95fe5078b7056f61584edd1dc0d0aa3173787e224551ec6fce2c9c26df7d73460ecd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEjhrQOhr7RXV2cD7KjbIdt8GeOPQ4IrHe\nApeQyzPKlf5QeLcFb2FYTt0dwNCqMXN4fiJFUexvziycJt99c0YOzQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 402,
+          "comment": "u2 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9d1c9e899ca306ad27fe1945de0242b89",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b254cb64dc9886d258c77d2f22245e9240385c375ecf58b3f3c47addca98637d87897a37bedd27856363e99ef88a1f4780f40d51dbf2b673a33d455080a79056",
+        "wx": "00b254cb64dc9886d258c77d2f22245e9240385c375ecf58b3f3c47addca98637d",
+        "wy": "0087897a37bedd27856363e99ef88a1f4780f40d51dbf2b673a33d455080a79056"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b254cb64dc9886d258c77d2f22245e9240385c375ecf58b3f3c47addca98637d87897a37bedd27856363e99ef88a1f4780f40d51dbf2b673a33d455080a79056",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEslTLZNyYhtJYx30vIiRekkA4XDdez1iz\n88R63cqYY32HiXo3vt0nhWNj6Z74ih9HgPQNUdvytnOjPUVQgKeQVg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 403,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02210096db8f94dfb3d00ecd17fe9ab22019c2cd5e42b1024e696b17d9f1b9c444eec9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046a3e00ea396499ea1b2445c8138528ea5465da376fc0185b41acc7423fcf301ad912ae4aad92eff7433222b185442739d43e0634ee5b0b59ec545f0bd21ab921",
+        "wx": "6a3e00ea396499ea1b2445c8138528ea5465da376fc0185b41acc7423fcf301a",
+        "wy": "00d912ae4aad92eff7433222b185442739d43e0634ee5b0b59ec545f0bd21ab921"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046a3e00ea396499ea1b2445c8138528ea5465da376fc0185b41acc7423fcf301ad912ae4aad92eff7433222b185442739d43e0634ee5b0b59ec545f0bd21ab921",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEaj4A6jlkmeobJEXIE4Uo6lRl2jdvwBhb\nQazHQj/PMBrZEq5KrZLv90MyIrGFRCc51D4GNO5bC1nsVF8L0hq5IQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 404,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202fe5caa8b5ba8fbf9fbffd9b874c3826004a38d2ea1af2060e744ce16deb275e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0458314ecd80245960a53ec7ffacae63745c465474e02a46f6c6f13388a784fe45e4ae69717db5492bb4c9584717655710c7a1c51ebef67a8554988e92dd59d67f",
+        "wx": "58314ecd80245960a53ec7ffacae63745c465474e02a46f6c6f13388a784fe45",
+        "wy": "00e4ae69717db5492bb4c9584717655710c7a1c51ebef67a8554988e92dd59d67f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000458314ecd80245960a53ec7ffacae63745c465474e02a46f6c6f13388a784fe45e4ae69717db5492bb4c9584717655710c7a1c51ebef67a8554988e92dd59d67f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEWDFOzYAkWWClPsf/rK5jdFxGVHTgKkb2\nxvEziKeE/kXkrmlxfbVJK7TJWEcXZVcQx6HFHr72eoVUmI6S3VnWfw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 405,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100ebc70148775c0588c86343020844f8714aa2b44b1e59c96364683def955bacea",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0461dcd030c448a718b72aea6dd6d2d976935ac3dc19015c12c49240c495cc7be26fe8a5bada1e942c67bcfdd726bfb0e137f666a479a9366eea5ada79fe440250",
+        "wx": "61dcd030c448a718b72aea6dd6d2d976935ac3dc19015c12c49240c495cc7be2",
+        "wy": "6fe8a5bada1e942c67bcfdd726bfb0e137f666a479a9366eea5ada79fe440250"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000461dcd030c448a718b72aea6dd6d2d976935ac3dc19015c12c49240c495cc7be26fe8a5bada1e942c67bcfdd726bfb0e137f666a479a9366eea5ada79fe440250",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYdzQMMRIpxi3Kupt1tLZdpNaw9wZAVwS\nxJJAxJXMe+Jv6KW62h6ULGe8/dcmv7DhN/ZmpHmpNm7qWtp5/kQCUA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 406,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220678faec65678ca993b6d514160e48fd3151dc8a4ee82b9061fb9e2ec68567ca5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04103e2bfe5515dc3f7e7f58fad53722e57654268e7f4a80543ab50faba0ae6c4fe57729b60e604ef8ec64833ec2c31e64cfa94e929a3c2efbbe249f37e1b44e2b",
+        "wx": "103e2bfe5515dc3f7e7f58fad53722e57654268e7f4a80543ab50faba0ae6c4f",
+        "wy": "00e57729b60e604ef8ec64833ec2c31e64cfa94e929a3c2efbbe249f37e1b44e2b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004103e2bfe5515dc3f7e7f58fad53722e57654268e7f4a80543ab50faba0ae6c4fe57729b60e604ef8ec64833ec2c31e64cfa94e929a3c2efbbe249f37e1b44e2b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEED4r/lUV3D9+f1j61Tci5XZUJo5/SoBU\nOrUPq6CubE/ldym2DmBO+Oxkgz7Cwx5kz6lOkpo8Lvu+JJ834bROKw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 407,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100faec65678ca993b6d514160e48fd398a41655aaa4dc3df7ac55b27a288d43388",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fdeaf5f60c791aaa116327296264c84f6ee569fd2288c95e7abd23a613533c9dafbfec7d9351dedf01cac0412d502e6b4c7531300faa0805551b89a21a296f60",
+        "wx": "00fdeaf5f60c791aaa116327296264c84f6ee569fd2288c95e7abd23a613533c9d",
+        "wy": "00afbfec7d9351dedf01cac0412d502e6b4c7531300faa0805551b89a21a296f60"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fdeaf5f60c791aaa116327296264c84f6ee569fd2288c95e7abd23a613533c9dafbfec7d9351dedf01cac0412d502e6b4c7531300faa0805551b89a21a296f60",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE/er19gx5GqoRYycpYmTIT27laf0iiMle\ner0jphNTPJ2vv+x9k1He3wHKwEEtUC5rTHUxMA+qCAVVG4miGilvYA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 408,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100f5d8cacf1953276daa282c1c91fa7315c81bd86dec3f1eb9cae3f0b8417225cf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043f75814e8cdb09ec839973f41f5701e4361033792cc24cadafbc94f594389944ca8463cf5b12e1d88f23918b1a35cf597531a12cd722abf4edc9f8f07890fa7b",
+        "wx": "3f75814e8cdb09ec839973f41f5701e4361033792cc24cadafbc94f594389944",
+        "wy": "00ca8463cf5b12e1d88f23918b1a35cf597531a12cd722abf4edc9f8f07890fa7b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043f75814e8cdb09ec839973f41f5701e4361033792cc24cadafbc94f594389944ca8463cf5b12e1d88f23918b1a35cf597531a12cd722abf4edc9f8f07890fa7b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEP3WBTozbCeyDmXP0H1cB5DYQM3kswkyt\nr7yU9ZQ4mUTKhGPPWxLh2I8jkYsaNc9ZdTGhLNciq/TtyfjweJD6ew==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 409,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02205678ca993b6d514160e48fd398b8042f7bbcf16da5178dc796ef83a77b6059ba",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e67ce84bb63666d0c6fe6a8b04e6257aa4049d2820b33daacbd99a3336a9a3a297d28fdf67ea1e921380f323f9a2827b9659b79a9c867dc8363547197bb51283",
+        "wx": "00e67ce84bb63666d0c6fe6a8b04e6257aa4049d2820b33daacbd99a3336a9a3a2",
+        "wy": "0097d28fdf67ea1e921380f323f9a2827b9659b79a9c867dc8363547197bb51283"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e67ce84bb63666d0c6fe6a8b04e6257aa4049d2820b33daacbd99a3336a9a3a297d28fdf67ea1e921380f323f9a2827b9659b79a9c867dc8363547197bb51283",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5nzoS7Y2ZtDG/mqLBOYleqQEnSggsz2q\ny9maMzapo6KX0o/fZ+oekhOA8yP5ooJ7llm3mpyGfcg2NUcZe7USgw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 410,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100b95c4bd1c9e96edb137f6dbf5d4860e823605850b82da484fabaa7a68ee9739f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043747a8c41c79d96874d1023fe5915d8af75c9b207c2be84536735acf7c29b7f1305c3f1681e2a26ae19c9f7e52e4cba3c1a3c2eb1f3a564662242a0aabf1919f",
+        "wx": "3747a8c41c79d96874d1023fe5915d8af75c9b207c2be84536735acf7c29b7f1",
+        "wy": "305c3f1681e2a26ae19c9f7e52e4cba3c1a3c2eb1f3a564662242a0aabf1919f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043747a8c41c79d96874d1023fe5915d8af75c9b207c2be84536735acf7c29b7f1305c3f1681e2a26ae19c9f7e52e4cba3c1a3c2eb1f3a564662242a0aabf1919f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEN0eoxBx52Wh00QI/5ZFdivdcmyB8K+hF\nNnNaz3wpt/EwXD8WgeKiauGcn35S5MujwaPC6x86VkZiJCoKq/GRnw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 411,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220051668895003afbd3824001149f6304d38e6ff342545e9e0ce5236d067cdbdcc",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04039914231dacaa7c6cda74293933151ce4000ed51ffadc291777a252e8bdb4f9476915da31f22b7647b9f8ddc407e5cd75003e95ad402eff542cec2a2915a260",
+        "wx": "039914231dacaa7c6cda74293933151ce4000ed51ffadc291777a252e8bdb4f9",
+        "wy": "476915da31f22b7647b9f8ddc407e5cd75003e95ad402eff542cec2a2915a260"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004039914231dacaa7c6cda74293933151ce4000ed51ffadc291777a252e8bdb4f9476915da31f22b7647b9f8ddc407e5cd75003e95ad402eff542cec2a2915a260",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEA5kUIx2sqnxs2nQpOTMVHOQADtUf+twp\nF3eiUui9tPlHaRXaMfIrdke5+N3EB+XNdQA+la1ALv9ULOwqKRWiYA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 412,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02200a83a4d7833ad1981eb0ccf087c99705fe21a9055e19057b43ff3e151acb550c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a7115d9be02a635a2b6fb286146b9d179a7761e5a83bab5967609933816e2f627e189ef7814f51e177ff4d75cc15a4d7cd7616c60ed217a7aada70f3eaca019c",
+        "wx": "00a7115d9be02a635a2b6fb286146b9d179a7761e5a83bab5967609933816e2f62",
+        "wy": "7e189ef7814f51e177ff4d75cc15a4d7cd7616c60ed217a7aada70f3eaca019c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a7115d9be02a635a2b6fb286146b9d179a7761e5a83bab5967609933816e2f627e189ef7814f51e177ff4d75cc15a4d7cd7616c60ed217a7aada70f3eaca019c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEpxFdm+AqY1orb7KGFGudF5p3YeWoO6tZ\nZ2CZM4FuL2J+GJ73gU9R4Xf/TXXMFaTXzXYWxg7SF6eq2nDz6soBnA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 413,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100843eaa601934e5b3af7adbba478b6830de49ed6e5de7074651a1ad8e24ef8911",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040dffe3c248f260c0f8fbc721561bae785c464e1e17011b10b60169b8e992a5ede1cf121285f5c5e95fa8516d174c9fa0e88f27c0bba582b6866c492980c997e7",
+        "wx": "0dffe3c248f260c0f8fbc721561bae785c464e1e17011b10b60169b8e992a5ed",
+        "wy": "00e1cf121285f5c5e95fa8516d174c9fa0e88f27c0bba582b6866c492980c997e7"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040dffe3c248f260c0f8fbc721561bae785c464e1e17011b10b60169b8e992a5ede1cf121285f5c5e95fa8516d174c9fa0e88f27c0bba582b6866c492980c997e7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEDf/jwkjyYMD4+8chVhuueFxGTh4XARsQ\ntgFpuOmSpe3hzxIShfXF6V+oUW0XTJ+g6I8nwLulgraGbEkpgMmX5w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 414,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022034923835902617f8997400b2a6eff31df6a84d1ad67d1b6853fc366985f8a93c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e3235a0167137f153c56b2ec5c642539c31d86027b7faa4f75707b9e7b1c09d0eda7e7e408abb2513771d36b71f04b5d67065b2270db053a4d988ddda8e2ca0f",
+        "wx": "00e3235a0167137f153c56b2ec5c642539c31d86027b7faa4f75707b9e7b1c09d0",
+        "wy": "00eda7e7e408abb2513771d36b71f04b5d67065b2270db053a4d988ddda8e2ca0f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e3235a0167137f153c56b2ec5c642539c31d86027b7faa4f75707b9e7b1c09d0eda7e7e408abb2513771d36b71f04b5d67065b2270db053a4d988ddda8e2ca0f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4yNaAWcTfxU8VrLsXGQlOcMdhgJ7f6pP\ndXB7nnscCdDtp+fkCKuyUTdx02tx8EtdZwZbInDbBTpNmI3dqOLKDw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 415,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02206924706b204c2ff132e801654ddfe63bed509a35acfa36d0a7f86cd30bf15278",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041cc3e31519a415a09f5d1cce39ecc742071af056b40f4ab2c2411d5e4e81c1f30b78c126cc6da95a93aadf7152bdd2e6318dcfbe79ac1e0f62134c33465c7e0e",
+        "wx": "1cc3e31519a415a09f5d1cce39ecc742071af056b40f4ab2c2411d5e4e81c1f3",
+        "wy": "0b78c126cc6da95a93aadf7152bdd2e6318dcfbe79ac1e0f62134c33465c7e0e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041cc3e31519a415a09f5d1cce39ecc742071af056b40f4ab2c2411d5e4e81c1f30b78c126cc6da95a93aadf7152bdd2e6318dcfbe79ac1e0f62134c33465c7e0e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHMPjFRmkFaCfXRzOOezHQgca8Fa0D0qy\nwkEdXk6BwfMLeMEmzG2pWpOq33FSvdLmMY3PvnmsHg9iE0wzRlx+Dg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 416,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0221009db6a8a0b07247e9cc5c0217f4cfd959e3f8e75083775238fbf4a33c91e9fbb4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c678da720a74e55e804e8fd4aecd17721e9665a9579c7a51131c0ec355b718ade7b9710b10454cc86823115c5b4940e8cec130368519e28c2fc69e1e6095ec06",
+        "wx": "00c678da720a74e55e804e8fd4aecd17721e9665a9579c7a51131c0ec355b718ad",
+        "wy": "00e7b9710b10454cc86823115c5b4940e8cec130368519e28c2fc69e1e6095ec06"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c678da720a74e55e804e8fd4aecd17721e9665a9579c7a51131c0ec355b718ade7b9710b10454cc86823115c5b4940e8cec130368519e28c2fc69e1e6095ec06",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAExnjacgp05V6ATo/Urs0Xch6WZalXnHpR\nExwOw1W3GK3nuXELEEVMyGgjEVxbSUDozsEwNoUZ4owvxp4eYJXsBg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 417,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022075e380a43bae02c46431a18104227c38a5515a258f2ce4b1b2341ef7caadd675",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04694a86dd0dcb0af89b5769f3c6686fe7016a4565b1538f0327693a1d77e50d2024b347593d4dc9038308198dfb09f55a310bac8dd029c9adeed014e1244bf0ea",
+        "wx": "694a86dd0dcb0af89b5769f3c6686fe7016a4565b1538f0327693a1d77e50d20",
+        "wy": "24b347593d4dc9038308198dfb09f55a310bac8dd029c9adeed014e1244bf0ea"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004694a86dd0dcb0af89b5769f3c6686fe7016a4565b1538f0327693a1d77e50d2024b347593d4dc9038308198dfb09f55a310bac8dd029c9adeed014e1244bf0ea",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEaUqG3Q3LCvibV2nzxmhv5wFqRWWxU48D\nJ2k6HXflDSAks0dZPU3JA4MIGY37CfVaMQusjdApya3u0BThJEvw6g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 418,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100d55555555555555555555555555555547c74934474db157d2a8c3f088aced62a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0478031915fc9f0c725ac6e0001978d82544567c6fdac6068637ab8f87a4fc8fc39291e97620aaa2dc5528bb69ba48f12d4448fff2ddb72fa96f84d4d7515d5354",
+        "wx": "78031915fc9f0c725ac6e0001978d82544567c6fdac6068637ab8f87a4fc8fc3",
+        "wy": "009291e97620aaa2dc5528bb69ba48f12d4448fff2ddb72fa96f84d4d7515d5354"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000478031915fc9f0c725ac6e0001978d82544567c6fdac6068637ab8f87a4fc8fc39291e97620aaa2dc5528bb69ba48f12d4448fff2ddb72fa96f84d4d7515d5354",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeAMZFfyfDHJaxuAAGXjYJURWfG/axgaG\nN6uPh6T8j8OSkel2IKqi3FUou2m6SPEtREj/8t23L6lvhNTXUV1TVA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 419,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100c1777c8853938e536213c02464a936000ba1e21c0fc62075d46c624e23b52f31",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e2ef37a5b327ba15ad0ba3a913e34e10f16b4313de90fc647d81e1347810ba86dfeb3ceef841b1164532094c1c248da7d1d019c4ca88836801cdf38f1c9ea484",
+        "wx": "00e2ef37a5b327ba15ad0ba3a913e34e10f16b4313de90fc647d81e1347810ba86",
+        "wy": "00dfeb3ceef841b1164532094c1c248da7d1d019c4ca88836801cdf38f1c9ea484"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e2ef37a5b327ba15ad0ba3a913e34e10f16b4313de90fc647d81e1347810ba86dfeb3ceef841b1164532094c1c248da7d1d019c4ca88836801cdf38f1c9ea484",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4u83pbMnuhWtC6OpE+NOEPFrQxPekPxk\nfYHhNHgQuobf6zzu+EGxFkUyCUwcJI2n0dAZxMqIg2gBzfOPHJ6khA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 420,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022030bbb794db588363b40679f6c182a50d3ce9679acdd3ffbe36d7813dacbdc818",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b72af48bc8d3cccf646bf4d248e59bfb3f4be05a65c6e137dfd33f89ae0538bda5245ea537238f91347a9fa911f93e8d69550cae815b5e6d340f0f5ab28e0fa0",
+        "wx": "00b72af48bc8d3cccf646bf4d248e59bfb3f4be05a65c6e137dfd33f89ae0538bd",
+        "wy": "00a5245ea537238f91347a9fa911f93e8d69550cae815b5e6d340f0f5ab28e0fa0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b72af48bc8d3cccf646bf4d248e59bfb3f4be05a65c6e137dfd33f89ae0538bda5245ea537238f91347a9fa911f93e8d69550cae815b5e6d340f0f5ab28e0fa0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEtyr0i8jTzM9ka/TSSOWb+z9L4FplxuE3\n39M/ia4FOL2lJF6lNyOPkTR6n6kR+T6NaVUMroFbXm00Dw9aso4PoA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 421,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202c37fd995622c4fb7fffffffffffffffc7cee745110cb45ab558ed7c90c15a2f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041c286c9b478065202336356e83f1887b052efbf637aca65bcafd033ba6df697d4c7fb641aa83f96579be9db51c555ecdbb7a5637311db2efab94b08afa01dae8",
+        "wx": "1c286c9b478065202336356e83f1887b052efbf637aca65bcafd033ba6df697d",
+        "wy": "4c7fb641aa83f96579be9db51c555ecdbb7a5637311db2efab94b08afa01dae8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041c286c9b478065202336356e83f1887b052efbf637aca65bcafd033ba6df697d4c7fb641aa83f96579be9db51c555ecdbb7a5637311db2efab94b08afa01dae8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHChsm0eAZSAjNjVug/GIewUu+/Y3rKZb\nyv0DO6bfaX1Mf7ZBqoP5ZXm+nbUcVV7Nu3pWNzEdsu+rlLCK+gHa6A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 422,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02207fd995622c4fb7ffffffffffffffffff5d883ffab5b32652ccdcaa290fccb97d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041008faa2a4177b7341135ca54dcac622ab3168f1261454d6ecd0a3063ed1165652750f2c7a4b4b11393e125240c701841e754c32f8e0340361595ae7677d5688",
+        "wx": "1008faa2a4177b7341135ca54dcac622ab3168f1261454d6ecd0a3063ed11656",
+        "wy": "52750f2c7a4b4b11393e125240c701841e754c32f8e0340361595ae7677d5688"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041008faa2a4177b7341135ca54dcac622ab3168f1261454d6ecd0a3063ed1165652750f2c7a4b4b11393e125240c701841e754c32f8e0340361595ae7677d5688",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEEAj6oqQXe3NBE1ylTcrGIqsxaPEmFFTW\n7NCjBj7RFlZSdQ8sektLETk+ElJAxwGEHnVMMvjgNANhWVrnZ31WiA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 423,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100ffb32ac4589f6ffffffffffffffffffebb107ff56b664ca599b954521f9972fa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b173f818f572ed7cb0deb165f4173f65f0f48bd49fb4d0b04f4e2ee81c8ed9d67af7091dc3474aeeceb4ed2097118c4262c978f06dda44fde8e5c60f222580a6",
+        "wx": "00b173f818f572ed7cb0deb165f4173f65f0f48bd49fb4d0b04f4e2ee81c8ed9d6",
+        "wy": "7af7091dc3474aeeceb4ed2097118c4262c978f06dda44fde8e5c60f222580a6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b173f818f572ed7cb0deb165f4173f65f0f48bd49fb4d0b04f4e2ee81c8ed9d67af7091dc3474aeeceb4ed2097118c4262c978f06dda44fde8e5c60f222580a6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsXP4GPVy7Xyw3rFl9Bc/ZfD0i9SftNCw\nT04u6ByO2dZ69wkdw0dK7s607SCXEYxCYsl48G3aRP3o5cYPIiWApg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 424,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02205622c4fb7fffffffffffffffffffffff928a8f1c7ac7bec1808b9f61c01ec327",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e49f6fa148d964041b5c6175d8e0db6626aa653afde03e1c6d804193778a615f69ecc0e5f8e22a49de05fea7ef8cd0c8ec9fb0cf28d8d8e05900abcd8d3874b0",
+        "wx": "00e49f6fa148d964041b5c6175d8e0db6626aa653afde03e1c6d804193778a615f",
+        "wy": "69ecc0e5f8e22a49de05fea7ef8cd0c8ec9fb0cf28d8d8e05900abcd8d3874b0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e49f6fa148d964041b5c6175d8e0db6626aa653afde03e1c6d804193778a615f69ecc0e5f8e22a49de05fea7ef8cd0c8ec9fb0cf28d8d8e05900abcd8d3874b0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5J9voUjZZAQbXGF12ODbZiaqZTr94D4c\nbYBBk3eKYV9p7MDl+OIqSd4F/qfvjNDI7J+wzyjY2OBZAKvNjTh0sA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 425,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022044104104104104104104104104104103b87853fd3b7d3f8e175125b4382f25ed",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0484db9801948d816235b76fbce2d41a8ee317565411daef97a8c3975f70df13f095dac7b1cbb82a2719c6c3fee23ef982725ca81f13551e129a20299e54ee4e83",
+        "wx": "0084db9801948d816235b76fbce2d41a8ee317565411daef97a8c3975f70df13f0",
+        "wy": "0095dac7b1cbb82a2719c6c3fee23ef982725ca81f13551e129a20299e54ee4e83"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000484db9801948d816235b76fbce2d41a8ee317565411daef97a8c3975f70df13f095dac7b1cbb82a2719c6c3fee23ef982725ca81f13551e129a20299e54ee4e83",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEhNuYAZSNgWI1t2+84tQajuMXVlQR2u+X\nqMOXX3DfE/CV2sexy7gqJxnGw/7iPvmCclyoHxNVHhKaICmeVO5Ogw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 426,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202739ce739ce739ce739ce739ce739ce705560298d1f2f08dc419ac273a5b54d9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "044789e4dc7c8d32aa842701a8e14a9667ee9a1620f764a8ebac822fa46bce3356572a8abb89e27a5d8d740ff6d3482d7c998dcd1a35ccf50bb07116fe3675eb7c",
+        "wx": "4789e4dc7c8d32aa842701a8e14a9667ee9a1620f764a8ebac822fa46bce3356",
+        "wy": "572a8abb89e27a5d8d740ff6d3482d7c998dcd1a35ccf50bb07116fe3675eb7c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200044789e4dc7c8d32aa842701a8e14a9667ee9a1620f764a8ebac822fa46bce3356572a8abb89e27a5d8d740ff6d3482d7c998dcd1a35ccf50bb07116fe3675eb7c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAER4nk3HyNMqqEJwGo4UqWZ+6aFiD3ZKjr\nrIIvpGvOM1ZXKoq7ieJ6XY10D/bTSC18mY3NGjXM9QuwcRb+NnXrfA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 427,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100b777777777777777777777777777777688e6a1fe808a97a348671222ff16b863",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0476677705ce4dee1ca8c7fa2444754938a01bd7216210a4b4d79a9054d4f97bf4aa18e93f6019119feb60fb64d180ff60e43e744cb928786cc8904f3b5879180d",
+        "wx": "76677705ce4dee1ca8c7fa2444754938a01bd7216210a4b4d79a9054d4f97bf4",
+        "wy": "00aa18e93f6019119feb60fb64d180ff60e43e744cb928786cc8904f3b5879180d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000476677705ce4dee1ca8c7fa2444754938a01bd7216210a4b4d79a9054d4f97bf4aa18e93f6019119feb60fb64d180ff60e43e744cb928786cc8904f3b5879180d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEdmd3Bc5N7hyox/okRHVJOKAb1yFiEKS0\n15qQVNT5e/SqGOk/YBkRn+tg+2TRgP9g5D50TLkoeGzIkE87WHkYDQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 428,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02206492492492492492492492492492492406dd3a19b8d5fb875235963c593bd2d3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04024377dbfad10b73555517c81f3b5a1ab1ffc2059d080070c0622b89d56209aa892de4161423ab7eff48d204a83783e769974cd67b4bd6ddefc86132a18d4abf",
+        "wx": "024377dbfad10b73555517c81f3b5a1ab1ffc2059d080070c0622b89d56209aa",
+        "wy": "00892de4161423ab7eff48d204a83783e769974cd67b4bd6ddefc86132a18d4abf"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004024377dbfad10b73555517c81f3b5a1ab1ffc2059d080070c0622b89d56209aa892de4161423ab7eff48d204a83783e769974cd67b4bd6ddefc86132a18d4abf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAkN32/rRC3NVVRfIHztaGrH/wgWdCABw\nwGIridViCaqJLeQWFCOrfv9I0gSoN4PnaZdM1ntL1t3vyGEyoY1Kvw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 429,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100955555555555555555555555555555547c74934474db157d2a8c3f088aced62c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04113150f49ada74a14dd2c383ec03f53ec1e27e957990e9033da50be6ee412fd8ddca40ad06596555f662133f587afc8c76f2ff5a086ceae5f88e0c2c1c3035d6",
+        "wx": "113150f49ada74a14dd2c383ec03f53ec1e27e957990e9033da50be6ee412fd8",
+        "wy": "00ddca40ad06596555f662133f587afc8c76f2ff5a086ceae5f88e0c2c1c3035d6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004113150f49ada74a14dd2c383ec03f53ec1e27e957990e9033da50be6ee412fd8ddca40ad06596555f662133f587afc8c76f2ff5a086ceae5f88e0c2c1c3035d6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEETFQ9JradKFN0sOD7AP1PsHifpV5kOkD\nPaUL5u5BL9jdykCtBlllVfZiEz9YevyMdvL/Wghs6uX4jgwsHDA11g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 430,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3e3a49a23a6d8abe95461f8445676b17",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043c5b0f99db1e52ce0f9376de29102d1f1bcc343a39f0cf0a665afd3669fa0a627ef25431ecafe6b876f2ba181f721fb7e06d71aa756a575574a181aa26a779eb",
+        "wx": "3c5b0f99db1e52ce0f9376de29102d1f1bcc343a39f0cf0a665afd3669fa0a62",
+        "wy": "7ef25431ecafe6b876f2ba181f721fb7e06d71aa756a575574a181aa26a779eb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043c5b0f99db1e52ce0f9376de29102d1f1bcc343a39f0cf0a665afd3669fa0a627ef25431ecafe6b876f2ba181f721fb7e06d71aa756a575574a181aa26a779eb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEPFsPmdseUs4Pk3beKRAtHxvMNDo58M8K\nZlr9Nmn6CmJ+8lQx7K/muHbyuhgfch+34G1xqnVqV1V0oYGqJqd56w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 431,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100bffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047f9bc1f653895da490829846836106cde3e8cd89bcd3aa66892c3e6db5e9f9ba6f344f323d5b0a4e75117ed634f3a4ed0cabd4e2d87c9be844c7d562ac4d9b90",
+        "wx": "7f9bc1f653895da490829846836106cde3e8cd89bcd3aa66892c3e6db5e9f9ba",
+        "wy": "6f344f323d5b0a4e75117ed634f3a4ed0cabd4e2d87c9be844c7d562ac4d9b90"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047f9bc1f653895da490829846836106cde3e8cd89bcd3aa66892c3e6db5e9f9ba6f344f323d5b0a4e75117ed634f3a4ed0cabd4e2d87c9be844c7d562ac4d9b90",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEf5vB9lOJXaSQgphGg2EGzePozYm806pm\niSw+bbXp+bpvNE8yPVsKTnURftY086TtDKvU4th8m+hEx9VirE2bkA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 432,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220185ddbca6dac41b1da033cfb60c152869e74b3cd66e9ffdf1b6bc09ed65ee40c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c8212982bde0e2b0e7dab30f3eed9820260641fa76a5221e5d086c9ac16d83f28aaf69",
+        "wx": "5f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c82129",
+        "wy": "0082bde0e2b0e7dab30f3eed9820260641fa76a5221e5d086c9ac16d83f28aaf69"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c8212982bde0e2b0e7dab30f3eed9820260641fa76a5221e5d086c9ac16d83f28aaf69",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEX0hVMAxyOWYAvyIMu2jKO6YQdzDX6QzK\n9UZUl2PIISmCveDisOfasw8+7ZggJgZB+nalIh5dCGyawW2D8oqvaQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 433,
+          "comment": "point duplication during verification",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022032b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda022100e8b6b0e5c1202774c31c0deb26db0fd15b080a0ac87c016af93236bde9f078f9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c821297d421f1d4f18254cf0c11267dfd9f9be05895adde1a2f793653e927b0d754cc6",
+        "wx": "5f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c82129",
+        "wy": "7d421f1d4f18254cf0c11267dfd9f9be05895adde1a2f793653e927b0d754cc6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045f4855300c72396600bf220cbb68ca3ba6107730d7e90ccaf546549763c821297d421f1d4f18254cf0c11267dfd9f9be05895adde1a2f793653e927b0d754cc6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEX0hVMAxyOWYAvyIMu2jKO6YQdzDX6QzK\n9UZUl2PIISl9Qh8dTxglTPDBEmff2fm+BYla3eGi95NlPpJ7DXVMxg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 434,
+          "comment": "duplication bug",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022032b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda022100e8b6b0e5c1202774c31c0deb26db0fd15b080a0ac87c016af93236bde9f078f9",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041070baba3f326768d7693b1daf238737e91b7e6b3ac750b497e0480c2dae4c4d950ab9368086a7fa8b972270f8238d4791b8f9082cf67ba75dff7b347b209986",
+        "wx": "1070baba3f326768d7693b1daf238737e91b7e6b3ac750b497e0480c2dae4c4d",
+        "wy": "00950ab9368086a7fa8b972270f8238d4791b8f9082cf67ba75dff7b347b209986"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041070baba3f326768d7693b1daf238737e91b7e6b3ac750b497e0480c2dae4c4d950ab9368086a7fa8b972270f8238d4791b8f9082cf67ba75dff7b347b209986",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEEHC6uj8yZ2jXaTsdryOHN+kbfms6x1C0\nl+BIDC2uTE2VCrk2gIan+ouXInD4I41Hkbj5CCz2e6dd/3s0eyCZhg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 435,
+          "comment": "comparison with point at infinity ",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0022033333333333333333333333333333332f222f8faefdb533f265d461c29a47373",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04934e4daf8b9b05dd5de34bcf83dcc2f1b5ba67d63b5e5a2fbed1a71f186b4dd91d89cb32ceba5162e317558ca86bc3aedec7356e115c7e9468da7d12fb10ce05",
+        "wx": "00934e4daf8b9b05dd5de34bcf83dcc2f1b5ba67d63b5e5a2fbed1a71f186b4dd9",
+        "wy": "1d89cb32ceba5162e317558ca86bc3aedec7356e115c7e9468da7d12fb10ce05"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004934e4daf8b9b05dd5de34bcf83dcc2f1b5ba67d63b5e5a2fbed1a71f186b4dd91d89cb32ceba5162e317558ca86bc3aedec7356e115c7e9468da7d12fb10ce05",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEk05Nr4ubBd1d40vPg9zC8bW6Z9Y7Xlov\nvtGnHxhrTdkdicsyzrpRYuMXVYyoa8Ou3sc1bhFcfpRo2n0S+xDOBQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 436,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042326edd3cdaece8c2ffab414190644b79d898fa9e347ca05f959827adff6916b336982ee7c35942f4af53b9b5a79e91dcc6e7ab4c6ced372b96824d8e1e2133c",
+        "wx": "2326edd3cdaece8c2ffab414190644b79d898fa9e347ca05f959827adff6916b",
+        "wy": "336982ee7c35942f4af53b9b5a79e91dcc6e7ab4c6ced372b96824d8e1e2133c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042326edd3cdaece8c2ffab414190644b79d898fa9e347ca05f959827adff6916b336982ee7c35942f4af53b9b5a79e91dcc6e7ab4c6ced372b96824d8e1e2133c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEIybt082uzowv+rQUGQZEt52Jj6njR8oF\n+VmCet/2kWszaYLufDWUL0r1O5taeekdzG56tMbO03K5aCTY4eITPA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 437,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022100b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ccfdb7f86de824470828ba57600382f20999e3e231a327c767c2d0e6d7286aaf72be7a9a8f45502e3134cc0ade853e149023395ed061649a3372957c2c90cf13",
+        "wx": "00ccfdb7f86de824470828ba57600382f20999e3e231a327c767c2d0e6d7286aaf",
+        "wy": "72be7a9a8f45502e3134cc0ade853e149023395ed061649a3372957c2c90cf13"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ccfdb7f86de824470828ba57600382f20999e3e231a327c767c2d0e6d7286aaf72be7a9a8f45502e3134cc0ade853e149023395ed061649a3372957c2c90cf13",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzP23+G3oJEcIKLpXYAOC8gmZ4+IxoyfH\nZ8LQ5tcoaq9yvnqaj0VQLjE0zArehT4UkCM5XtBhZJozcpV8LJDPEw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 438,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee502210099999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040355ab3652890e4871a8f597a71c499b3a78c68a229e6890fddb02922868cffde58bdfdbc55c59da91e6bb3cbbfe92b413cccd672e9624115c4b1badffd96ef2",
+        "wx": "0355ab3652890e4871a8f597a71c499b3a78c68a229e6890fddb02922868cffd",
+        "wy": "00e58bdfdbc55c59da91e6bb3cbbfe92b413cccd672e9624115c4b1badffd96ef2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040355ab3652890e4871a8f597a71c499b3a78c68a229e6890fddb02922868cffde58bdfdbc55c59da91e6bb3cbbfe92b413cccd672e9624115c4b1badffd96ef2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEA1WrNlKJDkhxqPWXpxxJmzp4xooinmiQ\n/dsCkihoz/3li9/bxVxZ2pHmuzy7/pK0E8zNZy6WJBFcSxut/9lu8g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 439,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022066666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042e2969ff37317dc22f50d7b80462f077eaf8c3789790b462a5ea66c0557a7e179caec6be59fcf1193ee5bfcd33007af97066f01989e746221dd26b71d9e4bccc",
+        "wx": "2e2969ff37317dc22f50d7b80462f077eaf8c3789790b462a5ea66c0557a7e17",
+        "wy": "009caec6be59fcf1193ee5bfcd33007af97066f01989e746221dd26b71d9e4bccc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042e2969ff37317dc22f50d7b80462f077eaf8c3789790b462a5ea66c0557a7e179caec6be59fcf1193ee5bfcd33007af97066f01989e746221dd26b71d9e4bccc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAELilp/zcxfcIvUNe4BGLwd+r4w3iXkLRi\npepmwFV6fhecrsa+WfzxGT7lv80zAHr5cGbwGYnnRiId0mtx2eS8zA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 440,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022049249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04751eab708173dcf2cb265424f9d6646c63865b89a46cc545169f8a227e72989668205e16739d2e9efece8343cf8c6115ae22b48d2ef8d478a1535c76311f9d10",
+        "wx": "751eab708173dcf2cb265424f9d6646c63865b89a46cc545169f8a227e729896",
+        "wy": "68205e16739d2e9efece8343cf8c6115ae22b48d2ef8d478a1535c76311f9d10"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004751eab708173dcf2cb265424f9d6646c63865b89a46cc545169f8a227e72989668205e16739d2e9efece8343cf8c6115ae22b48d2ef8d478a1535c76311f9d10",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEdR6rcIFz3PLLJlQk+dZkbGOGW4mkbMVF\nFp+KIn5ymJZoIF4Wc50unv7Og0PPjGEVriK0jS741HihU1x2MR+dEA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 441,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee502200eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0448b155ab6603c57a2a9184a0193d882f18e6bde72a24c11d9e2db4caabdcf25221d180a4aa53548a878b16fa5d7de0ce37d50717bfb2960a937fb358a07799b6",
+        "wx": "48b155ab6603c57a2a9184a0193d882f18e6bde72a24c11d9e2db4caabdcf252",
+        "wy": "21d180a4aa53548a878b16fa5d7de0ce37d50717bfb2960a937fb358a07799b6"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000448b155ab6603c57a2a9184a0193d882f18e6bde72a24c11d9e2db4caabdcf25221d180a4aa53548a878b16fa5d7de0ce37d50717bfb2960a937fb358a07799b6",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAESLFVq2YDxXoqkYSgGT2ILxjmvecqJMEd\nni20yqvc8lIh0YCkqlNUioeLFvpdfeDON9UHF7+ylgqTf7NYoHeZtg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 442,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d55558e86b9151a9cca8bf3f95c3095b6dd46fd59cd97fbfe81cc1012f1c9368344f003527679e991f9f4fe8e63d104d0d46798ed074b52416b73b62d2198e8c",
+        "wx": "00d55558e86b9151a9cca8bf3f95c3095b6dd46fd59cd97fbfe81cc1012f1c9368",
+        "wy": "344f003527679e991f9f4fe8e63d104d0d46798ed074b52416b73b62d2198e8c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d55558e86b9151a9cca8bf3f95c3095b6dd46fd59cd97fbfe81cc1012f1c9368344f003527679e991f9f4fe8e63d104d0d46798ed074b52416b73b62d2198e8c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE1VVY6GuRUanMqL8/lcMJW23Ub9Wc2X+/\n6BzBAS8ck2g0TwA1J2eemR+fT+jmPRBNDUZ5jtB0tSQWtzti0hmOjA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 443,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022100b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04659940ed14c45baba750ac48dd67af0bbe46d5a5d710558650ddcdb45bde3e1de2d921a2eb0ec8690a38a05c82f627bd9c4065d26ebbe38b55a1e68f564b4459",
+        "wx": "659940ed14c45baba750ac48dd67af0bbe46d5a5d710558650ddcdb45bde3e1d",
+        "wy": "00e2d921a2eb0ec8690a38a05c82f627bd9c4065d26ebbe38b55a1e68f564b4459"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004659940ed14c45baba750ac48dd67af0bbe46d5a5d710558650ddcdb45bde3e1de2d921a2eb0ec8690a38a05c82f627bd9c4065d26ebbe38b55a1e68f564b4459",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEZZlA7RTEW6unUKxI3WevC75G1aXXEFWG\nUN3NtFvePh3i2SGi6w7IaQo4oFyC9ie9nEBl0m6744tVoeaPVktEWQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 444,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179802210099999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047271061600121d1c88b6097f64bb68c4960f55c20b8feedca426a2b1f375eebe0a258bf99824ff3c8330cd8cf6e6973d5c3ccccaddfee8686c79bcc68253aa46",
+        "wx": "7271061600121d1c88b6097f64bb68c4960f55c20b8feedca426a2b1f375eebe",
+        "wy": "0a258bf99824ff3c8330cd8cf6e6973d5c3ccccaddfee8686c79bcc68253aa46"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047271061600121d1c88b6097f64bb68c4960f55c20b8feedca426a2b1f375eebe0a258bf99824ff3c8330cd8cf6e6973d5c3ccccaddfee8686c79bcc68253aa46",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEcnEGFgASHRyItgl/ZLtoxJYPVcILj+7c\npCaisfN17r4KJYv5mCT/PIMwzYz25pc9XDzMyt3+6GhsebzGglOqRg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 445,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022066666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047b939c4fba5a8ff3611afaddb37c4719b19c6a6a8fbd92589d84fb1ef8337aaf3bd3dc4c184fe7adee1a7193ed30a6cae3992e5b3bdebc26f100133e6d04be61",
+        "wx": "7b939c4fba5a8ff3611afaddb37c4719b19c6a6a8fbd92589d84fb1ef8337aaf",
+        "wy": "3bd3dc4c184fe7adee1a7193ed30a6cae3992e5b3bdebc26f100133e6d04be61"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047b939c4fba5a8ff3611afaddb37c4719b19c6a6a8fbd92589d84fb1ef8337aaf3bd3dc4c184fe7adee1a7193ed30a6cae3992e5b3bdebc26f100133e6d04be61",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEe5OcT7paj/NhGvrds3xHGbGcamqPvZJY\nnYT7Hvgzeq8709xMGE/nre4acZPtMKbK45kuWzvevCbxABM+bQS+YQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 446,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022049249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04645a699226e2dbabb31d76e06d5cdb9bb9c0c20da7ce87955ea93c82d22c236bbd49fbe2250e00622314cab4a29eef91e4524ab6238086147e73c01eda9fc244",
+        "wx": "645a699226e2dbabb31d76e06d5cdb9bb9c0c20da7ce87955ea93c82d22c236b",
+        "wy": "00bd49fbe2250e00622314cab4a29eef91e4524ab6238086147e73c01eda9fc244"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004645a699226e2dbabb31d76e06d5cdb9bb9c0c20da7ce87955ea93c82d22c236bbd49fbe2250e00622314cab4a29eef91e4524ab6238086147e73c01eda9fc244",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEZFppkibi26uzHXbgbVzbm7nAwg2nzoeV\nXqk8gtIsI2u9SfviJQ4AYiMUyrSinu+R5FJKtiOAhhR+c8Ae2p/CRA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 447,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179802200eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 448,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c492aebe9f1b702c6747fbd016604d49ad6beb2c57a29c0587bb76a07c988b1a02202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 449,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "304402203b6d514160e48fd398b8042fe99fb2b50d42f1ba57a604363816e7ec539db62702202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "00b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5i3xSWI2Vw7mqJbBAPx7vdXAuhLt1l6q+ZjuC9vBO8ndw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 450,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c492aebe9f1b702c6747fbd016604d49ad6beb2c57a29c0587bb76a07c988b1a02202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 451,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "304402203b6d514160e48fd398b8042fe99fb2b50d42f1ba57a604363816e7ec539db62702202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "01060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv8AAAABBgSS1aVnPg8l2NUPt+WMSdhtRtQhaVXgqj1A4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 452,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3044022013f7c539626f89a954dbe09c8cb68cf691fb808789139c70192d831752e8a6a902204b7a5beaa9e455940597b666a2a006caa6f58e7e8d35b189f0705d9243c0aa7b",
+          "result": "valid"
+        },
+        {
+          "tcId": 453,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022059f020bd01827233ebc883add6f2243235a2880b7dd7cfb6fde00b1be0871a44022100d64e496bc7937d954e6b5bef6b9390b2517af0f52efb026faa074777ed725015",
+          "result": "valid"
+        },
+        {
+          "tcId": 454,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3044022047bb77178d250fc3ffe251f0d0caa34cde1550c9f3433dd76c1a7571776b22d90220670cecf9838b07d360c742528e8640c75d02a1e92b291fafff70678f76ba31e1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "00fffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv/////++fttKlqYwfDaJyrwSBpztieSuSvelqoeVcK7Tg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 455,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30460221008cd4f2977044c51dd8805aa28304c54fdabd722462c0f3aab492f0b338bc5c97022100fbb0bf8d8f5b3735236f6d616fddec1ec27d69cb5ab14df460cec0fc813d3ec0",
+          "result": "valid"
+        },
+        {
+          "tcId": 456,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100b44a3977d35d577b52106ea2bece72ec5202cc6dcbf5f0e2df4195c6215cfc840220794754a83f6b4dd90b28418c37106177449b172487030f9e3c7430e0a213b708",
+          "result": "valid"
+        },
+        {
+          "tcId": 457,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100c4af8155dab795b096f7039dca9c38307d0935e50f1dc548d4dcb356620f7bd2022100e791b8d05a4fe1aa5cf03a1687460d0dc1938e5270fb49e6ec22538893740cd6",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+        "wx": "013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0",
+        "wy": "00f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAAAAAT/SIkjWTZX3PCm0irSGMYUL5QP9\nAPhGi18PcOD27nqkO8LG/SWx2CaSQcvdnbsNrJbcliMfQwcF+DhxfQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 458,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022021757478b5257b9afa77f0b984270e7e659c50450473dddcf7cbf9debdcdaebf022100e42d6fd80e720f8eac286d87620dd616d17202451d5c198c7ddf63ad4a0a8460",
+          "result": "valid"
+        },
+        {
+          "tcId": 459,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402204e3400b9d73d3e52c461c0b2257d694b057ca2278e44c290fbf62a13cfee6b6402207b04553c61d2ad7178aa15261bebaa3f70855ff21c6c9495d3a5c92750572f16",
+          "result": "valid"
+        },
+        {
+          "tcId": 460,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022020960e67a2bb64aae5109251eef514144f1b4d532a196ff3667b23a8f0426d25022100c83703e173afc7489e2a3a3dded23ee1a9e321c421c1ed31ba78d43cbe1d0dd4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+        "wx": "25afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dffffffff",
+        "wy": "00fa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJa/WiayrrtZ8Hylt5ZQG+MVQ9XFGoLTs\nLJeHbf/////6RqduUgMi37xJHsTwzBl0IPxOpYg9j23VPDVLxPZ8NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 461,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450220133ff714d612532cdc2142868cc9efb1e59fbfd1277ad9240488c1c547c2b7e3022100b4c6c1a8a32e6f0015a9b0a3c802e9f3ccba7ebb1bf50d2427b30d0d808f0ce2",
+          "result": "valid"
+        },
+        {
+          "tcId": 462,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402204e7f995e2bafb2ea3759160234184d63e99f9f29cd91299c93309ff3e4c0818302206e474385b295c7f9752f6c56c485813770192eaa8c06f57bbbdd8dff2cf69406",
+          "result": "valid"
+        },
+        {
+          "tcId": 463,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502205b226b26922de1dcf1b2ff2950a1926a3bfa1b47b0d3c0224d3d74cfd8a383a6022100a723f5420da8fa10a007e1cc0cd9314473ef32ae628683cb5779c8e451544053",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+        "wx": "00d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb9",
+        "wy": "3f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0S5sZrZ3NMPITSYBz1013Al+J2N/CspK\nT9t0tqrdO7k/W9/4i9VzbfiY5pkAbtdQ8RzwfFhmzXrXDHEh/////w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 464,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502204111c525606fa194f16dbd57f7338784173c4fa06a66bf44cfababc5458aaf22022100f53d185caa1020e7304dd2424986dab3a8f93c47135e0c0caaa825a175ac68c2",
+          "result": "valid"
+        },
+        {
+          "tcId": 465,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502207e482dee38b853850c8a3bad568b1e6fcf3ee0c00ba22bf3a799a352c3c61b41022100de6dfeac0902f82c61b20955bcea89260a41c5e220160705614e7397fbbec69f",
+          "result": "valid"
+        },
+        {
+          "tcId": 466,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502204f0736fc03a8d7e82130168136dcb9ff423d3d26a721d225422844af33c7bdc8022100c3e163974aa872b76fa0e6511c53f8ea2f39b117045e45adbd17a0ffbe4e2549",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+        "wx": "6d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000",
+        "wy": "00e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbUp/YNR3Sk8KqLve25U8fup5CUB+MWR1\nVmS8KAAAAADmWdNOTfONnoyeqt+6NmEsdpGVvobHeqw/NueLU4aA+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 467,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304602210081baafa92031d4d9be8083b2c93a5319faa507f88cc4e3db9dee9539d042d418022100f83234e54336c2ebf68230ab6015ced7176bd4164aea66ce828e7fab3f523261",
+          "result": "valid"
+        },
+        {
+          "tcId": 468,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30460221008acd6383aea9c70038538f30e4bb18ead6907e3a9245fa22f93cd1ad28dc4e85022100bb2ae2ac3d9bd94de4a3df80cee8499485e923c97b2e6a108c1f7299114cb99e",
+          "result": "valid"
+        },
+        {
+          "tcId": 469,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022050d5cd3ba1be23ad74f4eef7213024678999c2e0f2953c193c90f14615b620cd022100bf89d4a87902f306cb4a8b7c5fc0cb65c4593eab0d7df88d557cbbb4d764d3cc",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-non-minimal-tag",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE128",
+      "tests": [
+        {
+          "tcId": 470,
+          "comment": "signature with non-minimal SEQUENCE tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "3f10450220606e2e02683631c5fb803e8c92a594e4c444ffe2b83066029f62d637330dfc1f022100ea9f5b6c399a99bdbbc5a6ddc3cffde178f08f52774e47cc83a9d7bd19ec16ef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 471,
+          "comment": "signature with non-minimal INTEGER tag on r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "30461f0220606e2e02683631c5fb803e8c92a594e4c444ffe2b83066029f62d637330dfc1f022100ea9f5b6c399a99bdbbc5a6ddc3cffde178f08f52774e47cc83a9d7bd19ec16ef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 472,
+          "comment": "signature with non-minimal INTEGER tag on s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "30460220606e2e02683631c5fb803e8c92a594e4c444ffe2b83066029f62d637330dfc1f1f022100ea9f5b6c399a99bdbbc5a6ddc3cffde178f08f52774e47cc83a9d7bd19ec16ef",
+          "result": "invalid"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/ecc/_data/ecdsa_secp256k1_shake256_p1363_test.json
+++ b/tests/ecc/_data/ecdsa_secp256k1_shake256_p1363_test.json
@@ -1,0 +1,5984 @@
+{
+  "algorithm": "ECDSA",
+  "schema": "ecdsa_p1363_verify_schema_v1.json",
+  "numberOfTests": 318,
+  "header": [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of IEEE P1363 encoded ECDSA signatures."
+  ],
+  "notes": {
+    "ArithmeticError": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
+      "cves": [
+        "CVE-2017-18146"
+      ]
+    },
+    "EdgeCasePublicKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "ModifiedInteger": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves": [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SignatureSize": {
+      "bugType": "LEGACY",
+      "description": "This test vector contains valid values for r and s. But the values are encoded using a smaller number of bytes. The size of an IEEE P1363 encoded signature should always be twice the number of bytes of the size of the order. Some libraries accept signatures with less bytes. To our knowledge no standard (i.e., IEEE P1363 or RFC 7515) requires any explicit checks of the signature size during signature verification."
+    },
+    "SmallRandS": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "Untruncatedhash": {
+      "bugType": "MISSING_STEP",
+      "description": "If the size of the digest is longer than the size of the underlying order of the multiplicative subgroup then the hash digest must be truncated during signature generation and verification. This test vector contains a signature where this step has been omitted."
+    },
+    "ValidSignature": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx": "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy": "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "signature malleability",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d04176f8eb0d09bbf556ea61cdbd899523e1ad8222e79daf4d1925aeb35cf564b",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "replaced r by r + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "01ddcd43e8cdb75e3c286984ef197e212b39b70b7b640a0f2bea92838d643e90be00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 3,
+          "comment": "replaced r by r + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "0100ddcd43e8cdb75e3c286984ef197e1fe72de51543fd61aaaffd1eb1d0ca49907d0000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 4,
+          "comment": "replaced r by n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "2232bc173248a1c3d7967b10e681ded23ba6ae51fa87314b9512398c3c2df1c4fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 5,
+          "comment": "replaced r by r + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "01ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 6,
+          "comment": "replaced r by r + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "010000000000000000ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d000000000000000000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 7,
+          "comment": "replaced s by s + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "01fbe890714f2f6440aa9159e3242766ab3742e1ab30176582ae12622e6a9d2c3700fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 8,
+          "comment": "replaced s by s + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "0100fbe890714f2f6440aa9159e3242765672b70eb73c96f0106c09e9071d0a82bf60000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 9,
+          "comment": "replaced s by s + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "01fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf600fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "replaced s by s + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "010000000000000000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6000000000000000000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 11,
+          "comment": "Signature with special case values r=0 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 12,
+          "comment": "Signature with special case values r=0 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "Signature with special case values r=0 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "Signature with special case values r=0 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "Signature with special case values r=0 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "Signature with special case values r=0 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "Signature with special case values r=0 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000000fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "Signature with special case values r=1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "Signature with special case values r=1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "Signature with special case values r=1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "Signature with special case values r=1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "Signature with special case values r=1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "Signature with special case values r=1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "Signature with special case values r=1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000001fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "Signature with special case values r=n and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "Signature with special case values r=n and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "Signature with special case values r=n and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "Signature with special case values r=n and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "Signature with special case values r=n and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "Signature with special case values r=n and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "Signature with special case values r=n and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "Signature with special case values r=n - 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "Signature with special case values r=n - 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "Signature with special case values r=n - 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "Signature with special case values r=n - 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 36,
+          "comment": "Signature with special case values r=n - 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 37,
+          "comment": "Signature with special case values r=n - 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 38,
+          "comment": "Signature with special case values r=n - 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 39,
+          "comment": "Signature with special case values r=n + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 40,
+          "comment": "Signature with special case values r=n + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 41,
+          "comment": "Signature with special case values r=n + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 42,
+          "comment": "Signature with special case values r=n + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 43,
+          "comment": "Signature with special case values r=n + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 44,
+          "comment": "Signature with special case values r=n + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 45,
+          "comment": "Signature with special case values r=n + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 46,
+          "comment": "Signature with special case values r=p and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 47,
+          "comment": "Signature with special case values r=p and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 48,
+          "comment": "Signature with special case values r=p and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 49,
+          "comment": "Signature with special case values r=p and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 50,
+          "comment": "Signature with special case values r=p and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 51,
+          "comment": "Signature with special case values r=p and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 52,
+          "comment": "Signature with special case values r=p and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2ffffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 53,
+          "comment": "Signature with special case values r=p + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 54,
+          "comment": "Signature with special case values r=p + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300000000000000000000000000000000000000000000000000000000000000001",
+          "result": "invalid"
+        },
+        {
+          "tcId": 55,
+          "comment": "Signature with special case values r=p + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 56,
+          "comment": "Signature with special case values r=p + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 57,
+          "comment": "Signature with special case values r=p + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 58,
+          "comment": "Signature with special case values r=p + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 59,
+          "comment": "Signature with special case values r=p + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 60,
+          "comment": "Edge case for Shamir multiplication",
+          "flags": [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg": "3838393131",
+          "sig": "dd1b7d09a7bd8218961034a39a87fecf5314f00c4d25eb58a07ac85e85eab516175703ba6e1b31ff9f7826ee6491bf2b64a24e252128a7907c4549bc3a1705a1",
+          "result": "valid"
+        },
+        {
+          "tcId": 61,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34343531343631393831",
+          "sig": "febe44c291f8d00b23dd343d012815060c07f086934eab0a75812ca1c7cbfee38df2e30bb376e312ebc52bea8ed3e6bd000f28acc50530008e8c47772be39cab",
+          "result": "valid"
+        },
+        {
+          "tcId": 62,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373030393239393039",
+          "sig": "66bf0d17b683d67bbe5922dfeb4501cad0ffc30cd409bdb1ff7194e0c2f973bfdcb7e6f20d99d831c26752f675be5d12edb83a8b0052f5888f8c86649a257147",
+          "result": "valid"
+        },
+        {
+          "tcId": 63,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343830313737303637",
+          "sig": "b8b3d79edeb8912af9b7a24770331837124287bdbbb7539a551348a0475a0d68dd0077d1d38b356b6d2b521117b8aae6dcb9bf90256d9ef0ba88106fc2d5511a",
+          "result": "valid"
+        },
+        {
+          "tcId": 64,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373731363034393337",
+          "sig": "1b10d9085dc554204dabfaef23e7ccb1bf8b8230b151f69d72c090c25431151541cd4e2e57ee850160027c0e6fa5f54d853220944545baf7f2a06252ff566f71",
+          "result": "valid"
+        },
+        {
+          "tcId": 65,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131333035393331373331",
+          "sig": "0f735b8fce2e916009011cb3d8c40308e10c124aa7b983f9ad601e304a962b960a3c8804a48ebde1952bc54fa550e25896785d74b079678d0a48d85ca92c3bb5",
+          "result": "valid"
+        },
+        {
+          "tcId": 66,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134383635323132343538",
+          "sig": "31884994ff0e27f6bd15301eff0da96f47dd2ca84dfb0dd829f2a07f61d1fd70545f0241caf7623463137898afa8025a78ca0b6d2a74196c4370ad6683853ca1",
+          "result": "valid"
+        },
+        {
+          "tcId": 67,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363135323834393939",
+          "sig": "c59f661deca240b7306b6aa5fa889f293782dcdea542bdd2ea7c88dd17eabcf2765df309eeff37a7be634942f622ff3b02abb83be00124aa40e6cb4665ef9ebd",
+          "result": "valid"
+        },
+        {
+          "tcId": 68,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323839373132383731",
+          "sig": "e373195a8517ab1cf4de22de3a3372efbddd09babd93b81de4061a957c4368aebe3a5173cd9f152fc935b656b4a1c8ad9552cf10a94007bb3704013ae61f878e",
+          "result": "valid"
+        },
+        {
+          "tcId": 69,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34353134333236393935",
+          "sig": "c75fa1a940e191e4d4c54be00ad91278ade1399470ed8a8751935ec4100b85a75ae64db319748bd3f03e239ecc1401304aa9aaa77f840c302f49f6cd20ddb03d",
+          "result": "valid"
+        },
+        {
+          "tcId": 70,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313138303935373633",
+          "sig": "a4fa215de24e4d3b990037da3b7914f423db9c5775cac4f4b10c95a51a8c3e9a01e35025feb5eb96b642d26721011e4ed45b2cfe3329aa8a32d9e7bff5715ba7",
+          "result": "valid"
+        },
+        {
+          "tcId": 71,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333435343736353130",
+          "sig": "11ff5e2ba3ae1b034d293d10df9bdc837e589d6563e47b88c5671479b7f1e258f2d6b13f2adf4b28a694a12f8a72ac8e64765fa4e8dbb3bed1627ba09f2b8754",
+          "result": "valid"
+        },
+        {
+          "tcId": 72,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343232393938313032",
+          "sig": "bfdd84bba4f8a7f8ad94bf5276ae51400008c2e5bae40bcac55b3fac3464b30ab74631480be60c3c5022498410e7798dc22a1a76cb7862d702699f7b149e84e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 73,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323635343239383132",
+          "sig": "ae729bc37ac0de1a407f191f300203195fb579ad5d6674fe85573147567b43159112958ac5b86ab2cd2f890819055bd84d819593e8c856ac4b76178956369e48",
+          "result": "valid"
+        },
+        {
+          "tcId": 74,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373133303833323137",
+          "sig": "91f229d8af15d5d152f571637b568b295474b8256b5424694d2e5b84470fb4c06f0df837d5d07160a1d61d8c9c46dfab0db0b7cbbd748d5ffd55c6d200e281f1",
+          "result": "valid"
+        },
+        {
+          "tcId": 75,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383232373734333630",
+          "sig": "8990060cdfd5d03716985c6d5e13d70c9775b229ba68cda8edf4b78f34774d814511488f2dc8bb7f06ba5bdf4a0f49092b1ca72ecf001bbfc0f3c1920e8654a7",
+          "result": "valid"
+        },
+        {
+          "tcId": 76,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323834313630373935",
+          "sig": "182f648feed9a6c94e8c246eaf14678c04575f96a0644dcd90aec4d5606be92e5faf0bee69f700d573961a149a6ea4d801d82d014262d0eb0ab754ad218b27c9",
+          "result": "valid"
+        },
+        {
+          "tcId": 77,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34333135343738313236",
+          "sig": "57f4d830d887ca207c09c18386e38aa89c4186764d8130695e283de1856c8c9035d5203604bbfd38a82af452a1045fb31c13d41a7e2b93daa84d298e781d4691",
+          "result": "valid"
+        },
+        {
+          "tcId": 78,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323639373538373331",
+          "sig": "14d1eb8cc831c2d3529e2f0668be09e2491da72dd81856ddb3f3b2b6a599037f09faa962a09d2bcb03c7217a2424a78eec6e55f91ba8966b2a8a672511edb452",
+          "result": "valid"
+        },
+        {
+          "tcId": 79,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353637383031313934",
+          "sig": "5e55b2148c371a4804c72a183e96c42ea2723d5297985c378992edff5455dd1a161b624275d34dffec5809164ada6f87fbeb9c313f0203f2a170c8717421c070",
+          "result": "valid"
+        },
+        {
+          "tcId": 80,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333136323732363237",
+          "sig": "fed819a4507d19c1879fa919c82cecc331e05777b1e1f6987103cf165d230240053db04cb475a0c56b258ab822cd705d881b4af2d3ac5a8ab251d43120b0ed74",
+          "result": "valid"
+        },
+        {
+          "tcId": 81,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343638303735353233",
+          "sig": "dc9843356452f785515fd0d8224c591faf5522e86c0996f02b0f2b369cb2bec7d5791659abfdfb4415e0978edc4e4f6ce4c9dcaf0e8fc5759c404b527eb7b17a",
+          "result": "valid"
+        },
+        {
+          "tcId": 82,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373536303830323930",
+          "sig": "e25d10a8ba8129c0795917a34df3d94fad24ed1aa142557270aefda4c72d674ad829f1cc92ce5fee0bb15d15d279f7ab3540d7c9d29ecbdf0dd575eac3dd5765",
+          "result": "valid"
+        },
+        {
+          "tcId": 83,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333438303136313034",
+          "sig": "7a03c2f364a4a394b7063162f1d4fb0ba15e7d083440c5329e0aa57cd8d7de16787d35a1ff9c6101e1aedf413afe2230dc8322c5a13a07ea1f0d7e50f1aa0851",
+          "result": "valid"
+        },
+        {
+          "tcId": 84,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373432363433343935",
+          "sig": "381c935be8b793c51de9aede7def421e9917632337fb2619c83489a5ebcfef88d8f84b9647e1891b9c96a36b7aa825ce688d57acb6cb5a9ea9844bced84f3b93",
+          "result": "valid"
+        },
+        {
+          "tcId": 85,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323738343235383435",
+          "sig": "ba9ecc381fe98c5d4524c49f71804f65be95798ea12ed0d712e608d60cf20bd491d375bfb5aaafac26deae07296625c265a183b5df3d55cfd792679472d94c87",
+          "result": "valid"
+        },
+        {
+          "tcId": 86,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33363337313933383031",
+          "sig": "65660c90475057b4f70dc2426e666228194045eae878379b674479d6ec787216cb7c869959046e1553417e8b3ab6ff712d2c877a1aaab93d861e7992b3c45b9d",
+          "result": "valid"
+        },
+        {
+          "tcId": 87,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34353930363837353039",
+          "sig": "c49207258ba205a2147c82c3f81d90e3903cd641c2a504254c488306eff1b1f45f9c6f9f0f3bccd028a65d14830018287c050d39a2f8b3d0e32621a352ebd005",
+          "result": "valid"
+        },
+        {
+          "tcId": 88,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35383031393936323333",
+          "sig": "17be2a69f16f4155aef45d2eaa2d0ac7181436421a90b344e2e3723b491adaa3ab80ad0eafd9df39c031e5d43879fade19c51ff492034374895b2cdb5eb2fc52",
+          "result": "valid"
+        },
+        {
+          "tcId": 89,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37343836353732373338",
+          "sig": "51b43771b713926b82a4c90a9141d4ae9bbba8f1cb2974bdfcf453fadc531728de979c87f48e5ee915f1835fdc24759658e881b00322795a1be99f77460d761f",
+          "result": "valid"
+        },
+        {
+          "tcId": 90,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35323537363038333537",
+          "sig": "431e7e678d379a5e0d532861ec29bebf4918253734cecd1741637a1f60ab5ffdc884c7ef28d033c843f3e4e0acf834a83fba2bf876fbc91289215d496e17e954",
+          "result": "valid"
+        },
+        {
+          "tcId": 91,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363332383233323433",
+          "sig": "1db1d6a0c5f3274fda191993287c99cc4dff5c9c6e2332a2370e57f9718ef1fdcdd9743a33b63ff4b0244a5e32fdeaf7fa379de1c6c611c2e9278ffc9651f136",
+          "result": "valid"
+        },
+        {
+          "tcId": 92,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393736303637323438",
+          "sig": "7187361237f7270fe77d02af22186845db7fd70387cd64eb24994050dcf53dff3d2080e8f129502c73ea86ee5e20ae23fbd8e6760950965c617c207d27224323",
+          "result": "valid"
+        },
+        {
+          "tcId": 93,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35303636393137343638",
+          "sig": "68ab52fdde8e098071ea3b989f18c9062d1e88f186de78d162c9760c57af4717be37487a8080298e766138b9fe3dfe1ff509aec54ccd665605655d650f6da2b9",
+          "result": "valid"
+        },
+        {
+          "tcId": 94,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333133323633343833",
+          "sig": "1f114e8559664df9c5452f96c8e537223915e39dbdf92159c7fe9d716333660e3e2fe6ac85ea3621700ad7563ad7f083e49cad7254bdf3dbb4aa33ba59e5abe4",
+          "result": "valid"
+        },
+        {
+          "tcId": 95,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343535373733313536",
+          "sig": "8cc85260b7a08ed2f77e899ad73b185274844f2c267e798dbe1d7bb5e70e28dbe49d523795e0730171162f1a3f18424c21ef32697f2555e4faea5a9c6a8549e1",
+          "result": "valid"
+        },
+        {
+          "tcId": 96,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363036333337363930",
+          "sig": "2e3839872cbef3c7554042520c06b8d9508c3519198675387a7220c4fa8f1f6efac8721643d296b46e605ffc6ec8a67c1590b85b34743e0752dab44924738930",
+          "result": "valid"
+        },
+        {
+          "tcId": 97,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32393038373634353636",
+          "sig": "1074773c071aff445f7a0b462d335e4ee88c2b30f45a47e202f12d083e74bbc209d24b755b35046be8946a96ab61551062e9bd91e51e7ad4c284e68ed92b8997",
+          "result": "valid"
+        },
+        {
+          "tcId": 98,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37383231353536343934",
+          "sig": "604a909e30cc9a5caa5da85a855f08f51619914b6be757c3466137d896b3ca2221807764ef52afa757c8ec03a3e1ee611d633a5a2a4a112abc0fbfe6c31cf8be",
+          "result": "valid"
+        },
+        {
+          "tcId": 99,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3132313430303035393239",
+          "sig": "969749beab754b9fb67ad833c188396f631b89930fb85f5084eea9455b36df636e7fe6c81da3d96a0f182559f69e2fff067390a4ca195f0472a2c5da7b0bf340",
+          "result": "valid"
+        },
+        {
+          "tcId": 100,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363239393337313131",
+          "sig": "e73dd2f13791e056cc164c964806d1ec3f1f427bc970dafda4e6e2dbff83495b556f2a52c774b17b6b4fbb3c6cb96c5be2c0a0c4da4963cb7eff8a8403e3f93c",
+          "result": "valid"
+        },
+        {
+          "tcId": 101,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373232383437383135",
+          "sig": "1d8f05198aa2dc03ce13ea57b579d11376555e986134203a5262e14e98df076d208ef20d0f8deafbe6860579bbd198a9187bd62605062e23c1db6edb592f500d",
+          "result": "valid"
+        },
+        {
+          "tcId": 102,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3337343334313732353931",
+          "sig": "9549f21a6ddd1ad34c800686679ef7eeeacdf82943d360b5967fee54a6be3b2d8d60ca019ff567b0f93c37efc735c927f9c1d2110abf83dcea8f44d8c22eca62",
+          "result": "valid"
+        },
+        {
+          "tcId": 103,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313837363932303637",
+          "sig": "a072a85fd596859914601fe354d99e10068f90d3bc7ab3714c0cb88dc1efecc82425ff303cf382e3a640a903a6aa32d4db4b46bc1b9525946a881a50b61c6581",
+          "result": "valid"
+        },
+        {
+          "tcId": 104,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32393937353331383431",
+          "sig": "ac9d8ba3f67f51d4b9b71968a0743dcd06856da1edf1fcd5034f8bec9a1d70e70f4025e786cbcfd49668332949823945513229c19fdcf4e93aedb39dff7c4ff9",
+          "result": "valid"
+        },
+        {
+          "tcId": 105,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313039373331353732",
+          "sig": "3447d10be371effba54917c40169347cd843e804d886912c1c87a9a480b7a5d81a666c8bd1918a3a3d6bdfc6857245508e6a386c8d8525f24f92a1de37555608",
+          "result": "valid"
+        },
+        {
+          "tcId": 106,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39373334343133333034",
+          "sig": "3af219043891ec1ab04b8bfd0cdd6ab3b7e20131573e117138a3e7988553c38ed9360ba60bb3cc776b71d06c8552a46bf9978bf96b7669d80fb68ea3b6756f28",
+          "result": "valid"
+        },
+        {
+          "tcId": 107,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313033383236323134",
+          "sig": "e8e4108338a1317072d204883d2ad2b17328d9684c1f4ca1252b329e5285188cbf209e785eea25aedbaa5ceced6e77f0c22a5097718e56e44c06382c54864357",
+          "result": "valid"
+        },
+        {
+          "tcId": 108,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303630313336343438",
+          "sig": "a36b8eb29993689593d4197711c2e31c61d51c8eb0d4544680972e99cd78b95fdbaf69380e10beae378d508f17deba234da9a9bebebc853c8b1dacb694c46cd9",
+          "result": "valid"
+        },
+        {
+          "tcId": 109,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323133383338383130",
+          "sig": "6c645b462404b975ac4866740fb193affcf85a894f525d33999153bf3941df2c0bae62a8c81181f54e98263814f79596cbb329b1c5b94d0f1e185917e346e687",
+          "result": "valid"
+        },
+        {
+          "tcId": 110,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38313938383037333237",
+          "sig": "2beff020fa970adbeafe941dfc31a2d5e44037c991ce2bf83e1b476e2d91dd41736c4c5edc0b2183f8ce1220a4257a0f1041bac8de1d69376d3ee2109b9895b5",
+          "result": "valid"
+        },
+        {
+          "tcId": 111,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31313739313036333334",
+          "sig": "a5531117b86d4e412aae573c62f04da39cdaaa092e55f5f3aa8f1d3db65a8de91315724d2ba41b0cbf82b42a95bfc465d833de6390a0b9056b61340c3ec431ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 112,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303734373837393236",
+          "sig": "6ca8dafcbc1601ab03ec2730f656140866ff4973332c0de44ede1ece29eae6a7014ba379939522d4ff1d76444e9d8bb3f8f749208b277f0114e22a39eca884cb",
+          "result": "valid"
+        },
+        {
+          "tcId": 113,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36343636363033393934",
+          "sig": "2cd8a23c99e79836cceb0d4929ebde6cc57dfb4435ef468873848d64273a16036bf48320536a89bb35189666be3fb6f1a072b150b5f97b9d924f421b19ee01ce",
+          "result": "valid"
+        },
+        {
+          "tcId": 114,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38343138303032383736",
+          "sig": "7cf9b46ed27c1bccab6f311d05ff13c49ff0bea98a373e9de6e56717b15831f84d2d3538ff7a7886a75e28934ca78f4c75f9fe4c9ebe64bff85cece2d9b378d0",
+          "result": "valid"
+        },
+        {
+          "tcId": 115,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39323330323534343032",
+          "sig": "8ca58fe636d7f545a4c7eedb62fbc4ed4cb2b36ebe061f19e662221a5b1cb02ef552845079c2cf2502911f34d6ef4b2157dcd9ab4804fe4c5d50b2a7476db524",
+          "result": "valid"
+        },
+        {
+          "tcId": 116,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303135343735303437",
+          "sig": "68bd2e5d34a510df7b27f078e6f12789b294507445593253975969f7bbb9f733909f592a8002b9011912cfe6049f808eb9a75bd0dbf453e880bb4fcb6b5d830d",
+          "result": "valid"
+        },
+        {
+          "tcId": 117,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34383039333730393031",
+          "sig": "b4dd8c5128a94e747f906696c7c0b883eccee7be0cc324caf521ae2f4a7ecc35fed2ea22f2a1ab806454c4050f6dc7931f2d231be37c70eece1ba8f8a383e4d8",
+          "result": "valid"
+        },
+        {
+          "tcId": 118,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3133383934303933323238",
+          "sig": "22077f5ff01375836d63d03762851c8a28352434176ec44394b30b9175331583b79f23c9bf8d231eb87981615849ef2d92f6629af364989117636fbf025532be",
+          "result": "valid"
+        },
+        {
+          "tcId": 119,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32363236313230333131",
+          "sig": "03561a10658a0cb0944d9926b6db8dc63cd8d60cee19cbd4ef6135a3fdc4606bd6650e5b3cd58e03d3497607d086a7223098fa5b6e59c7efb7196f77db0cf2c2",
+          "result": "valid"
+        },
+        {
+          "tcId": 120,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353338303531353839",
+          "sig": "109e7b7db507f6679823ccd4421675321a0cd5b8add8ffadbb082ccd15748fddeb4696289031ed3b614a21a827b4dd4cd4d5fc57f02335f3b4cb303ac4d920a1",
+          "result": "valid"
+        },
+        {
+          "tcId": 121,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303533333430343739",
+          "sig": "639fb14939c3a87369b9f245e9dc41dbadb1af529fa5287037f46593101f90d4103385e29239bd4c01ef5e58efb4920d8f65e986791bf08ed89f15735bd8dc48",
+          "result": "valid"
+        },
+        {
+          "tcId": 122,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3331323139303635343939",
+          "sig": "d706b070086816bfe6f40503517dfc4d9709ae680201d258bcc60520499636f38719b517573e5be6210ba18d179d53558cd07d66204ac2d913e25edac50db569",
+          "result": "valid"
+        },
+        {
+          "tcId": 123,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383231393533303438",
+          "sig": "4af1e6ddc468d0d2f54789a306c0028061ebec45f49be6aea0b023350befd9389e5884bcd42c5ccc168a4ced32ff84f09e8d6bb85387ed6200a4114b204bd6d8",
+          "result": "valid"
+        },
+        {
+          "tcId": 124,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363833323934343538",
+          "sig": "ba8997cda5ade7dec3984afa2928958a63decf1a218c388232ef6f32f505d73805e4aac028675bdd3702d1ca6456153ab46312861cb5f9eb47b23b2e0c9e3cd5",
+          "result": "valid"
+        },
+        {
+          "tcId": 125,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39333038333139313638",
+          "sig": "6f5e56a7beb2e8d6450f8e79591df1334a393dfb7a10d13a43d0cfd52067e70c323e1d26fc7fea9e53ef7e2bcc5b579ee9a2748eefd14fced94cb71c0c2bfd38",
+          "result": "valid"
+        },
+        {
+          "tcId": 126,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36343136363737323733",
+          "sig": "e85424f9a617f5aa09ed9025e247de12b4390073805f0a822ba5b40833a8325f1d3efcb8f7cdb037a8e5482f909ba2bb5e731a0632b2d30474112805a2d3b368",
+          "result": "valid"
+        },
+        {
+          "tcId": 127,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130303834363531313632",
+          "sig": "7bafde959d1ae29b5c52e23b022bc525349236a9cc1b1089a5053f1c23d8fe670f37719dd4e27b9e088c9d938107e052020d1d5d183bc4b8654f74d437d18f52",
+          "result": "valid"
+        },
+        {
+          "tcId": 128,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323535343932353435",
+          "sig": "33603bdc69d4ed17bf32f131a936906d3c09b7c8ca70f885e55bb6e0e326d254133e193d33aff7ec98d455b4c6ab2df77d48b79953ac2e128beaf5e3577e66ec",
+          "result": "valid"
+        },
+        {
+          "tcId": 129,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353538383536393830",
+          "sig": "0615bbc3be8c532e869141476bb4f480bfc00d5a88990c40d9acb9bd3b417e03e7e11c9e7903537a1b970b6efecd3f29ede0746356387738376383e9c43e6a86",
+          "result": "valid"
+        },
+        {
+          "tcId": 130,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333138343333383638",
+          "sig": "195dd991ad5c579bc26dfc8ec6f5f0b79ec48f06d54175cb9ac501d5329815d40e9ed5bf444f21254eaad3d0ff313165e5f0b2f6c71ea9f4e518160a6d352475",
+          "result": "valid"
+        },
+        {
+          "tcId": 131,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373231333437373833",
+          "sig": "c80bf61f61d94f2b6c3a75c3c8e49516bb63d8c0167b95658a87d77b74882475542ee1cf303d71365df23685fe45009dd73085598af6596d1d7ede3b4fca8422",
+          "result": "valid"
+        },
+        {
+          "tcId": 132,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3135333138333534313932",
+          "sig": "2a29ca1b8ce4abed7c9c9452578c27234f42c22c2a8f3607519b67148f03251d5199d872ee3ec6760032b037aa49d559d7709784d4f0c93120096a4e20417394",
+          "result": "valid"
+        },
+        {
+          "tcId": 133,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363931353237373839",
+          "sig": "4e72bce8ea2a4c951bbd872e606ec889f9e176eb1004fe3f258f2c14afa4e137ee52c71710dbd94581a9edaf43b35d91e515ffe0eb20f3392fedc1c1f9f5d03a",
+          "result": "valid"
+        },
+        {
+          "tcId": 134,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323331343139343335",
+          "sig": "de978d7d58cd183f72d57250de1ea468d387d791912c07371804b915cc95a46b7da037f5356467d38dc3cc37604bb7ff56553145088cefbecee033fce4828a79",
+          "result": "valid"
+        },
+        {
+          "tcId": 135,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343031343832303137",
+          "sig": "e3504e083da7ccc2a8aeca8b51ff4a75786f55d43784f9805cc4c5dff75e8c9a46d629ba1ca8327f31e3f2c7492125494d02d4aaef62ecf66e7589baeadeacb7",
+          "result": "valid"
+        },
+        {
+          "tcId": 136,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343637393435383738",
+          "sig": "b4d4d740c46fd2e7a9f7281b3bd4ccf9938ab2d7fcaddfa60520aa8ef0fccd2c14cdef37fe8286559cbccfc676ce76eca6e002413c61898ce7ade124ca4f5504",
+          "result": "valid"
+        },
+        {
+          "tcId": 137,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383137333936383533",
+          "sig": "c768f33abb729a3a862ea6d3f692e23e8b278e99bde292bea1e360939af628450252aa6aaeeef400ab55ee31fe74a7013ea8469ef46f24afc237db4fdb1b508c",
+          "result": "valid"
+        },
+        {
+          "tcId": 138,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3334373939393937393237",
+          "sig": "7ac3f0bf2f8b9e870af11dd9dfc9c60df54cd6a5c18038fd1a17b066f873e7082f58ddaff64d8ab0d7fa1c0c56e7a62905d836f14a9e6bb32981f567099da8e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 139,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333934383937393939",
+          "sig": "a2397fbd0944035a30899072111011e6a86cfdb1da5fc5af38817360db4fa0ac17d359b54cccfd25effcd41aa71948a4462ce89fce045bb40bab06825abc3d45",
+          "result": "valid"
+        },
+        {
+          "tcId": 140,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39363530383637313438",
+          "sig": "2a2438aed96e942f383d2e89336c3471a1e5c8ad12092f5355d06480a36f32fe6029b359e8414921a27ed93542188e64e31b8de309f83b3ec6a67b53ef5a5441",
+          "result": "valid"
+        },
+        {
+          "tcId": 141,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333538323734313930",
+          "sig": "04a99e64afb690b165bc8180eb344e4a81dbecb816f60b1f476f4d93977d2de4aa549cebcacf522464b99337da3b9ee9711b9bcba105ca2ffe4a47c019d2ad7e",
+          "result": "valid"
+        },
+        {
+          "tcId": 142,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3238313432323939383839",
+          "sig": "d946fb7da88ab8b0a8da63836a82881786e47c7ea0d9cbc88d2b530f203a94c886cd840e774d8066d7cbfbf4ab76d6b94f139f1804182911d2f9bcc5e994677d",
+          "result": "valid"
+        },
+        {
+          "tcId": 143,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373636383035323435",
+          "sig": "daae16b786bc6fd11f1980625766de619a04ea85b9a8040ab8f0f5f240b8e31a6461cb1e744da25d5de8464ac69fcda00a3cb85a3ffb2c808e6ce07ce67c3c76",
+          "result": "valid"
+        },
+        {
+          "tcId": 144,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35353032323834363935",
+          "sig": "35e1ea767cb60ba6f7b0704f39bbec30b560203b8c45b77a397a5ebe4eecb2072c3286a204cc7557c79f3186deec63ce49f1ecdae3229bf413c1b114d30e0895",
+          "result": "valid"
+        },
+        {
+          "tcId": 145,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383435353338303639",
+          "sig": "110f14be145671c07d60ded97e155f0f6a7ea30cc61554925c24a09745304b8f88c8a85cdd291221549cbcbf1f433731917e4a828174bde8defe27a6caad3c90",
+          "result": "valid"
+        },
+        {
+          "tcId": 146,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3233383536313835",
+          "sig": "d91357b6a89943d13dec5ae308816a60099223659eb2fc4208b425490e3845e918578d09f1d08e2067866a3743be7d82b68c6031c2ce21d25a4b79782bf70e36",
+          "result": "valid"
+        },
+        {
+          "tcId": 147,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3137383538303131353832",
+          "sig": "8322182ec31426af2e6b7c9d6fbc3301e70a20c0897594194d9c84b24e39ff95ff9caab982c57235dc3ff955e1fae7935132307f5f242abe6bf2c6f2627d6dd6",
+          "result": "valid"
+        },
+        {
+          "tcId": 148,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131383035393431353334",
+          "sig": "ba6f6874f4c2d059b117405b39d67d30baa193103062ccff439f690434fdcdcffa91d8cf44155bea39c3dec3525f64e6abb83cedd82335b7e81820b526f7ebf9",
+          "result": "valid"
+        },
+        {
+          "tcId": 149,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343534393837313836",
+          "sig": "ed59f011090766cd886dde1ab970ca356a146492565cebe1e4dfce1201d44ea4eff21a6d9bcb4f1cc3d6562b044d7c96874b0d3b2355b872c1f8a063c6895a92",
+          "result": "valid"
+        },
+        {
+          "tcId": 150,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323236313131323234",
+          "sig": "01be2fe82648b2fc237b8e5816a9d682e38d9c7576da2540f0f1a41c7473dd5f44c3c037176407aab6bf10c64b2137bdf6bc46b3c76290a2510161be8dcac682",
+          "result": "valid"
+        },
+        {
+          "tcId": 151,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3135333138383330383730",
+          "sig": "05be16a3f289e5d77715283e2466a472e5b9de392027f381aade645a95bd5d53c3beee59b063781141fddc0bf86079fed74b4bf8add14fc7a8a92718c462c2a3",
+          "result": "valid"
+        },
+        {
+          "tcId": 152,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393739313833363236",
+          "sig": "b1db4ea3c2797203fa38dc40540be199c3992ba11fc02acf1ec6117bbffab0a707c9e16ca0efa18439810a2dd85bf30dafd78401b3ca149a49dc0ec0c316b8ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 153,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38363330333434363239",
+          "sig": "8d9d58c43f733c4d1a952a727da1e5310a5c09df70fc3a79a420444c5e1daa18a558798fdad2e612be1dc9a233bb66955b0e4d9b69eb22bffdeea2e7545922e9",
+          "result": "valid"
+        },
+        {
+          "tcId": 154,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393937313134343135",
+          "sig": "4e4f74085f21c4d248147da31cc35eb2f5cc29c547f4e278879ea7831a8a19646e6f93da2aea21b2f038721bdad822472d78b3b731d6c8f716651fdc68fee99f",
+          "result": "valid"
+        },
+        {
+          "tcId": 155,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3331313738303133353835",
+          "sig": "fe5bacf4563943e9789f8720a1bc4447f62fbab06505a66e53aa1caef0719aa092828e8bafba9d7cfac18c1caee977386ca522a821ac65d4749b913f5cbc16cf",
+          "result": "valid"
+        },
+        {
+          "tcId": 156,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323538383834383838",
+          "sig": "1cd68efb4b8a148296f063ddeb281cbbac86512e98475f397c74e113433429297961fdd3b06fce181049c19d9ad4056b7f5c16eafa213d100213e9e3e260ff08",
+          "result": "valid"
+        },
+        {
+          "tcId": 157,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373138363334353531",
+          "sig": "cf5e2aa9f0198300cfa05b1dd473b5e7295b1a39ef9c89a7c45999bbbf2193055b8ba96da5641c467f4b09febca752ddd14aac0fc878b6683da25cb6aa582754",
+          "result": "valid"
+        },
+        {
+          "tcId": 158,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37393132343632333539",
+          "sig": "3fd0ab73ecfb09ed13ef95fca69910cadbb1febf0e2c1d9abd3f2ade99d67a2deea66cd4878a9e187270be2f11698057f16781d3cfaabca692bbf303fff658b0",
+          "result": "valid"
+        },
+        {
+          "tcId": 159,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37303636303932383538",
+          "sig": "290312deffae60601b351095ffb1e52437ca6748e1a59aa04e8a41ea3f51c7016fa5dd5f46c324b8e2d268376410de141a4554b3859483503224f421e46ab51f",
+          "result": "valid"
+        },
+        {
+          "tcId": 160,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38353839363733373030",
+          "sig": "8a968d1218fbb4030ab2fe6d474ca4f8d56672e7b16d555e5a5cf9b1e98117ba188e0e2d7676c8d841becd9cd43e03f0c70461ebde7fbf353b86c28b4c4c5f26",
+          "result": "valid"
+        },
+        {
+          "tcId": 161,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373131343937353137",
+          "sig": "269324ba0d4835dc5e0f5d91865dc0a16fc75f670aca53eab4dc3305b3980553001fc55636b52101ff235529805cf530837ed3720391a47bae07be6ebe7b506f",
+          "result": "valid"
+        },
+        {
+          "tcId": 162,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3439383538393830343432",
+          "sig": "7da44bb346c325bc77232eb54374b355d360323403409297d105473014564d93e516b03a4aff1eb5bf25865c1d4e9d0c5659e29575431b3dfb1d8d42e49b2b71",
+          "result": "valid"
+        },
+        {
+          "tcId": 163,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "383036353534313038",
+          "sig": "1739e956775225e3398b5f1352d4a8ccf45cd05ff3e0c8f3dec5b31eecdcb5ef4c249a99ee8e8e20f7e674813569303450707bca57f77ba675e94bdb80ed357e",
+          "result": "valid"
+        },
+        {
+          "tcId": 164,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313637303439303839",
+          "sig": "8fa150c34cea9a9e543269796a0ca9c33df8114ec9f5413beea891a9e8b2d0fd6dc980032c81e9704edef2dacccf708d10759e209f9990172b2d32c6c0322a8f",
+          "result": "valid"
+        },
+        {
+          "tcId": 165,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353035383730393335",
+          "sig": "82e47bcaafe7dcd77f06ff988e146e11f0f9548af566a39391cc874c528948f8d112e0063261c271722d0a5aa95d4b4e3ce95933cf7727308e7c31559cb8b320",
+          "result": "valid"
+        },
+        {
+          "tcId": 166,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3330303136383931373035",
+          "sig": "16cd4fe6aa325447343e3beaea5b8ebae76505684c018656cd2141db51b3ae9e9890c6bf2bcaa9ea5aff8c588e88aca0c2bb1baea793bd1e5591873b83ff64ee",
+          "result": "valid"
+        },
+        {
+          "tcId": 167,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393235323336323338",
+          "sig": "41518c949594767d3ad9f3ea4e2d971a7f2b2bf457ab358486ccf7d9b4d04131eaced5006bbba83789ef26a6c25269c8a13ffb3fdf1cd1cbb6ccaebe1a6835e5",
+          "result": "valid"
+        },
+        {
+          "tcId": 168,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343630323536373638",
+          "sig": "4e44e1698e79770ae4eda3789a5dbceb846361ccde4cfc519229cda0567971c61a0ff7c6662f108e87c1af49c4abf21f2ea9db37ccc8b5534fe467237515253c",
+          "result": "valid"
+        },
+        {
+          "tcId": 169,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130323031363730313431",
+          "sig": "7ee2c2795b2949ff841c56e850249ad24b0906e200829de1d30d24fc302603fe32b454c1ba939c8b15ddd688aec45755dfb412745cb9bb16c7a4c7a24bd1aaa5",
+          "result": "valid"
+        },
+        {
+          "tcId": 170,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3139343130363631323337",
+          "sig": "f168c4c9af0b64c97987b364b32aae7e69740ff76492aa628d96ac3dcda151f069cad1ae8445d81c0bd8192e43a09038272ea83c64f90ae0e451255bf8dcaeac",
+          "result": "valid"
+        },
+        {
+          "tcId": 171,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39343930333734333238",
+          "sig": "609ee9ec224f98540ff6d7ff449593376039316f8174e7b883f0c1bf258f06583960a71821bb1816377e864a6f15462629061f96b69fe68ab85afd23c0fb6fdb",
+          "result": "valid"
+        },
+        {
+          "tcId": 172,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35393730363533373431",
+          "sig": "3c38e3bbe422f196b940355c4fcafadf838aacd63ed1b6d37186fe2813916d07f02c682ddf45ebcc34fee13b2d645d9b49342f2b43fe0d78e020104126a66013",
+          "result": "valid"
+        },
+        {
+          "tcId": 173,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39313532303939333835",
+          "sig": "75f91f4574bbbef93cec953f6155f84531538b6f6739c57cdd549ad26a4172c4d03ca4173f93cb2fba98a60f76f33fd44ebdc3e1e3a5a69902319a21d619d7bc",
+          "result": "valid"
+        },
+        {
+          "tcId": 174,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343633353538393338",
+          "sig": "64f6115e0f861be8a00e4fc4f2570595324ee1041bea54db281fe73ff31b4e42dca9dcb4295069df16380f2b7c3e4690d26ea0b757e4b1d0eba16b849167762e",
+          "result": "valid"
+        },
+        {
+          "tcId": 175,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3133383230373830313133",
+          "sig": "7b2000f60ae19acf1d97d492eaeebd04cebfd0d992c2150b82013c70befb1c3aefca7efbaf4b8079fd0f7d4285eb49bb645cc1b76b61867e64885fbe4a05adfd",
+          "result": "valid"
+        },
+        {
+          "tcId": 176,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34393730373834393439",
+          "sig": "65730e1a5482455c8f50f96bdb52e2e0abd5dd7b1f853ce2a708a6fcfc2e610543ec13bc7652168a7828f24353ab8a2de4c04628286dc0043156927e21650223",
+          "result": "valid"
+        },
+        {
+          "tcId": 177,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383234343232383730",
+          "sig": "3813eff4d1d0c04201e527036f4f0cbba72c314793437c8793bbbed07d93486921338f0102f972e48b91fa5ee0496c385513b831a07e4f1eb426c9590a19b41c",
+          "result": "valid"
+        },
+        {
+          "tcId": 178,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33383336323738383330",
+          "sig": "b602016d0535514c18285a693cc7ba9ed5cd6f340778953c4cc5e63ac1c147a69814ae4cb2fa960e52b542ebd9afe9b574d741fe2ea7861ebb2bd0fb39e07a9e",
+          "result": "valid"
+        },
+        {
+          "tcId": 179,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313637333332333735",
+          "sig": "69d8ff8190b39b9a298527f429e6d08655a099ad08faea129cff2d8f102a0bc5a4c7bbc160f455999993018d1292fdcd64914aeb8ae4eb157257c385571ec2dd",
+          "result": "valid"
+        },
+        {
+          "tcId": 180,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303032343935313334",
+          "sig": "393d20abd56bed26182ce3bd4616a057d5ca9a1de76976239a23801a5e00405adabd899f060553cd385faeabbc3b6abf023889fce5763dc48a1595b6e8a7761f",
+          "result": "valid"
+        },
+        {
+          "tcId": 181,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31313936393930353937",
+          "sig": "f81e106ba88e60b38df06d770e6570a4e268b8968e75b17323a23dca1cb041e9ada84e71af019c64d2a2f68ff70f608df09545796cbd7f4ee901bd51c5a40b1c",
+          "result": "valid"
+        },
+        {
+          "tcId": 182,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343932393736353338",
+          "sig": "553937645e5a72ec1a788b989502fc0c099cf47dc223c3a05a17511e8aaacf253d907444401725b6ce74e46c93b842da7165d66c4225dd9529b6c01aefc17887",
+          "result": "valid"
+        },
+        {
+          "tcId": 183,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303639343230353239",
+          "sig": "b952d6c90612db7d44cdc3427c8a04cbbfeb42f08400d7e43fcd491c2e2b29e0e090d16e7f8d8ecf349094c990fbbc608146bd42f0bf62ed4414c4f516ba8da6",
+          "result": "valid"
+        },
+        {
+          "tcId": 184,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35343434343734303338",
+          "sig": "cd9ca46a05f8e230b609248d93ba3109ce6d313fe1c2f446831e507a7adc3b1edc303aaed67ad227d16e8ba74c05c2158938ddc08fb62c704ab145d6fb48a654",
+          "result": "valid"
+        },
+        {
+          "tcId": 185,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353730393730303131",
+          "sig": "fe4204134e2f81a3a1533690d6c01babc5116b77054e00acce671fe2b42ad67ddea459c03b17919c2b7c572cb4053251feab5be2f8791e49d8591951fb8cbdad",
+          "result": "valid"
+        },
+        {
+          "tcId": 186,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35313831393239363035",
+          "sig": "018a82596f2afaec1676e2f42f0a99bdd3ec0b3c4a70690d8c018eb675ee52f571b483f2017a5757df033a2acb6b37518d3424a6643bcd1b107bf82d18a46010",
+          "result": "valid"
+        },
+        {
+          "tcId": 187,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34323636373735353134",
+          "sig": "a72643f331ef9fcd6e266d550fda197b7b14c95fee28100002e0546833bd141a945ebc905842f2e313632501a09329ed0fc41b4cf4ccb1402afe87e443bcbff2",
+          "result": "valid"
+        },
+        {
+          "tcId": 188,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134363137373433393834",
+          "sig": "738c2834aedbbe5586f7dc73540afb02a9f38d2d32d8d4c5c4af4cbb599f355e556cc8f3096884f7f3801d8a868de19dc857fd2fb647614dadbfd0b5f60dd3ac",
+          "result": "valid"
+        },
+        {
+          "tcId": 189,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38343837323933313330",
+          "sig": "7e112e7a251cf9d4223438193fd77c2d9131d82b0cfa712423acbcf01c35ca08e69051460cb2b740c3bb2150e5076757040705faba0fc54a0c30305ed13d0c02",
+          "result": "valid"
+        },
+        {
+          "tcId": 190,
+          "comment": "Signature generated without truncating the hash",
+          "flags": [
+            "Untruncatedhash"
+          ],
+          "msg": "313233343030",
+          "sig": "feb5a6ab646502be3fd3223349b11cf494324ce2b65c343572591a737d18c22a49464f6f0996c851c077d077ea1a22ea2bbdf92b241f1d6d7dd2f48b08ae35f8",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "uDj_ROW8F3vyEYnQdmCC_J2EMiaIf8l2A3EQC37iCm8",
+        "y": "8MnXW_unsxpryhl0SW7rVt41cHGVXYPEsbraoLIYMuk",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04422aa6bdbb76a2886463600f1224a80d2c9f984c212d57ed90ca49643ed673e157af3122aaa04597c5527354f1801425700c6d958c58d8ddbdaaec0ec721cb42",
+        "wx": "422aa6bdbb76a2886463600f1224a80d2c9f984c212d57ed90ca49643ed673e1",
+        "wy": "57af3122aaa04597c5527354f1801425700c6d958c58d8ddbdaaec0ec721cb42"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004422aa6bdbb76a2886463600f1224a80d2c9f984c212d57ed90ca49643ed673e157af3122aaa04597c5527354f1801425700c6d958c58d8ddbdaaec0ec721cb42",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQiqmvbt2oohkY2APEiSoDSyfmEwhLVft\nkMpJZD7Wc+FXrzEiqqBFl8VSc1TxgBQlcAxtlYxY2N29quwOxyHLQg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 191,
+          "comment": "k*G has a large x-coordinate",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000014551231950b75fc4402da1722fc9baebfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        },
+        {
+          "tcId": 192,
+          "comment": "r too large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2cfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Qiqmvbt2oohkY2APEiSoDSyfmEwhLVftkMpJZD7Wc-E",
+        "y": "V68xIqqgRZfFUnNU8YAUJXAMbZWMWNjdvarsDschy0I",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dd752c014ec002daf07db8f6d7988d804533ba104c8052e06a8877236d326d402aae02e1da209844e8ca24e9984d7b9c0e876979e131ec2cc00609bae520ade9",
+        "wx": "00dd752c014ec002daf07db8f6d7988d804533ba104c8052e06a8877236d326d40",
+        "wy": "2aae02e1da209844e8ca24e9984d7b9c0e876979e131ec2cc00609bae520ade9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dd752c014ec002daf07db8f6d7988d804533ba104c8052e06a8877236d326d402aae02e1da209844e8ca24e9984d7b9c0e876979e131ec2cc00609bae520ade9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3XUsAU7AAtrwfbj215iNgEUzuhBMgFLg\naoh3I20ybUAqrgLh2iCYROjKJOmYTXucDodpeeEx7CzABgm65SCt6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 193,
+          "comment": "r,s are large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413ffffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "3XUsAU7AAtrwfbj215iNgEUzuhBMgFLgaoh3I20ybUA",
+        "y": "Kq4C4dogmEToyiTpmE17nA6HaXnhMewswAYJuuUgrek",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041517cb0ff4b4fb4e2689ecb6a21ae96a5852b079884149cd63729b9724937cbe3dfe6274af762eb423a2b149756dc5bb4b253d23033b7cc9db5844887161525d",
+        "wx": "1517cb0ff4b4fb4e2689ecb6a21ae96a5852b079884149cd63729b9724937cbe",
+        "wy": "3dfe6274af762eb423a2b149756dc5bb4b253d23033b7cc9db5844887161525d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041517cb0ff4b4fb4e2689ecb6a21ae96a5852b079884149cd63729b9724937cbe3dfe6274af762eb423a2b149756dc5bb4b253d23033b7cc9db5844887161525d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFRfLD/S0+04miey2ohrpalhSsHmIQUnN\nY3KblySTfL49/mJ0r3YutCOisUl1bcW7SyU9IwM7fMnbWESIcWFSXQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 194,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc3e9a7582886089c62fb840cf3b83061cd1cff3ae4341808bb5bdee6191174177",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "FRfLD_S0-04miey2ohrpalhSsHmIQUnNY3KblySTfL4",
+        "y": "Pf5idK92LrQjorFJdW3Fu0slPSMDO3zJ21hEiHFhUl0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045ebb9309c3073c74e1024b9fedf40da99045962aa9189cbb1e5c5e37983fda6b4e6787cd4af3383c769b911647d42b671e72b751e37ea3a02b6321cf9a88e36e",
+        "wx": "5ebb9309c3073c74e1024b9fedf40da99045962aa9189cbb1e5c5e37983fda6b",
+        "wy": "4e6787cd4af3383c769b911647d42b671e72b751e37ea3a02b6321cf9a88e36e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045ebb9309c3073c74e1024b9fedf40da99045962aa9189cbb1e5c5e37983fda6b4e6787cd4af3383c769b911647d42b671e72b751e37ea3a02b6321cf9a88e36e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXruTCcMHPHThAkuf7fQNqZBFliqpGJy7\nHlxeN5g/2mtOZ4fNSvM4PHabkRZH1CtnHnK3UeN+o6ArYyHPmojjbg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 195,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc24238e70b431b1a64efdf9032669939d4b77f249503fc6905feb7540dea3e6d2",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "XruTCcMHPHThAkuf7fQNqZBFliqpGJy7HlxeN5g_2ms",
+        "y": "TmeHzUrzODx2m5EWR9QrZx5yt1HjfqOgK2Mhz5qI424",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041c64127c05117c1c3340748b560b97a36690aad3f1dc80e1f6fb11d8842a11f3408336777e1c1c0068b09658c28bade3074b0a0adee9fb508ef297c501e407dd",
+        "wx": "1c64127c05117c1c3340748b560b97a36690aad3f1dc80e1f6fb11d8842a11f3",
+        "wy": "408336777e1c1c0068b09658c28bade3074b0a0adee9fb508ef297c501e407dd"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041c64127c05117c1c3340748b560b97a36690aad3f1dc80e1f6fb11d8842a11f3408336777e1c1c0068b09658c28bade3074b0a0adee9fb508ef297c501e407dd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHGQSfAURfBwzQHSLVguXo2aQqtPx3IDh\n9vsR2IQqEfNAgzZ3fhwcAGiwlljCi63jB0sKCt7p+1CO8pfFAeQH3Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 196,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 197,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0101",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "HGQSfAURfBwzQHSLVguXo2aQqtPx3IDh9vsR2IQqEfM",
+        "y": "QIM2d34cHABosJZYwout4wdLCgre6ftQjvKXxQHkB90",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049921d16a1d0d3536cc21156636feb9d8885b75914ea638754b0ae3dd4d79c99ef46613ab32a5769c2857df6a3554d228a97fafac6b63dc8edefb3496760d7f63",
+        "wx": "009921d16a1d0d3536cc21156636feb9d8885b75914ea638754b0ae3dd4d79c99e",
+        "wy": "00f46613ab32a5769c2857df6a3554d228a97fafac6b63dc8edefb3496760d7f63"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049921d16a1d0d3536cc21156636feb9d8885b75914ea638754b0ae3dd4d79c99ef46613ab32a5769c2857df6a3554d228a97fafac6b63dc8edefb3496760d7f63",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEmSHRah0NNTbMIRVmNv652IhbdZFOpjh1\nSwrj3U15yZ70ZhOrMqV2nChX32o1VNIoqX+vrGtj3I7e+zSWdg1/Yw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 198,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002",
+          "result": "valid"
+        },
+        {
+          "tcId": 199,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0102",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "mSHRah0NNTbMIRVmNv652IhbdZFOpjh1Swrj3U15yZ4",
+        "y": "9GYTqzKldpwoV99qNVTSKKl_r6xrY9yO3vs0lnYNf2M",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b1bfd06dd462e53911f08f12126a90e5956d99dce41da5f757f463fa772f80338a8df80a8775efba16fd01c6ca63a67237167ff82cc513dbc18fc5b3c522ee69",
+        "wx": "00b1bfd06dd462e53911f08f12126a90e5956d99dce41da5f757f463fa772f8033",
+        "wy": "008a8df80a8775efba16fd01c6ca63a67237167ff82cc513dbc18fc5b3c522ee69"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b1bfd06dd462e53911f08f12126a90e5956d99dce41da5f757f463fa772f80338a8df80a8775efba16fd01c6ca63a67237167ff82cc513dbc18fc5b3c522ee69",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsb/QbdRi5TkR8I8SEmqQ5ZVtmdzkHaX3\nV/Rj+ncvgDOKjfgKh3Xvuhb9AcbKY6ZyNxZ/+CzFE9vBj8WzxSLuaQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 200,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000003",
+          "result": "valid"
+        },
+        {
+          "tcId": 201,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0103",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "sb_QbdRi5TkR8I8SEmqQ5ZVtmdzkHaX3V_Rj-ncvgDM",
+        "y": "io34Cod177oW_QHGymOmcjcWf_gsxRPbwY_Fs8Ui7mk",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041cea87abd1c52a6209662ff51fc0070b98c0209aff5e3833f4358d1ba757be1552c75e5aebdcf1705e5d82ccd55a830c1a9a3c322f61303a9663dc80ce644eaf",
+        "wx": "1cea87abd1c52a6209662ff51fc0070b98c0209aff5e3833f4358d1ba757be15",
+        "wy": "52c75e5aebdcf1705e5d82ccd55a830c1a9a3c322f61303a9663dc80ce644eaf"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041cea87abd1c52a6209662ff51fc0070b98c0209aff5e3833f4358d1ba757be1552c75e5aebdcf1705e5d82ccd55a830c1a9a3c322f61303a9663dc80ce644eaf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHOqHq9HFKmIJZi/1H8AHC5jAIJr/Xjgz\n9DWNG6dXvhVSx15a69zxcF5dgszVWoMMGpo8Mi9hMDqWY9yAzmROrw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 202,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 203,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0201",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "HOqHq9HFKmIJZi_1H8AHC5jAIJr_Xjgz9DWNG6dXvhU",
+        "y": "UsdeWuvc8XBeXYLM1VqDDBqaPDIvYTA6lmPcgM5kTq8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0462ddb94532ced199fc5579e42b434b0babc4af1b7bc64747a5f7ef59036271ed354bba6863ee5a77ef0d9c571b0f60c79080abc2012c55f578ac47d02d4fa859",
+        "wx": "62ddb94532ced199fc5579e42b434b0babc4af1b7bc64747a5f7ef59036271ed",
+        "wy": "354bba6863ee5a77ef0d9c571b0f60c79080abc2012c55f578ac47d02d4fa859"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000462ddb94532ced199fc5579e42b434b0babc4af1b7bc64747a5f7ef59036271ed354bba6863ee5a77ef0d9c571b0f60c79080abc2012c55f578ac47d02d4fa859",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYt25RTLO0Zn8VXnkK0NLC6vErxt7xkdH\npffvWQNice01S7poY+5ad+8NnFcbD2DHkICrwgEsVfV4rEfQLU+oWQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 204,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002",
+          "result": "valid"
+        },
+        {
+          "tcId": 205,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0202",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Yt25RTLO0Zn8VXnkK0NLC6vErxt7xkdHpffvWQNice0",
+        "y": "NUu6aGPuWnfvDZxXGw9gx5CAq8IBLFX1eKxH0C1PqFk",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045255cd9b6f770e1f653bc5e3588243e591b5c18bcec06ab02fd897e353610598c29e751be62659ad33553c280350711b53e16e00004c30de994f7a72a99b21ef",
+        "wx": "5255cd9b6f770e1f653bc5e3588243e591b5c18bcec06ab02fd897e353610598",
+        "wy": "00c29e751be62659ad33553c280350711b53e16e00004c30de994f7a72a99b21ef"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045255cd9b6f770e1f653bc5e3588243e591b5c18bcec06ab02fd897e353610598c29e751be62659ad33553c280350711b53e16e00004c30de994f7a72a99b21ef",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUlXNm293Dh9lO8XjWIJD5ZG1wYvOwGqw\nL9iX41NhBZjCnnUb5iZZrTNVPCgDUHEbU+FuAABMMN6ZT3pyqZsh7w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 206,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000003",
+          "result": "valid"
+        },
+        {
+          "tcId": 207,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "0203",
+          "result": "invalid"
+        },
+        {
+          "tcId": 208,
+          "comment": "r is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641430000000000000000000000000000000000000000000000000000000000000003",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "UlXNm293Dh9lO8XjWIJD5ZG1wYvOwGqwL9iX41NhBZg",
+        "y": "wp51G-YmWa0zVTwoA1BxG1PhbgAATDDemU96cqmbIe8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0446c59ef30d382bc4fe36ac4625311c426643a5311b666af25245220bd663dacb2e271c9b231518bc97208401dda643fc3876fe6ad326f7da9d0d8dc7937c5e72",
+        "wx": "46c59ef30d382bc4fe36ac4625311c426643a5311b666af25245220bd663dacb",
+        "wy": "2e271c9b231518bc97208401dda643fc3876fe6ad326f7da9d0d8dc7937c5e72"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000446c59ef30d382bc4fe36ac4625311c426643a5311b666af25245220bd663dacb2e271c9b231518bc97208401dda643fc3876fe6ad326f7da9d0d8dc7937c5e72",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAERsWe8w04K8T+NqxGJTEcQmZDpTEbZmry\nUkUiC9Zj2ssuJxybIxUYvJcghAHdpkP8OHb+atMm99qdDY3Hk3xecg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 209,
+          "comment": "s is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000002fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd04917c8",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "RsWe8w04K8T-NqxGJTEcQmZDpTEbZmryUkUiC9Zj2ss",
+        "y": "LiccmyMVGLyXIIQB3aZD_Dh2_mrTJvfanQ2Nx5N8XnI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ceff46890fe208a8f38cf264224cf3a1c898aab318a15ea99d4f08d3a4db7fbe5dbc13f704e04d842d65dba0096d6462a3574aacd07eb9f27cd20a800d1d3612",
+        "wx": "00ceff46890fe208a8f38cf264224cf3a1c898aab318a15ea99d4f08d3a4db7fbe",
+        "wy": "5dbc13f704e04d842d65dba0096d6462a3574aacd07eb9f27cd20a800d1d3612"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ceff46890fe208a8f38cf264224cf3a1c898aab318a15ea99d4f08d3a4db7fbe5dbc13f704e04d842d65dba0096d6462a3574aacd07eb9f27cd20a800d1d3612",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzv9GiQ/iCKjzjPJkIkzzociYqrMYoV6p\nnU8I06Tbf75dvBP3BOBNhC1l26AJbWRio1dKrNB+ufJ80gqADR02Eg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 210,
+          "comment": "small r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000101c58b162c58b162c58b162c58b162c58a1b242973853e16db75c8a1a71da4d39d",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "zv9GiQ_iCKjzjPJkIkzzociYqrMYoV6pnU8I06Tbf74",
+        "y": "XbwT9wTgTYQtZdugCW1kYqNXSqzQfrnyfNIKgA0dNhI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e7e62d42a46fd9171ec46b144f3bd0ea30ddc51e5420ea4c5c431cc57bb4ed88ccc42e2428e8321bd2ef58614dfa8df4a41a4e920d18491c832bcdb9c970fc27",
+        "wx": "00e7e62d42a46fd9171ec46b144f3bd0ea30ddc51e5420ea4c5c431cc57bb4ed88",
+        "wy": "00ccc42e2428e8321bd2ef58614dfa8df4a41a4e920d18491c832bcdb9c970fc27"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e7e62d42a46fd9171ec46b144f3bd0ea30ddc51e5420ea4c5c431cc57bb4ed88ccc42e2428e8321bd2ef58614dfa8df4a41a4e920d18491c832bcdb9c970fc27",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5+YtQqRv2RcexGsUTzvQ6jDdxR5UIOpM\nXEMcxXu07YjMxC4kKOgyG9LvWGFN+o30pBpOkg0YSRyDK825yXD8Jw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 211,
+          "comment": "smallish r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000000000000000000000002d9b4d347952ccfcbc5103d0da267477d1791461cf2aa44bf9d43198f79507bd8779d69a13108e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "5-YtQqRv2RcexGsUTzvQ6jDdxR5UIOpMXEMcxXu07Yg",
+        "y": "zMQuJCjoMhvS71hhTfqN9KQaTpINGEkcgyvNuclw_Cc",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bb581b856299baea7590b55481e117d444ccef77d3d75bd950ab2391d5f0979e4e59c5c4ba6bfdf4c2979e5bdec11aecaa05b3cc6853b702f592324b23966b40",
+        "wx": "00bb581b856299baea7590b55481e117d444ccef77d3d75bd950ab2391d5f0979e",
+        "wy": "4e59c5c4ba6bfdf4c2979e5bdec11aecaa05b3cc6853b702f592324b23966b40"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bb581b856299baea7590b55481e117d444ccef77d3d75bd950ab2391d5f0979e4e59c5c4ba6bfdf4c2979e5bdec11aecaa05b3cc6853b702f592324b23966b40",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEu1gbhWKZuup1kLVUgeEX1ETM73fT11vZ\nUKsjkdXwl55OWcXEumv99MKXnlvewRrsqgWzzGhTtwL1kjJLI5ZrQA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 212,
+          "comment": "100-bit r and small s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000000000001033e67e37b32b445580bf4efc906f906f906f906f906f906f906f906ed8e426f7b1968c35a204236a579723d2",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "u1gbhWKZuup1kLVUgeEX1ETM73fT11vZUKsjkdXwl54",
+        "y": "TlnFxLpr_fTCl55b3sEa7KoFs8xoU7cC9ZIySyOWa0A",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0469fac7b66097f6d267242f4d785691a8ca08c35dfdb631a350efd3c24fe0c98de9817010f5fddd7acecdd29c408650342ddc3ab9fa8cf9a21389d295788bbaf1",
+        "wx": "69fac7b66097f6d267242f4d785691a8ca08c35dfdb631a350efd3c24fe0c98d",
+        "wy": "00e9817010f5fddd7acecdd29c408650342ddc3ab9fa8cf9a21389d295788bbaf1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000469fac7b66097f6d267242f4d785691a8ca08c35dfdb631a350efd3c24fe0c98de9817010f5fddd7acecdd29c408650342ddc3ab9fa8cf9a21389d295788bbaf1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEafrHtmCX9tJnJC9NeFaRqMoIw139tjGj\nUO/Twk/gyY3pgXAQ9f3des7N0pxAhlA0Ldw6ufqM+aITidKVeIu68Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 213,
+          "comment": "small r and 100 bit s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000000000000000000101783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "afrHtmCX9tJnJC9NeFaRqMoIw139tjGjUO_Twk_gyY0",
+        "y": "6YFwEPX93XrOzdKcQIZQNC3cOrn6jPmiE4nSlXiLuvE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b35310c91902940bae2f1d9c4e111d1bef88a85793e835bb746512ef129f03fc8726e72947d215f99f9d8678d680c040c782e0df11c5ced4d3e566bcf80abe0d",
+        "wx": "00b35310c91902940bae2f1d9c4e111d1bef88a85793e835bb746512ef129f03fc",
+        "wy": "008726e72947d215f99f9d8678d680c040c782e0df11c5ced4d3e566bcf80abe0d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b35310c91902940bae2f1d9c4e111d1bef88a85793e835bb746512ef129f03fc8726e72947d215f99f9d8678d680c040c782e0df11c5ced4d3e566bcf80abe0d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEs1MQyRkClAuuLx2cThEdG++IqFeT6DW7\ndGUS7xKfA/yHJucpR9IV+Z+dhnjWgMBAx4Lg3xHFztTT5Wa8+Aq+DQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 214,
+          "comment": "100-bit r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "00000000000000000000000000000000000000062522bbd3ecbe7c39e93e7c26783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "s1MQyRkClAuuLx2cThEdG--IqFeT6DW7dGUS7xKfA_w",
+        "y": "hybnKUfSFfmfnYZ41oDAQMeC4N8Rxc7U0-VmvPgKvg0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04faa11612dc1cf47c88aebdfeb9619bff6194a92db86bfb0c6bddd7a46a6fbaff5219485362ad0fb96f7b5397ba21770f03737537b260f59d4bc6429caa708a25",
+        "wx": "00faa11612dc1cf47c88aebdfeb9619bff6194a92db86bfb0c6bddd7a46a6fbaff",
+        "wy": "5219485362ad0fb96f7b5397ba21770f03737537b260f59d4bc6429caa708a25"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004faa11612dc1cf47c88aebdfeb9619bff6194a92db86bfb0c6bddd7a46a6fbaff5219485362ad0fb96f7b5397ba21770f03737537b260f59d4bc6429caa708a25",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+qEWEtwc9HyIrr3+uWGb/2GUqS24a/sM\na93XpGpvuv9SGUhTYq0PuW97U5e6IXcPA3N1N7Jg9Z1LxkKcqnCKJQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 215,
+          "comment": "r and s^-1 are close to n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03640c155555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "-qEWEtwc9HyIrr3-uWGb_2GUqS24a_sMa93XpGpvuv8",
+        "y": "UhlIU2KtD7lve1OXuiF3DwNzdTeyYPWdS8ZCnKpwiiU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049befce446ab74d4fef99ebc1a047608f50383c7a9323b592a9935e68f340219b65671bb895039a40dc6256ac4ebd4e2a3a4617b0b6f775cc66fa31985257ad6f",
+        "wx": "009befce446ab74d4fef99ebc1a047608f50383c7a9323b592a9935e68f340219b",
+        "wy": "65671bb895039a40dc6256ac4ebd4e2a3a4617b0b6f775cc66fa31985257ad6f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049befce446ab74d4fef99ebc1a047608f50383c7a9323b592a9935e68f340219b65671bb895039a40dc6256ac4ebd4e2a3a4617b0b6f775cc66fa31985257ad6f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEm+/ORGq3TU/vmevBoEdgj1A4PHqTI7WS\nqZNeaPNAIZtlZxu4lQOaQNxiVqxOvU4qOkYXsLb3dcxm+jGYUletbw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 216,
+          "comment": "r and s are 64-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000000000000009c44febf31c3594d000000000000000000000000000000000000000000000000839ed28247c2b06b",
+          "result": "valid"
+        },
+        {
+          "tcId": 217,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "9c44febf31c3594d839ed28247c2b06b",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "m-_ORGq3TU_vmevBoEdgj1A4PHqTI7WSqZNeaPNAIZs",
+        "y": "ZWcbuJUDmkDcYlasTr1OKjpGF7C293XMZvoxmFJXrW8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0481c13215c3f5c1dee52a15059a78ad0dd27d4a6dd99260f7cce9e09220bdf48f50425bcc09fc9b5693914e3dad150b321e6151014902309c57e71255102fefa0",
+        "wx": "0081c13215c3f5c1dee52a15059a78ad0dd27d4a6dd99260f7cce9e09220bdf48f",
+        "wy": "50425bcc09fc9b5693914e3dad150b321e6151014902309c57e71255102fefa0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000481c13215c3f5c1dee52a15059a78ad0dd27d4a6dd99260f7cce9e09220bdf48f50425bcc09fc9b5693914e3dad150b321e6151014902309c57e71255102fefa0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEgcEyFcP1wd7lKhUFmnitDdJ9Sm3ZkmD3\nzOngkiC99I9QQlvMCfybVpORTj2tFQsyHmFRAUkCMJxX5xJVEC/voA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 218,
+          "comment": "r and s are 100-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "0000000000000000000000000000000000000009df8b682430beef6f5fd7c7cf000000000000000000000000000000000000000fd0a62e13778f4222a0d61c8a",
+          "result": "valid"
+        },
+        {
+          "tcId": 219,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "09df8b682430beef6f5fd7c7cf0fd0a62e13778f4222a0d61c8a",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "gcEyFcP1wd7lKhUFmnitDdJ9Sm3ZkmD3zOngkiC99I8",
+        "y": "UEJbzAn8m1aTkU49rRULMh5hUQFJAjCcV-cSVRAv76A",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a30a55982e075623552c705254bf8c0c3ea5e512048d480951e3d04906275eba3d90e7e1afbec7402f3c0b95326332707b08e54de51ede788888f063614b80bc",
+        "wx": "00a30a55982e075623552c705254bf8c0c3ea5e512048d480951e3d04906275eba",
+        "wy": "3d90e7e1afbec7402f3c0b95326332707b08e54de51ede788888f063614b80bc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a30a55982e075623552c705254bf8c0c3ea5e512048d480951e3d04906275eba3d90e7e1afbec7402f3c0b95326332707b08e54de51ede788888f063614b80bc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEowpVmC4HViNVLHBSVL+MDD6l5RIEjUgJ\nUePQSQYnXro9kOfhr77HQC88C5UyYzJwewjlTeUe3niIiPBjYUuAvA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 220,
+          "comment": "r and s are 128-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000000000008a598e563a89f526c32ebec8de26367a0000000000000000000000000000000084f633e2042630e99dd0f1e16f7a04bf",
+          "result": "valid"
+        },
+        {
+          "tcId": 221,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "8a598e563a89f526c32ebec8de26367a84f633e2042630e99dd0f1e16f7a04bf",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "owpVmC4HViNVLHBSVL-MDD6l5RIEjUgJUePQSQYnXro",
+        "y": "PZDn4a--x0AvPAuVMmMycHsI5U3lHt54iIjwY2FLgLw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04add44840ce5ad85ccd84523da02aa463efab664eca5d09a2b93f34aa34a6b495c0a0a63f15bf2e5149040e054be6bd1afbcc3371d5540efb45aa0203b4429147",
+        "wx": "00add44840ce5ad85ccd84523da02aa463efab664eca5d09a2b93f34aa34a6b495",
+        "wy": "00c0a0a63f15bf2e5149040e054be6bd1afbcc3371d5540efb45aa0203b4429147"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004add44840ce5ad85ccd84523da02aa463efab664eca5d09a2b93f34aa34a6b495c0a0a63f15bf2e5149040e054be6bd1afbcc3371d5540efb45aa0203b4429147",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErdRIQM5a2FzNhFI9oCqkY++rZk7KXQmi\nuT80qjSmtJXAoKY/Fb8uUUkEDgVL5r0a+8wzcdVUDvtFqgIDtEKRRw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 222,
+          "comment": "r and s are 160-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "000000000000000000000000aa6eeb5823f7fa31b466bb473797f0d0314c0bdf000000000000000000000000e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "valid"
+        },
+        {
+          "tcId": 223,
+          "comment": "incorrect size of signature",
+          "flags": [
+            "ArithmeticError",
+            "SignatureSize"
+          ],
+          "msg": "313233343030",
+          "sig": "aa6eeb5823f7fa31b466bb473797f0d0314c0bdfe2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "rdRIQM5a2FzNhFI9oCqkY--rZk7KXQmiuT80qjSmtJU",
+        "y": "wKCmPxW_LlFJBA4FS-a9GvvMM3HVVA77RaoCA7RCkUc",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0452274d1decb02dbdae051095322e3193fff185171f8dc9bc6586dcc02d0eca4a2e2c350530f58e5d86ee3b0eebd9bdc7691d361883e248a04d97bd289b36f18c",
+        "wx": "52274d1decb02dbdae051095322e3193fff185171f8dc9bc6586dcc02d0eca4a",
+        "wy": "2e2c350530f58e5d86ee3b0eebd9bdc7691d361883e248a04d97bd289b36f18c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000452274d1decb02dbdae051095322e3193fff185171f8dc9bc6586dcc02d0eca4a2e2c350530f58e5d86ee3b0eebd9bdc7691d361883e248a04d97bd289b36f18c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUidNHeywLb2uBRCVMi4xk//xhRcfjcm8\nZYbcwC0OykouLDUFMPWOXYbuOw7r2b3HaR02GIPiSKBNl70omzbxjA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 224,
+          "comment": "s == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10000000000000000000000000000000000000000000000000000000000000001",
+          "result": "valid"
+        },
+        {
+          "tcId": 225,
+          "comment": "s == 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "UidNHeywLb2uBRCVMi4xk__xhRcfjcm8ZYbcwC0Oyko",
+        "y": "Liw1BTD1jl2G7jsO69m9x2kdNhiD4kigTZe9KJs28Yw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04269870065bcb7ffe3cce3a9b4b2f89b66507e369a8eb9f29a305d0545c715f9772ec971603c708394485e1de726028ee2bedfcc714b6bda6b8afe9010410b10b",
+        "wx": "269870065bcb7ffe3cce3a9b4b2f89b66507e369a8eb9f29a305d0545c715f97",
+        "wy": "72ec971603c708394485e1de726028ee2bedfcc714b6bda6b8afe9010410b10b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004269870065bcb7ffe3cce3a9b4b2f89b66507e369a8eb9f29a305d0545c715f9772ec971603c708394485e1de726028ee2bedfcc714b6bda6b8afe9010410b10b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJphwBlvLf/48zjqbSy+JtmUH42mo658p\nowXQVFxxX5dy7JcWA8cIOUSF4d5yYCjuK+38xxS2vaa4r+kBBBCxCw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 226,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1419d981c515af8cc82545aac0c85e9e308fbb2eab6acd7ed497e0b4145a18fd9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "JphwBlvLf_48zjqbSy-JtmUH42mo658powXQVFxxX5c",
+        "y": "cuyXFgPHCDlEheHecmAo7ivt_McUtr2muK_pAQQQsQs",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e56487012920aff940cef12d632927d4b9e33a088e2aa939cbb61b51fd45c246b565fc50dfaafa63b97435ef2ecde39d9e260b1a6cf57335746540dadfe8793b",
+        "wx": "00e56487012920aff940cef12d632927d4b9e33a088e2aa939cbb61b51fd45c246",
+        "wy": "00b565fc50dfaafa63b97435ef2ecde39d9e260b1a6cf57335746540dadfe8793b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e56487012920aff940cef12d632927d4b9e33a088e2aa939cbb61b51fd45c246b565fc50dfaafa63b97435ef2ecde39d9e260b1a6cf57335746540dadfe8793b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5WSHASkgr/lAzvEtYykn1LnjOgiOKqk5\ny7YbUf1Fwka1ZfxQ36r6Y7l0Ne8uzeOdniYLGmz1czV0ZUDa3+h5Ow==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 227,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c11b21717ad71d23bbac60a9ad0baf75b063c9fdf52a00ebf99d022172910993c9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "5WSHASkgr_lAzvEtYykn1LnjOgiOKqk5y7YbUf1FwkY",
+        "y": "tWX8UN-q-mO5dDXvLs3jnZ4mCxps9XM1dGVA2t_oeTs",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0452b756fe31cc75bc1d2d8f7a366af5db2bd3f34690e91a06733f787977328248ac93242210fb19ccd5b7f6b26510ef0bff8d7082b7fa62f45fea16299426bb72",
+        "wx": "52b756fe31cc75bc1d2d8f7a366af5db2bd3f34690e91a06733f787977328248",
+        "wy": "00ac93242210fb19ccd5b7f6b26510ef0bff8d7082b7fa62f45fea16299426bb72"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000452b756fe31cc75bc1d2d8f7a366af5db2bd3f34690e91a06733f787977328248ac93242210fb19ccd5b7f6b26510ef0bff8d7082b7fa62f45fea16299426bb72",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUrdW/jHMdbwdLY96Nmr12yvT80aQ6RoG\ncz94eXcygkiskyQiEPsZzNW39rJlEO8L/41wgrf6YvRf6hYplCa7cg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 228,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c12f588f66018f3dd14db3e28e77996487e32486b521ed8e5a20f06591951777e9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "UrdW_jHMdbwdLY96Nmr12yvT80aQ6RoGcz94eXcygkg",
+        "y": "rJMkIhD7GczVt_ayZRDvC_-NcIK3-mL0X-oWKZQmu3I",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f7cfe21fd402b72361a79aad213163926c328453855e67bcc39ea23b8c59d5ae707bb4439721281f6f9752f666c67e036e488775cc688dd373b57697c390ba89",
+        "wx": "00f7cfe21fd402b72361a79aad213163926c328453855e67bcc39ea23b8c59d5ae",
+        "wy": "707bb4439721281f6f9752f666c67e036e488775cc688dd373b57697c390ba89"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f7cfe21fd402b72361a79aad213163926c328453855e67bcc39ea23b8c59d5ae707bb4439721281f6f9752f666c67e036e488775cc688dd373b57697c390ba89",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE98/iH9QCtyNhp5qtITFjkmwyhFOFXme8\nw56iO4xZ1a5we7RDlyEoH2+XUvZmxn4DbkiHdcxojdNztXaXw5C6iQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 229,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1091a08870ff4daf9123b30c20e8c4fc8505758dcf4074fcaff2170c9bfcf74f4",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "98_iH9QCtyNhp5qtITFjkmwyhFOFXme8w56iO4xZ1a4",
+        "y": "cHu0Q5chKB9vl1L2ZsZ-A25Ih3XMaI3Tc7V2l8OQuok",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cf59bdc9ccde51be450c5beb3a74a2a76457ad876fe15f5c097938de20dbf0993f75a4070ffb9196b6dd27a8248432dc149ab7444110651104ca84a571e8d477",
+        "wx": "00cf59bdc9ccde51be450c5beb3a74a2a76457ad876fe15f5c097938de20dbf099",
+        "wy": "3f75a4070ffb9196b6dd27a8248432dc149ab7444110651104ca84a571e8d477"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cf59bdc9ccde51be450c5beb3a74a2a76457ad876fe15f5c097938de20dbf0993f75a4070ffb9196b6dd27a8248432dc149ab7444110651104ca84a571e8d477",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEz1m9yczeUb5FDFvrOnSip2RXrYdv4V9c\nCXk43iDb8Jk/daQHD/uRlrbdJ6gkhDLcFJq3REEQZREEyoSlcejUdw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 230,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c17c370dc0ce8c59a8b273cba44a7c1191fc3186dc03cab96b0567312df0d0b250",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "z1m9yczeUb5FDFvrOnSip2RXrYdv4V9cCXk43iDb8Jk",
+        "y": "P3WkBw_7kZa23SeoJIQy3BSat0RBEGURBMqEpXHo1Hc",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0453c7b4981d9dba54ee3fd63f4bea83c893b1c8d4f98652039e62485f0f4639dd9ef9898a43219662edc8689b43e4fbc00f15201ac1c376c9a8f7a8828d9417c1",
+        "wx": "53c7b4981d9dba54ee3fd63f4bea83c893b1c8d4f98652039e62485f0f4639dd",
+        "wy": "009ef9898a43219662edc8689b43e4fbc00f15201ac1c376c9a8f7a8828d9417c1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000453c7b4981d9dba54ee3fd63f4bea83c893b1c8d4f98652039e62485f0f4639dd9ef9898a43219662edc8689b43e4fbc00f15201ac1c376c9a8f7a8828d9417c1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEU8e0mB2dulTuP9Y/S+qDyJOxyNT5hlID\nnmJIXw9GOd2e+YmKQyGWYu3IaJtD5PvADxUgGsHDdsmo96iCjZQXwQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 231,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c170b59a7d1ee77a2f9e0491c2a7cfcd0ed04df4a35192f6132dcc668c79a6160e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "U8e0mB2dulTuP9Y_S-qDyJOxyNT5hlIDnmJIXw9GOd0",
+        "y": "nvmJikMhlmLtyGibQ-T7wA8VIBrBw3bJqPeogo2UF8E",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fe7870a02775ab4597230b7d79afc53b9c98b1b2d61f2f2097e2971f5396840e154dde797afaee01c1794acffa797827148ce15e41880c994407cb03ba4a6fa2",
+        "wx": "00fe7870a02775ab4597230b7d79afc53b9c98b1b2d61f2f2097e2971f5396840e",
+        "wy": "154dde797afaee01c1794acffa797827148ce15e41880c994407cb03ba4a6fa2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fe7870a02775ab4597230b7d79afc53b9c98b1b2d61f2f2097e2971f5396840e154dde797afaee01c1794acffa797827148ce15e41880c994407cb03ba4a6fa2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE/nhwoCd1q0WXIwt9ea/FO5yYsbLWHy8g\nl+KXH1OWhA4VTd55evruAcF5Ss/6eXgnFIzhXkGIDJlEB8sDukpvog==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 232,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c12736d76e412246e097148e2bf62915614eb7c428913a58eb5e9cd4674a9423de",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "_nhwoCd1q0WXIwt9ea_FO5yYsbLWHy8gl-KXH1OWhA4",
+        "y": "FU3eeXr67gHBeUrP-nl4JxSM4V5BiAyZRAfLA7pKb6I",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0419e5abb15f8952ee436359cbf7b3d2eac74096b40055a0cd3ce2a6ce7e4135a76330ecb3c04d28d53fda2bfd746cbe5bfbe5b1818917428f8dabdf6a4d2d4812",
+        "wx": "19e5abb15f8952ee436359cbf7b3d2eac74096b40055a0cd3ce2a6ce7e4135a7",
+        "wy": "6330ecb3c04d28d53fda2bfd746cbe5bfbe5b1818917428f8dabdf6a4d2d4812"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000419e5abb15f8952ee436359cbf7b3d2eac74096b40055a0cd3ce2a6ce7e4135a76330ecb3c04d28d53fda2bfd746cbe5bfbe5b1818917428f8dabdf6a4d2d4812",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGeWrsV+JUu5DY1nL97PS6sdAlrQAVaDN\nPOKmzn5BNadjMOyzwE0o1T/aK/10bL5b++WxgYkXQo+Nq99qTS1IEg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 233,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c14a1e12831fbe93627b02d6e7f24bccdd6ef4b2d0f46739eaf3b1eaf0ca117770",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "GeWrsV-JUu5DY1nL97PS6sdAlrQAVaDNPOKmzn5BNac",
+        "y": "YzDss8BNKNU_2iv9dGy-W_vlsYGJF0KPjavfak0tSBI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04689e10d3c5468ff55a704e97fdf3bfe97ed3c647f6b2969a1d897d3d51584e206d7285c5241de34060a607d779839e507cc2e753954732ef4e1c0fa89eefdfde",
+        "wx": "689e10d3c5468ff55a704e97fdf3bfe97ed3c647f6b2969a1d897d3d51584e20",
+        "wy": "6d7285c5241de34060a607d779839e507cc2e753954732ef4e1c0fa89eefdfde"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004689e10d3c5468ff55a704e97fdf3bfe97ed3c647f6b2969a1d897d3d51584e206d7285c5241de34060a607d779839e507cc2e753954732ef4e1c0fa89eefdfde",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEaJ4Q08VGj/VacE6X/fO/6X7Txkf2spaa\nHYl9PVFYTiBtcoXFJB3jQGCmB9d5g55QfMLnU5VHMu9OHA+onu/f3g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 234,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c106c778d4dfff7dee06ed88bc4e0ed34fc553aad67caf796f2a1c6487c1b2e877",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "aJ4Q08VGj_VacE6X_fO_6X7Txkf2spaaHYl9PVFYTiA",
+        "y": "bXKFxSQd40BgpgfXeYOeUHzC51OVRzLvThwPqJ7v394",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0401600c657f4f365166a7f08dc692ffd19975c924e99e39ef0984c54564c54fd3d13241c61018d4a31afc3f4c6951215b7f37b83c884f97081446e831c830fa6b",
+        "wx": "01600c657f4f365166a7f08dc692ffd19975c924e99e39ef0984c54564c54fd3",
+        "wy": "00d13241c61018d4a31afc3f4c6951215b7f37b83c884f97081446e831c830fa6b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000401600c657f4f365166a7f08dc692ffd19975c924e99e39ef0984c54564c54fd3d13241c61018d4a31afc3f4c6951215b7f37b83c884f97081446e831c830fa6b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAWAMZX9PNlFmp/CNxpL/0Zl1ySTpnjnv\nCYTFRWTFT9PRMkHGEBjUoxr8P0xpUSFbfze4PIhPlwgURugxyDD6aw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 235,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c14de459ef9159afa057feb3ec40fef01c45b809f4ab296ea48c206d4249a2b451",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AWAMZX9PNlFmp_CNxpL_0Zl1ySTpnjnvCYTFRWTFT9M",
+        "y": "0TJBxhAY1KMa_D9MaVEhW383uDyIT5cIFEboMcgw-ms",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0440453ef2d8d1ddb0cea27f8045a543bf9a5fbade0e6bba074d3d351f95847006e37ffaaab752ba65d9b0442ea0c6fac76a6b05fe133cbf1f65b2e67774cc5010",
+        "wx": "40453ef2d8d1ddb0cea27f8045a543bf9a5fbade0e6bba074d3d351f95847006",
+        "wy": "00e37ffaaab752ba65d9b0442ea0c6fac76a6b05fe133cbf1f65b2e67774cc5010"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000440453ef2d8d1ddb0cea27f8045a543bf9a5fbade0e6bba074d3d351f95847006e37ffaaab752ba65d9b0442ea0c6fac76a6b05fe133cbf1f65b2e67774cc5010",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQEU+8tjR3bDOon+ARaVDv5pfut4Oa7oH\nTT01H5WEcAbjf/qqt1K6ZdmwRC6gxvrHamsF/hM8vx9lsuZ3dMxQEA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 236,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1745d294978007302033502e1acc48b63ae6500be43adbea1b258d6b423dbb416",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "QEU-8tjR3bDOon-ARaVDv5pfut4Oa7oHTT01H5WEcAY",
+        "y": "43_6qrdSumXZsEQuoMb6x2prBf4TPL8fZbLmd3TMUBA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04324bfdc82d30e6092d95fd232de108bbc72905da6a03e17a491e36d2336c4c2754d200e2cc5cf78ce662a4ccf2a09eab19c5fb6d2006a6225789c51b82e12259",
+        "wx": "324bfdc82d30e6092d95fd232de108bbc72905da6a03e17a491e36d2336c4c27",
+        "wy": "54d200e2cc5cf78ce662a4ccf2a09eab19c5fb6d2006a6225789c51b82e12259"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004324bfdc82d30e6092d95fd232de108bbc72905da6a03e17a491e36d2336c4c2754d200e2cc5cf78ce662a4ccf2a09eab19c5fb6d2006a6225789c51b82e12259",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMkv9yC0w5gktlf0jLeEIu8cpBdpqA+F6\nSR420jNsTCdU0gDizFz3jOZipMzyoJ6rGcX7bSAGpiJXicUbguEiWQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 237,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c17b2a785e3896f59b2d69da57648e80ad3c133a750a2847fd2098ccd902042b6c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Mkv9yC0w5gktlf0jLeEIu8cpBdpqA-F6SR420jNsTCc",
+        "y": "VNIA4sxc94zmYqTM8qCeqxnF-20gBqYiV4nFG4LhIlk",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c11122b88585f228a1db44b1aa52085db72656a3169956359ebf83dbf7dadf2f3929e9c971a6d0284358ed59230e2c8b1c79a0767e968f37ac53a0214ce97202",
+        "wx": "00c11122b88585f228a1db44b1aa52085db72656a3169956359ebf83dbf7dadf2f",
+        "wy": "3929e9c971a6d0284358ed59230e2c8b1c79a0767e968f37ac53a0214ce97202"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c11122b88585f228a1db44b1aa52085db72656a3169956359ebf83dbf7dadf2f3929e9c971a6d0284358ed59230e2c8b1c79a0767e968f37ac53a0214ce97202",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEwREiuIWF8iih20SxqlIIXbcmVqMWmVY1\nnr+D2/fa3y85KenJcabQKENY7VkjDiyLHHmgdn6WjzesU6AhTOlyAg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 238,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c171ae94a72ca896875e7aa4a4c3d29afdb4b35b6996273e63c47ac519256c5eb1",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "wREiuIWF8iih20SxqlIIXbcmVqMWmVY1nr-D2_fa3y8",
+        "y": "OSnpyXGm0ChDWO1ZIw4sixx5oHZ-lo83rFOgIUzpcgI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048990a37321de8f004b753835d0e1ec3d18ba9993b20a47a25674660ea62dc806b0d310bcb60199f55a1dcd877ac3992b70cf735a6cd534248fcc2420abf3397c",
+        "wx": "008990a37321de8f004b753835d0e1ec3d18ba9993b20a47a25674660ea62dc806",
+        "wy": "00b0d310bcb60199f55a1dcd877ac3992b70cf735a6cd534248fcc2420abf3397c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048990a37321de8f004b753835d0e1ec3d18ba9993b20a47a25674660ea62dc806b0d310bcb60199f55a1dcd877ac3992b70cf735a6cd534248fcc2420abf3397c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEiZCjcyHejwBLdTg10OHsPRi6mZOyCkei\nVnRmDqYtyAaw0xC8tgGZ9VodzYd6w5krcM9zWmzVNCSPzCQgq/M5fA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 239,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10fa527fa7343c0bc9ec35a6278bfbff4d83301b154fc4bd14aee7eb93445b5f9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "iZCjcyHejwBLdTg10OHsPRi6mZOyCkeiVnRmDqYtyAY",
+        "y": "sNMQvLYBmfVaHc2HesOZK3DPc1ps1TQkj8wkIKvzOXw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e06d6a6d24cf1ca77329457d1f25e95bff565bc6e432bc8d021b0bc958e1fc7e859ecc45ffceec07404af6a4c8a4c51e36cd4c17cbcc1ba199eb581a68f5e330",
+        "wx": "00e06d6a6d24cf1ca77329457d1f25e95bff565bc6e432bc8d021b0bc958e1fc7e",
+        "wy": "00859ecc45ffceec07404af6a4c8a4c51e36cd4c17cbcc1ba199eb581a68f5e330"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e06d6a6d24cf1ca77329457d1f25e95bff565bc6e432bc8d021b0bc958e1fc7e859ecc45ffceec07404af6a4c8a4c51e36cd4c17cbcc1ba199eb581a68f5e330",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4G1qbSTPHKdzKUV9HyXpW/9WW8bkMryN\nAhsLyVjh/H6FnsxF/87sB0BK9qTIpMUeNs1MF8vMG6GZ61gaaPXjMA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 240,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c16539c0adadd0525ff42622164ce9314348bd0863b4c80e936b23ca0414264671",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "4G1qbSTPHKdzKUV9HyXpW_9WW8bkMryNAhsLyVjh_H4",
+        "y": "hZ7MRf_O7AdASvakyKTFHjbNTBfLzBuhmetYGmj14zA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0450821196546b2d8ca52c8daa7b40d22efa31d6614f5204012103a67532c1dfaba7990db46e361a7e16c83649e5f3a8b4bf74b439866a6ed08c421502a7e45a7e",
+        "wx": "50821196546b2d8ca52c8daa7b40d22efa31d6614f5204012103a67532c1dfab",
+        "wy": "00a7990db46e361a7e16c83649e5f3a8b4bf74b439866a6ed08c421502a7e45a7e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000450821196546b2d8ca52c8daa7b40d22efa31d6614f5204012103a67532c1dfaba7990db46e361a7e16c83649e5f3a8b4bf74b439866a6ed08c421502a7e45a7e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUIIRllRrLYylLI2qe0DSLvox1mFPUgQB\nIQOmdTLB36unmQ20bjYafhbINknl86i0v3S0OYZqbtCMQhUCp+Rafg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 241,
+          "comment": "point at infinity during verify",
+          "flags": [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "UIIRllRrLYylLI2qe0DSLvox1mFPUgQBIQOmdTLB36s",
+        "y": "p5kNtG42Gn4WyDZJ5fOotL90tDmGam7QjEIVAqfkWn4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f92345a77015fbab4bae36a8eb39f8458e59decc419f44e576f3fbc4425685eb8be216bb36afbbaec2e7db957a9bc0543a91470d9b6ccc37be269b016d3f9ea2",
+        "wx": "00f92345a77015fbab4bae36a8eb39f8458e59decc419f44e576f3fbc4425685eb",
+        "wy": "008be216bb36afbbaec2e7db957a9bc0543a91470d9b6ccc37be269b016d3f9ea2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f92345a77015fbab4bae36a8eb39f8458e59decc419f44e576f3fbc4425685eb8be216bb36afbbaec2e7db957a9bc0543a91470d9b6ccc37be269b016d3f9ea2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+SNFp3AV+6tLrjao6zn4RY5Z3sxBn0Tl\ndvP7xEJWheuL4ha7Nq+7rsLn25V6m8BUOpFHDZtszDe+JpsBbT+eog==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 242,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a07fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "-SNFp3AV-6tLrjao6zn4RY5Z3sxBn0TldvP7xEJWhes",
+        "y": "i-IWuzavu67C59uVepvAVDqRRw2bbMw3viabAW0_nqI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043c8075011484b087b095ac2e59645e59769d5eaf157a2a510ccc028fb40e25552c0df748a38649ffb953ff6f2a2166e2b8ea120cfa39133876129ff6d77ea5c5",
+        "wx": "3c8075011484b087b095ac2e59645e59769d5eaf157a2a510ccc028fb40e2555",
+        "wy": "2c0df748a38649ffb953ff6f2a2166e2b8ea120cfa39133876129ff6d77ea5c5"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043c8075011484b087b095ac2e59645e59769d5eaf157a2a510ccc028fb40e25552c0df748a38649ffb953ff6f2a2166e2b8ea120cfa39133876129ff6d77ea5c5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEPIB1ARSEsIewlawuWWReWXadXq8VeipR\nDMwCj7QOJVUsDfdIo4ZJ/7lT/28qIWbiuOoSDPo5Ezh2Ep/2136lxQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 243,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a07fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a1",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "PIB1ARSEsIewlawuWWReWXadXq8VeipRDMwCj7QOJVU",
+        "y": "LA33SKOGSf-5U_9vKiFm4rjqEgz6ORM4dhKf9td-pcU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047295e1a1264d86aafcba55e0ff4fde8f6337ce21d8a4b8619b14139b292a9ad16c4ce418330bb154a3cfbe6d0b95f9d939396c6d947bbabacef1d2f6f1b6a26b",
+        "wx": "7295e1a1264d86aafcba55e0ff4fde8f6337ce21d8a4b8619b14139b292a9ad1",
+        "wy": "6c4ce418330bb154a3cfbe6d0b95f9d939396c6d947bbabacef1d2f6f1b6a26b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047295e1a1264d86aafcba55e0ff4fde8f6337ce21d8a4b8619b14139b292a9ad16c4ce418330bb154a3cfbe6d0b95f9d939396c6d947bbabacef1d2f6f1b6a26b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEcpXhoSZNhqr8ulXg/0/ej2M3ziHYpLhh\nmxQTmykqmtFsTOQYMwuxVKPPvm0LlfnZOTlsbZR7urrO8dL28baiaw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 244,
+          "comment": "u1 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8aa275665bf8cd2750115f3d8baf4693d8b02b8a06567c354931362f6b0127e64",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "cpXhoSZNhqr8ulXg_0_ej2M3ziHYpLhhmxQTmykqmtE",
+        "y": "bEzkGDMLsVSjz75tC5X52Tk5bG2Ue7q6zvHS9vG2oms",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ad7789e3f1175487c9eba2f061100ba6f552d2c16f956bfc5bef159019703613b3f4d3ba980210c57808ec181142a9bcd62aca5083e6571de3fbf770ae40319f",
+        "wx": "00ad7789e3f1175487c9eba2f061100ba6f552d2c16f956bfc5bef159019703613",
+        "wy": "00b3f4d3ba980210c57808ec181142a9bcd62aca5083e6571de3fbf770ae40319f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ad7789e3f1175487c9eba2f061100ba6f552d2c16f956bfc5bef159019703613b3f4d3ba980210c57808ec181142a9bcd62aca5083e6571de3fbf770ae40319f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErXeJ4/EXVIfJ66LwYRALpvVS0sFvlWv8\nW+8VkBlwNhOz9NO6mAIQxXgI7BgRQqm81irKUIPmVx3j+/dwrkAxnw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 245,
+          "comment": "u1 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b855d8a99a40732d8afeea0c27450b96c12fac244649e0dce72cbefb962023c2dd",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "rXeJ4_EXVIfJ66LwYRALpvVS0sFvlWv8W-8VkBlwNhM",
+        "y": "s_TTupgCEMV4COwYEUKpvNYqylCD5lcd4_v3cK5AMZ8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e712fcd6035acaaf40630e1279f559ebee905d1c0f9e0ed7fb4bc3e86f675e83fc06bab9d242359166c04e3cd7b0eebddd8e235465af82ce12498a1a44615228",
+        "wx": "00e712fcd6035acaaf40630e1279f559ebee905d1c0f9e0ed7fb4bc3e86f675e83",
+        "wy": "00fc06bab9d242359166c04e3cd7b0eebddd8e235465af82ce12498a1a44615228"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e712fcd6035acaaf40630e1279f559ebee905d1c0f9e0ed7fb4bc3e86f675e83fc06bab9d242359166c04e3cd7b0eebddd8e235465af82ce12498a1a44615228",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5xL81gNayq9AYw4SefVZ6+6QXRwPng7X\n+0vD6G9nXoP8Brq50kI1kWbATjzXsO693Y4jVGWvgs4SSYoaRGFSKA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 246,
+          "comment": "u2 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b855555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "5xL81gNayq9AYw4SefVZ6-6QXRwPng7X-0vD6G9nXoM",
+        "y": "_Aa6udJCNZFmwE4817Duvd2OI1Rlr4LOEkmKGkRhUig",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041943bfde4307943cbb7ebfabae05a5055756722296dd73532a4de17fd51c41e236328caaab9bbb6c33c9eab1ad70d986fffa66eb9ff6079e0a3cef7efd746543",
+        "wx": "1943bfde4307943cbb7ebfabae05a5055756722296dd73532a4de17fd51c41e2",
+        "wy": "36328caaab9bbb6c33c9eab1ad70d986fffa66eb9ff6079e0a3cef7efd746543"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041943bfde4307943cbb7ebfabae05a5055756722296dd73532a4de17fd51c41e236328caaab9bbb6c33c9eab1ad70d986fffa66eb9ff6079e0a3cef7efd746543",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGUO/3kMHlDy7fr+rrgWlBVdWciKW3XNT\nKk3hf9UcQeI2Moyqq5u7bDPJ6rGtcNmG//pm65/2B54KPO9+/XRlQw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 247,
+          "comment": "u2 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9d1c9e899ca306ad27fe1945de0242b89",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "GUO_3kMHlDy7fr-rrgWlBVdWciKW3XNTKk3hf9UcQeI",
+        "y": "NjKMqqubu2wzyeqxrXDZhv_6Zuuf9geeCjzvfv10ZUM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b29ef9666573fe03615ca7d016cd0c9f5f2671093accbb6f5b2e3d56d0869174d17c95b552436693e3056f7a8b05b845d01fc6b6b53a7f08dfb50a505011394d",
+        "wx": "00b29ef9666573fe03615ca7d016cd0c9f5f2671093accbb6f5b2e3d56d0869174",
+        "wy": "00d17c95b552436693e3056f7a8b05b845d01fc6b6b53a7f08dfb50a505011394d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b29ef9666573fe03615ca7d016cd0c9f5f2671093accbb6f5b2e3d56d0869174d17c95b552436693e3056f7a8b05b845d01fc6b6b53a7f08dfb50a505011394d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsp75ZmVz/gNhXKfQFs0Mn18mcQk6zLtv\nWy49VtCGkXTRfJW1UkNmk+MFb3qLBbhF0B/GtrU6fwjftQpQUBE5TQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 248,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc38b7c7773fd99b7c55b1fbf2e8fc231483ab92e021cd411c310676523ab0d4cc",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "sp75ZmVz_gNhXKfQFs0Mn18mcQk6zLtvWy49VtCGkXQ",
+        "y": "0XyVtVJDZpPjBW96iwW4RdAfxra1On8I37UKUFAROU0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0415a78bb608c50a6ae0af6ee8de7e9697292796907b9c4a92777c494ccdb7fdbf056b43e4ab26d42af517fa28a4daabe66bdde66cc90bc51a7246ae4ef8adcc4f",
+        "wx": "15a78bb608c50a6ae0af6ee8de7e9697292796907b9c4a92777c494ccdb7fdbf",
+        "wy": "056b43e4ab26d42af517fa28a4daabe66bdde66cc90bc51a7246ae4ef8adcc4f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000415a78bb608c50a6ae0af6ee8de7e9697292796907b9c4a92777c494ccdb7fdbf056b43e4ab26d42af517fa28a4daabe66bdde66cc90bc51a7246ae4ef8adcc4f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFaeLtgjFCmrgr27o3n6WlyknlpB7nEqS\nd3xJTM23/b8Fa0PkqybUKvUX+iik2qvma93mbMkLxRpyRq5O+K3MTw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 249,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc9a5a0b273772d372cee695421caf7e7d9d2a4577f962f77b23639ab8fc23df99",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "FaeLtgjFCmrgr27o3n6WlyknlpB7nEqSd3xJTM23_b8",
+        "y": "BWtD5Ksm1Cr1F_oopNqr5mvd5mzJC8UackauTvitzE8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d9dfb33fed5b674d35a97a8d4a88fc49f8c9faefcc47cd890c421953ffa1ff45f8d02f949d65a381b30d4ff51c885ba967d43b452bbdf9ca91870120e406422e",
+        "wx": "00d9dfb33fed5b674d35a97a8d4a88fc49f8c9faefcc47cd890c421953ffa1ff45",
+        "wy": "00f8d02f949d65a381b30d4ff51c885ba967d43b452bbdf9ca91870120e406422e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d9dfb33fed5b674d35a97a8d4a88fc49f8c9faefcc47cd890c421953ffa1ff45f8d02f949d65a381b30d4ff51c885ba967d43b452bbdf9ca91870120e406422e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE2d+zP+1bZ001qXqNSoj8SfjJ+u/MR82J\nDEIZU/+h/0X40C+UnWWjgbMNT/UciFupZ9Q7RSu9+cqRhwEg5AZCLg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 250,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffca0ce188fff736224cd05fd0c7b1b297fa21b9961c53e327aef81f168d6597ff9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "2d-zP-1bZ001qXqNSoj8SfjJ-u_MR82JDEIZU_-h_0U",
+        "y": "-NAvlJ1lo4GzDU_1HIhbqWfUO0UrvfnKkYcBIOQGQi4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f06dddbe7b3cd0d89eb237c70e06f6d97b118fcac41c7fed780cf8553b2dd8fd078920f3430023de121e7dcaad25f3456c192df69f6e3c27c04346816a2ef70c",
+        "wx": "00f06dddbe7b3cd0d89eb237c70e06f6d97b118fcac41c7fed780cf8553b2dd8fd",
+        "wy": "078920f3430023de121e7dcaad25f3456c192df69f6e3c27c04346816a2ef70c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f06dddbe7b3cd0d89eb237c70e06f6d97b118fcac41c7fed780cf8553b2dd8fd078920f3430023de121e7dcaad25f3456c192df69f6e3c27c04346816a2ef70c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE8G3dvns80NiesjfHDgb22XsRj8rEHH/t\neAz4VTst2P0HiSDzQwAj3hIefcqtJfNFbBkt9p9uPCfAQ0aBai73DA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 251,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffca0f26feb88efc16355d8a99a40732d8a3263414ac6f3b42c33d58489d9ce4cde",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "8G3dvns80NiesjfHDgb22XsRj8rEHH_teAz4VTst2P0",
+        "y": "B4kg80MAI94SHn3KrSXzRWwZLfafbjwnwENGgWou9ww",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046866935c3105dc0583d3bc37886d8fc071c08bc5e9edcbfa5f46a7d69fd602e2b2dda206a0253653f75917e3907f1a66791cee029d12fbdc9568c6e06ace60fe",
+        "wx": "6866935c3105dc0583d3bc37886d8fc071c08bc5e9edcbfa5f46a7d69fd602e2",
+        "wy": "00b2dda206a0253653f75917e3907f1a66791cee029d12fbdc9568c6e06ace60fe"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046866935c3105dc0583d3bc37886d8fc071c08bc5e9edcbfa5f46a7d69fd602e2b2dda206a0253653f75917e3907f1a66791cee029d12fbdc9568c6e06ace60fe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEaGaTXDEF3AWD07w3iG2PwHHAi8Xp7cv6\nX0an1p/WAuKy3aIGoCU2U/dZF+OQfxpmeRzuAp0S+9yVaMbgas5g/g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 252,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc26feb88efc16355d8a99a40732d8afee6f34b8121fbf0a3ee343933a93138331",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "aGaTXDEF3AWD07w3iG2PwHHAi8Xp7cv6X0an1p_WAuI",
+        "y": "st2iBqAlNlP3WRfjkH8aZnkc7gKdEvvclWjG4GrOYP4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049e2c0c97d33913ba72b6de833140e763cb7e05c03178d2746cf5b958cd07185c029c1d0b326a46339ec06819565cc7a52c04602bd7dc75a65e386e1adcc943ea",
+        "wx": "009e2c0c97d33913ba72b6de833140e763cb7e05c03178d2746cf5b958cd07185c",
+        "wy": "029c1d0b326a46339ec06819565cc7a52c04602bd7dc75a65e386e1adcc943ea"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049e2c0c97d33913ba72b6de833140e763cb7e05c03178d2746cf5b958cd07185c029c1d0b326a46339ec06819565cc7a52c04602bd7dc75a65e386e1adcc943ea",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEniwMl9M5E7pytt6DMUDnY8t+BcAxeNJ0\nbPW5WM0HGFwCnB0LMmpGM57AaBlWXMelLARgK9fcdaZeOG4a3MlD6g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 253,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc4dfd711df82c6abb1533480e65b15fdcde6970243f7e147dc687267526270662",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "niwMl9M5E7pytt6DMUDnY8t-BcAxeNJ0bPW5WM0HGFw",
+        "y": "ApwdCzJqRjOewGgZVlzHpSwEYCvX3HWmXjhuGtzJQ-o",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04074ab918d2517160345ce63335214b6eab8bfb89c1c11bf296a753a5eb39c26c501ec4eea1e1e2e33ad912199dd938e239cabe15066443e4049d66a3c8927d28",
+        "wx": "074ab918d2517160345ce63335214b6eab8bfb89c1c11bf296a753a5eb39c26c",
+        "wy": "501ec4eea1e1e2e33ad912199dd938e239cabe15066443e4049d66a3c8927d28"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004074ab918d2517160345ce63335214b6eab8bfb89c1c11bf296a753a5eb39c26c501ec4eea1e1e2e33ad912199dd938e239cabe15066443e4049d66a3c8927d28",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEB0q5GNJRcWA0XOYzNSFLbquL+4nBwRvy\nlqdTpes5wmxQHsTuoeHi4zrZEhmd2TjiOcq+FQZkQ+QEnWajyJJ9KA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 254,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc88efc16355d8a99a40732d8afeea0c269707cf9bfe51b58f2973b7410874ea55",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "B0q5GNJRcWA0XOYzNSFLbquL-4nBwRvylqdTpes5wmw",
+        "y": "UB7E7qHh4uM62RIZndk44jnKvhUGZEPkBJ1mo8iSfSg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c9b4145e17efd3b56930bcfa5fe6f797399cc7f0e383f85e26668d017777d219bbb434eb59f9529fcbaf844c9a2cb441116b194bff2c3bc402e19c351e953a73",
+        "wx": "00c9b4145e17efd3b56930bcfa5fe6f797399cc7f0e383f85e26668d017777d219",
+        "wy": "00bbb434eb59f9529fcbaf844c9a2cb441116b194bff2c3bc402e19c351e953a73"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c9b4145e17efd3b56930bcfa5fe6f797399cc7f0e383f85e26668d017777d219bbb434eb59f9529fcbaf844c9a2cb441116b194bff2c3bc402e19c351e953a73",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEybQUXhfv07VpMLz6X+b3lzmcx/Djg/he\nJmaNAXd30hm7tDTrWflSn8uvhEyaLLRBEWsZS/8sO8QC4Zw1HpU6cw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 255,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc602c62deaf3dddd25f7bc324e21260afca13dcd8a37e66286049e43fe035079a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ybQUXhfv07VpMLz6X-b3lzmcx_Djg_heJmaNAXd30hk",
+        "y": "u7Q061n5Up_Lr4RMmiy0QRFrGUv_LDvEAuGcNR6VOnM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04617b5b040673c839147cf29e114a6bf4026598e2a15bbbbcd331c90911a7ca1fdb1892be7a457a5f7497185de5956680aa0f55b2709f218bb87a84b8192a43e8",
+        "wx": "617b5b040673c839147cf29e114a6bf4026598e2a15bbbbcd331c90911a7ca1f",
+        "wy": "00db1892be7a457a5f7497185de5956680aa0f55b2709f218bb87a84b8192a43e8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004617b5b040673c839147cf29e114a6bf4026598e2a15bbbbcd331c90911a7ca1fdb1892be7a457a5f7497185de5956680aa0f55b2709f218bb87a84b8192a43e8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYXtbBAZzyDkUfPKeEUpr9AJlmOKhW7u8\n0zHJCRGnyh/bGJK+ekV6X3SXGF3llWaAqg9VsnCfIYu4eoS4GSpD6A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 256,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc3f51f2382a547037eb565b08e435dd44df7b889c0a91118e0e1912acbf47826a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "YXtbBAZzyDkUfPKeEUpr9AJlmOKhW7u80zHJCRGnyh8",
+        "y": "2xiSvnpFel90lxhd5ZVmgKoPVbJwnyGLuHqEuBkqQ-g",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0440562caf21c3b2642fa2f6c96d371c7702ff4e9c9f1649d59abe4202192e9d4b24ac6492255af8e1d2aebe2290acc8f019ed41d13045d2589e488f27d11df376",
+        "wx": "40562caf21c3b2642fa2f6c96d371c7702ff4e9c9f1649d59abe4202192e9d4b",
+        "wy": "24ac6492255af8e1d2aebe2290acc8f019ed41d13045d2589e488f27d11df376"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000440562caf21c3b2642fa2f6c96d371c7702ff4e9c9f1649d59abe4202192e9d4b24ac6492255af8e1d2aebe2290acc8f019ed41d13045d2589e488f27d11df376",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQFYsryHDsmQvovbJbTccdwL/TpyfFknV\nmr5CAhkunUskrGSSJVr44dKuviKQrMjwGe1B0TBF0lieSI8n0R3zdg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 257,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc60ba6c0dacd0a3a6c43b0067b58062e3d71b3012a9221ffb7b06b396809d9e6c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "QFYsryHDsmQvovbJbTccdwL_TpyfFknVmr5CAhkunUs",
+        "y": "JKxkkiVa-OHSrr4ikKzI8BntQdEwRdJYnkiPJ9Ed83Y",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04895939820528067c9cc153039394d3bea4af22fc56e887a0e72704eb3bf7b3c70135eaa7567722043ae5f4b4068cdb30068f918feda0040b838068f2dac0f635",
+        "wx": "00895939820528067c9cc153039394d3bea4af22fc56e887a0e72704eb3bf7b3c7",
+        "wy": "0135eaa7567722043ae5f4b4068cdb30068f918feda0040b838068f2dac0f635"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004895939820528067c9cc153039394d3bea4af22fc56e887a0e72704eb3bf7b3c70135eaa7567722043ae5f4b4068cdb30068f918feda0040b838068f2dac0f635",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEiVk5ggUoBnycwVMDk5TTvqSvIvxW6Ieg\n5ycE6zv3s8cBNeqnVnciBDrl9LQGjNswBo+Rj+2gBAuDgGjy2sD2NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 258,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc618f79d4292ccc655b59dc4bf2a56631eaa62ce9b197b6b82321ea98713a80a7",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "iVk5ggUoBnycwVMDk5TTvqSvIvxW6Ieg5ycE6zv3s8c",
+        "y": "ATXqp1Z3IgQ65fS0BozbMAaPkY_toAQLg4Bo8trA9jU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d6399ab723c5be273542adbe47fb7ea5eae6124260063c4d7badd5a6b638f5050bbca7ee76f7ff916686bc23670d20ecdfd28241ef86972c9e33bc69f009e11d",
+        "wx": "00d6399ab723c5be273542adbe47fb7ea5eae6124260063c4d7badd5a6b638f505",
+        "wy": "0bbca7ee76f7ff916686bc23670d20ecdfd28241ef86972c9e33bc69f009e11d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d6399ab723c5be273542adbe47fb7ea5eae6124260063c4d7badd5a6b638f5050bbca7ee76f7ff916686bc23670d20ecdfd28241ef86972c9e33bc69f009e11d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE1jmatyPFvic1Qq2+R/t+permEkJgBjxN\ne63VprY49QULvKfudvf/kWaGvCNnDSDs39KCQe+GlyyeM7xp8AnhHQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 259,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffce3a41c4460133241d52702068b81ee7478d913769e61ffada74f2363b2ddd6db",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "1jmatyPFvic1Qq2-R_t-permEkJgBjxNe63VprY49QU",
+        "y": "C7yn7nb3_5FmhrwjZw0g7N_SgkHvhpcsnjO8afAJ4R0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043be551eb7f05c6a27a21286a68354b26d9fb2c57647596d14b45c22ba53bc7c25a3f0472a400fc4268040b9a9c5bdeeb9b2ff36aebdb646693d4ec62f5d9e82b",
+        "wx": "3be551eb7f05c6a27a21286a68354b26d9fb2c57647596d14b45c22ba53bc7c2",
+        "wy": "5a3f0472a400fc4268040b9a9c5bdeeb9b2ff36aebdb646693d4ec62f5d9e82b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043be551eb7f05c6a27a21286a68354b26d9fb2c57647596d14b45c22ba53bc7c25a3f0472a400fc4268040b9a9c5bdeeb9b2ff36aebdb646693d4ec62f5d9e82b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEO+VR638FxqJ6IShqaDVLJtn7LFdkdZbR\nS0XCK6U7x8JaPwRypAD8QmgEC5qcW97rmy/zauvbZGaT1Oxi9dnoKw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 260,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcc7483888c0266483aa4e040d1703dcea37034a068d7b5f1f8ecbe83a95856c75",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "O-VR638FxqJ6IShqaDVLJtn7LFdkdZbRS0XCK6U7x8I",
+        "y": "Wj8EcqQA_EJoBAuanFve65sv82rr22Rmk9TsYvXZ6Cs",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0407212d36e78433243651ddd2ccdf23a83d609a40ffb317463fcce78dd6a55b12b5302470b57b879fc24ccd8a632453d427722f0eb2b12a6682d5f7c696d2fa91",
+        "wx": "07212d36e78433243651ddd2ccdf23a83d609a40ffb317463fcce78dd6a55b12",
+        "wy": "00b5302470b57b879fc24ccd8a632453d427722f0eb2b12a6682d5f7c696d2fa91"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000407212d36e78433243651ddd2ccdf23a83d609a40ffb317463fcce78dd6a55b12b5302470b57b879fc24ccd8a632453d427722f0eb2b12a6682d5f7c696d2fa91",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEByEtNueEMyQ2Ud3SzN8jqD1gmkD/sxdG\nP8znjdalWxK1MCRwtXuHn8JMzYpjJFPUJ3IvDrKxKmaC1ffGltL6kQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 261,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcaaec54cd203996c57f750613a285cb5ff52d80967c94be917648ad11782d020f",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "ByEtNueEMyQ2Ud3SzN8jqD1gmkD_sxdGP8znjdalWxI",
+        "y": "tTAkcLV7h5_CTM2KYyRT1CdyLw6ysSpmgtX3xpbS-pE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04216ce228e3584057d2833bfb5542883dc09027ba081f21a21499636e1a56beead81a4c155bf1bf73dadc756de945400094349cdac7c3e179b69734e3983f55c7",
+        "wx": "216ce228e3584057d2833bfb5542883dc09027ba081f21a21499636e1a56beea",
+        "wy": "00d81a4c155bf1bf73dadc756de945400094349cdac7c3e179b69734e3983f55c7"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004216ce228e3584057d2833bfb5542883dc09027ba081f21a21499636e1a56beead81a4c155bf1bf73dadc756de945400094349cdac7c3e179b69734e3983f55c7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEIWziKONYQFfSgzv7VUKIPcCQJ7oIHyGi\nFJljbhpWvurYGkwVW/G/c9rcdW3pRUAAlDSc2sfD4Xm2lzTjmD9Vxw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 262,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcd0670c47ffb9b1126682fe863d8d94bf2e653b243a43695b57aa27fad347e09d",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "IWziKONYQFfSgzv7VUKIPcCQJ7oIHyGiFJljbhpWvuo",
+        "y": "2BpMFVvxv3Pa3HVt6UVAAJQ0nNrHw-F5tpc045g_Vcc",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0443e899bc3ea443e5521aa6666a0e0b7977feb89b39ae9c9b46c9afcebc852af5828a867be817722818741340c40a86cc385a9aa7d344f87c0c16b1e767615e85",
+        "wx": "43e899bc3ea443e5521aa6666a0e0b7977feb89b39ae9c9b46c9afcebc852af5",
+        "wy": "00828a867be817722818741340c40a86cc385a9aa7d344f87c0c16b1e767615e85"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000443e899bc3ea443e5521aa6666a0e0b7977feb89b39ae9c9b46c9afcebc852af5828a867be817722818741340c40a86cc385a9aa7d344f87c0c16b1e767615e85",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQ+iZvD6kQ+VSGqZmag4LeXf+uJs5rpyb\nRsmvzryFKvWCioZ76BdyKBh0E0DECobMOFqap9NE+HwMFrHnZ2FehQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 263,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcd55555555555555555555555555555547c74934474db157d2a8c3f088aced62a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Q-iZvD6kQ-VSGqZmag4LeXf-uJs5rpybRsmvzryFKvU",
+        "y": "goqGe-gXcigYdBNAxAqGzDhamqfTRPh8DBax52dhXoU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042fa2e1f68d00b9e2504f013e0ded297f1b163583c150287f04b9717d37ef4401fcde8ffbb9f4cc74a3feb3f660cd0568983da04a475c85c99fe877556774103d",
+        "wx": "2fa2e1f68d00b9e2504f013e0ded297f1b163583c150287f04b9717d37ef4401",
+        "wy": "00fcde8ffbb9f4cc74a3feb3f660cd0568983da04a475c85c99fe877556774103d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042fa2e1f68d00b9e2504f013e0ded297f1b163583c150287f04b9717d37ef4401fcde8ffbb9f4cc74a3feb3f660cd0568983da04a475c85c99fe877556774103d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEL6Lh9o0AueJQTwE+De0pfxsWNYPBUCh/\nBLlxfTfvRAH83o/7ufTMdKP+s/ZgzQVomD2gSkdchcmf6HdVZ3QQPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 264,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcc1777c8853938e536213c02464a936000ba1e21c0fc62075d46c624e23b52f31",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "L6Lh9o0AueJQTwE-De0pfxsWNYPBUCh_BLlxfTfvRAE",
+        "y": "_N6P-7n0zHSj_rP2YM0FaJg9oEpHXIXJn-h3VWd0ED0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04020c6a477ea4322098c336cc759392e3ee97bbe004561fcbca503c4f9fb0d9df2b2518cd62254b5d4db44660b3cfa6811527a977c163b7e1114e194ea33d9272",
+        "wx": "020c6a477ea4322098c336cc759392e3ee97bbe004561fcbca503c4f9fb0d9df",
+        "wy": "2b2518cd62254b5d4db44660b3cfa6811527a977c163b7e1114e194ea33d9272"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004020c6a477ea4322098c336cc759392e3ee97bbe004561fcbca503c4f9fb0d9df2b2518cd62254b5d4db44660b3cfa6811527a977c163b7e1114e194ea33d9272",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAgxqR36kMiCYwzbMdZOS4+6Xu+AEVh/L\nylA8T5+w2d8rJRjNYiVLXU20RmCzz6aBFSepd8Fjt+ERThlOoz2Scg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 265,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc30bbb794db588363b40679f6c182a50d3ce9679acdd3ffbe36d7813dacbdc818",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AgxqR36kMiCYwzbMdZOS4-6Xu-AEVh_LylA8T5-w2d8",
+        "y": "KyUYzWIlS11NtEZgs8-mgRUnqXfBY7fhEU4ZTqM9knI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042906f7953642e20c07df87b82c6f69de287de1b1d14a27a6fbd195d9fffba1c2bba9167950ae639b981aa3bb5754dcf67fc4216074a09f6de11db8d456012a78",
+        "wx": "2906f7953642e20c07df87b82c6f69de287de1b1d14a27a6fbd195d9fffba1c2",
+        "wy": "00bba9167950ae639b981aa3bb5754dcf67fc4216074a09f6de11db8d456012a78"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042906f7953642e20c07df87b82c6f69de287de1b1d14a27a6fbd195d9fffba1c2bba9167950ae639b981aa3bb5754dcf67fc4216074a09f6de11db8d456012a78",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEKQb3lTZC4gwH34e4LG9p3ih94bHRSiem\n+9GV2f/7ocK7qRZ5UK5jm5gao7tXVNz2f8QhYHSgn23hHbjUVgEqeA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 266,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2c37fd995622c4fb7fffffffffffffffc7cee745110cb45ab558ed7c90c15a2f",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "KQb3lTZC4gwH34e4LG9p3ih94bHRSiem-9GV2f_7ocI",
+        "y": "u6kWeVCuY5uYGqO7V1Tc9n_EIWB0oJ9t4R241FYBKng",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f7f761cb2567c7bfb6c3f348d3c1571d00491b6a285da344d23e7999a9641b471384a9fb6498149c6c3ce970e2c88eeb0bf62e45c08b71e8c5c587019105a6ce",
+        "wx": "00f7f761cb2567c7bfb6c3f348d3c1571d00491b6a285da344d23e7999a9641b47",
+        "wy": "1384a9fb6498149c6c3ce970e2c88eeb0bf62e45c08b71e8c5c587019105a6ce"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f7f761cb2567c7bfb6c3f348d3c1571d00491b6a285da344d23e7999a9641b471384a9fb6498149c6c3ce970e2c88eeb0bf62e45c08b71e8c5c587019105a6ce",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE9/dhyyVnx7+2w/NI08FXHQBJG2ooXaNE\n0j55malkG0cThKn7ZJgUnGw86XDiyI7rC/YuRcCLcejFxYcBkQWmzg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 267,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc7fd995622c4fb7ffffffffffffffffff5d883ffab5b32652ccdcaa290fccb97d",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "9_dhyyVnx7-2w_NI08FXHQBJG2ooXaNE0j55malkG0c",
+        "y": "E4Sp-2SYFJxsPOlw4siO6wv2LkXAi3HoxcWHAZEFps4",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c435448e32ff34954bf85c1d0a195adcd6eecae96ed910a758090d4da5ca7ef45261ff9a807f88e53feab7943bb9d6af69862c26eb714647d6649c447e8ef64c",
+        "wx": "00c435448e32ff34954bf85c1d0a195adcd6eecae96ed910a758090d4da5ca7ef4",
+        "wy": "5261ff9a807f88e53feab7943bb9d6af69862c26eb714647d6649c447e8ef64c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c435448e32ff34954bf85c1d0a195adcd6eecae96ed910a758090d4da5ca7ef45261ff9a807f88e53feab7943bb9d6af69862c26eb714647d6649c447e8ef64c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAExDVEjjL/NJVL+FwdChla3Nbuyulu2RCn\nWAkNTaXKfvRSYf+agH+I5T/qt5Q7udavaYYsJutxRkfWZJxEfo72TA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 268,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcffb32ac4589f6ffffffffffffffffffebb107ff56b664ca599b954521f9972fa",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "xDVEjjL_NJVL-FwdChla3Nbuyulu2RCnWAkNTaXKfvQ",
+        "y": "UmH_moB_iOU_6reUO7nWr2mGLCbrcUZH1mScRH6O9kw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048e8bff94e8f067480874d4b0608b2fc20274565ef5793f891130c0bfded7ded92bb1b91f3435c2d664b258d2b4c0f7cb0a9245ae5883ed2fbd8671aef64c22df",
+        "wx": "008e8bff94e8f067480874d4b0608b2fc20274565ef5793f891130c0bfded7ded9",
+        "wy": "2bb1b91f3435c2d664b258d2b4c0f7cb0a9245ae5883ed2fbd8671aef64c22df"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048e8bff94e8f067480874d4b0608b2fc20274565ef5793f891130c0bfded7ded92bb1b91f3435c2d664b258d2b4c0f7cb0a9245ae5883ed2fbd8671aef64c22df",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEjov/lOjwZ0gIdNSwYIsvwgJ0Vl71eT+J\nETDAv97X3tkrsbkfNDXC1mSyWNK0wPfLCpJFrliD7S+9hnGu9kwi3w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 269,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc5622c4fb7fffffffffffffffffffffff928a8f1c7ac7bec1808b9f61c01ec327",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "jov_lOjwZ0gIdNSwYIsvwgJ0Vl71eT-JETDAv97X3tk",
+        "y": "K7G5HzQ1wtZksljStMD3ywqSRa5Yg-0vvYZxrvZMIt8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045cd7b15df5d3b4f31a55c290c6bc905272c1cfd4e814557df2faec5e2b5754a81ca33afb361084a08bda0e79258f99819989140d2bac928f527c172f77bd9bfb",
+        "wx": "5cd7b15df5d3b4f31a55c290c6bc905272c1cfd4e814557df2faec5e2b5754a8",
+        "wy": "1ca33afb361084a08bda0e79258f99819989140d2bac928f527c172f77bd9bfb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045cd7b15df5d3b4f31a55c290c6bc905272c1cfd4e814557df2faec5e2b5754a81ca33afb361084a08bda0e79258f99819989140d2bac928f527c172f77bd9bfb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXNexXfXTtPMaVcKQxryQUnLBz9ToFFV9\n8vrsXitXVKgcozr7NhCEoIvaDnklj5mBmYkUDSusko9SfBcvd72b+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 270,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc44104104104104104104104104104103b87853fd3b7d3f8e175125b4382f25ed",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "XNexXfXTtPMaVcKQxryQUnLBz9ToFFV98vrsXitXVKg",
+        "y": "HKM6-zYQhKCL2g55JY-ZgZmJFA0rrJKPUnwXL3e9m_s",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040e90cf16a6f6d82fb7e472e640e8b3ce9288a64c7894e3965bde308218d8bcf89e6a3d78a5599e1cfae0258608d2dc425c979cb11d61464423391eb29b353eb3",
+        "wx": "0e90cf16a6f6d82fb7e472e640e8b3ce9288a64c7894e3965bde308218d8bcf8",
+        "wy": "009e6a3d78a5599e1cfae0258608d2dc425c979cb11d61464423391eb29b353eb3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040e90cf16a6f6d82fb7e472e640e8b3ce9288a64c7894e3965bde308218d8bcf89e6a3d78a5599e1cfae0258608d2dc425c979cb11d61464423391eb29b353eb3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEDpDPFqb22C+35HLmQOizzpKIpkx4lOOW\nW94wghjYvPieaj14pVmeHPrgJYYI0txCXJecsR1hRkQjOR6ymzU+sw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 271,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2739ce739ce739ce739ce739ce739ce705560298d1f2f08dc419ac273a5b54d9",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "DpDPFqb22C-35HLmQOizzpKIpkx4lOOWW94wghjYvPg",
+        "y": "nmo9eKVZnhz64CWGCNLcQlyXnLEdYUZEIzkesps1PrM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046a504aa871137a2bbd2b05bdda8f6e2e32e9d1468fab78e098c7c0ad41a097e4590e79063b8531de4f0925aef955b80e56f88050f477339caa621100e75969d8",
+        "wx": "6a504aa871137a2bbd2b05bdda8f6e2e32e9d1468fab78e098c7c0ad41a097e4",
+        "wy": "590e79063b8531de4f0925aef955b80e56f88050f477339caa621100e75969d8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046a504aa871137a2bbd2b05bdda8f6e2e32e9d1468fab78e098c7c0ad41a097e4590e79063b8531de4f0925aef955b80e56f88050f477339caa621100e75969d8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEalBKqHETeiu9KwW92o9uLjLp0UaPq3jg\nmMfArUGgl+RZDnkGO4Ux3k8JJa75VbgOVviAUPR3M5yqYhEA51lp2A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 272,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcb777777777777777777777777777777688e6a1fe808a97a348671222ff16b863",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "alBKqHETeiu9KwW92o9uLjLp0UaPq3jgmMfArUGgl-Q",
+        "y": "WQ55BjuFMd5PCSWu-VW4Dlb4gFD0dzOcqmIRAOdZadg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cda3af8e54dd6af3ec691541db443c76c1a6b3a86d4ee72ed1cff6305f8ac91c122b45ed375a32756617921bc2cb8bf88e7e6b6d47320987b2ec71decd3476f8",
+        "wx": "00cda3af8e54dd6af3ec691541db443c76c1a6b3a86d4ee72ed1cff6305f8ac91c",
+        "wy": "122b45ed375a32756617921bc2cb8bf88e7e6b6d47320987b2ec71decd3476f8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cda3af8e54dd6af3ec691541db443c76c1a6b3a86d4ee72ed1cff6305f8ac91c122b45ed375a32756617921bc2cb8bf88e7e6b6d47320987b2ec71decd3476f8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzaOvjlTdavPsaRVB20Q8dsGms6htTucu\n0c/2MF+KyRwSK0XtN1oydWYXkhvCy4v4jn5rbUcyCYey7HHezTR2+A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 273,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc6492492492492492492492492492492406dd3a19b8d5fb875235963c593bd2d3",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "zaOvjlTdavPsaRVB20Q8dsGms6htTucu0c_2MF-KyRw",
+        "y": "EitF7TdaMnVmF5IbwsuL-I5-a21HMgmHsuxx3s00dvg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bf4f41debf5f679603c381d123515bd6c959ad29263a867a00946b29bed102f2bb23a6765eaf1e6391f59b70fbda073fca11be2072158c10df199982b7c3e21b",
+        "wx": "00bf4f41debf5f679603c381d123515bd6c959ad29263a867a00946b29bed102f2",
+        "wy": "00bb23a6765eaf1e6391f59b70fbda073fca11be2072158c10df199982b7c3e21b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bf4f41debf5f679603c381d123515bd6c959ad29263a867a00946b29bed102f2bb23a6765eaf1e6391f59b70fbda073fca11be2072158c10df199982b7c3e21b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEv09B3r9fZ5YDw4HRI1Fb1slZrSkmOoZ6\nAJRrKb7RAvK7I6Z2Xq8eY5H1m3D72gc/yhG+IHIVjBDfGZmCt8PiGw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 274,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc955555555555555555555555555555547c74934474db157d2a8c3f088aced62c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "v09B3r9fZ5YDw4HRI1Fb1slZrSkmOoZ6AJRrKb7RAvI",
+        "y": "uyOmdl6vHmOR9Ztw-9oHP8oRviByFYwQ3xmZgrfD4hs",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04face0b628008def15e20a566a8e26adc48d867ac515240c0a756c408dbea286ad70670fcb5847b773db0b966aaa77328c9434dbec55f2ac3fbd9f43dd99f3bf3",
+        "wx": "00face0b628008def15e20a566a8e26adc48d867ac515240c0a756c408dbea286a",
+        "wy": "00d70670fcb5847b773db0b966aaa77328c9434dbec55f2ac3fbd9f43dd99f3bf3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004face0b628008def15e20a566a8e26adc48d867ac515240c0a756c408dbea286ad70670fcb5847b773db0b966aaa77328c9434dbec55f2ac3fbd9f43dd99f3bf3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+s4LYoAI3vFeIKVmqOJq3EjYZ6xRUkDA\np1bECNvqKGrXBnD8tYR7dz2wuWaqp3MoyUNNvsVfKsP72fQ92Z878w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 275,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc2aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3e3a49a23a6d8abe95461f8445676b17",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "-s4LYoAI3vFeIKVmqOJq3EjYZ6xRUkDAp1bECNvqKGo",
+        "y": "1wZw_LWEe3c9sLlmqqdzKMlDTb7FXyrD-9n0PdmfO_M",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cf8abfd2c89106a46adc42f682a1d22172f3d5747e26175fb6d62d5432c775555465f71684eb6ab9811bd830b0e9e276e1160d5b3ad7eb99c72d5b06449a0551",
+        "wx": "00cf8abfd2c89106a46adc42f682a1d22172f3d5747e26175fb6d62d5432c77555",
+        "wy": "5465f71684eb6ab9811bd830b0e9e276e1160d5b3ad7eb99c72d5b06449a0551"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cf8abfd2c89106a46adc42f682a1d22172f3d5747e26175fb6d62d5432c775555465f71684eb6ab9811bd830b0e9e276e1160d5b3ad7eb99c72d5b06449a0551",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEz4q/0siRBqRq3EL2gqHSIXLz1XR+Jhdf\nttYtVDLHdVVUZfcWhOtquYEb2DCw6eJ24RYNWzrX65nHLVsGRJoFUQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 276,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffcbffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "z4q_0siRBqRq3EL2gqHSIXLz1XR-JhdfttYtVDLHdVU",
+        "y": "VGX3FoTrarmBG9gwsOniduEWDVs61-uZxy1bBkSaBVE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04050cef9f6e34137bcdb1a893b1eee574aae3550658abc6f4660a67b8e01914f254c54fd2613c3b0e1ac6843a197d0cccc0feceeee86f83c78adbb5fc7727a6ab",
+        "wx": "050cef9f6e34137bcdb1a893b1eee574aae3550658abc6f4660a67b8e01914f2",
+        "wy": "54c54fd2613c3b0e1ac6843a197d0cccc0feceeee86f83c78adbb5fc7727a6ab"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004050cef9f6e34137bcdb1a893b1eee574aae3550658abc6f4660a67b8e01914f254c54fd2613c3b0e1ac6843a197d0cccc0feceeee86f83c78adbb5fc7727a6ab",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEBQzvn240E3vNsaiTse7ldKrjVQZYq8b0\nZgpnuOAZFPJUxU/SYTw7DhrGhDoZfQzMwP7O7uhvg8eK27X8dyemqw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 277,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "7ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc185ddbca6dac41b1da033cfb60c152869e74b3cd66e9ffdf1b6bc09ed65ee40c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "BQzvn240E3vNsaiTse7ldKrjVQZYq8b0ZgpnuOAZFPI",
+        "y": "VMVP0mE8Ow4axoQ6GX0MzMD-zu7ob4PHitu1_Hcnpqs",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b67fa0d181e80cbeff1625ea48614da85e7a297bb4f200c32f164d3a22e39975e4",
+        "wx": "0fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b6",
+        "wy": "7fa0d181e80cbeff1625ea48614da85e7a297bb4f200c32f164d3a22e39975e4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b67fa0d181e80cbeff1625ea48614da85e7a297bb4f200c32f164d3a22e39975e4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAED9Xv+3g5Y2v0hjjs0E07e4QkT2dhDrVZ\n6jsrs5eHdLZ/oNGB6Ay+/xYl6khhTaheeil7tPIAwy8WTToi45l15A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 278,
+          "comment": "point duplication during verification",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "32b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda8cf5adcdbe8331099059b4336ece94ab3ba9761faf730b22260cbfcc47f174af",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "D9Xv-3g5Y2v0hjjs0E07e4QkT2dhDrVZ6jsrs5eHdLY",
+        "y": "f6DRgegMvv8WJepIYU2oXnope7TyAMMvFk06IuOZdeQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b6805f2e7e17f34100e9da15b79eb257a185d6844b0dff3cd0e9b2c5dc1c66864b",
+        "wx": "0fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b6",
+        "wy": "00805f2e7e17f34100e9da15b79eb257a185d6844b0dff3cd0e9b2c5dc1c66864b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b6805f2e7e17f34100e9da15b79eb257a185d6844b0dff3cd0e9b2c5dc1c66864b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAED9Xv+3g5Y2v0hjjs0E07e4QkT2dhDrVZ\n6jsrs5eHdLaAXy5+F/NBAOnaFbeeslehhdaESw3/PNDpssXcHGaGSw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 279,
+          "comment": "duplication bug",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "32b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda8cf5adcdbe8331099059b4336ece94ab3ba9761faf730b22260cbfcc47f174af",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "D9Xv-3g5Y2v0hjjs0E07e4QkT2dhDrVZ6jsrs5eHdLY",
+        "y": "gF8ufhfzQQDp2hW3nrJXoYXWhEsN_zzQ6bLF3Bxmhks",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043328dea23505062b5236e9f1880c85d251859d52c7e9479c44c82994404ca2b9efa683a714cfa079179a021f5ab6d9a36be886093ae0adfd7c88e3b44d579e8c",
+        "wx": "3328dea23505062b5236e9f1880c85d251859d52c7e9479c44c82994404ca2b9",
+        "wy": "00efa683a714cfa079179a021f5ab6d9a36be886093ae0adfd7c88e3b44d579e8c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043328dea23505062b5236e9f1880c85d251859d52c7e9479c44c82994404ca2b9efa683a714cfa079179a021f5ab6d9a36be886093ae0adfd7c88e3b44d579e8c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMyjeojUFBitSNunxiAyF0lGFnVLH6Uec\nRMgplEBMornvpoOnFM+geReaAh9attmja+iGCTrgrf18iOO0TVeejA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 280,
+          "comment": "comparison with point at infinity ",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "55555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c033333333333333333333333333333332f222f8faefdb533f265d461c29a47373",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "MyjeojUFBitSNunxiAyF0lGFnVLH6UecRMgplEBMork",
+        "y": "76aDpxTPoHkXmgIfWrbZo2vohgk64K39fIjjtE1Xnow",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04eff50ce9ca8262bc5a90bd53a8ec78d0b3dbb3dffc29b6a149a49a80c83b338c4dfee1651c973585a985b7eb64be41add1ce6c52e68ba073c562037983c04e33",
+        "wx": "00eff50ce9ca8262bc5a90bd53a8ec78d0b3dbb3dffc29b6a149a49a80c83b338c",
+        "wy": "4dfee1651c973585a985b7eb64be41add1ce6c52e68ba073c562037983c04e33"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004eff50ce9ca8262bc5a90bd53a8ec78d0b3dbb3dffc29b6a149a49a80c83b338c4dfee1651c973585a985b7eb64be41add1ce6c52e68ba073c562037983c04e33",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7/UM6cqCYrxakL1TqOx40LPbs9/8Kbah\nSaSagMg7M4xN/uFlHJc1hamFt+tkvkGt0c5sUuaLoHPFYgN5g8BOMw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 281,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee555555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "7_UM6cqCYrxakL1TqOx40LPbs9_8KbahSaSagMg7M4w",
+        "y": "Tf7hZRyXNYWphbfrZL5BrdHObFLmi6BzxWIDeYPATjM",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04197b7b0558c077fe7ca5617df4b7473b023bf94e96958c0aee53a51253be649a63b4c4703601e96a904475029e117407a9d56db5ff5cd5372c6aa91b86fd5e0f",
+        "wx": "197b7b0558c077fe7ca5617df4b7473b023bf94e96958c0aee53a51253be649a",
+        "wy": "63b4c4703601e96a904475029e117407a9d56db5ff5cd5372c6aa91b86fd5e0f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004197b7b0558c077fe7ca5617df4b7473b023bf94e96958c0aee53a51253be649a63b4c4703601e96a904475029e117407a9d56db5ff5cd5372c6aa91b86fd5e0f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGXt7BVjAd/58pWF99LdHOwI7+U6WlYwK\n7lOlElO+ZJpjtMRwNgHpapBEdQKeEXQHqdVttf9c1Tcsaqkbhv1eDw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 282,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "GXt7BVjAd_58pWF99LdHOwI7-U6WlYwK7lOlElO-ZJo",
+        "y": "Y7TEcDYB6WqQRHUCnhF0B6nVbbX_XNU3LGqpG4b9Xg8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b0587dbe6b08ebf735012fd702ad12581d5a69dc42372f0c9c64fe988d40f97178697a976684d662d8e4062135c508be49a8193d31fc309f51208f2df16508db",
+        "wx": "00b0587dbe6b08ebf735012fd702ad12581d5a69dc42372f0c9c64fe988d40f971",
+        "wy": "78697a976684d662d8e4062135c508be49a8193d31fc309f51208f2df16508db"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b0587dbe6b08ebf735012fd702ad12581d5a69dc42372f0c9c64fe988d40f97178697a976684d662d8e4062135c508be49a8193d31fc309f51208f2df16508db",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsFh9vmsI6/c1AS/XAq0SWB1aadxCNy8M\nnGT+mI1A+XF4aXqXZoTWYtjkBiE1xQi+SagZPTH8MJ9RII8t8WUI2w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 283,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee599999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "sFh9vmsI6_c1AS_XAq0SWB1aadxCNy8MnGT-mI1A-XE",
+        "y": "eGl6l2aE1mLY5AYhNcUIvkmoGT0x_DCfUSCPLfFlCNs",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f3ddf100facb4d04002a38d15626433ac3b95205b1b3282f9fa5c921518791ae63612a449709ab5e458c05d4880c6e4d1d21d6d1f7998bad8f605d6bedff6450",
+        "wx": "00f3ddf100facb4d04002a38d15626433ac3b95205b1b3282f9fa5c921518791ae",
+        "wy": "63612a449709ab5e458c05d4880c6e4d1d21d6d1f7998bad8f605d6bedff6450"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f3ddf100facb4d04002a38d15626433ac3b95205b1b3282f9fa5c921518791ae63612a449709ab5e458c05d4880c6e4d1d21d6d1f7998bad8f605d6bedff6450",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE893xAPrLTQQAKjjRViZDOsO5UgWxsygv\nn6XJIVGHka5jYSpElwmrXkWMBdSIDG5NHSHW0feZi62PYF1r7f9kUA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 284,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee566666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "893xAPrLTQQAKjjRViZDOsO5UgWxsygvn6XJIVGHka4",
+        "y": "Y2EqRJcJq15FjAXUiAxuTR0h1tH3mYutj2Bda-3_ZFA",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047aaf2dc5cec7aa23e8ecebc7ab039f52f4dcc297dee1e2721d38f19bcbc9893024186b29e48a4ca6272795a9743b313e2cbeab6d9dfc8dde8e722f0bdcf05f08",
+        "wx": "7aaf2dc5cec7aa23e8ecebc7ab039f52f4dcc297dee1e2721d38f19bcbc98930",
+        "wy": "24186b29e48a4ca6272795a9743b313e2cbeab6d9dfc8dde8e722f0bdcf05f08"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047aaf2dc5cec7aa23e8ecebc7ab039f52f4dcc297dee1e2721d38f19bcbc9893024186b29e48a4ca6272795a9743b313e2cbeab6d9dfc8dde8e722f0bdcf05f08",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeq8txc7HqiPo7OvHqwOfUvTcwpfe4eJy\nHTjxm8vJiTAkGGsp5IpMpicnlal0OzE+LL6rbZ38jd6Oci8L3PBfCA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 285,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee549249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eq8txc7HqiPo7OvHqwOfUvTcwpfe4eJyHTjxm8vJiTA",
+        "y": "JBhrKeSKTKYnJ5WpdDsxPiy-q22d_I3ejnIvC9zwXwg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0485b5f352382e9b7c6c4f06012fb9d8c6a7801cca1460ea18e1794d98727869ce2e8c1200428d29e116ce68562d0ca1ad9886b85c63899086256f3af90207c804",
+        "wx": "0085b5f352382e9b7c6c4f06012fb9d8c6a7801cca1460ea18e1794d98727869ce",
+        "wy": "2e8c1200428d29e116ce68562d0ca1ad9886b85c63899086256f3af90207c804"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000485b5f352382e9b7c6c4f06012fb9d8c6a7801cca1460ea18e1794d98727869ce2e8c1200428d29e116ce68562d0ca1ad9886b85c63899086256f3af90207c804",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEhbXzUjgum3xsTwYBL7nYxqeAHMoUYOoY\n4XlNmHJ4ac4ujBIAQo0p4RbOaFYtDKGtmIa4XGOJkIYlbzr5AgfIBA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 286,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee50eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "hbXzUjgum3xsTwYBL7nYxqeAHMoUYOoY4XlNmHJ4ac4",
+        "y": "LowSAEKNKeEWzmhWLQyhrZiGuFxjiZCGJW86-QIHyAQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d282b8c407e70a153c420461da7e376d501e9348b42d143f6c215ee2b61aed281cf6add6baf3e3fce0aad7da86061f1e5bf2de8016eb781fa87f260a0de748a8",
+        "wx": "00d282b8c407e70a153c420461da7e376d501e9348b42d143f6c215ee2b61aed28",
+        "wy": "1cf6add6baf3e3fce0aad7da86061f1e5bf2de8016eb781fa87f260a0de748a8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d282b8c407e70a153c420461da7e376d501e9348b42d143f6c215ee2b61aed281cf6add6baf3e3fce0aad7da86061f1e5bf2de8016eb781fa87f260a0de748a8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0oK4xAfnChU8QgRh2n43bVAek0i0LRQ/\nbCFe4rYa7Sgc9q3WuvPj/OCq19qGBh8eW/LegBbreB+ofyYKDedIqA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 287,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179855555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "0oK4xAfnChU8QgRh2n43bVAek0i0LRQ_bCFe4rYa7Sg",
+        "y": "HPat1rrz4_zgqtfahgYfHlvy3oAW63gfqH8mCg3nSKg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040b21e08ee53b735b32f51327fa4aac6b0ff775bf7ef0a4a7d9fa5f2a693104a44e9a4795f4999e25da0b9c314828bdd12f45aec22a19150004b1912afa019344",
+        "wx": "0b21e08ee53b735b32f51327fa4aac6b0ff775bf7ef0a4a7d9fa5f2a693104a4",
+        "wy": "4e9a4795f4999e25da0b9c314828bdd12f45aec22a19150004b1912afa019344"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040b21e08ee53b735b32f51327fa4aac6b0ff775bf7ef0a4a7d9fa5f2a693104a44e9a4795f4999e25da0b9c314828bdd12f45aec22a19150004b1912afa019344",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECyHgjuU7c1sy9RMn+kqsaw/3db9+8KSn\n2fpfKmkxBKROmkeV9JmeJdoLnDFIKL3RL0WuwioZFQAEsZEq+gGTRA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 288,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "CyHgjuU7c1sy9RMn-kqsaw_3db9-8KSn2fpfKmkxBKQ",
+        "y": "TppHlfSZniXaC5wxSCi90S9FrsIqGRUABLGRKvoBk0Q",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04de51929eb2137315db47731d4ef28c4177d04c4990018e0471656a6c3b84a3c11ff555ec1d66075af3b2c4335bbbe8bccb3568553d7205eb510d95592071e9ad",
+        "wx": "00de51929eb2137315db47731d4ef28c4177d04c4990018e0471656a6c3b84a3c1",
+        "wy": "1ff555ec1d66075af3b2c4335bbbe8bccb3568553d7205eb510d95592071e9ad"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004de51929eb2137315db47731d4ef28c4177d04c4990018e0471656a6c3b84a3c11ff555ec1d66075af3b2c4335bbbe8bccb3568553d7205eb510d95592071e9ad",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3lGSnrITcxXbR3MdTvKMQXfQTEmQAY4E\ncWVqbDuEo8Ef9VXsHWYHWvOyxDNbu+i8yzVoVT1yBetRDZVZIHHprQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 289,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179899999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "3lGSnrITcxXbR3MdTvKMQXfQTEmQAY4EcWVqbDuEo8E",
+        "y": "H_VV7B1mB1rzssQzW7vovMs1aFU9cgXrUQ2VWSBx6a0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047f478a0ec74f842347962c4c4fdf24556dd6072b1a787beb2ca0c0e0f6420965b08a367106c6d921397b0a322b55c6d658f93d1a08f541955c3f3b0a1c451194",
+        "wx": "7f478a0ec74f842347962c4c4fdf24556dd6072b1a787beb2ca0c0e0f6420965",
+        "wy": "00b08a367106c6d921397b0a322b55c6d658f93d1a08f541955c3f3b0a1c451194"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047f478a0ec74f842347962c4c4fdf24556dd6072b1a787beb2ca0c0e0f6420965b08a367106c6d921397b0a322b55c6d658f93d1a08f541955c3f3b0a1c451194",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEf0eKDsdPhCNHlixMT98kVW3WBysaeHvr\nLKDA4PZCCWWwijZxBsbZITl7CjIrVcbWWPk9Ggj1QZVcPzsKHEURlA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 290,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179866666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "f0eKDsdPhCNHlixMT98kVW3WBysaeHvrLKDA4PZCCWU",
+        "y": "sIo2cQbG2SE5ewoyK1XG1lj5PRoI9UGVXD87ChxFEZQ",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0431b6688798d48eda210ea3417b2e118ca727b9e147968359ee1edab60c4710b110a53fb782f5f67d6c0f84b18753708f16d22667ade0251a6cf2a885a4ef6b1c",
+        "wx": "31b6688798d48eda210ea3417b2e118ca727b9e147968359ee1edab60c4710b1",
+        "wy": "10a53fb782f5f67d6c0f84b18753708f16d22667ade0251a6cf2a885a4ef6b1c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000431b6688798d48eda210ea3417b2e118ca727b9e147968359ee1edab60c4710b110a53fb782f5f67d6c0f84b18753708f16d22667ade0251a6cf2a885a4ef6b1c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMbZoh5jUjtohDqNBey4RjKcnueFHloNZ\n7h7atgxHELEQpT+3gvX2fWwPhLGHU3CPFtImZ63gJRps8qiFpO9rHA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 291,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179849249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "MbZoh5jUjtohDqNBey4RjKcnueFHloNZ7h7atgxHELE",
+        "y": "EKU_t4L19n1sD4Sxh1NwjxbSJmet4CUabPKohaTvaxw",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e03e9628c7e440d051aafaa110f83ac5f2fd2d614504f0d8d96cb28175e56ebf0a0b78b5951a34adb39680b2bef533c745dd14c6d798188da2d5abf0b321e208",
+        "wx": "00e03e9628c7e440d051aafaa110f83ac5f2fd2d614504f0d8d96cb28175e56ebf",
+        "wy": "0a0b78b5951a34adb39680b2bef533c745dd14c6d798188da2d5abf0b321e208"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e03e9628c7e440d051aafaa110f83ac5f2fd2d614504f0d8d96cb28175e56ebf0a0b78b5951a34adb39680b2bef533c745dd14c6d798188da2d5abf0b321e208",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4D6WKMfkQNBRqvqhEPg6xfL9LWFFBPDY\n2WyygXXlbr8KC3i1lRo0rbOWgLK+9TPHRd0UxteYGI2i1avwsyHiCA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 292,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f817980eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "4D6WKMfkQNBRqvqhEPg6xfL9LWFFBPDY2WyygXXlbr8",
+        "y": "Cgt4tZUaNK2zloCyvvUzx0XdFMbXmBiNotWr8LMh4gg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 293,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "aa275665bf8cd2750115f3d8baf4693d8b02b8a06567c354931362f6b0127e642492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 294,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "55d8a99a40732d8afeea0c27450b96c12fac244649e0dce72cbefb962023c2dd2492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+        "y": "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "00b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5i3xSWI2Vw7mqJbBAPx7vdXAuhLt1l6q+ZjuC9vBO8ndw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 295,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "aa275665bf8cd2750115f3d8baf4693d8b02b8a06567c354931362f6b0127e642492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 296,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "55d8a99a40732d8afeea0c27450b96c12fac244649e0dce72cbefb962023c2dd2492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+        "y": "t8UliNlcO5qiWwQD8e73VwLoS7dZeqvmY7gvbwTvJ3c",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 297,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "",
+          "sig": "628b14cbf72917074fa426d416fa5c48f06478530212ad30ae2e9010b8c6fdec388acfa3ec598bfaf6688d476ee0cef3e8bf39eb316fcc1aa543d281990d187c",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "4d7367",
+          "sig": "637773158eadcb85866081effe3a45d179b18351eff65f1ab3856a60f7b4b49dfe84f96c9e6949a9c9577b79969a44c328f51ff667466721a0959ae6f1ba93c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "5a2b4d1b450c88b0eec269c6767089b5aafb38f617957a357cfa6e9ae4515fc954f4fb30d46fff7bc676fab15b3619168dd82bf8b568ec2fb2e6d1fa9aac3d16",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "sig": "588e02f8dadedba87c109febaf429d306750f840284f8bf332b78793163f8593645e04e95f243fb9aa72d23aa276bb226002492289a68b5c87031a27d8050305",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "eCyO0X47Kng7VGTzOwllKnHGeOBexR6E4rz8Zjo96WM",
+        "y": "r5rLQoC4x_fEL075q6YkXsHsFxL9OKD6lkGNjNaqYVI",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "01060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv8AAAABBgSS1aVnPg8l2NUPt+WMSdhtRtQhaVXgqj1A4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 301,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "464a46be43db95757410c8a665daede8e703a3699f8888fca4a43efde5efe909d390307c381e99c0bf1708788c05421e0fa46146b87eeae129755afbed10f833",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "d03531447558ba41e6fa8903c72810b59f554fb8c22a289e74de72a18fa2486a59820fc4d1eb161fde46addecf43a68ab392dfb5c5639645974c9e1d02a2d804",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "2b1accd781dfcfbee745099340ae0e3de2f03dbaa877c67a193d01e59af07fd92102bff66143cec438dfcf25a2830032a7ab997fff87e2d968e68316b0367c2e",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "boI1VUUpFAmRgsaywdbwtdKNUMzQBa8s4bulQapAyv8",
+        "y": "AAAAAQYEktWlZz4PJdjVD7fljEnYbUbUIWlV4Ko9QOE",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "00fffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv/////++fttKlqYwfDaJyrwSBpztieSuSvelqoeVcK7Tg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 304,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "a9bbaa431da61459f596aa0f0e0a04c4aa842c601d80b66df61ca31a956eff00f80836e4c9aed5fc5ae68ff3fcc2cc4708b3da87e6a62693eaa3d3fbbee4a62c",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "592022d84bd494ddda81c46a7b9a5c77636895a7e771767e5f4d7d5935c2bd36b0da09fb20d6d41b3ba0c3e2ff2a3f6c672d4c1e0b98224be73b8c731dcd8a7d",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "282d848ade945d708a5b24448c820af39109550c98acaa0388a42c0aefdd57eaf3813f887784763140ad75d92004dcc2c083f24c2021bca951a0e992c19f2375",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "boI1VUUpFAmRgsaywdbwtdKNUMzQBa8s4bulQapAyv8",
+        "y": "_____vn7bSpamMHw2icq8Egac7Ynkrkr3paqHlXCu04",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+        "wx": "013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0",
+        "wy": "00f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAAAAAT/SIkjWTZX3PCm0irSGMYUL5QP9\nAPhGi18PcOD27nqkO8LG/SWx2CaSQcvdnbsNrJbcliMfQwcF+DhxfQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 307,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "c684978c7a9b0b25d0fc46085f8fcf25333cf60faa9725f0e3bb8d36fad0115f86c7777485160d36534d738df96ebbe466724a2b0ba46037c3c7259d56fcbc69",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "84ead946823e99db2f868445267816f8c768918f43eb63db99fad185a77cb4bf1ccafad763bfe7f1126d14347281c308bfc26cfdeeceaa0b9500324592ba1d08",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "9809aee73683bdb2f11aed700e126218cf83390d03ced4ba1d0d7c510f28e171517d7b37cc5a135bc3ebb6b8893184c19cd55906fb81457921459dc2e405b289",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "AAAAAT_SIkjWTZX3PCm0irSGMYUL5QP9APhGi18PcOA",
+        "y": "9u56pDvCxv0lsdgmkkHL3Z27DayW3JYjH0MHBfg4cX0",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+        "wx": "25afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dffffffff",
+        "wy": "00fa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJa/WiayrrtZ8Hylt5ZQG+MVQ9XFGoLTs\nLJeHbf/////6RqduUgMi37xJHsTwzBl0IPxOpYg9j23VPDVLxPZ8NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 310,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "ffbd115248ced3e239e69f70aca6b88009a4ba70789dc069f6398bef2689b360cd5395067978dd2033be3683b2b89f325ffe36d6c322b3d3cfb0d830c2f6a9e8",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "ddcc741a775ba371fbf012387602e4df68ac6417c14a8bc07d33c5bb82012ee699c06c1e31ea5d7e599e30b64b4de29753fbd2240c19bca2d45e5c9257706b26",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "ab182993ac64e949230ca990dd5c34000265b89c96e65d17a1a459704e18c483acde94f7015284fd8ef8173f0b5848e27328cb53f9767674f3b2d636466f8aac",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "Ja_WiayrrtZ8Hylt5ZQG-MVQ9XFGoLTsLJeHbf____8",
+        "y": "-kanblIDIt-8SR7E8MwZdCD8TqWIPY9t1Tw1S8T2fDU",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+        "wx": "00d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb9",
+        "wy": "3f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0S5sZrZ3NMPITSYBz1013Al+J2N/CspK\nT9t0tqrdO7k/W9/4i9VzbfiY5pkAbtdQ8RzwfFhmzXrXDHEh/////w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 313,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3bdd807aa453ebb9f5414a5d69a2be960df3aeb77504baf914cb2e86ee3696f26cd9d8777addf855fa925cbaf96c0922eb77fbd9d5a694e54fc095311225bf37",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "90ef85d856713b3663b149af197cb2cdd02a182efc9febcb967cf94cc906a24549dcd3a2a3830ee767272fdcd6d71ea6d9ebef2966d062d1395997591e2663b0",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "d488ff59f0511e95f1c453a97f69f8348ebea8df3dd169cb86e3659f9ac3cf6d9cee77199ef61962d0536bb2d6ca8df1241c154c5d2b438c4a4642fb8300bf93",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "0S5sZrZ3NMPITSYBz1013Al-J2N_CspKT9t0tqrdO7k",
+        "y": "P1vf-IvVc234mOaZAG7XUPEc8HxYZs161wxxIf____8",
+        "kid": "none"
+      }
+    },
+    {
+      "type": "EcdsaP1363Verify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+        "wx": "6d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000",
+        "wy": "00e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbUp/YNR3Sk8KqLve25U8fup5CUB+MWR1\nVmS8KAAAAADmWdNOTfONnoyeqt+6NmEsdpGVvobHeqw/NueLU4aA+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 316,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "b1b6f8ef07f038033b16d9bf45bf0dede3933b13628bb0d42d700d6558d2fa27952e44f7ccce4b03219f7b03cbb25f8c7f248bff4a6b8dc86091715fa3b991fa",
+          "result": "valid"
+        },
+        {
+          "tcId": 317,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "1dfbe3475a56b7154581754170f9bd26ad587963f6602ac2a0b19dc95d5db1475f91c59ab77032687de74a9d16247342977444050e4b73167132782ad4a71c31",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "57a0f29be404873953639f069f5b4b0149a241f5da85df21eac9dd58995be0af2813f7d8bbe6f1d7f3f7dca63670393fd1709496253af1243493536a64eccd6f",
+          "result": "valid"
+        }
+      ],
+      "publicKeyJwk": {
+        "kty": "EC",
+        "crv": "secp256k1",
+        "x": "bUp_YNR3Sk8KqLve25U8fup5CUB-MWR1VmS8KAAAAAA",
+        "y": "5lnTTk3zjZ6MnqrfujZhLHaRlb6Gx3qsPzbni1OGgPs",
+        "kid": "none"
+      }
+    }
+  ]
+}

--- a/tests/ecc/_data/ecdsa_secp256k1_shake256_test.json
+++ b/tests/ecc/_data/ecdsa_secp256k1_shake256_test.json
@@ -1,0 +1,7565 @@
+{
+  "algorithm": "ECDSA",
+  "schema": "ecdsa_verify_schema_v1.json",
+  "numberOfTests": 542,
+  "header": [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
+  "notes": {
+    "ArithmeticError": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurrences.",
+      "cves": [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature": {
+      "bugType": "BER_ENCODING",
+      "description": "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect": "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves": [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature": {
+      "bugType": "AUTH_BYPASS",
+      "description": "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect": "Accepting such signatures can have the effect that an adversary can forge signatures without even knowing the message to sign.",
+      "cves": [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero": {
+      "bugType": "LEGACY",
+      "description": "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect": "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication": {
+      "bugType": "EDGE_CASE",
+      "description": "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves": [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck": {
+      "bugType": "CAN_OF_WORMS",
+      "description": "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect": "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect": "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves": [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash": {
+      "bugType": "EDGE_CASE",
+      "description": "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "Untruncatedhash": {
+      "bugType": "MISSING_STEP",
+      "description": "If the size of the digest is longer than the size of the underlying order of the multiplicative subgroup then the hash digest must be truncated during signature generation and verification. This test vector contains a signature where this step has been omitted."
+    },
+    "ValidSignature": {
+      "bugType": "BASIC",
+      "description": "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
+  },
+  "testGroups": [
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 1,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "",
+          "sig": "30440220628b14cbf72917074fa426d416fa5c48f06478530212ad30ae2e9010b8c6fdec0220388acfa3ec598bfaf6688d476ee0cef3e8bf39eb316fcc1aa543d281990d187c",
+          "result": "valid"
+        },
+        {
+          "tcId": 2,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "4d7367",
+          "sig": "30450220637773158eadcb85866081effe3a45d179b18351eff65f1ab3856a60f7b4b49d022100fe84f96c9e6949a9c9577b79969a44c328f51ff667466721a0959ae6f1ba93c6",
+          "result": "valid"
+        },
+        {
+          "tcId": 3,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304402205a2b4d1b450c88b0eec269c6767089b5aafb38f617957a357cfa6e9ae4515fc9022054f4fb30d46fff7bc676fab15b3619168dd82bf8b568ec2fb2e6d1fa9aac3d16",
+          "result": "valid"
+        },
+        {
+          "tcId": 4,
+          "comment": "pseudorandom signature",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "0000000000000000000000000000000000000000",
+          "sig": "30440220588e02f8dadedba87c109febaf429d306750f840284f8bf332b78793163f85930220645e04e95f243fb9aa72d23aa276bb226002492289a68b5c87031a27d8050305",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+        "wx": "00b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6f",
+        "wy": "00f0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b838ff44e5bc177bf21189d0766082fc9d843226887fc9760371100b7ee20a6ff0c9d75bfba7b31a6bca1974496eeb56de357071955d83c4b1badaa0b21832e9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEuDj/ROW8F3vyEYnQdmCC/J2EMiaIf8l2\nA3EQC37iCm/wyddb+6ezGmvKGXRJbutW3jVwcZVdg8Sxutqgshgy6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 5,
+          "comment": "signature malleability",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022004176f8eb0d09bbf556ea61cdbd899523e1ad8222e79daf4d1925aeb35cf564b",
+          "result": "valid"
+        },
+        {
+          "tcId": 6,
+          "comment": "Legacy: ASN encoding of r misses leading 0",
+          "flags": [
+            "MissingZero"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 7,
+          "comment": "Legacy: ASN encoding of s misses leading 0",
+          "flags": [
+            "MissingZero"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0220fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 8,
+          "comment": "valid",
+          "flags": [
+            "ValidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "valid"
+        },
+        {
+          "tcId": 9,
+          "comment": "length of sequence [r, s] uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308146022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 10,
+          "comment": "length of sequence [r, s] contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30820046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 11,
+          "comment": "length of sequence [r, s] uses 71 instead of 70",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 12,
+          "comment": "length of sequence [r, s] uses 69 instead of 70",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 13,
+          "comment": "uint32 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30850100000046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 14,
+          "comment": "uint64 overflow in length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3089010000000000000046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 15,
+          "comment": "length of sequence [r, s] = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30847fffffff022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 16,
+          "comment": "length of sequence [r, s] = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "308480000000022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 17,
+          "comment": "length of sequence [r, s] = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3084ffffffff022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 18,
+          "comment": "length of sequence [r, s] = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3085ffffffffff022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 19,
+          "comment": "length of sequence [r, s] = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3088ffffffffffffffff022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 20,
+          "comment": "incorrect length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30ff022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 21,
+          "comment": "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 22,
+          "comment": "removing sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "",
+          "result": "invalid"
+        },
+        {
+          "tcId": 23,
+          "comment": "lonely sequence tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 24,
+          "comment": "appending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 25,
+          "comment": "prepending 0's to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30480000022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 26,
+          "comment": "appending unused 0's to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 27,
+          "comment": "appending null value to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 28,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b4981773046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 29,
+          "comment": "prepending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a25003046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 30,
+          "comment": "appending garbage to sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30483046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 31,
+          "comment": "including undefined tags",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304eaa00bb00cd003046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 32,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e2229aa00bb00cd00022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 33,
+          "comment": "including undefined tags",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d2229aa00bb00cd00022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 34,
+          "comment": "truncated length of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3081",
+          "result": "invalid"
+        },
+        {
+          "tcId": 35,
+          "comment": "including undefined tags to sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304caa02aabb3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 36,
+          "comment": "using composition with indefinite length for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30803046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 37,
+          "comment": "using composition with wrong tag for sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30803146022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 38,
+          "comment": "Replacing sequence [r, s] with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 39,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2e46022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 40,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "2f46022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 41,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3146022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 42,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3246022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 43,
+          "comment": "changing tag value of sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "ff46022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 44,
+          "comment": "dropping value of sequence [r, s]",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 45,
+          "comment": "using composition for sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a30010230452100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 46,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66ea",
+          "result": "invalid"
+        },
+        {
+          "tcId": 47,
+          "comment": "truncated sequence [r, s]",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30452100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 48,
+          "comment": "sequence [r, s] of size 4167 to check for overflows",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30821047022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 49,
+          "comment": "indefinite length",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 50,
+          "comment": "indefinite length with truncated delimiter",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf600",
+          "result": "invalid"
+        },
+        {
+          "tcId": 51,
+          "comment": "indefinite length with additional element",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf605000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 52,
+          "comment": "indefinite length with truncated element",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6060811220000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 53,
+          "comment": "indefinite length with garbage",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000fe02beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 54,
+          "comment": "indefinite length with nonempty EOC",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3080022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60002beef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 55,
+          "comment": "prepend empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30483000022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 56,
+          "comment": "append empty sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf63000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 57,
+          "comment": "append zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 58,
+          "comment": "append garbage with high tag number",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3049022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6bf7f00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 59,
+          "comment": "append null with explicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6a0020500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 60,
+          "comment": "append null with implicit tag",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6a000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 61,
+          "comment": "sequence of sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30483046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 62,
+          "comment": "truncated sequence: removed last 1 elements",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3023022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d",
+          "result": "invalid"
+        },
+        {
+          "tcId": 63,
+          "comment": "repeating element in sequence",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3069022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 64,
+          "comment": "flipped bit 0 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304400ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7c022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 65,
+          "comment": "flipped bit 32 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304400ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250194084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 66,
+          "comment": "flipped bit 48 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304400ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac1250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 67,
+          "comment": "flipped bit 64 in r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304400ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef12ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 68,
+          "comment": "length of r uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "304702812100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 69,
+          "comment": "length of r contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30480282002100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 70,
+          "comment": "length of r uses 34 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022200ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 71,
+          "comment": "length of r uses 32 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022000ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 72,
+          "comment": "uint32 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b0285010000002100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 73,
+          "comment": "uint64 overflow in length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304f028901000000000000002100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 74,
+          "comment": "length of r = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02847fffffff00ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 75,
+          "comment": "length of r = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a02848000000000ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 76,
+          "comment": "length of r = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a0284ffffffff00ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 77,
+          "comment": "length of r = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b0285ffffffffff00ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 78,
+          "comment": "length of r = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e0288ffffffffffffffff00ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 79,
+          "comment": "incorrect length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304602ff00ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 80,
+          "comment": "replaced r by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046028000ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 81,
+          "comment": "removing r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3023022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 82,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "302402022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 83,
+          "comment": "lonely integer tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3024022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d02",
+          "result": "invalid"
+        },
+        {
+          "tcId": 84,
+          "comment": "appending 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022300ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0000022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 85,
+          "comment": "prepending 0's to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30480223000000ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 86,
+          "comment": "appending unused 0's to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0000022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 87,
+          "comment": "appending null value to r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022300ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0500022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 88,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b2226498177022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 89,
+          "comment": "prepending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a22252500022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 90,
+          "comment": "appending garbage to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e2223022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0004deadbeef022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 91,
+          "comment": "truncated length of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250281022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 92,
+          "comment": "including undefined tags to r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304c2227aa02aabb022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 93,
+          "comment": "using composition with indefinite length for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a2280022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0000022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 94,
+          "comment": "using composition with wrong tag for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a2280032100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0000022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 95,
+          "comment": "Replacing r with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30250500022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 96,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046002100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 97,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046012100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 98,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046032100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 99,
+          "comment": "changing tag value of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046042100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 100,
+          "comment": "changing tag value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046ff2100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 101,
+          "comment": "dropping value of r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "30250200022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 102,
+          "comment": "using composition for r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a22250201000220ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 103,
+          "comment": "modifying first byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022102ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 104,
+          "comment": "modifying last byte of r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084ffd022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 105,
+          "comment": "truncated r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022000ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 106,
+          "comment": "r of size 4130 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "308210490282102200ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 107,
+          "comment": "leading ff in r",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30470222ff00ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 108,
+          "comment": "replaced r by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026090180022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 109,
+          "comment": "replacing r with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 110,
+          "comment": "flipped bit 0 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf7",
+          "result": "invalid"
+        },
+        {
+          "tcId": 111,
+          "comment": "flipped bit 32 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a09a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 112,
+          "comment": "flipped bit 48 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4103a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 113,
+          "comment": "flipped bit 64 in s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d00fbe890714f2f6440aa9159e3242766ac7c9404c480cec547ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 114,
+          "comment": "length of s uses long form encoding",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d02812100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 115,
+          "comment": "length of s contains a leading 0",
+          "flags": [
+            "BerEncodedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0282002100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 116,
+          "comment": "length of s uses 34 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022200fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 117,
+          "comment": "length of s uses 32 instead of 33",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 118,
+          "comment": "uint32 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0285010000002100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 119,
+          "comment": "uint64 overflow in length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304f022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d028901000000000000002100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 120,
+          "comment": "length of s = 2**31 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d02847fffffff00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 121,
+          "comment": "length of s = 2**31",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d02848000000000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 122,
+          "comment": "length of s = 2**32 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0284ffffffff00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 123,
+          "comment": "length of s = 2**40 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0285ffffffffff00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 124,
+          "comment": "length of s = 2**64 - 1",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0288ffffffffffffffff00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 125,
+          "comment": "incorrect length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d02ff00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 126,
+          "comment": "replaced s by an indefinite length tag without termination",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d028000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 127,
+          "comment": "appending 0's to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022300fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 128,
+          "comment": "prepending 0's to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0223000000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 129,
+          "comment": "appending null value to s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3048022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022300fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 130,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304b022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d2226498177022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 131,
+          "comment": "prepending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d22252500022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 132,
+          "comment": "appending garbage to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304e022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d2223022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60004deadbeef",
+          "result": "invalid"
+        },
+        {
+          "tcId": 133,
+          "comment": "truncated length of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0281",
+          "result": "invalid"
+        },
+        {
+          "tcId": 134,
+          "comment": "including undefined tags to s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304c022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d2227aa02aabb022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 135,
+          "comment": "using composition with indefinite length for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d2280022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 136,
+          "comment": "using composition with wrong tag for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d2280032100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 137,
+          "comment": "Replacing s with NULL",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 138,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d002100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 139,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d012100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 140,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d032100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 141,
+          "comment": "changing tag value of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d042100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 142,
+          "comment": "changing tag value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7dff2100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 143,
+          "comment": "dropping value of s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0200",
+          "result": "invalid"
+        },
+        {
+          "tcId": 144,
+          "comment": "using composition for s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "313233343030",
+          "sig": "304a022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d22250201000220fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 145,
+          "comment": "modifying first byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022102fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 146,
+          "comment": "modifying last byte of s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66ea76",
+          "result": "invalid"
+        },
+        {
+          "tcId": 147,
+          "comment": "truncated s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66ea",
+          "result": "invalid"
+        },
+        {
+          "tcId": 148,
+          "comment": "s of size 4130 to check for overflows",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30821049022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0282102200fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf60000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 149,
+          "comment": "leading ff in s",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3047022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d0222ff00fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 150,
+          "comment": "replaced s by infinity",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d090180",
+          "result": "invalid"
+        },
+        {
+          "tcId": 151,
+          "comment": "replacing s with zero",
+          "flags": [
+            "ModifiedSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 152,
+          "comment": "replaced r by r + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101ddcd43e8cdb75e3c286984ef197e212b39b70b7b640a0f2bea92838d643e90be022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 153,
+          "comment": "replaced r by r - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220ddcd43e8cdb75e3c286984ef197e212dc45951ae0578ceb46aedc673c3d20e3c022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 154,
+          "comment": "replaced r by r + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "304702220100ddcd43e8cdb75e3c286984ef197e1fe72de51543fd61aaaffd1eb1d0ca49907d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 155,
+          "comment": "replaced r by -r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff2232bc173248a1c3d7967b10e681ded380f7d16b4b3e910fd53fdaff6bf7b083022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 156,
+          "comment": "replaced r by n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "304502202232bc173248a1c3d7967b10e681ded23ba6ae51fa87314b9512398c3c2df1c4022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 157,
+          "comment": "replaced r by -n - r",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fe2232bc173248a1c3d7967b10e681ded4c648f4849bf5f0d4156d7c729bc16f42022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 158,
+          "comment": "replaced r by r + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 159,
+          "comment": "replaced r by r + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e0229010000000000000000ddcd43e8cdb75e3c286984ef197e212c7f082e94b4c16ef02ac0250094084f7d022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 160,
+          "comment": "replaced s by s + n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101fbe890714f2f6440aa9159e3242766ab3742e1ab30176582ae12622e6a9d2c37022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 161,
+          "comment": "replaced s by s - n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220fbe890714f2f6440aa9159e3242766adc1e527ddd186250b2e6da514ca30a9b5022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 162,
+          "comment": "replaced s by s + 256 * n",
+          "flags": [
+            "RangeCheck"
+          ],
+          "msg": "313233343030",
+          "sig": "304702220100fbe890714f2f6440aa9159e3242765672b70eb73c96f0106c09e9071d0a82bf6022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 163,
+          "comment": "replaced s by -s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221ff04176f8eb0d09bbf556ea61cdbd89953836bfb3b7f313ab911bffc5e6599150a022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 164,
+          "comment": "replaced s by -n - s",
+          "flags": [
+            "ModifiedInteger"
+          ],
+          "msg": "313233343030",
+          "sig": "30460221fe04176f8eb0d09bbf556ea61cdbd89954c8bd1e54cfe89a7d51ed9dd19562d3c9022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 165,
+          "comment": "replaced s by s + 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022101fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 166,
+          "comment": "replaced s by s - 2**256",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "30450220fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 167,
+          "comment": "replaced s by s + 2**320",
+          "flags": [
+            "IntegerOverflow"
+          ],
+          "msg": "313233343030",
+          "sig": "304e0229010000000000000000fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6022100fbe890714f2f6440aa9159e3242766ac7c9404c480cec546ee4003a19a66eaf6",
+          "result": "invalid"
+        },
+        {
+          "tcId": 168,
+          "comment": "Signature with special case values r=0 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 169,
+          "comment": "Signature with special case values r=0 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 170,
+          "comment": "Signature with special case values r=0 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 171,
+          "comment": "Signature with special case values r=0 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 172,
+          "comment": "Signature with special case values r=0 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 173,
+          "comment": "Signature with special case values r=0 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 174,
+          "comment": "Signature with special case values r=0 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 175,
+          "comment": "Signature with special case values r=0 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020100022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 176,
+          "comment": "Signature with special case values r=1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 177,
+          "comment": "Signature with special case values r=1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 178,
+          "comment": "Signature with special case values r=1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 179,
+          "comment": "Signature with special case values r=1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 180,
+          "comment": "Signature with special case values r=1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 181,
+          "comment": "Signature with special case values r=1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 182,
+          "comment": "Signature with special case values r=1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 183,
+          "comment": "Signature with special case values r=1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020101022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 184,
+          "comment": "Signature with special case values r=-1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 185,
+          "comment": "Signature with special case values r=-1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 186,
+          "comment": "Signature with special case values r=-1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 187,
+          "comment": "Signature with special case values r=-1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 188,
+          "comment": "Signature with special case values r=-1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 189,
+          "comment": "Signature with special case values r=-1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 190,
+          "comment": "Signature with special case values r=-1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 191,
+          "comment": "Signature with special case values r=-1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30260201ff022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 192,
+          "comment": "Signature with special case values r=n and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 193,
+          "comment": "Signature with special case values r=n and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 194,
+          "comment": "Signature with special case values r=n and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 195,
+          "comment": "Signature with special case values r=n and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 196,
+          "comment": "Signature with special case values r=n and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 197,
+          "comment": "Signature with special case values r=n and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 198,
+          "comment": "Signature with special case values r=n and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 199,
+          "comment": "Signature with special case values r=n and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 200,
+          "comment": "Signature with special case values r=n - 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 201,
+          "comment": "Signature with special case values r=n - 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 202,
+          "comment": "Signature with special case values r=n - 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641400201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 203,
+          "comment": "Signature with special case values r=n - 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 204,
+          "comment": "Signature with special case values r=n - 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 205,
+          "comment": "Signature with special case values r=n - 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 206,
+          "comment": "Signature with special case values r=n - 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 207,
+          "comment": "Signature with special case values r=n - 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 208,
+          "comment": "Signature with special case values r=n + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 209,
+          "comment": "Signature with special case values r=n + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 210,
+          "comment": "Signature with special case values r=n + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641420201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 211,
+          "comment": "Signature with special case values r=n + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 212,
+          "comment": "Signature with special case values r=n + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 213,
+          "comment": "Signature with special case values r=n + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 214,
+          "comment": "Signature with special case values r=n + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 215,
+          "comment": "Signature with special case values r=n + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 216,
+          "comment": "Signature with special case values r=p and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 217,
+          "comment": "Signature with special case values r=p and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 218,
+          "comment": "Signature with special case values r=p and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 219,
+          "comment": "Signature with special case values r=p and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 220,
+          "comment": "Signature with special case values r=p and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 221,
+          "comment": "Signature with special case values r=p and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 222,
+          "comment": "Signature with special case values r=p and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 223,
+          "comment": "Signature with special case values r=p and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 224,
+          "comment": "Signature with special case values r=p + 1 and s=0",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 225,
+          "comment": "Signature with special case values r=p + 1 and s=1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30020101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 226,
+          "comment": "Signature with special case values r=p + 1 and s=-1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc300201ff",
+          "result": "invalid"
+        },
+        {
+          "tcId": 227,
+          "comment": "Signature with special case values r=p + 1 and s=n",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+          "result": "invalid"
+        },
+        {
+          "tcId": 228,
+          "comment": "Signature with special case values r=p + 1 and s=n - 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+          "result": "invalid"
+        },
+        {
+          "tcId": 229,
+          "comment": "Signature with special case values r=p + 1 and s=n + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 230,
+          "comment": "Signature with special case values r=p + 1 and s=p",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f",
+          "result": "invalid"
+        },
+        {
+          "tcId": 231,
+          "comment": "Signature with special case values r=p + 1 and s=p + 1",
+          "flags": [
+            "InvalidSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc30",
+          "result": "invalid"
+        },
+        {
+          "tcId": 232,
+          "comment": "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020100090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 233,
+          "comment": "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 234,
+          "comment": "Signature encoding contains incorrect types: r=0, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 235,
+          "comment": "Signature encoding contains incorrect types: r=0, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 236,
+          "comment": "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 237,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 238,
+          "comment": "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201000c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 239,
+          "comment": "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 240,
+          "comment": "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 241,
+          "comment": "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008020101090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 242,
+          "comment": "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 243,
+          "comment": "Signature encoding contains incorrect types: r=1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 244,
+          "comment": "Signature encoding contains incorrect types: r=1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 245,
+          "comment": "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 246,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201010c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 247,
+          "comment": "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201010c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 248,
+          "comment": "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201013000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 249,
+          "comment": "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201013003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 250,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 251,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 252,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 253,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 254,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 255,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 256,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060201ff0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 257,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050201ff3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 258,
+          "comment": "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30080201ff3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 259,
+          "comment": "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 260,
+          "comment": "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 261,
+          "comment": "Signature encoding contains incorrect types: r=n, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 262,
+          "comment": "Signature encoding contains incorrect types: r=n, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 263,
+          "comment": "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 264,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 265,
+          "comment": "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641410c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 266,
+          "comment": "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641413000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 267,
+          "comment": "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03641413003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 268,
+          "comment": "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 269,
+          "comment": "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 270,
+          "comment": "Signature encoding contains incorrect types: r=p, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 271,
+          "comment": "Signature encoding contains incorrect types: r=p, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 272,
+          "comment": "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 273,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 274,
+          "comment": "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f0c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 275,
+          "comment": "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 276,
+          "comment": "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3028022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 277,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a090380fe01090380fe01",
+          "result": "invalid"
+        },
+        {
+          "tcId": 278,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142090142",
+          "result": "invalid"
+        },
+        {
+          "tcId": 279,
+          "comment": "Signature encoding contains incorrect types: r=True, s=True",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101010101",
+          "result": "invalid"
+        },
+        {
+          "tcId": 280,
+          "comment": "Signature encoding contains incorrect types: r=False, s=False",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100010100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 281,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300405000500",
+          "result": "invalid"
+        },
+        {
+          "tcId": 282,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30040c000c00",
+          "result": "invalid"
+        },
+        {
+          "tcId": 283,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c01300c0130",
+          "result": "invalid"
+        },
+        {
+          "tcId": 284,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300430003000",
+          "result": "invalid"
+        },
+        {
+          "tcId": 285,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "300a30030201003003020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 286,
+          "comment": "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3008090380fe01020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 287,
+          "comment": "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006090142020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 288,
+          "comment": "Signature encoding contains incorrect types: r=True, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010101020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 289,
+          "comment": "Signature encoding contains incorrect types: r=False, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "3006010100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 290,
+          "comment": "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050500020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 291,
+          "comment": "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30050c00020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 292,
+          "comment": "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30060c0130020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 293,
+          "comment": "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30053000020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 294,
+          "comment": "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags": [
+            "InvalidTypesInSignature"
+          ],
+          "msg": "313233343030",
+          "sig": "30083003020100020100",
+          "result": "invalid"
+        },
+        {
+          "tcId": 295,
+          "comment": "Edge case for Shamir multiplication",
+          "flags": [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg": "3838393131",
+          "sig": "3045022100dd1b7d09a7bd8218961034a39a87fecf5314f00c4d25eb58a07ac85e85eab5160220175703ba6e1b31ff9f7826ee6491bf2b64a24e252128a7907c4549bc3a1705a1",
+          "result": "valid"
+        },
+        {
+          "tcId": 296,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34343531343631393831",
+          "sig": "3046022100febe44c291f8d00b23dd343d012815060c07f086934eab0a75812ca1c7cbfee30221008df2e30bb376e312ebc52bea8ed3e6bd000f28acc50530008e8c47772be39cab",
+          "result": "valid"
+        },
+        {
+          "tcId": 297,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373030393239393039",
+          "sig": "3045022066bf0d17b683d67bbe5922dfeb4501cad0ffc30cd409bdb1ff7194e0c2f973bf022100dcb7e6f20d99d831c26752f675be5d12edb83a8b0052f5888f8c86649a257147",
+          "result": "valid"
+        },
+        {
+          "tcId": 298,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32343830313737303637",
+          "sig": "3046022100b8b3d79edeb8912af9b7a24770331837124287bdbbb7539a551348a0475a0d68022100dd0077d1d38b356b6d2b521117b8aae6dcb9bf90256d9ef0ba88106fc2d5511a",
+          "result": "valid"
+        },
+        {
+          "tcId": 299,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373731363034393337",
+          "sig": "304402201b10d9085dc554204dabfaef23e7ccb1bf8b8230b151f69d72c090c254311515022041cd4e2e57ee850160027c0e6fa5f54d853220944545baf7f2a06252ff566f71",
+          "result": "valid"
+        },
+        {
+          "tcId": 300,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131333035393331373331",
+          "sig": "304402200f735b8fce2e916009011cb3d8c40308e10c124aa7b983f9ad601e304a962b9602200a3c8804a48ebde1952bc54fa550e25896785d74b079678d0a48d85ca92c3bb5",
+          "result": "valid"
+        },
+        {
+          "tcId": 301,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134383635323132343538",
+          "sig": "3044022031884994ff0e27f6bd15301eff0da96f47dd2ca84dfb0dd829f2a07f61d1fd700220545f0241caf7623463137898afa8025a78ca0b6d2a74196c4370ad6683853ca1",
+          "result": "valid"
+        },
+        {
+          "tcId": 302,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "363135323834393939",
+          "sig": "3045022100c59f661deca240b7306b6aa5fa889f293782dcdea542bdd2ea7c88dd17eabcf20220765df309eeff37a7be634942f622ff3b02abb83be00124aa40e6cb4665ef9ebd",
+          "result": "valid"
+        },
+        {
+          "tcId": 303,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323839373132383731",
+          "sig": "3046022100e373195a8517ab1cf4de22de3a3372efbddd09babd93b81de4061a957c4368ae022100be3a5173cd9f152fc935b656b4a1c8ad9552cf10a94007bb3704013ae61f878e",
+          "result": "valid"
+        },
+        {
+          "tcId": 304,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34353134333236393935",
+          "sig": "3045022100c75fa1a940e191e4d4c54be00ad91278ade1399470ed8a8751935ec4100b85a702205ae64db319748bd3f03e239ecc1401304aa9aaa77f840c302f49f6cd20ddb03d",
+          "result": "valid"
+        },
+        {
+          "tcId": 305,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313138303935373633",
+          "sig": "3045022100a4fa215de24e4d3b990037da3b7914f423db9c5775cac4f4b10c95a51a8c3e9a022001e35025feb5eb96b642d26721011e4ed45b2cfe3329aa8a32d9e7bff5715ba7",
+          "result": "valid"
+        },
+        {
+          "tcId": 306,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333435343736353130",
+          "sig": "3045022011ff5e2ba3ae1b034d293d10df9bdc837e589d6563e47b88c5671479b7f1e258022100f2d6b13f2adf4b28a694a12f8a72ac8e64765fa4e8dbb3bed1627ba09f2b8754",
+          "result": "valid"
+        },
+        {
+          "tcId": 307,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343232393938313032",
+          "sig": "3046022100bfdd84bba4f8a7f8ad94bf5276ae51400008c2e5bae40bcac55b3fac3464b30a022100b74631480be60c3c5022498410e7798dc22a1a76cb7862d702699f7b149e84e2",
+          "result": "valid"
+        },
+        {
+          "tcId": 308,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323635343239383132",
+          "sig": "3046022100ae729bc37ac0de1a407f191f300203195fb579ad5d6674fe85573147567b43150221009112958ac5b86ab2cd2f890819055bd84d819593e8c856ac4b76178956369e48",
+          "result": "valid"
+        },
+        {
+          "tcId": 309,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373133303833323137",
+          "sig": "304502210091f229d8af15d5d152f571637b568b295474b8256b5424694d2e5b84470fb4c002206f0df837d5d07160a1d61d8c9c46dfab0db0b7cbbd748d5ffd55c6d200e281f1",
+          "result": "valid"
+        },
+        {
+          "tcId": 310,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383232373734333630",
+          "sig": "30450221008990060cdfd5d03716985c6d5e13d70c9775b229ba68cda8edf4b78f34774d8102204511488f2dc8bb7f06ba5bdf4a0f49092b1ca72ecf001bbfc0f3c1920e8654a7",
+          "result": "valid"
+        },
+        {
+          "tcId": 311,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323834313630373935",
+          "sig": "30440220182f648feed9a6c94e8c246eaf14678c04575f96a0644dcd90aec4d5606be92e02205faf0bee69f700d573961a149a6ea4d801d82d014262d0eb0ab754ad218b27c9",
+          "result": "valid"
+        },
+        {
+          "tcId": 312,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34333135343738313236",
+          "sig": "3044022057f4d830d887ca207c09c18386e38aa89c4186764d8130695e283de1856c8c90022035d5203604bbfd38a82af452a1045fb31c13d41a7e2b93daa84d298e781d4691",
+          "result": "valid"
+        },
+        {
+          "tcId": 313,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323639373538373331",
+          "sig": "3044022014d1eb8cc831c2d3529e2f0668be09e2491da72dd81856ddb3f3b2b6a599037f022009faa962a09d2bcb03c7217a2424a78eec6e55f91ba8966b2a8a672511edb452",
+          "result": "valid"
+        },
+        {
+          "tcId": 314,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353637383031313934",
+          "sig": "304402205e55b2148c371a4804c72a183e96c42ea2723d5297985c378992edff5455dd1a0220161b624275d34dffec5809164ada6f87fbeb9c313f0203f2a170c8717421c070",
+          "result": "valid"
+        },
+        {
+          "tcId": 315,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333136323732363237",
+          "sig": "3045022100fed819a4507d19c1879fa919c82cecc331e05777b1e1f6987103cf165d2302400220053db04cb475a0c56b258ab822cd705d881b4af2d3ac5a8ab251d43120b0ed74",
+          "result": "valid"
+        },
+        {
+          "tcId": 316,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343638303735353233",
+          "sig": "3046022100dc9843356452f785515fd0d8224c591faf5522e86c0996f02b0f2b369cb2bec7022100d5791659abfdfb4415e0978edc4e4f6ce4c9dcaf0e8fc5759c404b527eb7b17a",
+          "result": "valid"
+        },
+        {
+          "tcId": 317,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "373536303830323930",
+          "sig": "3046022100e25d10a8ba8129c0795917a34df3d94fad24ed1aa142557270aefda4c72d674a022100d829f1cc92ce5fee0bb15d15d279f7ab3540d7c9d29ecbdf0dd575eac3dd5765",
+          "result": "valid"
+        },
+        {
+          "tcId": 318,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333438303136313034",
+          "sig": "304402207a03c2f364a4a394b7063162f1d4fb0ba15e7d083440c5329e0aa57cd8d7de160220787d35a1ff9c6101e1aedf413afe2230dc8322c5a13a07ea1f0d7e50f1aa0851",
+          "result": "valid"
+        },
+        {
+          "tcId": 319,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373432363433343935",
+          "sig": "30450220381c935be8b793c51de9aede7def421e9917632337fb2619c83489a5ebcfef88022100d8f84b9647e1891b9c96a36b7aa825ce688d57acb6cb5a9ea9844bced84f3b93",
+          "result": "valid"
+        },
+        {
+          "tcId": 320,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32323738343235383435",
+          "sig": "3046022100ba9ecc381fe98c5d4524c49f71804f65be95798ea12ed0d712e608d60cf20bd402210091d375bfb5aaafac26deae07296625c265a183b5df3d55cfd792679472d94c87",
+          "result": "valid"
+        },
+        {
+          "tcId": 321,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33363337313933383031",
+          "sig": "3045022065660c90475057b4f70dc2426e666228194045eae878379b674479d6ec787216022100cb7c869959046e1553417e8b3ab6ff712d2c877a1aaab93d861e7992b3c45b9d",
+          "result": "valid"
+        },
+        {
+          "tcId": 322,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34353930363837353039",
+          "sig": "3045022100c49207258ba205a2147c82c3f81d90e3903cd641c2a504254c488306eff1b1f402205f9c6f9f0f3bccd028a65d14830018287c050d39a2f8b3d0e32621a352ebd005",
+          "result": "valid"
+        },
+        {
+          "tcId": 323,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35383031393936323333",
+          "sig": "3045022017be2a69f16f4155aef45d2eaa2d0ac7181436421a90b344e2e3723b491adaa3022100ab80ad0eafd9df39c031e5d43879fade19c51ff492034374895b2cdb5eb2fc52",
+          "result": "valid"
+        },
+        {
+          "tcId": 324,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37343836353732373338",
+          "sig": "3045022051b43771b713926b82a4c90a9141d4ae9bbba8f1cb2974bdfcf453fadc531728022100de979c87f48e5ee915f1835fdc24759658e881b00322795a1be99f77460d761f",
+          "result": "valid"
+        },
+        {
+          "tcId": 325,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35323537363038333537",
+          "sig": "30450220431e7e678d379a5e0d532861ec29bebf4918253734cecd1741637a1f60ab5ffd022100c884c7ef28d033c843f3e4e0acf834a83fba2bf876fbc91289215d496e17e954",
+          "result": "valid"
+        },
+        {
+          "tcId": 326,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363332383233323433",
+          "sig": "304502201db1d6a0c5f3274fda191993287c99cc4dff5c9c6e2332a2370e57f9718ef1fd022100cdd9743a33b63ff4b0244a5e32fdeaf7fa379de1c6c611c2e9278ffc9651f136",
+          "result": "valid"
+        },
+        {
+          "tcId": 327,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393736303637323438",
+          "sig": "304402207187361237f7270fe77d02af22186845db7fd70387cd64eb24994050dcf53dff02203d2080e8f129502c73ea86ee5e20ae23fbd8e6760950965c617c207d27224323",
+          "result": "valid"
+        },
+        {
+          "tcId": 328,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35303636393137343638",
+          "sig": "3045022068ab52fdde8e098071ea3b989f18c9062d1e88f186de78d162c9760c57af4717022100be37487a8080298e766138b9fe3dfe1ff509aec54ccd665605655d650f6da2b9",
+          "result": "valid"
+        },
+        {
+          "tcId": 329,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333133323633343833",
+          "sig": "304402201f114e8559664df9c5452f96c8e537223915e39dbdf92159c7fe9d716333660e02203e2fe6ac85ea3621700ad7563ad7f083e49cad7254bdf3dbb4aa33ba59e5abe4",
+          "result": "valid"
+        },
+        {
+          "tcId": 330,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343535373733313536",
+          "sig": "30460221008cc85260b7a08ed2f77e899ad73b185274844f2c267e798dbe1d7bb5e70e28db022100e49d523795e0730171162f1a3f18424c21ef32697f2555e4faea5a9c6a8549e1",
+          "result": "valid"
+        },
+        {
+          "tcId": 331,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363036333337363930",
+          "sig": "304502202e3839872cbef3c7554042520c06b8d9508c3519198675387a7220c4fa8f1f6e022100fac8721643d296b46e605ffc6ec8a67c1590b85b34743e0752dab44924738930",
+          "result": "valid"
+        },
+        {
+          "tcId": 332,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32393038373634353636",
+          "sig": "304402201074773c071aff445f7a0b462d335e4ee88c2b30f45a47e202f12d083e74bbc2022009d24b755b35046be8946a96ab61551062e9bd91e51e7ad4c284e68ed92b8997",
+          "result": "valid"
+        },
+        {
+          "tcId": 333,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37383231353536343934",
+          "sig": "30440220604a909e30cc9a5caa5da85a855f08f51619914b6be757c3466137d896b3ca22022021807764ef52afa757c8ec03a3e1ee611d633a5a2a4a112abc0fbfe6c31cf8be",
+          "result": "valid"
+        },
+        {
+          "tcId": 334,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3132313430303035393239",
+          "sig": "3045022100969749beab754b9fb67ad833c188396f631b89930fb85f5084eea9455b36df6302206e7fe6c81da3d96a0f182559f69e2fff067390a4ca195f0472a2c5da7b0bf340",
+          "result": "valid"
+        },
+        {
+          "tcId": 335,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363239393337313131",
+          "sig": "3045022100e73dd2f13791e056cc164c964806d1ec3f1f427bc970dafda4e6e2dbff83495b0220556f2a52c774b17b6b4fbb3c6cb96c5be2c0a0c4da4963cb7eff8a8403e3f93c",
+          "result": "valid"
+        },
+        {
+          "tcId": 336,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373232383437383135",
+          "sig": "304402201d8f05198aa2dc03ce13ea57b579d11376555e986134203a5262e14e98df076d0220208ef20d0f8deafbe6860579bbd198a9187bd62605062e23c1db6edb592f500d",
+          "result": "valid"
+        },
+        {
+          "tcId": 337,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3337343334313732353931",
+          "sig": "30460221009549f21a6ddd1ad34c800686679ef7eeeacdf82943d360b5967fee54a6be3b2d0221008d60ca019ff567b0f93c37efc735c927f9c1d2110abf83dcea8f44d8c22eca62",
+          "result": "valid"
+        },
+        {
+          "tcId": 338,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313837363932303637",
+          "sig": "3045022100a072a85fd596859914601fe354d99e10068f90d3bc7ab3714c0cb88dc1efecc802202425ff303cf382e3a640a903a6aa32d4db4b46bc1b9525946a881a50b61c6581",
+          "result": "valid"
+        },
+        {
+          "tcId": 339,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32393937353331383431",
+          "sig": "3045022100ac9d8ba3f67f51d4b9b71968a0743dcd06856da1edf1fcd5034f8bec9a1d70e702200f4025e786cbcfd49668332949823945513229c19fdcf4e93aedb39dff7c4ff9",
+          "result": "valid"
+        },
+        {
+          "tcId": 340,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313039373331353732",
+          "sig": "304402203447d10be371effba54917c40169347cd843e804d886912c1c87a9a480b7a5d802201a666c8bd1918a3a3d6bdfc6857245508e6a386c8d8525f24f92a1de37555608",
+          "result": "valid"
+        },
+        {
+          "tcId": 341,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39373334343133333034",
+          "sig": "304502203af219043891ec1ab04b8bfd0cdd6ab3b7e20131573e117138a3e7988553c38e022100d9360ba60bb3cc776b71d06c8552a46bf9978bf96b7669d80fb68ea3b6756f28",
+          "result": "valid"
+        },
+        {
+          "tcId": 342,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "313033383236323134",
+          "sig": "3046022100e8e4108338a1317072d204883d2ad2b17328d9684c1f4ca1252b329e5285188c022100bf209e785eea25aedbaa5ceced6e77f0c22a5097718e56e44c06382c54864357",
+          "result": "valid"
+        },
+        {
+          "tcId": 343,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303630313336343438",
+          "sig": "3046022100a36b8eb29993689593d4197711c2e31c61d51c8eb0d4544680972e99cd78b95f022100dbaf69380e10beae378d508f17deba234da9a9bebebc853c8b1dacb694c46cd9",
+          "result": "valid"
+        },
+        {
+          "tcId": 344,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323133383338383130",
+          "sig": "304402206c645b462404b975ac4866740fb193affcf85a894f525d33999153bf3941df2c02200bae62a8c81181f54e98263814f79596cbb329b1c5b94d0f1e185917e346e687",
+          "result": "valid"
+        },
+        {
+          "tcId": 345,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38313938383037333237",
+          "sig": "304402202beff020fa970adbeafe941dfc31a2d5e44037c991ce2bf83e1b476e2d91dd410220736c4c5edc0b2183f8ce1220a4257a0f1041bac8de1d69376d3ee2109b9895b5",
+          "result": "valid"
+        },
+        {
+          "tcId": 346,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31313739313036333334",
+          "sig": "3045022100a5531117b86d4e412aae573c62f04da39cdaaa092e55f5f3aa8f1d3db65a8de902201315724d2ba41b0cbf82b42a95bfc465d833de6390a0b9056b61340c3ec431ca",
+          "result": "valid"
+        },
+        {
+          "tcId": 347,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303734373837393236",
+          "sig": "304402206ca8dafcbc1601ab03ec2730f656140866ff4973332c0de44ede1ece29eae6a70220014ba379939522d4ff1d76444e9d8bb3f8f749208b277f0114e22a39eca884cb",
+          "result": "valid"
+        },
+        {
+          "tcId": 348,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36343636363033393934",
+          "sig": "304402202cd8a23c99e79836cceb0d4929ebde6cc57dfb4435ef468873848d64273a160302206bf48320536a89bb35189666be3fb6f1a072b150b5f97b9d924f421b19ee01ce",
+          "result": "valid"
+        },
+        {
+          "tcId": 349,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38343138303032383736",
+          "sig": "304402207cf9b46ed27c1bccab6f311d05ff13c49ff0bea98a373e9de6e56717b15831f802204d2d3538ff7a7886a75e28934ca78f4c75f9fe4c9ebe64bff85cece2d9b378d0",
+          "result": "valid"
+        },
+        {
+          "tcId": 350,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39323330323534343032",
+          "sig": "30460221008ca58fe636d7f545a4c7eedb62fbc4ed4cb2b36ebe061f19e662221a5b1cb02e022100f552845079c2cf2502911f34d6ef4b2157dcd9ab4804fe4c5d50b2a7476db524",
+          "result": "valid"
+        },
+        {
+          "tcId": 351,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303135343735303437",
+          "sig": "3045022068bd2e5d34a510df7b27f078e6f12789b294507445593253975969f7bbb9f733022100909f592a8002b9011912cfe6049f808eb9a75bd0dbf453e880bb4fcb6b5d830d",
+          "result": "valid"
+        },
+        {
+          "tcId": 352,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34383039333730393031",
+          "sig": "3046022100b4dd8c5128a94e747f906696c7c0b883eccee7be0cc324caf521ae2f4a7ecc35022100fed2ea22f2a1ab806454c4050f6dc7931f2d231be37c70eece1ba8f8a383e4d8",
+          "result": "valid"
+        },
+        {
+          "tcId": 353,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3133383934303933323238",
+          "sig": "3045022022077f5ff01375836d63d03762851c8a28352434176ec44394b30b9175331583022100b79f23c9bf8d231eb87981615849ef2d92f6629af364989117636fbf025532be",
+          "result": "valid"
+        },
+        {
+          "tcId": 354,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32363236313230333131",
+          "sig": "3045022003561a10658a0cb0944d9926b6db8dc63cd8d60cee19cbd4ef6135a3fdc4606b022100d6650e5b3cd58e03d3497607d086a7223098fa5b6e59c7efb7196f77db0cf2c2",
+          "result": "valid"
+        },
+        {
+          "tcId": 355,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353338303531353839",
+          "sig": "30450220109e7b7db507f6679823ccd4421675321a0cd5b8add8ffadbb082ccd15748fdd022100eb4696289031ed3b614a21a827b4dd4cd4d5fc57f02335f3b4cb303ac4d920a1",
+          "result": "valid"
+        },
+        {
+          "tcId": 356,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303533333430343739",
+          "sig": "30440220639fb14939c3a87369b9f245e9dc41dbadb1af529fa5287037f46593101f90d40220103385e29239bd4c01ef5e58efb4920d8f65e986791bf08ed89f15735bd8dc48",
+          "result": "valid"
+        },
+        {
+          "tcId": 357,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3331323139303635343939",
+          "sig": "3046022100d706b070086816bfe6f40503517dfc4d9709ae680201d258bcc60520499636f30221008719b517573e5be6210ba18d179d53558cd07d66204ac2d913e25edac50db569",
+          "result": "valid"
+        },
+        {
+          "tcId": 358,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383231393533303438",
+          "sig": "304502204af1e6ddc468d0d2f54789a306c0028061ebec45f49be6aea0b023350befd9380221009e5884bcd42c5ccc168a4ced32ff84f09e8d6bb85387ed6200a4114b204bd6d8",
+          "result": "valid"
+        },
+        {
+          "tcId": 359,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363833323934343538",
+          "sig": "3045022100ba8997cda5ade7dec3984afa2928958a63decf1a218c388232ef6f32f505d738022005e4aac028675bdd3702d1ca6456153ab46312861cb5f9eb47b23b2e0c9e3cd5",
+          "result": "valid"
+        },
+        {
+          "tcId": 360,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39333038333139313638",
+          "sig": "304402206f5e56a7beb2e8d6450f8e79591df1334a393dfb7a10d13a43d0cfd52067e70c0220323e1d26fc7fea9e53ef7e2bcc5b579ee9a2748eefd14fced94cb71c0c2bfd38",
+          "result": "valid"
+        },
+        {
+          "tcId": 361,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "36343136363737323733",
+          "sig": "3045022100e85424f9a617f5aa09ed9025e247de12b4390073805f0a822ba5b40833a8325f02201d3efcb8f7cdb037a8e5482f909ba2bb5e731a0632b2d30474112805a2d3b368",
+          "result": "valid"
+        },
+        {
+          "tcId": 362,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130303834363531313632",
+          "sig": "304402207bafde959d1ae29b5c52e23b022bc525349236a9cc1b1089a5053f1c23d8fe6702200f37719dd4e27b9e088c9d938107e052020d1d5d183bc4b8654f74d437d18f52",
+          "result": "valid"
+        },
+        {
+          "tcId": 363,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323535343932353435",
+          "sig": "3044022033603bdc69d4ed17bf32f131a936906d3c09b7c8ca70f885e55bb6e0e326d2540220133e193d33aff7ec98d455b4c6ab2df77d48b79953ac2e128beaf5e3577e66ec",
+          "result": "valid"
+        },
+        {
+          "tcId": 364,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33353538383536393830",
+          "sig": "304502200615bbc3be8c532e869141476bb4f480bfc00d5a88990c40d9acb9bd3b417e03022100e7e11c9e7903537a1b970b6efecd3f29ede0746356387738376383e9c43e6a86",
+          "result": "valid"
+        },
+        {
+          "tcId": 365,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333138343333383638",
+          "sig": "30440220195dd991ad5c579bc26dfc8ec6f5f0b79ec48f06d54175cb9ac501d5329815d402200e9ed5bf444f21254eaad3d0ff313165e5f0b2f6c71ea9f4e518160a6d352475",
+          "result": "valid"
+        },
+        {
+          "tcId": 366,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373231333437373833",
+          "sig": "3045022100c80bf61f61d94f2b6c3a75c3c8e49516bb63d8c0167b95658a87d77b748824750220542ee1cf303d71365df23685fe45009dd73085598af6596d1d7ede3b4fca8422",
+          "result": "valid"
+        },
+        {
+          "tcId": 367,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3135333138333534313932",
+          "sig": "304402202a29ca1b8ce4abed7c9c9452578c27234f42c22c2a8f3607519b67148f03251d02205199d872ee3ec6760032b037aa49d559d7709784d4f0c93120096a4e20417394",
+          "result": "valid"
+        },
+        {
+          "tcId": 368,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31363931353237373839",
+          "sig": "304502204e72bce8ea2a4c951bbd872e606ec889f9e176eb1004fe3f258f2c14afa4e137022100ee52c71710dbd94581a9edaf43b35d91e515ffe0eb20f3392fedc1c1f9f5d03a",
+          "result": "valid"
+        },
+        {
+          "tcId": 369,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31323331343139343335",
+          "sig": "3045022100de978d7d58cd183f72d57250de1ea468d387d791912c07371804b915cc95a46b02207da037f5356467d38dc3cc37604bb7ff56553145088cefbecee033fce4828a79",
+          "result": "valid"
+        },
+        {
+          "tcId": 370,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343031343832303137",
+          "sig": "3045022100e3504e083da7ccc2a8aeca8b51ff4a75786f55d43784f9805cc4c5dff75e8c9a022046d629ba1ca8327f31e3f2c7492125494d02d4aaef62ecf66e7589baeadeacb7",
+          "result": "valid"
+        },
+        {
+          "tcId": 371,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343637393435383738",
+          "sig": "3045022100b4d4d740c46fd2e7a9f7281b3bd4ccf9938ab2d7fcaddfa60520aa8ef0fccd2c022014cdef37fe8286559cbccfc676ce76eca6e002413c61898ce7ade124ca4f5504",
+          "result": "valid"
+        },
+        {
+          "tcId": 372,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31383137333936383533",
+          "sig": "3045022100c768f33abb729a3a862ea6d3f692e23e8b278e99bde292bea1e360939af6284502200252aa6aaeeef400ab55ee31fe74a7013ea8469ef46f24afc237db4fdb1b508c",
+          "result": "valid"
+        },
+        {
+          "tcId": 373,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3334373939393937393237",
+          "sig": "304402207ac3f0bf2f8b9e870af11dd9dfc9c60df54cd6a5c18038fd1a17b066f873e70802202f58ddaff64d8ab0d7fa1c0c56e7a62905d836f14a9e6bb32981f567099da8e0",
+          "result": "valid"
+        },
+        {
+          "tcId": 374,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31333934383937393939",
+          "sig": "3045022100a2397fbd0944035a30899072111011e6a86cfdb1da5fc5af38817360db4fa0ac022017d359b54cccfd25effcd41aa71948a4462ce89fce045bb40bab06825abc3d45",
+          "result": "valid"
+        },
+        {
+          "tcId": 375,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39363530383637313438",
+          "sig": "304402202a2438aed96e942f383d2e89336c3471a1e5c8ad12092f5355d06480a36f32fe02206029b359e8414921a27ed93542188e64e31b8de309f83b3ec6a67b53ef5a5441",
+          "result": "valid"
+        },
+        {
+          "tcId": 376,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32333538323734313930",
+          "sig": "3045022004a99e64afb690b165bc8180eb344e4a81dbecb816f60b1f476f4d93977d2de4022100aa549cebcacf522464b99337da3b9ee9711b9bcba105ca2ffe4a47c019d2ad7e",
+          "result": "valid"
+        },
+        {
+          "tcId": 377,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3238313432323939383839",
+          "sig": "3046022100d946fb7da88ab8b0a8da63836a82881786e47c7ea0d9cbc88d2b530f203a94c802210086cd840e774d8066d7cbfbf4ab76d6b94f139f1804182911d2f9bcc5e994677d",
+          "result": "valid"
+        },
+        {
+          "tcId": 378,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32373636383035323435",
+          "sig": "3045022100daae16b786bc6fd11f1980625766de619a04ea85b9a8040ab8f0f5f240b8e31a02206461cb1e744da25d5de8464ac69fcda00a3cb85a3ffb2c808e6ce07ce67c3c76",
+          "result": "valid"
+        },
+        {
+          "tcId": 379,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35353032323834363935",
+          "sig": "3044022035e1ea767cb60ba6f7b0704f39bbec30b560203b8c45b77a397a5ebe4eecb20702202c3286a204cc7557c79f3186deec63ce49f1ecdae3229bf413c1b114d30e0895",
+          "result": "valid"
+        },
+        {
+          "tcId": 380,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383435353338303639",
+          "sig": "30450220110f14be145671c07d60ded97e155f0f6a7ea30cc61554925c24a09745304b8f02210088c8a85cdd291221549cbcbf1f433731917e4a828174bde8defe27a6caad3c90",
+          "result": "valid"
+        },
+        {
+          "tcId": 381,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3233383536313835",
+          "sig": "3045022100d91357b6a89943d13dec5ae308816a60099223659eb2fc4208b425490e3845e9022018578d09f1d08e2067866a3743be7d82b68c6031c2ce21d25a4b79782bf70e36",
+          "result": "valid"
+        },
+        {
+          "tcId": 382,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3137383538303131353832",
+          "sig": "30460221008322182ec31426af2e6b7c9d6fbc3301e70a20c0897594194d9c84b24e39ff95022100ff9caab982c57235dc3ff955e1fae7935132307f5f242abe6bf2c6f2627d6dd6",
+          "result": "valid"
+        },
+        {
+          "tcId": 383,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3131383035393431353334",
+          "sig": "3046022100ba6f6874f4c2d059b117405b39d67d30baa193103062ccff439f690434fdcdcf022100fa91d8cf44155bea39c3dec3525f64e6abb83cedd82335b7e81820b526f7ebf9",
+          "result": "valid"
+        },
+        {
+          "tcId": 384,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343534393837313836",
+          "sig": "3046022100ed59f011090766cd886dde1ab970ca356a146492565cebe1e4dfce1201d44ea4022100eff21a6d9bcb4f1cc3d6562b044d7c96874b0d3b2355b872c1f8a063c6895a92",
+          "result": "valid"
+        },
+        {
+          "tcId": 385,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "323236313131323234",
+          "sig": "3044022001be2fe82648b2fc237b8e5816a9d682e38d9c7576da2540f0f1a41c7473dd5f022044c3c037176407aab6bf10c64b2137bdf6bc46b3c76290a2510161be8dcac682",
+          "result": "valid"
+        },
+        {
+          "tcId": 386,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3135333138383330383730",
+          "sig": "3045022005be16a3f289e5d77715283e2466a472e5b9de392027f381aade645a95bd5d53022100c3beee59b063781141fddc0bf86079fed74b4bf8add14fc7a8a92718c462c2a3",
+          "result": "valid"
+        },
+        {
+          "tcId": 387,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "393739313833363236",
+          "sig": "3045022100b1db4ea3c2797203fa38dc40540be199c3992ba11fc02acf1ec6117bbffab0a7022007c9e16ca0efa18439810a2dd85bf30dafd78401b3ca149a49dc0ec0c316b8ba",
+          "result": "valid"
+        },
+        {
+          "tcId": 388,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38363330333434363239",
+          "sig": "30460221008d9d58c43f733c4d1a952a727da1e5310a5c09df70fc3a79a420444c5e1daa18022100a558798fdad2e612be1dc9a233bb66955b0e4d9b69eb22bffdeea2e7545922e9",
+          "result": "valid"
+        },
+        {
+          "tcId": 389,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33393937313134343135",
+          "sig": "304402204e4f74085f21c4d248147da31cc35eb2f5cc29c547f4e278879ea7831a8a196402206e6f93da2aea21b2f038721bdad822472d78b3b731d6c8f716651fdc68fee99f",
+          "result": "valid"
+        },
+        {
+          "tcId": 390,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3331313738303133353835",
+          "sig": "3046022100fe5bacf4563943e9789f8720a1bc4447f62fbab06505a66e53aa1caef0719aa002210092828e8bafba9d7cfac18c1caee977386ca522a821ac65d4749b913f5cbc16cf",
+          "result": "valid"
+        },
+        {
+          "tcId": 391,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33323538383834383838",
+          "sig": "304402201cd68efb4b8a148296f063ddeb281cbbac86512e98475f397c74e1134334292902207961fdd3b06fce181049c19d9ad4056b7f5c16eafa213d100213e9e3e260ff08",
+          "result": "valid"
+        },
+        {
+          "tcId": 392,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34373138363334353531",
+          "sig": "3045022100cf5e2aa9f0198300cfa05b1dd473b5e7295b1a39ef9c89a7c45999bbbf21930502205b8ba96da5641c467f4b09febca752ddd14aac0fc878b6683da25cb6aa582754",
+          "result": "valid"
+        },
+        {
+          "tcId": 393,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37393132343632333539",
+          "sig": "304502203fd0ab73ecfb09ed13ef95fca69910cadbb1febf0e2c1d9abd3f2ade99d67a2d022100eea66cd4878a9e187270be2f11698057f16781d3cfaabca692bbf303fff658b0",
+          "result": "valid"
+        },
+        {
+          "tcId": 394,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "37303636303932383538",
+          "sig": "30440220290312deffae60601b351095ffb1e52437ca6748e1a59aa04e8a41ea3f51c70102206fa5dd5f46c324b8e2d268376410de141a4554b3859483503224f421e46ab51f",
+          "result": "valid"
+        },
+        {
+          "tcId": 395,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38353839363733373030",
+          "sig": "30450221008a968d1218fbb4030ab2fe6d474ca4f8d56672e7b16d555e5a5cf9b1e98117ba0220188e0e2d7676c8d841becd9cd43e03f0c70461ebde7fbf353b86c28b4c4c5f26",
+          "result": "valid"
+        },
+        {
+          "tcId": 396,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31373131343937353137",
+          "sig": "30430220269324ba0d4835dc5e0f5d91865dc0a16fc75f670aca53eab4dc3305b3980553021f1fc55636b52101ff235529805cf530837ed3720391a47bae07be6ebe7b506f",
+          "result": "valid"
+        },
+        {
+          "tcId": 397,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3439383538393830343432",
+          "sig": "304502207da44bb346c325bc77232eb54374b355d360323403409297d105473014564d93022100e516b03a4aff1eb5bf25865c1d4e9d0c5659e29575431b3dfb1d8d42e49b2b71",
+          "result": "valid"
+        },
+        {
+          "tcId": 398,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "383036353534313038",
+          "sig": "304402201739e956775225e3398b5f1352d4a8ccf45cd05ff3e0c8f3dec5b31eecdcb5ef02204c249a99ee8e8e20f7e674813569303450707bca57f77ba675e94bdb80ed357e",
+          "result": "valid"
+        },
+        {
+          "tcId": 399,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32313637303439303839",
+          "sig": "30450221008fa150c34cea9a9e543269796a0ca9c33df8114ec9f5413beea891a9e8b2d0fd02206dc980032c81e9704edef2dacccf708d10759e209f9990172b2d32c6c0322a8f",
+          "result": "valid"
+        },
+        {
+          "tcId": 400,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353035383730393335",
+          "sig": "304602210082e47bcaafe7dcd77f06ff988e146e11f0f9548af566a39391cc874c528948f8022100d112e0063261c271722d0a5aa95d4b4e3ce95933cf7727308e7c31559cb8b320",
+          "result": "valid"
+        },
+        {
+          "tcId": 401,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3330303136383931373035",
+          "sig": "3045022016cd4fe6aa325447343e3beaea5b8ebae76505684c018656cd2141db51b3ae9e0221009890c6bf2bcaa9ea5aff8c588e88aca0c2bb1baea793bd1e5591873b83ff64ee",
+          "result": "valid"
+        },
+        {
+          "tcId": 402,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31393235323336323338",
+          "sig": "3045022041518c949594767d3ad9f3ea4e2d971a7f2b2bf457ab358486ccf7d9b4d04131022100eaced5006bbba83789ef26a6c25269c8a13ffb3fdf1cd1cbb6ccaebe1a6835e5",
+          "result": "valid"
+        },
+        {
+          "tcId": 403,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33343630323536373638",
+          "sig": "304402204e44e1698e79770ae4eda3789a5dbceb846361ccde4cfc519229cda0567971c602201a0ff7c6662f108e87c1af49c4abf21f2ea9db37ccc8b5534fe467237515253c",
+          "result": "valid"
+        },
+        {
+          "tcId": 404,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3130323031363730313431",
+          "sig": "304402207ee2c2795b2949ff841c56e850249ad24b0906e200829de1d30d24fc302603fe022032b454c1ba939c8b15ddd688aec45755dfb412745cb9bb16c7a4c7a24bd1aaa5",
+          "result": "valid"
+        },
+        {
+          "tcId": 405,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3139343130363631323337",
+          "sig": "3045022100f168c4c9af0b64c97987b364b32aae7e69740ff76492aa628d96ac3dcda151f0022069cad1ae8445d81c0bd8192e43a09038272ea83c64f90ae0e451255bf8dcaeac",
+          "result": "valid"
+        },
+        {
+          "tcId": 406,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39343930333734333238",
+          "sig": "30440220609ee9ec224f98540ff6d7ff449593376039316f8174e7b883f0c1bf258f065802203960a71821bb1816377e864a6f15462629061f96b69fe68ab85afd23c0fb6fdb",
+          "result": "valid"
+        },
+        {
+          "tcId": 407,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35393730363533373431",
+          "sig": "304502203c38e3bbe422f196b940355c4fcafadf838aacd63ed1b6d37186fe2813916d07022100f02c682ddf45ebcc34fee13b2d645d9b49342f2b43fe0d78e020104126a66013",
+          "result": "valid"
+        },
+        {
+          "tcId": 408,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "39313532303939333835",
+          "sig": "3045022075f91f4574bbbef93cec953f6155f84531538b6f6739c57cdd549ad26a4172c4022100d03ca4173f93cb2fba98a60f76f33fd44ebdc3e1e3a5a69902319a21d619d7bc",
+          "result": "valid"
+        },
+        {
+          "tcId": 409,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31343633353538393338",
+          "sig": "3045022064f6115e0f861be8a00e4fc4f2570595324ee1041bea54db281fe73ff31b4e42022100dca9dcb4295069df16380f2b7c3e4690d26ea0b757e4b1d0eba16b849167762e",
+          "result": "valid"
+        },
+        {
+          "tcId": 410,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3133383230373830313133",
+          "sig": "304502207b2000f60ae19acf1d97d492eaeebd04cebfd0d992c2150b82013c70befb1c3a022100efca7efbaf4b8079fd0f7d4285eb49bb645cc1b76b61867e64885fbe4a05adfd",
+          "result": "valid"
+        },
+        {
+          "tcId": 411,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34393730373834393439",
+          "sig": "3044022065730e1a5482455c8f50f96bdb52e2e0abd5dd7b1f853ce2a708a6fcfc2e6105022043ec13bc7652168a7828f24353ab8a2de4c04628286dc0043156927e21650223",
+          "result": "valid"
+        },
+        {
+          "tcId": 412,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32383234343232383730",
+          "sig": "304402203813eff4d1d0c04201e527036f4f0cbba72c314793437c8793bbbed07d934869022021338f0102f972e48b91fa5ee0496c385513b831a07e4f1eb426c9590a19b41c",
+          "result": "valid"
+        },
+        {
+          "tcId": 413,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "33383336323738383330",
+          "sig": "3046022100b602016d0535514c18285a693cc7ba9ed5cd6f340778953c4cc5e63ac1c147a60221009814ae4cb2fa960e52b542ebd9afe9b574d741fe2ea7861ebb2bd0fb39e07a9e",
+          "result": "valid"
+        },
+        {
+          "tcId": 414,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34313637333332333735",
+          "sig": "3045022069d8ff8190b39b9a298527f429e6d08655a099ad08faea129cff2d8f102a0bc5022100a4c7bbc160f455999993018d1292fdcd64914aeb8ae4eb157257c385571ec2dd",
+          "result": "valid"
+        },
+        {
+          "tcId": 415,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31303032343935313334",
+          "sig": "30450220393d20abd56bed26182ce3bd4616a057d5ca9a1de76976239a23801a5e00405a022100dabd899f060553cd385faeabbc3b6abf023889fce5763dc48a1595b6e8a7761f",
+          "result": "valid"
+        },
+        {
+          "tcId": 416,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "31313936393930353937",
+          "sig": "3046022100f81e106ba88e60b38df06d770e6570a4e268b8968e75b17323a23dca1cb041e9022100ada84e71af019c64d2a2f68ff70f608df09545796cbd7f4ee901bd51c5a40b1c",
+          "result": "valid"
+        },
+        {
+          "tcId": 417,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "343932393736353338",
+          "sig": "30440220553937645e5a72ec1a788b989502fc0c099cf47dc223c3a05a17511e8aaacf2502203d907444401725b6ce74e46c93b842da7165d66c4225dd9529b6c01aefc17887",
+          "result": "valid"
+        },
+        {
+          "tcId": 418,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32303639343230353239",
+          "sig": "3046022100b952d6c90612db7d44cdc3427c8a04cbbfeb42f08400d7e43fcd491c2e2b29e0022100e090d16e7f8d8ecf349094c990fbbc608146bd42f0bf62ed4414c4f516ba8da6",
+          "result": "valid"
+        },
+        {
+          "tcId": 419,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35343434343734303338",
+          "sig": "3046022100cd9ca46a05f8e230b609248d93ba3109ce6d313fe1c2f446831e507a7adc3b1e022100dc303aaed67ad227d16e8ba74c05c2158938ddc08fb62c704ab145d6fb48a654",
+          "result": "valid"
+        },
+        {
+          "tcId": 420,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "32353730393730303131",
+          "sig": "3046022100fe4204134e2f81a3a1533690d6c01babc5116b77054e00acce671fe2b42ad67d022100dea459c03b17919c2b7c572cb4053251feab5be2f8791e49d8591951fb8cbdad",
+          "result": "valid"
+        },
+        {
+          "tcId": 421,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "35313831393239363035",
+          "sig": "30440220018a82596f2afaec1676e2f42f0a99bdd3ec0b3c4a70690d8c018eb675ee52f5022071b483f2017a5757df033a2acb6b37518d3424a6643bcd1b107bf82d18a46010",
+          "result": "valid"
+        },
+        {
+          "tcId": 422,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "34323636373735353134",
+          "sig": "3046022100a72643f331ef9fcd6e266d550fda197b7b14c95fee28100002e0546833bd141a022100945ebc905842f2e313632501a09329ed0fc41b4cf4ccb1402afe87e443bcbff2",
+          "result": "valid"
+        },
+        {
+          "tcId": 423,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "3134363137373433393834",
+          "sig": "30440220738c2834aedbbe5586f7dc73540afb02a9f38d2d32d8d4c5c4af4cbb599f355e0220556cc8f3096884f7f3801d8a868de19dc857fd2fb647614dadbfd0b5f60dd3ac",
+          "result": "valid"
+        },
+        {
+          "tcId": 424,
+          "comment": "special case hash",
+          "flags": [
+            "SpecialCaseHash"
+          ],
+          "msg": "38343837323933313330",
+          "sig": "304502207e112e7a251cf9d4223438193fd77c2d9131d82b0cfa712423acbcf01c35ca08022100e69051460cb2b740c3bb2150e5076757040705faba0fc54a0c30305ed13d0c02",
+          "result": "valid"
+        },
+        {
+          "tcId": 425,
+          "comment": "Signature generated without truncating the hash",
+          "flags": [
+            "Untruncatedhash"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100feb5a6ab646502be3fd3223349b11cf494324ce2b65c343572591a737d18c22a022049464f6f0996c851c077d077ea1a22ea2bbdf92b241f1d6d7dd2f48b08ae35f8",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04422aa6bdbb76a2886463600f1224a80d2c9f984c212d57ed90ca49643ed673e157af3122aaa04597c5527354f1801425700c6d958c58d8ddbdaaec0ec721cb42",
+        "wx": "422aa6bdbb76a2886463600f1224a80d2c9f984c212d57ed90ca49643ed673e1",
+        "wy": "57af3122aaa04597c5527354f1801425700c6d958c58d8ddbdaaec0ec721cb42"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004422aa6bdbb76a2886463600f1224a80d2c9f984c212d57ed90ca49643ed673e157af3122aaa04597c5527354f1801425700c6d958c58d8ddbdaaec0ec721cb42",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQiqmvbt2oohkY2APEiSoDSyfmEwhLVft\nkMpJZD7Wc+FXrzEiqqBFl8VSc1TxgBQlcAxtlYxY2N29quwOxyHLQg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 426,
+          "comment": "k*G has a large x-coordinate",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30360211014551231950b75fc4402da1722fc9baeb022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        },
+        {
+          "tcId": 427,
+          "comment": "r too large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2c022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04dd752c014ec002daf07db8f6d7988d804533ba104c8052e06a8877236d326d402aae02e1da209844e8ca24e9984d7b9c0e876979e131ec2cc00609bae520ade9",
+        "wx": "00dd752c014ec002daf07db8f6d7988d804533ba104c8052e06a8877236d326d40",
+        "wy": "2aae02e1da209844e8ca24e9984d7b9c0e876979e131ec2cc00609bae520ade9"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004dd752c014ec002daf07db8f6d7988d804533ba104c8052e06a8877236d326d402aae02e1da209844e8ca24e9984d7b9c0e876979e131ec2cc00609bae520ade9",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3XUsAU7AAtrwfbj215iNgEUzuhBMgFLg\naoh3I20ybUAqrgLh2iCYROjKJOmYTXucDodpeeEx7CzABgm65SCt6Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 428,
+          "comment": "r,s are large",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413f022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd036413e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041517cb0ff4b4fb4e2689ecb6a21ae96a5852b079884149cd63729b9724937cbe3dfe6274af762eb423a2b149756dc5bb4b253d23033b7cc9db5844887161525d",
+        "wx": "1517cb0ff4b4fb4e2689ecb6a21ae96a5852b079884149cd63729b9724937cbe",
+        "wy": "3dfe6274af762eb423a2b149756dc5bb4b253d23033b7cc9db5844887161525d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041517cb0ff4b4fb4e2689ecb6a21ae96a5852b079884149cd63729b9724937cbe3dfe6274af762eb423a2b149756dc5bb4b253d23033b7cc9db5844887161525d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFRfLD/S0+04miey2ohrpalhSsHmIQUnN\nY3KblySTfL49/mJ0r3YutCOisUl1bcW7SyU9IwM7fMnbWESIcWFSXQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 429,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02203e9a7582886089c62fb840cf3b83061cd1cff3ae4341808bb5bdee6191174177",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045ebb9309c3073c74e1024b9fedf40da99045962aa9189cbb1e5c5e37983fda6b4e6787cd4af3383c769b911647d42b671e72b751e37ea3a02b6321cf9a88e36e",
+        "wx": "5ebb9309c3073c74e1024b9fedf40da99045962aa9189cbb1e5c5e37983fda6b",
+        "wy": "4e6787cd4af3383c769b911647d42b671e72b751e37ea3a02b6321cf9a88e36e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045ebb9309c3073c74e1024b9fedf40da99045962aa9189cbb1e5c5e37983fda6b4e6787cd4af3383c769b911647d42b671e72b751e37ea3a02b6321cf9a88e36e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXruTCcMHPHThAkuf7fQNqZBFliqpGJy7\nHlxeN5g/2mtOZ4fNSvM4PHabkRZH1CtnHnK3UeN+o6ArYyHPmojjbg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 430,
+          "comment": "r and s^-1 have a large Hamming weight",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022024238e70b431b1a64efdf9032669939d4b77f249503fc6905feb7540dea3e6d2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041c64127c05117c1c3340748b560b97a36690aad3f1dc80e1f6fb11d8842a11f3408336777e1c1c0068b09658c28bade3074b0a0adee9fb508ef297c501e407dd",
+        "wx": "1c64127c05117c1c3340748b560b97a36690aad3f1dc80e1f6fb11d8842a11f3",
+        "wy": "408336777e1c1c0068b09658c28bade3074b0a0adee9fb508ef297c501e407dd"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041c64127c05117c1c3340748b560b97a36690aad3f1dc80e1f6fb11d8842a11f3408336777e1c1c0068b09658c28bade3074b0a0adee9fb508ef297c501e407dd",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHGQSfAURfBwzQHSLVguXo2aQqtPx3IDh\n9vsR2IQqEfNAgzZ3fhwcAGiwlljCi63jB0sKCt7p+1CO8pfFAeQH3Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 431,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049921d16a1d0d3536cc21156636feb9d8885b75914ea638754b0ae3dd4d79c99ef46613ab32a5769c2857df6a3554d228a97fafac6b63dc8edefb3496760d7f63",
+        "wx": "009921d16a1d0d3536cc21156636feb9d8885b75914ea638754b0ae3dd4d79c99e",
+        "wy": "00f46613ab32a5769c2857df6a3554d228a97fafac6b63dc8edefb3496760d7f63"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049921d16a1d0d3536cc21156636feb9d8885b75914ea638754b0ae3dd4d79c99ef46613ab32a5769c2857df6a3554d228a97fafac6b63dc8edefb3496760d7f63",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEmSHRah0NNTbMIRVmNv652IhbdZFOpjh1\nSwrj3U15yZ70ZhOrMqV2nChX32o1VNIoqX+vrGtj3I7e+zSWdg1/Yw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 432,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020102",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b1bfd06dd462e53911f08f12126a90e5956d99dce41da5f757f463fa772f80338a8df80a8775efba16fd01c6ca63a67237167ff82cc513dbc18fc5b3c522ee69",
+        "wx": "00b1bfd06dd462e53911f08f12126a90e5956d99dce41da5f757f463fa772f8033",
+        "wy": "008a8df80a8775efba16fd01c6ca63a67237167ff82cc513dbc18fc5b3c522ee69"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b1bfd06dd462e53911f08f12126a90e5956d99dce41da5f757f463fa772f80338a8df80a8775efba16fd01c6ca63a67237167ff82cc513dbc18fc5b3c522ee69",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsb/QbdRi5TkR8I8SEmqQ5ZVtmdzkHaX3\nV/Rj+ncvgDOKjfgKh3Xvuhb9AcbKY6ZyNxZ/+CzFE9vBj8WzxSLuaQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 433,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020101020103",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041cea87abd1c52a6209662ff51fc0070b98c0209aff5e3833f4358d1ba757be1552c75e5aebdcf1705e5d82ccd55a830c1a9a3c322f61303a9663dc80ce644eaf",
+        "wx": "1cea87abd1c52a6209662ff51fc0070b98c0209aff5e3833f4358d1ba757be15",
+        "wy": "52c75e5aebdcf1705e5d82ccd55a830c1a9a3c322f61303a9663dc80ce644eaf"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041cea87abd1c52a6209662ff51fc0070b98c0209aff5e3833f4358d1ba757be1552c75e5aebdcf1705e5d82ccd55a830c1a9a3c322f61303a9663dc80ce644eaf",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEHOqHq9HFKmIJZi/1H8AHC5jAIJr/Xjgz\n9DWNG6dXvhVSx15a69zxcF5dgszVWoMMGpo8Mi9hMDqWY9yAzmROrw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 434,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020101",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0462ddb94532ced199fc5579e42b434b0babc4af1b7bc64747a5f7ef59036271ed354bba6863ee5a77ef0d9c571b0f60c79080abc2012c55f578ac47d02d4fa859",
+        "wx": "62ddb94532ced199fc5579e42b434b0babc4af1b7bc64747a5f7ef59036271ed",
+        "wy": "354bba6863ee5a77ef0d9c571b0f60c79080abc2012c55f578ac47d02d4fa859"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000462ddb94532ced199fc5579e42b434b0babc4af1b7bc64747a5f7ef59036271ed354bba6863ee5a77ef0d9c571b0f60c79080abc2012c55f578ac47d02d4fa859",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYt25RTLO0Zn8VXnkK0NLC6vErxt7xkdH\npffvWQNice01S7poY+5ad+8NnFcbD2DHkICrwgEsVfV4rEfQLU+oWQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 435,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020102",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045255cd9b6f770e1f653bc5e3588243e591b5c18bcec06ab02fd897e353610598c29e751be62659ad33553c280350711b53e16e00004c30de994f7a72a99b21ef",
+        "wx": "5255cd9b6f770e1f653bc5e3588243e591b5c18bcec06ab02fd897e353610598",
+        "wy": "00c29e751be62659ad33553c280350711b53e16e00004c30de994f7a72a99b21ef"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045255cd9b6f770e1f653bc5e3588243e591b5c18bcec06ab02fd897e353610598c29e751be62659ad33553c280350711b53e16e00004c30de994f7a72a99b21ef",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUlXNm293Dh9lO8XjWIJD5ZG1wYvOwGqw\nL9iX41NhBZjCnnUb5iZZrTNVPCgDUHEbU+FuAABMMN6ZT3pyqZsh7w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 436,
+          "comment": "small r and s",
+          "flags": [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3006020102020103",
+          "result": "valid"
+        },
+        {
+          "tcId": 437,
+          "comment": "r is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143020103",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0446c59ef30d382bc4fe36ac4625311c426643a5311b666af25245220bd663dacb2e271c9b231518bc97208401dda643fc3876fe6ad326f7da9d0d8dc7937c5e72",
+        "wx": "46c59ef30d382bc4fe36ac4625311c426643a5311b666af25245220bd663dacb",
+        "wy": "2e271c9b231518bc97208401dda643fc3876fe6ad326f7da9d0d8dc7937c5e72"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000446c59ef30d382bc4fe36ac4625311c426643a5311b666af25245220bd663dacb2e271c9b231518bc97208401dda643fc3876fe6ad326f7da9d0d8dc7937c5e72",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAERsWe8w04K8T+NqxGJTEcQmZDpTEbZmry\nUkUiC9Zj2ssuJxybIxUYvJcghAHdpkP8OHb+atMm99qdDY3Hk3xecg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 438,
+          "comment": "s is larger than n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020102022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd04917c8",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ceff46890fe208a8f38cf264224cf3a1c898aab318a15ea99d4f08d3a4db7fbe5dbc13f704e04d842d65dba0096d6462a3574aacd07eb9f27cd20a800d1d3612",
+        "wx": "00ceff46890fe208a8f38cf264224cf3a1c898aab318a15ea99d4f08d3a4db7fbe",
+        "wy": "5dbc13f704e04d842d65dba0096d6462a3574aacd07eb9f27cd20a800d1d3612"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ceff46890fe208a8f38cf264224cf3a1c898aab318a15ea99d4f08d3a4db7fbe5dbc13f704e04d842d65dba0096d6462a3574aacd07eb9f27cd20a800d1d3612",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzv9GiQ/iCKjzjPJkIkzzociYqrMYoV6p\nnU8I06Tbf75dvBP3BOBNhC1l26AJbWRio1dKrNB+ufJ80gqADR02Eg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 439,
+          "comment": "small r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302702020101022100c58b162c58b162c58b162c58b162c58a1b242973853e16db75c8a1a71da4d39d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e7e62d42a46fd9171ec46b144f3bd0ea30ddc51e5420ea4c5c431cc57bb4ed88ccc42e2428e8321bd2ef58614dfa8df4a41a4e920d18491c832bcdb9c970fc27",
+        "wx": "00e7e62d42a46fd9171ec46b144f3bd0ea30ddc51e5420ea4c5c431cc57bb4ed88",
+        "wy": "00ccc42e2428e8321bd2ef58614dfa8df4a41a4e920d18491c832bcdb9c970fc27"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e7e62d42a46fd9171ec46b144f3bd0ea30ddc51e5420ea4c5c431cc57bb4ed88ccc42e2428e8321bd2ef58614dfa8df4a41a4e920d18491c832bcdb9c970fc27",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5+YtQqRv2RcexGsUTzvQ6jDdxR5UIOpM\nXEMcxXu07YjMxC4kKOgyG9LvWGFN+o30pBpOkg0YSRyDK825yXD8Jw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 440,
+          "comment": "smallish r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302c02072d9b4d347952cc022100fcbc5103d0da267477d1791461cf2aa44bf9d43198f79507bd8779d69a13108e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bb581b856299baea7590b55481e117d444ccef77d3d75bd950ab2391d5f0979e4e59c5c4ba6bfdf4c2979e5bdec11aecaa05b3cc6853b702f592324b23966b40",
+        "wx": "00bb581b856299baea7590b55481e117d444ccef77d3d75bd950ab2391d5f0979e",
+        "wy": "4e59c5c4ba6bfdf4c2979e5bdec11aecaa05b3cc6853b702f592324b23966b40"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bb581b856299baea7590b55481e117d444ccef77d3d75bd950ab2391d5f0979e4e59c5c4ba6bfdf4c2979e5bdec11aecaa05b3cc6853b702f592324b23966b40",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEu1gbhWKZuup1kLVUgeEX1ETM73fT11vZ\nUKsjkdXwl55OWcXEumv99MKXnlvewRrsqgWzzGhTtwL1kjJLI5ZrQA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 441,
+          "comment": "100-bit r and small s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3032020d1033e67e37b32b445580bf4efc022100906f906f906f906f906f906f906f906ed8e426f7b1968c35a204236a579723d2",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0469fac7b66097f6d267242f4d785691a8ca08c35dfdb631a350efd3c24fe0c98de9817010f5fddd7acecdd29c408650342ddc3ab9fa8cf9a21389d295788bbaf1",
+        "wx": "69fac7b66097f6d267242f4d785691a8ca08c35dfdb631a350efd3c24fe0c98d",
+        "wy": "00e9817010f5fddd7acecdd29c408650342ddc3ab9fa8cf9a21389d295788bbaf1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000469fac7b66097f6d267242f4d785691a8ca08c35dfdb631a350efd3c24fe0c98de9817010f5fddd7acecdd29c408650342ddc3ab9fa8cf9a21389d295788bbaf1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEafrHtmCX9tJnJC9NeFaRqMoIw139tjGj\nUO/Twk/gyY3pgXAQ9f3des7N0pxAhlA0Ldw6ufqM+aITidKVeIu68Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 442,
+          "comment": "small r and 100 bit s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3026020201010220783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b35310c91902940bae2f1d9c4e111d1bef88a85793e835bb746512ef129f03fc8726e72947d215f99f9d8678d680c040c782e0df11c5ced4d3e566bcf80abe0d",
+        "wx": "00b35310c91902940bae2f1d9c4e111d1bef88a85793e835bb746512ef129f03fc",
+        "wy": "008726e72947d215f99f9d8678d680c040c782e0df11c5ced4d3e566bcf80abe0d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b35310c91902940bae2f1d9c4e111d1bef88a85793e835bb746512ef129f03fc8726e72947d215f99f9d8678d680c040c782e0df11c5ced4d3e566bcf80abe0d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEs1MQyRkClAuuLx2cThEdG++IqFeT6DW7\ndGUS7xKfA/yHJucpR9IV+Z+dhnjWgMBAx4Lg3xHFztTT5Wa8+Aq+DQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 443,
+          "comment": "100-bit r and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3031020d062522bbd3ecbe7c39e93e7c260220783266e90f43dafe5cd9b3b0be86de22f9de83677d0f50713a468ec72fcf5d57",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04faa11612dc1cf47c88aebdfeb9619bff6194a92db86bfb0c6bddd7a46a6fbaff5219485362ad0fb96f7b5397ba21770f03737537b260f59d4bc6429caa708a25",
+        "wx": "00faa11612dc1cf47c88aebdfeb9619bff6194a92db86bfb0c6bddd7a46a6fbaff",
+        "wy": "5219485362ad0fb96f7b5397ba21770f03737537b260f59d4bc6429caa708a25"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004faa11612dc1cf47c88aebdfeb9619bff6194a92db86bfb0c6bddd7a46a6fbaff5219485362ad0fb96f7b5397ba21770f03737537b260f59d4bc6429caa708a25",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+qEWEtwc9HyIrr3+uWGb/2GUqS24a/sM\na93XpGpvuv9SGUhTYq0PuW97U5e6IXcPA3N1N7Jg9Z1LxkKcqnCKJQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 444,
+          "comment": "r and s^-1 are close to n",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd03640c1022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049befce446ab74d4fef99ebc1a047608f50383c7a9323b592a9935e68f340219b65671bb895039a40dc6256ac4ebd4e2a3a4617b0b6f775cc66fa31985257ad6f",
+        "wx": "009befce446ab74d4fef99ebc1a047608f50383c7a9323b592a9935e68f340219b",
+        "wy": "65671bb895039a40dc6256ac4ebd4e2a3a4617b0b6f775cc66fa31985257ad6f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049befce446ab74d4fef99ebc1a047608f50383c7a9323b592a9935e68f340219b65671bb895039a40dc6256ac4ebd4e2a3a4617b0b6f775cc66fa31985257ad6f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEm+/ORGq3TU/vmevBoEdgj1A4PHqTI7WS\nqZNeaPNAIZtlZxu4lQOaQNxiVqxOvU4qOkYXsLb3dcxm+jGYUletbw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 445,
+          "comment": "r and s are 64-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30160209009c44febf31c3594d020900839ed28247c2b06b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0481c13215c3f5c1dee52a15059a78ad0dd27d4a6dd99260f7cce9e09220bdf48f50425bcc09fc9b5693914e3dad150b321e6151014902309c57e71255102fefa0",
+        "wx": "0081c13215c3f5c1dee52a15059a78ad0dd27d4a6dd99260f7cce9e09220bdf48f",
+        "wy": "50425bcc09fc9b5693914e3dad150b321e6151014902309c57e71255102fefa0"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000481c13215c3f5c1dee52a15059a78ad0dd27d4a6dd99260f7cce9e09220bdf48f50425bcc09fc9b5693914e3dad150b321e6151014902309c57e71255102fefa0",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEgcEyFcP1wd7lKhUFmnitDdJ9Sm3ZkmD3\nzOngkiC99I9QQlvMCfybVpORTj2tFQsyHmFRAUkCMJxX5xJVEC/voA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 446,
+          "comment": "r and s are 100-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "301e020d09df8b682430beef6f5fd7c7cf020d0fd0a62e13778f4222a0d61c8a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04a30a55982e075623552c705254bf8c0c3ea5e512048d480951e3d04906275eba3d90e7e1afbec7402f3c0b95326332707b08e54de51ede788888f063614b80bc",
+        "wx": "00a30a55982e075623552c705254bf8c0c3ea5e512048d480951e3d04906275eba",
+        "wy": "3d90e7e1afbec7402f3c0b95326332707b08e54de51ede788888f063614b80bc"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004a30a55982e075623552c705254bf8c0c3ea5e512048d480951e3d04906275eba3d90e7e1afbec7402f3c0b95326332707b08e54de51ede788888f063614b80bc",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEowpVmC4HViNVLHBSVL+MDD6l5RIEjUgJ\nUePQSQYnXro9kOfhr77HQC88C5UyYzJwewjlTeUe3niIiPBjYUuAvA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 447,
+          "comment": "r and s are 128-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "30260211008a598e563a89f526c32ebec8de26367a02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04add44840ce5ad85ccd84523da02aa463efab664eca5d09a2b93f34aa34a6b495c0a0a63f15bf2e5149040e054be6bd1afbcc3371d5540efb45aa0203b4429147",
+        "wx": "00add44840ce5ad85ccd84523da02aa463efab664eca5d09a2b93f34aa34a6b495",
+        "wy": "00c0a0a63f15bf2e5149040e054be6bd1afbcc3371d5540efb45aa0203b4429147"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004add44840ce5ad85ccd84523da02aa463efab664eca5d09a2b93f34aa34a6b495c0a0a63f15bf2e5149040e054be6bd1afbcc3371d5540efb45aa0203b4429147",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErdRIQM5a2FzNhFI9oCqkY++rZk7KXQmi\nuT80qjSmtJXAoKY/Fb8uUUkEDgVL5r0a+8wzcdVUDvtFqgIDtEKRRw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 448,
+          "comment": "r and s are 160-bit integer",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0bdf021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0452274d1decb02dbdae051095322e3193fff185171f8dc9bc6586dcc02d0eca4a2e2c350530f58e5d86ee3b0eebd9bdc7691d361883e248a04d97bd289b36f18c",
+        "wx": "52274d1decb02dbdae051095322e3193fff185171f8dc9bc6586dcc02d0eca4a",
+        "wy": "2e2c350530f58e5d86ee3b0eebd9bdc7691d361883e248a04d97bd289b36f18c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000452274d1decb02dbdae051095322e3193fff185171f8dc9bc6586dcc02d0eca4a2e2c350530f58e5d86ee3b0eebd9bdc7691d361883e248a04d97bd289b36f18c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUidNHeywLb2uBRCVMi4xk//xhRcfjcm8\nZYbcwC0OykouLDUFMPWOXYbuOw7r2b3HaR02GIPiSKBNl70omzbxjA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 449,
+          "comment": "s == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1020101",
+          "result": "valid"
+        },
+        {
+          "tcId": 450,
+          "comment": "s == 0",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3025022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1020100",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04269870065bcb7ffe3cce3a9b4b2f89b66507e369a8eb9f29a305d0545c715f9772ec971603c708394485e1de726028ee2bedfcc714b6bda6b8afe9010410b10b",
+        "wx": "269870065bcb7ffe3cce3a9b4b2f89b66507e369a8eb9f29a305d0545c715f97",
+        "wy": "72ec971603c708394485e1de726028ee2bedfcc714b6bda6b8afe9010410b10b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004269870065bcb7ffe3cce3a9b4b2f89b66507e369a8eb9f29a305d0545c715f9772ec971603c708394485e1de726028ee2bedfcc714b6bda6b8afe9010410b10b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJphwBlvLf/48zjqbSy+JtmUH42mo658p\nowXQVFxxX5dy7JcWA8cIOUSF4d5yYCjuK+38xxS2vaa4r+kBBBCxCw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 451,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220419d981c515af8cc82545aac0c85e9e308fbb2eab6acd7ed497e0b4145a18fd9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e56487012920aff940cef12d632927d4b9e33a088e2aa939cbb61b51fd45c246b565fc50dfaafa63b97435ef2ecde39d9e260b1a6cf57335746540dadfe8793b",
+        "wx": "00e56487012920aff940cef12d632927d4b9e33a088e2aa939cbb61b51fd45c246",
+        "wy": "00b565fc50dfaafa63b97435ef2ecde39d9e260b1a6cf57335746540dadfe8793b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e56487012920aff940cef12d632927d4b9e33a088e2aa939cbb61b51fd45c246b565fc50dfaafa63b97435ef2ecde39d9e260b1a6cf57335746540dadfe8793b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5WSHASkgr/lAzvEtYykn1LnjOgiOKqk5\ny7YbUf1Fwka1ZfxQ36r6Y7l0Ne8uzeOdniYLGmz1czV0ZUDa3+h5Ow==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 452,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102201b21717ad71d23bbac60a9ad0baf75b063c9fdf52a00ebf99d022172910993c9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0452b756fe31cc75bc1d2d8f7a366af5db2bd3f34690e91a06733f787977328248ac93242210fb19ccd5b7f6b26510ef0bff8d7082b7fa62f45fea16299426bb72",
+        "wx": "52b756fe31cc75bc1d2d8f7a366af5db2bd3f34690e91a06733f787977328248",
+        "wy": "00ac93242210fb19ccd5b7f6b26510ef0bff8d7082b7fa62f45fea16299426bb72"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000452b756fe31cc75bc1d2d8f7a366af5db2bd3f34690e91a06733f787977328248ac93242210fb19ccd5b7f6b26510ef0bff8d7082b7fa62f45fea16299426bb72",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUrdW/jHMdbwdLY96Nmr12yvT80aQ6RoG\ncz94eXcygkiskyQiEPsZzNW39rJlEO8L/41wgrf6YvRf6hYplCa7cg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 453,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102202f588f66018f3dd14db3e28e77996487e32486b521ed8e5a20f06591951777e9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f7cfe21fd402b72361a79aad213163926c328453855e67bcc39ea23b8c59d5ae707bb4439721281f6f9752f666c67e036e488775cc688dd373b57697c390ba89",
+        "wx": "00f7cfe21fd402b72361a79aad213163926c328453855e67bcc39ea23b8c59d5ae",
+        "wy": "707bb4439721281f6f9752f666c67e036e488775cc688dd373b57697c390ba89"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f7cfe21fd402b72361a79aad213163926c328453855e67bcc39ea23b8c59d5ae707bb4439721281f6f9752f666c67e036e488775cc688dd373b57697c390ba89",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE98/iH9QCtyNhp5qtITFjkmwyhFOFXme8\nw56iO4xZ1a5we7RDlyEoH2+XUvZmxn4DbkiHdcxojdNztXaXw5C6iQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 454,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220091a08870ff4daf9123b30c20e8c4fc8505758dcf4074fcaff2170c9bfcf74f4",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cf59bdc9ccde51be450c5beb3a74a2a76457ad876fe15f5c097938de20dbf0993f75a4070ffb9196b6dd27a8248432dc149ab7444110651104ca84a571e8d477",
+        "wx": "00cf59bdc9ccde51be450c5beb3a74a2a76457ad876fe15f5c097938de20dbf099",
+        "wy": "3f75a4070ffb9196b6dd27a8248432dc149ab7444110651104ca84a571e8d477"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cf59bdc9ccde51be450c5beb3a74a2a76457ad876fe15f5c097938de20dbf0993f75a4070ffb9196b6dd27a8248432dc149ab7444110651104ca84a571e8d477",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEz1m9yczeUb5FDFvrOnSip2RXrYdv4V9c\nCXk43iDb8Jk/daQHD/uRlrbdJ6gkhDLcFJq3REEQZREEyoSlcejUdw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 455,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102207c370dc0ce8c59a8b273cba44a7c1191fc3186dc03cab96b0567312df0d0b250",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0453c7b4981d9dba54ee3fd63f4bea83c893b1c8d4f98652039e62485f0f4639dd9ef9898a43219662edc8689b43e4fbc00f15201ac1c376c9a8f7a8828d9417c1",
+        "wx": "53c7b4981d9dba54ee3fd63f4bea83c893b1c8d4f98652039e62485f0f4639dd",
+        "wy": "009ef9898a43219662edc8689b43e4fbc00f15201ac1c376c9a8f7a8828d9417c1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000453c7b4981d9dba54ee3fd63f4bea83c893b1c8d4f98652039e62485f0f4639dd9ef9898a43219662edc8689b43e4fbc00f15201ac1c376c9a8f7a8828d9417c1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEU8e0mB2dulTuP9Y/S+qDyJOxyNT5hlID\nnmJIXw9GOd2e+YmKQyGWYu3IaJtD5PvADxUgGsHDdsmo96iCjZQXwQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 456,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022070b59a7d1ee77a2f9e0491c2a7cfcd0ed04df4a35192f6132dcc668c79a6160e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04fe7870a02775ab4597230b7d79afc53b9c98b1b2d61f2f2097e2971f5396840e154dde797afaee01c1794acffa797827148ce15e41880c994407cb03ba4a6fa2",
+        "wx": "00fe7870a02775ab4597230b7d79afc53b9c98b1b2d61f2f2097e2971f5396840e",
+        "wy": "154dde797afaee01c1794acffa797827148ce15e41880c994407cb03ba4a6fa2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004fe7870a02775ab4597230b7d79afc53b9c98b1b2d61f2f2097e2971f5396840e154dde797afaee01c1794acffa797827148ce15e41880c994407cb03ba4a6fa2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE/nhwoCd1q0WXIwt9ea/FO5yYsbLWHy8g\nl+KXH1OWhA4VTd55evruAcF5Ss/6eXgnFIzhXkGIDJlEB8sDukpvog==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 457,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102202736d76e412246e097148e2bf62915614eb7c428913a58eb5e9cd4674a9423de",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0419e5abb15f8952ee436359cbf7b3d2eac74096b40055a0cd3ce2a6ce7e4135a76330ecb3c04d28d53fda2bfd746cbe5bfbe5b1818917428f8dabdf6a4d2d4812",
+        "wx": "19e5abb15f8952ee436359cbf7b3d2eac74096b40055a0cd3ce2a6ce7e4135a7",
+        "wy": "6330ecb3c04d28d53fda2bfd746cbe5bfbe5b1818917428f8dabdf6a4d2d4812"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000419e5abb15f8952ee436359cbf7b3d2eac74096b40055a0cd3ce2a6ce7e4135a76330ecb3c04d28d53fda2bfd746cbe5bfbe5b1818917428f8dabdf6a4d2d4812",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGeWrsV+JUu5DY1nL97PS6sdAlrQAVaDN\nPOKmzn5BNadjMOyzwE0o1T/aK/10bL5b++WxgYkXQo+Nq99qTS1IEg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 458,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102204a1e12831fbe93627b02d6e7f24bccdd6ef4b2d0f46739eaf3b1eaf0ca117770",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04689e10d3c5468ff55a704e97fdf3bfe97ed3c647f6b2969a1d897d3d51584e206d7285c5241de34060a607d779839e507cc2e753954732ef4e1c0fa89eefdfde",
+        "wx": "689e10d3c5468ff55a704e97fdf3bfe97ed3c647f6b2969a1d897d3d51584e20",
+        "wy": "6d7285c5241de34060a607d779839e507cc2e753954732ef4e1c0fa89eefdfde"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004689e10d3c5468ff55a704e97fdf3bfe97ed3c647f6b2969a1d897d3d51584e206d7285c5241de34060a607d779839e507cc2e753954732ef4e1c0fa89eefdfde",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEaJ4Q08VGj/VacE6X/fO/6X7Txkf2spaa\nHYl9PVFYTiBtcoXFJB3jQGCmB9d5g55QfMLnU5VHMu9OHA+onu/f3g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 459,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022006c778d4dfff7dee06ed88bc4e0ed34fc553aad67caf796f2a1c6487c1b2e877",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0401600c657f4f365166a7f08dc692ffd19975c924e99e39ef0984c54564c54fd3d13241c61018d4a31afc3f4c6951215b7f37b83c884f97081446e831c830fa6b",
+        "wx": "01600c657f4f365166a7f08dc692ffd19975c924e99e39ef0984c54564c54fd3",
+        "wy": "00d13241c61018d4a31afc3f4c6951215b7f37b83c884f97081446e831c830fa6b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000401600c657f4f365166a7f08dc692ffd19975c924e99e39ef0984c54564c54fd3d13241c61018d4a31afc3f4c6951215b7f37b83c884f97081446e831c830fa6b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAWAMZX9PNlFmp/CNxpL/0Zl1ySTpnjnv\nCYTFRWTFT9PRMkHGEBjUoxr8P0xpUSFbfze4PIhPlwgURugxyDD6aw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 460,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102204de459ef9159afa057feb3ec40fef01c45b809f4ab296ea48c206d4249a2b451",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0440453ef2d8d1ddb0cea27f8045a543bf9a5fbade0e6bba074d3d351f95847006e37ffaaab752ba65d9b0442ea0c6fac76a6b05fe133cbf1f65b2e67774cc5010",
+        "wx": "40453ef2d8d1ddb0cea27f8045a543bf9a5fbade0e6bba074d3d351f95847006",
+        "wy": "00e37ffaaab752ba65d9b0442ea0c6fac76a6b05fe133cbf1f65b2e67774cc5010"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000440453ef2d8d1ddb0cea27f8045a543bf9a5fbade0e6bba074d3d351f95847006e37ffaaab752ba65d9b0442ea0c6fac76a6b05fe133cbf1f65b2e67774cc5010",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQEU+8tjR3bDOon+ARaVDv5pfut4Oa7oH\nTT01H5WEcAbjf/qqt1K6ZdmwRC6gxvrHamsF/hM8vx9lsuZ3dMxQEA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 461,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c10220745d294978007302033502e1acc48b63ae6500be43adbea1b258d6b423dbb416",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04324bfdc82d30e6092d95fd232de108bbc72905da6a03e17a491e36d2336c4c2754d200e2cc5cf78ce662a4ccf2a09eab19c5fb6d2006a6225789c51b82e12259",
+        "wx": "324bfdc82d30e6092d95fd232de108bbc72905da6a03e17a491e36d2336c4c27",
+        "wy": "54d200e2cc5cf78ce662a4ccf2a09eab19c5fb6d2006a6225789c51b82e12259"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004324bfdc82d30e6092d95fd232de108bbc72905da6a03e17a491e36d2336c4c2754d200e2cc5cf78ce662a4ccf2a09eab19c5fb6d2006a6225789c51b82e12259",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMkv9yC0w5gktlf0jLeEIu8cpBdpqA+F6\nSR420jNsTCdU0gDizFz3jOZipMzyoJ6rGcX7bSAGpiJXicUbguEiWQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 462,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102207b2a785e3896f59b2d69da57648e80ad3c133a750a2847fd2098ccd902042b6c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c11122b88585f228a1db44b1aa52085db72656a3169956359ebf83dbf7dadf2f3929e9c971a6d0284358ed59230e2c8b1c79a0767e968f37ac53a0214ce97202",
+        "wx": "00c11122b88585f228a1db44b1aa52085db72656a3169956359ebf83dbf7dadf2f",
+        "wy": "3929e9c971a6d0284358ed59230e2c8b1c79a0767e968f37ac53a0214ce97202"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c11122b88585f228a1db44b1aa52085db72656a3169956359ebf83dbf7dadf2f3929e9c971a6d0284358ed59230e2c8b1c79a0767e968f37ac53a0214ce97202",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEwREiuIWF8iih20SxqlIIXbcmVqMWmVY1\nnr+D2/fa3y85KenJcabQKENY7VkjDiyLHHmgdn6WjzesU6AhTOlyAg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 463,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c1022071ae94a72ca896875e7aa4a4c3d29afdb4b35b6996273e63c47ac519256c5eb1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048990a37321de8f004b753835d0e1ec3d18ba9993b20a47a25674660ea62dc806b0d310bcb60199f55a1dcd877ac3992b70cf735a6cd534248fcc2420abf3397c",
+        "wx": "008990a37321de8f004b753835d0e1ec3d18ba9993b20a47a25674660ea62dc806",
+        "wy": "00b0d310bcb60199f55a1dcd877ac3992b70cf735a6cd534248fcc2420abf3397c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048990a37321de8f004b753835d0e1ec3d18ba9993b20a47a25674660ea62dc806b0d310bcb60199f55a1dcd877ac3992b70cf735a6cd534248fcc2420abf3397c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEiZCjcyHejwBLdTg10OHsPRi6mZOyCkei\nVnRmDqYtyAaw0xC8tgGZ9VodzYd6w5krcM9zWmzVNCSPzCQgq/M5fA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 464,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102200fa527fa7343c0bc9ec35a6278bfbff4d83301b154fc4bd14aee7eb93445b5f9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e06d6a6d24cf1ca77329457d1f25e95bff565bc6e432bc8d021b0bc958e1fc7e859ecc45ffceec07404af6a4c8a4c51e36cd4c17cbcc1ba199eb581a68f5e330",
+        "wx": "00e06d6a6d24cf1ca77329457d1f25e95bff565bc6e432bc8d021b0bc958e1fc7e",
+        "wy": "00859ecc45ffceec07404af6a4c8a4c51e36cd4c17cbcc1ba199eb581a68f5e330"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e06d6a6d24cf1ca77329457d1f25e95bff565bc6e432bc8d021b0bc958e1fc7e859ecc45ffceec07404af6a4c8a4c51e36cd4c17cbcc1ba199eb581a68f5e330",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4G1qbSTPHKdzKUV9HyXpW/9WW8bkMryN\nAhsLyVjh/H6FnsxF/87sB0BK9qTIpMUeNs1MF8vMG6GZ61gaaPXjMA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 465,
+          "comment": "edge case modular inverse",
+          "flags": [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c102206539c0adadd0525ff42622164ce9314348bd0863b4c80e936b23ca0414264671",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0450821196546b2d8ca52c8daa7b40d22efa31d6614f5204012103a67532c1dfaba7990db46e361a7e16c83649e5f3a8b4bf74b439866a6ed08c421502a7e45a7e",
+        "wx": "50821196546b2d8ca52c8daa7b40d22efa31d6614f5204012103a67532c1dfab",
+        "wy": "00a7990db46e361a7e16c83649e5f3a8b4bf74b439866a6ed08c421502a7e45a7e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000450821196546b2d8ca52c8daa7b40d22efa31d6614f5204012103a67532c1dfaba7990db46e361a7e16c83649e5f3a8b4bf74b439866a6ed08c421502a7e45a7e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEUIIRllRrLYylLI2qe0DSLvox1mFPUgQB\nIQOmdTLB36unmQ20bjYafhbINknl86i0v3S0OYZqbtCMQhUCp+Rafg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 466,
+          "comment": "point at infinity during verify",
+          "flags": [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f92345a77015fbab4bae36a8eb39f8458e59decc419f44e576f3fbc4425685eb8be216bb36afbbaec2e7db957a9bc0543a91470d9b6ccc37be269b016d3f9ea2",
+        "wx": "00f92345a77015fbab4bae36a8eb39f8458e59decc419f44e576f3fbc4425685eb",
+        "wy": "008be216bb36afbbaec2e7db957a9bc0543a91470d9b6ccc37be269b016d3f9ea2"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f92345a77015fbab4bae36a8eb39f8458e59decc419f44e576f3fbc4425685eb8be216bb36afbbaec2e7db957a9bc0543a91470d9b6ccc37be269b016d3f9ea2",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+SNFp3AV+6tLrjao6zn4RY5Z3sxBn0Tl\ndvP7xEJWheuL4ha7Nq+7rsLn25V6m8BUOpFHDZtszDe+JpsBbT+eog==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 467,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043c8075011484b087b095ac2e59645e59769d5eaf157a2a510ccc028fb40e25552c0df748a38649ffb953ff6f2a2166e2b8ea120cfa39133876129ff6d77ea5c5",
+        "wx": "3c8075011484b087b095ac2e59645e59769d5eaf157a2a510ccc028fb40e2555",
+        "wy": "2c0df748a38649ffb953ff6f2a2166e2b8ea120cfa39133876129ff6d77ea5c5"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043c8075011484b087b095ac2e59645e59769d5eaf157a2a510ccc028fb40e25552c0df748a38649ffb953ff6f2a2166e2b8ea120cfa39133876129ff6d77ea5c5",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEPIB1ARSEsIewlawuWWReWXadXq8VeipR\nDMwCj7QOJVUsDfdIo4ZJ/7lT/28qIWbiuOoSDPo5Ezh2Ep/2136lxQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 468,
+          "comment": "edge case for signature malleability",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a002207fffffffffffffffffffffffffffffff5d576e7357a4501ddfe92f46681b20a1",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047295e1a1264d86aafcba55e0ff4fde8f6337ce21d8a4b8619b14139b292a9ad16c4ce418330bb154a3cfbe6d0b95f9d939396c6d947bbabacef1d2f6f1b6a26b",
+        "wx": "7295e1a1264d86aafcba55e0ff4fde8f6337ce21d8a4b8619b14139b292a9ad1",
+        "wy": "6c4ce418330bb154a3cfbe6d0b95f9d939396c6d947bbabacef1d2f6f1b6a26b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047295e1a1264d86aafcba55e0ff4fde8f6337ce21d8a4b8619b14139b292a9ad16c4ce418330bb154a3cfbe6d0b95f9d939396c6d947bbabacef1d2f6f1b6a26b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEcpXhoSZNhqr8ulXg/0/ej2M3ziHYpLhh\nmxQTmykqmtFsTOQYMwuxVKPPvm0LlfnZOTlsbZR7urrO8dL28baiaw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 469,
+          "comment": "u1 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022100aa275665bf8cd2750115f3d8baf4693d8b02b8a06567c354931362f6b0127e64",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04ad7789e3f1175487c9eba2f061100ba6f552d2c16f956bfc5bef159019703613b3f4d3ba980210c57808ec181142a9bcd62aca5083e6571de3fbf770ae40319f",
+        "wx": "00ad7789e3f1175487c9eba2f061100ba6f552d2c16f956bfc5bef159019703613",
+        "wy": "00b3f4d3ba980210c57808ec181142a9bcd62aca5083e6571de3fbf770ae40319f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004ad7789e3f1175487c9eba2f061100ba6f552d2c16f956bfc5bef159019703613b3f4d3ba980210c57808ec181142a9bcd62aca5083e6571de3fbf770ae40319f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAErXeJ4/EXVIfJ66LwYRALpvVS0sFvlWv8\nW+8VkBlwNhOz9NO6mAIQxXgI7BgRQqm81irKUIPmVx3j+/dwrkAxnw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 470,
+          "comment": "u1 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022055d8a99a40732d8afeea0c27450b96c12fac244649e0dce72cbefb962023c2dd",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e712fcd6035acaaf40630e1279f559ebee905d1c0f9e0ed7fb4bc3e86f675e83fc06bab9d242359166c04e3cd7b0eebddd8e235465af82ce12498a1a44615228",
+        "wx": "00e712fcd6035acaaf40630e1279f559ebee905d1c0f9e0ed7fb4bc3e86f675e83",
+        "wy": "00fc06bab9d242359166c04e3cd7b0eebddd8e235465af82ce12498a1a44615228"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e712fcd6035acaaf40630e1279f559ebee905d1c0f9e0ed7fb4bc3e86f675e83fc06bab9d242359166c04e3cd7b0eebddd8e235465af82ce12498a1a44615228",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE5xL81gNayq9AYw4SefVZ6+6QXRwPng7X\n+0vD6G9nXoP8Brq50kI1kWbATjzXsO693Y4jVGWvgs4SSYoaRGFSKA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 471,
+          "comment": "u2 == 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "041943bfde4307943cbb7ebfabae05a5055756722296dd73532a4de17fd51c41e236328caaab9bbb6c33c9eab1ad70d986fffa66eb9ff6079e0a3cef7efd746543",
+        "wx": "1943bfde4307943cbb7ebfabae05a5055756722296dd73532a4de17fd51c41e2",
+        "wy": "36328caaab9bbb6c33c9eab1ad70d986fffa66eb9ff6079e0a3cef7efd746543"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200041943bfde4307943cbb7ebfabae05a5055756722296dd73532a4de17fd51c41e236328caaab9bbb6c33c9eab1ad70d986fffa66eb9ff6079e0a3cef7efd746543",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGUO/3kMHlDy7fr+rrgWlBVdWciKW3XNT\nKk3hf9UcQeI2Moyqq5u7bDPJ6rGtcNmG//pm65/2B54KPO9+/XRlQw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 472,
+          "comment": "u2 == n - 1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215b8022100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9d1c9e899ca306ad27fe1945de0242b89",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b29ef9666573fe03615ca7d016cd0c9f5f2671093accbb6f5b2e3d56d0869174d17c95b552436693e3056f7a8b05b845d01fc6b6b53a7f08dfb50a505011394d",
+        "wx": "00b29ef9666573fe03615ca7d016cd0c9f5f2671093accbb6f5b2e3d56d0869174",
+        "wy": "00d17c95b552436693e3056f7a8b05b845d01fc6b6b53a7f08dfb50a505011394d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b29ef9666573fe03615ca7d016cd0c9f5f2671093accbb6f5b2e3d56d0869174d17c95b552436693e3056f7a8b05b845d01fc6b6b53a7f08dfb50a505011394d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsp75ZmVz/gNhXKfQFs0Mn18mcQk6zLtv\nWy49VtCGkXTRfJW1UkNmk+MFb3qLBbhF0B/GtrU6fwjftQpQUBE5TQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 473,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022038b7c7773fd99b7c55b1fbf2e8fc231483ab92e021cd411c310676523ab0d4cc",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0415a78bb608c50a6ae0af6ee8de7e9697292796907b9c4a92777c494ccdb7fdbf056b43e4ab26d42af517fa28a4daabe66bdde66cc90bc51a7246ae4ef8adcc4f",
+        "wx": "15a78bb608c50a6ae0af6ee8de7e9697292796907b9c4a92777c494ccdb7fdbf",
+        "wy": "056b43e4ab26d42af517fa28a4daabe66bdde66cc90bc51a7246ae4ef8adcc4f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000415a78bb608c50a6ae0af6ee8de7e9697292796907b9c4a92777c494ccdb7fdbf056b43e4ab26d42af517fa28a4daabe66bdde66cc90bc51a7246ae4ef8adcc4f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEFaeLtgjFCmrgr27o3n6WlyknlpB7nEqS\nd3xJTM23/b8Fa0PkqybUKvUX+iik2qvma93mbMkLxRpyRq5O+K3MTw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 474,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0221009a5a0b273772d372cee695421caf7e7d9d2a4577f962f77b23639ab8fc23df99",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d9dfb33fed5b674d35a97a8d4a88fc49f8c9faefcc47cd890c421953ffa1ff45f8d02f949d65a381b30d4ff51c885ba967d43b452bbdf9ca91870120e406422e",
+        "wx": "00d9dfb33fed5b674d35a97a8d4a88fc49f8c9faefcc47cd890c421953ffa1ff45",
+        "wy": "00f8d02f949d65a381b30d4ff51c885ba967d43b452bbdf9ca91870120e406422e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d9dfb33fed5b674d35a97a8d4a88fc49f8c9faefcc47cd890c421953ffa1ff45f8d02f949d65a381b30d4ff51c885ba967d43b452bbdf9ca91870120e406422e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE2d+zP+1bZ001qXqNSoj8SfjJ+u/MR82J\nDEIZU/+h/0X40C+UnWWjgbMNT/UciFupZ9Q7RSu9+cqRhwEg5AZCLg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 475,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100a0ce188fff736224cd05fd0c7b1b297fa21b9961c53e327aef81f168d6597ff9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f06dddbe7b3cd0d89eb237c70e06f6d97b118fcac41c7fed780cf8553b2dd8fd078920f3430023de121e7dcaad25f3456c192df69f6e3c27c04346816a2ef70c",
+        "wx": "00f06dddbe7b3cd0d89eb237c70e06f6d97b118fcac41c7fed780cf8553b2dd8fd",
+        "wy": "078920f3430023de121e7dcaad25f3456c192df69f6e3c27c04346816a2ef70c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f06dddbe7b3cd0d89eb237c70e06f6d97b118fcac41c7fed780cf8553b2dd8fd078920f3430023de121e7dcaad25f3456c192df69f6e3c27c04346816a2ef70c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE8G3dvns80NiesjfHDgb22XsRj8rEHH/t\neAz4VTst2P0HiSDzQwAj3hIefcqtJfNFbBkt9p9uPCfAQ0aBai73DA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 476,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100a0f26feb88efc16355d8a99a40732d8a3263414ac6f3b42c33d58489d9ce4cde",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046866935c3105dc0583d3bc37886d8fc071c08bc5e9edcbfa5f46a7d69fd602e2b2dda206a0253653f75917e3907f1a66791cee029d12fbdc9568c6e06ace60fe",
+        "wx": "6866935c3105dc0583d3bc37886d8fc071c08bc5e9edcbfa5f46a7d69fd602e2",
+        "wy": "00b2dda206a0253653f75917e3907f1a66791cee029d12fbdc9568c6e06ace60fe"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046866935c3105dc0583d3bc37886d8fc071c08bc5e9edcbfa5f46a7d69fd602e2b2dda206a0253653f75917e3907f1a66791cee029d12fbdc9568c6e06ace60fe",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEaGaTXDEF3AWD07w3iG2PwHHAi8Xp7cv6\nX0an1p/WAuKy3aIGoCU2U/dZF+OQfxpmeRzuAp0S+9yVaMbgas5g/g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 477,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022026feb88efc16355d8a99a40732d8afee6f34b8121fbf0a3ee343933a93138331",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "049e2c0c97d33913ba72b6de833140e763cb7e05c03178d2746cf5b958cd07185c029c1d0b326a46339ec06819565cc7a52c04602bd7dc75a65e386e1adcc943ea",
+        "wx": "009e2c0c97d33913ba72b6de833140e763cb7e05c03178d2746cf5b958cd07185c",
+        "wy": "029c1d0b326a46339ec06819565cc7a52c04602bd7dc75a65e386e1adcc943ea"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200049e2c0c97d33913ba72b6de833140e763cb7e05c03178d2746cf5b958cd07185c029c1d0b326a46339ec06819565cc7a52c04602bd7dc75a65e386e1adcc943ea",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEniwMl9M5E7pytt6DMUDnY8t+BcAxeNJ0\nbPW5WM0HGFwCnB0LMmpGM57AaBlWXMelLARgK9fcdaZeOG4a3MlD6g==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 478,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02204dfd711df82c6abb1533480e65b15fdcde6970243f7e147dc687267526270662",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04074ab918d2517160345ce63335214b6eab8bfb89c1c11bf296a753a5eb39c26c501ec4eea1e1e2e33ad912199dd938e239cabe15066443e4049d66a3c8927d28",
+        "wx": "074ab918d2517160345ce63335214b6eab8bfb89c1c11bf296a753a5eb39c26c",
+        "wy": "501ec4eea1e1e2e33ad912199dd938e239cabe15066443e4049d66a3c8927d28"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004074ab918d2517160345ce63335214b6eab8bfb89c1c11bf296a753a5eb39c26c501ec4eea1e1e2e33ad912199dd938e239cabe15066443e4049d66a3c8927d28",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEB0q5GNJRcWA0XOYzNSFLbquL+4nBwRvy\nlqdTpes5wmxQHsTuoeHi4zrZEhmd2TjiOcq+FQZkQ+QEnWajyJJ9KA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 479,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02210088efc16355d8a99a40732d8afeea0c269707cf9bfe51b58f2973b7410874ea55",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c9b4145e17efd3b56930bcfa5fe6f797399cc7f0e383f85e26668d017777d219bbb434eb59f9529fcbaf844c9a2cb441116b194bff2c3bc402e19c351e953a73",
+        "wx": "00c9b4145e17efd3b56930bcfa5fe6f797399cc7f0e383f85e26668d017777d219",
+        "wy": "00bbb434eb59f9529fcbaf844c9a2cb441116b194bff2c3bc402e19c351e953a73"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c9b4145e17efd3b56930bcfa5fe6f797399cc7f0e383f85e26668d017777d219bbb434eb59f9529fcbaf844c9a2cb441116b194bff2c3bc402e19c351e953a73",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEybQUXhfv07VpMLz6X+b3lzmcx/Djg/he\nJmaNAXd30hm7tDTrWflSn8uvhEyaLLRBEWsZS/8sO8QC4Zw1HpU6cw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 480,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220602c62deaf3dddd25f7bc324e21260afca13dcd8a37e66286049e43fe035079a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04617b5b040673c839147cf29e114a6bf4026598e2a15bbbbcd331c90911a7ca1fdb1892be7a457a5f7497185de5956680aa0f55b2709f218bb87a84b8192a43e8",
+        "wx": "617b5b040673c839147cf29e114a6bf4026598e2a15bbbbcd331c90911a7ca1f",
+        "wy": "00db1892be7a457a5f7497185de5956680aa0f55b2709f218bb87a84b8192a43e8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004617b5b040673c839147cf29e114a6bf4026598e2a15bbbbcd331c90911a7ca1fdb1892be7a457a5f7497185de5956680aa0f55b2709f218bb87a84b8192a43e8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEYXtbBAZzyDkUfPKeEUpr9AJlmOKhW7u8\n0zHJCRGnyh/bGJK+ekV6X3SXGF3llWaAqg9VsnCfIYu4eoS4GSpD6A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 481,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02203f51f2382a547037eb565b08e435dd44df7b889c0a91118e0e1912acbf47826a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0440562caf21c3b2642fa2f6c96d371c7702ff4e9c9f1649d59abe4202192e9d4b24ac6492255af8e1d2aebe2290acc8f019ed41d13045d2589e488f27d11df376",
+        "wx": "40562caf21c3b2642fa2f6c96d371c7702ff4e9c9f1649d59abe4202192e9d4b",
+        "wy": "24ac6492255af8e1d2aebe2290acc8f019ed41d13045d2589e488f27d11df376"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000440562caf21c3b2642fa2f6c96d371c7702ff4e9c9f1649d59abe4202192e9d4b24ac6492255af8e1d2aebe2290acc8f019ed41d13045d2589e488f27d11df376",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQFYsryHDsmQvovbJbTccdwL/TpyfFknV\nmr5CAhkunUskrGSSJVr44dKuviKQrMjwGe1B0TBF0lieSI8n0R3zdg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 482,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022060ba6c0dacd0a3a6c43b0067b58062e3d71b3012a9221ffb7b06b396809d9e6c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04895939820528067c9cc153039394d3bea4af22fc56e887a0e72704eb3bf7b3c70135eaa7567722043ae5f4b4068cdb30068f918feda0040b838068f2dac0f635",
+        "wx": "00895939820528067c9cc153039394d3bea4af22fc56e887a0e72704eb3bf7b3c7",
+        "wy": "0135eaa7567722043ae5f4b4068cdb30068f918feda0040b838068f2dac0f635"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004895939820528067c9cc153039394d3bea4af22fc56e887a0e72704eb3bf7b3c70135eaa7567722043ae5f4b4068cdb30068f918feda0040b838068f2dac0f635",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEiVk5ggUoBnycwVMDk5TTvqSvIvxW6Ieg\n5ycE6zv3s8cBNeqnVnciBDrl9LQGjNswBo+Rj+2gBAuDgGjy2sD2NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 483,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220618f79d4292ccc655b59dc4bf2a56631eaa62ce9b197b6b82321ea98713a80a7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d6399ab723c5be273542adbe47fb7ea5eae6124260063c4d7badd5a6b638f5050bbca7ee76f7ff916686bc23670d20ecdfd28241ef86972c9e33bc69f009e11d",
+        "wx": "00d6399ab723c5be273542adbe47fb7ea5eae6124260063c4d7badd5a6b638f505",
+        "wy": "0bbca7ee76f7ff916686bc23670d20ecdfd28241ef86972c9e33bc69f009e11d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d6399ab723c5be273542adbe47fb7ea5eae6124260063c4d7badd5a6b638f5050bbca7ee76f7ff916686bc23670d20ecdfd28241ef86972c9e33bc69f009e11d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE1jmatyPFvic1Qq2+R/t+permEkJgBjxN\ne63VprY49QULvKfudvf/kWaGvCNnDSDs39KCQe+GlyyeM7xp8AnhHQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 484,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100e3a41c4460133241d52702068b81ee7478d913769e61ffada74f2363b2ddd6db",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043be551eb7f05c6a27a21286a68354b26d9fb2c57647596d14b45c22ba53bc7c25a3f0472a400fc4268040b9a9c5bdeeb9b2ff36aebdb646693d4ec62f5d9e82b",
+        "wx": "3be551eb7f05c6a27a21286a68354b26d9fb2c57647596d14b45c22ba53bc7c2",
+        "wy": "5a3f0472a400fc4268040b9a9c5bdeeb9b2ff36aebdb646693d4ec62f5d9e82b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043be551eb7f05c6a27a21286a68354b26d9fb2c57647596d14b45c22ba53bc7c25a3f0472a400fc4268040b9a9c5bdeeb9b2ff36aebdb646693d4ec62f5d9e82b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEO+VR638FxqJ6IShqaDVLJtn7LFdkdZbR\nS0XCK6U7x8JaPwRypAD8QmgEC5qcW97rmy/zauvbZGaT1Oxi9dnoKw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 485,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100c7483888c0266483aa4e040d1703dcea37034a068d7b5f1f8ecbe83a95856c75",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0407212d36e78433243651ddd2ccdf23a83d609a40ffb317463fcce78dd6a55b12b5302470b57b879fc24ccd8a632453d427722f0eb2b12a6682d5f7c696d2fa91",
+        "wx": "07212d36e78433243651ddd2ccdf23a83d609a40ffb317463fcce78dd6a55b12",
+        "wy": "00b5302470b57b879fc24ccd8a632453d427722f0eb2b12a6682d5f7c696d2fa91"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000407212d36e78433243651ddd2ccdf23a83d609a40ffb317463fcce78dd6a55b12b5302470b57b879fc24ccd8a632453d427722f0eb2b12a6682d5f7c696d2fa91",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEByEtNueEMyQ2Ud3SzN8jqD1gmkD/sxdG\nP8znjdalWxK1MCRwtXuHn8JMzYpjJFPUJ3IvDrKxKmaC1ffGltL6kQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 486,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100aaec54cd203996c57f750613a285cb5ff52d80967c94be917648ad11782d020f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04216ce228e3584057d2833bfb5542883dc09027ba081f21a21499636e1a56beead81a4c155bf1bf73dadc756de945400094349cdac7c3e179b69734e3983f55c7",
+        "wx": "216ce228e3584057d2833bfb5542883dc09027ba081f21a21499636e1a56beea",
+        "wy": "00d81a4c155bf1bf73dadc756de945400094349cdac7c3e179b69734e3983f55c7"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004216ce228e3584057d2833bfb5542883dc09027ba081f21a21499636e1a56beead81a4c155bf1bf73dadc756de945400094349cdac7c3e179b69734e3983f55c7",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEIWziKONYQFfSgzv7VUKIPcCQJ7oIHyGi\nFJljbhpWvurYGkwVW/G/c9rcdW3pRUAAlDSc2sfD4Xm2lzTjmD9Vxw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 487,
+          "comment": "edge case for u1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100d0670c47ffb9b1126682fe863d8d94bf2e653b243a43695b57aa27fad347e09d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0443e899bc3ea443e5521aa6666a0e0b7977feb89b39ae9c9b46c9afcebc852af5828a867be817722818741340c40a86cc385a9aa7d344f87c0c16b1e767615e85",
+        "wx": "43e899bc3ea443e5521aa6666a0e0b7977feb89b39ae9c9b46c9afcebc852af5",
+        "wy": "00828a867be817722818741340c40a86cc385a9aa7d344f87c0c16b1e767615e85"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000443e899bc3ea443e5521aa6666a0e0b7977feb89b39ae9c9b46c9afcebc852af5828a867be817722818741340c40a86cc385a9aa7d344f87c0c16b1e767615e85",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEQ+iZvD6kQ+VSGqZmag4LeXf+uJs5rpyb\nRsmvzryFKvWCioZ76BdyKBh0E0DECobMOFqap9NE+HwMFrHnZ2FehQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 488,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100d55555555555555555555555555555547c74934474db157d2a8c3f088aced62a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042fa2e1f68d00b9e2504f013e0ded297f1b163583c150287f04b9717d37ef4401fcde8ffbb9f4cc74a3feb3f660cd0568983da04a475c85c99fe877556774103d",
+        "wx": "2fa2e1f68d00b9e2504f013e0ded297f1b163583c150287f04b9717d37ef4401",
+        "wy": "00fcde8ffbb9f4cc74a3feb3f660cd0568983da04a475c85c99fe877556774103d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042fa2e1f68d00b9e2504f013e0ded297f1b163583c150287f04b9717d37ef4401fcde8ffbb9f4cc74a3feb3f660cd0568983da04a475c85c99fe877556774103d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEL6Lh9o0AueJQTwE+De0pfxsWNYPBUCh/\nBLlxfTfvRAH83o/7ufTMdKP+s/ZgzQVomD2gSkdchcmf6HdVZ3QQPQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 489,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100c1777c8853938e536213c02464a936000ba1e21c0fc62075d46c624e23b52f31",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04020c6a477ea4322098c336cc759392e3ee97bbe004561fcbca503c4f9fb0d9df2b2518cd62254b5d4db44660b3cfa6811527a977c163b7e1114e194ea33d9272",
+        "wx": "020c6a477ea4322098c336cc759392e3ee97bbe004561fcbca503c4f9fb0d9df",
+        "wy": "2b2518cd62254b5d4db44660b3cfa6811527a977c163b7e1114e194ea33d9272"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004020c6a477ea4322098c336cc759392e3ee97bbe004561fcbca503c4f9fb0d9df2b2518cd62254b5d4db44660b3cfa6811527a977c163b7e1114e194ea33d9272",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAgxqR36kMiCYwzbMdZOS4+6Xu+AEVh/L\nylA8T5+w2d8rJRjNYiVLXU20RmCzz6aBFSepd8Fjt+ERThlOoz2Scg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 490,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022030bbb794db588363b40679f6c182a50d3ce9679acdd3ffbe36d7813dacbdc818",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "042906f7953642e20c07df87b82c6f69de287de1b1d14a27a6fbd195d9fffba1c2bba9167950ae639b981aa3bb5754dcf67fc4216074a09f6de11db8d456012a78",
+        "wx": "2906f7953642e20c07df87b82c6f69de287de1b1d14a27a6fbd195d9fffba1c2",
+        "wy": "00bba9167950ae639b981aa3bb5754dcf67fc4216074a09f6de11db8d456012a78"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200042906f7953642e20c07df87b82c6f69de287de1b1d14a27a6fbd195d9fffba1c2bba9167950ae639b981aa3bb5754dcf67fc4216074a09f6de11db8d456012a78",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEKQb3lTZC4gwH34e4LG9p3ih94bHRSiem\n+9GV2f/7ocK7qRZ5UK5jm5gao7tXVNz2f8QhYHSgn23hHbjUVgEqeA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 491,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202c37fd995622c4fb7fffffffffffffffc7cee745110cb45ab558ed7c90c15a2f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f7f761cb2567c7bfb6c3f348d3c1571d00491b6a285da344d23e7999a9641b471384a9fb6498149c6c3ce970e2c88eeb0bf62e45c08b71e8c5c587019105a6ce",
+        "wx": "00f7f761cb2567c7bfb6c3f348d3c1571d00491b6a285da344d23e7999a9641b47",
+        "wy": "1384a9fb6498149c6c3ce970e2c88eeb0bf62e45c08b71e8c5c587019105a6ce"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f7f761cb2567c7bfb6c3f348d3c1571d00491b6a285da344d23e7999a9641b471384a9fb6498149c6c3ce970e2c88eeb0bf62e45c08b71e8c5c587019105a6ce",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE9/dhyyVnx7+2w/NI08FXHQBJG2ooXaNE\n0j55malkG0cThKn7ZJgUnGw86XDiyI7rC/YuRcCLcejFxYcBkQWmzg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 492,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02207fd995622c4fb7ffffffffffffffffff5d883ffab5b32652ccdcaa290fccb97d",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04c435448e32ff34954bf85c1d0a195adcd6eecae96ed910a758090d4da5ca7ef45261ff9a807f88e53feab7943bb9d6af69862c26eb714647d6649c447e8ef64c",
+        "wx": "00c435448e32ff34954bf85c1d0a195adcd6eecae96ed910a758090d4da5ca7ef4",
+        "wy": "5261ff9a807f88e53feab7943bb9d6af69862c26eb714647d6649c447e8ef64c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004c435448e32ff34954bf85c1d0a195adcd6eecae96ed910a758090d4da5ca7ef45261ff9a807f88e53feab7943bb9d6af69862c26eb714647d6649c447e8ef64c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAExDVEjjL/NJVL+FwdChla3Nbuyulu2RCn\nWAkNTaXKfvRSYf+agH+I5T/qt5Q7udavaYYsJutxRkfWZJxEfo72TA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 493,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100ffb32ac4589f6ffffffffffffffffffebb107ff56b664ca599b954521f9972fa",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "048e8bff94e8f067480874d4b0608b2fc20274565ef5793f891130c0bfded7ded92bb1b91f3435c2d664b258d2b4c0f7cb0a9245ae5883ed2fbd8671aef64c22df",
+        "wx": "008e8bff94e8f067480874d4b0608b2fc20274565ef5793f891130c0bfded7ded9",
+        "wy": "2bb1b91f3435c2d664b258d2b4c0f7cb0a9245ae5883ed2fbd8671aef64c22df"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200048e8bff94e8f067480874d4b0608b2fc20274565ef5793f891130c0bfded7ded92bb1b91f3435c2d664b258d2b4c0f7cb0a9245ae5883ed2fbd8671aef64c22df",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEjov/lOjwZ0gIdNSwYIsvwgJ0Vl71eT+J\nETDAv97X3tkrsbkfNDXC1mSyWNK0wPfLCpJFrliD7S+9hnGu9kwi3w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 494,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02205622c4fb7fffffffffffffffffffffff928a8f1c7ac7bec1808b9f61c01ec327",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "045cd7b15df5d3b4f31a55c290c6bc905272c1cfd4e814557df2faec5e2b5754a81ca33afb361084a08bda0e79258f99819989140d2bac928f527c172f77bd9bfb",
+        "wx": "5cd7b15df5d3b4f31a55c290c6bc905272c1cfd4e814557df2faec5e2b5754a8",
+        "wy": "1ca33afb361084a08bda0e79258f99819989140d2bac928f527c172f77bd9bfb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200045cd7b15df5d3b4f31a55c290c6bc905272c1cfd4e814557df2faec5e2b5754a81ca33afb361084a08bda0e79258f99819989140d2bac928f527c172f77bd9bfb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEXNexXfXTtPMaVcKQxryQUnLBz9ToFFV9\n8vrsXitXVKgcozr7NhCEoIvaDnklj5mBmYkUDSusko9SfBcvd72b+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 495,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022044104104104104104104104104104103b87853fd3b7d3f8e175125b4382f25ed",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040e90cf16a6f6d82fb7e472e640e8b3ce9288a64c7894e3965bde308218d8bcf89e6a3d78a5599e1cfae0258608d2dc425c979cb11d61464423391eb29b353eb3",
+        "wx": "0e90cf16a6f6d82fb7e472e640e8b3ce9288a64c7894e3965bde308218d8bcf8",
+        "wy": "009e6a3d78a5599e1cfae0258608d2dc425c979cb11d61464423391eb29b353eb3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040e90cf16a6f6d82fb7e472e640e8b3ce9288a64c7894e3965bde308218d8bcf89e6a3d78a5599e1cfae0258608d2dc425c979cb11d61464423391eb29b353eb3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEDpDPFqb22C+35HLmQOizzpKIpkx4lOOW\nW94wghjYvPieaj14pVmeHPrgJYYI0txCXJecsR1hRkQjOR6ymzU+sw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 496,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202739ce739ce739ce739ce739ce739ce705560298d1f2f08dc419ac273a5b54d9",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046a504aa871137a2bbd2b05bdda8f6e2e32e9d1468fab78e098c7c0ad41a097e4590e79063b8531de4f0925aef955b80e56f88050f477339caa621100e75969d8",
+        "wx": "6a504aa871137a2bbd2b05bdda8f6e2e32e9d1468fab78e098c7c0ad41a097e4",
+        "wy": "590e79063b8531de4f0925aef955b80e56f88050f477339caa621100e75969d8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046a504aa871137a2bbd2b05bdda8f6e2e32e9d1468fab78e098c7c0ad41a097e4590e79063b8531de4f0925aef955b80e56f88050f477339caa621100e75969d8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEalBKqHETeiu9KwW92o9uLjLp0UaPq3jg\nmMfArUGgl+RZDnkGO4Ux3k8JJa75VbgOVviAUPR3M5yqYhEA51lp2A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 497,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100b777777777777777777777777777777688e6a1fe808a97a348671222ff16b863",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cda3af8e54dd6af3ec691541db443c76c1a6b3a86d4ee72ed1cff6305f8ac91c122b45ed375a32756617921bc2cb8bf88e7e6b6d47320987b2ec71decd3476f8",
+        "wx": "00cda3af8e54dd6af3ec691541db443c76c1a6b3a86d4ee72ed1cff6305f8ac91c",
+        "wy": "122b45ed375a32756617921bc2cb8bf88e7e6b6d47320987b2ec71decd3476f8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cda3af8e54dd6af3ec691541db443c76c1a6b3a86d4ee72ed1cff6305f8ac91c122b45ed375a32756617921bc2cb8bf88e7e6b6d47320987b2ec71decd3476f8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEzaOvjlTdavPsaRVB20Q8dsGms6htTucu\n0c/2MF+KyRwSK0XtN1oydWYXkhvCy4v4jn5rbUcyCYey7HHezTR2+A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 498,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02206492492492492492492492492492492406dd3a19b8d5fb875235963c593bd2d3",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04bf4f41debf5f679603c381d123515bd6c959ad29263a867a00946b29bed102f2bb23a6765eaf1e6391f59b70fbda073fca11be2072158c10df199982b7c3e21b",
+        "wx": "00bf4f41debf5f679603c381d123515bd6c959ad29263a867a00946b29bed102f2",
+        "wy": "00bb23a6765eaf1e6391f59b70fbda073fca11be2072158c10df199982b7c3e21b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004bf4f41debf5f679603c381d123515bd6c959ad29263a867a00946b29bed102f2bb23a6765eaf1e6391f59b70fbda073fca11be2072158c10df199982b7c3e21b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEv09B3r9fZ5YDw4HRI1Fb1slZrSkmOoZ6\nAJRrKb7RAvK7I6Z2Xq8eY5H1m3D72gc/yhG+IHIVjBDfGZmCt8PiGw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 499,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100955555555555555555555555555555547c74934474db157d2a8c3f088aced62c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04face0b628008def15e20a566a8e26adc48d867ac515240c0a756c408dbea286ad70670fcb5847b773db0b966aaa77328c9434dbec55f2ac3fbd9f43dd99f3bf3",
+        "wx": "00face0b628008def15e20a566a8e26adc48d867ac515240c0a756c408dbea286a",
+        "wy": "00d70670fcb5847b773db0b966aaa77328c9434dbec55f2ac3fbd9f43dd99f3bf3"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004face0b628008def15e20a566a8e26adc48d867ac515240c0a756c408dbea286ad70670fcb5847b773db0b966aaa77328c9434dbec55f2ac3fbd9f43dd99f3bf3",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE+s4LYoAI3vFeIKVmqOJq3EjYZ6xRUkDA\np1bECNvqKGrXBnD8tYR7dz2wuWaqp3MoyUNNvsVfKsP72fQ92Z878w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 500,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02202aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3e3a49a23a6d8abe95461f8445676b17",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04cf8abfd2c89106a46adc42f682a1d22172f3d5747e26175fb6d62d5432c775555465f71684eb6ab9811bd830b0e9e276e1160d5b3ad7eb99c72d5b06449a0551",
+        "wx": "00cf8abfd2c89106a46adc42f682a1d22172f3d5747e26175fb6d62d5432c77555",
+        "wy": "5465f71684eb6ab9811bd830b0e9e276e1160d5b3ad7eb99c72d5b06449a0551"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004cf8abfd2c89106a46adc42f682a1d22172f3d5747e26175fb6d62d5432c775555465f71684eb6ab9811bd830b0e9e276e1160d5b3ad7eb99c72d5b06449a0551",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEz4q/0siRBqRq3EL2gqHSIXLz1XR+Jhdf\nttYtVDLHdVVUZfcWhOtquYEb2DCw6eJ24RYNWzrX65nHLVsGRJoFUQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 501,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc022100bffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364143",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04050cef9f6e34137bcdb1a893b1eee574aae3550658abc6f4660a67b8e01914f254c54fd2613c3b0e1ac6843a197d0cccc0feceeee86f83c78adbb5fc7727a6ab",
+        "wx": "050cef9f6e34137bcdb1a893b1eee574aae3550658abc6f4660a67b8e01914f2",
+        "wy": "54c54fd2613c3b0e1ac6843a197d0cccc0feceeee86f83c78adbb5fc7727a6ab"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004050cef9f6e34137bcdb1a893b1eee574aae3550658abc6f4660a67b8e01914f254c54fd2613c3b0e1ac6843a197d0cccc0feceeee86f83c78adbb5fc7727a6ab",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEBQzvn240E3vNsaiTse7ldKrjVQZYq8b0\nZgpnuOAZFPJUxU/SYTw7DhrGhDoZfQzMwP7O7uhvg8eK27X8dyemqw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 502,
+          "comment": "edge case for u2",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0220185ddbca6dac41b1da033cfb60c152869e74b3cd66e9ffdf1b6bc09ed65ee40c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b67fa0d181e80cbeff1625ea48614da85e7a297bb4f200c32f164d3a22e39975e4",
+        "wx": "0fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b6",
+        "wy": "7fa0d181e80cbeff1625ea48614da85e7a297bb4f200c32f164d3a22e39975e4"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b67fa0d181e80cbeff1625ea48614da85e7a297bb4f200c32f164d3a22e39975e4",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAED9Xv+3g5Y2v0hjjs0E07e4QkT2dhDrVZ\n6jsrs5eHdLZ/oNGB6Ay+/xYl6khhTaheeil7tPIAwy8WTToi45l15A==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 503,
+          "comment": "point duplication during verification",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022032b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda0221008cf5adcdbe8331099059b4336ece94ab3ba9761faf730b22260cbfcc47f174af",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b6805f2e7e17f34100e9da15b79eb257a185d6844b0dff3cd0e9b2c5dc1c66864b",
+        "wx": "0fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b6",
+        "wy": "00805f2e7e17f34100e9da15b79eb257a185d6844b0dff3cd0e9b2c5dc1c66864b"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040fd5effb7839636bf48638ecd04d3b7b84244f67610eb559ea3b2bb3978774b6805f2e7e17f34100e9da15b79eb257a185d6844b0dff3cd0e9b2c5dc1c66864b",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAED9Xv+3g5Y2v0hjjs0E07e4QkT2dhDrVZ\n6jsrs5eHdLaAXy5+F/NBAOnaFbeeslehhdaESw3/PNDpssXcHGaGSw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 504,
+          "comment": "duplication bug",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022032b0d10d8d0e04bc8d4d064d270699e87cffc9b49c5c20730e1c26f6105ddcda0221008cf5adcdbe8331099059b4336ece94ab3ba9761faf730b22260cbfcc47f174af",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "043328dea23505062b5236e9f1880c85d251859d52c7e9479c44c82994404ca2b9efa683a714cfa079179a021f5ab6d9a36be886093ae0adfd7c88e3b44d579e8c",
+        "wx": "3328dea23505062b5236e9f1880c85d251859d52c7e9479c44c82994404ca2b9",
+        "wy": "00efa683a714cfa079179a021f5ab6d9a36be886093ae0adfd7c88e3b44d579e8c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200043328dea23505062b5236e9f1880c85d251859d52c7e9479c44c82994404ca2b9efa683a714cfa079179a021f5ab6d9a36be886093ae0adfd7c88e3b44d579e8c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMyjeojUFBitSNunxiAyF0lGFnVLH6Uec\nRMgplEBMornvpoOnFM+geReaAh9attmja+iGCTrgrf18iOO0TVeejA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 505,
+          "comment": "comparison with point at infinity ",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0022033333333333333333333333333333332f222f8faefdb533f265d461c29a47373",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04eff50ce9ca8262bc5a90bd53a8ec78d0b3dbb3dffc29b6a149a49a80c83b338c4dfee1651c973585a985b7eb64be41add1ce6c52e68ba073c562037983c04e33",
+        "wx": "00eff50ce9ca8262bc5a90bd53a8ec78d0b3dbb3dffc29b6a149a49a80c83b338c",
+        "wy": "4dfee1651c973585a985b7eb64be41add1ce6c52e68ba073c562037983c04e33"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004eff50ce9ca8262bc5a90bd53a8ec78d0b3dbb3dffc29b6a149a49a80c83b338c4dfee1651c973585a985b7eb64be41add1ce6c52e68ba073c562037983c04e33",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7/UM6cqCYrxakL1TqOx40LPbs9/8Kbah\nSaSagMg7M4xN/uFlHJc1hamFt+tkvkGt0c5sUuaLoHPFYgN5g8BOMw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 506,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04197b7b0558c077fe7ca5617df4b7473b023bf94e96958c0aee53a51253be649a63b4c4703601e96a904475029e117407a9d56db5ff5cd5372c6aa91b86fd5e0f",
+        "wx": "197b7b0558c077fe7ca5617df4b7473b023bf94e96958c0aee53a51253be649a",
+        "wy": "63b4c4703601e96a904475029e117407a9d56db5ff5cd5372c6aa91b86fd5e0f"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004197b7b0558c077fe7ca5617df4b7473b023bf94e96958c0aee53a51253be649a63b4c4703601e96a904475029e117407a9d56db5ff5cd5372c6aa91b86fd5e0f",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEGXt7BVjAd/58pWF99LdHOwI7+U6WlYwK\n7lOlElO+ZJpjtMRwNgHpapBEdQKeEXQHqdVttf9c1Tcsaqkbhv1eDw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 507,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022100b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04b0587dbe6b08ebf735012fd702ad12581d5a69dc42372f0c9c64fe988d40f97178697a976684d662d8e4062135c508be49a8193d31fc309f51208f2df16508db",
+        "wx": "00b0587dbe6b08ebf735012fd702ad12581d5a69dc42372f0c9c64fe988d40f971",
+        "wy": "78697a976684d662d8e4062135c508be49a8193d31fc309f51208f2df16508db"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004b0587dbe6b08ebf735012fd702ad12581d5a69dc42372f0c9c64fe988d40f97178697a976684d662d8e4062135c508be49a8193d31fc309f51208f2df16508db",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEsFh9vmsI6/c1AS/XAq0SWB1aadxCNy8M\nnGT+mI1A+XF4aXqXZoTWYtjkBiE1xQi+SagZPTH8MJ9RII8t8WUI2w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 508,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3046022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee502210099999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04f3ddf100facb4d04002a38d15626433ac3b95205b1b3282f9fa5c921518791ae63612a449709ab5e458c05d4880c6e4d1d21d6d1f7998bad8f605d6bedff6450",
+        "wx": "00f3ddf100facb4d04002a38d15626433ac3b95205b1b3282f9fa5c921518791ae",
+        "wy": "63612a449709ab5e458c05d4880c6e4d1d21d6d1f7998bad8f605d6bedff6450"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004f3ddf100facb4d04002a38d15626433ac3b95205b1b3282f9fa5c921518791ae63612a449709ab5e458c05d4880c6e4d1d21d6d1f7998bad8f605d6bedff6450",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE893xAPrLTQQAKjjRViZDOsO5UgWxsygv\nn6XJIVGHka5jYSpElwmrXkWMBdSIDG5NHSHW0feZi62PYF1r7f9kUA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 509,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022066666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047aaf2dc5cec7aa23e8ecebc7ab039f52f4dcc297dee1e2721d38f19bcbc9893024186b29e48a4ca6272795a9743b313e2cbeab6d9dfc8dde8e722f0bdcf05f08",
+        "wx": "7aaf2dc5cec7aa23e8ecebc7ab039f52f4dcc297dee1e2721d38f19bcbc98930",
+        "wy": "24186b29e48a4ca6272795a9743b313e2cbeab6d9dfc8dde8e722f0bdcf05f08"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047aaf2dc5cec7aa23e8ecebc7ab039f52f4dcc297dee1e2721d38f19bcbc9893024186b29e48a4ca6272795a9743b313e2cbeab6d9dfc8dde8e722f0bdcf05f08",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeq8txc7HqiPo7OvHqwOfUvTcwpfe4eJy\nHTjxm8vJiTAkGGsp5IpMpicnlal0OzE+LL6rbZ38jd6Oci8L3PBfCA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 510,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5022049249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0485b5f352382e9b7c6c4f06012fb9d8c6a7801cca1460ea18e1794d98727869ce2e8c1200428d29e116ce68562d0ca1ad9886b85c63899086256f3af90207c804",
+        "wx": "0085b5f352382e9b7c6c4f06012fb9d8c6a7801cca1460ea18e1794d98727869ce",
+        "wy": "2e8c1200428d29e116ce68562d0ca1ad9886b85c63899086256f3af90207c804"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000485b5f352382e9b7c6c4f06012fb9d8c6a7801cca1460ea18e1794d98727869ce2e8c1200428d29e116ce68562d0ca1ad9886b85c63899086256f3af90207c804",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEhbXzUjgum3xsTwYBL7nYxqeAHMoUYOoY\n4XlNmHJ4ac4ujBIAQo0p4RbOaFYtDKGtmIa4XGOJkIYlbzr5AgfIBA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 511,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee502200eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d282b8c407e70a153c420461da7e376d501e9348b42d143f6c215ee2b61aed281cf6add6baf3e3fce0aad7da86061f1e5bf2de8016eb781fa87f260a0de748a8",
+        "wx": "00d282b8c407e70a153c420461da7e376d501e9348b42d143f6c215ee2b61aed28",
+        "wy": "1cf6add6baf3e3fce0aad7da86061f1e5bf2de8016eb781fa87f260a0de748a8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d282b8c407e70a153c420461da7e376d501e9348b42d143f6c215ee2b61aed281cf6add6baf3e3fce0aad7da86061f1e5bf2de8016eb781fa87f260a0de748a8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0oK4xAfnChU8QgRh2n43bVAek0i0LRQ/\nbCFe4rYa7Sgc9q3WuvPj/OCq19qGBh8eW/LegBbreB+ofyYKDedIqA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 512,
+          "comment": "extreme value for k and edgecase s",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022055555555555555555555555555555554e8e4f44ce51835693ff0ca2ef01215c0",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "040b21e08ee53b735b32f51327fa4aac6b0ff775bf7ef0a4a7d9fa5f2a693104a44e9a4795f4999e25da0b9c314828bdd12f45aec22a19150004b1912afa019344",
+        "wx": "0b21e08ee53b735b32f51327fa4aac6b0ff775bf7ef0a4a7d9fa5f2a693104a4",
+        "wy": "4e9a4795f4999e25da0b9c314828bdd12f45aec22a19150004b1912afa019344"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200040b21e08ee53b735b32f51327fa4aac6b0ff775bf7ef0a4a7d9fa5f2a693104a44e9a4795f4999e25da0b9c314828bdd12f45aec22a19150004b1912afa019344",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAECyHgjuU7c1sy9RMn+kqsaw/3db9+8KSn\n2fpfKmkxBKROmkeV9JmeJdoLnDFIKL3RL0WuwioZFQAEsZEq+gGTRA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 513,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022100b6db6db6db6db6db6db6db6db6db6db5f30f30127d33e02aad96438927022e9c",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04de51929eb2137315db47731d4ef28c4177d04c4990018e0471656a6c3b84a3c11ff555ec1d66075af3b2c4335bbbe8bccb3568553d7205eb510d95592071e9ad",
+        "wx": "00de51929eb2137315db47731d4ef28c4177d04c4990018e0471656a6c3b84a3c1",
+        "wy": "1ff555ec1d66075af3b2c4335bbbe8bccb3568553d7205eb510d95592071e9ad"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004de51929eb2137315db47731d4ef28c4177d04c4990018e0471656a6c3b84a3c11ff555ec1d66075af3b2c4335bbbe8bccb3568553d7205eb510d95592071e9ad",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE3lGSnrITcxXbR3MdTvKMQXfQTEmQAY4E\ncWVqbDuEo8Ef9VXsHWYHWvOyxDNbu+i8yzVoVT1yBetRDZVZIHHprQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 514,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179802210099999999999999999999999999999998d668eaf0cf91f9bd7317d2547ced5a5a",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "047f478a0ec74f842347962c4c4fdf24556dd6072b1a787beb2ca0c0e0f6420965b08a367106c6d921397b0a322b55c6d658f93d1a08f541955c3f3b0a1c451194",
+        "wx": "7f478a0ec74f842347962c4c4fdf24556dd6072b1a787beb2ca0c0e0f6420965",
+        "wy": "00b08a367106c6d921397b0a322b55c6d658f93d1a08f541955c3f3b0a1c451194"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200047f478a0ec74f842347962c4c4fdf24556dd6072b1a787beb2ca0c0e0f6420965b08a367106c6d921397b0a322b55c6d658f93d1a08f541955c3f3b0a1c451194",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEf0eKDsdPhCNHlixMT98kVW3WBysaeHvr\nLKDA4PZCCWWwijZxBsbZITl7CjIrVcbWWPk9Ggj1QZVcPzsKHEURlA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 515,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022066666666666666666666666666666665e445f1f5dfb6a67e4cba8c385348e6e7",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0431b6688798d48eda210ea3417b2e118ca727b9e147968359ee1edab60c4710b110a53fb782f5f67d6c0f84b18753708f16d22667ade0251a6cf2a885a4ef6b1c",
+        "wx": "31b6688798d48eda210ea3417b2e118ca727b9e147968359ee1edab60c4710b1",
+        "wy": "10a53fb782f5f67d6c0f84b18753708f16d22667ade0251a6cf2a885a4ef6b1c"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000431b6688798d48eda210ea3417b2e118ca727b9e147968359ee1edab60c4710b110a53fb782f5f67d6c0f84b18753708f16d22667ade0251a6cf2a885a4ef6b1c",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEMbZoh5jUjtohDqNBey4RjKcnueFHloNZ\n7h7atgxHELEQpT+3gvX2fWwPhLGHU3CPFtImZ63gJRps8qiFpO9rHA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 516,
+          "comment": "extreme value for k and s^-1",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798022049249249249249249249249249249248c79facd43214c011123c1b03a93412a5",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04e03e9628c7e440d051aafaa110f83ac5f2fd2d614504f0d8d96cb28175e56ebf0a0b78b5951a34adb39680b2bef533c745dd14c6d798188da2d5abf0b321e208",
+        "wx": "00e03e9628c7e440d051aafaa110f83ac5f2fd2d614504f0d8d96cb28175e56ebf",
+        "wy": "0a0b78b5951a34adb39680b2bef533c745dd14c6d798188da2d5abf0b321e208"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004e03e9628c7e440d051aafaa110f83ac5f2fd2d614504f0d8d96cb28175e56ebf0a0b78b5951a34adb39680b2bef533c745dd14c6d798188da2d5abf0b321e208",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE4D6WKMfkQNBRqvqhEPg6xfL9LWFFBPDY\n2WyygXXlbr8KC3i1lRo0rbOWgLK+9TPHRd0UxteYGI2i1avwsyHiCA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 517,
+          "comment": "extreme value for k",
+          "flags": [
+            "ArithmeticError"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f8179802200eb10e5ab95f2f275348d82ad2e4d7949c8193800d8c9c75df58e343f0ebba7b",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5hIOtp3JqPEZV2k+/wOEQio/Re0SKaFVBmcR9CP+xDUuA==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 518,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100aa275665bf8cd2750115f3d8baf4693d8b02b8a06567c354931362f6b0127e6402202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 519,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055d8a99a40732d8afeea0c27450b96c12fac244649e0dce72cbefb962023c2dd02202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+        "wx": "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+        "wy": "00b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeb5mfvncu6xVoGKVzocLBwKb/NstzijZ\nWfKBWxb4F5i3xSWI2Vw7mqJbBAPx7vdXAuhLt1l6q+ZjuC9vBO8ndw==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 520,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3045022100aa275665bf8cd2750115f3d8baf4693d8b02b8a06567c354931362f6b0127e6402202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        },
+        {
+          "tcId": 521,
+          "comment": "public key shares x-coordinate with generator",
+          "flags": [
+            "PointDuplication"
+          ],
+          "msg": "313233343030",
+          "sig": "3044022055d8a99a40732d8afeea0c27450b96c12fac244649e0dce72cbefb962023c2dd02202492492492492492492492492492492463cfd66a190a6008891e0d81d49a0952",
+          "result": "invalid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "01060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff00000001060492d5a5673e0f25d8d50fb7e58c49d86d46d4216955e0aa3d40e1",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv8AAAABBgSS1aVnPg8l2NUPt+WMSdhtRtQhaVXgqj1A4Q==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 522,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450220464a46be43db95757410c8a665daede8e703a3699f8888fca4a43efde5efe909022100d390307c381e99c0bf1708788c05421e0fa46146b87eeae129755afbed10f833",
+          "result": "valid"
+        },
+        {
+          "tcId": 523,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3045022100d03531447558ba41e6fa8903c72810b59f554fb8c22a289e74de72a18fa2486a022059820fc4d1eb161fde46addecf43a68ab392dfb5c5639645974c9e1d02a2d804",
+          "result": "valid"
+        },
+        {
+          "tcId": 524,
+          "comment": "y-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402202b1accd781dfcfbee745099340ae0e3de2f03dbaa877c67a193d01e59af07fd902202102bff66143cec438dfcf25a2830032a7ab997fff87e2d968e68316b0367c2e",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+        "wx": "6e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40caff",
+        "wy": "00fffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046e823555452914099182c6b2c1d6f0b5d28d50ccd005af2ce1bba541aa40cafffffffffef9fb6d2a5a98c1f0da272af0481a73b62792b92bde96aa1e55c2bb4e",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEboI1VUUpFAmRgsaywdbwtdKNUMzQBa8s\n4bulQapAyv/////++fttKlqYwfDaJyrwSBpztieSuSvelqoeVcK7Tg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 525,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100a9bbaa431da61459f596aa0f0e0a04c4aa842c601d80b66df61ca31a956eff00022100f80836e4c9aed5fc5ae68ff3fcc2cc4708b3da87e6a62693eaa3d3fbbee4a62c",
+          "result": "valid"
+        },
+        {
+          "tcId": 526,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450220592022d84bd494ddda81c46a7b9a5c77636895a7e771767e5f4d7d5935c2bd36022100b0da09fb20d6d41b3ba0c3e2ff2a3f6c672d4c1e0b98224be73b8c731dcd8a7d",
+          "result": "valid"
+        },
+        {
+          "tcId": 527,
+          "comment": "y-coordinate of the public key is large",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450220282d848ade945d708a5b24448c820af39109550c98acaa0388a42c0aefdd57ea022100f3813f887784763140ad75d92004dcc2c083f24c2021bca951a0e992c19f2375",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+        "wx": "013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0",
+        "wy": "00f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004000000013fd22248d64d95f73c29b48ab48631850be503fd00f8468b5f0f70e0f6ee7aa43bc2c6fd25b1d8269241cbdd9dbb0dac96dc96231f430705f838717d",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEAAAAAT/SIkjWTZX3PCm0irSGMYUL5QP9\nAPhGi18PcOD27nqkO8LG/SWx2CaSQcvdnbsNrJbcliMfQwcF+DhxfQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 528,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100c684978c7a9b0b25d0fc46085f8fcf25333cf60faa9725f0e3bb8d36fad0115f02210086c7777485160d36534d738df96ebbe466724a2b0ba46037c3c7259d56fcbc69",
+          "result": "valid"
+        },
+        {
+          "tcId": 529,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502210084ead946823e99db2f868445267816f8c768918f43eb63db99fad185a77cb4bf02201ccafad763bfe7f1126d14347281c308bfc26cfdeeceaa0b9500324592ba1d08",
+          "result": "valid"
+        },
+        {
+          "tcId": 530,
+          "comment": "x-coordinate of the public key is small",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "30450221009809aee73683bdb2f11aed700e126218cf83390d03ced4ba1d0d7c510f28e1710220517d7b37cc5a135bc3ebb6b8893184c19cd55906fb81457921459dc2e405b289",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "0425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+        "wx": "25afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dffffffff",
+        "wy": "00fa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a0342000425afd689acabaed67c1f296de59406f8c550f57146a0b4ec2c97876dfffffffffa46a76e520322dfbc491ec4f0cc197420fc4ea5883d8f6dd53c354bc4f67c35",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEJa/WiayrrtZ8Hylt5ZQG+MVQ9XFGoLTs\nLJeHbf/////6RqduUgMi37xJHsTwzBl0IPxOpYg9j23VPDVLxPZ8NQ==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 531,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100ffbd115248ced3e239e69f70aca6b88009a4ba70789dc069f6398bef2689b360022100cd5395067978dd2033be3683b2b89f325ffe36d6c322b3d3cfb0d830c2f6a9e8",
+          "result": "valid"
+        },
+        {
+          "tcId": 532,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100ddcc741a775ba371fbf012387602e4df68ac6417c14a8bc07d33c5bb82012ee602210099c06c1e31ea5d7e599e30b64b4de29753fbd2240c19bca2d45e5c9257706b26",
+          "result": "valid"
+        },
+        {
+          "tcId": 533,
+          "comment": "x-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100ab182993ac64e949230ca990dd5c34000265b89c96e65d17a1a459704e18c483022100acde94f7015284fd8ef8173f0b5848e27328cb53f9767674f3b2d636466f8aac",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+        "wx": "00d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb9",
+        "wy": "3f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004d12e6c66b67734c3c84d2601cf5d35dc097e27637f0aca4a4fdb74b6aadd3bb93f5bdff88bd5736df898e699006ed750f11cf07c5866cd7ad70c7121ffffffff",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE0S5sZrZ3NMPITSYBz1013Al+J2N/CspK\nT9t0tqrdO7k/W9/4i9VzbfiY5pkAbtdQ8RzwfFhmzXrXDHEh/////w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 534,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402203bdd807aa453ebb9f5414a5d69a2be960df3aeb77504baf914cb2e86ee3696f202206cd9d8777addf855fa925cbaf96c0922eb77fbd9d5a694e54fc095311225bf37",
+          "result": "valid"
+        },
+        {
+          "tcId": 535,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304502210090ef85d856713b3663b149af197cb2cdd02a182efc9febcb967cf94cc906a245022049dcd3a2a3830ee767272fdcd6d71ea6d9ebef2966d062d1395997591e2663b0",
+          "result": "valid"
+        },
+        {
+          "tcId": 536,
+          "comment": "y-coordinate of the public key has many trailing 1's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100d488ff59f0511e95f1c453a97f69f8348ebea8df3dd169cb86e3659f9ac3cf6d0221009cee77199ef61962d0536bb2d6ca8df1241c154c5d2b438c4a4642fb8300bf93",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "google-wycheproof",
+        "version": "0.9"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+        "wx": "6d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000",
+        "wy": "00e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a034200046d4a7f60d4774a4f0aa8bbdedb953c7eea7909407e3164755664bc2800000000e659d34e4df38d9e8c9eaadfba36612c769195be86c77aac3f36e78b538680fb",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEbUp/YNR3Sk8KqLve25U8fup5CUB+MWR1\nVmS8KAAAAADmWdNOTfONnoyeqt+6NmEsdpGVvobHeqw/NueLU4aA+w==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 537,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3046022100b1b6f8ef07f038033b16d9bf45bf0dede3933b13628bb0d42d700d6558d2fa27022100952e44f7ccce4b03219f7b03cbb25f8c7f248bff4a6b8dc86091715fa3b991fa",
+          "result": "valid"
+        },
+        {
+          "tcId": 538,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "304402201dfbe3475a56b7154581754170f9bd26ad587963f6602ac2a0b19dc95d5db14702205f91c59ab77032687de74a9d16247342977444050e4b73167132782ad4a71c31",
+          "result": "valid"
+        },
+        {
+          "tcId": 539,
+          "comment": "x-coordinate of the public key has many trailing 0's",
+          "flags": [
+            "EdgeCasePublicKey"
+          ],
+          "msg": "4d657373616765",
+          "sig": "3044022057a0f29be404873953639f069f5b4b0149a241f5da85df21eac9dd58995be0af02202813f7d8bbe6f1d7f3f7dca63670393fd1709496253af1243493536a64eccd6f",
+          "result": "valid"
+        }
+      ]
+    },
+    {
+      "type": "EcdsaVerify",
+      "source": {
+        "name": "github/davidben/ecdsa-non-minimal-tag",
+        "version": "0.1"
+      },
+      "publicKey": {
+        "type": "EcPublicKey",
+        "curve": "secp256k1",
+        "keySize": 256,
+        "uncompressed": "04782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+        "wx": "782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963",
+        "wy": "00af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152"
+      },
+      "publicKeyDer": "3056301006072a8648ce3d020106052b8104000a03420004782c8ed17e3b2a783b5464f33b09652a71c678e05ec51e84e2bcfc663a3de963af9acb4280b8c7f7c42f4ef9aba6245ec1ec1712fd38a0fa96418d8cd6aa6152",
+      "publicKeyPem": "-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAEeCyO0X47Kng7VGTzOwllKnHGeOBexR6E\n4rz8Zjo96WOvmstCgLjH98QvTvmrpiRewewXEv04oPqWQY2M1qphUg==\n-----END PUBLIC KEY-----\n",
+      "sha": "SHAKE256",
+      "tests": [
+        {
+          "tcId": 540,
+          "comment": "signature with non-minimal SEQUENCE tag",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "3f10440220628b14cbf72917074fa426d416fa5c48f06478530212ad30ae2e9010b8c6fdec0220388acfa3ec598bfaf6688d476ee0cef3e8bf39eb316fcc1aa543d281990d187c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 541,
+          "comment": "signature with non-minimal INTEGER tag on r",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "30451f0220628b14cbf72917074fa426d416fa5c48f06478530212ad30ae2e9010b8c6fdec0220388acfa3ec598bfaf6688d476ee0cef3e8bf39eb316fcc1aa543d281990d187c",
+          "result": "invalid"
+        },
+        {
+          "tcId": 542,
+          "comment": "signature with non-minimal INTEGER tag on s",
+          "flags": [
+            "InvalidEncoding"
+          ],
+          "msg": "",
+          "sig": "30450220628b14cbf72917074fa426d416fa5c48f06478530212ad30ae2e9010b8c6fdec1f0220388acfa3ec598bfaf6688d476ee0cef3e8bf39eb316fcc1aa543d281990d187c",
+          "result": "invalid"
+        }
+      ]
+    }
+  ]
+}

--- a/tests/ecc/wycheproof_test.py
+++ b/tests/ecc/wycheproof_test.py
@@ -36,14 +36,26 @@ key and the same signature under both, `invalid` in the first file and
 of the two files whichever way it is wired -- which neither file could
 report on its own.
 
-Four hash functions, for the same reason in a second direction. Bitcoin
-signs with sha256 and nothing else, so the sha512 and SHA3 files are not
-bitcoin signatures and are not here pretending to be: what they hold to
-account is the *generic* ECDSA `dsa.verify_` promises, and they are the
-only adversarial vectors that reach it. `_libsecp256k1_applicable`
-declines every hash but sha256, so those files land on the Python path
-by construction rather than by a patch -- the path `SECURITY.md`
-publishes as not constant-time, under an adversary for the first time.
+Hash functions beyond sha256, for the same reason in a second direction.
+Bitcoin signs with sha256 and nothing else, so the sha512, SHA3 and SHAKE
+files are not bitcoin signatures and are not here pretending to be: what
+they hold to account is the *generic* ECDSA `dsa.verify_` promises, and
+they are the only adversarial vectors that reach it.
+`_libsecp256k1_applicable` declines every hash but sha256, so those files
+land on the Python path by construction rather than by a patch -- the
+path `SECURITY.md` publishes as not constant-time, under an adversary for
+the first time.
+
+The SHAKE files arrive through an adapter, `_PinnedXof` below, because an
+extendable-output function is not a `HashF` and `btclib/alias.py` states
+that it is not: a SHAKE's `digest()` takes the output length that a
+`HashObject`'s does not declare, and its `digest_size` reads 0. The
+adapter pins a length rather than the library growing one, and it is
+`n_size` here because that is the width `challenge_` reads: any length
+from there up is the same test, a SHAKE's output being a stream whose
+longer forms have these very bytes as their prefix. What the adapter is
+not is a route to signing with SHAKE -- `dsa.sign` derives its nonce
+through RFC6979, which is HMAC, and HMAC over an XOF is not defined.
 
 Which implementations answer is therefore read off the hash rather than
 asserted: `_paths` below. Under sha256 a vector runs twice, against the
@@ -55,14 +67,15 @@ so it runs once.
 
 from __future__ import annotations
 
-from hashlib import sha3_256, sha3_512, sha256, sha512
+from collections.abc import Callable
+from hashlib import sha3_256, sha3_512, sha256, sha512, shake_128, shake_256
 from io import BytesIO
 from types import ModuleType
-from typing import Any
+from typing import Any, Protocol
 
 import pytest
 
-from btclib.alias import HashF, Point
+from btclib.alias import HashF, HashObject, Point
 from btclib.curves import mult, point_from_octets, secp256k1
 from btclib.ecc import dh, dsa
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
@@ -74,8 +87,12 @@ _ECDSA = "ecdsa_secp256k1_sha256_test.json"
 _ECDSA_SHA512 = "ecdsa_secp256k1_sha512_test.json"
 _ECDSA_SHA3_256 = "ecdsa_secp256k1_sha3_256_test.json"
 _ECDSA_SHA3_512 = "ecdsa_secp256k1_sha3_512_test.json"
+_ECDSA_SHAKE128 = "ecdsa_secp256k1_shake128_test.json"
+_ECDSA_SHAKE256 = "ecdsa_secp256k1_shake256_test.json"
 _ECDSA_P1363 = "ecdsa_secp256k1_sha256_p1363_test.json"
 _ECDSA_SHA512_P1363 = "ecdsa_secp256k1_sha512_p1363_test.json"
+_ECDSA_SHAKE128_P1363 = "ecdsa_secp256k1_shake128_p1363_test.json"
+_ECDSA_SHAKE256_P1363 = "ecdsa_secp256k1_shake256_p1363_test.json"
 _ECDH = "ecdh_secp256k1_test.json"
 
 # the DER tags the SubjectPublicKeyInfo below is made of
@@ -204,6 +221,111 @@ def _digest(hf: HashF, data: bytes) -> bytes:
     return hash_object.digest()
 
 
+class _Xof(Protocol):
+    """What a SHAKE offers: a digest of the length asked of it.
+
+    `hashlib.shake_128` and `shake_256` satisfy this and not
+    `alias.HashObject`, and the argument of `digest` is the whole of the
+    difference -- an XOF has no output length of its own to report, which
+    is why its `digest_size` is 0 rather than a size.
+    """
+
+    @property
+    def block_size(self) -> int:
+        """Return the internal block length in bytes."""
+        ...
+
+    @property
+    def name(self) -> str:
+        """Return the name hashlib.new would accept."""
+        ...
+
+    def update(self, data: Any, /) -> None:
+        """Absorb more data, as hashlib's update does."""
+        ...
+
+    def digest(self, length: int, /) -> bytes:
+        """Return that many bytes of output."""
+        ...
+
+    def hexdigest(self, length: int, /) -> str:
+        """Return that many bytes of output, as a hex string."""
+        ...
+
+    def copy(self) -> _Xof:
+        """Return a clone that can absorb independently."""
+        ...
+
+
+class _PinnedXof:
+    """A SHAKE at a pinned output length, which is a `HashObject`.
+
+    The one thing it adds is the length, and it adds it where the length
+    is missing: everything else is the wrapped SHAKE answering for
+    itself, `name` and `block_size` included, so a failure names the
+    function that computed the digest rather than this class.
+
+    A test's adapter, deliberately not a library one. `HashF` admitting
+    an XOF would admit it to `dsa.sign` as well, whose nonce is RFC6979
+    -- HMAC, which over an XOF is not defined -- and would answer inside
+    a test module a question `btclib/alias.py` states the answer to.
+    """
+
+    def __init__(self, xof: _Xof, size: int) -> None:
+        self.xof = xof
+        self.size = size
+
+    @property
+    def digest_size(self) -> int:
+        """Return the pinned digest length in bytes."""
+        return self.size
+
+    @property
+    def block_size(self) -> int:
+        """Return the wrapped function's internal block length."""
+        return self.xof.block_size
+
+    @property
+    def name(self) -> str:
+        """Return the wrapped function's name."""
+        return self.xof.name
+
+    def update(self, data: Any, /) -> None:
+        """Absorb more data."""
+        self.xof.update(data)
+
+    def digest(self) -> bytes:
+        """Return the digest, at the pinned length."""
+        return self.xof.digest(self.size)
+
+    def hexdigest(self) -> str:
+        """Return the digest as a hex string, at the pinned length."""
+        return self.xof.hexdigest(self.size)
+
+    def copy(self) -> HashObject:
+        """Return a clone that can absorb independently."""
+        return _PinnedXof(self.xof.copy(), self.size)
+
+
+def _pinned(xof: Callable[[], _Xof], size: int) -> HashF:
+    """Return the `HashF` an XOF is not: a constructor of sized objects.
+
+    A fresh SHAKE per call, not one shared by every caller: a `HashF` is
+    a constructor, and two signatures verified out of one hash object
+    would absorb each other's messages.
+    """
+    return lambda: _PinnedXof(xof(), size)
+
+
+# the pinned length: n_size, and any length from there up is the same
+# test. `challenge_` takes the leftmost `nlen` bits of the message hash,
+# and a SHAKE's output is a stream, so a longer digest has these very
+# bytes as its prefix -- measured, all four files verify identically at
+# 32 and at 64
+_SHAKE128 = _pinned(shake_128, secp256k1.n_size)
+_SHAKE256 = _pinned(shake_256, secp256k1.n_size)
+
+
 def _paths(hf: HashF) -> list[bool]:
     """Say which implementations answer a vector: both, or Python alone.
 
@@ -252,13 +374,44 @@ def _signature_vectors(fname: str, prefix: str, hf: HashF, *extra: Any) -> list[
     ]
 
 
+def test_pinned_xof() -> None:
+    """The adapter pins the output length and answers for nothing else.
+
+    A test of the harness rather than of btclib, and it earns its place
+    twice: the SHAKE files below are read through this class, so a class
+    that quietly hashed something else would make them pass while
+    testing nothing; and the pinned length is only free because a SHAKE's
+    output is a stream, which is asserted here rather than asserted by
+    running every vector a second time at another length.
+    """
+    hash_object = _SHAKE128()
+    hash_object.update(b"btclib")
+    reference = shake_128(b"btclib")
+
+    assert hash_object.digest_size == secp256k1.n_size
+    assert hash_object.block_size == reference.block_size
+    assert hash_object.name == reference.name
+    assert hash_object.digest() == reference.digest(secp256k1.n_size)
+    assert hash_object.hexdigest() == reference.hexdigest(secp256k1.n_size)
+
+    clone = hash_object.copy()
+    clone.update(b"!")
+    assert clone.digest() != hash_object.digest()
+
+    wider = _pinned(shake_128, 2 * secp256k1.n_size)()
+    wider.update(b"btclib")
+    assert wider.digest()[: secp256k1.n_size] == hash_object.digest()
+
+
 @pytest.mark.parametrize(
     "key, vector, lower_s, hf, bindings",
     _signature_vectors(_ECDSA_BITCOIN, "bitcoin", sha256, True)
     + _signature_vectors(_ECDSA, "ecdsa", sha256, False)
     + _signature_vectors(_ECDSA_SHA512, "sha512", sha512, False)
     + _signature_vectors(_ECDSA_SHA3_256, "sha3-256", sha3_256, False)
-    + _signature_vectors(_ECDSA_SHA3_512, "sha3-512", sha3_512, False),
+    + _signature_vectors(_ECDSA_SHA3_512, "sha3-512", sha3_512, False)
+    + _signature_vectors(_ECDSA_SHAKE128, "shake128", _SHAKE128, False)
+    + _signature_vectors(_ECDSA_SHAKE256, "shake256", _SHAKE256, False),
 )
 def test_ecdsa_der(
     key: str,
@@ -297,7 +450,9 @@ def test_ecdsa_der(
 @pytest.mark.parametrize(
     "key, vector, hf, bindings",
     _signature_vectors(_ECDSA_P1363, "p1363", sha256)
-    + _signature_vectors(_ECDSA_SHA512_P1363, "p1363-sha512", sha512),
+    + _signature_vectors(_ECDSA_SHA512_P1363, "p1363-sha512", sha512)
+    + _signature_vectors(_ECDSA_SHAKE128_P1363, "p1363-shake128", _SHAKE128)
+    + _signature_vectors(_ECDSA_SHAKE256_P1363, "p1363-shake256", _SHAKE256),
 )
 def test_ecdsa_p1363(
     key: str,


### PR DESCRIPTION
Group 2 of https://github.com/btclib-org/btclib/issues/706, the one the
issue left open as a decision: Wycheproof's four SHAKE files are 1580
more adversarial cases for the *generic* ECDSA of `dsa.verify_`, and the
only thing in front of them was a type.

`hashlib.shake_128` is not a `HashF`. An extendable-output function has
no output length of its own -- `digest()` takes one as an argument and
`digest_size` reads 0 -- so it fails `alias.HashObject` under mypy, and
at run time makes `challenge_` demand a zero-length message hash, which
`verify_` catches and reports as `False`. Importing the files with no
adapter would have produced a half-green suite reporting an unsupported
hash as a bad signature.

## The decision: the length is pinned here, not in the library

`_PinnedXof` in `tests/ecc/wycheproof_test.py` wraps a SHAKE and reports
the length it was built with. Everything else is the wrapped function
answering for itself, `name` and `block_size` included.

`HashF` does not grow to admit an XOF, and the reason is not aesthetic:
it would admit one to `dsa.sign` too, whose nonce is RFC6979 -- HMAC,
which over an XOF is not defined, NIST specifying KMAC instead. The
standard library refuses the same substitution in the same place, which
is the measured half of the argument:

```text
error: Argument 3 to "new" has incompatible type
  "def openssl_shake_128(...) -> HASHXOF";
  expected "str | Callable[[], _HashObject] | Module"
```

and typeshed derives `HASHXOF` from `HASH` only through a
`type: ignore[override]`. https://github.com/btclib-org/btclib/pull/708
writes that rule into `btclib/alias.py`, so this adapter applies a stated
rule instead of quietly answering the question in a test module. The two
PRs touch no file in common and either can land first.

## Why `n_size` is a free choice

`challenge_` reads the leftmost `nlen` bits of the message hash, and a
SHAKE's output is a stream: a longer digest carries these very bytes as
its prefix. Measured -- all four files verify identically at 32 bytes and
at 64. `test_pinned_xof` asserts that prefix property, and asserts the
adapter passes the wrapped function's own answers through, rather than
running every vector a second time at another length.

## What the vectors do

All 1580 pass as they are, so this is coverage of a class rather than a
fix. All of them land on the Python arithmetic by construction:
`_libsecp256k1_applicable` admits sha256 alone, so a SHAKE never reaches
the bindings -- `SECURITY.md`'s not-constant-time path, under an
adversary. The two SHAKE256 files carry a case the others cannot,
upstream's `Untruncatedhash`: a signature made over the whole digest
instead of its leftmost `nlen` bits, `invalid` and staying so.

## Also

- `tests/_data/README.md`: four entries replacing the "not vendored"
  one, each with upstream's blob id, which is identical to ours byte for
  byte. `behind` names the commit that last changed the path
  (`e0df04e0`, 2025-10-07) rather than claiming the pin is that commit.
- The README's stated counts of Wycheproof files go, as `CLAUDE.md`
  asks: the entries are the count, and "seven" was already wrong at
  eight files.

Gates green locally: `pre-commit run --all-files`, `pytest` (25958
passed, +1580 and the adapter's own test, coverage ratchet included), and
`sphinx-build -W`.

Closes #706

## Summary by Sourcery

Add Wycheproof SHAKE ECDSA test vectors and support them via a test-only adapter that pins SHAKE output length, while documenting the decision and updating data/README and changelog accordingly.

New Features:
- Include four SHAKE-based ECDSA Wycheproof JSON vector files in the test data and run them against generic ECDSA verification in both DER and P1363 profiles.

Enhancements:
- Introduce a `_PinnedXof` adapter and helper to treat SHAKE as fixed-length hashes for tests without changing the library hash type surface.
- Clarify documentation around Wycheproof file counts, SHAKE handling, and the distinction between vendored and non-vendored test vectors in tests/_data/README.md.
- Update the changelog to record the addition of SHAKE Wycheproof tests and the decision to keep XOF support out of the public hash API.

Tests:
- Add test coverage for the `_PinnedXof` adapter and integrate SHAKE128 and SHAKE256 Wycheproof ECDSA vectors into the existing parametrized ECDSA test suite.