### PR TITLE
Close the rest of #684's census: an object validated as a string is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -759,6 +759,21 @@ documented at release-notes length in the first place, and are still in
   `encode_to_bip32_derivs` then wrote `master_fingerprint.hex()` of whatever
   it held into the json. `assert_valid_hd_key_paths`, the validating
   counterpart, was already sitting beside both.
+- **`slip132`'s two public entries validate an already-built key too**
+  (#684). `address_from_xpub` and the `_helper_checks` behind the three
+  `*_xkey` functions checked a string by decoding it -- which validates by
+  default -- and trusted an already-built `BIP32KeyData` as it stood. Both
+  now go through `_key_data_from_bip32_key`, the one place either spelling
+  becomes a validated key.
+- **Three hand-rolled copies of that same validate-or-decode step, gone**
+  (#684). `to_pub_key._point_from_xpub`, `to_pub_key._pub_keyinfo_from_xpub`
+  and `to_prv_key._prv_keyinfo_from_xprv` each repeated the isinstance
+  check, the `assert_valid` and the `b58decode` that
+  `_key_data_from_bip32_key` already is -- validating an object correctly,
+  three times over, rather than composing the one place that does it. All
+  three now call it; `_prv_keyinfo_from_xprv` keeps its own remapping of a
+  decode failure to `NotAPrvKeyError` around the call, that being this
+  caller's decision and not the shared function's to make.
 
 - **Batch verification validates every signature it is handed** (#688).
   `ssa.batch_verify_` answered `True` for a signature `ssa.verify_` answers
@@ -1321,6 +1336,12 @@ documented at release-notes length in the first place, and are still in
   exists to be believed about a list of addresses somebody wrote down
   (#596). One helper and not three copies, for the reason `_script_from`
   gives about itself.
+- **`account_descriptors` validates an already-built key too** (#684). A
+  string went through `BIP32KeyData.b58decode`, which validates by
+  default; an already-built `BIP32KeyData` was trusted as it stood, its
+  depth and version read before anything asked whether it was a valid
+  key. It now goes through `_key_data_from_bip32_key`, the one place
+  either spelling becomes one.
 
 - **`at_index()` and `normalized()` reach the keys inside a miniscript**
   (#592). `_mapped_keys` is the one walk both are written in terms of,
@@ -1432,6 +1453,15 @@ documented at release-notes length in the first place, and are still in
   cost and a different algorithm.
 
 ### Wallets
+
+- **`BIP32KeyWallet` and `KeyGroup` validate an already-built key too**
+  (#684). Both took a `BIP32Key`: a string went through
+  `BIP32KeyData.b58decode`, which validates by default, and an
+  already-built `BIP32KeyData` was trusted as it stood -- read for its
+  depth and index, or mapped straight into the group's `keys`, before
+  anything asked whether it was one. Both now go through
+  `_key_data_from_bip32_key`, the one place either spelling becomes a
+  validated key.
 
 - **The private BIP32 functions validate nothing, which is what their
   leading underscore says.** `derive(xpub, "m/0/1")` validated the same

--- a/btclib/descriptors/descriptors.py
+++ b/btclib/descriptors/descriptors.py
@@ -2744,8 +2744,7 @@ def account_descriptors(
     is text and not a parsed descriptor: `multipath_descriptors` expands
     one and `parse` refuses one, so what this returns is the two.
     """
-    if not isinstance(xkey, BIP32KeyData):
-        xkey = BIP32KeyData.b58decode(xkey)
+    xkey = _key_data_from_bip32_key(xkey)
 
     indexes = indexes_from_der_path(der_path)
     _assert_valid_account_path(indexes)

--- a/btclib/slip132.py
+++ b/btclib/slip132.py
@@ -15,7 +15,13 @@ from typing import Any
 
 from btclib import b32, b58
 from btclib.alias import NetworkField
-from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, derive, xpub_from_xprv
+from btclib.bip32.bip32 import (
+    BIP32Key,
+    BIP32KeyData,
+    _key_data_from_bip32_key,
+    derive,
+    xpub_from_xprv,
+)
 from btclib.bip32.der_path import DerPath
 from btclib.exceptions import BTClibValueError
 from btclib.network import (
@@ -51,8 +57,7 @@ def address_from_xpub(xpub: BIP32Key) -> str:
     The address is always derived from the compressed public key, as
     this is the default public key representation in BIP32.
     """
-    if not isinstance(xpub, BIP32KeyData):
-        xpub = BIP32KeyData.b58decode(xpub)
+    xpub = _key_data_from_bip32_key(xpub)
 
     if xpub.key[0] not in {2, 3}:
         # this branch is reached with an xprv: never echo it,
@@ -83,8 +88,7 @@ def address_from_xpub(xpub: BIP32Key) -> str:
 def _helper_checks(
     xkey: BIP32Key, check_root_xkey: bool
 ) -> tuple[BIP32KeyData, Network]:
-    if not isinstance(xkey, BIP32KeyData):
-        xkey = BIP32KeyData.b58decode(xkey)
+    xkey = _key_data_from_bip32_key(xkey)
     if check_root_xkey and not xkey.is_root:
         # xkey may be an xprv: never echo it; depth and
         # parent fingerprint are the non-root, non-secret, parts

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from btclib.alias import String
 from btclib.base58 import decode as b58decode
-from btclib.bip32 import BIP32Key, BIP32KeyData
+from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, _key_data_from_bip32_key
 from btclib.curves import Curve, secp256k1
 from btclib.exceptions import (
     BTClibValueError,
@@ -219,13 +219,13 @@ def _prv_keyinfo_from_xprv(
     """
     if isinstance(xprv, BIP32KeyData):
         # the caller has already committed to the format by building one
-        xprv.assert_valid()
+        xprv = _key_data_from_bip32_key(xprv)
     else:
         # base58, 78 bytes, and a known xkey version or not: a negative
         # answer leaves the input free to be octets or an int, so it is
         # NotAPrvKeyError, carrying the reason rather than discarding it
         try:
-            xprv = BIP32KeyData.b58decode(xprv)
+            xprv = _key_data_from_bip32_key(xprv)
         except ValueError as e:
             raise NotAPrvKeyError(f"not a BIP32 xkey ({e})") from e
 

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import contextlib
 
 from btclib.alias import Point
-from btclib.bip32 import BIP32Key, BIP32KeyData
+from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, _key_data_from_bip32_key
 from btclib.curves import (
     Curve,
     bytes_from_point,
@@ -53,10 +53,7 @@ Key = int | bytes | str | BIP32KeyData | Point
 
 def _point_from_xpub(xpub: BIP32Key, ec: Curve) -> Point:
     """Return an elliptic curve point tuple from a xpub key."""
-    if isinstance(xpub, BIP32KeyData):
-        xpub.assert_valid()
-    else:
-        xpub = BIP32KeyData.b58decode(xpub)
+    xpub = _key_data_from_bip32_key(xpub)
 
     if xpub.is_private:
         # never echo the key, which is private here:
@@ -130,10 +127,7 @@ def _pub_keyinfo_from_xpub(
     if not compressed:
         raise BTClibValueError("Uncompressed SEC / compressed BIP32 mismatch")
 
-    if isinstance(xpub, BIP32KeyData):
-        xpub.assert_valid()
-    else:
-        xpub = BIP32KeyData.b58decode(xpub)
+    xpub = _key_data_from_bip32_key(xpub)
 
     if xpub.key[0] not in {2, 3}:
         # this branch is reached with an xprv: never echo it,

--- a/btclib/wallet/key_wallet.py
+++ b/btclib/wallet/key_wallet.py
@@ -50,6 +50,7 @@ from btclib.alias import BIP44ScriptType, Octets, String
 from btclib.bip32.bip32 import (
     BIP32Key,
     BIP32KeyData,
+    _key_data_from_bip32_key,
     derive,
     derive_from_account,
 )
@@ -258,8 +259,7 @@ class BIP32KeyWallet(KeyWallet, RangedWallet):
         der_path: DerPath = _DEFAULT_ACCOUNT,
         script_type: BIP44ScriptType | None = None,
     ) -> None:
-        if not isinstance(xkey, BIP32KeyData):
-            xkey = BIP32KeyData.b58decode(xkey)
+        xkey = _key_data_from_bip32_key(xkey)
 
         indexes = indexes_from_der_path(der_path)
         if len(indexes) != _ACCOUNT_LEVELS:

--- a/btclib/wallet/script_wallet.py
+++ b/btclib/wallet/script_wallet.py
@@ -132,6 +132,7 @@ from btclib.alias import Command, EmbeddedScriptType, KeyOrder, ScriptList
 from btclib.bip32.bip32 import (
     BIP32Key,
     BIP32KeyData,
+    _key_data_from_bip32_key,
     derive_from_account,
     xpub_from_xprv,
 )
@@ -322,10 +323,7 @@ class KeyGroup:
         verify: bool = False,
         origins: Sequence[BIP32KeyOrigin | None] | None = None,
     ) -> None:
-        self.keys = tuple(
-            key if isinstance(key, BIP32KeyData) else BIP32KeyData.b58decode(key)
-            for key in keys
-        )
+        self.keys = tuple(_key_data_from_bip32_key(key) for key in keys)
         # one per key, so that the pairing is positional and stays so
         # through the account order, which sorts the keys and not this
         self.origins: tuple[BIP32KeyOrigin | None, ...] = (

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -40,7 +40,7 @@ from hypothesis import strategies as st
 
 from btclib.alias import BIP44ScriptType, Octets
 from btclib.bip32 import BIP32KeyOrigin
-from btclib.bip32.bip32 import derive, xpub_from_xprv
+from btclib.bip32.bip32 import BIP32KeyData, derive, xpub_from_xprv
 from btclib.bip32.der_path import _HARDENING
 from btclib.bip44 import SCRIPT_TYPE_FROM_PURPOSE
 from btclib.descriptors import (
@@ -2943,6 +2943,25 @@ def test_an_account_descriptor_needs_a_fingerprint_it_cannot_compute() -> None:
     ) == (str(computed[0]))
     with pytest.raises(BTClibValueError, match="is not the key's own"):
         account_descriptors(XPRV_ROOT, "m/84h/0h/0h", "deadbeef")
+
+
+def test_account_descriptors_validates_an_already_built_key_too() -> None:
+    """The rule of #684: an object is validated as a string is.
+
+    A string went through `BIP32KeyData.b58decode`, which validates by
+    default; an already-built `BIP32KeyData` was trusted as it stood.
+    """
+    good = BIP32KeyData.b58decode(XPRV_ROOT)
+    receive, _ = account_descriptors(good, "m/84h/0h/0h")
+    assert str(receive) == str(account_descriptors(XPRV_ROOT, "m/84h/0h/0h")[0])
+
+    bad = BIP32KeyData.b58decode(XPRV_ROOT)
+    bad.index = -1
+    err_msg = "invalid index: -1"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bad.assert_valid()
+    with pytest.raises(BTClibValueError, match=err_msg):
+        account_descriptors(bad, "m/84h/0h/0h")
 
 
 def test_an_account_descriptor_holds_a_bip32_version() -> None:

--- a/tests/slip132_test.py
+++ b/tests/slip132_test.py
@@ -75,6 +75,29 @@ def test_slip132() -> None:
         slip132.p2wpkh_xkey(xprv)
 
 
+def test_an_already_built_key_is_validated_too() -> None:
+    """`address_from_xpub` and `_helper_checks` (rule of #684).
+
+    A string went through `BIP32KeyData.b58decode`, which validates by
+    default; an already-built `BIP32KeyData` was trusted as it stood,
+    unlike the four `to_prv_key`/`to_pub_key`/`bip32` functions the same
+    census names as compliant.
+    """
+    xpub = "xpub6C6uNUWrxKLNyNLy6CJgx2SkUvx7yynLVrZ79zrCseWHyGKtj8sUGZUq3dw9fqJGETSEeX1iztXAfRvxh6Gk2m7yVjDCx5cbRP2So559Hb5"
+    good = bip32.BIP32KeyData.b58decode(xpub)
+    assert slip132.address_from_xpub(good) == slip132.address_from_xpub(xpub)
+
+    bad = bip32.BIP32KeyData.b58decode(xpub)
+    bad.index = -1
+    err_msg = "invalid index: -1"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bad.assert_valid()
+    with pytest.raises(BTClibValueError, match=err_msg):
+        slip132.address_from_xpub(bad)
+    with pytest.raises(BTClibValueError, match=err_msg):
+        slip132.p2pkh_xkey(bad)
+
+
 def test_slip132_test_vectors() -> None:
     """SLIP132 test vector.
 

--- a/tests/wallet/key_wallet_test.py
+++ b/tests/wallet/key_wallet_test.py
@@ -158,6 +158,23 @@ def test_a_bip32keydata_is_taken_as_it_is() -> None:
     assert wallet.next_address() == "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA"
 
 
+def test_a_bip32keydata_is_validated_even_when_already_one() -> None:
+    """The rule of #684: an object is validated as a string is.
+
+    A string went through `BIP32KeyData.b58decode`, which validates by
+    default; an already-built `BIP32KeyData` was trusted as it stood,
+    unlike the four `to_prv_key`/`to_pub_key`/`bip32` functions the same
+    census names as compliant.
+    """
+    bad = bip32.BIP32KeyData.b58decode(_ACCOUNT_44_XPUB)
+    bad.index = -1
+    err_msg = "invalid index: -1"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bad.assert_valid()
+    with pytest.raises(BTClibValueError, match=err_msg):
+        BIP32KeyWallet(bad, "m/44h/0h/0h")
+
+
 def test_the_key_index_must_be_the_path_element_at_its_depth() -> None:
     """Refuse a key at the wrong index, or past the account depth."""
     # the account 0 xpub against the path of account 1, and the message

--- a/tests/wallet/script_wallet_test.py
+++ b/tests/wallet/script_wallet_test.py
@@ -323,6 +323,22 @@ def test_a_quorum_is_bounded_by_what_op_int_spells() -> None:
     assert repr(KeyGroup(2, _XPUBS)) == "KeyGroup(2, 3 keys)"
 
 
+def test_a_decoded_key_is_validated_too() -> None:
+    """The rule of #684: an object is validated as a string is.
+
+    `KeyGroup.__init__` mapped every key through `BIP32KeyData.b58decode`,
+    which validates by default, but trusted an already-built
+    `BIP32KeyData` in `keys` unasked.
+    """
+    bad = BIP32KeyData.b58decode(_XPUBS[0])
+    bad.index = -1
+    err_msg = "invalid index: -1"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        bad.assert_valid()
+    with pytest.raises(BTClibValueError, match=err_msg):
+        KeyGroup(1, [bad])
+
+
 def test_verify_writes_checkmultisigverify_and_nothing_else() -> None:
     """The required-quorum form miniscript's `v:` wrapper compiles to.
 


### PR DESCRIPTION
The rule #684 decided:

> Every public function must always validate its inputs, optionally
> deferring the work itself to a private twin that does not validate and
> that can then be used wherever the inputs have already been validated
> and revalidating them makes no sense.

`slip132.address_from_xpub`, the `_helper_checks` behind its three
`*_xkey` functions, `BIP32KeyWallet.__init__`, `KeyGroup.__init__` and
`account_descriptors` each took a `BIP32Key`: a string went through
`BIP32KeyData.b58decode`, which validates by default, and an
already-built `BIP32KeyData` was trusted as it stood -- read for its
depth, index or version before anything asked whether it was one.

All five now go through `_key_data_from_bip32_key`, the one place
either spelling becomes a validated `BIP32KeyData` -- the same private
twin #643 and #693 already composed `bip32`'s and `descriptors`' own
public functions around.

Three more hand-rolled copies of that same validate-or-decode dance --
`to_pub_key._point_from_xpub`, `to_pub_key._pub_keyinfo_from_xpub` and
`to_prv_key._prv_keyinfo_from_xprv` -- were already correct but
repeated the isinstance check, the `assert_valid` and the `b58decode`
as their own lines. All three now call `_key_data_from_bip32_key` too,
so the four sites the issue named collapse to one.
`_prv_keyinfo_from_xprv` keeps its own remapping of a decode failure
to `NotAPrvKeyError` around the call, that being this caller's
decision and not the shared function's to make.

This is the last item of #684's own census -- `bip32.crack_prv_key`
was fixed in #693, and the rule itself was written into
`CONTRIBUTING.md` by #698. The six issues the audit filed
(#688, #690-#694) stay their own: #690 is still open on its own account
and is not part of this census.

## Verified

- `uv run pytest`: **25969 passed, 6 skipped**, exit 0 -- the gated
  run, `--cov` being in addopts, so the 100% ratchet passed with it.
- `uv run pre-commit run --all-files`: every hook, `mypy` strict
  included. Exit code checked, not filtered output.
- The sphinx build with `-W --keep-going`: `build succeeded`, exit 0.

Closes #684

## Summary by Sourcery

Unify BIP32 key validation so both strings and already-built BIP32KeyData objects are consistently validated before use across slip132, descriptor, and wallet helpers, completing the #684 census.

Enhancements:
- Route slip132 address and helper functions through the shared _key_data_from_bip32_key validator instead of ad-hoc decode/validate logic.
- Apply _key_data_from_bip32_key to descriptor account_descriptors and wallet BIP32KeyWallet/KeyGroup constructors so pre-decoded keys are validated like strings.
- Replace hand-rolled xkey validation in to_pub_key and to_prv_key helpers with calls to _key_data_from_bip32_key while preserving caller-specific error mapping.

Documentation:
- Extend CHANGELOG entries to document the unified BIP32 key validation behavior for slip132, descriptors, and wallet constructors.

Tests:
- Add tests for slip132, account_descriptors, BIP32KeyWallet, and KeyGroup to ensure already-built BIP32KeyData instances are validated and reject structurally invalid keys.