### PR TITLE
Name both underscore conventions, the trailing one being public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,9 +163,24 @@ documented at release-notes length in the first place, and are still in
   `btclib.bip32` is the shape to copy, `derive` validating and `_derive`
   not, with `_key_data_from_bip32_key` the one place a `BIP32Key` becomes a
   validated `BIP32KeyData` and `descriptors` composing the twins directly.
-  And that a leading underscore therefore says a second thing here, beside
-  what `__all__` decides about publicity: the twin does not validate, and
-  calling it asserts that its caller did.
+  And that the leading underscore those twins carry means what it means
+  anywhere in Python: private, `__all__` deciding publicity, so that an
+  unvalidating twin belongs on the private side of that list and calling
+  one asserts that its caller validated.
+
+  **Both underscore conventions, each with what it means** (#711). The two
+  spellings are different things, and the section named only one of them: a
+  *trailing* underscore is public -- `dsa.sign_`, `musig2.nonce_gen_` and
+  `musig2.partial_sig_verify_` are all in their module's `__all__` -- and
+  marks the spelling whose input the caller has already prepared, not one
+  that skips the validation. `btclib.ecc.dsa._assert_as_valid_` carries
+  both underscores, which is what shows the conventions to be independent.
+  Publishing both names of a pair is then what makes their agreement a
+  promise: a keyword added to `verify` goes on `verify_` too, with the same
+  default, the prepared argument being the one difference the pair exists
+  for. Left unsaid, the wording invited exactly the mistake #695's first
+  design made, giving the trailing-underscore spellings a default their
+  plain siblings did not have.
 
   The exception is named rather than passed over, because a reader finding
   a class that asks nothing needs to know which kind it is: where a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -728,9 +728,29 @@ a `BIP32Key` of any spelling becomes a validated `BIP32KeyData`, every
 public wrapper going through it. `descriptors` then composes the twins
 directly — `_xpub_from_xprv(_derive(_key_data_from_bip32_key(xprv),
 prefix))` — paying one validation instead of three, and no base58 round
-trip between them. So a leading underscore says a second thing here,
-beside what `__all__` already decides about publicity: the twin does not
-validate, and calling it asserts that its caller did.
+trip between them. The leading underscore those three carry means what it
+means anywhere in Python: private. `__all__` is what decides publicity, so
+it is a reader's hint rather than the rule, but an unvalidating twin
+belongs on the private side of that list, and calling one asserts that its
+caller validated.
+
+**A trailing underscore is the other convention, and it is public.** It
+marks the spelling whose input the caller has already prepared: `dsa.sign_`
+takes the hash `sign` would compute, `musig2.nonce_gen_` the randomness
+`nonce_gen` draws, `musig2.partial_sig_verify_` the session context
+`partial_sig_verify` aggregates. Both names of the pair are in `__all__`,
+so it is an offer to skip work the caller has already paid for, not a way
+past the validation above: `sign_` checks its `msg_hash` as `sign` checks
+its `msg`. The two conventions are independent, and
+`btclib.ecc.dsa._assert_as_valid_` carries both.
+
+Publishing both names is what makes their agreement a promise rather than
+a tidiness. A keyword added to `verify` is added to `verify_` or to
+neither, with the same default in both: a flag that changes the answer on
+one and is missing or defaulted differently on the other makes the pair
+two functions instead of two spellings, and a caller who reduced the
+message first quietly gets a different rule. The prepared argument is the
+one difference the pair exists for.
 
 The exception is a boundary at which nothing can be invalid, and it is
 named rather than passed over: where a class's invariants are exactly the


### PR DESCRIPTION
CONTRIBUTING.md's "The public surface" said that a leading underscore
means the twin does not validate. That is true of `_derive` and wrong as
a statement about the convention: the two spellings are different things,
and the section named only one of them. A reader taking it at face value
reads `verify_` as private, and reads a trailing-underscore twin as free
to differ from its plain sibling.

A leading underscore means what it means anywhere in Python — private,
with `__all__` deciding publicity here — and an unvalidating twin is on
the private side of that list. A trailing underscore is public:
`dsa.sign_`, `musig2.nonce_gen_` and `musig2.partial_sig_verify_` are each
in their module's `__all__` beside their plain sibling, and each takes an
input the caller has already prepared — the hash `sign` would compute, the
randomness `nonce_gen` draws, the session context `partial_sig_verify`
aggregates. It is an offer to skip work already paid for, not a way past
the validation: `sign_` checks its `msg_hash` as `sign` checks its `msg`.
`dsa._assert_as_valid_` carries both underscores, which is what shows the
conventions to be independent.

Publishing both names of a pair is then what makes their agreement a
promise rather than a tidiness, so the same-signature rule goes where the
pair is described: a keyword added to `verify` goes on `verify_` too, with
the same default, the prepared argument being the one difference the pair
exists for. Left unsaid, the old wording invited exactly the mistake
https://github.com/btclib-org/btclib/issues/695's first design made,
giving the trailing-underscore spellings a default their plain siblings
did not have.

The bip32 example around the sentence stands and is kept; it is the
generalisation that does not.

One detail of the issue is not in the tree and so is not in the text:
`bms.__all__` has no trailing-underscore name. Every public one lives in
`btclib/ecc`, `dsa`, `ssa`, `musig2`, `rfc6979_nonce`, `bip340_nonce` and
`commit_nonce` being the modules.

The CHANGELOG bullet of
https://github.com/btclib-org/btclib/pull/698 is corrected in place rather
than answered by a second one: v2026.9 is unreleased, so its record is
what the file will say, not a pair of entries contradicting each other.

Gates, all green locally: `uv run pre-commit run --all-files`, the sphinx
`-W` build, and `uv run pytest` at 25958 passed with coverage 100.00%.

Closes https://github.com/btclib-org/btclib/issues/711

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify the underscore naming conventions used in the public API, distinguishing private leading-underscore helpers from public trailing-underscore variants with preprocessed inputs, and update release notes to reflect this corrected explanation.

Documentation:
- Revise CONTRIBUTING guidance to clearly document both leading-underscore (private, non-validating helpers) and trailing-underscore (public, prevalidated-input) conventions and their contractual alignment.
- Correct the unreleased CHANGELOG entry to describe both underscore conventions consistently and reference the prior design mistake without adding a separate contradictory entry.