### PR TITLE
Default lower_s to the rule, and drop it where it is dropped

### DIFF
--- a/.github/mutation/bms.toml
+++ b/.github/mutation/bms.toml
@@ -41,8 +41,8 @@ excluded-modules = []
 #   range, which every operator that survived still does most draws.
 #
 # A second pass worked through the address-type dispatch and the
-# check_validity/lower_s defaults this file's first pass sampled rather
-# than chased, closing the rest of the real gaps:
+# check_validity defaults this file's first pass sampled rather than
+# chased, closing the rest of the real gaps:
 #
 # - `_assert_p2pkh`/`_assert_p2wpkh`/`_assert_p2wpkh_p2sh`'s recovery-
 #   flag ranges were each pinned by a single vector -- 39 for p2pkh, 35
@@ -66,8 +66,7 @@ excluded-modules = []
 #   version-0-only length check cannot rule out on its own.
 # - check_validity defaults on `serialize`, `b64encode` and `parse` had
 #   no test building an invalid `Sig` and calling any of the three at
-#   their default; `assert_as_valid`'s and `verify`'s `lower_s` default
-#   had no test relying on it instead of passing the keyword.
+#   their default.
 #
 # Checked and left equivalent: `script_type == "p2pkh"` against `<=`,
 # `p2sh` being the only other value and always sorting after `p2pkh`;

--- a/.github/mutation/signatures.toml
+++ b/.github/mutation/signatures.toml
@@ -65,8 +65,8 @@ excluded-modules = []
 # random on every call is not what a fixed vector can hold an operator to.
 # Message-formatting thresholds (`self.r > 0xFFFFFFFF` deciding hex or
 # decimal display) account for several more, cosmetic rather than a
-# validity boundary. check_validity and `lower_s` defaults account for
-# another block, the same class parsers.toml's follow-up already names;
+# validity boundary. check_validity defaults account for another block,
+# the same class parsers.toml's follow-up already names;
 # the remainder is comparison operators and DER sign-byte handling
 # scattered across the parse/serialize/recover paths, sampled as data
 # here rather than chased to completion.
@@ -128,16 +128,15 @@ excluded-modules = []
 # - `Sig.assert_valid`'s `0 < self.r` and `0 < self.s`: pinned at zero
 #   the same way `ssa.Sig`'s test already was, `-1 <` accepting the one
 #   value below the range dsa.Sig -- unlike ssa.Sig -- excludes.
-# - `lower_s`'s default, `True`, on `assert_as_valid`, `verify` and
-#   `anti_exfil_host_verify`: three functions, the same class as the
-#   guard above, and no test had asked any of the three to refuse a
-#   malleated (high-s) signature *without* passing the keyword. The
-#   malleated twin already built for `verify(..., lower_s=False)`
-#   answers the question at the default too; libsecp256k1's own verify
-#   is what refuses it there, lower_s deciding only whether the
-#   signature is normalized in front of that call, so the message is
-#   "signature verification failed" and not `_assert_as_valid_`'s "not
-#   a low s", which the Python path alone raises.
+# - `lower_s`'s default, `True`, on the leading-underscore workers under
+#   verification and recovery -- `_assert_as_valid_`, `_recover_pub_key_`,
+#   `_recover_pub_keys_` and the two `_libsecp256k1_recover_*`, which is
+#   every place the flag survives outside signing. The public functions
+#   above them pass `lower_s=False`, so a default flipped there changes
+#   nothing any public call can see: what pins it is a test calling each
+#   of the five *without* the keyword and requiring "not a low s" of the
+#   malleated twin, which is
+#   `test_the_low_s_rule_is_the_default_the_public_surface_turns_off`.
 #
 # Checked and left equivalent, most of it the patterns already
 # established elsewhere in this session applied to this pair's own call

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -730,12 +730,16 @@ documented at release-notes length in the first place, and are still in
   `STANDARD_SCRIPT_VERIFY_FLAGS` (`src/policy/policy.h`), so one inside a
   transaction is non-standard and does not relay. `sign` therefore keeps
   `lower_s=True`, which is where the rule belongs, and the script engine
