### PR TITLE
Freeze BIP32KeyData: an object handed to a public function is valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -736,6 +736,44 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **`BIP32KeyData` is frozen** (#727). It was the last mutable wire-value
+  class in the tree -- `Sig`, `Witness`, `OutPoint`, `TxOut`,
+  `ScriptPubKey`, `BIP32KeyOrigin`, `Network` and every descriptor and
+  miniscript node are already `frozen=True`, the same `object.__setattr__`
+  shape as the rewritten `__init__` here -- and being the exception is
+  what made every fix in the #684 family necessary: a public function
+  could not trust an already-built `BIP32KeyData` because a caller could
+  build one with `check_validity=False` and never ask again, or ask once
+  and then reassign a field afterward. Frozen closes that as a category:
+  the only way to hold one is through `__init__`, which always coerces
+  and optionally checks, so a public function taking one can trust it
+  the way it already trusts a `TxOut` it did not just decode itself.
+
+  `_BIP32KeyData`, the mutable working copy the derivation loop rewrites
+  field by field across up to 255 levels of a path, stops being a
+  subclass -- `dataclasses` refuses a mutable dataclass inheriting from a
+  frozen one -- and becomes a standalone struct with the same six fields
+  plus `prv_key_int`; `_derive` builds one, mutates it in the loop as
+  before, and returns a real `BIP32KeyData` built from its final fields.
+  One allocation for the whole path rather than one per level: measured
+  on a five-level path, 29.5 us against 29.6 before, the two indistinguishable
+  from run to run against a 0.7 us noise floor. `crack_prv_key`, the one
+  production function that mutated a `BIP32KeyData` outside that loop,
+  now builds its answer the same way `_xpub_from_xprv` already did rather
+  than mutating a copy of the parent.
+
+  Every fixture across the suite that built an invalid key by decoding a
+  good one and then reassigning a field -- `tests/bip32/bip32_test.py`'s
+  systematic corruption of each field, `tests/to_key_test.py`'s bad BIP32
+  vectors, and the five fixtures #723 added for the census this issue
+  grew out of -- now either constructs the invalid object directly
+  (`tests/__init__.py`'s new `replace_unchecked`, `dataclasses.replace`
+  with `check_validity` unset not being able to build one on purpose) or,
+  for the handful of type-mismatches no constructor can produce any more
+  -- a string surviving as a string where `bytes_from_octets` would have
+  turned it into bytes -- reaches past the frozen guard with
+  `object.__setattr__`, the same escape `__init__` itself uses.
+
 - **Nothing that reads a signature takes `lower_s` any more** (#695, #645).
   `dsa.assert_as_valid`, `verify`, `recover_pub_keys`, `recover_pub_key`,
   their four trailing-underscore twins, `dsa.anti_exfil_host_verify` and

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -103,6 +103,13 @@ full year, short month, short day (YYYY-M-D)
   the arithmetic behind it having always used secp256k1's generator
   whatever was passed.
 
+- **`BIP32KeyData` is frozen.** `xkey.index = 0` on an already-built
+  extended key, or on one `b58decode`/`parse` returned, now raises
+  `dataclasses.FrozenInstanceError` instead of silently taking effect. A
+  caller that needs a modified copy uses `dataclasses.replace(xkey,
+  index=0)`, which re-validates by default -- the same function
+  `BIP32KeyData(...)` still takes, and still defaulting to `True`.
+
 ### The bindings are now `btclib_secp256k1`
 
 - **The secp256k1 bindings were renamed, and btclib requires the new

--- a/btclib/bip32/bip32.py
+++ b/btclib/bip32/bip32.py
@@ -23,7 +23,6 @@ A BIP32 extended key is 78 bytes:
 
 from __future__ import annotations
 
-import copy
 import hmac
 from dataclasses import dataclass
 
@@ -137,7 +136,7 @@ def _assert_valid_key(version: bytes, key: bytes) -> None:
         raise BTClibValueError(f"unknown extended key version: 0x{version.hex()}")
 
 
-@dataclass
+@dataclass(frozen=True, init=False)
 class BIP32KeyData:
     """A BIP32 extended key, decoded into its six fields.
 
@@ -146,6 +145,14 @@ class BIP32KeyData:
     carrying their 0x00 prefix. The wire form is the 78-byte serialize
     and parse; b58encode and b58decode add the customary Base58Check
     spelling. repr masks the key material of a private one.
+
+    Frozen, so that a public function handed one can trust it rather
+    than revalidate it: `check_validity=False` says "not checked yet",
+    and a mutable field would let that stay true forever, one attribute
+    write after the check that never came (issue 727). `_BIP32KeyData`
+    below is where derivation still needs to mutate one field at a
+    time -- a sibling struct now, and not a subclass, frozen and
+    non-frozen dataclasses refusing to mix in one inheritance chain.
     """
 
     version: bytes
@@ -203,7 +210,7 @@ class BIP32KeyData:
         *,
         check_validity: bool = True,
     ) -> None:
-        self.version = bytes_from_octets(version)
+        object.__setattr__(self, "version", bytes_from_octets(version))
         # a coercion, where the annotation already says int, for the same
         # reason bytes_from_octets is called on the four Octets fields:
         # from_dict feeds this constructor a json object, where a whole
@@ -212,11 +219,13 @@ class BIP32KeyData:
         # called by serialize() and to_dict(), so reading a key would
         # mutate it. A bool is refused rather than coerced: `true` out of
         # json is a schema error, not depth one
-        self.depth = int_from_json_number(depth, "depth")
-        self.parent_fingerprint = bytes_from_octets(parent_fingerprint)
-        self.index = int_from_json_number(index, "index")
-        self.chain_code = bytes_from_octets(chain_code)
-        self.key = bytes_from_octets(key)
+        object.__setattr__(self, "depth", int_from_json_number(depth, "depth"))
+        object.__setattr__(
+            self, "parent_fingerprint", bytes_from_octets(parent_fingerprint)
+        )
+        object.__setattr__(self, "index", int_from_json_number(index, "index"))
+        object.__setattr__(self, "chain_code", bytes_from_octets(chain_code))
+        object.__setattr__(self, "key", bytes_from_octets(key))
 
         if check_validity:
             self.assert_valid()
@@ -391,10 +400,6 @@ def _xpub_from_xprv(xprv: BIP32KeyData) -> BIP32KeyData:
 
     q = int.from_bytes(xprv.key[1:], byteorder="big", signed=False)
 
-    # built rather than copied: `copy.copy` of a `_BIP32KeyData` -- which
-    # is what `_derive` hands back -- would carry that subclass's
-    # `prv_key_int` into an object whose key is public, the one scalar
-    # this function exists to drop
     return BIP32KeyData(
         version=xpubversion_from_xprvversion(xprv.version),
         depth=xprv.depth,
@@ -417,46 +422,47 @@ def xpub_from_xprv(xprv: BIP32Key) -> str:
     return xkey.b58encode()
 
 
-# repr=False: a generated __repr__ would print prv_key_int, the very
-# scalar the inherited masking __repr__ exists to hide
+# repr=False: a generated __repr__ would print key and prv_key_int, the
+# private scalar and the key material BIP32KeyData's own masking repr
+# exists to hide -- this struct has no repr of its own to mask with, so
+# it takes the default's silence instead
 @dataclass(repr=False)
-class _BIP32KeyData(BIP32KeyData):
-    # the one intermediate result multi-level derivation reuses: do not
-    # rely on it elsewhere. The public counterpart a private key needs is
-    # not cached beside it -- __prv_key_path_derivation computes it once,
-    # for the fingerprint, and hands it to the step that would recompute
-    # it; a point cached here would instead be built for every key,
-    # including the public ones that never look at it
+class _BIP32KeyData:
+    """The mutable working copy the derivation loop rewrites in place.
 
+    Not a `BIP32KeyData`, and deliberately: that class is frozen so a
+    public function can trust one it is handed (issue 727), and
+    `dataclasses` refuses a mutable dataclass inheriting from a frozen
+    one. `__prv_key_derivation`, `__pub_key_derivation` and the two
+    path-walkers below mutate `chain_code`, `key`, `prv_key_int` and
+    `parent_fingerprint` field by field across up to 255 levels of a
+    path, for the measured performance reasons their own comments give;
+    `_derive` builds one, mutates it, and hands a real `BIP32KeyData`
+    back built from its final fields -- one allocation for the whole
+    path, not one per level. Never validates and never coerces: every
+    field always comes from a `BIP32KeyData` already valid or from this
+    same loop, so there is nothing here for `check_validity` to gate.
+
+    `prv_key_int` is the one intermediate result multi-level derivation
+    reuses: do not rely on it elsewhere. The public counterpart a
+    private key needs is not cached beside it -- `__prv_key_path_derivation`
+    computes it once, for the fingerprint, and hands it to the step that
+    would recompute it; a point cached here would instead be built for
+    every key, including the public ones that never look at it.
+    """
+
+    version: bytes
+    depth: int
+    parent_fingerprint: bytes
+    index: int
+    chain_code: bytes
+    key: bytes
     prv_key_int: int  # non-zero for private key only
 
-    def __init__(
-        self,
-        version: Octets,
-        depth: int,
-        parent_fingerprint: Octets,
-        index: int,
-        chain_code: Octets,
-        key: Octets,
-        *,
-        check_validity: bool = True,
-    ) -> None:
-        super().__init__(
-            version,
-            depth,
-            parent_fingerprint,
-            index,
-            chain_code,
-            key,
-            check_validity=False,
-        )
-
-        self.prv_key_int = (
-            int.from_bytes(self.key[1:], "big", signed=False) if self.is_private else 0
-        )
-
-        if check_validity:
-            self.assert_valid()
+    @property
+    def is_private(self) -> bool:
+        """Answer whether the key is private, by its 0x00 prefix."""
+        return self.key[0] == 0
 
 
 def _invalid_child(index: int, reason: str) -> BTClibValueError:
@@ -672,32 +678,45 @@ def _derive(
         err_msg = f"final depth greater than 255: {final_depth}"
         raise BTClibValueError(err_msg)
 
-    # `check_validity=False`: the six fields come from a key the caller
-    # has validated, and the one that changes here -- the depth -- is
-    # bounded on the line above. Validating again would also ask the
-    # depth-zero rule about `final_depth`, where it means nothing
-    xkey = _BIP32KeyData(
+    # the mutable working copy the loop below rewrites field by field:
+    # the six fields come from a key the caller has validated, and the
+    # one that changes here -- the depth -- is bounded on the line above
+    working = _BIP32KeyData(
         version=xkey.version,
         depth=final_depth,
         parent_fingerprint=xkey.parent_fingerprint,
         index=xkey.index,
         chain_code=xkey.chain_code,
         key=xkey.key,
-        check_validity=False,
+        prv_key_int=(
+            int.from_bytes(xkey.key[1:], "big", signed=False) if xkey.is_private else 0
+        ),
     )
 
     if forced_version:
-        xkey.version = _force_version(xkey.version, forced_version)
+        working.version = _force_version(working.version, forced_version)
 
     if indexes:
-        if xkey.is_private:
-            __prv_key_path_derivation(xkey, indexes)
+        if working.is_private:
+            __prv_key_path_derivation(working, indexes)
         else:
-            __pub_key_path_derivation(xkey, indexes)
+            __pub_key_path_derivation(working, indexes)
 
-        xkey.index = indexes[-1]
+        working.index = indexes[-1]
 
-    return xkey
+    # `check_validity=False`: validating here would also ask the
+    # depth-zero rule about the depth this just walked to, where it no
+    # longer means anything; the one validation the wrapper is entitled
+    # to is its own, on what this hands back
+    return BIP32KeyData(
+        version=working.version,
+        depth=working.depth,
+        parent_fingerprint=working.parent_fingerprint,
+        index=working.index,
+        chain_code=working.chain_code,
+        key=working.key,
+        check_validity=False,
+    )
 
 
 def derive(
@@ -782,10 +801,9 @@ def crack_prv_key(parent_xpub: BIP32Key, child_xprv: BIP32Key) -> str:
     # both arguments through the one place a BIP32Key becomes a validated
     # BIP32KeyData: this function exists to demonstrate a known BIP32
     # weakness, so an answer it gives for a child its own assert_valid
-    # refuses is a wrong lesson. Copied because the parent is mutated
-    # below into the answer, and the caller's object is not this
-    # function's to write to
-    p = copy.copy(_key_data_from_bip32_key(parent_xpub))
+    # refuses is a wrong lesson. Frozen, so aliased rather than copied --
+    # there is nothing in it for a copy to protect any more
+    p = _key_data_from_bip32_key(parent_xpub)
 
     if p.key[0] not in {2, 3}:
         raise BTClibValueError(_err_msg("parent", "not a public", p))
@@ -804,8 +822,6 @@ def crack_prv_key(parent_xpub: BIP32Key, child_xprv: BIP32Key) -> str:
     if c.is_hardened:
         raise BTClibValueError("hardened child derivation")
 
-    p.version = c.version
-
     hmac_ = hmac.new(
         p.chain_code,
         p.key + c.index.to_bytes(4, byteorder="big", signed=False),
@@ -814,9 +830,17 @@ def crack_prv_key(parent_xpub: BIP32Key, child_xprv: BIP32Key) -> str:
     child_q = int.from_bytes(c.key[1:], byteorder="big", signed=False)
     offset = int.from_bytes(hmac_[:32], byteorder="big", signed=False)
     parent_q = (child_q - offset) % secp256k1.n
-    p.key = b"\x00" + parent_q.to_bytes(32, byteorder="big", signed=False)
 
-    return p.b58encode()
+    parent = BIP32KeyData(
+        version=c.version,
+        depth=p.depth,
+        parent_fingerprint=p.parent_fingerprint,
+        index=p.index,
+        chain_code=p.chain_code,
+        key=b"\x00" + parent_q.to_bytes(32, byteorder="big", signed=False),
+        check_validity=False,
+    )
+    return parent.b58encode()
 
 
 def _err_msg(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -31,6 +31,7 @@ beside the helpers of `tests/script/__init__.py` and
 import csv
 import json
 import re
+from dataclasses import fields
 from pathlib import Path
 from typing import Any
 
@@ -92,3 +93,19 @@ def vector_id(index: int, *description: object) -> str:
     text = "-".join(str(d) for d in description if d)
     text = _NOT_IN_AN_ID.sub("-", text).strip("-")
     return f"{index}-{text[:60]}" if text else str(index)
+
+
+def replace_unchecked(instance: Any, **changes: Any) -> Any:
+    """Return `instance` with the given fields changed, validation skipped.
+
+    `dataclasses.replace` always re-validates through `__init__` -- right
+    for a modified copy meant to stay valid, wrong for a fixture built to
+    fail its own `assert_valid` on purpose. Every frozen, validating
+    dataclass in this project takes `check_validity` the same
+    keyword-only way (`CONTRIBUTING.md`'s "The public surface"), so this
+    is the one helper any of them can use in place of the direct field
+    mutation a frozen instance now refuses.
+    """
+    current = {field.name: getattr(instance, field.name) for field in fields(instance)}
+    current.update(changes)
+    return type(instance)(**current, check_validity=False)

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -6,7 +6,7 @@
 
 import hmac
 import re
-from dataclasses import fields
+from dataclasses import FrozenInstanceError, fields, replace
 from typing import Any
 
 import pytest
@@ -39,7 +39,7 @@ from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import NETWORKS
 from btclib.to_pub_key import pub_keyinfo_from_key
-from tests import load, vector_id
+from tests import load, replace_unchecked, vector_id
 
 
 def test_exceptions() -> None:
@@ -72,90 +72,127 @@ def test_exceptions() -> None:
     assert rootxprv_from_seed("00" * 64)
 
 
+def test_bip32keydata_is_still_a_dataclass() -> None:
+    """Frozen trades the hand-written __init__ for object.__setattr__.
+
+    The same shape `test_dsa_sig_is_still_a_dataclass` checks for the
+    three `Sig` classes (issue 727): what `dataclasses` generates around
+    a written-out `__init__` is what is left to check once the
+    generated one is gone, and it must not go missing too.
+    """
+    xkey = "xprv9s21ZrQH143K2ZP8tyNiUtgoezZosUkw9hhir2JFzDhcUWKz8qFYk3cxdgSFoCMzt8E2Ubi1nXw71TLhwgCfzqFHfM5Snv4zboSebePRmLS"
+    xkey_data = BIP32KeyData.b58decode(xkey)
+
+    assert [f.name for f in fields(xkey_data)] == [
+        "version",
+        "depth",
+        "parent_fingerprint",
+        "index",
+        "chain_code",
+        "key",
+    ]
+    assert xkey_data == BIP32KeyData.b58decode(xkey)
+    assert hash(xkey_data) == hash(BIP32KeyData.b58decode(xkey))
+    assert replace(xkey_data, index=xkey_data.index) == xkey_data
+    assert "check_validity" not in repr(xkey_data)
+
+    # frozen: the hand-written __init__ assigns through
+    # object.__setattr__, which must not leave the class writable
+    with pytest.raises(FrozenInstanceError):
+        xkey_data.index = 1  # type: ignore[misc]
+
+
 def test_assert_valid2() -> None:
-    """Corrupt each BIP32KeyData field and check the error it raises."""
+    """Corrupt each BIP32KeyData field and check the error it raises.
+
+    Frozen, so `object.__setattr__` and not a plain attribute write: a
+    fixture built to fail `assert_valid` on purpose is the one reason to
+    reach past the guard `__init__` puts there for everyone else.
+    """
     xkey = "xprv9s21ZrQH143K2ZP8tyNiUtgoezZosUkw9hhir2JFzDhcUWKz8qFYk3cxdgSFoCMzt8E2Ubi1nXw71TLhwgCfzqFHfM5Snv4zboSebePRmLS"
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.version = (xkey_data.version)[:-1]
+    object.__setattr__(xkey_data, "version", xkey_data.version[:-1])
     with pytest.raises(BTClibValueError, match="invalid version length: "):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.version = "1234"  # type: ignore[assignment]
+    object.__setattr__(xkey_data, "version", "1234")
     with pytest.raises(TypeError):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.depth = -1
+    object.__setattr__(xkey_data, "depth", -1)
     with pytest.raises(BTClibValueError, match="invalid depth: "):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.depth = 256
+    object.__setattr__(xkey_data, "depth", 256)
     with pytest.raises(BTClibValueError, match="invalid depth: "):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.depth = ()  # type: ignore[assignment]
+    object.__setattr__(xkey_data, "depth", ())
     with pytest.raises(TypeError):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.parent_fingerprint = (xkey_data.parent_fingerprint)[:-1]
+    object.__setattr__(
+        xkey_data, "parent_fingerprint", xkey_data.parent_fingerprint[:-1]
+    )
     with pytest.raises(BTClibValueError, match="invalid parent_fingerprint length: "):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.parent_fingerprint = "1234"  # type: ignore[assignment]
+    object.__setattr__(xkey_data, "parent_fingerprint", "1234")
     with pytest.raises(TypeError):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.index = -1
+    object.__setattr__(xkey_data, "index", -1)
     with pytest.raises(BTClibValueError, match="invalid index: "):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.index = 0xFFFFFFFF + 1
+    object.__setattr__(xkey_data, "index", 0xFFFFFFFF + 1)
     with pytest.raises(BTClibValueError, match="invalid index: "):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.index = ()  # type: ignore[assignment]
+    object.__setattr__(xkey_data, "index", ())
     with pytest.raises(TypeError):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.chain_code = (xkey_data.chain_code)[:-1]
+    object.__setattr__(xkey_data, "chain_code", xkey_data.chain_code[:-1])
     with pytest.raises(BTClibValueError, match="invalid chain_code length: "):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.chain_code = "length is 32 but not a chaincode"  # type: ignore[assignment]
+    object.__setattr__(xkey_data, "chain_code", "length is 32 but not a chaincode")
     assert len(xkey_data.chain_code) == 32
     with pytest.raises(TypeError):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.key = (xkey_data.key)[:-1]
+    object.__setattr__(xkey_data, "key", xkey_data.key[:-1])
     with pytest.raises(BTClibValueError, match="invalid key length: "):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.key = "length is 33, but not a key      "  # type: ignore[assignment]
+    object.__setattr__(xkey_data, "key", "length is 33, but not a key      ")
     assert len(xkey_data.key) == 33
     with pytest.raises(TypeError):
         xkey_data.assert_valid()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.parent_fingerprint = bytes.fromhex("deadbeef")
+    object.__setattr__(xkey_data, "parent_fingerprint", bytes.fromhex("deadbeef"))
     err_msg = "zero depth with non-zero parent fingerprint: "
     with pytest.raises(BTClibValueError, match=err_msg):
         xkey_data.b58encode()
 
     xkey_data = BIP32KeyData.b58decode(xkey)
-    xkey_data.index = 1
+    object.__setattr__(xkey_data, "index", 1)
     with pytest.raises(BTClibValueError, match="zero depth with non-zero index: "):
         xkey_data.b58encode()
 
@@ -401,12 +438,9 @@ def test_derive_exceptions() -> None:
     # root key, zero depth
     rootmxprv = "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi"
     xprv = BIP32KeyData.b58decode(rootmxprv)
-    # not `xprv == _derive(xprv, "m")`: `_derive` returns the private
-    # `_BIP32KeyData`, whose two caching fields the class tells the reader
-    # not to rely on, and a dataclass __eq__ answers False across classes
-    # however equal the six fields are. What that would mean to assert --
-    # the empty path derives the key itself -- is the line below, in the
-    # encoding that compares all six
+    # the empty path derives the key itself, both as the object _derive
+    # hands back and as the string derive encodes it to
+    assert xprv == _derive(xprv, "m", None)
     assert rootmxprv == derive(xprv, "m")
     assert rootmxprv == derive(xprv, "")
 
@@ -584,8 +618,9 @@ def test_pub_key_derivation() -> None:
     parent_fingerprint = hash160(parent_key)[:4]
     assert BIP32KeyData.b58decode(proper_child).parent_fingerprint == parent_fingerprint
 
-    orphan_child_key = BIP32KeyData.b58decode(proper_child)
-    orphan_child_key.parent_fingerprint = b"\x00" * 4
+    orphan_child_key = replace_unchecked(
+        BIP32KeyData.b58decode(proper_child), parent_fingerprint=b"\x00" * 4
+    )
     orphan_child = "xpub6DXuQW1FgeHbhsSchbuDWE9Bj8mPiPUpiroAmAvRdRqYbGHXHTyEkttkxSvtCac64QzpasL1Tvd5Znvn5GQMswQUrpRBsPRz7npvyZ8ExWi"
     assert orphan_child_key.b58encode() == orphan_child
 
@@ -748,7 +783,7 @@ def test_assert_valid_does_not_rewrite_the_key_data() -> None:
     # function for unreachable and checks none of it -- warn_unreachable
     # being off, in silence. Measured: with the assertion written directly
     # on the attribute, a reveal_type below it prints nothing at all
-    xkey_data.chain_code = bytearray(xkey_data.chain_code)  # type: ignore[assignment]
+    xkey_data = replace_unchecked(xkey_data, chain_code=bytearray(xkey_data.chain_code))
     chain_code: object = xkey_data.chain_code
     assert isinstance(chain_code, bytearray)
 
@@ -760,7 +795,7 @@ def test_assert_valid_does_not_rewrite_the_key_data() -> None:
 def test_assert_valid_does_not_rewrite_on_a_read() -> None:
     """Keep b58encode and serialize from coercing fields in place."""
     xkey_data = BIP32KeyData.b58decode(XKEY)
-    xkey_data.chain_code = bytearray(xkey_data.chain_code)  # type: ignore[assignment]
+    xkey_data = replace_unchecked(xkey_data, chain_code=bytearray(xkey_data.chain_code))
 
     xkey_data.b58encode()
     after_b58encode: object = xkey_data.chain_code
@@ -778,14 +813,14 @@ def test_assert_valid_reports_a_float_field_instead_of_coercing_it() -> None:
     to_bytes and leave the library through an AttributeError.
     """
     xkey_data = BIP32KeyData.b58decode(XKEY)
-    xkey_data.index = float(xkey_data.index)  # type: ignore[assignment]
+    object.__setattr__(xkey_data, "index", float(xkey_data.index))
     with pytest.raises(BTClibTypeError, match="invalid index type: float"):
         xkey_data.assert_valid()
     index: object = xkey_data.index
     assert isinstance(index, float)
 
     xkey_data = BIP32KeyData.b58decode(XKEY)
-    xkey_data.depth = float(xkey_data.depth)  # type: ignore[assignment]
+    object.__setattr__(xkey_data, "depth", float(xkey_data.depth))
     with pytest.raises(BTClibTypeError, match="invalid depth type: float"):
         xkey_data.assert_valid()
 
@@ -939,8 +974,10 @@ def test_assert_valid_key_refuses_a_scalar_above_n_too() -> None:
     `q != n` alone would already refuse either one; only a scalar
     strictly above n tells `q < n` apart from it.
     """
-    xkey_data = BIP32KeyData.b58decode(XKEY)
-    xkey_data.key = b"\x00" + (ec.n + 1).to_bytes(32, byteorder="big", signed=False)
+    xkey_data = replace_unchecked(
+        BIP32KeyData.b58decode(XKEY),
+        key=b"\x00" + (ec.n + 1).to_bytes(32, byteorder="big", signed=False),
+    )
     with pytest.raises(BTClibValueError, match="invalid private key not in 1..n-1"):
         xkey_data.assert_valid()
 
@@ -955,15 +992,17 @@ def test_invalid_key_prefix_messages_show_exactly_one_byte() -> None:
     """
     root = BIP32KeyData.b58decode(XKEY)
 
-    bad_prv = BIP32KeyData.b58decode(XKEY)
-    bad_prv.key = b"\x05" + root.key[1:]
+    bad_prv = replace_unchecked(
+        BIP32KeyData.b58decode(XKEY), key=b"\x05" + root.key[1:]
+    )
     with pytest.raises(BTClibValueError) as excinfo:
         bad_prv.assert_valid()
     assert str(excinfo.value) == "invalid private key prefix: 0x05"
 
     xpub = BIP32KeyData.b58decode(xpub_from_xprv(XKEY))
-    bad_pub = BIP32KeyData.b58decode(xpub_from_xprv(XKEY))
-    bad_pub.key = b"\x05" + xpub.key[1:]
+    bad_pub = replace_unchecked(
+        BIP32KeyData.b58decode(xpub_from_xprv(XKEY)), key=b"\x05" + xpub.key[1:]
+    )
     with pytest.raises(BTClibValueError) as excinfo:
         bad_pub.assert_valid()
     assert str(excinfo.value) == "invalid public key prefix not in (0x02, 0x03): 0x05"
@@ -1074,37 +1113,6 @@ def test_check_validity_defaults_to_true() -> None:
     assert BIP32KeyData.parse(as_bytes, check_validity=False) == invalid
 
 
-def test_bip32keydata_init_check_validity_guard_is_not_negated() -> None:
-    """`_BIP32KeyData`'s own check_validity guard, not just its parent's.
-
-    `_derive` always builds one from an already-valid key, so nothing
-    through the public API ever constructs an invalid `_BIP32KeyData`;
-    the private class itself has to be called directly to reach `if
-    check_validity` negated to `if not check_validity`, which would
-    validate exactly backwards.
-    """
-    root = BIP32KeyData.b58decode(XKEY)
-    with pytest.raises(BTClibValueError, match="invalid depth: "):
-        _BIP32KeyData(
-            version=root.version,
-            depth=256,
-            parent_fingerprint=root.parent_fingerprint,
-            index=root.index,
-            chain_code=root.chain_code,
-            key=root.key,
-        )
-    unchecked = _BIP32KeyData(
-        version=root.version,
-        depth=256,
-        parent_fingerprint=root.parent_fingerprint,
-        index=root.index,
-        chain_code=root.chain_code,
-        key=root.key,
-        check_validity=False,
-    )
-    assert unchecked.depth == 256
-
-
 def test_the_tweaks_of_a_public_derivation_are_the_derivation() -> None:
     """The scalars a path adds up to, against the key the path derives.
 
@@ -1207,16 +1215,18 @@ def test_cracking_refuses_a_child_its_own_assert_valid_refuses() -> None:
     This function exists to demonstrate a known BIP32 weakness, so an
     answer it gives for a child the library itself refuses is a wrong
     lesson: it subtracted the offset from a key set to the zero scalar and
-    returned an xprv. The parent is affected too, going through
-    `copy.copy` with only its `key[0]` prefix looked at.
+    returned an xprv. The parent is affected too, its `key[0]` prefix
+    the only field looked at before the answer is built.
     """
     root = rootxprv_from_seed("0102030405060708090a0b0c0d0e0f10")
     parent_xpub = xpub_from_xprv(root)
     child_xprv = derive(root, "m/0")
     assert crack_prv_key(parent_xpub, child_xprv) == root
 
-    bad_child = BIP32KeyData.b58decode(child_xprv)
-    bad_child.key = b"\x00" * 33  # the zero scalar
+    bad_child = replace_unchecked(
+        BIP32KeyData.b58decode(child_xprv),
+        key=b"\x00" * 33,  # the zero scalar
+    )
     err_msg = "invalid private key not in 1..n-1"
     with pytest.raises(BTClibValueError, match=err_msg):
         bad_child.assert_valid()

--- a/tests/descriptors/descriptors_test.py
+++ b/tests/descriptors/descriptors_test.py
@@ -88,7 +88,7 @@ from btclib.script.witness import Witness
 from btclib.to_prv_key import prv_keyinfo_from_prv_key
 from btclib.to_pub_key import fingerprint, pub_keyinfo_from_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
-from tests import load, vector_id
+from tests import load, replace_unchecked, vector_id
 
 DOC_DESCRIPTORS = [
     descriptor_data["desc"]
@@ -2955,8 +2955,7 @@ def test_account_descriptors_validates_an_already_built_key_too() -> None:
     receive, _ = account_descriptors(good, "m/84h/0h/0h")
     assert str(receive) == str(account_descriptors(XPRV_ROOT, "m/84h/0h/0h")[0])
 
-    bad = BIP32KeyData.b58decode(XPRV_ROOT)
-    bad.index = -1
+    bad = replace_unchecked(BIP32KeyData.b58decode(XPRV_ROOT), index=-1)
     err_msg = "invalid index: -1"
     with pytest.raises(BTClibValueError, match=err_msg):
         bad.assert_valid()

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -23,7 +23,7 @@ from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueEr
 from btclib.hashes import reduce_to_hlen
 from btclib.number_theory import mod_inv
 from btclib.utils import int_from_bits
-from tests import load_csv, vector_id
+from tests import load_csv, replace_unchecked, vector_id
 from tests.curves.curve_test import low_card_curves, no_bindings, secp256k1_bis
 
 
@@ -287,7 +287,7 @@ def test_point_from_bip340pub_key() -> None:
     xpub_data = BIP32KeyData.b58decode(
         "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
     )
-    xpub_data.key = bytes_from_point(Q)
+    xpub_data = replace_unchecked(xpub_data, key=bytes_from_point(Q))
     # BIP32KeyData
     assert ssa.point_from_bip340pub_key(xpub_data) == Q
     # BIP32Key encoded str

--- a/tests/slip132_test.py
+++ b/tests/slip132_test.py
@@ -13,6 +13,7 @@ from btclib.bip32 import bip32
 from btclib.exceptions import BTClibValueError
 from btclib.mnemonic import bip39
 from btclib.network import NETWORKS
+from tests import replace_unchecked
 
 
 def test_slip132() -> None:
@@ -87,8 +88,7 @@ def test_an_already_built_key_is_validated_too() -> None:
     good = bip32.BIP32KeyData.b58decode(xpub)
     assert slip132.address_from_xpub(good) == slip132.address_from_xpub(xpub)
 
-    bad = bip32.BIP32KeyData.b58decode(xpub)
-    bad.index = -1
+    bad = replace_unchecked(bip32.BIP32KeyData.b58decode(xpub), index=-1)
     err_msg = "invalid index: -1"
     with pytest.raises(BTClibValueError, match=err_msg):
         bad.assert_valid()
@@ -277,6 +277,8 @@ def test_unknown_xpub_version() -> None:
     xpub = bip32.xpub_from_xprv(slip132.p2pkh_xkey(mxprv))
     xpub_data = bip32.BIP32KeyData.b58decode(xpub)
     for version in ("slip132_p2wsh_pub", "slip132_p2wsh_p2sh_pub"):
-        xpub_data.version = getattr(NETWORKS["mainnet"], version)
+        reversioned = replace_unchecked(
+            xpub_data, version=getattr(NETWORKS["mainnet"], version)
+        )
         with pytest.raises(BTClibValueError, match="unknown xpub version: "):
-            slip132.address_from_xpub(xpub_data)
+            slip132.address_from_xpub(reversioned)

--- a/tests/to_key_test.py
+++ b/tests/to_key_test.py
@@ -10,12 +10,11 @@ Test vectors do include str only: no int, point tuble, or BIP32KeyData.
 
 from __future__ import annotations
 
-import copy
-
 from btclib.alias import INF
 from btclib.base58 import encode as b58encode
 from btclib.bip32 import BIP32KeyData
 from btclib.curves import mult, secp256k1
+from tests import replace_unchecked
 
 ec = secp256k1
 
@@ -133,50 +132,43 @@ net_unaware_pub_keys = (
 # all bad BIP32 keys
 bad_bip32_keys: list[bytes | str] = []
 # version / key mismatch
-xprv_data_bad = copy.copy(xprv_data)
-xpub_data_bad = copy.copy(xpub_data)
-xprv_data_bad.version = bytes.fromhex("04 88 b2 1e")
-xpub_data_bad.version = bytes.fromhex("04 88 ad e4")
+xprv_data_bad = replace_unchecked(xprv_data, version=bytes.fromhex("04 88 b2 1e"))
+xpub_data_bad = replace_unchecked(xpub_data, version=bytes.fromhex("04 88 ad e4"))
 bad_bip32_keys += [
     xprv_data_bad.b58encode(check_validity=False),
     xpub_data_bad.b58encode(check_validity=False),
 ]
 # key starts with 04
-xprv_data_bad.key = b"\x04" + xprv_data_bad.key[1:]
-xpub_data_bad.key = b"\x04" + xprv_data_bad.key[1:]
+xprv_data_bad = replace_unchecked(xprv_data_bad, key=b"\x04" + xprv_data_bad.key[1:])
+xpub_data_bad = replace_unchecked(xpub_data_bad, key=b"\x04" + xprv_data_bad.key[1:])
 bad_bip32_keys += [
     xprv_data_bad.b58encode(check_validity=False),
     xpub_data_bad.b58encode(check_validity=False),
 ]
 # key starts with 01
-xprv_data_bad.key = b"\x01" + xprv_data_bad.key[1:]
-xpub_data_bad.key = b"\x01" + xprv_data_bad.key[1:]
+xprv_data_bad = replace_unchecked(xprv_data_bad, key=b"\x01" + xprv_data_bad.key[1:])
+xpub_data_bad = replace_unchecked(xpub_data_bad, key=b"\x01" + xprv_data_bad.key[1:])
 bad_bip32_keys += [
     xprv_data_bad.b58encode(check_validity=False),
     xpub_data_bad.b58encode(check_validity=False),
 ]
 # depth_pfp_index mismatch
-xprv_data_bad = copy.copy(xprv_data)
-xpub_data_bad = copy.copy(xpub_data)
-xprv_data_bad.parent_fingerprint = b"\x01\x01\x01\x01"
-xpub_data_bad.parent_fingerprint = b"\x01\x01\x01\x01"
+xprv_data_bad = replace_unchecked(xprv_data, parent_fingerprint=b"\x01\x01\x01\x01")
+xpub_data_bad = replace_unchecked(xpub_data, parent_fingerprint=b"\x01\x01\x01\x01")
 bad_bip32_keys += [
     xprv_data_bad.b58encode(check_validity=False),
     xpub_data_bad.b58encode(check_validity=False),
 ]
 # depth_pfp_index mismatch
-xprv_data_bad = copy.copy(xprv_data)
-xpub_data_bad = copy.copy(xpub_data)
-xprv_data_bad.index = xpub_data_bad.index = 101
+xprv_data_bad = replace_unchecked(xprv_data, index=101)
+xpub_data_bad = replace_unchecked(xpub_data, index=101)
 bad_bip32_keys += [
     xprv_data_bad.b58encode(check_validity=False),
     xpub_data_bad.b58encode(check_validity=False),
 ]
 # unknown version
-xprv_data_bad = copy.copy(xprv_data)
-xpub_data_bad = copy.copy(xpub_data)
-xprv_data_bad.version = b"\x01\x01\x01\x01"
-xpub_data_bad.version = b"\x01\x01\x01\x01"
+xprv_data_bad = replace_unchecked(xprv_data, version=b"\x01\x01\x01\x01")
+xpub_data_bad = replace_unchecked(xpub_data, version=b"\x01\x01\x01\x01")
 bad_bip32_keys += [
     xprv_data_bad.b58encode(check_validity=False),
     xpub_data_bad.b58encode(check_validity=False),

--- a/tests/wallet/key_wallet_test.py
+++ b/tests/wallet/key_wallet_test.py
@@ -14,6 +14,7 @@ from btclib.bip32 import bip32
 from btclib.ecc import bms
 from btclib.exceptions import BTClibValueError
 from btclib.wallet import AddressInfo, BIP32KeyWallet, KeyWallet
+from tests import replace_unchecked
 
 # the "abandon abandon ... about" seed, whose master key BIP84 and BIP86
 # both publish as their rootpriv and whose addresses SLIP132, BIP49,
@@ -166,8 +167,7 @@ def test_a_bip32keydata_is_validated_even_when_already_one() -> None:
     unlike the four `to_prv_key`/`to_pub_key`/`bip32` functions the same
     census names as compliant.
     """
-    bad = bip32.BIP32KeyData.b58decode(_ACCOUNT_44_XPUB)
-    bad.index = -1
+    bad = replace_unchecked(bip32.BIP32KeyData.b58decode(_ACCOUNT_44_XPUB), index=-1)
     err_msg = "invalid index: -1"
     with pytest.raises(BTClibValueError, match=err_msg):
         bad.assert_valid()

--- a/tests/wallet/script_wallet_test.py
+++ b/tests/wallet/script_wallet_test.py
@@ -48,6 +48,7 @@ from btclib.tx.tx_in import TxIn
 from btclib.tx.tx_out import TxOut
 from btclib.wallet import DescriptorWallet, KeyGroup, ScriptWallet
 from btclib.wallet import script_wallet as script_wallet_module
+from tests import replace_unchecked
 
 # the "abandon abandon ... about" seed, and three account keys of it in an
 # order that none of the sorts below answers: the account keys sort one
@@ -330,8 +331,7 @@ def test_a_decoded_key_is_validated_too() -> None:
     which validates by default, but trusted an already-built
     `BIP32KeyData` in `keys` unasked.
     """
-    bad = BIP32KeyData.b58decode(_XPUBS[0])
-    bad.index = -1
+    bad = replace_unchecked(BIP32KeyData.b58decode(_XPUBS[0]), index=-1)
     err_msg = "invalid index: -1"
     with pytest.raises(BTClibValueError, match=err_msg):
         bad.assert_valid()


### PR DESCRIPTION
The rule #684 decided, and #723 spent five call sites on:

> Every public function must always validate its inputs...

works site by site, patching one function at a time to stop trusting an
object it had not checked. That leaves the gap open for the next one:
`BIP32KeyData` is a plain mutable dataclass, so `check_validity=False`
can build an instance nothing ever checks, and even a checked one can
be mutated afterward into something its own `assert_valid` would
refuse. #727 asked whether the class itself could close this instead
of every call site separately.

## `BIP32KeyData` is the odd one out, not a new pattern

Every other wire-decoded value type in the tree is already
`@dataclass(frozen=True[, init=False])`: `Sig` (`ecc.dsa`/`ssa`/`bms`/`ecies`),
`Witness`, `OutPoint`, `TxOut`, `ScriptPubKey`, `BIP32KeyOrigin`,
`Network`, every descriptor and miniscript node. `BIP32KeyData` and its
subclass `_BIP32KeyData` were the only two mutable ones left. `Sig`'s
shape is the one this copies: `object.__setattr__` per field in a
hand-written `__init__`, `check_validity` gating `assert_valid()` and
nothing else.

Frozen, a public function taking one can trust it structurally: there
is no way to hold a `BIP32KeyData` that was never checked at least
once, and no way to invalidate one afterward with a plain attribute
write.

## The one real mutator: the derivation loop

`__prv_key_derivation`, `__pub_key_derivation` and the two path-walkers
mutate `chain_code`, `key`, `prv_key_int` and `parent_fingerprint`
field by field across up to 255 levels of a path, for the measured
performance reasons their own comments give. That is `_BIP32KeyData`
today — but it *subclassed* `BIP32KeyData`, and `dataclasses` refuses a
non-frozen dataclass inheriting from a frozen one. `_BIP32KeyData`
stops being a subclass and becomes an independent mutable struct with
the same six fields plus `prv_key_int`; `_derive` builds one, mutates
it exactly as before, and returns a real `BIP32KeyData` built from its
final fields — one allocation for the whole path, not one per level.

Checked every external call site of `_derive`/`_derive_from_account`
(`bip44.address_from_der_path`, `descriptors._account_xpub`,
`descriptors._normalized_key`): each consumes the result immediately
as a `Key`-shaped object and none reads `.prv_key_int` or mutates
further, so severing the inheritance costs nothing at those
boundaries.

`crack_prv_key`, the one production function that mutated a
`BIP32KeyData` outside that loop, now builds its answer the way
`_xpub_from_xprv` already did rather than mutating a copy of the
parent — and drops the `copy.copy` there was nothing left to protect.

## Tests

Every fixture across the suite that built an invalid key by decoding a
good one and then reassigning a field now either:

- constructs the invalid object directly, via `tests/__init__.py`'s new
  `replace_unchecked` (`dataclasses.replace` can't turn `check_validity`
  off, which is correct — a caller wanting a *valid* modified copy is
  exactly who should get re-validated), or
- for the handful of type-mismatches no constructor can produce any
  more (a string surviving as a string where `bytes_from_octets` would
  turn it into bytes; a tuple where `int_from_json_number` would raise
  first), reaches past the frozen guard with `object.__setattr__`, the
  same escape `__init__` itself uses.

`test_bip32keydata_is_still_a_dataclass` mirrors
`test_dsa_sig_is_still_a_dataclass`: fields, equality, hash,
`dataclasses.replace`, no `check_validity` in `repr`, and the
`FrozenInstanceError` a plain attribute write now raises.

## Verified

- `uv run pytest`: **25971 passed, 6 skipped**, exit 0 — the gated run,
  `--cov` being in addopts, so the 100% ratchet passed with it.
- `uv run pre-commit run --all-files`: every hook, `mypy` strict
  included. Exit code checked, not filtered output.
- The sphinx build with `-W --keep-going`: `build succeeded`, exit 0.
- A/B benchmark of `_derive` against the `origin/main` implementation
  (loaded side by side in one process), three independent runs,
  alternating with a `hash160` control as the noise floor: the delta
  was within noise every time (+1.7%, +0.1%, −0.7%), never separating
  from the ~0.7 us control against a ~30 us baseline.

## Breaking change

`xkey.field = value` on an already-built `BIP32KeyData` now raises
`dataclasses.FrozenInstanceError` instead of silently taking effect.
`HISTORY.md` has the entry; `dataclasses.replace(xkey, field=value)` is
the replacement, re-validating by default as `BIP32KeyData(...)` itself
does.

Closes #727

## Summary by Sourcery

Freeze BIP32KeyData to ensure extended key objects handed to public APIs are structurally trusted and cannot be mutated after validation.

Enhancements:
- Introduce a frozen BIP32KeyData dataclass with a hand-written __init__ using object.__setattr__ for field coercion and validation gating.
- Replace the _BIP32KeyData subclass with an independent mutable working struct used only inside the derivation loop, returning a validated BIP32KeyData at the boundary.
- Refactor crack_prv_key to build a new BIP32KeyData for the recovered parent key instead of mutating a copied instance.
- Add tests asserting BIP32KeyData remains a dataclass with the expected semantics, including FrozenInstanceError on field assignment.
- Introduce a replace_unchecked helper to construct intentionally invalid frozen dataclass instances for tests without revalidation.

Documentation:
- Document the freezing of BIP32KeyData and its behavioural change in CHANGELOG.md and HISTORY.md, including the new pattern of using dataclasses.replace or replace_unchecked.

Tests:
- Update existing BIP32-related, SLIP132, descriptor, ECC, and wallet tests to work with frozen BIP32KeyData by using replace_unchecked or object.__setattr__ instead of direct field mutation, and expand coverage around validation of already-built keys.