### PR TITLE
Pair grind's default with the nonce's, rather than resolving the two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1021,39 +1021,41 @@ documented at release-notes length in the first place, and are still in
   own, retries included. No attempt cap, as in Core: one would answer an
   event of probability `2**-k` with an error a caller can do nothing about.
 
-  `grind` has three states, not two, and it is on when left unsaid: a
-  btclib signature is the one Core would have made. `grind=None` is that
-  default, `grind=True` is a caller asking outright and `grind=False` is
-  the plain RFC6979 signature -- which is what a test pinning deterministic
-  bytes now asks for, the five python-bitcoinlib vectors among them, four
-  of the five having a high `r` so that grinding departs from exactly those
-  four (`test_rfc6979_secp256k1_grinding_leaves_only_the_low_r_one`, beside
-  the test that counts the four `s` values normalization moves).
-  Keyword-only, `ec` and `hf` being positional and a flag inserted before
-  them renumbering both.
+  `grind=True` is the default, as it is in Core, so a btclib signature is
+  the one Core would have made; `grind=False` is the plain RFC6979
+  signature, which is what a test pinning deterministic bytes asks for --
+  the five python-bitcoinlib vectors among them, four of the five having a
+  high `r` so that grinding departs from exactly those four
+  (`test_rfc6979_secp256k1_grinding_leaves_only_the_low_r_one`, beside the
+  test that counts the four `s` values normalization moves). Keyword-only,
+  `ec` and `hf` being positional and a flag inserted before them
+  renumbering both.
 