-  keeps reading it off its own flags. Asking a verifier for it is what the
-  leading-underscore functions are for -- `_assert_as_valid_`,
+  keeps reading it off its own flags. The strict answer is what the
+  leading-underscore workers give -- `_assert_as_valid_`,
   `_recover_pub_key_`, `_recover_pub_keys_` and the two
-  `_libsecp256k1_recover_*` -- each taking `lower_s: bool = False`
-  keyword-only, so the strict answer is asked for rather than assumed, and
-  the bindings path and the Python path can be held to one answer under it.
+  `_libsecp256k1_recover_*` -- each taking `lower_s: bool = True`
+  keyword-only, as every default of this flag in the module is `True`: the
+  canonical form is the library's preference, and the public functions
+  above them say `lower_s=False` in so many words, so where the rule is
+  dropped is readable at the call site instead of arranged by a default
+  nobody sees. Having it there at all is what lets the bindings path and
+  the Python path be held to one answer under the rule.
   A trailing underscore does not enter into it: those functions are public,
   offered beside the plain name so a caller can skip work already paid, and
   a keyword on one and not the other would make them two functions instead

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -31,8 +31,9 @@ full year, short month, short day (YYYY-M-D)
   the `True` default refused and what Bitcoin Core's `verifymessage`
   always accepted -- whether `s` is the low one of the two was decided by
   whoever signed. A caller that does want the strict answer asks a private
-  function for it: `dsa._assert_as_valid_(c, QJ, r, s, ec,
-  lower_s=True)`. `dsa.sign` is unchanged, `lower_s=True` and all, the
+  function for it, where it is the default:
+  `dsa._assert_as_valid_(c, QJ, r, s, ec)`. `dsa.sign` is unchanged,
+  `lower_s=True` and all, the
   rule being the signer's: a high-s signature in a transaction is
   non-standard and does not relay.
 - **an ECDSA signature is low-R now, and signing with your own nonce asks

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -395,7 +395,7 @@ def assert_as_valid(msg: Octets, addr: String, sig: Sig | String) -> None:
     # itself and 2.4 the r-congruence check of the Sig validation above
     if _libsecp256k1_applicable(secp256k1):
         pub_key = _libsecp256k1_recover_sec_(
-            key_id, reduce_to_hlen(magic_msg), sig.dsa_sig, compressed
+            key_id, reduce_to_hlen(magic_msg), sig.dsa_sig, compressed, lower_s=False
         )
     else:
         Q = dsa.recover_pub_key(key_id, magic_msg, sig.dsa_sig, sha256)

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -14,8 +14,10 @@ normalizing is the signer's job. Verification and recovery take both
 forms and offer no flag to refuse either -- which form s carries was
 decided by whoever signed, and refusing one refuses a signature that
 signer was free to make. The rule survives where it belongs: in ``sign``,
-in the script engine's own flags, and in the leading-underscore functions
-a test asks for it with.
+in the script engine's own flags, and in the leading-underscore workers
+under verification and recovery, which keep it as their default and are
+told ``lower_s=False`` by the public functions above them. A test that
+wants the strict answer calls one of those and passes nothing.
 
 ``sign`` also grinds for a low-R signature -- one byte shorter in DER --
 by default, as Core does; ``_grind_low_r`` is the loop and says why. Its
