### PR TITLE
Refuse a version or lock_time width four bytes cannot hold at serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -529,6 +529,19 @@ documented at release-notes length in the first place, and are still in
   the script code. Refusing the width at the serialization boundary is what
   those two want, and it is a decision of its own.
 
+- **The last two of #690, closed at the serialization boundary rather than
+  the object's.** Neither wants the transaction judged whole -- the decision
+  the entry above left open -- so `Tx.serialize` now refuses a `version` or
+  `lock_time` outside the four bytes it writes them in on its own account,
+  regardless of `check_validity`: the same range `assert_valid` already
+  enforced, asked again where `check_validity=False` skips it, rather than
+  left to `int.to_bytes`'s `OverflowError`.
+  `merkle_root_and_mutated_from_transactions` and `legacy`'s own
+  transaction copy both reach it that way, and both are fixed by the one
+  check. The range itself was already written twice, inline, in
+  `assert_valid`; a named helper is what the two call sites now share
+  instead of a third copy of it.
+
 - **A declared count is bounded by what could hold it, before anything is
   allocated for it** (#569). `var_int.parse`'s `MAX_SIZE` is Core's
   `ReadCompactSize` range check and answers whether a CompactSize is one

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -44,6 +44,22 @@ _TX_MIN_STANDARD_VERSION = 1
 _TX_MAX_STANDARD_VERSION = 3
 
 
+def _assert_valid_4_byte_field(name: str, value: int) -> None:
+    """Refuse an int no four unsigned bytes can hold.
+
+    Called from `serialize` as well as from `assert_valid`, and
+    unconditionally there: `check_validity=False` is what lets
+    `legacy` and `merkle_root_and_mutated_from_transactions` copy or
+    walk a transaction without judging it whole, and the width is the
+    one thing serializing four bytes cannot skip regardless -- the
+    alternative is `int.to_bytes`'s own OverflowError, past the
+    BTClibValueError every caller here is written to catch (issue
+    #690).
+    """
+    if not 0 <= value <= 0xFFFFFFFF:
+        raise BTClibValueError(f"invalid {name}: {value}")
+
+
 def _assert_valid_coinbase(vin: Sequence[TxIn], *, is_coinbase: bool) -> None:
     """Raise an exception if the inputs disagree with the coinbase rule.
 
@@ -284,13 +300,8 @@ class Tx:  # noqa: PLW1641
                 err_msg = f"invalid {key} type: {type(value).__name__}"
                 raise BTClibTypeError(err_msg)
 
-        # must be a 4-bytes integer
-        if not 0 <= self.version <= 0xFFFFFFFF:
-            raise BTClibValueError(f"invalid version: {self.version}")
-
-        # must be a 4-bytes int
-        if not 0 <= self.lock_time <= 0xFFFFFFFF:
-            raise BTClibValueError(f"invalid lock time: {self.lock_time}")
+        _assert_valid_4_byte_field("version", self.version)
+        _assert_valid_4_byte_field("lock time", self.lock_time)
 
         if not unsigned_template and not self.vin:
             raise BTClibValueError("Missing inputs")
@@ -322,6 +333,16 @@ class Tx:  # noqa: PLW1641
         """
         if check_validity:
             self.assert_valid()
+        else:
+            # the width alone, checked here regardless: check_validity=False
+            # is what lets a caller copy or walk a transaction without
+            # judging it whole (`legacy`'s copy, the merkle root's loop),
+            # and int.to_bytes below would otherwise answer a version or
+            # lock_time outside it with an OverflowError, past the
+            # BTClibValueError every caller here is written to catch
+            # (issue #690)
+            _assert_valid_4_byte_field("version", self.version)
+            _assert_valid_4_byte_field("lock time", self.lock_time)
 
         segwit = include_witness and self.is_segwit()
 

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -403,6 +403,24 @@ def test_merkle_root_and_witness_commitment_serialize_without_judging() -> None:
     block.assert_valid_witness_commitment()
 
 
+def test_merkle_root_still_refuses_a_version_no_four_bytes_hold() -> None:
+    """Not judging the transaction is not the same as not judging its width.
+
+    The loop above serializes with check_validity=False on purpose --
+    that is the transaction's own account, `missing_outputs`' empty vout
+    among what it does not judge. A version outside the four bytes the
+    wire writes it in is not on that list: `Tx.serialize` refuses it
+    regardless, and did not before (issue #690), where it answered with
+    the OverflowError `int.to_bytes` raises rather than the
+    BTClibValueError every caller here is written to catch.
+    """
+    coinbase, missing_outputs = _coinbase_and_a_transaction_missing_its_outputs()
+    missing_outputs.version = 2**32
+
+    with pytest.raises(BTClibValueError, match="invalid version: "):
+        merkle_root_and_mutated_from_transactions([coinbase, missing_outputs])
+
+
 def test_block_170() -> None:
     """Test first block with a transaction."""
     fname = "block_170.bin"

--- a/tests/script/sig_hash_legacy_test.py
+++ b/tests/script/sig_hash_legacy_test.py
@@ -344,3 +344,18 @@ def test_hash_type_too_wide_for_its_four_bytes(hash_type: int) -> None:
     tx = _two_in_one_out()
     with pytest.raises(BTClibValueError, match="sig_hash type too wide"):
         sig_hash.legacy(_SCRIPT_CODE, tx, 1, hash_type)
+
+
+def test_a_version_too_wide_for_its_four_bytes_is_refused_too() -> None:
+    """The copy `legacy` hashes over commits to the caller's own version.
+
+    `_legacy_tx_copy` builds it with check_validity=False, so nothing
+    upstream of the final `serialize` asks whether the version it copied
+    fits the four bytes the wire writes it in -- `int.to_bytes` used to
+    answer that with an OverflowError instead of the BTClibValueError
+    every caller here is written to catch (issue #690).
+    """
+    tx = _two_in_one_out()
+    tx.version = 2**32
+    with pytest.raises(BTClibValueError, match="invalid version: "):
+        sig_hash.legacy(_SCRIPT_CODE, tx, 0, sig_hash.ALL)


### PR DESCRIPTION
Closes the last two of #690's eight leaks, the other six already fixed by
PR #701.

## The decision #701 left open

`merkle_root_and_mutated_from_transactions` and `legacy`'s own transaction
copy both serialize with `check_validity=False` on purpose, and neither
wants the object judged for it:
`test_merkle_root_and_witness_commitment_serialize_without_judging` pins
that a block's validity is `Block.assert_valid`'s job, once, outside the
loop; eight tests in `sig_hash_script_code_test.py` hand `legacy` synthetic
transactions -- a coinbase script of invalid size among them -- to
exercise the script code, which a full `assert_valid` would refuse.

Both still leaked an `OverflowError` past the `BTClibValueError` every
caller here is written to catch, because `check_validity=False` skips the
one check a width does need regardless of anything else: whether
`version` or `lock_time` fits the four bytes `int.to_bytes` is about to
write them in.

## The fix

`Tx.serialize` now asks that question on its own account, unconditionally,
rather than only when `check_validity` runs the whole of `assert_valid`.
The range itself was already written twice, inline, in `assert_valid`; it
is a named helper now (`_assert_valid_4_byte_field`), shared by the two
call sites instead of duplicated a third time.

Both remaining leaks reach `Tx.serialize` this way --
`merkle_root_and_mutated_from_transactions` directly, and `legacy` through
`_legacy_tx_copy`'s `new_tx.serialize(..., check_validity=False)` -- so the
one check closes both, and `mining.candidate_block_header` with it, it
delegating to the merkle root function.

## Verified

- `uv run pytest`: **25967 passed, 6 skipped**, exit 0 -- the gated run,
  100% coverage.
- `uv run pre-commit run --all-files`: every hook, exit 0.
- The sphinx build with `-W --keep-going`: `build succeeded`, exit 0.

Closes #690.

## Summary by Sourcery

Ensure transaction serialization always rejects version and lock_time values that exceed 4-byte width, even when full validity checks are skipped.

Bug Fixes:
- Prevent OverflowError escaping from Tx.serialize by validating 4-byte width for version and lock_time regardless of check_validity.
- Fix merkle_root_and_mutated_from_transactions leaking OverflowError when serializing transactions with out-of-range version.
- Fix sig_hash.legacy transaction copy leaking OverflowError for out-of-range version during serialization.

Enhancements:
- Factor 4-byte range validation for transaction version and lock_time into a shared helper used by both assert_valid and serialize.

Documentation:
- Document closure of the last two leaks from issue #690 and the new serialization-time validation behavior in the changelog.

Tests:
- Add tests ensuring merkle_root_and_mutated_from_transactions raises BTClibValueError for versions exceeding 4-byte width.
- Add tests ensuring sig_hash.legacy raises BTClibValueError when the transaction version is too wide for its four-byte field.