### PR TITLE
Take both forms of s, and grind low-R by default as Core does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,6 +688,47 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **Nothing that reads a signature takes `lower_s` any more** (#695, #645).
+  `dsa.assert_as_valid`, `verify`, `recover_pub_keys`, `recover_pub_key`,
+  their four trailing-underscore twins, `dsa.anti_exfil_host_verify` and
+  `bms.assert_as_valid` and `bms.verify` all had it, defaulting to `True`,
+  and all nine have lost it: whether `s` is the low one of the two was
+  decided by whoever signed, so a verifier refusing the other is refusing a
+  signature that signer was free to make. Bitcoin Core's `MessageVerify`
+  never applied the rule, and its `CPubKey::Verify` normalizes `s` before
+  verifying for this very reason.
+
+  What that measured, on the 200 vectors of
+  `tests/ecc/_data/signmessage.json`: Core v31.1.0's `verifymessage`
+  accepts every one, btclib's default refused the 88 that are high-s, and
+  the low-s rule was the whole of the disagreement. Two library callers of
+  `bms.assert_as_valid` sat on that default and are fixed by losing it --
+  `bip322`'s legacy path, the compatibility spelling BIP322 keeps, and
+  `psbt_signer.sign_message`, checking what an *external* signer returned
+  through HWI, which is not btclib's to normalize. The two `dsa.verify_`
+  calls inside `psbt` had already reached the conclusion the other way
+  round: both passed `lower_s=False`, with a docstring saying the rule is
+  the script engine's and not the Finalizer's.
+
+  The rule itself is not gone, and none of this makes a high-s signature a
+  good idea: `SCRIPT_VERIFY_LOW_S` is in Core's
+  `STANDARD_SCRIPT_VERIFY_FLAGS` (`src/policy/policy.h`), so one inside a
+  transaction is non-standard and does not relay. `sign` therefore keeps
+  `lower_s=True`, which is where the rule belongs, and the script engine
+  keeps reading it off its own flags. Asking a verifier for it is what the
+  leading-underscore functions are for -- `_assert_as_valid_`,
+  `_recover_pub_key_`, `_recover_pub_keys_` and the two
+  `_libsecp256k1_recover_*` -- each taking `lower_s: bool = False`
+  keyword-only, so the strict answer is asked for rather than assumed, and
+  the bindings path and the Python path can be held to one answer under it.
+  A trailing underscore does not enter into it: those functions are public,
+  offered beside the plain name so a caller can skip work already paid, and
+  a keyword on one and not the other would make them two functions instead
+  of a bypass.
+
+  On the bindings path `assert_as_valid_` now normalizes unconditionally --
+  libsecp256k1 rejects what is not in lower-s form -- where it normalized
+  only when the rule was switched off.
 - **Cracking refuses a child the library itself refuses** (#693).
   `crack_prv_key` exists to demonstrate a known BIP32 weakness, so a wrong
   answer from it is a wrong lesson: it subtracted the derivation offset
@@ -965,29 +1006,39 @@ documented at release-notes length in the first place, and are still in
   own, retries included. No attempt cap, as in Core: one would answer an
   event of probability `2**-k` with an error a caller can do nothing about.
 
-  `grind=False` is the default, where Core has it on. A ground signature is
-  not the RFC6979 one for about half of all messages, and a caller pinning
-  btclib's deterministic signatures is entitled to keep getting them; the
-  five python-bitcoinlib vectors say the same thing from the other side,
-  four of the five having a high `r`, so grinding departs from exactly
-  those four -- `test_rfc6979_secp256k1_grinding_leaves_only_the_low_r_one`
-  beside the test that counts the four `s` values normalization moves.
+  `grind` has three states, not two, and it is on when left unsaid: a
+  btclib signature is the one Core would have made. `grind=None` is that
+  default, `grind=True` is a caller asking outright and `grind=False` is
+  the plain RFC6979 signature -- which is what a test pinning deterministic
+  bytes now asks for, the five python-bitcoinlib vectors among them, four
+  of the five having a high `r` so that grinding departs from exactly those
+  four (`test_rfc6979_secp256k1_grinding_leaves_only_the_low_r_one`, beside
+  the test that counts the four `s` values normalization moves).
   Keyword-only, `ec` and `hf` being positional and a flag inserted before
   them renumbering both.
 
   Grinding is refused with a nonce of the caller's and with a
   sign-to-contract commitment, each of which already owns what grinding
   needs -- the nonce itself, and the extra entropy the counter travels
-  through. For the commitment that is more than a clash of encodings:
-  grinding a nonce is exactly the freedom the ECDSA anti-exfil protocol
-  takes away from a signing device, and `sign_` is the call that protocol
-  signs through. `sign_recoverable` takes no `grind` either, and there it
-  is not a matter of what owns the nonce: 65 bytes of `r`, `s` and the
-  recovery flag have no pad for a low `r` to save, which is why Core's
-  `SignCompact` does not grind. What grinding chooses is `r` and not the
-  encoded length: embit stops its loop at `len(sig.serialize()) > 70`,
-  which is the same question only for a low `s`, and with `lower_s=False`
-  btclib produces the 71-byte low-R signature Core cannot reach.
+  through -- and the third state is why the refusal is a refusal rather
+  than a footgun: `grind=True` beside either of those is a caller asking
+  for both halves of a contradiction, while the default is a library
+  preference and gives way, so `sign(msg, key, nonce)` signs instead of
+  raising. For the commitment the refusal is more than a clash of
+  encodings: grinding a nonce is exactly the freedom the ECDSA anti-exfil
+  protocol takes away from a signing device, and `sign_` is the call that
+  protocol signs through -- `anti_exfil_sign` therefore grinds nothing,
+  without having to say so. `sign_recoverable` takes no `grind` at all,
+  and there it is not a matter of what owns the nonce: 65 bytes of `r`, `s`
+  and the recovery flag have no pad for a low `r` to save, which is why
+  Core's `SignCompact` does not grind and why a message signature is
+  unaffected. `bip322.sign` asks for `grind=False` in so many words: the
+  BIP's reference implementation signs plain, its vectors are the whole
+  interoperability claim, and nothing there is broadcast for the byte to
+  matter. What grinding chooses is `r` and not the encoded length: embit
+  stops its loop at `len(sig.serialize()) > 70`, which is the same
+  question only for a low `s`, and with `lower_s=False` btclib produces
+  the 71-byte low-R signature Core cannot reach.
 
   The private `_rfc6979_nonce_` takes `None` for no additional data now,
   where it took `b""`, so one counter value travels down either path
@@ -1529,12 +1580,17 @@ documented at release-notes length in the first place, and are still in
   rather than written here.
 
   Two of the four are the same algorithm over the same curve and hash,
-  and that is the point of taking both: `EcdsaBitcoinVerify` is
-  `lower_s=True` and refuses the malleable high-s twin, `EcdsaVerify` is
-  `lower_s=False` and accepts it, and their tcId 5 is the same key and the
-  same signature -- `invalid` in one file and `valid` in the other. A
-  `lower_s` wired the wrong way round now fails one of the two whichever
-  way it is wired, which neither file could report on its own. The third
+  and that is the point of taking both: `EcdsaBitcoinVerify` requires the
+  strict DER encoding and the low-s rule where `EcdsaVerify` requires
+  neither, so the same key and the same signature is `invalid` in one file
+  and `valid` in the other -- twice over, tcId 1 and tcId 388 of the
+  bitcoin file being tcId 5 and tcId 392 of the generic one. btclib's
+  parser is the strict one and its verifier applies no low-s rule, so those
+  two verdicts are exempted, and the exemption is read out of the second
+  file rather than written down: `invalid` there and `valid` here is a case
+  whose only defect is the form of `s`. A flag would find one of the two,
+  tcId 388 carrying `ArithmeticError` beside six cases that are invalid for
+  their arithmetic. The third
   is IEEE P1363, raw `r` and `s` side by side with no DER in front, so
   `Sig` answers for the pair directly: r and s at zero, at n, and at n
   plus a valid value. The fourth is ECDH, where the public key arrives

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,30 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **verifying and recovering no longer take `lower_s`.**
+  `dsa.assert_as_valid`, `dsa.verify`, `dsa.recover_pub_keys`,
+  `dsa.recover_pub_key` and their four trailing-underscore twins used to
+  take `lower_s: bool = True` in the slot before `hf`, and
+  `bms.assert_as_valid` and `bms.verify` in the slot after the signature:
+  `dsa.verify(msg, key, sig, True, sha256)` and `bms.verify(msg, addr,
+  sig, False)` are a `TypeError` now, as is either spelled as a keyword.
+  Drop the argument. Both forms of `s` are then accepted, which is what
+  the `True` default refused and what Bitcoin Core's `verifymessage`
+  always accepted -- whether `s` is the low one of the two was decided by
+  whoever signed. A caller that does want the strict answer asks a private
+  function for it: `dsa._assert_as_valid_(c, QJ, r, s, ec,
+  lower_s=True)`. `dsa.sign` is unchanged, `lower_s=True` and all, the
+  rule being the signer's: a high-s signature in a transaction is
+  non-standard and does not relay.
+- **an ECDSA signature is low-R now.** `dsa.sign` and `dsa.sign_` grind
+  for it wherever the nonce is theirs to derive, as Core has done since
+  its 0.17, so the signature of a given key and message is a different one
+  for about half of all messages -- and one DER byte shorter. `grind=False`
+  is the plain RFC6979 signature, which is what a caller pinning btclib's
+  bytes has to pass now. `dsa.sign_recoverable` and with it `bms.sign` are
+  unaffected, a compact signature having no DER pad to save, and so is
+  `bip322.sign`, which asks for the plain signature to keep reproducing
+  the BIP's own vectors.
 - **a MOV-weak curve is refused with `BTClibValueError`, not
   `UserWarning`.** `Curve(p, a, b, G, n, cofactor)` with the default
   `weakness_check=True` used to raise `UserWarning("weak curve")` for a

--- a/btclib/bip322.py
+++ b/btclib/bip322.py
@@ -693,7 +693,12 @@ def sign(msg: Octets, prv_key: PrvKey, addr: String) -> Sig:
         return Sig(Witness([ssa.sign_(msg_hash, tweaked).serialize()]))
 
     msg_hash = from_tx(spend.vout, tx, 0, ALL)
-    signature = dsa.sign_(msg_hash, q).serialize() + ALL.to_bytes(1, "big")
+    # grind=False, against `sign_`'s own default: the BIP's reference
+    # implementation signs the plain RFC6979 signature, and its vectors are
+    # the whole interoperability claim of this function -- a ground one
+    # would be valid, a byte shorter, and equal to nobody's published bytes.
+    # Nothing is broadcast here either, so that byte buys nothing
+    signature = dsa.sign_(msg_hash, q, grind=False).serialize() + ALL.to_bytes(1, "big")
 
     if script_type == "p2pkh":
         tx.vin[0].script_sig = serialize([signature, pub_key])

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -365,9 +365,7 @@ def _assert_p2wpkh_p2sh(addr: String, rf: int, pub_key: bytes, h160: bytes) -> N
         raise BTClibValueError(f"invalid p2wpkh-p2sh address: {addr!r}")
 
 
-def assert_as_valid(
-    msg: Octets, addr: String, sig: Sig | String, lower_s: bool = True
-) -> None:
+def assert_as_valid(msg: Octets, addr: String, sig: Sig | String) -> None:
     """Refuse a signature that does not open to the address.
 
     The public key is recovered from the signature under the magic
@@ -397,10 +395,10 @@ def assert_as_valid(
     # itself and 2.4 the r-congruence check of the Sig validation above
     if _libsecp256k1_applicable(secp256k1):
         pub_key = _libsecp256k1_recover_sec_(
-            key_id, reduce_to_hlen(magic_msg), sig.dsa_sig, lower_s, compressed
+            key_id, reduce_to_hlen(magic_msg), sig.dsa_sig, compressed
         )
     else:
-        Q = dsa.recover_pub_key(key_id, magic_msg, sig.dsa_sig, lower_s, sha256)
+        Q = dsa.recover_pub_key(key_id, magic_msg, sig.dsa_sig, sha256)
         pub_key = bytes_from_point(Q, compressed=compressed)
 
     # the address says which of the three checks applies, and each of them
@@ -421,7 +419,7 @@ def assert_as_valid(
     _assert_p2wpkh_p2sh(addr, sig.rf, pub_key, h160)
 
 
-def verify(msg: Octets, addr: String, sig: Sig | String, lower_s: bool = True) -> bool:
+def verify(msg: Octets, addr: String, sig: Sig | String) -> bool:
     """Verify address-based compact signature for the provided message."""
     # ValueError and BTClibRuntimeError, not Exception: an input that is not
     # a valid signature is False, and so is a verification that failed, but
@@ -430,7 +428,7 @@ def verify(msg: Octets, addr: String, sig: Sig | String, lower_s: bool = True) -
     # BTClibRuntimeError by name and not RuntimeError, because
     # RecursionError is one and is not an answer about a signature
     try:
-        assert_as_valid(msg, addr, sig, lower_s)
+        assert_as_valid(msg, addr, sig)
     except (ValueError, BTClibRuntimeError):
         return False
 

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -8,12 +8,18 @@ Implementation according to SEC 1 v.2:
 
 http://www.secg.org/sec1-v2.pdf
 
-specialized with bitcoin canonical 'lower-s' form
-to avoid accepting malleable signatures.
+specialized with bitcoin canonical 'lower-s' form, which is what ``sign``
+produces: a high-s signature is non-standard and does not relay, so
+normalizing is the signer's job. Verification and recovery take both
+forms and offer no flag to refuse either -- which form s carries was
+decided by whoever signed, and refusing one refuses a signature that
+signer was free to make. The rule survives where it belongs: in ``sign``,
+in the script engine's own flags, and in the leading-underscore functions
+a test asks for it with.
 
-``sign`` grinds for a low-R signature -- one byte shorter in DER -- when
-asked to, which is Core's default and not this library's: ``_grind_low_r``
-is the loop and says why.
+``sign`` also grinds for a low-R signature -- one byte shorter in DER --
+wherever the nonce is its own to derive, as Core does; ``_grind_low_r`` is
+the loop and says why.
 
 ``sign`` also takes a value to commit to inside the nonce,
 sign-to-contract style (see btclib.ecc.commit_nonce for the tweak), and
@@ -456,7 +462,7 @@ def sign_(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool = ...,
+    grind: bool | None = ...,
     commit_hash: None = None,
 ) -> Sig: ...
 
@@ -470,7 +476,7 @@ def sign_(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool = ...,
+    grind: bool | None = ...,
     commit_hash: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -483,7 +489,7 @@ def sign_(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     *,
-    grind: bool = False,
+    grind: bool | None = None,
     commit_hash: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """Sign a hf_len bytes message according to ECDSA signature algorithm.
@@ -491,14 +497,17 @@ def sign_(
     If the deterministic nonce is not provided, the RFC6979
     specification is used.
 
-    grind asks for a low-R signature, one byte shorter in DER: `_grind_low_r`
-    is the loop, Core's since its 0.17. Off by default, where Core has it
-    on, because it is a departure from RFC6979 for about half of all
-    messages -- the nonce of a ground signature is derived with a counter
-    in it -- and a caller pinning this library's deterministic signatures
-    is entitled to keep getting them. Keyword-only, rather than beside
-    lower_s where it belongs by subject: ec and hf are positional here and
-    a flag inserted before them would renumber both.
+    grind asks for a low-R signature, one byte shorter in DER:
+    `_grind_low_r` is the loop, Core's since its 0.17 and its default
+    there. Left unsaid it is on wherever the nonce is this library's to
+    derive, so that a btclib signature is the one Core would have made;
+    asked for outright it is refused beside a nonce or a commitment, which
+    is the difference the three states carry -- a default is a library
+    preference and cannot contradict a caller, where `grind=True` beside
+    either of those two is a caller asking for both halves of a
+    contradiction. Keyword-only, rather than beside lower_s where it
+    belongs by subject: ec and hf are positional here and a flag inserted
+    before them would renumber both.
 
     commit_hash is a value to commit to inside the nonce, sign-to-contract
     style: the signature is an ordinary one, and the receipt returned
@@ -534,8 +543,15 @@ def sign_(
     # protocol takes away from a signing device, see
     # anti_exfil_host_commit, and this is the call that protocol signs
     # through
-    if grind and (nonce is not None or commit_hash is not None):
+    owns_the_nonce = nonce is not None or commit_hash is not None
+    if grind and owns_the_nonce:
         raise BTClibValueError("grinding derives its own nonce")
+    # and None is the caller not having said: grind where there is a nonce
+    # to grind and stay out of the way where there is not. Refusing those
+    # two by default would refuse `sign(msg, key, nonce)` itself -- a
+    # caller who asked for one thing, told they asked for two
+    if grind is None:
+        grind = not owns_the_nonce
 
     # a nonce provided by the caller is the nonce, while what
     # libsecp256k1 takes is extra entropy for the RFC6979 nonce it
@@ -599,7 +615,7 @@ def sign(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool = ...,
+    grind: bool | None = ...,
     commit: None = None,
 ) -> Sig: ...
 
@@ -613,7 +629,7 @@ def sign(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool = ...,
+    grind: bool | None = ...,
     commit: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -626,7 +642,7 @@ def sign(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     *,
-    grind: bool = False,
+    grind: bool | None = None,
     commit: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """ECDSA signature with canonical low-s preference.
@@ -746,7 +762,7 @@ def sign_recoverable(
 
 
 def _assert_as_valid_(
-    c: int, QJ: JacPoint, r: int, s: int, lower_s: bool, ec: Curve
+    c: int, QJ: JacPoint, r: int, s: int, ec: Curve, *, lower_s: bool = False
 ) -> None:
     # Private function for test/dev purposes
 
@@ -805,7 +821,6 @@ def assert_as_valid_(
     msg_hash: Octets,
     key: PubKey,
     sig: Sig | Octets,
-    lower_s: bool = True,
     hf: HashF = sha256,
     *,
     commit_hash: Octets | None = None,
@@ -816,9 +831,14 @@ def assert_as_valid_(
     The message enters already reduced -- msg_hash, not the message --
     which is what the trailing underscore says; assert_as_valid is the
     spelling that reduces with hf first. Errors carry the reason,
-    ``verify_`` being the boolean answer; lower_s asks for the BIP62 rule
-    that refuses the malleable high-s twin. With commit_hash and
-    receipt the sign-to-contract commitment is opened as well.
+    ``verify_`` being the boolean answer. With commit_hash and receipt the
+    sign-to-contract commitment is opened as well.
+
+    Both forms of s are accepted, and there is no flag to ask otherwise:
+    which of the two a signature carries was decided by whoever signed it,
+    so a verifier refusing one is refusing a signature the signer was free
+    to make. The low-s rule belongs to the signer -- ``sign`` applies it --
+    and to the script engine, which reads it off its own flags.
     """
     # key is a PubKey, not a Key: verification is where a private key
     # accepted for a public one does real harm, silently checking a
@@ -850,10 +870,10 @@ def assert_as_valid_(
         # not free even delegated: 0.54 us against 3.1, of a verification
         # that is 22 in total
         sig_bytes = sig.serialize(check_validity=False)
-        # libsecp256k1 rejects what is not in the lower-s form: if it is
-        # not to be enforced, then normalize
-        if not lower_s:
-            sig_bytes = libsecp256k1_dsa.normalize(sig_bytes)
+        # libsecp256k1 rejects what is not in the lower-s form, and which
+        # form a signature is in was the signer's choice: normalize, rather
+        # than refuse what the signer was free to produce
+        sig_bytes = libsecp256k1_dsa.normalize(sig_bytes)
         if not libsecp256k1_dsa.verify(msg_hash_bytes, pubkey_bytes, sig_bytes):
             raise BTClibRuntimeError("signature verification failed")
         return
@@ -862,14 +882,13 @@ def assert_as_valid_(
     Q = point_from_pub_key(key, sig.ec)
     QJ = Q[0], Q[1], 1
     # second part delegated to helper function
-    _assert_as_valid_(c, QJ, sig.r, sig.s, lower_s, sig.ec)
+    _assert_as_valid_(c, QJ, sig.r, sig.s, sig.ec)
 
 
 def assert_as_valid(
     msg: Octets,
     key: PubKey,
     sig: Sig | Octets,
-    lower_s: bool = True,
     hf: HashF = sha256,
     *,
     commit: Octets | None = None,
@@ -878,16 +897,13 @@ def assert_as_valid(
     """Refuse an invalid ECDSA signature, reducing the message with hf."""
     msg_hash = reduce_to_hlen(msg, hf)
     commit_hash = None if commit is None else reduce_to_hlen(commit, hf)
-    assert_as_valid_(
-        msg_hash, key, sig, lower_s, hf, commit_hash=commit_hash, receipt=receipt
-    )
+    assert_as_valid_(msg_hash, key, sig, hf, commit_hash=commit_hash, receipt=receipt)
 
 
 def verify_(
     msg_hash: Octets,
     key: PubKey,
     sig: Sig | Octets,
-    lower_s: bool = True,
     hf: HashF = sha256,
     *,
     commit_hash: Octets | None = None,
@@ -907,7 +923,7 @@ def verify_(
     # RecursionError is one and is not an answer about a signature
     try:
         assert_as_valid_(
-            msg_hash, key, sig, lower_s, hf, commit_hash=commit_hash, receipt=receipt
+            msg_hash, key, sig, hf, commit_hash=commit_hash, receipt=receipt
         )
     except (ValueError, BTClibRuntimeError):
         return False
@@ -919,7 +935,6 @@ def verify(
     msg: Octets,
     key: PubKey,
     sig: Sig | Octets,
-    lower_s: bool = True,
     hf: HashF = sha256,
     *,
     commit: Octets | None = None,
@@ -932,9 +947,7 @@ def verify(
     """
     msg_hash = reduce_to_hlen(msg, hf)
     commit_hash = None if commit is None else reduce_to_hlen(commit, hf)
-    return verify_(
-        msg_hash, key, sig, lower_s, hf, commit_hash=commit_hash, receipt=receipt
-    )
+    return verify_(msg_hash, key, sig, hf, commit_hash=commit_hash, receipt=receipt)
 
 
 def anti_exfil_host_commit(rho: Octets, hf: HashF = sha256) -> bytes:
@@ -1048,7 +1061,6 @@ def anti_exfil_host_verify(
     sig: Sig | Octets,
     rho: Octets,
     receipt: Point,
-    lower_s: bool = True,
     hf: HashF = sha256,
 ) -> bool:
     """Check the signature against R and rho: step 5 of the anti-exfil protocol.
@@ -1066,11 +1078,11 @@ def anti_exfil_host_verify(
     answers: a rho of the wrong size is a rho this commitment does
     not open to.
     """
-    return verify_(msg_hash, key, sig, lower_s, hf, commit_hash=rho, receipt=receipt)
+    return verify_(msg_hash, key, sig, hf, commit_hash=rho, receipt=receipt)
 
 
 def _recover_pub_keys_(
-    c: int, r: int, s: int, lower_s: bool, ec: Curve
+    c: int, r: int, s: int, ec: Curve, *, lower_s: bool = False
 ) -> list[JacPoint]:
     # Private function provided for testing purposes only.
 
@@ -1109,12 +1121,12 @@ def _recover_pub_keys_(
         # range: it is what a caller indexes to name a key_id, which is
         # only that key_id when no earlier candidate dropped out
         with contextlib.suppress(BTClibValueError, BTClibRuntimeError):
-            keys.append(_recover_pub_key_(key_id, c, r, s, lower_s, ec))
+            keys.append(_recover_pub_key_(key_id, c, r, s, ec, lower_s=lower_s))
     return keys
 
 
 def recover_pub_keys_(
-    msg_hash: Octets, sig: Sig | Octets, lower_s: bool = True, hf: HashF = sha256
+    msg_hash: Octets, sig: Sig | Octets, hf: HashF = sha256
 ) -> list[Point]:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
 
@@ -1145,23 +1157,18 @@ def recover_pub_keys_(
             # a candidate that recovers nothing is dropped rather than
             # reported, as in _recover_pub_keys_: the bindings' refusal
             # arrives as the BTClibValueError _libsecp256k1_recover_sec_
-            # maps it to, and a high-s signature under lower_s enumerates
-            # to the empty list, every candidate failing the same rule
+            # maps it to
             with contextlib.suppress(BTClibValueError, BTClibRuntimeError):
-                keys.append(
-                    _libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s)
-                )
+                keys.append(_libsecp256k1_recover_point_(key_id, msg_hash, sig))
         return keys
 
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 
-    QJs = _recover_pub_keys_(c, sig.r, sig.s, lower_s, sig.ec)
+    QJs = _recover_pub_keys_(c, sig.r, sig.s, sig.ec)
     return [sig.ec.aff_from_jac(QJ) for QJ in QJs]
 
 
-def recover_pub_keys(
-    msg: Octets, sig: Sig | Octets, lower_s: bool = True, hf: HashF = sha256
-) -> list[Point]:
+def recover_pub_keys(msg: Octets, sig: Sig | Octets, hf: HashF = sha256) -> list[Point]:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
 
     See Also:
@@ -1169,11 +1176,11 @@ def recover_pub_keys(
 
     """
     msg_hash = reduce_to_hlen(msg, hf)
-    return recover_pub_keys_(msg_hash, sig, lower_s, hf)
+    return recover_pub_keys_(msg_hash, sig, hf)
 
 
 def _recover_pub_key_(
-    key_id: int, c: int, r: int, s: int, lower_s: bool, ec: Curve
+    key_id: int, c: int, r: int, s: int, ec: Curve, *, lower_s: bool = False
 ) -> JacPoint:
     # Private function provided for testing purposes only.
 
@@ -1222,12 +1229,12 @@ def _recover_pub_key_(
     # representative its ladder reached. Every caller converts with
     # aff_from_jac, which is what a Jacobian coordinate is for
     QJ = _jac_double_mult(r1s, KJ, r1e, ec.GJ, ec)  # 1.6.1
-    _assert_as_valid_(c, QJ, r, s, lower_s, ec)  # 1.6.2
+    _assert_as_valid_(c, QJ, r, s, ec, lower_s=lower_s)  # 1.6.2
     return QJ
 
 
 def _libsecp256k1_recover_sec_(
-    key_id: int, msg_hash: bytes, sig: Sig, lower_s: bool, compressed: bool
+    key_id: int, msg_hash: bytes, sig: Sig, compressed: bool, *, lower_s: bool = False
 ) -> bytes:
     # Private function: the caller has asked _libsecp256k1_applicable
     # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
@@ -1244,11 +1251,13 @@ def _libsecp256k1_recover_sec_(
     # equation by construction, and a candidate whose x-coordinate is not
     # on the curve is the failure caught below.
     #
-    # The lower-s rule is checked here and not there. The recoverable
-    # parser takes any s in [1, n-1], as it must: a malleated signature
-    # recovers a key too, and lower_s is the caller saying whether that
-    # answer is wanted -- the same question _assert_as_valid_ answers with
-    # this very message
+    # The lower-s rule is checked here and not there, and only when asked
+    # for: the recoverable parser takes any s in [1, n-1], as it must, a
+    # malleated signature recovering a key too. Nothing in the public
+    # surface asks -- which form s took was the signer's choice -- so this
+    # is the private spelling of the same question _assert_as_valid_
+    # answers with this very message, and it exists so that the two
+    # implementations of the step can be held to one answer under it
     if lower_s and sig.s > sig.ec.n // 2:
         raise BTClibValueError("not a low s")
 
@@ -1277,7 +1286,7 @@ def _libsecp256k1_recover_sec_(
 
 
 def _libsecp256k1_recover_point_(
-    key_id: int, msg_hash: bytes, sig: Sig, lower_s: bool
+    key_id: int, msg_hash: bytes, sig: Sig, *, lower_s: bool = False
 ) -> Point:
     # Private function: the caller has asked _libsecp256k1_applicable
     # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
@@ -1288,7 +1297,9 @@ def _libsecp256k1_recover_point_(
     # answer. The two callers are the named candidate and the enumeration
     # over all four of them, which is the only reason this is a function:
     # bms wants the octets and never builds the point at all.
-    sec = _libsecp256k1_recover_sec_(key_id, msg_hash, sig, lower_s, compressed=False)
+    sec = _libsecp256k1_recover_sec_(
+        key_id, msg_hash, sig, compressed=False, lower_s=lower_s
+    )
     p_size = sig.ec.p_size
     return (
         int.from_bytes(sec[1 : 1 + p_size], byteorder="big", signed=False),
@@ -1300,7 +1311,6 @@ def recover_pub_key_(
     key_id: int,
     msg_hash: Octets,
     sig: Sig | Octets,
-    lower_s: bool = True,
     hf: HashF = sha256,
 ) -> Point:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
@@ -1327,11 +1337,11 @@ def recover_pub_key_(
     # x_K = r + ec.n - ec.p otherwise, which fails step 1.6.2 for every r
     # -- passing it would need ec.p ≡ 0 mod ec.n
     if _libsecp256k1_applicable(sig.ec, hf) and 0 <= key_id <= 3:
-        return _libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s)
+        return _libsecp256k1_recover_point_(key_id, msg_hash, sig)
 
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 
-    QJ = _recover_pub_key_(key_id, c, sig.r, sig.s, lower_s, sig.ec)
+    QJ = _recover_pub_key_(key_id, c, sig.r, sig.s, sig.ec)
     return sig.ec.aff_from_jac(QJ)
 
 
@@ -1339,7 +1349,6 @@ def recover_pub_key(
     key_id: int,
     msg: Octets,
     sig: Sig | Octets,
-    lower_s: bool = True,
     hf: HashF = sha256,
 ) -> Point:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
@@ -1349,7 +1358,7 @@ def recover_pub_key(
 
     """
     msg_hash = reduce_to_hlen(msg, hf)
-    return recover_pub_key_(key_id, msg_hash, sig, lower_s, hf)
+    return recover_pub_key_(key_id, msg_hash, sig, hf)
 
 
 def crack_prv_key_(

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -2378,9 +2378,10 @@ def _assert_ecdsa_sigs_verify(
     which is what `assert_signed` asks of a psbt that is nobody's answer
     in particular.
 
-    lower_s=False for the Finalizer's reason: the question is whether that
-    key made that signature, the low-s rule being policy the script engine
-    applies under its flags.
+    `verify_` asks whether that key made that signature and nothing about
+    which form its s took, the low-s rule being policy the script engine
+    applies under its flags -- which is the Finalizer's reason, and is now
+    the only answer that function gives.
     """
     for pub_key, sig in psbt_in.partial_sigs.items():
         if request_in is not None and pub_key in request_in.partial_sigs:
@@ -2390,7 +2391,7 @@ def _assert_ecdsa_sigs_verify(
             err_msg = f"input {vin_i}: cannot verify the signature of "
             err_msg += f"{pub_key.hex()}, the psbt does not say what was signed"
             raise BTClibValueError(err_msg)
-        if not dsa.verify_(msg_hash, pub_key, sig[:-1], lower_s=False):
+        if not dsa.verify_(msg_hash, pub_key, sig[:-1]):
             err_msg = f"input {vin_i}: invalid signature for pub_key {pub_key.hex()}"
             raise BTClibValueError(err_msg)
 
@@ -2795,9 +2796,9 @@ def _assert_partial_sigs_verify(psbt_in: PsbtIn, tx: Tx, vin_i: int) -> None:
     on bytes nothing vouches for, so skipping the check would finalize
     exactly the input whose signature cannot be believed.
 
-    lower_s=False because the question here is whether that key made that
-    signature: the low-s rule is policy, applied by the script engine
-    under its flags, and Bitcoin Core's CPubKey::Verify normalizes s
+    The question here is whether that key made that signature, and not
+    which form its s took: the low-s rule is policy, applied by the script
+    engine under its flags, and Bitcoin Core's CPubKey::Verify normalizes s
     before verifying for this very reason.
     """
     # the hash is the input's and the hash type's, never the key's, so an
@@ -2815,7 +2816,7 @@ def _assert_partial_sigs_verify(psbt_in: PsbtIn, tx: Tx, vin_i: int) -> None:
         msg_hash = sig_hashes[hash_type]
         if msg_hash is None:
             continue
-        if not dsa.verify_(msg_hash, pub_key, sig[:-1], lower_s=False):
+        if not dsa.verify_(msg_hash, pub_key, sig[:-1]):
             err_msg = f"invalid partial signature for pub_key {pub_key.hex()}"
             raise BTClibValueError(err_msg)
 

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -489,11 +489,12 @@ hash its argument again, which is not what you want here — the sighash
 >>> msg_hash = sig_hash.from_tx([prevout], unsigned, 0, 0x01)
 >>> sig = dsa.sign_(msg_hash, prv_key)
 >>> sig.serialize().hex()
-'3045022100f6e18672602b1c3cbbd13695c5d83f2d6271b9427836e718de7bc69b1593a222022071f1c0677de22fa18c65e6da25ab68de6280c97b63a1b6fc1c21ba404d6dbe9c'
+'304402207b7dffe084afa0d951726827d8469628e646349e9e6e1d60b76aa91d4a459ff2022003c3fd5ed4795126862efa7bc194d03c76af29741eb36c47659ac39506f2de10'
 
-The nonce is RFC-6979 deterministic and the ``s`` value is the canonical
-low one, so this signature is the same on every machine and every run.
-btclib never invents randomness for an ECDSA signature.
+The nonce is RFC-6979 deterministic, the ``s`` value is the canonical
+low one and the ``r`` is ground low as Bitcoin Core grinds it — 70 bytes
+of DER rather than 71 — so this signature is the same on every machine
+and every run. btclib never invents randomness for an ECDSA signature.
 
 A segwit v0 input is spent with a witness, not with a script_sig: the
 DER signature with the hash type appended, then the public key.
@@ -504,7 +505,7 @@ DER signature with the hash type appended, then the public key.
 >>> signed.is_segwit()
 True
 >>> signed.serialize(include_witness=True).hex()
-'01000000000101ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff01c003b423000000001600141d0f172a0ecb48aee1be1f2687d2963ae33f71a102483045022100f6e18672602b1c3cbbd13695c5d83f2d6271b9427836e718de7bc69b1593a222022071f1c0677de22fa18c65e6da25ab68de6280c97b63a1b6fc1c21ba404d6dbe9c0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635700000000'
+'01000000000101ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff01c003b423000000001600141d0f172a0ecb48aee1be1f2687d2963ae33f71a10247304402207b7dffe084afa0d951726827d8469628e646349e9e6e1d60b76aa91d4a459ff2022003c3fd5ed4795126862efa7bc194d03c76af29741eb36c47659ac39506f2de100121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635700000000'
 
 Now the two identifiers differ, which is what segwit bought: the witness
 is not covered by the txid.
@@ -512,11 +513,11 @@ is not covered by the txid.
 >>> signed.id.hex()
 '4ebbcec1c2b21740e5e4ffe6aaffe485f6285e7afcbce3130cf34cee05d653c7'
 >>> signed.hash.hex()
-'35c212ed54735c3677aadc9271d1fff153b6e06daea3341ef36323967f5833f2'
+'3f0a8a5f75909c79c075e7f62333ad7ae2cf05112283225a67202fa6deec4a19'
 >>> signed.id == unsigned.id
 True
 >>> signed.size, signed.vsize, signed.weight
-(192, 110, 438)
+(191, 110, 437)
 
 Finally, do not take your own word for it. btclib ships a script
 interpreter, so the transaction can be verified against the outputs it
@@ -555,7 +556,7 @@ ECDSA
 >>> from btclib.ecc import dsa
 >>> sig = dsa.sign(b"Satoshi Nakamoto", prv_key)
 >>> sig.serialize().hex()
-'3045022100f297566536c80c492421e0e8b4df4749e8e31ab70700519b3b123776823cd6950220627e8c87a97fe41e4a86f2ecfabec52b39a0ab6868617b39bd748d84fabec702'
+'304402204729dbf89f9288d56d32d1aea04db19df37c45c0a02863602f9ad98e7e506ce4022017489be41857144bf5782e964632d254b6b13ea22ce84837f775540784341f43'
 >>> dsa.verify(b"Satoshi Nakamoto", pub_key, sig)
 True
 >>> dsa.verify(b"satoshi nakamoto", pub_key, sig)

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1368,8 +1368,11 @@ behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **identical**. The bitcoin profile, `EcdsaBitcoinVerify`: the
-`lower_s=True` default, where the malleable high-s twin of a valid
-signature is `invalid`.
+strict DER encoding, and the low-s rule, under which the malleable high-s
+twin of a valid signature is `invalid`. btclib's parser is the strict one
+and its verifier no longer applies that rule, so two of these verdicts
+are exempted rather than asserted — `wycheproof_test.py` reads which two
+out of the file below.
 
 ### `tests/ecc/_data/ecdsa_secp256k1_sha256_test.json`
 
@@ -1383,8 +1386,10 @@ behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **identical**. The same algorithm, curve and hash as the file
-above, under `lower_s=False`: what a general-purpose ECDSA verifier must
-accept and the bitcoin one must not.
+above, without the bitcoin profile's two extra rules: what a
+general-purpose ECDSA verifier must accept. It is therefore also the
+oracle for the exemption named above — a key and a signature `valid` here
+and `invalid` there differ by the low-s rule and by nothing else.
 
 ### `tests/ecc/_data/ecdsa_secp256k1_sha256_p1363_test.json`
 

--- a/tests/ecc/anti_exfil_test.py
+++ b/tests/ecc/anti_exfil_test.py
@@ -151,16 +151,15 @@ def test_the_whole_handshake() -> None:
         secp256k1.add(R, secp256k1.G),
     )
 
-    # lower_s defaults to True here too: the malleated twin shares r, so
-    # the commitment check alone would still open, and only the default
-    # refuses it
+    # the malleated twin shares r, so the commitment opens to it as well,
+    # and step 5 accepts it: what this step proves is that the nonce was
+    # the committed one, which the negation of s does not touch. Whether s
+    # is the low one was the device's choice and is nobody's business here
+    # (issue 695) -- a host that wants the canonical form has the signature
+    # in hand and can look
     malleated = dsa.Sig(sig.r, sig.ec.n - sig.s)
-    assert dsa.anti_exfil_host_verify(
-        _HANDSHAKE_MSG_HASH, _PUB_KEY, malleated, _RHO, R, lower_s=False
-    )
-    assert not dsa.anti_exfil_host_verify(
-        _HANDSHAKE_MSG_HASH, _PUB_KEY, malleated, _RHO, R
-    )
+    assert dsa.anti_exfil_host_verify(_HANDSHAKE_MSG_HASH, _PUB_KEY, malleated, _RHO, R)
+    assert malleated.s > secp256k1.n // 2
 
 
 def test_the_signer_keeps_no_state() -> None:
@@ -242,4 +241,4 @@ def test_rho_and_the_commitment_are_hf_len() -> None:
         dsa.anti_exfil_signer_commit(msg_hash, _PRV_KEY, _RHO, secp256k1, sha1)
     R = dsa.anti_exfil_signer_commit(msg_hash, _PRV_KEY, commitment, secp256k1, sha1)
     sig = dsa.anti_exfil_sign(msg_hash, _PRV_KEY, rho, True, secp256k1, sha1)
-    assert dsa.anti_exfil_host_verify(msg_hash, _PUB_KEY, sig, rho, R, True, sha1)
+    assert dsa.anti_exfil_host_verify(msg_hash, _PUB_KEY, sig, rho, R, sha1)

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -87,26 +87,21 @@ def test_signature() -> None:
 
     # malleated signature
     dsa_sig = dsa.Sig(bms_sig.dsa_sig.r, bms_sig.dsa_sig.ec.n - bms_sig.dsa_sig.s)
-    # without updating rf verification will fail, even with lower_s=False
+    # the recovery flag names which candidate the key is, and negating s
+    # mirrors the nonce's point: without updating rf the signature opens
+    # to a different key, hence to a different address
     bms_sig = bms.Sig(bms_sig.rf, dsa_sig)
     err_msg = "invalid p2pkh address: "
     with pytest.raises(BTClibValueError, match=err_msg):
-        bms.assert_as_valid(msg, addr, bms_sig, lower_s=False)
+        bms.assert_as_valid(msg, addr, bms_sig)
     # update rf to satisfy above malleation
     i = 1 if bms_sig.rf % 2 else -1
     bms_sig = bms.Sig(bms_sig.rf + i, dsa_sig)
-    bms.assert_as_valid(msg, addr, bms_sig, lower_s=False)
-    assert bms.verify(msg, addr, bms_sig, lower_s=False)
-    # anyway, with lower_s=True malleation does fail verification
-    err_msg = "not a low s"
-    with pytest.raises(BTClibValueError, match=err_msg):
-        bms.assert_as_valid(msg, addr, bms_sig, lower_s=True)
-    # and the same is true left to the default: assert_as_valid's and
-    # verify's lower_s both default to True, and every other call in
-    # this file passes the keyword explicitly
-    with pytest.raises(BTClibValueError, match=err_msg):
-        bms.assert_as_valid(msg, addr, bms_sig)
-    assert not bms.verify(msg, addr, bms_sig)
+    # and then it opens to the address, which is the whole answer: which
+    # form s took was the signer's choice, and Core's verifymessage
+    # accepts the high one too (issue 695)
+    bms.assert_as_valid(msg, addr, bms_sig)
+    assert bms.verify(msg, addr, bms_sig)
 
     # bms_sig taken from (Electrum and) Bitcoin Core
     wif, addr = bms.gen_keys("5KMWWy2d3Mjc8LojNoj8Lcz9B1aWu8bRofUgGwQk959Dw5h2iyw")
@@ -470,19 +465,14 @@ def test_msgsign_p2pkh() -> None:
     # malleate s
     s = ec.n - bms_sig1c.dsa_sig.s
     dsa_sig = dsa.Sig(bms_sig1c.dsa_sig.r, s, bms_sig1c.dsa_sig.ec)
-    # without updating rf verification will fail, even with lower_s=False
+    # without updating rf the signature opens to a different key
     bms_sig = bms.Sig(bms_sig1c.rf, dsa_sig)
-    assert not bms.verify(msg, add1c, bms_sig, lower_s=False)
+    assert not bms.verify(msg, add1c, bms_sig)
 
-    # update rf to satisfy above malleation
+    # update rf to satisfy above malleation, and it is accepted
     i = 1 if bms_sig1c.rf % 2 else -1
     bms_sig = bms.Sig(bms_sig1c.rf + i, dsa_sig)
-    assert bms.verify(msg, add1c, bms_sig, lower_s=False)
-
-    # anyway, with lower_s=True malleation does fail verification
-    err_msg = "not a low s"
-    with pytest.raises(BTClibValueError, match=err_msg):
-        bms.assert_as_valid(msg, add1c, bms_sig, lower_s=True)
+    assert bms.verify(msg, add1c, bms_sig)
 
 
 def test_msgsign_p2pkh_2() -> None:
@@ -544,7 +534,7 @@ def test_verify_p2pkh() -> None:
     msg = b"test message"
     address = "16vqGo3KRKE9kTsTZxKoJKLzwZGTodK3ce"
     exp_sig = "HPDs1TesA48a9up4QORIuub67VHBM37X66skAYz0Esg23gdfMuCTYDFORc6XGpKZ2/flJ2h/DUF569FJxGoVZ50="
-    assert bms.verify(msg, address, exp_sig, lower_s=False)
+    assert bms.verify(msg, address, exp_sig)
 
     msg = b"test message 2"
     assert not bms.verify(msg, address, exp_sig)
@@ -562,7 +552,7 @@ def test_verify_p2pkh() -> None:
     msg = b"testtest"
     address = "18uitB5ARAhyxmkN2Sa9TbEuoGN1he83BX"
     exp_sig = "IMAtT1SjRyP6bz6vm5tKDTTTNYS6D8w2RQQyKD3VGPq2i2txGd2ar18L8/nvF1+kAMo5tNc4x0xAOGP0HRjKLjc="
-    assert bms.verify(msg, address, exp_sig, lower_s=False)
+    assert bms.verify(msg, address, exp_sig)
 
     msg = b"testtest"
     address = "1LsPb3D1o1Z7CzEt1kv5QVxErfqzXxaZXv"
@@ -709,11 +699,12 @@ def test_vector_python_bitcoinlib(vector: dict[str, Any]) -> None:
     # Core/Electrum/btclib provide identical signature
     # they use "low-s" canonical signature
     assert bms_sig.dsa_sig.s < ec.n - bms_sig.dsa_sig.s
-    assert bms.verify(msg, vector["address"], bms_sig_encoded, lower_s=True)
 
     # python-bitcoinlib provides a valid signature
-    # but does not respect low-s
-    assert bms.verify(msg, vector["address"], vector["signature"], lower_s=False)
+    # but does not respect low-s, and it is accepted all the same: this
+    # is the disagreement with Core's verifymessage that issue 645
+    # measured over all 200 of these vectors, and issue 695 settled
+    assert bms.verify(msg, vector["address"], vector["signature"])
 
     # python-bitcoinlib has a signature different from Core/Electrum/btclib
     assert bms_sig_encoded != vector["signature"]
@@ -725,9 +716,9 @@ def test_vector_python_bitcoinlib(vector: dict[str, Any]) -> None:
     # properly malleated fixing also rf
     i = 1 if bms_sig.rf % 2 else -1
     bms_sig_malleated = bms.Sig(bms_sig.rf + i, dsa_sig)
-    assert bms.verify(msg, vector["address"], bms_sig_malleated, lower_s=False)
+    assert bms.verify(msg, vector["address"], bms_sig_malleated)
     bms_sig_encoded = bms_sig_malleated.b64encode()
-    assert bms.verify(msg, vector["address"], bms_sig_encoded, lower_s=False)
+    assert bms.verify(msg, vector["address"], bms_sig_encoded)
 
     # the malleated signature is still not equal to the python-bitcoinlib one
     assert bms_sig_encoded != vector["signature"]
@@ -801,7 +792,7 @@ def test_ledger() -> None:
     # ECDSA signature verification of the patched dersig;
     # the xpub, verification taking public keys alone
     xpub = bip32.xpub_from_xprv(xprv)
-    dsa.assert_as_valid(magic_msg, xpub, dsa_sig, lower_s=True)
+    dsa.assert_as_valid(magic_msg, xpub, dsa_sig)
     assert dsa.verify(magic_msg, xpub, dsa_sig)
 
     # compressed address
@@ -825,10 +816,8 @@ def test_recover_pub_key_input_type() -> None:
 
     key_id = bms_sig.rf - 27 & 0b11
     magic_msg = magic_message(msg)
-    Q = dsa.recover_pub_key(
-        key_id, magic_msg, bms_sig.dsa_sig.serialize(), True, sha256
-    )
-    Q2 = dsa.recover_pub_key(key_id, magic_msg, bms_sig.dsa_sig, True, sha256)
+    Q = dsa.recover_pub_key(key_id, magic_msg, bms_sig.dsa_sig.serialize(), sha256)
+    Q2 = dsa.recover_pub_key(key_id, magic_msg, bms_sig.dsa_sig, sha256)
     assert Q == Q2
 
 
@@ -959,7 +948,10 @@ def test_recoverable_signing_answers_the_key_id_the_search_finds(
 
         magic_msg = magic_message(msg)
         q = prv_keyinfo_from_prv_key(wif)[0]
-        dsa_sig = dsa.sign(magic_msg, q)
+        # grind=False is what `sign_recoverable` does and cannot do
+        # otherwise: a message signature is the fixed 65-byte compact form,
+        # where a low r saves no DER pad, so there is nothing to grind for
+        dsa_sig = dsa.sign(magic_msg, q, grind=False)
         assert bms_sig.dsa_sig == dsa_sig
         key_id = bms_sig.rf - 27 & 0b11
         assert key_id == _search_key_id(magic_msg, dsa_sig, q)

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -86,26 +86,19 @@ def test_dsa_commitment() -> None:
                     _MSG, _PRV_KEY, None, lower_s, ec, hf, commit=_COMMIT
                 )
                 # an ordinary signature, whether or not it commits
-                dsa.assert_as_valid(_MSG, pub_key, sig, lower_s, hf)
+                dsa.assert_as_valid(_MSG, pub_key, sig, hf)
                 dsa.assert_as_valid(
-                    _MSG, pub_key, sig, lower_s, hf, commit=_COMMIT, receipt=receipt
+                    _MSG, pub_key, sig, hf, commit=_COMMIT, receipt=receipt
                 )
                 # to that value and to no other
                 assert not dsa.verify(
-                    _MSG,
-                    pub_key,
-                    sig,
-                    lower_s,
-                    hf,
-                    commit=b"not this",
-                    receipt=receipt,
+                    _MSG, pub_key, sig, hf, commit=b"not this", receipt=receipt
                 )
                 # and with the receipt the signer kept, not another point
                 assert not dsa.verify(
                     _MSG,
                     pub_key,
                     sig,
-                    lower_s,
                     hf,
                     commit=_COMMIT,
                     receipt=mult(2, receipt, ec),

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -25,6 +25,7 @@ from btclib.curves import (
 from btclib.curves.curve import CURVES
 from btclib.curves.curve_group import _mult
 from btclib.ecc import dsa
+from btclib.ecc.rfc6979_nonce import challenge_
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import reduce_to_hlen
 from btclib.number_theory import mod_inv
@@ -101,19 +102,22 @@ def test_signature() -> None:
     # Deterministic Usage of DSA and ECDSA (RFC 6979)
     r = 0x934B1EA10A4B3C1757E2B0C017D0B6143CE3C9A7E6A4A49860D7A6AB210EE3D8
     s = 0x2442CE9D2B916064108014783E923EC36B49743E2FFA1C4496F01A512AAFD9E5
-    assert sig.r == r
-    assert sig.s in {s, sig.ec.n - s}
+    # the vector is the plain RFC6979 signature, and grinding is a search
+    # over nonces: this message's first draw has a high r, so the default
+    # signs it again with a counter and lands somewhere else
+    plain = dsa.sign(msg, q, grind=False)
+    assert plain.r == r
+    assert plain.s in {s, sig.ec.n - s}
+    assert sig != plain
+    assert dsa.verify(msg, Q, plain)
 
-    # malleability
+    # malleability: the high-s twin is a valid signature of the same
+    # message under the same key, and verification says so -- which form s
+    # took was the signer's choice, so nothing that only reads the
+    # signature has standing to refuse it (issue 695)
     malleated_sig = dsa.Sig(sig.r, sig.ec.n - sig.s)
-    assert dsa.verify(msg, Q, malleated_sig, lower_s=False)
-    # lower_s defaults to True on both assert_as_valid and verify, refusing
-    # the same high-s twin the line above accepts by asking not to --
-    # libsecp256k1's own verify does the refusing here, lower_s deciding
-    # only whether the signature is normalized in front of it first
-    assert not dsa.verify(msg, Q, malleated_sig)
-    with pytest.raises(BTClibRuntimeError, match="signature verification failed"):
-        dsa.assert_as_valid(msg, Q, malleated_sig)
+    assert dsa.verify(msg, Q, malleated_sig)
+    dsa.assert_as_valid(msg, Q, malleated_sig)
 
     keys = dsa.recover_pub_keys(msg, sig)
     assert len(keys) == 2
@@ -209,8 +213,8 @@ def test_gec() -> None:
     assert sig.ec == ec
 
     # 2.1.4 Verifying Operation for V
-    dsa.assert_as_valid(msg, QU, sig, lower_s, hf)
-    assert dsa.verify(msg, QU, sig, lower_s, hf)
+    dsa.assert_as_valid(msg, QU, sig, hf)
+    assert dsa.verify(msg, QU, sig, hf)
 
 
 @pytest.mark.parametrize("name", list(low_card_curves))
@@ -238,10 +242,11 @@ def test_low_cardinality(name: str) -> None:
                     assert r == sig.r
                     assert s == sig.s
                     assert ec == sig.ec
-                    # valid signature must pass verification
-                    dsa._assert_as_valid_(e, QJ, r, s, lower_s, ec)
+                    # valid signature must pass verification, and here even
+                    # under the strict rule: every s above was normalized
+                    dsa._assert_as_valid_(e, QJ, r, s, ec, lower_s=lower_s)
 
-                    jac_keys = dsa._recover_pub_keys_(e, r, s, lower_s, ec)
+                    jac_keys = dsa._recover_pub_keys_(e, r, s, ec, lower_s=lower_s)
                     Qs = [ec.aff_from_jac(key) for key in jac_keys]
                     assert ec.aff_from_jac(QJ) in Qs
                     assert len(jac_keys) in {2, 4}
@@ -296,7 +301,7 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
                         # a candidate x_K off the curve, or a key that
                         # does not verify, is "not this key_id"
                         try:
-                            QJ = dsa._recover_pub_key_(key_id, e, r, s, False, ec)
+                            QJ = dsa._recover_pub_key_(key_id, e, r, s, ec)
                         except (BTClibValueError, BTClibRuntimeError):
                             continue
                         recovered.append((key_id, ec.aff_from_jac(QJ)))
@@ -307,7 +312,7 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
                     assert all(key_id >> 1 == 1 for key_id in key_ids)
 
                     # and the plural is that range, less what dropped out
-                    jac_keys = dsa._recover_pub_keys_(e, r, s, False, ec)
+                    jac_keys = dsa._recover_pub_keys_(e, r, s, ec)
                     assert [ec.aff_from_jac(QJ) for QJ in jac_keys] == [
                         Q_ for _, Q_ in recovered
                     ]
@@ -352,7 +357,7 @@ def test_key_id_is_the_j_zero_pair_when_n_is_above_p() -> None:
                 key_ids = []
                 for key_id in range(2 * (ec.cofactor + 1)):
                     try:
-                        QJ = dsa._recover_pub_key_(key_id, e, r, s, False, ec)
+                        QJ = dsa._recover_pub_key_(key_id, e, r, s, ec)
                     except (BTClibValueError, BTClibRuntimeError):
                         continue
                     if ec.aff_from_jac(QJ) == Q:
@@ -521,7 +526,10 @@ def test_libsecp256k1() -> None:
     """Verify btclib and the bindings sign and verify byte-for-byte."""
     msg = b"Satoshi Nakamoto"
     prvkey_int, pubkey_point = dsa.gen_keys(0x1)
-    btclib_sig = dsa.sign(msg, prvkey_int)
+    # grind=False on both sides: the bindings' sign() with no extra
+    # entropy is the plain RFC6979 signature, which is what byte-for-byte
+    # means here
+    btclib_sig = dsa.sign(msg, prvkey_int, grind=False)
     pub_key = bytes_from_point(pubkey_point)
     assert dsa.verify(msg, pub_key, btclib_sig)
     assert dsa.verify(msg, pub_key, btclib_sig.serialize())
@@ -560,7 +568,7 @@ def test_grinding_lands_on_a_low_r() -> None:
     unchanged = 0
     for i in range(64):
         msg = f"btclib grind {i}".encode()
-        plain = dsa.sign(msg, q)
+        plain = dsa.sign(msg, q, grind=False)
         ground = dsa.sign(msg, q, grind=True)
         assert ground.r < _LOW_R
         assert len(ground.serialize()) <= 70
@@ -651,7 +659,7 @@ def test_grinding_is_about_r_and_not_about_the_encoded_length() -> None:
         msg = f"btclib grind {i}".encode()
         sig = dsa.sign(msg, q, lower_s=False, grind=True)
         assert sig.r < _LOW_R
-        assert dsa.verify(msg, Q, sig, lower_s=False)
+        assert dsa.verify(msg, Q, sig)
         lengths.add(len(sig.serialize()))
     # both, and the 71 is the byte s asked for: grinding did not go looking
     # for another s, and a loop on the length would have
@@ -769,18 +777,16 @@ def test_core_grinds_the_same_signatures(
     # the retry count is a claim about which element of Core's sequence
     # this is, so it is checked and not merely recorded: the plain
     # signature for a count of zero, the counter's own signature otherwise
-    plain = dsa.sign_(sig_hash, prv_key)
+    plain = dsa.sign_(sig_hash, prv_key, grind=False)
     assert (plain == sig) == (retries == 0)
     ndata = None if retries == 0 else retries.to_bytes(32, "little")
     assert sig.serialize() == libsecp256k1_dsa.sign(sig_hash, prv_key, ndata)
 
 
-def _recovered(
-    key_id: int, msg: bytes, sig: dsa.Sig, lower_s: bool = True
-) -> Point | None:
+def _recovered(key_id: int, msg: bytes, sig: dsa.Sig) -> Point | None:
     """Return the recovered key, None for a candidate recovering nothing."""
     try:
-        return dsa.recover_pub_key(key_id, msg, sig, lower_s)
+        return dsa.recover_pub_key(key_id, msg, sig)
     except (BTClibValueError, BTClibRuntimeError):
         return None
 
@@ -830,14 +836,76 @@ def test_libsecp256k1_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
         # 2^-127 of signatures, and both implementations require it
         assert recovering == [0, 1]
 
-        # the lower-s rule is the caller's, and it is btclib that applies
-        # it: the recoverable parser takes any s in [1, n-1]
+        # negating s mirrors the nonce's point, so the candidate that
+        # recovers the signer is the one whose parity bit flipped -- and
+        # the malleated signature does recover it, on both
+        # implementations, no lower-s rule refusing what the signer was
+        # free to produce (issue 695). The recoverable parser takes any s
+        # in [1, n-1] and that is now the whole of the rule
         key_id = next(k for k in recovering if _recovered(k, msg, sig) == Q)
         malleated = dsa.Sig(sig.r, secp256k1.n - sig.s)
-        err_msg = "not a low s"
-        with pytest.raises(BTClibValueError, match=err_msg):
-            dsa.recover_pub_key(key_id ^ 1, msg, malleated)
-        assert _recovered(key_id ^ 1, msg, malleated, lower_s=False) == Q
+        assert _recovered(key_id ^ 1, msg, malleated) == Q
+        with monkeypatch.context() as no_bindings:
+            no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            assert _recovered(key_id ^ 1, msg, malleated) == Q
+
+
+def test_the_low_s_rule_is_asked_for_and_not_assumed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Where the strict rule lives once the public surface drops it (issue 695).
+
+    The rule is not gone: `SCRIPT_VERIFY_LOW_S` is in Core's
+    `STANDARD_SCRIPT_VERIFY_FLAGS`, so a high-s signature inside a
+    transaction is non-standard and does not relay, and `sign` normalizes
+    for that reason. What is gone is a verifier refusing one -- so the
+    strict answer is what a leading-underscore function gives when asked
+    for it, `lower_s=False` being the default there too.
+
+    Both implementations of the recovery are asked, being one step written
+    twice: the bindings answer the named candidate and the Python path
+    answers all four, and a rule enforced by one and not the other would
+    make the two disagree about a signature neither made.
+    """
+    msg = b"Satoshi Nakamoto"
+    prv_key, Q = dsa.gen_keys(prv_key_int)
+    msg_hash = reduce_to_hlen(msg)
+    sig = dsa.sign(msg, prv_key)
+    malleated = dsa.Sig(sig.r, secp256k1.n - sig.s)
+    key_id = _search_key_id(msg, sig, Q)
+    c = challenge_(msg_hash, secp256k1, sha256)
+    QJ = Q[0], Q[1], 1
+    err_msg = "not a low s"
+
+    # the public spellings take the malleated signature, both of them
+    assert dsa.verify(msg, Q, malleated)
+    assert dsa.recover_pub_key(key_id ^ 1, msg, malleated) == Q
+
+    # and every private spelling refuses it when told to
+    with pytest.raises(BTClibValueError, match=err_msg):
+        dsa._assert_as_valid_(c, QJ, malleated.r, malleated.s, secp256k1, lower_s=True)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        dsa._libsecp256k1_recover_point_(key_id ^ 1, msg_hash, malleated, lower_s=True)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        dsa._recover_pub_key_(
+            key_id ^ 1, c, malleated.r, malleated.s, secp256k1, lower_s=True
+        )
+    # the enumeration drops a candidate that fails rather than report it,
+    # so there the same refusal is an empty list: every one of the four
+    # fails the one rule at once
+    assert (
+        dsa._recover_pub_keys_(c, malleated.r, malleated.s, secp256k1, lower_s=True)
+        == []
+    )
+
+    # the signature as signed passes the strict rule on both paths, which
+    # is what says the refusals above are about the malleation and not
+    # about the arguments being threaded wrongly
+    dsa._assert_as_valid_(c, QJ, sig.r, sig.s, secp256k1, lower_s=True)
+    assert dsa._libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s=True) == Q
+    with monkeypatch.context() as no_bindings:
+        no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+        assert dsa.recover_pub_key(key_id, msg, sig) == Q
 
 
 def test_recover_pub_keys_takes_the_hash_that_recover_pub_keys_reduces() -> None:
@@ -850,13 +918,12 @@ def test_recover_pub_keys_takes_the_hash_that_recover_pub_keys_reduces() -> None
     Nothing in btclib calls either, bms naming its own key_id since issue
     269, so this is what holds the pairing that justifies both.
 
-    The malleated signature is the plural's answer where the singular
-    raises: a candidate that fails is dropped rather than reported, and
-    every candidate fails the lower-s rule at once, so the enumeration of
-    a high-s signature is empty and not an error. Both spellings say so on
-    both implementations -- sha256 here is the four recover calls, sha512
-    the Python loop -- the rule being btclib's either way, since the
-    recoverable parser takes any s in [1, n-1].
+    The malleated signature is enumerated exactly as the signature it was
+    made from: negating s mirrors the nonce's point, so the same keys come
+    back with the parity bit of each candidate flipped, and the signer's
+    own is among them. Both spellings say so on both implementations --
+    sha256 here is the four recover calls, sha512 the Python loop -- which
+    form s took having been the signer's choice (issue 695).
     """
     msg = b"Satoshi Nakamoto"
     for q in (0x1, 0x2, prv_key_int, secp256k1.n - 1):
@@ -875,8 +942,9 @@ def test_recover_pub_keys_takes_the_hash_that_recover_pub_keys_reduces() -> None
             assert dsa.recover_pub_keys_(msg_hash.hex(), sig.serialize(), hf=hf) == keys
 
             malleated = dsa.Sig(sig.r, secp256k1.n - sig.s)
-            assert dsa.recover_pub_keys_(msg_hash, malleated, hf=hf) == []
-            assert Q in dsa.recover_pub_keys_(msg_hash, malleated, lower_s=False, hf=hf)
+            malleated_keys = dsa.recover_pub_keys_(msg_hash, malleated, hf=hf)
+            assert Q in malleated_keys
+            assert dsa.recover_pub_keys(msg, malleated, hf=hf) == malleated_keys
 
 
 def test_recovery_multiplies_in_libsecp256k1(
@@ -968,7 +1036,7 @@ def test_the_enumeration_asks_for_the_j_one_candidates(
         assert dsa.recover_pub_keys_(msg_hash, sig) == keys
 
 
-def _search_key_id(msg: bytes, sig: dsa.Sig, Q: Point, lower_s: bool = True) -> int:
+def _search_key_id(msg: bytes, sig: dsa.Sig, Q: Point) -> int:
     """Find the key_id by recovering and comparing, not by signing.
 
     The derivation `sign_recoverable` exists not to run: it is here as the
@@ -976,7 +1044,7 @@ def _search_key_id(msg: bytes, sig: dsa.Sig, Q: Point, lower_s: bool = True) -> 
     candidate until one is the signer's own key.
     """
     for key_id in range(2 * (sig.ec.cofactor + 1)):
-        if _recovered(key_id, msg, sig, lower_s) == Q:
+        if _recovered(key_id, msg, sig) == Q:
             return key_id
     raise AssertionError("no key_id recovers the public key")
 
@@ -1015,6 +1083,11 @@ def test_sign_recoverable_is_sign_plus_the_key_id_a_search_would_find(
     for all three too, the dispatch patched off, because that is where the
     key_id is derived rather than reported -- read off the nonce's point at
     signing time, which is the whole of issue 285.
+
+    `sign` is asked with `grind=False`, that being the signature the
+    recoverable spelling makes: it takes no `grind` at all, a compact
+    signature having no DER pad for a low r to save, so the plain one is
+    what the two have in common.
     """
     for i in range(20):
         msg = f"message {i}".encode()
@@ -1022,7 +1095,7 @@ def test_sign_recoverable_is_sign_plus_the_key_id_a_search_would_find(
         msg_hash = reduce_to_hlen(msg)
 
         sig, key_id = dsa.sign_recoverable(msg, prv_key)
-        assert sig == dsa.sign(msg, prv_key)
+        assert sig == dsa.sign(msg, prv_key, grind=False)
         assert (sig, key_id) == dsa.sign_recoverable_(msg_hash, prv_key)
         assert dsa.recover_pub_key(key_id, msg, sig) == Q
         assert key_id == _search_key_id(msg, sig, Q)
@@ -1061,10 +1134,9 @@ def test_the_key_id_survives_what_the_bindings_decline(
         {"hf": sha512},
     ]
     for kwargs in cases:
-        lower_s = bool(kwargs.get("lower_s", True))
         sig, key_id = dsa.sign_recoverable(msg, prv_key, **kwargs)
         hf = kwargs.get("hf", sha256)
-        assert dsa.recover_pub_key(key_id, msg, sig, lower_s, hf) == Q
+        assert dsa.recover_pub_key(key_id, msg, sig, hf) == Q
         with monkeypatch.context() as no_bindings:
             no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
             assert dsa.sign_recoverable(msg, prv_key, **kwargs) == (sig, key_id)
@@ -1089,7 +1161,9 @@ def test_recover_pub_key_dispatches_to_the_bindings_for_0_to_3_only() -> None:
     ways this guard survived moved.
     """
     q = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD
-    sig = dsa.sign(b"msg", q)
+    # grind=False: this signature is the fixture, chosen for the four
+    # answers below, and another r is another set of candidates
+    sig = dsa.sign(b"msg", q, grind=False)
     msg_hash = b"\x00" * 32
 
     cases = {
@@ -1158,7 +1232,9 @@ def test_the_key_id_names_j_where_j_is_reachable() -> None:
                             sig, key_id = dsa._sign_recoverable_(c, q, k, lower_s, ec)
                         except BTClibRuntimeError:  # r == 0 or s == 0
                             continue
-                        QJ = dsa._recover_pub_key_(key_id, c, sig.r, sig.s, lower_s, ec)
+                        QJ = dsa._recover_pub_key_(
+                            key_id, c, sig.r, sig.s, ec, lower_s=lower_s
+                        )
                         assert ec.aff_from_jac(QJ) == Q
                         cases += 1
                         j_reached += key_id >> 1
@@ -1190,7 +1266,9 @@ def test_libsecp256k1_py_vectors_ecdsa(vector: dict[str, str]) -> None:
     prv_key = bytes.fromhex(vector["privkey"])
     assert len(prv_key) == 32
 
-    sig = dsa.sign_(msg_hash, prv_key)
+    # the vectors are libsecp256k1's own plain signatures, as the
+    # comparison below says in the same breath
+    sig = dsa.sign_(msg_hash, prv_key, grind=False)
     assert sig.serialize() == sig_raw[:-1]
     pub_key = pub_keyinfo_from_prv_key(prv_key, compressed=True)[0]
     assert dsa.verify_(msg_hash, pub_key, sig)
@@ -1234,7 +1312,7 @@ def test_verify_infinity_point() -> None:
     ec = CURVES["secp256k1"]
     err_msg = r"invalid \(INF\) key"
     with pytest.raises(BTClibRuntimeError, match=err_msg):
-        dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, True, ec)
+        dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, ec)
 
 
 def test_verify_with_another_hash_function_on_both_arithmetics(
@@ -1267,7 +1345,7 @@ def test_verify_with_another_hash_function_on_both_arithmetics(
         assert not dsa.verify(b"another message", Q, sig, hf=sha512)
         # K = u*G + v*Q is INF for Q = G, r = s = 1 and c = n-1
         with pytest.raises(BTClibRuntimeError, match=r"invalid \(INF\) key"):
-            dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, True, ec)
+            dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, ec)
 
     checks()
     no_bindings(monkeypatch)

--- a/tests/ecc/rfc6979_test.py
+++ b/tests/ecc/rfc6979_test.py
@@ -35,7 +35,9 @@ from tests.curves.curve_test import low_card_curves
 # for none of the five. The s values are the low ones -- as libsecp256k1
 # hands them back, and as `sign_` returns by default -- and four of the
 # five differ from what RFC6979 arrives at before that normalization, so
-# they pin lower_s as much as the nonce.
+# they pin lower_s as much as the nonce. The r values are the plain ones,
+# which is the other half of what a vector here has to be asked for:
+# `grind` is on by default and four of the five have a high r.
 #
 # The two long messages are named above the table rather than written in
 # it: a multi-line string inside a tuple literal is a missing comma away
@@ -107,7 +109,7 @@ def test_rfc6979_secp256k1(prv_key: int, msg: str, k: int, r: str, s: str) -> No
     # the nonce is the default, so the signature is what the library
     # produces unprompted -- the vector pins the whole of it, not the
     # derivation with the answer handed back in
-    sig = dsa.sign_(msg_hash, prv_key)
+    sig = dsa.sign_(msg_hash, prv_key, grind=False)
     assert (sig.r, sig.s) == (int(r, 16), int(s, 16))
     assert sig == dsa.sign_(msg_hash, prv_key, k)
 
@@ -126,7 +128,7 @@ def test_rfc6979_secp256k1_s_is_normalized() -> None:
     normalized = 0
     for prv_key, msg, _, _, s in SECP256K1_VECTORS:
         msg_hash = hashlib.sha256(msg.encode()).digest()
-        raw = dsa.sign_(msg_hash, prv_key, lower_s=False)
+        raw = dsa.sign_(msg_hash, prv_key, lower_s=False, grind=False)
         assert raw.s in {int(s, 16), secp256k1.n - int(s, 16)}
         normalized += raw.s != int(s, 16)
     assert normalized == 4
@@ -135,13 +137,13 @@ def test_rfc6979_secp256k1_s_is_normalized() -> None:
 def test_rfc6979_secp256k1_grinding_leaves_only_the_low_r_one() -> None:
     """Four of the five have a high r, which is what grinding re-signs.
 
-    The vectors are the plain RFC6979 signatures -- `grind=False`, this
-    library's default and the reason it is the default -- so `grind=True`
-    reproduces the one whose r is already below 2**255 and departs from the
-    other four, which is the whole of what the flag does to a
-    deterministic signature. `tests/ecc/dsa_test.py` is where the loop is
-    held to Core's, this being about the vectors: no vector is lost, and
-    the fourth is a vector for both spellings.
+    The vectors are the plain RFC6979 signatures, which is why every test
+    above asks for `grind=False`: grinding is on by default, as it is in
+    Core, so the default reproduces the one whose r is already below
+    2**255 and departs from the other four. That is the whole of what the
+    flag does to a deterministic signature. `tests/ecc/dsa_test.py` is
+    where the loop is held to Core's, this being about the vectors: no
+    vector is lost, and the fourth is a vector for both spellings.
     """
     ground = 0
     for prv_key, msg, _, r, _ in SECP256K1_VECTORS:
@@ -209,14 +211,16 @@ def test_rfc6979_nonce_tv(
     assert int(r, 16) == sig.r
     assert int(s, 16) == sig.s
     # test that RFC6979 is the default nonce for DSA
-    sig = dsa.sign_(m, prv_key, None, lower_s, ec=ec, hf=getattr(hashlib, hf))
+    sig = dsa.sign_(
+        m, prv_key, None, lower_s, ec=ec, hf=getattr(hashlib, hf), grind=False
+    )
     assert int(r, 16) == sig.r
     assert int(s, 16) == sig.s
     # test key-pair coherence
     U = mult(prv_key, ec.G, ec)
     assert (int(x_U, 16), int(y_U, 16)) == U
     # test signature validity
-    dsa.assert_as_valid(msg_bytes, U, sig, lower_s, getattr(hashlib, hf))
+    dsa.assert_as_valid(msg_bytes, U, sig, getattr(hashlib, hf))
 
 
 # RFC6979 against BIP340: the two deterministic nonces this library

--- a/tests/ecc/wycheproof_test.py
+++ b/tests/ecc/wycheproof_test.py
@@ -28,13 +28,20 @@ of how strict a parser is, and pinning it here would make a legitimate
 loosening or tightening of one look like a regression.
 
 Two profiles of ECDSA, which is why two of the files are the same
-algorithm over the same curve and hash. `EcdsaBitcoinVerify` is btclib's
-`lower_s=True` default and refuses the malleable high-s twin;
-`EcdsaVerify` is `lower_s=False` and accepts it. Their tcId 5 is the same
-key and the same signature under both, `invalid` in the first file and
-`valid` in the second, so a `lower_s` wired the wrong way round fails one
-of the two files whichever way it is wired -- which neither file could
-report on its own.
+algorithm over the same curve and hash. `EcdsaBitcoinVerify` requires the
+strict DER encoding bitcoin requires, where `EcdsaVerify` accepts the BER
+forms a generic parser takes, and `Sig.parse` is the strict one: the
+`BerEncodedSignature` and `InvalidEncoding` cases are `invalid` in the
+first file and `valid` in the second, and btclib answers with the first.
+
+What it does not share is the low-s rule, and the two files say so by
+naming the same signature twice: tcId 1 and tcId 388 of the bitcoin file
+are tcId 5 and tcId 392 of the generic one -- one key and one signature
+each time, `invalid` there and `valid` here. btclib answers `valid` for
+all four, which form s took having been the signer's choice, so a verifier
+has no standing to refuse it (issue 695); the rule itself lives on in
+`sign` and in the leading-underscore spellings. `_generic_valid` below is
+how those two are found, and says why a flag would find only one.
 
 Hash functions beyond sha256, for the same reason in a second direction.
 Bitcoin signs with sha256 and nothing else, so the sha512, SHA3 and SHAKE
@@ -403,20 +410,41 @@ def test_pinned_xof() -> None:
     assert wider.digest()[: secp256k1.n_size] == hash_object.digest()
 
 
+def _generic_valid() -> frozenset[tuple[str, str]]:
+    """Return the (key, signature) pairs the generic profile calls valid.
+
+    Which is how the two verdicts btclib no longer shares with the bitcoin
+    profile are found, rather than by naming their numbers: one key, one
+    signature, `invalid` under the bitcoin profile and `valid` under the
+    generic one is a case whose only defect is the form of s, and that is
+    the rule a verifier no longer applies (issue 695). There are two of
+    them, and a flag reaches only the first -- tcId 1 is
+    `SignatureMalleabilityBitcoin`, while tcId 388, "edge case for
+    signature malleability", is flagged `ArithmeticError` along with six
+    cases that are invalid for their arithmetic and not for their s.
+    """
+    return frozenset(
+        (group["publicKey"]["uncompressed"], test["sig"])
+        for group in load("ecc", "_data", _ECDSA)["testGroups"]
+        for test in group["tests"]
+        if test["result"] == "valid"
+    )
+
+
 @pytest.mark.parametrize(
-    "key, vector, lower_s, hf, bindings",
-    _signature_vectors(_ECDSA_BITCOIN, "bitcoin", sha256, True)
-    + _signature_vectors(_ECDSA, "ecdsa", sha256, False)
-    + _signature_vectors(_ECDSA_SHA512, "sha512", sha512, False)
-    + _signature_vectors(_ECDSA_SHA3_256, "sha3-256", sha3_256, False)
-    + _signature_vectors(_ECDSA_SHA3_512, "sha3-512", sha3_512, False)
-    + _signature_vectors(_ECDSA_SHAKE128, "shake128", _SHAKE128, False)
-    + _signature_vectors(_ECDSA_SHAKE256, "shake256", _SHAKE256, False),
+    "key, vector, low_s_exempt, hf, bindings",
+    _signature_vectors(_ECDSA_BITCOIN, "bitcoin", sha256, _generic_valid())
+    + _signature_vectors(_ECDSA, "ecdsa", sha256, frozenset())
+    + _signature_vectors(_ECDSA_SHA512, "sha512", sha512, frozenset())
+    + _signature_vectors(_ECDSA_SHA3_256, "sha3-256", sha3_256, frozenset())
+    + _signature_vectors(_ECDSA_SHA3_512, "sha3-512", sha3_512, frozenset())
+    + _signature_vectors(_ECDSA_SHAKE128, "shake128", _SHAKE128, frozenset())
+    + _signature_vectors(_ECDSA_SHAKE256, "shake256", _SHAKE256, frozenset()),
 )
 def test_ecdsa_der(
     key: str,
     vector: dict[str, Any],
-    lower_s: bool,
+    low_s_exempt: frozenset[tuple[str, str]],
     hf: HashF,
     bindings: bool,
     monkeypatch: pytest.MonkeyPatch,
@@ -443,8 +471,10 @@ def test_ecdsa_der(
 
     msg_hash = _digest(hf, bytes.fromhex(vector["msg"]))
     sig = bytes.fromhex(vector["sig"])
-    verified = dsa.verify_(msg_hash, key, sig, lower_s, hf)
-    assert verified == (vector["result"] == "valid")
+    verified = dsa.verify_(msg_hash, key, sig, hf)
+    # `_generic_valid` above is where the exemption comes from, and why it
+    # is not a flag and not a list of tcIds
+    assert verified == (vector["result"] == "valid" or (key, sig.hex()) in low_s_exempt)
 
 
 @pytest.mark.parametrize(
@@ -471,8 +501,9 @@ def test_ecdsa_p1363(
     `RangeCheck` and `InvalidSignature` cases are r and s at 0, at n, and
     at n plus a valid value, none of which any DER framing can hide.
 
-    `lower_s=False` for both files, neither having a bitcoin profile: the
-    sha256 one's tcId 1 is the malleable high-s signature and is `valid`.
+    No exemption is needed here, none of these files having a bitcoin
+    profile: the sha256 one's tcId 1 is the malleable high-s signature and
+    is `valid`, which is the answer `verify_` gives everywhere now.
 
     The size rule is the encoding's and not the hash's, so it is `n_size`
     twice over under sha512 as under sha256: P1363 pads each of r and s
@@ -496,7 +527,7 @@ def test_ecdsa_p1363(
         return
 
     msg_hash = _digest(hf, bytes.fromhex(vector["msg"]))
-    assert dsa.verify_(msg_hash, key, sig, False, hf) == (vector["result"] == "valid")
+    assert dsa.verify_(msg_hash, key, sig, hf) == (vector["result"] == "valid")
 
 
 @pytest.mark.parametrize(

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -2864,7 +2864,7 @@ def test_the_sig_hash_of_every_input_kind_a_partial_signature_signs() -> None:
             for pub_key, sig in psbt_in.partial_sigs.items():
                 msg_hash = _sig_hash_from_psbt_in(psbt_in, psbt.tx, vin_i, sig[-1])
                 assert msg_hash is not None
-                assert dsa.verify_(msg_hash, pub_key, sig[:-1], lower_s=False)
+                assert dsa.verify_(msg_hash, pub_key, sig[:-1])
                 checked += 1
     # a count, so that a loop that stops finding signatures is a failure
     # and not a green run over nothing


### PR DESCRIPTION
Closes #695
Closes #645

## Low-s is the signer's choice

Whether `s` is the low one of the two was decided by whoever signed, so
nothing that only reads a signature has standing to refuse the other.
`lower_s` is gone from nine functions: dsa's `assert_as_valid`, `verify`,
`recover_pub_keys`, `recover_pub_key`, their four trailing-underscore
twins, `anti_exfil_host_verify`, and `bms.assert_as_valid` and
`bms.verify`.

It went from **both members of each pair or from neither**. A trailing
underscore names a *public* function, offered beside the plain name so a
caller can skip work it has already paid; a keyword on one and not the
other would make them two functions instead of a bypass.

What #645 measured, over the 200 vectors of
`tests/ecc/_data/signmessage.json`: Core v31.1.0's `verifymessage`
accepts every one, btclib's default refused the 88 that are high-s, and
the low-s rule was the whole of the disagreement. Two callers of
`bms.assert_as_valid` sat on that default and are fixed by losing it —
`bip322`'s legacy path and `psbt_signer.sign_message`, which checks what
an *external* signer returned through HWI. The two `dsa.verify_` calls in
`psbt` had reached the conclusion already: both passed `lower_s=False`,
with a docstring saying the rule is the script engine's.

### The rule is not gone, it is where it belongs

`SCRIPT_VERIFY_LOW_S` is in Core's `STANDARD_SCRIPT_VERIFY_FLAGS`
(`src/policy/policy.h`), so a high-s signature inside a transaction is
non-standard and does not relay. So `sign` keeps `lower_s=True`, the
script engine keeps reading the rule off its own flags, and asking a
verifier for it is what the *leading*-underscore functions are for —
`_assert_as_valid_`, `_recover_pub_key_`, `_recover_pub_keys_`,
`_libsecp256k1_recover_sec_` and `_libsecp256k1_recover_point_`, each
taking `lower_s: bool = False` keyword-only. Keeping it on the last two
is what lets the bindings path and the Python path be held to one answer
under the strict rule, which is a claim only a test can make now.

On the bindings path `assert_as_valid_` normalizes unconditionally, where
it normalized only when the rule was switched off.

## Grinding becomes the default, with three states

The other half of matching Core. `grind` is now `bool | None`:

| | |
|---|---|
| unsaid (`None`) | grind wherever the nonce is the library's to derive |
| `True` | asked for outright, and still refused beside a nonce or a commitment |
| `False` | the plain RFC6979 signature |

Two states would have made `sign(msg, key, nonce)` **raise** — a caller
who asked for one thing, told they asked for two — and would have forced
`anti_exfil_sign` to say `grind=False` to keep a signing device from
grinding a nonce it had committed to. A default is a library preference
and gives way; `grind=True` beside either of those is a caller asking for
both halves of a contradiction, and that is still refused.

`sign_recoverable`, and with it `bms.sign`, grind nothing: a compact
65-byte signature has no DER pad for a low `r` to save, which is why
Core's `SignCompact` does not grind either. `bip322.sign` asks for
`grind=False` in so many words — the BIP's reference implementation signs
plain and its vectors are the whole interoperability claim there, with
nothing broadcast for the byte to matter.

## Two Wycheproof verdicts are now exempted, and how they are found

The bitcoin profile refuses two signatures the generic profile accepts:
tcId 1 and tcId 388 of `ecdsa_secp256k1_sha256_bitcoin_test.json` are
tcId 5 and tcId 392 of `ecdsa_secp256k1_sha256_test.json` — one key and
one signature each time. The exemption is read out of the second file
rather than written down: `invalid` there and `valid` here is a case whose
only defect is the form of `s`. A flag would find one of the two, tcId 388
carrying `ArithmeticError` beside six cases invalid for their arithmetic.

## Gates

- `uv run pytest`: 25959 passed, 6 skipped, coverage 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align ECDSA signing, verification, and key recovery behavior with Bitcoin Core by accepting both low- and high-s signatures everywhere while grinding low-R by default when the nonce is library-derived.

Bug Fixes:
- Resolve mismatches with Bitcoin Core and python-bitcoinlib message verification by no longer rejecting valid high-s signatures.
- Fix Wycheproof bitcoin-profile discrepancies by exempting cases that differ only by the low-s rule while keeping strict DER parsing.

Enhancements:
- Change dsa.sign/sign_ grind behavior to a three-state option defaulting to grinding when btclib owns the nonce, so default signatures match Core’s low-R behavior.
- Remove the public lower_s parameter from verification, recovery, anti-exfil, PSBT, and BMS APIs, keeping the low-s rule only in signing and private underscore helpers.
- Ensure libsecp256k1 bindings and pure-Python recovery/verification paths give consistent results under the strict low-s rule via internal keyword-only controls.

Documentation:
- Update changelog, history, test-data README, and Wycheproof documentation to describe new low-s handling, grinding defaults, and the special-case Wycheproof exemptions.
- Clarify guides and comments around ECDSA signing, recovery, anti-exfil, BMS, and PSBT behavior to reflect acceptance of both s forms and Core-aligned grinding.

Tests:
- Adjust and extend DSA, BMS, RFC6979, anti-exfil, PSBT, Wycheproof, and commit-nonce tests to cover high-s acceptance, grinding defaults, and the two Wycheproof exemptions.