### PR TITLE
Let the signer pick s, and never refuse that pick when reading (#695)

### DIFF
--- a/.github/mutation/bms.toml
+++ b/.github/mutation/bms.toml
@@ -41,8 +41,8 @@ excluded-modules = []
 #   range, which every operator that survived still does most draws.
 #
 # A second pass worked through the address-type dispatch and the
-# check_validity/lower_s defaults this file's first pass sampled rather
-# than chased, closing the rest of the real gaps:
+# check_validity defaults this file's first pass sampled rather than
+# chased, closing the rest of the real gaps:
 #
 # - `_assert_p2pkh`/`_assert_p2wpkh`/`_assert_p2wpkh_p2sh`'s recovery-
 #   flag ranges were each pinned by a single vector -- 39 for p2pkh, 35
@@ -66,8 +66,7 @@ excluded-modules = []
 #   version-0-only length check cannot rule out on its own.
 # - check_validity defaults on `serialize`, `b64encode` and `parse` had
 #   no test building an invalid `Sig` and calling any of the three at
-#   their default; `assert_as_valid`'s and `verify`'s `lower_s` default
-#   had no test relying on it instead of passing the keyword.
+#   their default.
 #
 # Checked and left equivalent: `script_type == "p2pkh"` against `<=`,
 # `p2sh` being the only other value and always sorting after `p2pkh`;

--- a/.github/mutation/signatures.toml
+++ b/.github/mutation/signatures.toml
@@ -65,8 +65,8 @@ excluded-modules = []
 # random on every call is not what a fixed vector can hold an operator to.
 # Message-formatting thresholds (`self.r > 0xFFFFFFFF` deciding hex or
 # decimal display) account for several more, cosmetic rather than a
-# validity boundary. check_validity and `lower_s` defaults account for
-# another block, the same class parsers.toml's follow-up already names;
+# validity boundary. check_validity defaults account for another block,
+# the same class parsers.toml's follow-up already names;
 # the remainder is comparison operators and DER sign-byte handling
 # scattered across the parse/serialize/recover paths, sampled as data
 # here rather than chased to completion.
@@ -128,16 +128,13 @@ excluded-modules = []
 # - `Sig.assert_valid`'s `0 < self.r` and `0 < self.s`: pinned at zero
 #   the same way `ssa.Sig`'s test already was, `-1 <` accepting the one
 #   value below the range dsa.Sig -- unlike ssa.Sig -- excludes.
-# - `lower_s`'s default, `True`, on `assert_as_valid`, `verify` and
-#   `anti_exfil_host_verify`: three functions, the same class as the
-#   guard above, and no test had asked any of the three to refuse a
-#   malleated (high-s) signature *without* passing the keyword. The
-#   malleated twin already built for `verify(..., lower_s=False)`
-#   answers the question at the default too; libsecp256k1's own verify
-#   is what refuses it there, lower_s deciding only whether the
-#   signature is normalized in front of that call, so the message is
-#   "signature verification failed" and not `_assert_as_valid_`'s "not
-#   a low s", which the Python path alone raises.
+# - `_assert_as_valid_`'s `lower_s`, which is where the low-s rule now
+#   lives and nowhere else: the public verification and recovery
+#   functions do not take the flag at all, so its default, `False`, is
+#   what every one of them asks for. A mutant flipping it to `True`
+#   makes the private function refuse a high s nobody asked it about,
+#   which `tests/ecc/dsa_test.py` holds by calling it both ways round
+#   over the malleated twin it already builds.
 #
 # Checked and left equivalent, most of it the patterns already
 # established elsewhere in this session applied to this pair's own call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -688,6 +688,38 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **Nothing that reads a signature refuses it for a high `s`** (#695,
+  #645). `lower_s` is gone from `dsa.assert_as_valid`, `assert_as_valid_`,
+  `verify`, `verify_`, `recover_pub_key`, `recover_pub_key_`,
+  `recover_pub_keys`, `recover_pub_keys_`, `anti_exfil_host_verify`,
+  `bms.assert_as_valid` and `bms.verify`, and every one of them now
+  answers as though it were false. Which of `s` and `n - s` a signature
+  carries is the signer's choice, made where `lower_s` remains -- `sign`,
+  `sign_`, `sign_recoverable`, `sign_recoverable_` and `anti_exfil_sign`,
+  all still defaulting to the low one, as Core and Electrum sign -- and a
+  reader that refused the twin refused a signature its signer was free to
+  produce. Bitcoin Core's `verifymessage` and `CPubKey::Verify` do not
+  refuse it either: the low-s rule is transaction policy, where it keeps
+  a txid from being malleated, and a message signature has no txid.
+
+  The size of the divergence, measured against a node: of the 200 vectors
+  of `tests/ecc/_data/signmessage.json`, python-bitcoinlib's own file,
+  Core v31.1.0's `verifymessage` accepts all 200 and btclib's default
+  refused the 88 that are high-s. All 200 verify now, and
+  `test_the_vectors_core_accepts_and_the_low_s_rule_would_refuse` asserts
+  both halves together -- every vector accepted, 88 of them high-s --
+  because a rule put back on the verification side would otherwise leave
+  this suite green, refusing them one vector per case with nothing to say
+  that Core does not.
+
+  The strict answer keeps one home, `dsa._assert_as_valid_`, whose
+  `lower_s` now defaults to `False` and is keyword-only: a test asks for
+  it, no public path does. Wycheproof's `EcdsaBitcoinVerify` file stays in
+  the suite, with the two vectors it marks invalid for that rule alone
+  excepted by tcId and the other verdicts asserted as written; btclib
+  answers the generic `EcdsaVerify` profile for both files. `psbt.py`'s
+  two verifications drop the keyword they passed, having always wanted
+  this answer.
 - **Cracking refuses a child the library itself refuses** (#693).
   `crack_prv_key` exists to demonstrate a known BIP32 weakness, so a wrong
   answer from it is a wrong lesson: it subtracted the derivation offset
@@ -965,15 +997,27 @@ documented at release-notes length in the first place, and are still in
   own, retries included. No attempt cap, as in Core: one would answer an
   event of probability `2**-k` with an error a caller can do nothing about.
 
-  `grind=False` is the default, where Core has it on. A ground signature is
-  not the RFC6979 one for about half of all messages, and a caller pinning
-  btclib's deterministic signatures is entitled to keep getting them; the
+  Grinding is the default, as it is Core's. A ground signature is not the
+  RFC6979 one for about half of all messages, so a caller pinning btclib's
+  plain deterministic signatures passes `grind=False` and gets them; the
   five python-bitcoinlib vectors say the same thing from the other side,
   four of the five having a high `r`, so grinding departs from exactly
   those four -- `test_rfc6979_secp256k1_grinding_leaves_only_the_low_r_one`
   beside the test that counts the four `s` values normalization moves.
   Keyword-only, `ec` and `hf` being positional and a flag inserted before
   them renumbering both.
+
+  The default is spelled `None` rather than `True`, because grinding is a
+  search over nonces and two calls have none to search: a nonce of the
+  caller's is the nonce, and a commitment owns the extra entropy the
+  counter travels through. `None` is "grind wherever that search exists",
+  which leaves `sign(msg, key, nonce)` and `sign(msg, key, commit=...)`
+  the ordinary spelling of both; `True` beside either is a request that
+  cannot be met, and is refused as before. `bip322.sign` passes
+  `grind=False` for its own reason: the BIP's vectors are the plain
+  signatures, and reproducing them byte for byte is what makes the
+  construction the BIP's rather than a lookalike -- a proof that is never
+  relayed has no byte of DER to save.
 
   Grinding is refused with a nonce of the caller's and with a
   sign-to-contract commitment, each of which already owns what grinding

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,31 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **verification and recovery no longer take `lower_s`, and accept a high
+  `s`.** `dsa.verify(msg, key, sig, lower_s, hf)`,
+  `dsa.assert_as_valid`, `verify_`, `assert_as_valid_`,
+  `recover_pub_key`, `recover_pub_key_`, `recover_pub_keys`,
+  `recover_pub_keys_`, `bms.verify(msg, addr, sig, lower_s)` and
+  `bms.assert_as_valid` have dropped the parameter: a caller passing it
+  positionally now hands `hf` a `bool`, and one passing it by keyword
+  gets a `TypeError`. Drop the argument. What changes with it is the
+  answer: the malleable high-`s` twin of a valid signature verifies now,
+  where the `lower_s=True` default refused it — which is what Bitcoin
+  Core answers, `verifymessage` and `CPubKey::Verify` alike, and 88 of
+  the 200 `signmessage.json` vectors are that case. Signing is
+  unchanged: `sign`, `sign_`, `sign_recoverable`, `sign_recoverable_`
+  and `anti_exfil_sign` keep `lower_s=True`, so what btclib produces is
+  the low-`s` signature it always produced.
+- **ECDSA signatures are ground for a low `r` by default**, as Bitcoin
+  Core has ground them since 0.17: about half of all messages now sign
+  to a different, one-byte-shorter DER than before. The signature is
+  still deterministic, the retry sequence being Core's own, and it
+  verifies wherever the previous one did. A caller pinning btclib's
+  plain RFC6979 signatures — reproducing a fixed vector, or comparing
+  bytes across versions — passes `grind=False` to `dsa.sign` or
+  `dsa.sign_` and gets exactly what it got before. Message signatures
+  are unaffected: `bms.sign` and `dsa.sign_recoverable` do not grind, a
+  recoverable signature having no DER pad for a low `r` to save.
 - **a MOV-weak curve is refused with `BTClibValueError`, not
   `UserWarning`.** `Curve(p, a, b, G, n, cofactor)` with the default
   `weakness_check=True` used to raise `UserWarning("weak curve")` for a

--- a/btclib/bip322.py
+++ b/btclib/bip322.py
@@ -693,7 +693,12 @@ def sign(msg: Octets, prv_key: PrvKey, addr: String) -> Sig:
         return Sig(Witness([ssa.sign_(msg_hash, tweaked).serialize()]))
 
     msg_hash = from_tx(spend.vout, tx, 0, ALL)
-    signature = dsa.sign_(msg_hash, q).serialize() + ALL.to_bytes(1, "big")
+    # grind=False, against `dsa.sign_`'s default: the BIP's own vectors are
+    # the plain RFC6979 signatures, and reproducing them byte for byte is
+    # what makes this construction the BIP's rather than a lookalike. The
+    # byte of DER a low r saves is worth nothing here anyway -- a BIP322
+    # proof is never relayed, its transaction never spendable
+    signature = dsa.sign_(msg_hash, q, grind=False).serialize() + ALL.to_bytes(1, "big")
 
     if script_type == "p2pkh":
         tx.vin[0].script_sig = serialize([signature, pub_key])

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -365,15 +365,20 @@ def _assert_p2wpkh_p2sh(addr: String, rf: int, pub_key: bytes, h160: bytes) -> N
         raise BTClibValueError(f"invalid p2wpkh-p2sh address: {addr!r}")
 
 
-def assert_as_valid(
-    msg: Octets, addr: String, sig: Sig | String, lower_s: bool = True
-) -> None:
+def assert_as_valid(msg: Octets, addr: String, sig: Sig | String) -> None:
     """Refuse a signature that does not open to the address.
 
     The public key is recovered from the signature under the magic
     message envelope, then rendered as the address type the recovery
     flag claims; anything short of a match is an error, verify being
     the boolean answer.
+
+    A high s is accepted, as Core's own verifymessage accepts it and as
+    ``dsa.recover_pub_key`` does: the lower-s rule is bitcoin policy on
+    transaction signatures, where it keeps a txid from being malleated,
+    and a message signature has no txid and nothing downstream that
+    depends on its uniqueness. The signer's side keeps the rule -- sign
+    below produces a low s, as Core and Electrum do.
     """
     if isinstance(sig, Sig):
         sig.assert_valid()
@@ -397,10 +402,10 @@ def assert_as_valid(
     # itself and 2.4 the r-congruence check of the Sig validation above
     if _libsecp256k1_applicable(secp256k1):
         pub_key = _libsecp256k1_recover_sec_(
-            key_id, reduce_to_hlen(magic_msg), sig.dsa_sig, lower_s, compressed
+            key_id, reduce_to_hlen(magic_msg), sig.dsa_sig, compressed
         )
     else:
-        Q = dsa.recover_pub_key(key_id, magic_msg, sig.dsa_sig, lower_s, sha256)
+        Q = dsa.recover_pub_key(key_id, magic_msg, sig.dsa_sig, sha256)
         pub_key = bytes_from_point(Q, compressed=compressed)
 
     # the address says which of the three checks applies, and each of them
@@ -421,7 +426,7 @@ def assert_as_valid(
     _assert_p2wpkh_p2sh(addr, sig.rf, pub_key, h160)
 
 
-def verify(msg: Octets, addr: String, sig: Sig | String, lower_s: bool = True) -> bool:
+def verify(msg: Octets, addr: String, sig: Sig | String) -> bool:
     """Verify address-based compact signature for the provided message."""
     # ValueError and BTClibRuntimeError, not Exception: an input that is not
     # a valid signature is False, and so is a verification that failed, but
@@ -430,7 +435,7 @@ def verify(msg: Octets, addr: String, sig: Sig | String, lower_s: bool = True) -
     # BTClibRuntimeError by name and not RuntimeError, because
     # RecursionError is one and is not an answer about a signature
     try:
-        assert_as_valid(msg, addr, sig, lower_s)
+        assert_as_valid(msg, addr, sig)
     except (ValueError, BTClibRuntimeError):
         return False
 

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -8,12 +8,13 @@ Implementation according to SEC 1 v.2:
 
 http://www.secg.org/sec1-v2.pdf
 
-specialized with bitcoin canonical 'lower-s' form
-to avoid accepting malleable signatures.
+specialized with the bitcoin canonical 'lower-s' form on the signing
+side, which is where the choice between s and n - s is made: nothing
+here refuses the high-s twin of a valid signature, ``lower_s`` being a
+parameter of ``sign`` and of no verification or recovery function.
 
-``sign`` grinds for a low-R signature -- one byte shorter in DER -- when
-asked to, which is Core's default and not this library's: ``_grind_low_r``
-is the loop and says why.
+``sign`` grinds for a low-R signature -- one byte shorter in DER -- as
+Core does: ``_grind_low_r`` is the loop and says why.
 
 ``sign`` also takes a value to commit to inside the nonce,
 sign-to-contract style (see btclib.ecc.commit_nonce for the tweak), and
@@ -456,7 +457,7 @@ def sign_(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool = ...,
+    grind: bool | None = ...,
     commit_hash: None = None,
 ) -> Sig: ...
 
@@ -470,7 +471,7 @@ def sign_(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool = ...,
+    grind: bool | None = ...,
     commit_hash: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -483,7 +484,7 @@ def sign_(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     *,
-    grind: bool = False,
+    grind: bool | None = None,
     commit_hash: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """Sign a hf_len bytes message according to ECDSA signature algorithm.
@@ -491,14 +492,23 @@ def sign_(
     If the deterministic nonce is not provided, the RFC6979
     specification is used.
 
-    grind asks for a low-R signature, one byte shorter in DER: `_grind_low_r`
-    is the loop, Core's since its 0.17. Off by default, where Core has it
-    on, because it is a departure from RFC6979 for about half of all
-    messages -- the nonce of a ground signature is derived with a counter
-    in it -- and a caller pinning this library's deterministic signatures
-    is entitled to keep getting them. Keyword-only, rather than beside
-    lower_s where it belongs by subject: ec and hf are positional here and
-    a flag inserted before them would renumber both.
+    grind asks for a low-R signature, one byte shorter in DER:
+    `_grind_low_r` is the loop, Core's since its 0.17 and its default,
+    hence this library's. It is a departure from RFC6979 for about half of
+    all messages -- the nonce of a ground signature is derived with a
+    counter in it -- so a caller pinning the plain deterministic signature
+    passes grind=False and gets it.
+
+    Its default is None rather than True because grinding is a search over
+    nonces, and two of the calls here have no nonce to search: a nonce of
+    the caller's is the nonce, and a commitment owns the extra entropy the
+    counter would travel through. None is "grind wherever that search
+    exists", so those two calls stay legal; an explicit grind=True beside
+    either is a request that cannot be met, and is refused below.
+
+    Keyword-only, rather than beside lower_s where it belongs by subject:
+    ec and hf are positional here and a flag inserted before them would
+    renumber both.
 
     commit_hash is a value to commit to inside the nonce, sign-to-contract
     style: the signature is an ordinary one, and the receipt returned
@@ -536,6 +546,12 @@ def sign_(
     # through
     if grind and (nonce is not None or commit_hash is not None):
         raise BTClibValueError("grinding derives its own nonce")
+
+    # past that refusal, the default asks for grinding wherever the nonce
+    # derivation is this call's to make, which is what those two
+    # conditions have just ruled out
+    if grind is None:
+        grind = nonce is None and commit_hash is None
 
     # a nonce provided by the caller is the nonce, while what
     # libsecp256k1 takes is extra entropy for the RFC6979 nonce it
@@ -599,7 +615,7 @@ def sign(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool = ...,
+    grind: bool | None = ...,
     commit: None = None,
 ) -> Sig: ...
 
@@ -613,7 +629,7 @@ def sign(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool = ...,
+    grind: bool | None = ...,
     commit: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -626,7 +642,7 @@ def sign(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     *,
-    grind: bool = False,
+    grind: bool | None = None,
     commit: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """ECDSA signature with canonical low-s preference.
@@ -746,9 +762,15 @@ def sign_recoverable(
 
 
 def _assert_as_valid_(
-    c: int, QJ: JacPoint, r: int, s: int, lower_s: bool, ec: Curve
+    c: int, QJ: JacPoint, r: int, s: int, ec: Curve, *, lower_s: bool = False
 ) -> None:
-    # Private function for test/dev purposes
+    # Private function for test/dev purposes, and the one place the
+    # lower-s rule is asked of a signature being read: the public
+    # verification and recovery functions do not take the flag, s or n - s
+    # being the signer's choice and neither making the other invalid.
+    # Default False, so that the strict answer is asked for rather than
+    # assumed, and keyword-only, ec keeping the position ssa's twin has it
+    # in
 
     if lower_s and s > ec.n // 2:
         raise BTClibValueError("not a low s")
@@ -805,7 +827,6 @@ def assert_as_valid_(
     msg_hash: Octets,
     key: PubKey,
     sig: Sig | Octets,
-    lower_s: bool = True,
     hf: HashF = sha256,
     *,
     commit_hash: Octets | None = None,
@@ -816,9 +837,16 @@ def assert_as_valid_(
     The message enters already reduced -- msg_hash, not the message --
     which is what the trailing underscore says; assert_as_valid is the
     spelling that reduces with hf first. Errors carry the reason,
-    ``verify_`` being the boolean answer; lower_s asks for the BIP62 rule
-    that refuses the malleable high-s twin. With commit_hash and
-    receipt the sign-to-contract commitment is opened as well.
+    ``verify_`` being the boolean answer. With commit_hash and receipt the
+    sign-to-contract commitment is opened as well.
+
+    Both s and n - s verify, and this answers about both: which one a
+    signature carries is the signer's choice, made in ``sign``, and a
+    reader that refused the high-s twin would refuse a signature its
+    signer was free to produce. It is what Core's own verification does --
+    the lower-s rule is a policy rule on transaction signatures and not
+    part of the equation -- so a signature accepted here is one every
+    reference implementation accepts.
     """
     # key is a PubKey, not a Key: verification is where a private key
     # accepted for a public one does real harm, silently checking a
@@ -850,10 +878,12 @@ def assert_as_valid_(
         # not free even delegated: 0.54 us against 3.1, of a verification
         # that is 22 in total
         sig_bytes = sig.serialize(check_validity=False)
-        # libsecp256k1 rejects what is not in the lower-s form: if it is
-        # not to be enforced, then normalize
-        if not lower_s:
-            sig_bytes = libsecp256k1_dsa.normalize(sig_bytes)
+        # libsecp256k1 refuses what is not in the lower-s form, that rule
+        # being bitcoin policy rather than the verification equation, so
+        # the high-s twin is normalized in front of it: what is asked of
+        # the bindings is whether the signature verifies, and both s and
+        # n - s do
+        sig_bytes = libsecp256k1_dsa.normalize(sig_bytes)
         if not libsecp256k1_dsa.verify(msg_hash_bytes, pubkey_bytes, sig_bytes):
             raise BTClibRuntimeError("signature verification failed")
         return
@@ -861,15 +891,15 @@ def assert_as_valid_(
     c = challenge_(msg_hash, sig.ec, hf)  # 2, 3
     Q = point_from_pub_key(key, sig.ec)
     QJ = Q[0], Q[1], 1
-    # second part delegated to helper function
-    _assert_as_valid_(c, QJ, sig.r, sig.s, lower_s, sig.ec)
+    # second part delegated to helper function, its lower_s left to the
+    # False that is this function's answer about a high s
+    _assert_as_valid_(c, QJ, sig.r, sig.s, sig.ec)
 
 
 def assert_as_valid(
     msg: Octets,
     key: PubKey,
     sig: Sig | Octets,
-    lower_s: bool = True,
     hf: HashF = sha256,
     *,
     commit: Octets | None = None,
@@ -878,16 +908,13 @@ def assert_as_valid(
     """Refuse an invalid ECDSA signature, reducing the message with hf."""
     msg_hash = reduce_to_hlen(msg, hf)
     commit_hash = None if commit is None else reduce_to_hlen(commit, hf)
-    assert_as_valid_(
-        msg_hash, key, sig, lower_s, hf, commit_hash=commit_hash, receipt=receipt
-    )
+    assert_as_valid_(msg_hash, key, sig, hf, commit_hash=commit_hash, receipt=receipt)
 
 
 def verify_(
     msg_hash: Octets,
     key: PubKey,
     sig: Sig | Octets,
-    lower_s: bool = True,
     hf: HashF = sha256,
     *,
     commit_hash: Octets | None = None,
@@ -907,7 +934,7 @@ def verify_(
     # RecursionError is one and is not an answer about a signature
     try:
         assert_as_valid_(
-            msg_hash, key, sig, lower_s, hf, commit_hash=commit_hash, receipt=receipt
+            msg_hash, key, sig, hf, commit_hash=commit_hash, receipt=receipt
         )
     except (ValueError, BTClibRuntimeError):
         return False
@@ -919,7 +946,6 @@ def verify(
     msg: Octets,
     key: PubKey,
     sig: Sig | Octets,
-    lower_s: bool = True,
     hf: HashF = sha256,
     *,
     commit: Octets | None = None,
@@ -932,9 +958,7 @@ def verify(
     """
     msg_hash = reduce_to_hlen(msg, hf)
     commit_hash = None if commit is None else reduce_to_hlen(commit, hf)
-    return verify_(
-        msg_hash, key, sig, lower_s, hf, commit_hash=commit_hash, receipt=receipt
-    )
+    return verify_(msg_hash, key, sig, hf, commit_hash=commit_hash, receipt=receipt)
 
 
 def anti_exfil_host_commit(rho: Octets, hf: HashF = sha256) -> bytes:
@@ -1048,7 +1072,6 @@ def anti_exfil_host_verify(
     sig: Sig | Octets,
     rho: Octets,
     receipt: Point,
-    lower_s: bool = True,
     hf: HashF = sha256,
 ) -> bool:
     """Check the signature against R and rho: step 5 of the anti-exfil protocol.
@@ -1066,12 +1089,10 @@ def anti_exfil_host_verify(
     answers: a rho of the wrong size is a rho this commitment does
     not open to.
     """
-    return verify_(msg_hash, key, sig, lower_s, hf, commit_hash=rho, receipt=receipt)
+    return verify_(msg_hash, key, sig, hf, commit_hash=rho, receipt=receipt)
 
 
-def _recover_pub_keys_(
-    c: int, r: int, s: int, lower_s: bool, ec: Curve
-) -> list[JacPoint]:
+def _recover_pub_keys_(c: int, r: int, s: int, ec: Curve) -> list[JacPoint]:
     # Private function provided for testing purposes only.
 
     # The Python enumeration: `recover_pub_keys_` above asks the bindings
@@ -1109,14 +1130,21 @@ def _recover_pub_keys_(
         # range: it is what a caller indexes to name a key_id, which is
         # only that key_id when no earlier candidate dropped out
         with contextlib.suppress(BTClibValueError, BTClibRuntimeError):
-            keys.append(_recover_pub_key_(key_id, c, r, s, lower_s, ec))
+            keys.append(_recover_pub_key_(key_id, c, r, s, ec))
     return keys
 
 
 def recover_pub_keys_(
-    msg_hash: Octets, sig: Sig | Octets, lower_s: bool = True, hf: HashF = sha256
+    msg_hash: Octets, sig: Sig | Octets, hf: HashF = sha256
 ) -> list[Point]:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
+
+    No lower-s rule stands in front of this, ``verify_`` saying why for
+    the equation itself. Recovery is where the rule makes least sense of
+    all: negating s mirrors the nonce's point, so the high-s twin
+    recovers the very same keys, each under the key_id whose parity bit
+    is flipped -- which is the bit ``_sign_recoverable_`` flips when it
+    lowers s, from the other side of the same identity.
 
     See Also:
     - https://crypto.stackexchange.com/questions/18105/how-does-recovering-the-public-key-from-an-ecdsa-signature-work/18106#18106
@@ -1145,23 +1173,18 @@ def recover_pub_keys_(
             # a candidate that recovers nothing is dropped rather than
             # reported, as in _recover_pub_keys_: the bindings' refusal
             # arrives as the BTClibValueError _libsecp256k1_recover_sec_
-            # maps it to, and a high-s signature under lower_s enumerates
-            # to the empty list, every candidate failing the same rule
+            # maps it to
             with contextlib.suppress(BTClibValueError, BTClibRuntimeError):
-                keys.append(
-                    _libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s)
-                )
+                keys.append(_libsecp256k1_recover_point_(key_id, msg_hash, sig))
         return keys
 
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 
-    QJs = _recover_pub_keys_(c, sig.r, sig.s, lower_s, sig.ec)
+    QJs = _recover_pub_keys_(c, sig.r, sig.s, sig.ec)
     return [sig.ec.aff_from_jac(QJ) for QJ in QJs]
 
 
-def recover_pub_keys(
-    msg: Octets, sig: Sig | Octets, lower_s: bool = True, hf: HashF = sha256
-) -> list[Point]:
+def recover_pub_keys(msg: Octets, sig: Sig | Octets, hf: HashF = sha256) -> list[Point]:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
 
     See Also:
@@ -1169,12 +1192,10 @@ def recover_pub_keys(
 
     """
     msg_hash = reduce_to_hlen(msg, hf)
-    return recover_pub_keys_(msg_hash, sig, lower_s, hf)
+    return recover_pub_keys_(msg_hash, sig, hf)
 
 
-def _recover_pub_key_(
-    key_id: int, c: int, r: int, s: int, lower_s: bool, ec: Curve
-) -> JacPoint:
+def _recover_pub_key_(key_id: int, c: int, r: int, s: int, ec: Curve) -> JacPoint:
     # Private function provided for testing purposes only.
 
     # precomputations
@@ -1222,12 +1243,12 @@ def _recover_pub_key_(
     # representative its ladder reached. Every caller converts with
     # aff_from_jac, which is what a Jacobian coordinate is for
     QJ = _jac_double_mult(r1s, KJ, r1e, ec.GJ, ec)  # 1.6.1
-    _assert_as_valid_(c, QJ, r, s, lower_s, ec)  # 1.6.2
+    _assert_as_valid_(c, QJ, r, s, ec)  # 1.6.2
     return QJ
 
 
 def _libsecp256k1_recover_sec_(
-    key_id: int, msg_hash: bytes, sig: Sig, lower_s: bool, compressed: bool
+    key_id: int, msg_hash: bytes, sig: Sig, compressed: bool
 ) -> bytes:
     # Private function: the caller has asked _libsecp256k1_applicable
     # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
@@ -1244,14 +1265,10 @@ def _libsecp256k1_recover_sec_(
     # equation by construction, and a candidate whose x-coordinate is not
     # on the curve is the failure caught below.
     #
-    # The lower-s rule is checked here and not there. The recoverable
-    # parser takes any s in [1, n-1], as it must: a malleated signature
-    # recovers a key too, and lower_s is the caller saying whether that
-    # answer is wanted -- the same question _assert_as_valid_ answers with
-    # this very message
-    if lower_s and sig.s > sig.ec.n // 2:
-        raise BTClibValueError("not a low s")
-
+    # The recoverable parser takes any s in [1, n-1], as it must, and
+    # nothing here narrows that: a malleated signature recovers the same
+    # keys, and refusing it is not this library's to do -- see
+    # recover_pub_keys_
     n_size = sig.ec.n_size
     compact = sig.r.to_bytes(n_size, byteorder="big", signed=False)
     compact += sig.s.to_bytes(n_size, byteorder="big", signed=False)
@@ -1276,9 +1293,7 @@ def _libsecp256k1_recover_sec_(
     return libsecp256k1_keys.serialize(libsecp256k1_keys.parse(sec), compressed=False)
 
 
-def _libsecp256k1_recover_point_(
-    key_id: int, msg_hash: bytes, sig: Sig, lower_s: bool
-) -> Point:
+def _libsecp256k1_recover_point_(key_id: int, msg_hash: bytes, sig: Sig) -> Point:
     # Private function: the caller has asked _libsecp256k1_applicable
     # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
     #
@@ -1288,7 +1303,7 @@ def _libsecp256k1_recover_point_(
     # answer. The two callers are the named candidate and the enumeration
     # over all four of them, which is the only reason this is a function:
     # bms wants the octets and never builds the point at all.
-    sec = _libsecp256k1_recover_sec_(key_id, msg_hash, sig, lower_s, compressed=False)
+    sec = _libsecp256k1_recover_sec_(key_id, msg_hash, sig, compressed=False)
     p_size = sig.ec.p_size
     return (
         int.from_bytes(sec[1 : 1 + p_size], byteorder="big", signed=False),
@@ -1297,11 +1312,7 @@ def _libsecp256k1_recover_point_(
 
 
 def recover_pub_key_(
-    key_id: int,
-    msg_hash: Octets,
-    sig: Sig | Octets,
-    lower_s: bool = True,
-    hf: HashF = sha256,
+    key_id: int, msg_hash: Octets, sig: Sig | Octets, hf: HashF = sha256
 ) -> Point:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
 
@@ -1327,20 +1338,16 @@ def recover_pub_key_(
     # x_K = r + ec.n - ec.p otherwise, which fails step 1.6.2 for every r
     # -- passing it would need ec.p ≡ 0 mod ec.n
     if _libsecp256k1_applicable(sig.ec, hf) and 0 <= key_id <= 3:
-        return _libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s)
+        return _libsecp256k1_recover_point_(key_id, msg_hash, sig)
 
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 
-    QJ = _recover_pub_key_(key_id, c, sig.r, sig.s, lower_s, sig.ec)
+    QJ = _recover_pub_key_(key_id, c, sig.r, sig.s, sig.ec)
     return sig.ec.aff_from_jac(QJ)
 
 
 def recover_pub_key(
-    key_id: int,
-    msg: Octets,
-    sig: Sig | Octets,
-    lower_s: bool = True,
-    hf: HashF = sha256,
+    key_id: int, msg: Octets, sig: Sig | Octets, hf: HashF = sha256
 ) -> Point:
     """ECDSA public key recovery (SEC 1 v.2 section 4.1.6).
 
@@ -1349,7 +1356,7 @@ def recover_pub_key(
 
     """
     msg_hash = reduce_to_hlen(msg, hf)
-    return recover_pub_key_(key_id, msg_hash, sig, lower_s, hf)
+    return recover_pub_key_(key_id, msg_hash, sig, hf)
 
 
 def crack_prv_key_(

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -2378,9 +2378,10 @@ def _assert_ecdsa_sigs_verify(
     which is what `assert_signed` asks of a psbt that is nobody's answer
     in particular.
 
-    lower_s=False for the Finalizer's reason: the question is whether that
-    key made that signature, the low-s rule being policy the script engine
-    applies under its flags.
+    The question is whether that key made that signature, which is what
+    `dsa.verify_` answers and all it answers: the low-s rule is policy the
+    script engine applies under its flags, and it is not asked here for
+    the Finalizer's reason below.
     """
     for pub_key, sig in psbt_in.partial_sigs.items():
         if request_in is not None and pub_key in request_in.partial_sigs:
@@ -2390,7 +2391,7 @@ def _assert_ecdsa_sigs_verify(
             err_msg = f"input {vin_i}: cannot verify the signature of "
             err_msg += f"{pub_key.hex()}, the psbt does not say what was signed"
             raise BTClibValueError(err_msg)
-        if not dsa.verify_(msg_hash, pub_key, sig[:-1], lower_s=False):
+        if not dsa.verify_(msg_hash, pub_key, sig[:-1]):
             err_msg = f"input {vin_i}: invalid signature for pub_key {pub_key.hex()}"
             raise BTClibValueError(err_msg)
 
@@ -2795,10 +2796,11 @@ def _assert_partial_sigs_verify(psbt_in: PsbtIn, tx: Tx, vin_i: int) -> None:
     on bytes nothing vouches for, so skipping the check would finalize
     exactly the input whose signature cannot be believed.
 
-    lower_s=False because the question here is whether that key made that
-    signature: the low-s rule is policy, applied by the script engine
-    under its flags, and Bitcoin Core's CPubKey::Verify normalizes s
-    before verifying for this very reason.
+    The question here is whether that key made that signature, and a high
+    s is not evidence that it did not: the low-s rule is policy, applied
+    by the script engine under its flags, and Bitcoin Core's
+    CPubKey::Verify normalizes s before verifying for this very reason,
+    which is what `dsa.verify_` does for every caller.
     """
     # the hash is the input's and the hash type's, never the key's, so an
     # n-of-m input whose signatures agree on the type -- which is the
@@ -2815,7 +2817,7 @@ def _assert_partial_sigs_verify(psbt_in: PsbtIn, tx: Tx, vin_i: int) -> None:
         msg_hash = sig_hashes[hash_type]
         if msg_hash is None:
             continue
-        if not dsa.verify_(msg_hash, pub_key, sig[:-1], lower_s=False):
+        if not dsa.verify_(msg_hash, pub_key, sig[:-1]):
             err_msg = f"invalid partial signature for pub_key {pub_key.hex()}"
             raise BTClibValueError(err_msg)
 

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -489,11 +489,15 @@ hash its argument again, which is not what you want here — the sighash
 >>> msg_hash = sig_hash.from_tx([prevout], unsigned, 0, 0x01)
 >>> sig = dsa.sign_(msg_hash, prv_key)
 >>> sig.serialize().hex()
-'3045022100f6e18672602b1c3cbbd13695c5d83f2d6271b9427836e718de7bc69b1593a222022071f1c0677de22fa18c65e6da25ab68de6280c97b63a1b6fc1c21ba404d6dbe9c'
+'304402207b7dffe084afa0d951726827d8469628e646349e9e6e1d60b76aa91d4a459ff2022003c3fd5ed4795126862efa7bc194d03c76af29741eb36c47659ac39506f2de10'
 
-The nonce is RFC-6979 deterministic and the ``s`` value is the canonical
-low one, so this signature is the same on every machine and every run.
-btclib never invents randomness for an ECDSA signature.
+The nonce is RFC-6979 deterministic, the ``s`` value is the canonical
+low one, and ``r`` is ground low as Bitcoin Core grinds it — one byte
+shorter in DER, at the price of re-signing until it lands there. So this
+signature is the same on every machine and every run: btclib never
+invents randomness for an ECDSA signature, and grinding walks a fixed
+sequence of nonces (``dsa.sign_(..., grind=False)`` is the plain RFC6979
+signature, for a caller who wants that one).
 
 A segwit v0 input is spent with a witness, not with a script_sig: the
 DER signature with the hash type appended, then the public key.
@@ -504,7 +508,7 @@ DER signature with the hash type appended, then the public key.
 >>> signed.is_segwit()
 True
 >>> signed.serialize(include_witness=True).hex()
-'01000000000101ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff01c003b423000000001600141d0f172a0ecb48aee1be1f2687d2963ae33f71a102483045022100f6e18672602b1c3cbbd13695c5d83f2d6271b9427836e718de7bc69b1593a222022071f1c0677de22fa18c65e6da25ab68de6280c97b63a1b6fc1c21ba404d6dbe9c0121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635700000000'
+'01000000000101ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff01c003b423000000001600141d0f172a0ecb48aee1be1f2687d2963ae33f71a10247304402207b7dffe084afa0d951726827d8469628e646349e9e6e1d60b76aa91d4a459ff2022003c3fd5ed4795126862efa7bc194d03c76af29741eb36c47659ac39506f2de100121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635700000000'
 
 Now the two identifiers differ, which is what segwit bought: the witness
 is not covered by the txid.
@@ -512,11 +516,11 @@ is not covered by the txid.
 >>> signed.id.hex()
 '4ebbcec1c2b21740e5e4ffe6aaffe485f6285e7afcbce3130cf34cee05d653c7'
 >>> signed.hash.hex()
-'35c212ed54735c3677aadc9271d1fff153b6e06daea3341ef36323967f5833f2'
+'3f0a8a5f75909c79c075e7f62333ad7ae2cf05112283225a67202fa6deec4a19'
 >>> signed.id == unsigned.id
 True
 >>> signed.size, signed.vsize, signed.weight
-(192, 110, 438)
+(191, 110, 437)
 
 Finally, do not take your own word for it. btclib ships a script
 interpreter, so the transaction can be verified against the outputs it
@@ -555,7 +559,7 @@ ECDSA
 >>> from btclib.ecc import dsa
 >>> sig = dsa.sign(b"Satoshi Nakamoto", prv_key)
 >>> sig.serialize().hex()
-'3045022100f297566536c80c492421e0e8b4df4749e8e31ab70700519b3b123776823cd6950220627e8c87a97fe41e4a86f2ecfabec52b39a0ab6868617b39bd748d84fabec702'
+'304402204729dbf89f9288d56d32d1aea04db19df37c45c0a02863602f9ad98e7e506ce4022017489be41857144bf5782e964632d254b6b13ea22ce84837f775540784341f43'
 >>> dsa.verify(b"Satoshi Nakamoto", pub_key, sig)
 True
 >>> dsa.verify(b"satoshi nakamoto", pub_key, sig)
@@ -571,7 +575,9 @@ key plus a signature. Recovery answers up to four candidate keys, so the
 signer has to say which one is theirs: ``dsa.sign_recoverable`` is
 ``dsa.sign`` with that number beside it — the ``key_id``
 ``dsa.recover_pub_key`` takes. It costs nothing to ask for: the two bits
-are computed by any signer and thrown away by ``sign``.
+are computed by any signer and thrown away by ``sign``. It does not
+grind, where ``sign`` does: a recoverable signature is the fixed 65-byte
+form, with no DER pad for a low ``r`` to save.
 
 >>> sig, key_id = dsa.sign_recoverable(b"Satoshi Nakamoto", prv_key)
 >>> key_id

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -1367,9 +1367,11 @@ pulled  2026-08-13
 behind  0 revisions; that commit is the tip of the path
 ```
 
-Verdict: **identical**. The bitcoin profile, `EcdsaBitcoinVerify`: the
-`lower_s=True` default, where the malleable high-s twin of a valid
-signature is `invalid`.
+Verdict: **identical**. The bitcoin profile, `EcdsaBitcoinVerify`,
+where the malleable high-s twin of a valid signature is `invalid`. Not
+btclib's profile — nothing here refuses a signature for its `s` — so the
+two vectors that say so are excepted in `tests/ecc/wycheproof_test.py`
+and the rest of the file is adversarial vectors like any other.
 
 ### `tests/ecc/_data/ecdsa_secp256k1_sha256_test.json`
 
@@ -1383,8 +1385,8 @@ behind  0 revisions; that commit is the tip of the path
 ```
 
 Verdict: **identical**. The same algorithm, curve and hash as the file
-above, under `lower_s=False`: what a general-purpose ECDSA verifier must
-accept and the bitcoin one must not.
+above, without the low-s rule: what a general-purpose ECDSA verifier
+must accept, which is what `dsa.verify_` answers.
 
 ### `tests/ecc/_data/ecdsa_secp256k1_sha256_p1363_test.json`
 

--- a/tests/ecc/anti_exfil_test.py
+++ b/tests/ecc/anti_exfil_test.py
@@ -151,16 +151,13 @@ def test_the_whole_handshake() -> None:
         secp256k1.add(R, secp256k1.G),
     )
 
-    # lower_s defaults to True here too: the malleated twin shares r, so
-    # the commitment check alone would still open, and only the default
-    # refuses it
+    # the malleated twin shares r, so it opens the same commitment and
+    # verifies as the signature it is a twin of: step 5 is about the
+    # nonce, and the low-s rule is no part of what the host is checking
     malleated = dsa.Sig(sig.r, sig.ec.n - sig.s)
-    assert dsa.anti_exfil_host_verify(
-        _HANDSHAKE_MSG_HASH, _PUB_KEY, malleated, _RHO, R, lower_s=False
-    )
-    assert not dsa.anti_exfil_host_verify(
-        _HANDSHAKE_MSG_HASH, _PUB_KEY, malleated, _RHO, R
-    )
+    assert dsa.anti_exfil_host_verify(_HANDSHAKE_MSG_HASH, _PUB_KEY, malleated, _RHO, R)
+    # and the device signs low-s all the same, lower_s being sign_'s
+    assert sig.s < sig.ec.n - sig.s
 
 
 def test_the_signer_keeps_no_state() -> None:
@@ -242,4 +239,4 @@ def test_rho_and_the_commitment_are_hf_len() -> None:
         dsa.anti_exfil_signer_commit(msg_hash, _PRV_KEY, _RHO, secp256k1, sha1)
     R = dsa.anti_exfil_signer_commit(msg_hash, _PRV_KEY, commitment, secp256k1, sha1)
     sig = dsa.anti_exfil_sign(msg_hash, _PRV_KEY, rho, True, secp256k1, sha1)
-    assert dsa.anti_exfil_host_verify(msg_hash, _PUB_KEY, sig, rho, R, True, sha1)
+    assert dsa.anti_exfil_host_verify(msg_hash, _PUB_KEY, sig, rho, R, sha1)

--- a/tests/ecc/bms_test.py
+++ b/tests/ecc/bms_test.py
@@ -87,26 +87,24 @@ def test_signature() -> None:
 
     # malleated signature
     dsa_sig = dsa.Sig(bms_sig.dsa_sig.r, bms_sig.dsa_sig.ec.n - bms_sig.dsa_sig.s)
-    # without updating rf verification will fail, even with lower_s=False
+    # the recovery flag is the parity bit of the key_id, so a malleated s
+    # with the flag left alone recovers the other candidate: a valid
+    # signature of somebody else's key, hence a different address
     bms_sig = bms.Sig(bms_sig.rf, dsa_sig)
     err_msg = "invalid p2pkh address: "
     with pytest.raises(BTClibValueError, match=err_msg):
-        bms.assert_as_valid(msg, addr, bms_sig, lower_s=False)
-    # update rf to satisfy above malleation
+        bms.assert_as_valid(msg, addr, bms_sig)
+    # update rf to satisfy above malleation, and the twin is accepted:
+    # neither assert_as_valid nor verify takes a lower_s to refuse it
+    # with, and Core's verifymessage accepts it too
     i = 1 if bms_sig.rf % 2 else -1
     bms_sig = bms.Sig(bms_sig.rf + i, dsa_sig)
-    bms.assert_as_valid(msg, addr, bms_sig, lower_s=False)
-    assert bms.verify(msg, addr, bms_sig, lower_s=False)
-    # anyway, with lower_s=True malleation does fail verification
-    err_msg = "not a low s"
-    with pytest.raises(BTClibValueError, match=err_msg):
-        bms.assert_as_valid(msg, addr, bms_sig, lower_s=True)
-    # and the same is true left to the default: assert_as_valid's and
-    # verify's lower_s both default to True, and every other call in
-    # this file passes the keyword explicitly
-    with pytest.raises(BTClibValueError, match=err_msg):
-        bms.assert_as_valid(msg, addr, bms_sig)
-    assert not bms.verify(msg, addr, bms_sig)
+    bms.assert_as_valid(msg, addr, bms_sig)
+    assert bms.verify(msg, addr, bms_sig)
+    assert bms.verify(msg, addr, bms_sig.b64encode())
+    # the twin is the high-s one, which is to say what bms.sign produced
+    # was low-s: the rule the signer keeps
+    assert dsa_sig.s > dsa_sig.ec.n - dsa_sig.s
 
     # bms_sig taken from (Electrum and) Bitcoin Core
     wif, addr = bms.gen_keys("5KMWWy2d3Mjc8LojNoj8Lcz9B1aWu8bRofUgGwQk959Dw5h2iyw")
@@ -470,19 +468,15 @@ def test_msgsign_p2pkh() -> None:
     # malleate s
     s = ec.n - bms_sig1c.dsa_sig.s
     dsa_sig = dsa.Sig(bms_sig1c.dsa_sig.r, s, bms_sig1c.dsa_sig.ec)
-    # without updating rf verification will fail, even with lower_s=False
+    # without updating rf the recovered key is the other candidate, hence
+    # another address
     bms_sig = bms.Sig(bms_sig1c.rf, dsa_sig)
-    assert not bms.verify(msg, add1c, bms_sig, lower_s=False)
+    assert not bms.verify(msg, add1c, bms_sig)
 
-    # update rf to satisfy above malleation
+    # update rf to satisfy above malleation, and the high-s twin verifies
     i = 1 if bms_sig1c.rf % 2 else -1
     bms_sig = bms.Sig(bms_sig1c.rf + i, dsa_sig)
-    assert bms.verify(msg, add1c, bms_sig, lower_s=False)
-
-    # anyway, with lower_s=True malleation does fail verification
-    err_msg = "not a low s"
-    with pytest.raises(BTClibValueError, match=err_msg):
-        bms.assert_as_valid(msg, add1c, bms_sig, lower_s=True)
+    assert bms.verify(msg, add1c, bms_sig)
 
 
 def test_msgsign_p2pkh_2() -> None:
@@ -544,7 +538,7 @@ def test_verify_p2pkh() -> None:
     msg = b"test message"
     address = "16vqGo3KRKE9kTsTZxKoJKLzwZGTodK3ce"
     exp_sig = "HPDs1TesA48a9up4QORIuub67VHBM37X66skAYz0Esg23gdfMuCTYDFORc6XGpKZ2/flJ2h/DUF569FJxGoVZ50="
-    assert bms.verify(msg, address, exp_sig, lower_s=False)
+    assert bms.verify(msg, address, exp_sig)
 
     msg = b"test message 2"
     assert not bms.verify(msg, address, exp_sig)
@@ -562,7 +556,7 @@ def test_verify_p2pkh() -> None:
     msg = b"testtest"
     address = "18uitB5ARAhyxmkN2Sa9TbEuoGN1he83BX"
     exp_sig = "IMAtT1SjRyP6bz6vm5tKDTTTNYS6D8w2RQQyKD3VGPq2i2txGd2ar18L8/nvF1+kAMo5tNc4x0xAOGP0HRjKLjc="
-    assert bms.verify(msg, address, exp_sig, lower_s=False)
+    assert bms.verify(msg, address, exp_sig)
 
     msg = b"testtest"
     address = "1LsPb3D1o1Z7CzEt1kv5QVxErfqzXxaZXv"
@@ -697,6 +691,12 @@ def test_vector_python_bitcoinlib(vector: dict[str, Any]) -> None:
     `signmessage.json` is upstream's own name for it,
     `bitcoin/tests/data/signmessage.json`; tests/_data/README.md pins
     the revision.
+
+    Every vector verifies, high-s ones included, which is the whole of
+    what issue 695 measured against a node: Bitcoin Core v31.1.0's
+    `verifymessage` answers true for all 200 of these, and so does
+    `bms.verify` -- 88 of them are the malleable high-s twin, which the
+    signer was free to produce and no reader may refuse.
     """
     msg = vector["address"].encode()
 
@@ -709,11 +709,11 @@ def test_vector_python_bitcoinlib(vector: dict[str, Any]) -> None:
     # Core/Electrum/btclib provide identical signature
     # they use "low-s" canonical signature
     assert bms_sig.dsa_sig.s < ec.n - bms_sig.dsa_sig.s
-    assert bms.verify(msg, vector["address"], bms_sig_encoded, lower_s=True)
 
-    # python-bitcoinlib provides a valid signature
-    # but does not respect low-s
-    assert bms.verify(msg, vector["address"], vector["signature"], lower_s=False)
+    # python-bitcoinlib provides a valid signature, low-s or not, and
+    # verification does not ask which: the 88 high-s ones are accepted
+    # here as they are by Core
+    assert bms.verify(msg, vector["address"], vector["signature"])
 
     # python-bitcoinlib has a signature different from Core/Electrum/btclib
     assert bms_sig_encoded != vector["signature"]
@@ -725,9 +725,9 @@ def test_vector_python_bitcoinlib(vector: dict[str, Any]) -> None:
     # properly malleated fixing also rf
     i = 1 if bms_sig.rf % 2 else -1
     bms_sig_malleated = bms.Sig(bms_sig.rf + i, dsa_sig)
-    assert bms.verify(msg, vector["address"], bms_sig_malleated, lower_s=False)
+    assert bms.verify(msg, vector["address"], bms_sig_malleated)
     bms_sig_encoded = bms_sig_malleated.b64encode()
-    assert bms.verify(msg, vector["address"], bms_sig_encoded, lower_s=False)
+    assert bms.verify(msg, vector["address"], bms_sig_encoded)
 
     # the malleated signature is still not equal to the python-bitcoinlib one
     assert bms_sig_encoded != vector["signature"]
@@ -736,6 +736,30 @@ def test_vector_python_bitcoinlib(vector: dict[str, Any]) -> None:
     # as proved by different r compared to Core/Electrum/btclib
     test_vector_sig = bms.Sig.b64decode(vector["signature"])
     assert bms_sig.dsa_sig.r != test_vector_sig.dsa_sig.r
+
+
+def test_the_vectors_core_accepts_and_the_low_s_rule_would_refuse() -> None:
+    """The divergence, asserted rather than implied by a default value.
+
+    `bms.verify` accepts every vector of the file, and part of the file is
+    high-s: without those two facts stated together, a low-s rule put back
+    on the verification side would keep this suite green -- the vectors
+    would simply be refused one by one, each in its own test case, and
+    nothing would say that Core accepts them.
+
+    88 of the 200 are high-s, measured against Bitcoin Core v31.1.0's
+    `verifymessage` in issue 695: it answers true for all 200, and the
+    count is pinned here because it is a property of the vendored file
+    rather than of this tree -- a file swapped for another would satisfy
+    "some are high-s" without being these vectors at all.
+    """
+    high_s = 0
+    for vector in load("ecc", "_data", "signmessage.json"):
+        msg = vector["address"].encode()
+        sig = bms.Sig.b64decode(vector["signature"])
+        assert bms.verify(msg, vector["address"], vector["signature"])
+        high_s += sig.dsa_sig.s > ec.n - sig.dsa_sig.s
+    assert high_s == 88
 
 
 def test_ledger() -> None:
@@ -801,7 +825,7 @@ def test_ledger() -> None:
     # ECDSA signature verification of the patched dersig;
     # the xpub, verification taking public keys alone
     xpub = bip32.xpub_from_xprv(xprv)
-    dsa.assert_as_valid(magic_msg, xpub, dsa_sig, lower_s=True)
+    dsa.assert_as_valid(magic_msg, xpub, dsa_sig)
     assert dsa.verify(magic_msg, xpub, dsa_sig)
 
     # compressed address
@@ -825,10 +849,8 @@ def test_recover_pub_key_input_type() -> None:
 
     key_id = bms_sig.rf - 27 & 0b11
     magic_msg = magic_message(msg)
-    Q = dsa.recover_pub_key(
-        key_id, magic_msg, bms_sig.dsa_sig.serialize(), True, sha256
-    )
-    Q2 = dsa.recover_pub_key(key_id, magic_msg, bms_sig.dsa_sig, True, sha256)
+    Q = dsa.recover_pub_key(key_id, magic_msg, bms_sig.dsa_sig.serialize(), sha256)
+    Q2 = dsa.recover_pub_key(key_id, magic_msg, bms_sig.dsa_sig, sha256)
     assert Q == Q2
 
 
@@ -959,7 +981,10 @@ def test_recoverable_signing_answers_the_key_id_the_search_finds(
 
         magic_msg = magic_message(msg)
         q = prv_keyinfo_from_prv_key(wif)[0]
-        dsa_sig = dsa.sign(magic_msg, q)
+        # grind=False, `sign_recoverable` having no grind to match: a
+        # recoverable signature is the fixed 65-byte form, where a low r
+        # saves no DER pad
+        dsa_sig = dsa.sign(magic_msg, q, grind=False)
         assert bms_sig.dsa_sig == dsa_sig
         key_id = bms_sig.rf - 27 & 0b11
         assert key_id == _search_key_id(magic_msg, dsa_sig, q)

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -86,26 +86,19 @@ def test_dsa_commitment() -> None:
                     _MSG, _PRV_KEY, None, lower_s, ec, hf, commit=_COMMIT
                 )
                 # an ordinary signature, whether or not it commits
-                dsa.assert_as_valid(_MSG, pub_key, sig, lower_s, hf)
+                dsa.assert_as_valid(_MSG, pub_key, sig, hf)
                 dsa.assert_as_valid(
-                    _MSG, pub_key, sig, lower_s, hf, commit=_COMMIT, receipt=receipt
+                    _MSG, pub_key, sig, hf, commit=_COMMIT, receipt=receipt
                 )
                 # to that value and to no other
                 assert not dsa.verify(
-                    _MSG,
-                    pub_key,
-                    sig,
-                    lower_s,
-                    hf,
-                    commit=b"not this",
-                    receipt=receipt,
+                    _MSG, pub_key, sig, hf, commit=b"not this", receipt=receipt
                 )
                 # and with the receipt the signer kept, not another point
                 assert not dsa.verify(
                     _MSG,
                     pub_key,
                     sig,
-                    lower_s,
                     hf,
                     commit=_COMMIT,
                     receipt=mult(2, receipt, ec),

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -25,6 +25,7 @@ from btclib.curves import (
 from btclib.curves.curve import CURVES
 from btclib.curves.curve_group import _mult
 from btclib.ecc import dsa
+from btclib.ecc.rfc6979_nonce import challenge_
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import reduce_to_hlen
 from btclib.number_theory import mod_inv
@@ -91,7 +92,9 @@ def test_signature() -> None:
     msg = b"Satoshi Nakamoto"
 
     q, Q = dsa.gen_keys(0x1)
-    sig = dsa.sign(msg, q)
+    # grind=False: the vector below is the plain RFC6979 signature, which
+    # is what the default departs from for about half of all messages
+    sig = dsa.sign(msg, q, grind=False)
     dsa.assert_as_valid(msg, Q, sig)
     assert dsa.verify(msg, Q, sig)
     assert sig == dsa.Sig.parse(sig.serialize())
@@ -104,16 +107,19 @@ def test_signature() -> None:
     assert sig.r == r
     assert sig.s in {s, sig.ec.n - s}
 
-    # malleability
+    # malleability: the high-s twin is a valid signature of the same key
+    # over the same message, and verification says so -- neither
+    # assert_as_valid nor verify takes a lower_s to refuse it with, and
+    # libsecp256k1's own refusal is normalized away in front of it
     malleated_sig = dsa.Sig(sig.r, sig.ec.n - sig.s)
-    assert dsa.verify(msg, Q, malleated_sig, lower_s=False)
-    # lower_s defaults to True on both assert_as_valid and verify, refusing
-    # the same high-s twin the line above accepts by asking not to --
-    # libsecp256k1's own verify does the refusing here, lower_s deciding
-    # only whether the signature is normalized in front of it first
-    assert not dsa.verify(msg, Q, malleated_sig)
-    with pytest.raises(BTClibRuntimeError, match="signature verification failed"):
-        dsa.assert_as_valid(msg, Q, malleated_sig)
+    dsa.assert_as_valid(msg, Q, malleated_sig)
+    assert dsa.verify(msg, Q, malleated_sig)
+    # the strict answer is the private function's, and has to be asked for
+    c = challenge_(reduce_to_hlen(msg), sig.ec, sha256)
+    QJ = (Q[0], Q[1], 1)
+    with pytest.raises(BTClibValueError, match="not a low s"):
+        dsa._assert_as_valid_(c, QJ, sig.r, sig.ec.n - sig.s, sig.ec, lower_s=True)
+    dsa._assert_as_valid_(c, QJ, sig.r, sig.s, sig.ec, lower_s=True)
 
     keys = dsa.recover_pub_keys(msg, sig)
     assert len(keys) == 2
@@ -208,9 +214,10 @@ def test_gec() -> None:
     assert sig.s == 0x3480EC1371A091A464B31CE47DF0CB8AA2D98B54
     assert sig.ec == ec
 
-    # 2.1.4 Verifying Operation for V
-    dsa.assert_as_valid(msg, QU, sig, lower_s, hf)
-    assert dsa.verify(msg, QU, sig, lower_s, hf)
+    # 2.1.4 Verifying Operation for V: the vector's s is the one the
+    # scheme computed, high or low, and verification does not ask
+    dsa.assert_as_valid(msg, QU, sig, hf)
+    assert dsa.verify(msg, QU, sig, hf)
 
 
 @pytest.mark.parametrize("name", list(low_card_curves))
@@ -238,10 +245,11 @@ def test_low_cardinality(name: str) -> None:
                     assert r == sig.r
                     assert s == sig.s
                     assert ec == sig.ec
-                    # valid signature must pass verification
-                    dsa._assert_as_valid_(e, QJ, r, s, lower_s, ec)
+                    # valid signature must pass verification, and the
+                    # lower-s rule too: lower_s above is what produced it
+                    dsa._assert_as_valid_(e, QJ, r, s, ec, lower_s=lower_s)
 
-                    jac_keys = dsa._recover_pub_keys_(e, r, s, lower_s, ec)
+                    jac_keys = dsa._recover_pub_keys_(e, r, s, ec)
                     Qs = [ec.aff_from_jac(key) for key in jac_keys]
                     assert ec.aff_from_jac(QJ) in Qs
                     assert len(jac_keys) in {2, 4}
@@ -296,7 +304,7 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
                         # a candidate x_K off the curve, or a key that
                         # does not verify, is "not this key_id"
                         try:
-                            QJ = dsa._recover_pub_key_(key_id, e, r, s, False, ec)
+                            QJ = dsa._recover_pub_key_(key_id, e, r, s, ec)
                         except (BTClibValueError, BTClibRuntimeError):
                             continue
                         recovered.append((key_id, ec.aff_from_jac(QJ)))
@@ -307,7 +315,7 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
                     assert all(key_id >> 1 == 1 for key_id in key_ids)
 
                     # and the plural is that range, less what dropped out
-                    jac_keys = dsa._recover_pub_keys_(e, r, s, False, ec)
+                    jac_keys = dsa._recover_pub_keys_(e, r, s, ec)
                     assert [ec.aff_from_jac(QJ) for QJ in jac_keys] == [
                         Q_ for _, Q_ in recovered
                     ]
@@ -352,7 +360,7 @@ def test_key_id_is_the_j_zero_pair_when_n_is_above_p() -> None:
                 key_ids = []
                 for key_id in range(2 * (ec.cofactor + 1)):
                     try:
-                        QJ = dsa._recover_pub_key_(key_id, e, r, s, False, ec)
+                        QJ = dsa._recover_pub_key_(key_id, e, r, s, ec)
                     except (BTClibValueError, BTClibRuntimeError):
                         continue
                     if ec.aff_from_jac(QJ) == Q:
@@ -421,7 +429,7 @@ def test_forge_hash_sig() -> None:
     s = r * u2inv % ec.n
     s = ec.n - s if s > ec.n / 2 else s
     e = s * u1 % ec.n
-    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, lower_s=True, ec=ec)
+    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, ec, lower_s=True)
 
     # pick u1 and u2 at will
     u1 = 1234567890
@@ -432,7 +440,7 @@ def test_forge_hash_sig() -> None:
     s = r * u2inv % ec.n
     s = ec.n - s if s > ec.n / 2 else s
     e = s * u1 % ec.n
-    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, lower_s=True, ec=ec)
+    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, ec, lower_s=True)
 
 
 def test_sign_input_type() -> None:
@@ -521,7 +529,9 @@ def test_libsecp256k1() -> None:
     """Verify btclib and the bindings sign and verify byte-for-byte."""
     msg = b"Satoshi Nakamoto"
     prvkey_int, pubkey_point = dsa.gen_keys(0x1)
-    btclib_sig = dsa.sign(msg, prvkey_int)
+    # grind=False on both sides: `libsecp256k1_dsa.sign` with no extra
+    # entropy is the first attempt of the grind and not the whole loop
+    btclib_sig = dsa.sign(msg, prvkey_int, grind=False)
     pub_key = bytes_from_point(pubkey_point)
     assert dsa.verify(msg, pub_key, btclib_sig)
     assert dsa.verify(msg, pub_key, btclib_sig.serialize())
@@ -560,8 +570,10 @@ def test_grinding_lands_on_a_low_r() -> None:
     unchanged = 0
     for i in range(64):
         msg = f"btclib grind {i}".encode()
-        plain = dsa.sign(msg, q)
+        plain = dsa.sign(msg, q, grind=False)
         ground = dsa.sign(msg, q, grind=True)
+        # and grinding is what the default asks for
+        assert ground == dsa.sign(msg, q)
         assert ground.r < _LOW_R
         assert len(ground.serialize()) <= 70
         assert dsa.verify(msg, Q, ground)
@@ -651,7 +663,7 @@ def test_grinding_is_about_r_and_not_about_the_encoded_length() -> None:
         msg = f"btclib grind {i}".encode()
         sig = dsa.sign(msg, q, lower_s=False, grind=True)
         assert sig.r < _LOW_R
-        assert dsa.verify(msg, Q, sig, lower_s=False)
+        assert dsa.verify(msg, Q, sig)
         lengths.add(len(sig.serialize()))
     # both, and the 71 is the byte s asked for: grinding did not go looking
     # for another s, and a loop on the length would have
@@ -671,7 +683,12 @@ def test_grinding_refuses_what_already_owns_the_nonce() -> None:
     to search, and a commitment already occupies the extra entropy the
     counter travels through. The second is not only a clash of encodings --
     grinding a nonce is exactly the freedom the anti-exfil protocol takes
-    away from a signing device -- and neither is refused without `grind`.
+    away from a signing device.
+
+    Refused only when it is asked for: `grind` defaults to None and not to
+    the True it resolves to elsewhere, so the two calls at the bottom --
+    a nonce of the caller's, and a commitment -- are the ordinary spelling
+    of both and neither raises. A default of True would make them errors.
     """
     msg = b"Satoshi Nakamoto"
     nonce = 0x9E5755E5A8FCC1B0A2FD1E0AD9E8D6B29B67D67E6C6A0DEE01E7E1F30DB9A0BE
@@ -769,18 +786,16 @@ def test_core_grinds_the_same_signatures(
     # the retry count is a claim about which element of Core's sequence
     # this is, so it is checked and not merely recorded: the plain
     # signature for a count of zero, the counter's own signature otherwise
-    plain = dsa.sign_(sig_hash, prv_key)
+    plain = dsa.sign_(sig_hash, prv_key, grind=False)
     assert (plain == sig) == (retries == 0)
     ndata = None if retries == 0 else retries.to_bytes(32, "little")
     assert sig.serialize() == libsecp256k1_dsa.sign(sig_hash, prv_key, ndata)
 
 
-def _recovered(
-    key_id: int, msg: bytes, sig: dsa.Sig, lower_s: bool = True
-) -> Point | None:
+def _recovered(key_id: int, msg: bytes, sig: dsa.Sig) -> Point | None:
     """Return the recovered key, None for a candidate recovering nothing."""
     try:
-        return dsa.recover_pub_key(key_id, msg, sig, lower_s)
+        return dsa.recover_pub_key(key_id, msg, sig)
     except (BTClibValueError, BTClibRuntimeError):
         return None
 
@@ -830,14 +845,16 @@ def test_libsecp256k1_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
         # 2^-127 of signatures, and both implementations require it
         assert recovering == [0, 1]
 
-        # the lower-s rule is the caller's, and it is btclib that applies
-        # it: the recoverable parser takes any s in [1, n-1]
+        # the recoverable parser takes any s in [1, n-1], and so does
+        # this: negating s mirrors K, so the malleated twin recovers the
+        # very same key under the key_id whose parity bit is flipped.
+        # Both implementations, the rule being absent from both
         key_id = next(k for k in recovering if _recovered(k, msg, sig) == Q)
         malleated = dsa.Sig(sig.r, secp256k1.n - sig.s)
-        err_msg = "not a low s"
-        with pytest.raises(BTClibValueError, match=err_msg):
-            dsa.recover_pub_key(key_id ^ 1, msg, malleated)
-        assert _recovered(key_id ^ 1, msg, malleated, lower_s=False) == Q
+        assert _recovered(key_id ^ 1, msg, malleated) == Q
+        with monkeypatch.context() as no_bindings:
+            no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
+            assert _recovered(key_id ^ 1, msg, malleated) == Q
 
 
 def test_recover_pub_keys_takes_the_hash_that_recover_pub_keys_reduces() -> None:
@@ -850,13 +867,12 @@ def test_recover_pub_keys_takes_the_hash_that_recover_pub_keys_reduces() -> None
     Nothing in btclib calls either, bms naming its own key_id since issue
     269, so this is what holds the pairing that justifies both.
 
-    The malleated signature is the plural's answer where the singular
-    raises: a candidate that fails is dropped rather than reported, and
-    every candidate fails the lower-s rule at once, so the enumeration of
-    a high-s signature is empty and not an error. Both spellings say so on
-    both implementations -- sha256 here is the four recover calls, sha512
-    the Python loop -- the rule being btclib's either way, since the
-    recoverable parser takes any s in [1, n-1].
+    The malleated signature enumerates to the same keys the low-s twin
+    does, in the other order: negating s mirrors the nonce's point, so
+    each key answers to the key_id whose parity bit is flipped, and the
+    dense list is that pair reversed. Both spellings say so on both
+    implementations -- sha256 here is the four recover calls, sha512 the
+    Python loop -- neither of which refuses a high s.
     """
     msg = b"Satoshi Nakamoto"
     for q in (0x1, 0x2, prv_key_int, secp256k1.n - 1):
@@ -875,8 +891,10 @@ def test_recover_pub_keys_takes_the_hash_that_recover_pub_keys_reduces() -> None
             assert dsa.recover_pub_keys_(msg_hash.hex(), sig.serialize(), hf=hf) == keys
 
             malleated = dsa.Sig(sig.r, secp256k1.n - sig.s)
-            assert dsa.recover_pub_keys_(msg_hash, malleated, hf=hf) == []
-            assert Q in dsa.recover_pub_keys_(msg_hash, malleated, lower_s=False, hf=hf)
+            malleated_keys = dsa.recover_pub_keys_(msg_hash, malleated, hf=hf)
+            assert Q in malleated_keys
+            assert malleated_keys == keys[::-1]
+            assert dsa.recover_pub_keys(msg, malleated, hf=hf) == malleated_keys
 
 
 def test_recovery_multiplies_in_libsecp256k1(
@@ -968,7 +986,7 @@ def test_the_enumeration_asks_for_the_j_one_candidates(
         assert dsa.recover_pub_keys_(msg_hash, sig) == keys
 
 
-def _search_key_id(msg: bytes, sig: dsa.Sig, Q: Point, lower_s: bool = True) -> int:
+def _search_key_id(msg: bytes, sig: dsa.Sig, Q: Point) -> int:
     """Find the key_id by recovering and comparing, not by signing.
 
     The derivation `sign_recoverable` exists not to run: it is here as the
@@ -976,7 +994,7 @@ def _search_key_id(msg: bytes, sig: dsa.Sig, Q: Point, lower_s: bool = True) -> 
     candidate until one is the signer's own key.
     """
     for key_id in range(2 * (sig.ec.cofactor + 1)):
-        if _recovered(key_id, msg, sig, lower_s) == Q:
+        if _recovered(key_id, msg, sig) == Q:
             return key_id
     raise AssertionError("no key_id recovers the public key")
 
@@ -1022,7 +1040,10 @@ def test_sign_recoverable_is_sign_plus_the_key_id_a_search_would_find(
         msg_hash = reduce_to_hlen(msg)
 
         sig, key_id = dsa.sign_recoverable(msg, prv_key)
-        assert sig == dsa.sign(msg, prv_key)
+        # grind=False, the recoverable spelling having no grind: r is not
+        # DER-encoded there, so a low one saves nothing (see
+        # `sign_recoverable_`), and this is the same signature otherwise
+        assert sig == dsa.sign(msg, prv_key, grind=False)
         assert (sig, key_id) == dsa.sign_recoverable_(msg_hash, prv_key)
         assert dsa.recover_pub_key(key_id, msg, sig) == Q
         assert key_id == _search_key_id(msg, sig, Q)
@@ -1061,10 +1082,9 @@ def test_the_key_id_survives_what_the_bindings_decline(
         {"hf": sha512},
     ]
     for kwargs in cases:
-        lower_s = bool(kwargs.get("lower_s", True))
         sig, key_id = dsa.sign_recoverable(msg, prv_key, **kwargs)
         hf = kwargs.get("hf", sha256)
-        assert dsa.recover_pub_key(key_id, msg, sig, lower_s, hf) == Q
+        assert dsa.recover_pub_key(key_id, msg, sig, hf) == Q
         with monkeypatch.context() as no_bindings:
             no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
             assert dsa.sign_recoverable(msg, prv_key, **kwargs) == (sig, key_id)
@@ -1089,7 +1109,9 @@ def test_recover_pub_key_dispatches_to_the_bindings_for_0_to_3_only() -> None:
     ways this guard survived moved.
     """
     q = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCD
-    sig = dsa.sign(b"msg", q)
+    # grind=False: which candidate fails how is a property of this r, and
+    # the four cases below are what this signature's r produces
+    sig = dsa.sign(b"msg", q, grind=False)
     msg_hash = b"\x00" * 32
 
     cases = {
@@ -1158,7 +1180,7 @@ def test_the_key_id_names_j_where_j_is_reachable() -> None:
                             sig, key_id = dsa._sign_recoverable_(c, q, k, lower_s, ec)
                         except BTClibRuntimeError:  # r == 0 or s == 0
                             continue
-                        QJ = dsa._recover_pub_key_(key_id, c, sig.r, sig.s, lower_s, ec)
+                        QJ = dsa._recover_pub_key_(key_id, c, sig.r, sig.s, ec)
                         assert ec.aff_from_jac(QJ) == Q
                         cases += 1
                         j_reached += key_id >> 1
@@ -1190,7 +1212,8 @@ def test_libsecp256k1_py_vectors_ecdsa(vector: dict[str, str]) -> None:
     prv_key = bytes.fromhex(vector["privkey"])
     assert len(prv_key) == 32
 
-    sig = dsa.sign_(msg_hash, prv_key)
+    # the vectors are the plain RFC6979 signatures, as upstream made them
+    sig = dsa.sign_(msg_hash, prv_key, grind=False)
     assert sig.serialize() == sig_raw[:-1]
     pub_key = pub_keyinfo_from_prv_key(prv_key, compressed=True)[0]
     assert dsa.verify_(msg_hash, pub_key, sig)
@@ -1234,7 +1257,7 @@ def test_verify_infinity_point() -> None:
     ec = CURVES["secp256k1"]
     err_msg = r"invalid \(INF\) key"
     with pytest.raises(BTClibRuntimeError, match=err_msg):
-        dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, True, ec)
+        dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, ec)
 
 
 def test_verify_with_another_hash_function_on_both_arithmetics(
@@ -1267,7 +1290,7 @@ def test_verify_with_another_hash_function_on_both_arithmetics(
         assert not dsa.verify(b"another message", Q, sig, hf=sha512)
         # K = u*G + v*Q is INF for Q = G, r = s = 1 and c = n-1
         with pytest.raises(BTClibRuntimeError, match=r"invalid \(INF\) key"):
-            dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, True, ec)
+            dsa._assert_as_valid_(ec.n - 1, ec.GJ, 1, 1, ec)
 
     checks()
     no_bindings(monkeypatch)

--- a/tests/ecc/rfc6979_test.py
+++ b/tests/ecc/rfc6979_test.py
@@ -104,10 +104,12 @@ def test_rfc6979_secp256k1(prv_key: int, msg: str, k: int, r: str, s: str) -> No
     msg_hash = hashlib.sha256(msg.encode()).digest()
     assert rfc6979_nonce_(msg_hash, prv_key, hf=hashlib.sha256) == k
 
-    # the nonce is the default, so the signature is what the library
-    # produces unprompted -- the vector pins the whole of it, not the
-    # derivation with the answer handed back in
-    sig = dsa.sign_(msg_hash, prv_key)
+    # the nonce is the default, so the signature is the plain RFC6979 one
+    # -- the vector pins the whole of it, not the derivation with the
+    # answer handed back in. grind=False because that is what these are:
+    # the signature the nonce alone determines, where grinding draws
+    # another nonce for the four whose r is high (see below)
+    sig = dsa.sign_(msg_hash, prv_key, grind=False)
     assert (sig.r, sig.s) == (int(r, 16), int(s, 16))
     assert sig == dsa.sign_(msg_hash, prv_key, k)
 
@@ -126,7 +128,7 @@ def test_rfc6979_secp256k1_s_is_normalized() -> None:
     normalized = 0
     for prv_key, msg, _, _, s in SECP256K1_VECTORS:
         msg_hash = hashlib.sha256(msg.encode()).digest()
-        raw = dsa.sign_(msg_hash, prv_key, lower_s=False)
+        raw = dsa.sign_(msg_hash, prv_key, lower_s=False, grind=False)
         assert raw.s in {int(s, 16), secp256k1.n - int(s, 16)}
         normalized += raw.s != int(s, 16)
     assert normalized == 4
@@ -135,13 +137,14 @@ def test_rfc6979_secp256k1_s_is_normalized() -> None:
 def test_rfc6979_secp256k1_grinding_leaves_only_the_low_r_one() -> None:
     """Four of the five have a high r, which is what grinding re-signs.
 
-    The vectors are the plain RFC6979 signatures -- `grind=False`, this
-    library's default and the reason it is the default -- so `grind=True`
-    reproduces the one whose r is already below 2**255 and departs from the
-    other four, which is the whole of what the flag does to a
-    deterministic signature. `tests/ecc/dsa_test.py` is where the loop is
-    held to Core's, this being about the vectors: no vector is lost, and
-    the fourth is a vector for both spellings.
+    The vectors are the plain RFC6979 signatures -- `grind=False`, which
+    is why every call above spells it: grinding is the default, as it is
+    Core's -- so grinding reproduces the one whose r is already below
+    2**255 and departs from the other four, which is the whole of what
+    the flag does to a deterministic signature.
+    `tests/ecc/dsa_test.py` is where the loop is held to Core's, this
+    being about the vectors: no vector is lost, and the fourth is a
+    vector for both spellings.
     """
     ground = 0
     for prv_key, msg, _, r, _ in SECP256K1_VECTORS:
@@ -208,15 +211,18 @@ def test_rfc6979_nonce_tv(
     sig = dsa.sign_(m, prv_key, k2, lower_s, ec=ec, hf=getattr(hashlib, hf))
     assert int(r, 16) == sig.r
     assert int(s, 16) == sig.s
-    # test that RFC6979 is the default nonce for DSA
-    sig = dsa.sign_(m, prv_key, None, lower_s, ec=ec, hf=getattr(hashlib, hf))
+    # test that RFC6979 is the default nonce for DSA; grind=False, the
+    # vector being the signature that nonce alone determines
+    sig = dsa.sign_(
+        m, prv_key, None, lower_s, ec=ec, hf=getattr(hashlib, hf), grind=False
+    )
     assert int(r, 16) == sig.r
     assert int(s, 16) == sig.s
     # test key-pair coherence
     U = mult(prv_key, ec.G, ec)
     assert (int(x_U, 16), int(y_U, 16)) == U
     # test signature validity
-    dsa.assert_as_valid(msg_bytes, U, sig, lower_s, getattr(hashlib, hf))
+    dsa.assert_as_valid(msg_bytes, U, sig, getattr(hashlib, hf))
 
 
 # RFC6979 against BIP340: the two deterministic nonces this library

--- a/tests/ecc/wycheproof_test.py
+++ b/tests/ecc/wycheproof_test.py
@@ -28,13 +28,15 @@ of how strict a parser is, and pinning it here would make a legitimate
 loosening or tightening of one look like a regression.
 
 Two profiles of ECDSA, which is why two of the files are the same
-algorithm over the same curve and hash. `EcdsaBitcoinVerify` is btclib's
-`lower_s=True` default and refuses the malleable high-s twin;
-`EcdsaVerify` is `lower_s=False` and accepts it. Their tcId 5 is the same
-key and the same signature under both, `invalid` in the first file and
-`valid` in the second, so a `lower_s` wired the wrong way round fails one
-of the two files whichever way it is wired -- which neither file could
-report on its own.
+algorithm over the same curve and hash. `EcdsaVerify` is the generic
+one, and is what `dsa.verify_` answers: both s and n - s verify.
+`EcdsaBitcoinVerify` adds the low-s rule, which btclib applies when it
+signs and never when it reads, so the two files disagree with each other
+on two verdicts and btclib takes the generic one for both --
+`_BITCOIN_LOW_S_ONLY` below names them and says how they were found.
+Every other vector of the bitcoin file is a verdict the two profiles
+share, which is what keeps it here: much of it is cases the generic file
+does not carry, and they are adversarial vectors like any other.
 
 Hash functions beyond sha256, for the same reason in a second direction.
 Bitcoin signs with sha256 and nothing else, so the sha512, SHA3 and SHAKE
@@ -403,8 +405,17 @@ def test_pinned_xof() -> None:
     assert wider.digest()[: secp256k1.n_size] == hash_object.digest()
 
 
+# the two vectors of `EcdsaBitcoinVerify` that are invalid for the low-s
+# rule alone, and valid under every other profile: their comments are
+# "Signature malleability" and "edge case for signature malleability",
+# and `EcdsaVerify`'s tcId 5 and 392 are the same key, message and
+# signature marked valid. Found by comparing the verdicts of the two
+# files case by case, which is also what says there are no others
+_BITCOIN_LOW_S_ONLY = frozenset({1, 388})
+
+
 @pytest.mark.parametrize(
-    "key, vector, lower_s, hf, bindings",
+    "key, vector, low_s_profile, hf, bindings",
     _signature_vectors(_ECDSA_BITCOIN, "bitcoin", sha256, True)
     + _signature_vectors(_ECDSA, "ecdsa", sha256, False)
     + _signature_vectors(_ECDSA_SHA512, "sha512", sha512, False)
@@ -416,7 +427,7 @@ def test_pinned_xof() -> None:
 def test_ecdsa_der(
     key: str,
     vector: dict[str, Any],
-    lower_s: bool,
+    low_s_profile: bool,
     hf: HashF,
     bindings: bool,
     monkeypatch: pytest.MonkeyPatch,
@@ -437,14 +448,22 @@ def test_ecdsa_der(
     message: a digest wider than the order is truncated to the leftmost
     `nlen` bits there, which is what the sha512 and SHA3-512 files
     exercise and what the sha256 ones cannot.
+
+    low_s_profile says the file is `EcdsaBitcoinVerify`, whose verdict on
+    the two malleability vectors is not btclib's: they verify here, as
+    they do under `EcdsaVerify`. Every other verdict in that file is
+    asserted as it is written.
     """
     if not bindings:
         _python_path(monkeypatch, dsa)
 
+    expected = vector["result"] == "valid"
+    if low_s_profile and vector["tcId"] in _BITCOIN_LOW_S_ONLY:
+        expected = True
+
     msg_hash = _digest(hf, bytes.fromhex(vector["msg"]))
     sig = bytes.fromhex(vector["sig"])
-    verified = dsa.verify_(msg_hash, key, sig, lower_s, hf)
-    assert verified == (vector["result"] == "valid")
+    assert dsa.verify_(msg_hash, key, sig, hf) == expected
 
 
 @pytest.mark.parametrize(
@@ -471,8 +490,9 @@ def test_ecdsa_p1363(
     `RangeCheck` and `InvalidSignature` cases are r and s at 0, at n, and
     at n plus a valid value, none of which any DER framing can hide.
 
-    `lower_s=False` for both files, neither having a bitcoin profile: the
-    sha256 one's tcId 1 is the malleable high-s signature and is `valid`.
+    Neither file has a bitcoin profile, and nothing needs excepting for
+    it: the sha256 one's tcId 1 is the malleable high-s signature and is
+    `valid`, which is what `dsa.verify_` answers.
 
     The size rule is the encoding's and not the hash's, so it is `n_size`
     twice over under sha512 as under sha256: P1363 pads each of r and s
@@ -496,7 +516,7 @@ def test_ecdsa_p1363(
         return
 
     msg_hash = _digest(hf, bytes.fromhex(vector["msg"]))
-    assert dsa.verify_(msg_hash, key, sig, False, hf) == (vector["result"] == "valid")
+    assert dsa.verify_(msg_hash, key, sig, hf) == (vector["result"] == "valid")
 
 
 @pytest.mark.parametrize(

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -2864,7 +2864,7 @@ def test_the_sig_hash_of_every_input_kind_a_partial_signature_signs() -> None:
             for pub_key, sig in psbt_in.partial_sigs.items():
                 msg_hash = _sig_hash_from_psbt_in(psbt_in, psbt.tx, vin_i, sig[-1])
                 assert msg_hash is not None
-                assert dsa.verify_(msg_hash, pub_key, sig[:-1], lower_s=False)
+                assert dsa.verify_(msg_hash, pub_key, sig[:-1])
                 checked += 1
     # a count, so that a loop that stops finding signatures is a failure
     # and not a green run over nothing


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/695, and with it
https://github.com/btclib-org/btclib/issues/645, whose source reading is
what it implements.

## What changes

**`lower_s` is gone from everything that reads a signature.** It is the
signer's choice between `s` and `n - s`, so a reader that refused the
high-s twin refused a signature its signer was free to produce:

| pair | now |
| --- | --- |
| `dsa.assert_as_valid` / `assert_as_valid_` | no `lower_s` on either |
| `dsa.verify` / `verify_` | no `lower_s` on either |
| `dsa.recover_pub_key` / `recover_pub_key_` | no `lower_s` on either |
| `dsa.recover_pub_keys` / `recover_pub_keys_` | no `lower_s` on either |
| `dsa.anti_exfil_host_verify` | no `lower_s` |
| `bms.assert_as_valid`, `bms.verify` | no `lower_s` |
| `sign` / `sign_`, `sign_recoverable` / `sign_recoverable_`, `anti_exfil_sign` | `lower_s=True` kept |

Each pair moves together, a trailing underscore naming a public function
that cannot carry a signature different from its plain twin. The strict
answer keeps one home: the private `dsa._assert_as_valid_`, whose
`lower_s` now defaults to `False` and is keyword-only — asked for, never
assumed — with `ec` moved into the position `ssa._assert_as_valid_` has
it in.

**The 88.** Of the 200 vectors of `tests/ecc/_data/signmessage.json`,
Core v31.1.0's `verifymessage` accepts all 200 and btclib's default
refused the 88 that are high-s. All 200 verify now, and
`test_the_vectors_core_accepts_and_the_low_s_rule_would_refuse` asserts
both halves in one place — every vector accepted, 88 of them high-s —
because a rule put back on the verification side would otherwise leave
this suite green, refusing them one vector per case with nothing to say
that Core does not.

**`grind` defaults to on**, as the issue's decision asks, which is Core's
default; `psbt.py`'s two verifications drop the keyword they passed.

## The one thing decided here rather than in the issue

`grind`'s default is spelled `None`, not `True`. Grinding is a search
over nonces and two calls have none to search — a nonce of the caller's
is the nonce, and a commitment owns the extra entropy the counter travels
through — and both are refused when grinding is *asked for*. A default of
`True` would have made `dsa.sign(msg, key, nonce)` and
`dsa.sign(msg, key, commit=...)` errors, RFC6979's own vectors among the
casualties. `None` reads as "grind wherever that search exists"; an
explicit `grind=True` beside either still raises, as before.

Two callers pass `grind=False` for reasons of their own:
`bip322.sign`, whose BIP vectors are the plain RFC6979 signatures and
reproducing them byte for byte is what makes the construction the BIP's;
and the vendored-vector tests, which stay oracles rather than being
adapted to whatever btclib now does.

## Wycheproof

`EcdsaBitcoinVerify` stays in the suite. btclib answers the generic
`EcdsaVerify` profile for both files, and the two verdicts where the two
files disagree — found by comparing them case by case, both flagged
malleability, both high-s — are excepted by tcId in
`tests/ecc/wycheproof_test.py`; every other verdict is asserted as
written.

## Gates

- `uv run pytest`: 25959 passed, coverage 100.00% (the ratchet)
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

`docs/source/guide.rst` moves with the default: the BIP143 example is now
Core's ground signature, one byte shorter, and the prose says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Accept high-s ECDSA signatures and public key recovery results while keeping low-s normalization on the signing side, and make low-R grinding the default for ECDSA signing with a nonce-search-aware None default.

New Features:
- Support verification and recovery of both low-s and high-s ECDSA signatures consistently across DSA and BMS APIs, matching Bitcoin Core’s behaviour.
- Introduce explicit accounting and tests showing that all 200 python-bitcoinlib signmessage vectors, including 88 high-s cases, are accepted.

Bug Fixes:
- Align Wycheproof bitcoin-profile expectations with btclib’s generic ECDSA verification by excepting low-s-only malleability cases, avoiding spurious failures.
- Ensure anti-exfil and PSBT signature checks treat high-s signatures as valid while still enforcing structural correctness.

Enhancements:
- Simplify verification and recovery APIs by removing the lower_s parameter from public functions and documenting that low-s is a signing policy, not a verification rule.
- Retain a single private verification helper that can enforce the low-s rule on demand for tests and strict checks.
- Update documentation, changelog, and history to describe the new verification semantics, grinding default, and compatibility with Core’s verifymessage and CPubKey::Verify.
- Improve tests to cover high-s malleated signatures, recovery behaviour, grinding semantics, and RFC6979 vectors under both plain and ground signing modes.

Documentation:
- Clarify in user-facing documentation that verification and recovery accept high-s signatures, that low-s is enforced only when signing, and that grinding is now the default for ECDSA signatures.

Tests:
- Extend DSA, BMS, RFC6979, Wycheproof, PSBT, anti-exfil, and commit-nonce test suites to cover high-s acceptance, key recovery invariants, and the new grinding default.
- Add a dedicated test that asserts both that all python-bitcoinlib signmessage vectors verify and that exactly 88 of them are high-s, guarding against regressions in policy behaviour.