### PR TITLE
Say what keeps a name out of btclib.ecc, which is not the underscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1066,6 +1066,24 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`btclib.ecc`'s docstring stops crediting the trailing underscore** for
+  a decision it has no part in (issue #721). The paragraph said that what
+  is not in the package's `__all__` is "any name ending in an underscore",
+  which reads as the misconception #711 was about: a trailing underscore
+  is public, and each of those names is exported by the module that
+  defines it. What the package keeps out is a module's own functions,
+  plain or prepared alike -- `dsa.sign` and `dsa.sign_` are both in
+  `dsa.__all__` and neither is in the package's, as `musig2.key_agg`,
+  `ecies.encrypt` and `ellswift.xdh` are not -- with the three loose
+  helpers named there the whole of the exception. For four of them there
+  is no decision to make at all: `sign_`, `verify_` and `assert_as_valid_`
+  are defined by both dsa and ssa, `challenge_` by both ssa and
+  rfc6979_nonce, so a package-level export would collide, exactly as one
+  of `sign` or `gen_keys` would. Nothing else changes: `__all__` is the
+  same list, and the census behind the wording found every
+  trailing-underscore name in the library already exported, which
+  `tests/all_test.py` is what enforces.
+
 - **`NETWORKS` is fixed at import, and read-only** (issue #683). A
   `MappingProxyType` over the dict the five json files fill, so
   `NETWORKS["custom"] = ...` is a `TypeError` where it used to be a

--- a/btclib/ecc/__init__.py
+++ b/btclib/ecc/__init__.py
@@ -28,11 +28,18 @@ The three nonces are named the same way, as modules. A nonce derivation
 is a scheme of its own -- RFC6979 has test vectors, BIP340's auxiliary
 randomness is part of the signing standard, and sign-to-contract has its
 commitment and its opening -- so `btclib.ecc.rfc6979_nonce` is the
-spelling, as `btclib.ecc.dsa` is. What is *not* here is any name ending
-in an underscore: `bip340_nonce_`, `rfc6979_nonce_`, `commit_nonce_` and
-`challenge_` take a message already reduced to a scalar and an explicit
-curve, which is the expert door of the module that defines them, and
-`dsa.sign_` and `ssa.sign_` are not exported either.
+spelling, as `btclib.ecc.dsa` is.
+
+What is *not* here is a module's own functions, plain or prepared:
+`dsa.sign` and `dsa.sign_` are both in `dsa.__all__` and neither is in
+this one, and nor are `musig2.key_agg`, `ecies.encrypt` or
+`ellswift.xdh`. The three loose helpers ``__all__`` names above are the
+whole of the exception. So the trailing underscore is no part of the
+decision, and for four names there is no decision to make: dsa and ssa
+both define `sign_`, `verify_` and `assert_as_valid_`, ssa and
+rfc6979_nonce both define `challenge_`, and a package-level export of
+any of the four would collide -- as one of `sign` would, which five of
+these modules define, or of `gen_keys`, which three do.
 
 bms does `from btclib.ecc import dsa`, i.e. it imports a name from the
 package that is importing it, and the order of the line below does not


### PR DESCRIPTION
`btclib/ecc/__init__.py`'s docstring said that what is not in the package's
`__all__` is "any name ending in an underscore". The fact was right and the
reason was not: it reads as the misconception
https://github.com/btclib-org/btclib/issues/711 was about, a trailing
underscore taken for a mark of lesser publicity. A trailing underscore is
public, and each of those names is exported by the module that defines it.

What the package keeps out is a module's own functions, plain or prepared
alike. `dsa.sign` and `dsa.sign_` are both in `dsa.__all__` and neither is in
the package's, as `musig2.key_agg`, `ecies.encrypt` and `ellswift.xdh` are
not. For four of them there is no decision to make at all: dsa and ssa both
define `sign_`, `verify_` and `assert_as_valid_`, ssa and rfc6979_nonce both
define `challenge_`, so a package-level export would collide — exactly as one
of `sign` would, which five of these modules define, or of `gen_keys`, which
three do.

## What the wording deliberately does not claim

My first draft said the package re-exports a loose name where it is the only
one of its name, `ansi_x9_63_kdf`, `diffie_hellman` and `second_generator`
each being unique. Measured, that is false as a criterion: an `ast` pass over
the package finds 53 further names that are unique and are not re-exported,
`ecies.encrypt`, `pedersen.commit`, `musig2.key_agg`, `ellswift.xdh` and
`dsa.sign_recoverable` among them. Nothing in the tree says what admitted the
three, so the docstring calls them the exception and invents no rule for them.
The correction is recorded on the issue as well.

## Nothing is exported that was not

`__all__` is unchanged, in the package and in every module. The audit that
started this — after
https://github.com/btclib-org/btclib/pull/713, whether any trailing-underscore
name was left unexported — found all 21 of them already in their module's
`__all__`:

| module | names |
| --- | --- |
| `dsa` | `sign_`, `sign_recoverable_`, `assert_as_valid_`, `verify_`, `recover_pub_key_`, `recover_pub_keys_`, `crack_prv_key_` |
| `ssa` | `sign_`, `assert_as_valid_`, `verify_`, `assert_batch_as_valid_`, `batch_verify_`, `challenge_` |
| `commit_nonce` | `commit_entropy_`, `commit_nonce_`, `commit_point_` |
| `rfc6979_nonce` | `challenge_`, `rfc6979_nonce_` |
| `musig2` | `nonce_gen_`, `partial_sig_verify_` |
| `bip340_nonce` | `bip340_nonce_` |

That is `tests/all_test.py` doing its job rather than luck:
`defined_public_names` drops a name on `startswith("_")`, so a *trailing*
underscore exempts nothing from `test_nothing_becomes_public_by_accident`,
and none of the 21 is in the `UNEXPORTED` table. Sphinx publishes them too,
`docs/source/conf.py` setting no `ignore-module-all`.

Gates, all green locally: `uv run pre-commit run --all-files` at exit 0, the
sphinx `-W` build at exit 0, and `uv run pytest` at 25965 passed with coverage
100.00%.

Closes https://github.com/btclib-org/btclib/issues/721

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify btclib.ecc package export semantics in documentation without changing the public API.

Enhancements:
- Record the correction to btclib.ecc export rules and trailing-underscore behavior in the changelog under public API and module layout, without modifying any __all__ definitions.

Documentation:
- Update btclib.ecc.__init__ docstring to explain that package-level exports exclude module-local functions regardless of trailing underscores, documenting the few helper functions that are exceptions.