@@ -762,9 +764,16 @@ def sign_recoverable(
 
 
 def _assert_as_valid_(
-    c: int, QJ: JacPoint, r: int, s: int, ec: Curve, *, lower_s: bool = False
+    c: int, QJ: JacPoint, r: int, s: int, ec: Curve, *, lower_s: bool = True
 ) -> None:
-    # Private function for test/dev purposes
+    # Private function for test/dev purposes.
+    #
+    # lower_s defaults to the rule, as every default of this flag in this
+    # module does: the canonical form is what the library prefers, and a
+    # caller that wants the other one says so. Here that caller is
+    # `assert_as_valid_` above, and it says `lower_s=False` in so many
+    # words -- so where the rule is dropped is readable at the call site
+    # rather than left to a default nobody sees
 
     if lower_s and s > ec.n // 2:
         raise BTClibValueError("not a low s")
@@ -881,8 +890,11 @@ def assert_as_valid_(
     c = challenge_(msg_hash, sig.ec, hf)  # 2, 3
     Q = point_from_pub_key(key, sig.ec)
     QJ = Q[0], Q[1], 1
-    # second part delegated to helper function
-    _assert_as_valid_(c, QJ, sig.r, sig.s, sig.ec)
+    # second part delegated to helper function, `lower_s=False` being
+    # this function's answer about a high s: the private worker keeps the
+    # rule as its default, and dropping it is said here rather than
+    # arranged there
+    _assert_as_valid_(c, QJ, sig.r, sig.s, sig.ec, lower_s=False)
 
 
 def assert_as_valid(
@@ -1089,7 +1101,7 @@ def anti_exfil_host_verify(
 
 
 def _recover_pub_keys_(
-    c: int, r: int, s: int, ec: Curve, *, lower_s: bool = False
+    c: int, r: int, s: int, ec: Curve, *, lower_s: bool = True
 ) -> list[JacPoint]:
     # Private function provided for testing purposes only.
 
@@ -1166,12 +1178,14 @@ def recover_pub_keys_(
             # arrives as the BTClibValueError _libsecp256k1_recover_sec_
             # maps it to
             with contextlib.suppress(BTClibValueError, BTClibRuntimeError):
-                keys.append(_libsecp256k1_recover_point_(key_id, msg_hash, sig))
+                keys.append(
+                    _libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s=False)
+                )
         return keys
 
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 
-    QJs = _recover_pub_keys_(c, sig.r, sig.s, sig.ec)
+    QJs = _recover_pub_keys_(c, sig.r, sig.s, sig.ec, lower_s=False)
     return [sig.ec.aff_from_jac(QJ) for QJ in QJs]
 
 
@@ -1187,7 +1201,7 @@ def recover_pub_keys(msg: Octets, sig: Sig | Octets, hf: HashF = sha256) -> list
 
 
 def _recover_pub_key_(
-    key_id: int, c: int, r: int, s: int, ec: Curve, *, lower_s: bool = False
+    key_id: int, c: int, r: int, s: int, ec: Curve, *, lower_s: bool = True
 ) -> JacPoint:
     # Private function provided for testing purposes only.
 
@@ -1241,7 +1255,7 @@ def _recover_pub_key_(
 
 
 def _libsecp256k1_recover_sec_(
-    key_id: int, msg_hash: bytes, sig: Sig, compressed: bool, *, lower_s: bool = False
+    key_id: int, msg_hash: bytes, sig: Sig, compressed: bool, *, lower_s: bool = True
 ) -> bytes:
     # Private function: the caller has asked _libsecp256k1_applicable
     # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
@@ -1258,13 +1272,13 @@ def _libsecp256k1_recover_sec_(
     # equation by construction, and a candidate whose x-coordinate is not
     # on the curve is the failure caught below.
     #
-    # The lower-s rule is checked here and not there, and only when asked
-    # for: the recoverable parser takes any s in [1, n-1], as it must, a
-    # malleated signature recovering a key too. Nothing in the public
-    # surface asks -- which form s took was the signer's choice -- so this
-    # is the private spelling of the same question _assert_as_valid_
-    # answers with this very message, and it exists so that the two
-    # implementations of the step can be held to one answer under it
+    # The lower-s rule is checked here and not there: the recoverable
+    # parser takes any s in [1, n-1], as it must, a malleated signature
+    # recovering a key too. It is this function's default and every public
+    # caller turns it off -- which form s took was the signer's choice --
+    # so what the flag is for is holding the two implementations of the
+    # step to one answer, the same question _assert_as_valid_ answers with
+    # this very message
     if lower_s and sig.s > sig.ec.n // 2:
         raise BTClibValueError("not a low s")
 
@@ -1293,7 +1307,7 @@ def _libsecp256k1_recover_sec_(
 
 
 def _libsecp256k1_recover_point_(
-    key_id: int, msg_hash: bytes, sig: Sig, *, lower_s: bool = False
+    key_id: int, msg_hash: bytes, sig: Sig, *, lower_s: bool = True
 ) -> Point:
     # Private function: the caller has asked _libsecp256k1_applicable
     # already, and hands in a 32-byte msg_hash and a key_id in [0, 3].
@@ -1344,11 +1358,11 @@ def recover_pub_key_(
     # x_K = r + ec.n - ec.p otherwise, which fails step 1.6.2 for every r
     # -- passing it would need ec.p ≡ 0 mod ec.n
     if _libsecp256k1_applicable(sig.ec, hf) and 0 <= key_id <= 3:
-        return _libsecp256k1_recover_point_(key_id, msg_hash, sig)
+        return _libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s=False)
 
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 
-    QJ = _recover_pub_key_(key_id, c, sig.r, sig.s, sig.ec)
+    QJ = _recover_pub_key_(key_id, c, sig.r, sig.s, sig.ec, lower_s=False)
     return sig.ec.aff_from_jac(QJ)
 
 

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -299,9 +299,15 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
                     recovered = []
                     for key_id in range(2 * (ec.cofactor + 1)):
                         # a candidate x_K off the curve, or a key that
-                        # does not verify, is "not this key_id"
+                        # does not verify, is "not this key_id".
+                        # lower_s=False, the signatures here being built
+                        # from the equation rather than by `sign`: half of
+                        # them carry the high s, and this is about which
+                        # key_id recovers the signer
                         try:
-                            QJ = dsa._recover_pub_key_(key_id, e, r, s, ec)
+                            QJ = dsa._recover_pub_key_(
+                                key_id, e, r, s, ec, lower_s=False
+                            )
                         except (BTClibValueError, BTClibRuntimeError):
                             continue
                         recovered.append((key_id, ec.aff_from_jac(QJ)))
@@ -312,7 +318,7 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
                     assert all(key_id >> 1 == 1 for key_id in key_ids)
 
                     # and the plural is that range, less what dropped out
-                    jac_keys = dsa._recover_pub_keys_(e, r, s, ec)
+                    jac_keys = dsa._recover_pub_keys_(e, r, s, ec, lower_s=False)
                     assert [ec.aff_from_jac(QJ) for QJ in jac_keys] == [
                         Q_ for _, Q_ in recovered
                     ]
@@ -356,8 +362,10 @@ def test_key_id_is_the_j_zero_pair_when_n_is_above_p() -> None:
                     continue
                 key_ids = []
                 for key_id in range(2 * (ec.cofactor + 1)):
+                    # lower_s=False, as above: s is whatever the equation
+                    # gave, and the question is the key_id
                     try:
-                        QJ = dsa._recover_pub_key_(key_id, e, r, s, ec)
+                        QJ = dsa._recover_pub_key_(key_id, e, r, s, ec, lower_s=False)
                     except (BTClibValueError, BTClibRuntimeError):
                         continue
                     if ec.aff_from_jac(QJ) == Q:
@@ -426,7 +434,7 @@ def test_forge_hash_sig() -> None:
     s = r * u2inv % ec.n
     s = ec.n - s if s > ec.n / 2 else s
     e = s * u1 % ec.n
-    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, lower_s=True, ec=ec)
+    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, ec)
 
     # pick u1 and u2 at will
     u1 = 1234567890
@@ -437,7 +445,7 @@ def test_forge_hash_sig() -> None:
     s = r * u2inv % ec.n
     s = ec.n - s if s > ec.n / 2 else s
     e = s * u1 % ec.n
-    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, lower_s=True, ec=ec)
+    dsa._assert_as_valid_(e, (Q[0], Q[1], 1), r, s, ec)
 
 
 def test_sign_input_type() -> None:
@@ -866,7 +874,7 @@ def test_libsecp256k1_recovery(monkeypatch: pytest.MonkeyPatch) -> None:
             assert _recovered(key_id ^ 1, msg, malleated) == Q
 
 
-def test_the_low_s_rule_is_asked_for_and_not_assumed(
+def test_the_low_s_rule_is_the_default_the_public_surface_turns_off(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Where the strict rule lives once the public surface drops it (issue 695).
@@ -874,9 +882,14 @@ def test_the_low_s_rule_is_asked_for_and_not_assumed(
     The rule is not gone: `SCRIPT_VERIFY_LOW_S` is in Core's
     `STANDARD_SCRIPT_VERIFY_FLAGS`, so a high-s signature inside a
     transaction is non-standard and does not relay, and `sign` normalizes
-    for that reason. What is gone is a verifier refusing one -- so the
-    strict answer is what a leading-underscore function gives when asked
-    for it, `lower_s=False` being the default there too.
+    for that reason. What is gone is a *verifier* refusing one -- so the
+    rule is what every leading-underscore worker under verification and
+    recovery does by default, and `lower_s=False` at the public call sites
+    above them is where it is dropped.
+
+    Which is why nothing here passes the keyword: these calls are the
+    default, and a default flipped the other way would make every one of
+    them answer instead of raise.
 
     Both implementations of the recovery are asked, being one step written
     twice: the bindings answer the named candidate and the Python path
@@ -897,28 +910,28 @@ def test_the_low_s_rule_is_asked_for_and_not_assumed(
     assert dsa.verify(msg, Q, malleated)
     assert dsa.recover_pub_key(key_id ^ 1, msg, malleated) == Q
 
-    # and every private spelling refuses it when told to
+    # and every private spelling refuses it, left to its default
     with pytest.raises(BTClibValueError, match=err_msg):
-        dsa._assert_as_valid_(c, QJ, malleated.r, malleated.s, secp256k1, lower_s=True)
+        dsa._assert_as_valid_(c, QJ, malleated.r, malleated.s, secp256k1)
     with pytest.raises(BTClibValueError, match=err_msg):
-        dsa._libsecp256k1_recover_point_(key_id ^ 1, msg_hash, malleated, lower_s=True)
+        dsa._libsecp256k1_recover_point_(key_id ^ 1, msg_hash, malleated)
     with pytest.raises(BTClibValueError, match=err_msg):
-        dsa._recover_pub_key_(
-            key_id ^ 1, c, malleated.r, malleated.s, secp256k1, lower_s=True
-        )
+        dsa._libsecp256k1_recover_sec_(key_id ^ 1, msg_hash, malleated, compressed=True)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        dsa._recover_pub_key_(key_id ^ 1, c, malleated.r, malleated.s, secp256k1)
     # the enumeration drops a candidate that fails rather than report it,
     # so there the same refusal is an empty list: every one of the four
     # fails the one rule at once
-    assert (
-        dsa._recover_pub_keys_(c, malleated.r, malleated.s, secp256k1, lower_s=True)
-        == []
-    )
+    assert dsa._recover_pub_keys_(c, malleated.r, malleated.s, secp256k1) == []
 
     # the signature as signed passes the strict rule on both paths, which
     # is what says the refusals above are about the malleation and not
     # about the arguments being threaded wrongly
-    dsa._assert_as_valid_(c, QJ, sig.r, sig.s, secp256k1, lower_s=True)
-    assert dsa._libsecp256k1_recover_point_(key_id, msg_hash, sig, lower_s=True) == Q
+    dsa._assert_as_valid_(c, QJ, sig.r, sig.s, secp256k1)
+    assert dsa._libsecp256k1_recover_point_(key_id, msg_hash, sig) == Q
+    assert dsa._libsecp256k1_recover_sec_(
+        key_id, msg_hash, sig, compressed=True
+    ) == bytes_from_point(Q)
     with monkeypatch.context() as no_bindings:
         no_bindings.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
         assert dsa.recover_pub_key(key_id, msg, sig) == Q


### PR DESCRIPTION
Follow-up to https://github.com/btclib-org/btclib/pull/715, on the rule
that a default expresses the library's preference: **wherever `grind` or
`lower_s` has a default, that default is `True`, and a caller that needs
`False` says so.** `grind` already reads that way; `lower_s` did not,
below the public surface.

## What changes

The five leading-underscore workers under verification and recovery —
`_assert_as_valid_`, `_recover_pub_key_`, `_recover_pub_keys_`,
`_libsecp256k1_recover_sec_` and `_libsecp256k1_recover_point_` — went
from `lower_s: bool = False` to `lower_s: bool = True`. The callers that
want the rule dropped now drop it in so many words:

| caller | now passes |
| --- | --- |
| `dsa.assert_as_valid_` | `_assert_as_valid_(..., lower_s=False)` |
| `dsa.recover_pub_keys_` | `_recover_pub_keys_(..., lower_s=False)`, `_libsecp256k1_recover_point_(..., lower_s=False)` |
| `dsa.recover_pub_key_` | `_recover_pub_key_(..., lower_s=False)`, `_libsecp256k1_recover_point_(..., lower_s=False)` |
| `bms.assert_as_valid` | `_libsecp256k1_recover_sec_(..., lower_s=False)` |

No public behaviour moves: verification and recovery answer exactly what
they answered before, high-s signatures included, and the 200
`signmessage.json` vectors still verify. What moves is where the reader
learns that the rule is being set aside — the call site, not a default
three functions away.

## The test that makes those defaults real

`test_the_low_s_rule_is_asked_for_and_not_assumed` becomes
`test_the_low_s_rule_is_the_default_the_public_surface_turns_off` and
passes **no keyword at all**: with every caller spelling the flag out, a
default flipped the other way would change nothing any test could see. It
also calls `_libsecp256k1_recover_sec_` directly, that being the spelling
`bms` reaches and the one the point spelling would otherwise hide.

Two low-cardinality tests that built signatures from the equation rather
than from `sign` — half of them high-s — now ask for `lower_s=False`
explicitly, which is what the old default was giving them silently.

`.github/mutation/*.toml` lose two notes about mutants on defaults that
no longer exist, and gain the one that names what pins these five.

## Gates

- `uv run pytest`: 25960 passed, coverage 100.00%
- `uv run pre-commit run --all-files`: exit 0
- `sphinx-build -W --keep-going`: build succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Default the low-s rule to True in internal ECDSA verification and recovery helpers while keeping public verification behavior unchanged by explicitly turning the rule off at call sites.

Enhancements:
- Align lower_s defaults across leading-underscore verification and recovery helpers to express the library’s preference for canonical (low-s) signatures.
- Make public ECDSA and message-signature verification functions explicitly drop the low-s rule via lower_s=False parameters instead of relying on hidden defaults.

Build:
- Adjust mutation-testing configuration comments to reflect that lower_s defaults now live only on internal helpers and are pinned by dedicated tests.

Documentation:
- Clarify documentation and history around the low-s rule, emphasizing that internal workers keep it as the default and public functions explicitly turn it off.

Tests:
- Update and rename low-s rule tests to assert that internal helpers enforce the default while public surfaces disable it, adding explicit lower_s=False where high-s signatures are constructed manually.