-  Grinding is refused with a nonce of the caller's and with a
-  sign-to-contract commitment, each of which already owns what grinding
-  needs -- the nonce itself, and the extra entropy the counter travels
-  through -- and the third state is why the refusal is a refusal rather
-  than a footgun: `grind=True` beside either of those is a caller asking
-  for both halves of a contradiction, while the default is a library
-  preference and gives way, so `sign(msg, key, nonce)` signs instead of
-  raising. For the commitment the refusal is more than a clash of
-  encodings: grinding a nonce is exactly the freedom the ECDSA anti-exfil
-  protocol takes away from a signing device, and `sign_` is the call that
-  protocol signs through -- `anti_exfil_sign` therefore grinds nothing,
-  without having to say so. `sign_recoverable` takes no `grind` at all,
-  and there it is not a matter of what owns the nonce: 65 bytes of `r`, `s`
-  and the recovery flag have no pad for a low `r` to save, which is why
-  Core's `SignCompact` does not grind and why a message signature is
-  unaffected. `bip322.sign` asks for `grind=False` in so many words: the
-  BIP's reference implementation signs plain, its vectors are the whole
-  interoperability claim, and nothing there is broadcast for the byte to
-  matter. What grinding chooses is `r` and not the encoded length: embit
-  stops its loop at `len(sig.serialize()) > 70`, which is the same
-  question only for a low `s`, and with `lower_s=False` btclib produces
-  the 71-byte low-R signature Core cannot reach.
+  Its default pairs with the nonce's, `grind=True` beside `nonce=None`:
+  grinding is a search over nonces, so a nonce that is given leaves
+  nothing to search, and a sign-to-contract commitment already owns the
+  extra entropy the counter travels through. The two together are refused
+  rather than one of them quietly winning, at the default exactly as when
+  `grind=True` is passed -- which one would have won is precisely what a
+  caller pinning a signature could not have read back out of the bytes --
+  so signing with a nonce of one's own means asking for `grind=False`, and
+  `sign(msg, key, nonce)` now raises instead. For the commitment the
+  refusal is more than a clash of encodings: grinding a nonce is exactly
+  the freedom the ECDSA anti-exfil protocol takes away from a signing
+  device, and `sign_` is the call that protocol signs through, so
+  `anti_exfil_sign` says `grind=False` where the protocol requires it.
+
+  `sign_recoverable` takes no `grind` at all, and there it is not a matter
+  of what owns the nonce: 65 bytes of `r`, `s` and the recovery flag have
+  no pad for a low `r` to save, which is why Core's `SignCompact` does not
+  grind and why a message signature is unaffected. `bip322.sign` asks for
+  `grind=False` in so many words: the BIP's reference implementation signs
+  plain, its vectors are the whole interoperability claim, and nothing
+  there is broadcast for the byte to matter. What grinding chooses is `r`
+  and not the encoded length: embit stops its loop at
+  `len(sig.serialize()) > 70`, which is the same question only for a low
+  `s`, and with `lower_s=False` btclib produces the 71-byte low-R
+  signature Core cannot reach.
 
   The private `_rfc6979_nonce_` takes `None` for no additional data now,
   where it took `b""`, so one counter value travels down either path

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -35,15 +35,25 @@ full year, short month, short day (YYYY-M-D)
   lower_s=True)`. `dsa.sign` is unchanged, `lower_s=True` and all, the
   rule being the signer's: a high-s signature in a transaction is
   non-standard and does not relay.
-- **an ECDSA signature is low-R now.** `dsa.sign` and `dsa.sign_` grind
-  for it wherever the nonce is theirs to derive, as Core has done since
-  its 0.17, so the signature of a given key and message is a different one
-  for about half of all messages -- and one DER byte shorter. `grind=False`
-  is the plain RFC6979 signature, which is what a caller pinning btclib's
-  bytes has to pass now. `dsa.sign_recoverable` and with it `bms.sign` are
-  unaffected, a compact signature having no DER pad to save, and so is
-  `bip322.sign`, which asks for the plain signature to keep reproducing
-  the BIP's own vectors.
+- **an ECDSA signature is low-R now, and signing with your own nonce asks
+  for `grind=False`.** `dsa.sign` and `dsa.sign_` grind by default, as
+  Core has done since its 0.17, so the signature of a given key and
+  message is a different one for about half of all messages -- and one DER
+  byte shorter. `grind=False` is the plain RFC6979 signature, which is
+  what a caller pinning btclib's bytes has to pass now.
+
+  Two things to act on rather than one, because grinding is a search over
+  nonces and its default pairs with `nonce=None`: `dsa.sign(msg, key,
+  nonce)` and `dsa.sign_(msg_hash, key, nonce)` raise
+  `BTClibValueError("grinding derives its own nonce")`, as does either
+  with a sign-to-contract `commit`. Pass `grind=False` beside the nonce.
+  The pair is refused rather than resolved in the caller's favour or the
+  library's: which of the two won would not be readable back out of the
+  signature.
+
+  `dsa.sign_recoverable` and with it `bms.sign` are unaffected, a compact
+  signature having no DER pad to save, and so is `bip322.sign`, which asks
+  for the plain signature to keep reproducing the BIP's own vectors.
 - **a MOV-weak curve is refused with `BTClibValueError`, not
   `UserWarning`.** `Curve(p, a, b, G, n, cofactor)` with the default
   `weakness_check=True` used to raise `UserWarning("weak curve")` for a

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -18,8 +18,10 @@ in the script engine's own flags, and in the leading-underscore functions
 a test asks for it with.
 
 ``sign`` also grinds for a low-R signature -- one byte shorter in DER --
-wherever the nonce is its own to derive, as Core does; ``_grind_low_r`` is
-the loop and says why.
+by default, as Core does; ``_grind_low_r`` is the loop and says why. Its
+default goes with the nonce's: ``grind=True`` and ``nonce=None``, so a
+caller who wants the nonce asks for ``grind=False`` and gets an error
+rather than a guess if they forget.
 
 ``sign`` also takes a value to commit to inside the nonce,
 sign-to-contract style (see btclib.ecc.commit_nonce for the tweak), and
@@ -462,7 +464,7 @@ def sign_(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool | None = ...,
+    grind: bool = ...,
     commit_hash: None = None,
 ) -> Sig: ...
 
@@ -476,7 +478,7 @@ def sign_(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool | None = ...,
+    grind: bool = ...,
     commit_hash: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -489,7 +491,7 @@ def sign_(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     *,
-    grind: bool | None = None,
+    grind: bool = True,
     commit_hash: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """Sign a hf_len bytes message according to ECDSA signature algorithm.
@@ -499,15 +501,20 @@ def sign_(
 
     grind asks for a low-R signature, one byte shorter in DER:
     `_grind_low_r` is the loop, Core's since its 0.17 and its default
-    there. Left unsaid it is on wherever the nonce is this library's to
-    derive, so that a btclib signature is the one Core would have made;
-    asked for outright it is refused beside a nonce or a commitment, which
-    is the difference the three states carry -- a default is a library
-    preference and cannot contradict a caller, where `grind=True` beside
-    either of those two is a caller asking for both halves of a
-    contradiction. Keyword-only, rather than beside lower_s where it
-    belongs by subject: ec and hf are positional here and a flag inserted
-    before them would renumber both.
+    there and here, so that a btclib signature is the one Core would have
+    made. Its default pairs with the nonce's: `grind=True` and
+    `nonce=None`, the signature of a key and a message and nothing else.
+
+    A caller who wants the nonce -- or a commitment, which owns the extra
+    entropy the counter travels through -- asks for `grind=False` in so
+    many words, because grinding is a search over nonces and a nonce that
+    is given leaves nothing to search. The two together are refused rather
+    than one of them quietly winning: which one would win is exactly what
+    a caller pinning a signature cannot afford to guess.
+
+    Keyword-only, rather than beside lower_s where it belongs by subject:
+    ec and hf are positional here and a flag inserted before them would
+    renumber both.
 
     commit_hash is a value to commit to inside the nonce, sign-to-contract
     style: the signature is an ordinary one, and the receipt returned
@@ -543,15 +550,8 @@ def sign_(
     # protocol takes away from a signing device, see
     # anti_exfil_host_commit, and this is the call that protocol signs
     # through
-    owns_the_nonce = nonce is not None or commit_hash is not None
-    if grind and owns_the_nonce:
+    if grind and (nonce is not None or commit_hash is not None):
         raise BTClibValueError("grinding derives its own nonce")
-    # and None is the caller not having said: grind where there is a nonce
-    # to grind and stay out of the way where there is not. Refusing those
-    # two by default would refuse `sign(msg, key, nonce)` itself -- a
-    # caller who asked for one thing, told they asked for two
-    if grind is None:
-        grind = not owns_the_nonce
 
     # a nonce provided by the caller is the nonce, while what
     # libsecp256k1 takes is extra entropy for the RFC6979 nonce it
@@ -615,7 +615,7 @@ def sign(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool | None = ...,
+    grind: bool = ...,
     commit: None = None,
 ) -> Sig: ...
 
@@ -629,7 +629,7 @@ def sign(
     ec: Curve = ...,
     hf: HashF = ...,
     *,
-    grind: bool | None = ...,
+    grind: bool = ...,
     commit: Octets,
 ) -> tuple[Sig, Point]: ...
 
@@ -642,7 +642,7 @@ def sign(
     ec: Curve = secp256k1,
     hf: HashF = sha256,
     *,
-    grind: bool | None = None,
+    grind: bool = True,
     commit: Octets | None = None,
 ) -> Sig | tuple[Sig, Point]:
     """ECDSA signature with canonical low-s preference.
@@ -1043,6 +1043,12 @@ def anti_exfil_sign(
     commitment it was derived from, no nonce is ever used twice and the
     device's key is never the thing at risk.
     """
+    # grind=False, and it is the protocol that requires it rather than the
+    # encoding: grinding a nonce is the freedom this exchange takes away
+    # from the device, which promised R in step 2 and would be drawing a
+    # different nonce here. `sign_` refuses the pair anyway, a commitment
+    # owning the entropy a counter would travel through, so this says out
+    # loud what would otherwise be an error message
     sig, _ = sign_(
         msg_hash,
         prv_key,
@@ -1050,6 +1056,7 @@ def anti_exfil_sign(
         lower_s,
         ec,
         hf,
+        grind=False,
         commit_hash=bytes_from_octets(rho, hf().digest_size),
     )
     return sig

--- a/tests/ecc/anti_exfil_test.py
+++ b/tests/ecc/anti_exfil_test.py
@@ -113,7 +113,7 @@ def test_step_2_and_step_4_reach_one_nonce(
     R = dsa.anti_exfil_signer_commit(_MSG_HASH, _PRV_KEY, commitment)
     assert bytes_from_point(R, secp256k1).hex() == opening
 
-    sig, receipt = dsa.sign_(_MSG_HASH, _PRV_KEY, commit_hash=rho)
+    sig, receipt = dsa.sign_(_MSG_HASH, _PRV_KEY, grind=False, commit_hash=rho)
     assert receipt == R
     assert dsa.anti_exfil_sign(_MSG_HASH, _PRV_KEY, rho) == sig
     assert dsa.anti_exfil_host_verify(_MSG_HASH, _PUB_KEY, sig, rho, R)

--- a/tests/ecc/commit_nonce_test.py
+++ b/tests/ecc/commit_nonce_test.py
@@ -83,7 +83,14 @@ def test_dsa_commitment() -> None:
             pub_key = mult(_PRV_KEY, ec.G, ec)
             for lower_s in (True, False):
                 sig, receipt = dsa.sign(
-                    _MSG, _PRV_KEY, None, lower_s, ec, hf, commit=_COMMIT
+                    _MSG,
+                    _PRV_KEY,
+                    None,
+                    lower_s,
+                    ec,
+                    hf,
+                    grind=False,
+                    commit=_COMMIT,
                 )
                 # an ordinary signature, whether or not it commits
                 dsa.assert_as_valid(_MSG, pub_key, sig, hf)
@@ -146,7 +153,7 @@ def test_the_python_path_is_the_committing_one() -> None:
     commit_hash = reduce_to_hlen(_COMMIT, hf)
     msg_hash = reduce_to_hlen(_MSG, hf)
 
-    sig, receipt = dsa.sign_(msg_hash, _PRV_KEY, commit_hash=commit_hash)
+    sig, receipt = dsa.sign_(msg_hash, _PRV_KEY, grind=False, commit_hash=commit_hash)
 
     entropy = commit_entropy_(commit_hash, _S2C_DATA_TAG, hf)
     nonce = rfc6979_nonce_(msg_hash, _PRV_KEY, ec, hf, entropy)
@@ -155,7 +162,7 @@ def test_the_python_path_is_the_committing_one() -> None:
         commit_hash, nonce, _S2C_POINT_TAG, ec, hf
     )
     assert tweaked_receipt == receipt
-    assert sig == dsa.sign_(msg_hash, _PRV_KEY, tweaked_nonce)
+    assert sig == dsa.sign_(msg_hash, _PRV_KEY, tweaked_nonce, grind=False)
     # and the point a verifier recomputes is the tweaked nonce's
     assert commit_point_(commit_hash, receipt, _S2C_POINT_TAG, ec, hf) == mult(
         tweaked_nonce, ec.G, ec
@@ -190,7 +197,9 @@ _ZKP_VECTORS = [
 @pytest.mark.parametrize("commit_hash, opening", _ZKP_VECTORS)
 def test_libsecp256k1_zkp_fixed_vectors(commit_hash: str, opening: str) -> None:
     """The receipt is the opening libsecp256k1-zkp's own fixture expects."""
-    sig, receipt = dsa.sign_(_ZKP_MSG_HASH, _ZKP_PRV_KEY, commit_hash=commit_hash)
+    sig, receipt = dsa.sign_(
+        _ZKP_MSG_HASH, _ZKP_PRV_KEY, grind=False, commit_hash=commit_hash
+    )
     assert bytes_from_point(receipt, secp256k1).hex() == opening
 
     # and the commitment opens, which is what the fixture asserts next
@@ -270,8 +279,8 @@ def test_the_commitment_reaches_the_nonce() -> None:
     a plain signature's nonce must be a third value again.
     """
     hf = sha256
-    _, receipt_a = dsa.sign(_MSG, _PRV_KEY, commit=b"contract A")
-    _, receipt_b = dsa.sign(_MSG, _PRV_KEY, commit=b"contract B")
+    _, receipt_a = dsa.sign(_MSG, _PRV_KEY, grind=False, commit=b"contract A")
+    _, receipt_b = dsa.sign(_MSG, _PRV_KEY, grind=False, commit=b"contract B")
     plain_nonce = rfc6979_nonce_(reduce_to_hlen(_MSG, hf), _PRV_KEY)
     plain_point = mult(plain_nonce, secp256k1.G, secp256k1)
     assert receipt_a != receipt_b
@@ -308,7 +317,7 @@ def test_a_plain_signature_opens_no_commitment() -> None:
     nonce = 1 + random.randrange(ec.n - 1)
     receipt = mult(nonce, ec.G, ec)
     pub_key = mult(_PRV_KEY, ec.G, ec)
-    sig = dsa.sign(_MSG, _PRV_KEY, nonce)
+    sig = dsa.sign(_MSG, _PRV_KEY, nonce, grind=False)
     with pytest.raises(BTClibRuntimeError, match="commitment verification failed"):
         dsa.assert_as_valid(_MSG, pub_key, sig, commit=_COMMIT, receipt=receipt)
 
@@ -325,7 +334,7 @@ def test_commitment_needs_the_receipt() -> None:
     "nothing here opens this" is not an answer about one.
     """
     pub_key = mult(_PRV_KEY, secp256k1.G, secp256k1)
-    sig, receipt = dsa.sign(_MSG, _PRV_KEY, commit=_COMMIT)
+    sig, receipt = dsa.sign(_MSG, _PRV_KEY, grind=False, commit=_COMMIT)
     with pytest.raises(BTClibTypeError, match="commitment without the receipt"):
         dsa.verify(_MSG, pub_key, sig, commit=_COMMIT)
     with pytest.raises(BTClibTypeError, match="receipt without the commitment"):

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -177,9 +177,9 @@ def test_signature() -> None:
     # ephemeral key not in 1..n-1
     err_msg = "private key not in 1..n-1"
     with pytest.raises(BTClibValueError, match=err_msg):
-        dsa.sign_(reduce_to_hlen(msg), q, 0)
+        dsa.sign_(reduce_to_hlen(msg), q, 0, grind=False)
     with pytest.raises(BTClibValueError, match=err_msg):
-        dsa.sign_(reduce_to_hlen(msg), q, sig.ec.n)
+        dsa.sign_(reduce_to_hlen(msg), q, sig.ec.n, grind=False)
 
 
 def test_gec() -> None:
@@ -207,7 +207,7 @@ def test_gec() -> None:
     msg = b"abc"
     k = 702232148019446860144825009548118511996283736794
     lower_s = False
-    sig = dsa.sign_(reduce_to_hlen(msg, hf), dU, k, lower_s, ec, hf)
+    sig = dsa.sign_(reduce_to_hlen(msg, hf), dU, k, lower_s, ec, hf, grind=False)
     assert sig.r == 0xCE2873E5BE449563391FEB47DDCBA2DC16379191
     assert sig.s == 0x3480EC1371A091A464B31CE47DF0CB8AA2D98B54
     assert sig.ec == ec
@@ -378,11 +378,11 @@ def test_crack_prv_key() -> None:
 
     msg1 = b"Paolo is afraid of ephemeral random numbers"
     m_1 = reduce_to_hlen(msg1)
-    sig1 = dsa.sign_(m_1, q, k)
+    sig1 = dsa.sign_(m_1, q, k, grind=False)
 
     msg2 = b"and Paolo is right to be afraid"
     m_2 = reduce_to_hlen(msg2)
-    sig2 = dsa.sign_(m_2, q, k)
+    sig2 = dsa.sign_(m_2, q, k, grind=False)
 
     q_cracked, k_cracked = dsa.crack_prv_key(msg1, sig1.serialize(), msg2, sig2)
 
@@ -679,11 +679,18 @@ def test_grinding_refuses_what_already_owns_the_nonce() -> None:
     to search, and a commitment already occupies the extra entropy the
     counter travels through. The second is not only a clash of encodings --
     grinding a nonce is exactly the freedom the anti-exfil protocol takes
-    away from a signing device -- and neither is refused without `grind`.
+    away from a signing device.
+
+    The refusal is the same whether `grind` was asked for or left at its
+    `True` default, which is what makes `grind=False` the only way to sign
+    with a nonce of one's own: neither of the two quietly wins, and which
+    one did is exactly what a caller pinning a signature could not have
+    guessed from the bytes.
     """
     msg = b"Satoshi Nakamoto"
     nonce = 0x9E5755E5A8FCC1B0A2FD1E0AD9E8D6B29B67D67E6C6A0DEE01E7E1F30DB9A0BE
     err_msg = "grinding derives its own nonce"
+    # asked for outright
     with pytest.raises(BTClibValueError, match=err_msg):
         dsa.sign(msg, prv_key_int, nonce, grind=True)
     with pytest.raises(BTClibValueError, match=err_msg):
@@ -691,9 +698,18 @@ def test_grinding_refuses_what_already_owns_the_nonce() -> None:
     with pytest.raises(BTClibValueError, match=err_msg):
         dsa.sign_(reduce_to_hlen(msg), prv_key_int, grind=True, commit_hash=bytes(32))
 
+    # and left at the default, which is that same True and that same refusal
+    with pytest.raises(BTClibValueError, match=err_msg):
+        dsa.sign(msg, prv_key_int, nonce)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        dsa.sign(msg, prv_key_int, commit=b"a commitment")
+    with pytest.raises(BTClibValueError, match=err_msg):
+        dsa.sign_(reduce_to_hlen(msg), prv_key_int, commit_hash=bytes(32))
+
+    # and `grind=False` is what signs either of them
     _, Q = dsa.gen_keys(prv_key_int)
-    assert dsa.verify(msg, Q, dsa.sign(msg, prv_key_int, nonce))
-    sig, receipt = dsa.sign(msg, prv_key_int, commit=b"a commitment")
+    assert dsa.verify(msg, Q, dsa.sign(msg, prv_key_int, nonce, grind=False))
+    sig, receipt = dsa.sign(msg, prv_key_int, grind=False, commit=b"a commitment")
     assert dsa.verify(msg, Q, sig, commit=b"a commitment", receipt=receipt)
 
 
@@ -1292,7 +1308,7 @@ def test_libsecp256k1_py_vectors_ecdsa_nonce(vector: dict[str, str]) -> None:
     prv_key = bytes.fromhex(vector["privkey"])
     assert len(prv_key) == 32
 
-    sig = dsa.sign_(msg_hash, prv_key, nonce)
+    sig = dsa.sign_(msg_hash, prv_key, nonce, grind=False)
     assert sig.serialize() == sig_der
     pub_key = pub_keyinfo_from_prv_key(prv_key, compressed=True)[0]
     assert dsa.verify_(msg_hash, pub_key, sig_der)

--- a/tests/ecc/rfc6979_test.py
+++ b/tests/ecc/rfc6979_test.py
@@ -111,7 +111,7 @@ def test_rfc6979_secp256k1(prv_key: int, msg: str, k: int, r: str, s: str) -> No
     # derivation with the answer handed back in
     sig = dsa.sign_(msg_hash, prv_key, grind=False)
     assert (sig.r, sig.s) == (int(r, 16), int(s, 16))
-    assert sig == dsa.sign_(msg_hash, prv_key, k)
+    assert sig == dsa.sign_(msg_hash, prv_key, k, grind=False)
 
     U = mult(prv_key)
     assert dsa.verify_(msg_hash, U, sig)
@@ -207,7 +207,9 @@ def test_rfc6979_nonce_tv(
     k2 = rfc6979_nonce_(m, prv_key, ec, getattr(hashlib, hf))
     assert int(k, 16) == k2
     # test RFC6979 usage in DSA
-    sig = dsa.sign_(m, prv_key, k2, lower_s, ec=ec, hf=getattr(hashlib, hf))
+    sig = dsa.sign_(
+        m, prv_key, k2, lower_s, ec=ec, hf=getattr(hashlib, hf), grind=False
+    )
     assert int(r, 16) == sig.r
     assert int(s, 16) == sig.s
     # test that RFC6979 is the default nonce for DSA


### PR DESCRIPTION
Follow-up to #715, on the one point it got wrong: `grind` is a plain
`bool` again and its default is `True`, paired with `nonce=None`.

## What changes

#715 made `grind` a tri-state (`bool | None`) so that the default could
give way to a nonce instead of colliding with it. That resolved the
contest silently, and silence is the wrong answer here: which of the two
won is not readable back out of the signature. So the pairing is the
design instead —

| | |
|---|---|
| `grind=True`, `nonce=None` | the defaults: the signature of a key and a message, the one Core would have made |
| a nonce, or a `commit` | `BTClibValueError("grinding derives its own nonce")`, at the default exactly as for an explicit `grind=True` |
| `grind=False` | how a caller signs with a nonce of their own, or with a commitment |

Grinding is a search over nonces: a nonce that is given leaves nothing to
search, and a sign-to-contract commitment already owns the extra entropy
the counter travels through. Both refusals were already there and already
tested; what changes is that they now fire when `grind` is left unsaid,
which is what makes `grind=False` a thing a caller states rather than a
thing the library infers.

## What it costs, stated plainly

`dsa.sign(msg, key, nonce)` raises. That is a source break for a
v2023.7.12 caller, where the call worked and grinding did not exist, and
HISTORY.md's breaking-changes bullet says so with the fix (`grind=False`
beside the nonce).

Inside the library one call site needed it: `anti_exfil_sign`, which signs
through a commitment. The comment there says it is the protocol and not
the encoding that requires it — the device promised R in step 2 and would
be drawing a different nonce. `sign_recoverable` and `bms.sign` are
untouched, a compact 65-byte signature having no DER pad for a low `r` to
save; `bip322.sign` already asked for the plain signature, its vectors
being the interoperability claim there.

## How much of the suite it moved

267 failures, one cause each: every test that hands in a nonce or a
commitment now says `grind=False`. One test changed in substance rather
than mechanically — `test_grinding_refuses_what_already_owns_the_nonce`,
whose docstring claimed "neither is refused without `grind`" and which now
asserts both refusals twice, once asked for and once left at the default.

## Gates

- `uv run pytest`: 25959 passed, 6 skipped, coverage 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make ECDSA low-R grinding the default paired with absence of a nonce or commitment, and require callers that supply a nonce or commitment to explicitly pass grind=False, with corresponding documentation and tests updated.

Enhancements:
- Simplify the DSA signing API by returning grind to a plain boolean with a default of True instead of a tri-state.
- Enforce that grinding cannot be combined with caller-provided nonces or sign-to-contract commitments, raising an error consistently at the default and when grind=True.

Documentation:
- Update CHANGELOG and HISTORY to describe the default grinding behavior, its interaction with user-supplied nonces/commitments, and the resulting breaking change.

Tests:
- Adjust signing and commitment tests to pass grind=False whenever providing a nonce or commitment, and expand grinding refusal tests to cover both explicit and default grind settings.

Chores:
- Document the anti-exfil signing protocol’s requirement to disable grinding and set grind=False at its internal call site.