### PR TITLE
Drop the bytes() around a digest, which HashObject made a no-op

### DIFF
--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -51,7 +51,7 @@ def _hash(m: bytes, R: bytes, i: int, j: int, hf: HashF) -> bytes:
     )
     hasher = hf()
     hasher.update(temp)
-    return bytes(hasher.digest())
+    return hasher.digest()
 
 
 PubkeyRing = Sequence[Point]
@@ -65,7 +65,7 @@ def _get_msg_format(
     )
     hasher = hf()
     hasher.update(msg + t)
-    return bytes(hasher.digest())
+    return hasher.digest()
 
 
 SValues = Sequence[list[int]]
@@ -141,7 +141,7 @@ def sign(
         e0bytes += r
     hasher = hf()
     hasher.update(e0bytes)
-    e0 = bytes(hasher.digest())
+    e0 = hasher.digest()
     # step 2
     # strict=True: see step 1
     for i, (j_star, k) in enumerate(zip(sign_key_idx, ks, strict=True)):
@@ -239,6 +239,6 @@ def assert_as_valid(
                 e0bytes += r
     hasher = hf()
     hasher.update(e0bytes)
-    e0_prime = bytes(hasher.digest())
+    e0_prime = hasher.digest()
     if e0_prime != e0:
         raise BTClibRuntimeError("signature verification failed")

--- a/btclib/hashes.py
+++ b/btclib/hashes.py
@@ -129,7 +129,7 @@ def reduce_to_hlen(msg: Octets, hf: HashF = hashlib.sha256) -> bytes:
     # Step 4 of SEC 1 v.2 section 4.1.3
     h = hf()
     h.update(msg)
-    return bytes(h.digest())
+    return h.digest()
 
 
 def magic_message(msg: Octets) -> bytes:
@@ -310,4 +310,4 @@ def tagged_hash(tag: bytes, m: bytes, hf: HashF = hashlib.sha256) -> bytes:
     # it could be sped up by storing the above midstate
 
     h2.update(m)
-    return bytes(h2.digest())
+    return h2.digest()


### PR DESCRIPTION
`bytes(h.digest())` was the cast that made mypy see `bytes`, back when
the `hf` alias was `Callable[[], Any]` and `digest()` answered `Any`.
`alias.HashObject` types it `-> bytes`, so today the call converts bytes
to bytes -- and not even a copy:

```text
>>> d = hashlib.sha256(b"btclib").digest()
>>> bytes(d) is d
True
```

Six sites, which is all of them:

```shell
git grep 'bytes(.*\.digest()' -- btclib tests   # re-measured to zero
```

`btclib/hashes.py` in `reduce_to_hlen` and `tagged_hash`,
`btclib/ecc/borromean.py` in `_hash`, `_get_msg_format`, `sign` and
`assert_as_valid`. Every one returns exactly what it returned;
`reduce_to_hlen` and `tagged_hash` still hand back `bytes`, checked at
run time and not only by mypy.

**Nothing replaces them.** `hf()` then `update()` then `digest()` is
hashlib's own spelling, and folding it into a `_digest(data, hf)` helper
would trade an idiom every Python reader knows for one of btclib's, at
three new cross-module imports of a private name for fourteen lines. The
one place the repetition was real is `tests/ecc/wycheproof_test.py`,
which already has its own `_digest` at the call site that needed it --
which is the shape to keep.

The `bytes(...)` calls left in the package are conversions that convert:
a bytearray out of a base conversion, a dataclass field, a memoryview
slice.

No CHANGELOG entry: the values, the types and the API are unchanged.

Gates green locally: `pre-commit run --all-files`, `pytest` (25958
passed, coverage ratchet included).

## Summary by Sourcery

Enhancements:
- Remove no-op bytes() wrapping around hashlib digest results in Borromean signature helpers and hash utilities to streamline code.