### PR TITLE
Make the point-arithmetic variants private, not a menu of them public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1146,6 +1146,52 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **the point-arithmetic variants of `curve_group` and `curve_group_2` are
+  private** (issue #728). Eighteen names in the first and six in the
+  second: `_mult_aff`, `_mult_jac`, `_mult_base_3`, `_mult_mont_ladder`,
+  the two `_mult_recursive_*`, the two `_mult_fixed_window*`,
+  `_mult_regular_window`, `_mult_sliding_window`, `_mult_w_NAF`, the two
+  `_double_mult_*`, `_mult_endomorphism_secp256k1`, and the `_multiples`,
+  `_cached_multiples`, `_cached_multiples_fixwind`, `_odd_multiples`,
+  `_signed_odd_multiples`, `_jac_from_aff`, `_mods`, `_wNAF_of_m`,
+  `_convert_number_to_base` and `_multiplier_decomposer` they are built on.
+  `curve_group_2`'s `__all__` is empty as a result, which is the answer for
+  a module with nothing public of its own.
+
+  Each took a point it assumed to be on the curve and checked nothing, so a
+  malformed one was answered with a point rather than refused -- the one
+  shape of missing validation that produces a wrong answer instead of an
+  exception, and the reason this was worth acting on rather than recording.
+  Validating inside them was the alternative and is the wrong fix: they
+  exist to be measured against each other, so a check in each would be
+  measured with the arithmetic. `mult`, `double_mult` and `multi_mult`
+  already call `require_on_curve` on every point on every path,
+  libsecp256k1 dispatch included, and `btclib.curves` already declined to
+  export the variants; the underscore finishes that decision in the one
+  place a caller could still reach them, and states it in the name rather
+  than in a paragraph. What stays open is named rather than claimed shut:
+  the private name is still importable, so the wrong-answer path is
+  narrower, not closed.
+
+  Nine of them carried a default -- `w=4` on seven, with `cached=False`,
+  `scalar_len=0` and `regular=True` beside it -- which a private signature
+  may not, so each call site states the width it used to inherit.
+  `curve_group._mult` becomes a function rather than an alias of
+  `_mult_regular_window` for that reason, carrying `_MULT_W`; `curve.py`
+  gains `_ENDOMORPHISM_W` and `_DOUBLE_MULT_W`, two constants and not one
+  because they are two algorithms, a window of the endomorphism's
+  half-length scalars not being a window of an interleaved wNAF's
+  full-length ones. Each sits next to the caller that chose it, as
+  `_MULTI_MULT_W` does, and the measurement behind each is in the docstring
+  of the function it is passed to.
+
+  `CurveGroup`'s six group-law methods have the same gap and are not part
+  of this: `aff_from_jac`, `jac_equality`, `add_jac`, `double_jac`,
+  `add_aff` and `double_aff` are methods on a public class rather than
+  names in an `__all__`, and `ecc/dsa.py` calls two of them across the
+  `curves` -> `ecc` boundary, which makes them a decision of their own.
+  `signed_odd_digits` stays public, validating `m`, `w` and `size` in full.
+
 - **`btclib.ecc`'s docstring stops crediting the trailing underscore** for
   a decision it has no part in (issue #721). The paragraph said that what
   is not in the package's `__all__` is "any name ending in an underscore",

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,17 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **the individual point multiplications are private.** `from
+  btclib.curves.curve_group import mult_jac` is an `ImportError` now, and
+  so is every other variant of `curve_group` and `curve_group_2`: the
+  `mult_*`, the two `double_mult_*`, `multiples`, `cached_multiples`,
+  `cached_multiples_fixwind`, `odd_multiples`, `signed_odd_multiples`,
+  `jac_from_aff`, `mods`, `wNAF_of_m`, `convert_number_to_base` and
+  `multiplier_decomposer` each carry a leading underscore. Use `mult`,
+  `double_mult` and `multi_mult`, which are where they were and are the
+  three that check a point is on the curve before multiplying it -- which
+  is what the variants never did and what made them worth hiding. A variant
+  that used to default to `w=4` takes the width from its caller.
 - **verifying and recovering no longer take `lower_s`.**
   `dsa.assert_as_valid`, `dsa.verify`, `dsa.recover_pub_keys`,
   `dsa.recover_pub_key` and their four trailing-underscore twins used to

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -26,21 +26,30 @@ dictionary left the paragraph above naming curves a caller could not get
 at without importing the module the name is defined in. The four
 catalogues it is the union of (SEC2v1, SEC2v2, NIST, Brainpool) stay
 where they are defined: which standard a curve comes from is a question
-about a curve, not a way of finding one. The other mult_* of
-btclib.curves.curve_group and btclib.curves.curve_group_2 -- mult_aff, mult_jac,
-mult_base_3, mult_mont_ladder, the two mult_recursive_*, the two
-mult_fixed_window*, mult_regular_window, mult_sliding_window, mult_w_NAF and
-mult_endomorphism_secp256k1 -- are deliberately not exported, nor are the
-multiples, cached_multiples, odd_multiples and jac_from_aff they are built on.
+about a curve, not a way of finding one.
+
+The other multiplications of btclib.curves.curve_group and
+btclib.curves.curve_group_2 -- _mult_aff, _mult_jac, _mult_base_3,
+_mult_mont_ladder, the two _mult_recursive_*, the two _mult_fixed_window*,
+_mult_regular_window, _mult_sliding_window, _mult_w_NAF, the two
+_double_mult_* and _mult_endomorphism_secp256k1 -- are private, as are the
+_multiples, _cached_multiples, _odd_multiples and _jac_from_aff they are
+built on.
 
 They are implementations of one operation, kept side by side to be measured
-against each other, and exporting them would make a menu out of a benchmark:
-a caller reading btclib.curves would find every way of multiplying a point
-this package implements and nothing to say that mult is the one to use, that
-it dispatches to libsecp256k1 for secp256k1 and the generator, and that
-mult_jac is not the faster alternative its name suggests. Each is importable
-from the module that defines it, which is where the test suite takes them
-from.
+against each other, and a menu of them is not an API: a caller reading them
+would find every way of multiplying a point this package implements and
+nothing to say that mult is the one to use, that it dispatches to
+libsecp256k1 for secp256k1 and the generator, and that _mult_jac is not the
+faster alternative its name suggests.
+
+The underscore says the second thing too, which is what decided it: each
+takes a point it assumes to be on the curve and checks nothing, so a
+malformed one is answered with a point rather than refused. mult,
+double_mult and multi_mult are where require_on_curve runs, on every
+argument and every path, and reaching past them is reaching past that. The
+test suite takes each variant from the module that defines it, which is
+what a private name is still good for.
 
 The codec has a third function, bytes_from_prv_key_int: the composition of
 a multiplication and an encoding that every private-to-public conversion

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -43,13 +43,13 @@ from btclib.curves.curve_group import (
     HEX_THRESHOLD,
     CurveGroup,
     _is_prime,
+    _jac_from_aff,
     _mult,
     _multi_mult,
-    jac_from_aff,
 )
 from btclib.curves.curve_group_2 import (
-    double_mult_w_NAF,
-    mult_endomorphism_secp256k1,
+    _double_mult_w_NAF,
+    _mult_endomorphism_secp256k1,
 )
 from btclib.exceptions import BTClibValueError
 from btclib.utils import hex_string, int_from_integer
@@ -183,7 +183,7 @@ class Curve(CurveGroup):
         # curve, so nlen is a tighter bound than the plen + 1 CurveGroup
         # took from Hasse -- one window less at w=4 on secp256k1, and
         # log2(cofactor) bits less on a curve with a cofactor.
-        # mult_regular_window fixes its digit count to it, and reads it
+        # _mult_regular_window fixes its digit count to it, and reads it
         # under this name rather than as nlen so that a CurveGroup, which
         # has no n, can be multiplied in as well
         self.scalar_len = self.nlen
@@ -551,6 +551,15 @@ def _libsecp256k1_multi_mult(scalars: Sequence[int], points: Sequence[Point]) ->
     )
 
 
+# the widths mult and double_mult hand the two variants below them; the
+# measurement behind each is in the docstring of the function it is passed
+# to, and they are two constants rather than one because they are two
+# algorithms: a window of the GLV endomorphism's half-length scalars is
+# not a window of an interleaved wNAF's full-length ones
+_ENDOMORPHISM_W = 4
+_DOUBLE_MULT_W = 4
+
+
 def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point:
     """Elliptic curve scalar multiplication."""
     m: int = int_from_integer(m_int) % ec.n
@@ -570,7 +579,7 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
         QJ = ec.GJ
     else:
         ec.require_on_curve(Q)
-        QJ = jac_from_aff(Q)
+        QJ = _jac_from_aff(Q)
 
     # what reaches here on secp256k1 is the arguments the bindings decline
     # -- a zero scalar, or infinity -- and, with the dispatch
@@ -587,7 +596,11 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
     # endomorphism, so patching the bindings off must leave this arm --
     # python_path_test.py's pattern, which otherwise would compare the
     # bindings against the generic double-and-add of every other curve
-    R = mult_endomorphism_secp256k1(m, QJ, ec) if ec == secp256k1 else _mult(m, QJ, ec)
+    R = (
+        _mult_endomorphism_secp256k1(m, QJ, ec, _ENDOMORPHISM_W, regular=True)
+        if ec == secp256k1
+        else _mult(m, QJ, ec)
+    )
     return ec.aff_from_jac(R)
 
 
@@ -608,9 +621,9 @@ def double_mult(
     if u and v and H[1] and Q[1] and _libsecp256k1_applicable(ec, None):
         return _libsecp256k1_multi_mult([u, v], [H, Q])
 
-    HJ = jac_from_aff(H)
-    QJ = jac_from_aff(Q)
-    R = double_mult_w_NAF(u, HJ, v, QJ, ec)
+    HJ = _jac_from_aff(H)
+    QJ = _jac_from_aff(Q)
+    R = _double_mult_w_NAF(u, HJ, v, QJ, ec, _DOUBLE_MULT_W)
     return ec.aff_from_jac(R)
 
 
@@ -629,7 +642,7 @@ def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> J
     affine coordinates, because it is not only their arithmetic that is
     projective: so are the infinity test, the y parity and the x
     comparison each makes, and so is the QJ that public key recovery
-    threads through dsa's. jac_from_aff is what keeps that exact --
+    threads through dsa's. _jac_from_aff is what keeps that exact --
     infinity has no serialization on the other side of the boundary, and
     it answers the z == 0 both functions already recognize, so each still
     raises what it raised before, from the same line.
@@ -641,10 +654,10 @@ def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> J
     caller's own mod_inv(1) on the way back out, 0.14 us.
     """
     if not _libsecp256k1_applicable(ec, None):
-        return double_mult_w_NAF(u, HJ, v, QJ, ec)
+        return _double_mult_w_NAF(u, HJ, v, QJ, ec, _DOUBLE_MULT_W)
 
     R = double_mult(u, ec.aff_from_jac(HJ), v, ec.aff_from_jac(QJ), ec)
-    return jac_from_aff(R)
+    return _jac_from_aff(R)
 
 
 def multi_mult(
@@ -676,6 +689,6 @@ def multi_mult(
     ):
         return _libsecp256k1_multi_mult(ints, points)
 
-    jac_points = [jac_from_aff(Q) for Q in points]
+    jac_points = [_jac_from_aff(Q) for Q in points]
     R = _multi_mult(ints, jac_points, ec)
     return ec.aff_from_jac(R)

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -28,25 +28,7 @@ __all__ = [
     "HEX_THRESHOLD",
     "MAX_W",
     "CurveGroup",
-    "cached_multiples",
-    "cached_multiples_fixwind",
-    "convert_number_to_base",
-    "jac_from_aff",
-    "mods",
-    "mult_aff",
-    "mult_base_3",
-    "mult_fixed_window",
-    "mult_fixed_window_cached",
-    "mult_jac",
-    "mult_mont_ladder",
-    "mult_recursive_aff",
-    "mult_recursive_jac",
-    "mult_regular_window",
-    "multiples",
-    "odd_multiples",
     "signed_odd_digits",
-    "signed_odd_multiples",
-    "wNAF_of_m",
 ]
 
 HEX_THRESHOLD = 0xFFFFFFFF
@@ -72,7 +54,7 @@ def _is_prime(x: int) -> bool:
     return x >= 2 and x % 2 != 0 and pow(2, x - 1, x) == 1
 
 
-def jac_from_aff(Q: Point) -> JacPoint:
+def _jac_from_aff(Q: Point) -> JacPoint:
     """Return the Jacobian representation of the affine point.
 
     The input point is assumed to be on curve.
@@ -125,7 +107,7 @@ class CurveGroup:
         self.p = p
 
         # how many bits a scalar of this group has, which is what fixes
-        # the digit count of mult_regular_window below -- the quantity a
+        # the digit count of _mult_regular_window below -- the quantity a
         # loop running once per digit of the scalar in hand puts on the
         # clock. Hasse bounds the order of the group by p + 1 + 2*sqrt(p),
         # so a scalar reduced mod that order is under 2^(plen+1); Curve
@@ -230,7 +212,7 @@ class CurveGroup:
 
     def __hash__(self) -> int:
         # __eq__ without __hash__ would set __hash__ to None, and curves
-        # are lru_cache keys in cached_multiples below; equal curves
+        # are lru_cache keys in _cached_multiples below; equal curves
         # share those cache entries rather than each filling its own
         return hash(self._eq_key())
 
@@ -339,7 +321,7 @@ class CurveGroup:
         # random -- over 2000 random scalars _mult reached it 3.98 times
         # on average and only 23 of them not at all, and the count *is*
         # the secret: exactly the number of zero base-16 digits of the
-        # scalar, or for mult_jac the number of its low zero bits. An
+        # scalar, or for _mult_jac the number of its low zero bits. An
         # early return there put that on the clock, 0.03 us against the
         # 3.7 us of a generic addition, and _mult measured 0.93 ms with no
         # zero digit against 0.55 ms with 63.
@@ -355,7 +337,7 @@ class CurveGroup:
         # the additions an early return answers for free, at the price of
         # putting their count on the clock. Dropping the early return
         # without the stand-ins is not enough: P + INFJ still costs
-        # 1.8 us against 5.4, and mult_jac is still 25% faster on a
+        # 1.8 us against 5.4, and _mult_jac is still 25% faster on a
         # scalar with 128 low zero bits
         QS = (Q, self._stand_in_q)[Q[2] == 0]
         RS = (R, self._stand_in_r)[R[2] == 0]
@@ -405,7 +387,7 @@ class CurveGroup:
         #
         # Q[2] and R[2] because V says nothing when either is zero: Z == 0
         # leaves X and Y unconstrained, and the x of INFJ is 7 while the x
-        # of jac_from_aff(INF) is 5, picked for being invalid rather than
+        # of _jac_from_aff(INF) is 5, picked for being invalid rather than
         # for being zero, so on a curve of characteristic 7 or 5 they
         # reduce to zero and V vanishes for an operand that is not a point
         # at all -- P + INFJ answered 2*P, and eight of the ten scalar
@@ -487,7 +469,7 @@ class CurveGroup:
 
         p = self.p
         # lam reduced before it is squared, as in add_jac, though here it
-        # is worth 6% of mult_aff rather than a factor of two: mod_inv is
+        # is worth 6% of _mult_aff rather than a factor of two: mod_inv is
         # what affine coordinates cost, and is why the ladders are not
         lam = (R[1] - Q[1]) * mod_inv(R[0] - Q[0], p) % p
         x = (lam * lam - Q[0] - R[0]) % p
@@ -569,7 +551,7 @@ class CurveGroup:
         return root if legendre else self.p - root
 
 
-def mult_recursive_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
+def _mult_recursive_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
     """Scalar multiplication of a curve point in affine coordinates.
 
     This implementation uses a recursive version of 'double & add',
@@ -586,12 +568,12 @@ def mult_recursive_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
         return INF
 
     if m % 2 == 1:
-        return ec.add_aff(Q, mult_recursive_aff((m - 1), Q, ec))
+        return ec.add_aff(Q, _mult_recursive_aff((m - 1), Q, ec))
 
-    return mult_recursive_aff((m // 2), ec.double_aff(Q), ec)
+    return _mult_recursive_aff((m // 2), ec.double_aff(Q), ec)
 
 
-def mult_recursive_jac(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
+def _mult_recursive_jac(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     """Scalar multiplication of a curve point in affine coordinates.
 
     This implementation uses a recursive version of 'double & add',
@@ -608,12 +590,12 @@ def mult_recursive_jac(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
         return INFJ
 
     if m % 2 == 1:
-        return ec.add_jac(Q, mult_recursive_jac((m - 1), Q, ec))
+        return ec.add_jac(Q, _mult_recursive_jac((m - 1), Q, ec))
 
-    return mult_recursive_jac((m // 2), ec.double_jac(Q), ec)
+    return _mult_recursive_jac((m // 2), ec.double_jac(Q), ec)
 
 
-def mult_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
+def _mult_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
     """Scalar multiplication of a curve point in affine coordinates.
 
     This implementation uses 'double & add' algorithm, 'right-to-left'
@@ -636,7 +618,7 @@ def mult_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
         # the doubling part of 'double & add'
         Q = ec.double_aff(Q)
         # always perform the 'add', even if useless: one addition per bit
-        # whatever the bit is, as in mult_jac. It buys less here, add_aff
+        # whatever the bit is, as in _mult_jac. It buys less here, add_aff
         # branching on its own special cases and mod_inv taking the time
         # its input asks for, which is why the affine variants are the
         # readable ones rather than the ones to sign with
@@ -647,7 +629,7 @@ def mult_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
     return R[0]
 
 
-def mult_jac(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
+def _mult_jac(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     """Scalar multiplication of a curve point in Jacobian coordinates.
 
     This implementation uses 'double & add' algorithm, 'right-to-left'
@@ -678,7 +660,7 @@ def mult_jac(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     return R[0]
 
 
-def multiples(Q: JacPoint, size: int, ec: CurveGroup) -> list[JacPoint]:
+def _multiples(Q: JacPoint, size: int, ec: CurveGroup) -> list[JacPoint]:
     """Return {k_i * Q} for k_i in {0, ..., size-1}."""
     if size < 2:
         raise BTClibValueError(f"size too low: {size}")
@@ -704,7 +686,7 @@ MAX_W = 5
 
 
 @functools.lru_cache  # results are cached to increase efficiency
-def cached_multiples(Q: JacPoint, ec: CurveGroup) -> list[JacPoint]:
+def _cached_multiples(Q: JacPoint, ec: CurveGroup) -> list[JacPoint]:
     """Return the multiples 0..(2^MAX_W - 1) of Q, memoized on (Q, ec).
 
     The table the fixed-window ladder indexes when asked to cache; the
@@ -712,17 +694,17 @@ def cached_multiples(Q: JacPoint, ec: CurveGroup) -> list[JacPoint]:
     """
     T = [INFJ, Q]
     for i in range(3, 2**MAX_W, 2):
-        # not extend(): multiples() above has why
+        # not extend(): _multiples() above has why
         T.append(ec.double_jac(T[(i - 1) // 2]))
         T.append(ec.add_jac(T[-1], Q))
     return T
 
 
 @functools.lru_cache  # results are cached to increase efficiency
-def cached_multiples_fixwind(
-    Q: JacPoint, ec: CurveGroup, w: int = 4
+def _cached_multiples_fixwind(
+    Q: JacPoint, ec: CurveGroup, w: int
 ) -> list[list[JacPoint]]:
-    """Made to precompute values for mult_fixed_window_cached.
+    """Made to precompute values for _mult_fixed_window_cached.
 
     Do not use it for other functions. Made to be used for w=4, do not
     use w.
@@ -732,7 +714,7 @@ def cached_multiples_fixwind(
     for _ in range((ec.p_size * 8) // w + 1):
         sublist = [INFJ, K]
         for j in range(3, 2**w, 2):
-            # not extend(): multiples() above has why
+            # not extend(): _multiples() above has why
             sublist.append(ec.double_jac(sublist[(j - 1) // 2]))
             sublist.append(ec.add_jac(sublist[-1], K))
         K = ec.double_jac(sublist[2 ** (w - 1)])
@@ -741,7 +723,7 @@ def cached_multiples_fixwind(
     return T
 
 
-def convert_number_to_base(i: int, base: int) -> list[int]:
+def _convert_number_to_base(i: int, base: int) -> list[int]:
     """Return the digits of an integer in the requested base."""
     digits: list[int] = []
     while i or not digits:
@@ -750,14 +732,14 @@ def convert_number_to_base(i: int, base: int) -> list[int]:
     return digits[::-1]
 
 
-def mods(m: int, w: int) -> int:
+def _mods(m: int, w: int) -> int:
     """Signed modulo function."""
     w2: int = pow(2, w)
     M = m % w2
     return M - w2 if (w2 // 2) <= M else M
 
 
-def wNAF_of_m(m: int, w: int) -> list[int]:
+def _wNAF_of_m(m: int, w: int) -> list[int]:
     """WNAF (width-w Non-adjacent form) of number m.
 
     Given an integer m, wNAF is a method of representation
@@ -769,7 +751,7 @@ def wNAF_of_m(m: int, w: int) -> list[int]:
     representation of k.
     -The average density of nonzero digits is approximately 1/(w + 1).
 
-    This recoding sits here next to convert_number_to_base, the same kind
+    This recoding sits here next to _convert_number_to_base, the same kind
     of integer-only helper, rather than with the wNAF multiplications of
     curve_group_2: the interleaved _multi_mult_w_NAF below needs it, and
     curve_group cannot import the module that imports it.
@@ -787,7 +769,7 @@ def wNAF_of_m(m: int, w: int) -> list[int]:
                 M.append(2 - (m % 4))
             else:
                 # Computing wNAF of m
-                M.append(mods(m, w))
+                M.append(_mods(m, w))
             m -= M[i]
         else:
             M.append(0)
@@ -802,7 +784,7 @@ def signed_odd_digits(m: int, w: int, size: int) -> list[int]:
 
     Regular recoding, Joye-Tunstall: m = sum(digits[i] * 2^(w*i)) with
     every digit odd and in {±1, ±3, ..., ±(2^w - 1)}, least significant
-    first, as wNAF_of_m returns its own. Two properties are what it is
+    first, as _wNAF_of_m returns its own. Two properties are what it is
     for, and neither is the wNAF's:
 
     - no digit is zero, so the multiplication that indexes them makes one
@@ -849,7 +831,7 @@ def signed_odd_digits(m: int, w: int, size: int) -> list[int]:
     return digits
 
 
-def odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
+def _odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
     """Return the odd multiples 1*Q, 3*Q, ..., (2^(w-1) - 1)*Q.
 
     The table a width-w NAF indexes: its digits are odd and smaller than
@@ -865,26 +847,26 @@ def odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
     return T
 
 
-def signed_odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
+def _signed_odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
     """Return the 2^w multiples a signed odd width-w digit names.
 
     -(2^w - 1)*Q first and (2^w - 1)*Q last, so the digit d of
     signed_odd_digits picks entry (d + 2^w - 1) // 2 and nothing has to
-    test its sign, where the wNAF loops negate an entry of `odd_multiples`
+    test its sign, where the wNAF loops negate an entry of `_odd_multiples`
     on the fly under an `if`. Cheaper, too, and not only regular: 2^(w-1)
     modular subtractions once -- 8 of them at w=4 -- against the one per
     negative digit the loop would make, which is half of the 64 digits a
     256-bit scalar has at that width.
 
-    The table it is built on is `odd_multiples(Q, ec, w + 1)`: a regular
+    The table it is built on is `_odd_multiples(Q, ec, w + 1)`: a regular
     digit reaches 2^w - 1 where a width-w NAF digit stops at 2^(w-1) - 1,
     so the table is twice as long as that recoding's for the same window.
     """
-    T = odd_multiples(Q, ec, w + 1)
+    T = _odd_multiples(Q, ec, w + 1)
     return [ec.negate_jac(P) for P in reversed(T)] + T
 
 
-def mult_mont_ladder(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
+def _mult_mont_ladder(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     """Scalar multiplication using 'Montgomery ladder' algorithm.
 
     This implementation uses
@@ -917,7 +899,7 @@ def mult_mont_ladder(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     return R[0]
 
 
-def mult_base_3(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
+def _mult_base_3(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     """Scalar multiplication using ternary decomposition of the scalar.
 
     This implementation uses 'triple & add' algorithm, 'left-to-right'
@@ -933,7 +915,7 @@ def mult_base_3(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     # at each step one of the points in T will be added
     T = [INFJ, Q, ec.double_jac(Q)]
 
-    digits = convert_number_to_base(m, 3)
+    digits = _convert_number_to_base(m, 3)
 
     R = T[digits[0]]
     for i in digits[1:]:
@@ -945,8 +927,8 @@ def mult_base_3(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     return R
 
 
-def mult_fixed_window(
-    m: int, Q: JacPoint, ec: CurveGroup, w: int = 4, cached: bool = False
+def _mult_fixed_window(
+    m: int, Q: JacPoint, ec: CurveGroup, w: int, cached: bool
 ) -> JacPoint:
     """Scalar multiplication using "fixed window".
 
@@ -968,9 +950,9 @@ def mult_fixed_window(
         raise BTClibValueError(f"non positive w: {w}")
 
     # at each step one of the points in T will be added
-    T = cached_multiples(Q, ec) if cached else multiples(Q, 2**w, ec)
+    T = _cached_multiples(Q, ec) if cached else _multiples(Q, 2**w, ec)
 
-    digits = convert_number_to_base(m, 2**w)
+    digits = _convert_number_to_base(m, 2**w)
 
     R = T[digits[0]]
     for i in digits[1:]:
@@ -982,9 +964,7 @@ def mult_fixed_window(
     return R
 
 
-def mult_fixed_window_cached(
-    m: int, Q: JacPoint, ec: CurveGroup, w: int = 4
-) -> JacPoint:
+def _mult_fixed_window_cached(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     """Scalar multiplication using "fixed window" & cached values.
 
     This implementation uses 'multiple-double & add' algorithm, 'left-
@@ -1005,9 +985,9 @@ def mult_fixed_window_cached(
     if w <= 0:
         raise BTClibValueError(f"non positive w: {w}")
 
-    T = cached_multiples_fixwind(Q, ec, w)
+    T = _cached_multiples_fixwind(Q, ec, w)
 
-    digits = convert_number_to_base(m, 2**w)
+    digits = _convert_number_to_base(m, 2**w)
 
     k = len(digits) - 1
 
@@ -1020,7 +1000,7 @@ def mult_fixed_window_cached(
     return R
 
 
-def mult_regular_window(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacPoint:
+def _mult_regular_window(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     """Scalar multiplication using a regular window: no digit is zero.
 
     The fixed window above, with the quantity the scalar still decided
@@ -1041,7 +1021,7 @@ def mult_regular_window(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacP
     `_mult` the package reaches for rather than an option beside it. The
     fixed window stays as what it is didactically, the plain one, and the
     wNAF multiplications stay the fast irregular ones for coefficients
-    that are public: `double_mult_w_NAF` is what verification runs.
+    that are public: `_double_mult_w_NAF` is what verification runs.
 
     w=4 by measurement, as for the fixed window: 0.803 ms at w=5 and 0.831
     at w=6, the window paying for a table twice the size of the NAF's at
@@ -1076,7 +1056,7 @@ def mult_regular_window(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacP
     # all, and m + n would be the same point only for a point whose order
     # it is -- which the group this multiplies in cannot say
     digits = signed_odd_digits(m | 1, w, size)
-    T = signed_odd_multiples(Q, ec, w)
+    T = _signed_odd_multiples(Q, ec, w)
     offset = (1 << w) - 1
 
     # a table entry, the top digit being positive, and never infinity
@@ -1094,11 +1074,25 @@ def mult_regular_window(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacP
     return ec.add_jac(R, (INFJ, ec.negate_jac(Q))[not m & 1])
 
 
-# what the rest of the package multiplies with, on every curve but
-# secp256k1, where curves.mult has the GLV endomorphism: the regular
-# window, whose cost is the same for every scalar of the curve, at the
-# cost of nothing measurable against the fixed window it recodes
-_mult = mult_regular_window
+# the width _mult hands the regular window; the measurement behind it is
+# in the docstring of the function it is passed to
+_MULT_W = 4
+
+
+def _mult(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
+    """Return m*Q, with what the rest of the package multiplies with.
+
+    On every curve but secp256k1, where curves.mult has the GLV
+    endomorphism: the regular window, whose cost is the same for every
+    scalar of the curve, at the cost of nothing measurable against the
+    fixed window it recodes.
+
+    A function and not an alias of _mult_regular_window, the width being an
+    argument: a private signature carries no default, so the width this one
+    picks belongs here, where the choice is, rather than in the signature of
+    a variant every other caller passes its own width to.
+    """
+    return _mult_regular_window(m, Q, ec, _MULT_W)
 
 
 def _double_mult(
@@ -1192,7 +1186,7 @@ def _multi_mult_w_NAF(
     """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
 
     Strauss' algorithm with interleaved wNAFs, the many-point form of
-    curve_group_2's double_mult_w_NAF (HMV algorithm 3.51): each scalar
+    curve_group_2's _double_mult_w_NAF (HMV algorithm 3.51): each scalar
     gets its own width-w NAF and its own table of odd multiples, and a
     single left-to-right loop shares one doubling per bit position among
     all of them, adding a (possibly negated) table entry wherever a NAF
@@ -1232,8 +1226,8 @@ def _multi_mult_w_NAF(
     if not pairs:
         return INFJ
 
-    nafs = [wNAF_of_m(n, w) for n, _ in pairs]
-    tables = [odd_multiples(PJ, ec, w) for _, PJ in pairs]
+    nafs = [_wNAF_of_m(n, w) for n, _ in pairs]
+    tables = [_odd_multiples(PJ, ec, w) for _, PJ in pairs]
 
     R = INFJ
     for j in range(max(len(naf) for naf in nafs) - 1, -1, -1):
@@ -1298,15 +1292,15 @@ def _multi_mult_bos_coster(
         np2 = heapq.heappop(x)
         n_1, p_1 = -np1[0], np1[1]
         n_2, p_2 = -np2[0], np2[1]
-        # mult_jac, not the faster _mult: the quotient is 1 about 40% of
+        # _mult_jac, not the faster _mult: the quotient is 1 about 40% of
         # the time (Gauss-Kuzmin), and _mult would rebuild its 16-entry
         # table of multiples for each of those -- 10x slower over 128
-        # random scalars. mult_jac(1, P) is P at no cost, so this is the
+        # random scalars. _mult_jac(1, P) is P at no cost, so this is the
         # subtractive step precisely when the subtractive step is right;
         # measured, spelling that case out as a branch buys nothing, and
         # subtracting for q up to 4 or up to 16 costs 3% and 11%.
         q, n_1 = divmod(n_1, n_2)
-        p_2 = ec.add_jac(mult_jac(q, p_1, ec), p_2)
+        p_2 = ec.add_jac(_mult_jac(q, p_1, ec), p_2)
         if n_1 > 0:
             heapq.heappush(x, (-n_1, p_1))
         heapq.heappush(x, (-n_2, p_2))

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -52,7 +52,7 @@ follow-ups; what is here is the rest:
 
         - https://briansmith.org/ecc-inversion-addition-chains-01
     - Joint sparse form (JSF, HMV algorithm 3.50) for double mult: the
-      alternative to the interleaving double_mult_w_NAF implements --
+      alternative to the interleaving _double_mult_w_NAF implements --
       one joint recoding of both scalars instead of one NAF each, fewer
       total additions in exchange for digit pairs that do not index a
       per-point table of odd multiples
@@ -66,27 +66,25 @@ from math import ceil
 from btclib.alias import INFJ, JacPoint
 
 # the wNAF recoding and the table of odd multiples it indexes live in
-# curve_group, next to convert_number_to_base and for the same reason:
+# curve_group, next to _convert_number_to_base and for the same reason:
 # its interleaved _multi_mult_w_NAF needs them, and the dependency runs
 # one way, this module importing that one
 from btclib.curves.curve_group import (
     CurveGroup,
-    convert_number_to_base,
-    odd_multiples,
+    _convert_number_to_base,
+    _odd_multiples,
+    _signed_odd_multiples,
+    _wNAF_of_m,
     signed_odd_digits,
-    signed_odd_multiples,
-    wNAF_of_m,
 )
 from btclib.exceptions import BTClibValueError
 
-__all__ = [
-    "double_mult_regular_window",
-    "double_mult_w_NAF",
-    "mult_endomorphism_secp256k1",
-    "mult_sliding_window",
-    "mult_w_NAF",
-    "multiplier_decomposer",
-]
+# empty, and declared rather than omitted: every multiplication here is a
+# variant kept to be measured against the others, which is what the leading
+# underscore says, so this module has nothing public of its own.
+# `curve.py`'s mult, double_mult and multi_mult are what a caller reaches,
+# and they validate every point before dispatching to any of these
+__all__: list[str] = []
 
 
 def _sliding_window_table(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
@@ -117,7 +115,7 @@ def _double_and_add(
     return R
 
 
-def mult_sliding_window(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacPoint:
+def _mult_sliding_window(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     """Scalar multiplication using "sliding window".
 
     It has the benefit that the pre-computation stage is roughly half as
@@ -139,7 +137,7 @@ def mult_sliding_window(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacP
     T = _sliding_window_table(Q, ec, w)
     p = pow(2, w - 1)
 
-    digits = convert_number_to_base(m, 2)
+    digits = _convert_number_to_base(m, 2)
 
     R = INFJ
     i = 0
@@ -167,7 +165,7 @@ def mult_sliding_window(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacP
     return R
 
 
-def mult_w_NAF(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacPoint:
+def _mult_w_NAF(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     """Scalar multiplication in Jacobian coordinates using wNAF.
 
     The "w-ary non-adjacent form": on a Weierstrass curve -P costs
@@ -187,7 +185,7 @@ def mult_w_NAF(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacPoint:
     if w <= 0:
         raise BTClibValueError(f"non positive w: {w}")
 
-    M = wNAF_of_m(m, w)
+    M = _wNAF_of_m(m, w)
 
     p = len(M)
 
@@ -213,8 +211,8 @@ def mult_w_NAF(m: int, Q: JacPoint, ec: CurveGroup, w: int = 4) -> JacPoint:
     return R
 
 
-def double_mult_w_NAF(
-    u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: CurveGroup, w: int = 4
+def _double_mult_w_NAF(
+    u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: CurveGroup, w: int
 ) -> JacPoint:
     """Double scalar multiplication (u*H + v*Q), interleaved wNAFs.
 
@@ -234,9 +232,9 @@ def double_mult_w_NAF(
     suite holding the Python path against them. Measured over random
     256-bit coefficients, best of seven: 1.03 ms against the 1.53 ms of
     curve_group's _double_mult, which stays as the reference the tests
-    compare this against. w=5 measures 0.99 ms and w=3 1.10, so the
-    default is within 4% of the best window and the table is half the
-    size of w=5's.
+    compare this against. w=5 measures 0.99 ms and w=3 1.10, so the w=4
+    `curve.py` passes is within 4% of the best window and its table is
+    half the size of w=5's.
 
     The gap over _double_mult is the wider since add_jac stopped
     shortcutting infinity: fewer additions is worth the more when an
@@ -267,13 +265,13 @@ def double_mult_w_NAF(
     if w <= 0:
         raise BTClibValueError(f"non positive w: {w}")
 
-    us = wNAF_of_m(u, w)
-    vs = wNAF_of_m(v, w)
+    us = _wNAF_of_m(u, w)
+    vs = _wNAF_of_m(v, w)
 
     # one table of odd multiples per point, the same curve_group's
     # interleaved _multi_mult_w_NAF builds for each of its own
-    TH = odd_multiples(HJ, ec, w)
-    TQ = odd_multiples(QJ, ec, w)
+    TH = _odd_multiples(HJ, ec, w)
+    TQ = _odd_multiples(QJ, ec, w)
 
     R = INFJ
     for j in range(max(len(us), len(vs)) - 1, -1, -1):
@@ -289,39 +287,39 @@ def double_mult_w_NAF(
     return R
 
 
-def double_mult_regular_window(
+def _double_mult_regular_window(
     u: int,
     HJ: JacPoint,
     v: int,
     QJ: JacPoint,
     ec: CurveGroup,
-    w: int = 4,
-    scalar_len: int = 0,
+    w: int,
+    scalar_len: int,
 ) -> JacPoint:
     """Double scalar multiplication (u*H + v*Q), regular windows.
 
-    curve_group's mult_regular_window for two coefficients, sharing the
+    curve_group's _mult_regular_window for two coefficients, sharing the
     doublings as the interleaved wNAF above does: one recoding and one
     table of signed odd multiples per coefficient, and a loop of w
     doublings and two additions per window, both of them made whatever the
     digits are. So the cost is the same for every pair (u, v) of a given
     scalar_len -- 143 additions and 254 doublings on secp256k1, over 200
-    random pairs -- where double_mult_w_NAF's is the recoded weight of the
+    random pairs -- where _double_mult_w_NAF's is the recoded weight of the
     two coefficients and is 101 to 116 additions over the same pairs, and
     0.996 ms against 1.11.
 
-    Which is mult_regular_window's trade, twice: a table of 2^(w-1) points
+    Which is _mult_regular_window's trade, twice: a table of 2^(w-1) points
     per coefficient, and their opposites, to make one addition per window
     per coefficient -- where the wNAF builds half as many points and adds
     on one digit in w+1. This function is therefore not what
     `double_mult` runs -- verification's coefficients are public -- but
-    what mult_endomorphism_secp256k1 runs, whose two are halves of a
+    what _mult_endomorphism_secp256k1 runs, whose two are halves of a
     secret.
 
     scalar_len is the bit count the digits are fixed to, ec.scalar_len by
     default. It is a parameter because the caller that wants this function
     has coefficients shorter than the group's by construction:
-    mult_endomorphism_secp256k1 splits a 256-bit scalar into two halves of
+    _mult_endomorphism_secp256k1 splits a 256-bit scalar into two halves of
     128 bits, and the group's own 256 would double the work for nothing.
 
     The input points are assumed to be on curve, and the u and v
@@ -336,15 +334,15 @@ def double_mult_regular_window(
     if w <= 0:
         raise BTClibValueError(f"non positive w: {w}")
 
-    # as in mult_regular_window: the count is the curve's, or the caller's,
+    # as in _mult_regular_window: the count is the curve's, or the caller's,
     # and a coefficient above it is multiplied in the digits it needs
     bits = max(scalar_len or ec.scalar_len, u.bit_length(), v.bit_length())
     size = ceil(bits / w)
     us = signed_odd_digits(u | 1, w, size)
     vs = signed_odd_digits(v | 1, w, size)
 
-    TH = signed_odd_multiples(HJ, ec, w)
-    TQ = signed_odd_multiples(QJ, ec, w)
+    TH = _signed_odd_multiples(HJ, ec, w)
+    TQ = _signed_odd_multiples(QJ, ec, w)
     offset = (1 << w) - 1
 
     # the accumulator starts at the sum of two table entries, so infinity
@@ -379,7 +377,7 @@ _A2 = 0x114CA50F7A8E2F3F657C1108D9D44CFD8
 _B2 = 0x3086D221A7D46BCDE86C90E49284EB15
 
 
-def multiplier_decomposer(m: int) -> tuple[int, int]:
+def _multiplier_decomposer(m: int) -> tuple[int, int]:
     """Decompose m into m1, m2 with m1 + m2*lambda = m mod n.
 
     Balanced length-two representation, algorithm 3.74 of D. Hankerson,
@@ -414,52 +412,52 @@ def multiplier_decomposer(m: int) -> tuple[int, int]:
 
 
 # the bits either half of the decomposition can have, and the digit count
-# double_mult_regular_window is fixed to below. It is the rounding error of
-# multiplier_decomposer and not a measurement: round-to-nearest leaves at
+# _double_mult_regular_window is fixed to below. It is the rounding error of
+# _multiplier_decomposer and not a measurement: round-to-nearest leaves at
 # most half a basis vector of each, |m1| <= (|a1| + |a2|)/2 and
 # |m2| <= (|b1| + |b2|)/2, both of which are 128-bit numbers with the
 # constants above. libsecp256k1's scalar_split_lambda states the same 128
 _HALF_LEN = 128
 
 
-def mult_endomorphism_secp256k1(
-    m: int, Q: JacPoint, ec: CurveGroup, w: int = 4, regular: bool = True
+def _mult_endomorphism_secp256k1(
+    m: int, Q: JacPoint, ec: CurveGroup, w: int, regular: bool
 ) -> JacPoint:
     """Scalar multiplication in Jacobian coordinates using endomorphism.
 
     Algorithm 3.77 of D. Hankerson, 'Guide to Elliptic Curve
     Cryptography': m*Q as m1*Q + m2*(lambda*Q), the halves coming from
-    multiplier_decomposer and a double multiplication sharing their
+    _multiplier_decomposer and a double multiplication sharing their
     doublings. It is the fastest Python multiplication in the package and
     what `curves.mult` runs for every secp256k1 point the bindings do not
     take.
 
     Which double multiplication is `regular`, and the two answer the same
     point at different costs. Measured over 30 random 256-bit scalars,
-    best of five, at the default w=4:
+    best of five, at w=4:
 
-    - the regular windows of double_mult_regular_window, 0.589 ms, and 79
+    - the regular windows of _double_mult_regular_window, 0.589 ms, and 79
       additions and 126 doublings for every one of 200 random scalars
-    - the interleaved wNAFs of double_mult_w_NAF, 0.509 ms, which is
+    - the interleaved wNAFs of _double_mult_w_NAF, 0.509 ms, which is
       algorithm 3.77 as it is written, and 51 to 64 additions and 124 to
       131 doublings over the same scalars: a quarter more work for the
       worst scalar than for the best, and which it is is a property of
       the secret (issue 254)
 
-    The regular one is the default because the scalar of a `curves.mult`
-    is a private key or a nonce in every caller btclib has, and 16% of a
-    multiplication that libsecp256k1 answers in 13 us is not what this
-    path is for. Both stay: the wNAF is what verification wants, its
-    coefficients being public, and `double_mult` reaches it directly.
+    The regular one is what `curves.mult` asks for because the scalar of a
+    `curves.mult` is a private key or a nonce in every caller btclib has,
+    and 16% of a multiplication that libsecp256k1 answers in 13 us is not
+    what this path is for. Both stay: the wNAF is what verification wants,
+    its coefficients being public, and `double_mult` reaches it directly.
 
     w=4 by measurement for both: the regular windows give 0.610 ms at
-    w=5, and the wNAFs 0.527 at w=3 and 0.510 at w=5, which is the
-    default's own noise.
+    w=5, and the wNAFs 0.527 at w=3 and 0.510 at w=5, which is w=4's own
+    noise.
     """
     if m < 0:
         raise BTClibValueError(f"negative m: {hex(m)}")
 
-    m1, m2 = multiplier_decomposer(m)
+    m1, m2 = _multiplier_decomposer(m)
 
     K = ((Q[0] * _BETA) % ec.p), Q[1], Q[2]  # K = lambda*Q, direct calculation
 
@@ -474,5 +472,5 @@ def mult_endomorphism_secp256k1(
     m1, m2 = abs(m1), abs(m2)
 
     if regular:
-        return double_mult_regular_window(m1, P, m2, K, ec, w, _HALF_LEN)
-    return double_mult_w_NAF(m1, P, m2, K, ec, w)
+        return _double_mult_regular_window(m1, P, m2, K, ec, w, _HALF_LEN)
+    return _double_mult_w_NAF(m1, P, m2, K, ec, w)

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -1234,7 +1234,7 @@ def _recover_pub_key_(
     # 850 for the enumeration that runs it once per candidate.
     #
     # It is the same point either way and not the same triple: what comes
-    # back is jac_from_aff, i.e. z == 1, where the wNAF answered whatever
+    # back is _jac_from_aff, i.e. z == 1, where the wNAF answered whatever
     # representative its ladder reached. Every caller converts with
     # aff_from_jac, which is what a Jacobian coordinate is for
     QJ = _jac_double_mult(r1s, KJ, r1e, ec.GJ, ec)  # 1.6.1

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -316,7 +316,7 @@ def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
     """One multiplication, not fourteen ways to spell it.
 
     mult dispatches to libsecp256k1 for secp256k1 and the generator, which
-    is exactly what a caller choosing mult_jac from the same namespace --
+    is exactly what a caller choosing _mult_jac from the same namespace --
     on the strength of its name -- gives up.
     """
     assert sorted(btclib.curves.__all__) == [
@@ -336,20 +336,20 @@ def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
 
     # the implementations are still there, in the module that defines them
     variants = [
-        (curve_group, "mult_aff"),
-        (curve_group, "mult_base_3"),
-        (curve_group, "mult_fixed_window"),
-        (curve_group, "mult_fixed_window_cached"),
-        (curve_group, "mult_jac"),
-        (curve_group, "mult_mont_ladder"),
-        (curve_group, "mult_recursive_aff"),
-        (curve_group, "mult_recursive_jac"),
-        (curve_group, "cached_multiples"),
-        (curve_group, "jac_from_aff"),
-        (curve_group, "multiples"),
-        (curve_group_2, "mult_endomorphism_secp256k1"),
-        (curve_group_2, "mult_sliding_window"),
-        (curve_group_2, "mult_w_NAF"),
+        (curve_group, "_mult_aff"),
+        (curve_group, "_mult_base_3"),
+        (curve_group, "_mult_fixed_window"),
+        (curve_group, "_mult_fixed_window_cached"),
+        (curve_group, "_mult_jac"),
+        (curve_group, "_mult_mont_ladder"),
+        (curve_group, "_mult_recursive_aff"),
+        (curve_group, "_mult_recursive_jac"),
+        (curve_group, "_cached_multiples"),
+        (curve_group, "_jac_from_aff"),
+        (curve_group, "_multiples"),
+        (curve_group_2, "_mult_endomorphism_secp256k1"),
+        (curve_group_2, "_mult_sliding_window"),
+        (curve_group_2, "_mult_w_NAF"),
     ]
     for module, name in variants:
         assert hasattr(module, name), f"{module.__name__}.{name} went missing"

--- a/tests/curves/curve_group_2_test.py
+++ b/tests/curves/curve_group_2_test.py
@@ -18,12 +18,12 @@ from btclib.curves.curve_group_2 import (
     _HALF_LEN,
     _LAM,
     _N,
-    double_mult_regular_window,
-    double_mult_w_NAF,
-    mult_endomorphism_secp256k1,
-    mult_sliding_window,
-    mult_w_NAF,
-    multiplier_decomposer,
+    _double_mult_regular_window,
+    _double_mult_w_NAF,
+    _mult_endomorphism_secp256k1,
+    _mult_sliding_window,
+    _mult_w_NAF,
+    _multiplier_decomposer,
 )
 from btclib.exceptions import BTClibValueError
 from tests.curves.curve_test import low_card_curves
@@ -35,32 +35,32 @@ def test_mult_sliding_window() -> None:
     """Check the sliding-window mult on boundary scalars and against _mult."""
     for w in range(1, 6):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(mult_sliding_window(0, ec.GJ, ec, w), INFJ)
-            assert ec.jac_equality(mult_sliding_window(0, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_sliding_window(0, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_sliding_window(0, INFJ, ec, w), INFJ)
 
-            assert ec.jac_equality(mult_sliding_window(1, INFJ, ec, w), INFJ)
-            assert ec.jac_equality(mult_sliding_window(1, ec.GJ, ec, w), ec.GJ)
+            assert ec.jac_equality(_mult_sliding_window(1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_sliding_window(1, ec.GJ, ec, w), ec.GJ)
 
-            PJ = mult_sliding_window(2, ec.GJ, ec, w)
+            PJ = _mult_sliding_window(2, ec.GJ, ec, w)
             assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-            PJ = mult_sliding_window(ec.n - 1, ec.GJ, ec, w)
+            PJ = _mult_sliding_window(ec.n - 1, ec.GJ, ec, w)
             assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
 
-            assert ec.jac_equality(mult_sliding_window(ec.n - 1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_sliding_window(ec.n - 1, INFJ, ec, w), INFJ)
             assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(mult_sliding_window(ec.n, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_sliding_window(ec.n, ec.GJ, ec, w), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
-                mult_sliding_window(-1, ec.GJ, ec, w)
+                _mult_sliding_window(-1, ec.GJ, ec, w)
 
             with pytest.raises(BTClibValueError, match="non positive w: "):
-                mult_sliding_window(1, ec.GJ, ec, -w)
+                _mult_sliding_window(1, ec.GJ, ec, -w)
 
     ec = ec23_31
     for w in range(1, 10):
         for k1 in range(ec.n):
-            K1 = mult_sliding_window(k1, ec.GJ, ec, w)
+            K1 = _mult_sliding_window(k1, ec.GJ, ec, w)
             assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
@@ -68,32 +68,32 @@ def test_mult_w_NAF() -> None:
     """Check the wNAF mult on boundary scalars and against _mult."""
     for w in range(1, 6):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(mult_w_NAF(0, ec.GJ, ec, w), INFJ)
-            assert ec.jac_equality(mult_w_NAF(0, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_w_NAF(0, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_w_NAF(0, INFJ, ec, w), INFJ)
 
-            assert ec.jac_equality(mult_w_NAF(1, INFJ, ec, w), INFJ)
-            assert ec.jac_equality(mult_w_NAF(1, ec.GJ, ec, w), ec.GJ)
+            assert ec.jac_equality(_mult_w_NAF(1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_w_NAF(1, ec.GJ, ec, w), ec.GJ)
 
-            PJ = mult_w_NAF(2, ec.GJ, ec, w)
+            PJ = _mult_w_NAF(2, ec.GJ, ec, w)
             assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-            PJ = mult_w_NAF(ec.n - 1, ec.GJ, ec, w)
+            PJ = _mult_w_NAF(ec.n - 1, ec.GJ, ec, w)
             assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
 
-            assert ec.jac_equality(mult_w_NAF(ec.n - 1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_w_NAF(ec.n - 1, INFJ, ec, w), INFJ)
             assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(mult_w_NAF(ec.n, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_w_NAF(ec.n, ec.GJ, ec, w), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
-                mult_w_NAF(-1, ec.GJ, ec, w)
+                _mult_w_NAF(-1, ec.GJ, ec, w)
 
             with pytest.raises(BTClibValueError, match="non positive w: "):
-                mult_w_NAF(1, ec.GJ, ec, -w)
+                _mult_w_NAF(1, ec.GJ, ec, -w)
 
     ec = ec23_31
     for w in range(1, 10):
         for k1 in range(ec.n):
-            K1 = mult_w_NAF(k1, ec.GJ, ec, w)
+            K1 = _mult_w_NAF(k1, ec.GJ, ec, w)
             assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
@@ -107,7 +107,7 @@ def test_mult_endomorphism_secp256k1(regular: bool) -> None:
     """
 
     def mult(m: int, QJ: JacPoint) -> JacPoint:
-        return mult_endomorphism_secp256k1(m, QJ, secp256k1, regular=regular)
+        return _mult_endomorphism_secp256k1(m, QJ, secp256k1, regular=regular, w=4)
 
     ec = secp256k1
     assert ec.jac_equality(mult(0, ec.GJ), INFJ)
@@ -155,7 +155,7 @@ def test_mult_endomorphism_agrees_with_mult_above_2_127() -> None:
     for m in scalars:
         expected = _mult(m, ec.GJ, ec)
         for regular in (True, False):
-            got = mult_endomorphism_secp256k1(m, ec.GJ, ec, regular=regular)
+            got = _mult_endomorphism_secp256k1(m, ec.GJ, ec, regular=regular, w=4)
             assert ec.jac_equality(got, expected), (m, regular)
 
 
@@ -169,20 +169,20 @@ def test_multiplier_decomposer() -> None:
     the caller owns the sign handling.
     """
     # the identity decompositions, exact values rather than properties
-    assert multiplier_decomposer(0) == (0, 0)
-    assert multiplier_decomposer(1) == (1, 0)
-    assert multiplier_decomposer(_N - 1) == (-1, 0)
-    assert multiplier_decomposer(_LAM) == (0, 1)
-    assert multiplier_decomposer(_N - _LAM) == (0, -1)
+    assert _multiplier_decomposer(0) == (0, 0)
+    assert _multiplier_decomposer(1) == (1, 0)
+    assert _multiplier_decomposer(_N - 1) == (-1, 0)
+    assert _multiplier_decomposer(_LAM) == (0, 1)
+    assert _multiplier_decomposer(_N - _LAM) == (0, -1)
     # reduction mod n first: -7 is n - 7, whose balanced form is -7
-    assert multiplier_decomposer(-7) == (-7, 0)
-    assert multiplier_decomposer(_N + 42) == (42, 0)
+    assert _multiplier_decomposer(-7) == (-7, 0)
+    assert _multiplier_decomposer(_N + 42) == (42, 0)
 
     scalars = [1 << 127, (1 << 128) - 1, _N - 2, _LAM - 1, _LAM + 1] + [
         secrets.randbelow(_N) for _ in range(20)
     ]
     for m in scalars:
-        m1, m2 = multiplier_decomposer(m)
+        m1, m2 = _multiplier_decomposer(m)
         # congruent: m1 + m2*lambda is m mod n, which is the identity
         # making m1*Q + m2*(lambda*Q) equal m*Q
         assert (m1 + m2 * _LAM - m) % _N == 0
@@ -208,17 +208,17 @@ def test_double_mult_w_NAF() -> None:
             for u in range(ec.n):
                 for v in range(ec.n):
                     expected = _double_mult(u, HJ, v, QJ, ec)
-                    got = double_mult_w_NAF(u, HJ, v, QJ, ec, w)
+                    got = _double_mult_w_NAF(u, HJ, v, QJ, ec, w)
                     assert ec.jac_equality(got, expected), (u, v, w)
 
     ec = secp256k1
-    assert ec.jac_equality(double_mult_w_NAF(0, ec.GJ, 0, ec.GJ, ec), INFJ)
+    assert ec.jac_equality(_double_mult_w_NAF(0, ec.GJ, 0, ec.GJ, ec, w=4), INFJ)
     with pytest.raises(BTClibValueError, match="negative first coefficient: "):
-        double_mult_w_NAF(-1, ec.GJ, 1, ec.GJ, ec)
+        _double_mult_w_NAF(-1, ec.GJ, 1, ec.GJ, ec, w=4)
     with pytest.raises(BTClibValueError, match="negative second coefficient: "):
-        double_mult_w_NAF(1, ec.GJ, -1, ec.GJ, ec)
+        _double_mult_w_NAF(1, ec.GJ, -1, ec.GJ, ec, w=4)
     with pytest.raises(BTClibValueError, match="non positive w: "):
-        double_mult_w_NAF(1, ec.GJ, 1, ec.GJ, ec, 0)
+        _double_mult_w_NAF(1, ec.GJ, 1, ec.GJ, ec, 0)
 
 
 def test_double_mult_regular_window() -> None:
@@ -236,7 +236,7 @@ def test_double_mult_regular_window() -> None:
             for u in range(ec.n):
                 for v in range(ec.n):
                     expected = _double_mult(u, HJ, v, QJ, ec)
-                    got = double_mult_regular_window(u, HJ, v, QJ, ec, w)
+                    got = _double_mult_regular_window(u, HJ, v, QJ, ec, w, scalar_len=0)
                     assert ec.jac_equality(got, expected), (u, v, w)
 
     ec = secp256k1
@@ -245,12 +245,12 @@ def test_double_mult_regular_window() -> None:
     for u, v in ((0, 0), (1, _N - 1), (_N - 1, 1), (_N - 1, _N - 2)):
         expected = _double_mult(u, ec.GJ, v, ec.GJ, ec)
         for scalar_len in (0, _HALF_LEN):
-            got = double_mult_regular_window(u, ec.GJ, v, ec.GJ, ec, 4, scalar_len)
+            got = _double_mult_regular_window(u, ec.GJ, v, ec.GJ, ec, 4, scalar_len)
             assert ec.jac_equality(got, expected), (u, v, scalar_len)
 
     with pytest.raises(BTClibValueError, match="negative first coefficient: "):
-        double_mult_regular_window(-1, ec.GJ, 1, ec.GJ, ec)
+        _double_mult_regular_window(-1, ec.GJ, 1, ec.GJ, ec, w=4, scalar_len=0)
     with pytest.raises(BTClibValueError, match="negative second coefficient: "):
-        double_mult_regular_window(1, ec.GJ, -1, ec.GJ, ec)
+        _double_mult_regular_window(1, ec.GJ, -1, ec.GJ, ec, w=4, scalar_len=0)
     with pytest.raises(BTClibValueError, match="non positive w: "):
-        double_mult_regular_window(1, ec.GJ, 1, ec.GJ, ec, 0)
+        _double_mult_regular_window(1, ec.GJ, 1, ec.GJ, ec, 0, scalar_len=0)

--- a/tests/curves/curve_group_f_test.py
+++ b/tests/curves/curve_group_f_test.py
@@ -7,7 +7,7 @@
 import pytest
 
 from btclib.curves import CurveGroup, find_all_points, find_subgroup_points
-from btclib.curves.curve_group import mult_aff
+from btclib.curves.curve_group import _mult_aff
 from btclib.exceptions import BTClibValueError
 
 
@@ -36,9 +36,9 @@ def test_ecf() -> None:
 
     # Scalar Multiplication
     X = (5323, 5438)
-    assert mult_aff(1337, X, ec) == (1089, 6931)
+    assert _mult_aff(1337, X, ec) == (1089, 6931)
     P = (2339, 2213)
-    S = mult_aff(7863, P, ec)
+    S = _mult_aff(7863, P, ec)
     ec.require_on_curve(S)
     S_exp = (9467, 2742)
     assert S_exp == S

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -5,6 +5,7 @@
 """Tests for the `btclib.curve_group` module."""
 
 import random
+from functools import partial
 
 import pytest
 
@@ -18,25 +19,25 @@ from btclib.curves.curve_group import (
     _MULTI_MULT_W,
     BOS_COSTER_THRESHOLD,
     MAX_W,
+    _cached_multiples,
     _double_mult,
+    _jac_from_aff,
     _mult,
+    _mult_aff,
+    _mult_base_3,
+    _mult_fixed_window,
+    _mult_fixed_window_cached,
+    _mult_jac,
+    _mult_mont_ladder,
+    _mult_recursive_aff,
+    _mult_recursive_jac,
+    _mult_regular_window,
     _multi_mult,
     _multi_mult_bos_coster,
     _multi_mult_w_NAF,
-    cached_multiples,
-    jac_from_aff,
-    mult_aff,
-    mult_base_3,
-    mult_fixed_window,
-    mult_fixed_window_cached,
-    mult_jac,
-    mult_mont_ladder,
-    mult_recursive_aff,
-    mult_recursive_jac,
-    mult_regular_window,
-    multiples,
+    _multiples,
+    _signed_odd_multiples,
     signed_odd_digits,
-    signed_odd_multiples,
 )
 from btclib.ecc import second_generator
 from btclib.exceptions import BTClibValueError
@@ -48,191 +49,191 @@ ec23_31 = low_card_curves["ec23_31"]
 def test_mult_recursive_aff() -> None:
     """Check the recursive affine mult on boundary scalars, every curve."""
     for ec in all_curves.values():
-        assert mult_recursive_aff(0, ec.G, ec) == INF
-        assert mult_recursive_aff(0, INF, ec) == INF
+        assert _mult_recursive_aff(0, ec.G, ec) == INF
+        assert _mult_recursive_aff(0, INF, ec) == INF
 
-        assert mult_recursive_aff(1, INF, ec) == INF
-        assert mult_aff(1, ec.G, ec) == ec.G
+        assert _mult_recursive_aff(1, INF, ec) == INF
+        assert _mult_aff(1, ec.G, ec) == ec.G
 
         Q = ec.add_aff(ec.G, ec.G)
-        assert mult_recursive_aff(2, ec.G, ec) == Q
+        assert _mult_recursive_aff(2, ec.G, ec) == Q
 
-        Q = mult_recursive_aff(ec.n - 1, ec.G, ec)
+        Q = _mult_recursive_aff(ec.n - 1, ec.G, ec)
         assert ec.negate(ec.G) == Q
-        assert mult_recursive_aff(ec.n - 1, INF, ec) == INF
+        assert _mult_recursive_aff(ec.n - 1, INF, ec) == INF
 
         assert ec.add_aff(Q, ec.G) == INF
-        assert mult_recursive_aff(ec.n, ec.G, ec) == INF
-        assert mult_recursive_aff(ec.n, INF, ec) == INF
+        assert _mult_recursive_aff(ec.n, ec.G, ec) == INF
+        assert _mult_recursive_aff(ec.n, INF, ec) == INF
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            mult_recursive_aff(-1, ec.G, ec)
+            _mult_recursive_aff(-1, ec.G, ec)
 
     for ec in low_card_curves.values():
         for q in range(ec.n):
-            Q = mult_recursive_aff(q, ec.G, ec)
+            Q = _mult_recursive_aff(q, ec.G, ec)
             assert ec.is_on_curve(Q), f"{q}, {ec}"
             QJ = _mult(q, ec.GJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(QJ)), f"{q}, {ec}"
             assert ec.aff_from_jac(QJ) == Q, f"{q}, {ec}"
-            assert mult_recursive_aff(q, INF, ec) == INF, f"{q}, {ec}"
+            assert _mult_recursive_aff(q, INF, ec) == INF, f"{q}, {ec}"
             assert ec.jac_equality(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
 
 
 def test_mult_recursive_jac() -> None:
     """Check the recursive Jacobian mult on boundary scalars, every curve."""
     for ec in all_curves.values():
-        assert ec.jac_equality(mult_recursive_jac(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(mult_recursive_jac(0, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac(0, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(mult_recursive_jac(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(mult_recursive_jac(1, ec.GJ, ec), ec.GJ)
+        assert ec.jac_equality(_mult_recursive_jac(1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac(1, ec.GJ, ec), ec.GJ)
 
         PJ = ec.add_jac(ec.GJ, ec.GJ)
-        assert ec.jac_equality(PJ, mult_recursive_jac(2, ec.GJ, ec))
+        assert ec.jac_equality(PJ, _mult_recursive_jac(2, ec.GJ, ec))
 
-        PJ = mult_recursive_jac(ec.n - 1, ec.GJ, ec)
+        PJ = _mult_recursive_jac(ec.n - 1, ec.GJ, ec)
         assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(mult_recursive_jac(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac(ec.n - 1, INFJ, ec), INFJ)
 
         assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(mult_recursive_jac(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(mult_recursive_jac(ec.n, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac(ec.n, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            mult_recursive_jac(-1, ec.GJ, ec)
+            _mult_recursive_jac(-1, ec.GJ, ec)
 
     ec = ec23_31
     for k1 in range(ec.n):
-        K1 = mult_recursive_jac(k1, ec.GJ, ec)
+        K1 = _mult_recursive_jac(k1, ec.GJ, ec)
         assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_mult_aff() -> None:
     """Check the affine double-and-add on boundary scalars, every curve."""
     for ec in all_curves.values():
-        assert mult_aff(0, ec.G, ec) == INF
-        assert mult_aff(0, INF, ec) == INF
+        assert _mult_aff(0, ec.G, ec) == INF
+        assert _mult_aff(0, INF, ec) == INF
 
-        assert mult_aff(1, INF, ec) == INF
-        assert mult_aff(1, ec.G, ec) == ec.G
+        assert _mult_aff(1, INF, ec) == INF
+        assert _mult_aff(1, ec.G, ec) == ec.G
 
         Q = ec.add_aff(ec.G, ec.G)
-        assert mult_aff(2, ec.G, ec) == Q
+        assert _mult_aff(2, ec.G, ec) == Q
 
-        Q = mult_aff(ec.n - 1, ec.G, ec)
+        Q = _mult_aff(ec.n - 1, ec.G, ec)
         assert ec.negate(ec.G) == Q
-        assert mult_aff(ec.n - 1, INF, ec) == INF
+        assert _mult_aff(ec.n - 1, INF, ec) == INF
 
         assert ec.add_aff(Q, ec.G) == INF
-        assert mult_aff(ec.n, ec.G, ec) == INF
-        assert mult_aff(ec.n, INF, ec) == INF
+        assert _mult_aff(ec.n, ec.G, ec) == INF
+        assert _mult_aff(ec.n, INF, ec) == INF
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            mult_aff(-1, ec.G, ec)
+            _mult_aff(-1, ec.G, ec)
 
     for ec in low_card_curves.values():
         for q in range(ec.n):
-            Q = mult_aff(q, ec.G, ec)
+            Q = _mult_aff(q, ec.G, ec)
             assert ec.is_on_curve(Q), f"{q}, {ec}"
             QJ = _mult(q, ec.GJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(QJ)), f"{q}, {ec}"
             assert ec.aff_from_jac(QJ) == Q, f"{q}, {ec}"
-            assert mult_aff(q, INF, ec) == INF, f"{q}, {ec}"
+            assert _mult_aff(q, INF, ec) == INF, f"{q}, {ec}"
             assert ec.jac_equality(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
 
 
 def test_mult_jac() -> None:
     """Check the Jacobian double-and-add on boundary scalars, every curve."""
     for ec in all_curves.values():
-        assert ec.jac_equality(mult_jac(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(mult_jac(0, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac(0, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(mult_jac(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(mult_jac(1, ec.GJ, ec), ec.GJ)
+        assert ec.jac_equality(_mult_jac(1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac(1, ec.GJ, ec), ec.GJ)
 
         PJ = ec.add_jac(ec.GJ, ec.GJ)
-        assert ec.jac_equality(PJ, mult_jac(2, ec.GJ, ec))
+        assert ec.jac_equality(PJ, _mult_jac(2, ec.GJ, ec))
 
-        PJ = mult_jac(ec.n - 1, ec.GJ, ec)
+        PJ = _mult_jac(ec.n - 1, ec.GJ, ec)
         assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(mult_jac(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac(ec.n - 1, INFJ, ec), INFJ)
 
         assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(mult_jac(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(mult_jac(ec.n, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac(ec.n, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            mult_jac(-1, ec.GJ, ec)
+            _mult_jac(-1, ec.GJ, ec)
 
     ec = ec23_31
     for k1 in range(ec.n):
-        K1 = mult_jac(k1, ec.GJ, ec)
+        K1 = _mult_jac(k1, ec.GJ, ec)
         assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_mont_ladder() -> None:
     """Check the Montgomery ladder on boundary scalars and against _mult."""
     for ec in low_card_curves.values():
-        assert ec.jac_equality(mult_mont_ladder(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(mult_mont_ladder(0, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder(0, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(mult_mont_ladder(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(mult_mont_ladder(1, ec.GJ, ec), ec.GJ)
+        assert ec.jac_equality(_mult_mont_ladder(1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder(1, ec.GJ, ec), ec.GJ)
 
-        PJ = mult_mont_ladder(2, ec.GJ, ec)
+        PJ = _mult_mont_ladder(2, ec.GJ, ec)
         assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-        PJ = mult_mont_ladder(ec.n - 1, ec.GJ, ec)
+        PJ = _mult_mont_ladder(ec.n - 1, ec.GJ, ec)
         assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(mult_mont_ladder(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder(ec.n - 1, INFJ, ec), INFJ)
 
         assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(mult_mont_ladder(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(mult_mont_ladder(ec.n, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder(ec.n, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            mult_mont_ladder(-1, ec.GJ, ec)
+            _mult_mont_ladder(-1, ec.GJ, ec)
 
     ec = ec23_31
     for k1 in range(ec.n):
-        K1 = mult_mont_ladder(k1, ec.GJ, ec)
+        K1 = _mult_mont_ladder(k1, ec.GJ, ec)
         assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_mult_base_3() -> None:
     """Check the base-3 mult on boundary scalars and against _mult."""
     for ec in low_card_curves.values():
-        assert ec.jac_equality(mult_base_3(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(mult_base_3(0, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_base_3(0, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_base_3(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(mult_base_3(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(mult_base_3(1, ec.GJ, ec), ec.GJ)
+        assert ec.jac_equality(_mult_base_3(1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_base_3(1, ec.GJ, ec), ec.GJ)
 
-        PJ = mult_base_3(2, ec.GJ, ec)
+        PJ = _mult_base_3(2, ec.GJ, ec)
         assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-        PJ = mult_base_3(ec.n - 1, ec.GJ, ec)
+        PJ = _mult_base_3(ec.n - 1, ec.GJ, ec)
         assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(mult_base_3(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_base_3(ec.n - 1, INFJ, ec), INFJ)
 
         assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(mult_base_3(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(mult_mont_ladder(ec.n, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_base_3(ec.n, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            mult_base_3(-1, ec.GJ, ec)
+            _mult_base_3(-1, ec.GJ, ec)
 
     ec = ec23_31
     for k1 in range(ec.n):
-        K1 = mult_base_3(k1, ec.GJ, ec)
+        K1 = _mult_base_3(k1, ec.GJ, ec)
         assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_cached_multiples() -> None:
     """Verify the cache holds 2**MAX_W multiples of the generator."""
     ec = secp256k1
-    M = cached_multiples(ec.GJ, ec)
+    M = _cached_multiples(ec.GJ, ec)
     assert len(M) == 2**MAX_W
 
 
@@ -240,50 +241,50 @@ def test_multiples() -> None:
     """Check the table of multiples, size by size, against additions."""
     ec = secp256k1
     with pytest.raises(BTClibValueError, match="size too low: "):
-        multiples(ec.GJ, 1, ec)
+        _multiples(ec.GJ, 1, ec)
 
     T = [INFJ, ec.GJ]
-    M = multiples(ec.GJ, 2, ec)
+    M = _multiples(ec.GJ, 2, ec)
     assert len(M) == 2
     assert M == T
 
     T.append(ec.double_jac(ec.GJ))
-    M = multiples(ec.GJ, 3, ec)
+    M = _multiples(ec.GJ, 3, ec)
     assert len(M) == 3
     assert M == T
 
     T.append(ec.add_jac(T[-1], ec.GJ))
-    M = multiples(ec.GJ, 4, ec)
+    M = _multiples(ec.GJ, 4, ec)
     assert len(M) == 4
     assert M == T
 
     T.append(ec.double_jac(T[2]))
-    M = multiples(ec.GJ, 5, ec)
+    M = _multiples(ec.GJ, 5, ec)
     assert len(M) == 5
     assert M == T
 
     T.append(ec.add_jac(T[-1], ec.GJ))
-    M = multiples(ec.GJ, 6, ec)
+    M = _multiples(ec.GJ, 6, ec)
     assert len(M) == 6
     assert M == T
 
     T.append(ec.double_jac(T[3]))
-    M = multiples(ec.GJ, 7, ec)
+    M = _multiples(ec.GJ, 7, ec)
     assert len(M) == 7
     assert M == T
 
     T.append(ec.add_jac(T[-1], ec.GJ))
-    M = multiples(ec.GJ, 8, ec)
+    M = _multiples(ec.GJ, 8, ec)
     assert len(M) == 8
     assert M == T
 
     T.append(ec.double_jac(T[4]))
-    M = multiples(ec.GJ, 9, ec)
+    M = _multiples(ec.GJ, 9, ec)
     assert len(M) == 9
     assert M == T
 
     T.append(ec.add_jac(T[-1], ec.GJ))
-    M = multiples(ec.GJ, 10, ec)
+    M = _multiples(ec.GJ, 10, ec)
     assert len(M) == 10
     assert M == T
 
@@ -292,34 +293,46 @@ def test_mult_fixed_window() -> None:
     """Check the fixed-window mult on boundary scalars, for every width."""
     for w in range(1, MAX_W):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(mult_fixed_window(0, ec.GJ, ec, w), INFJ)
-            assert ec.jac_equality(mult_fixed_window(0, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(
+                _mult_fixed_window(0, ec.GJ, ec, w, cached=False), INFJ
+            )
+            assert ec.jac_equality(
+                _mult_fixed_window(0, INFJ, ec, w, cached=False), INFJ
+            )
 
-            assert ec.jac_equality(mult_fixed_window(1, INFJ, ec, w), INFJ)
-            assert ec.jac_equality(mult_fixed_window(1, ec.GJ, ec, w), ec.GJ)
+            assert ec.jac_equality(
+                _mult_fixed_window(1, INFJ, ec, w, cached=False), INFJ
+            )
+            assert ec.jac_equality(
+                _mult_fixed_window(1, ec.GJ, ec, w, cached=False), ec.GJ
+            )
 
-            PJ = mult_fixed_window(2, ec.GJ, ec, w)
+            PJ = _mult_fixed_window(2, ec.GJ, ec, w, cached=False)
             assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-            PJ = mult_fixed_window(ec.n - 1, ec.GJ, ec, w)
+            PJ = _mult_fixed_window(ec.n - 1, ec.GJ, ec, w, cached=False)
             assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-            assert ec.jac_equality(mult_fixed_window(ec.n - 1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(
+                _mult_fixed_window(ec.n - 1, INFJ, ec, w, cached=False), INFJ
+            )
 
             assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(mult_fixed_window(ec.n, ec.GJ, ec, w), INFJ)
-            assert ec.jac_equality(mult_mont_ladder(ec.n, INFJ, ec), INFJ)
+            assert ec.jac_equality(
+                _mult_fixed_window(ec.n, ec.GJ, ec, w, cached=False), INFJ
+            )
+            assert ec.jac_equality(_mult_mont_ladder(ec.n, INFJ, ec), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
-                mult_fixed_window(-1, ec.GJ, ec, w)
+                _mult_fixed_window(-1, ec.GJ, ec, w, cached=False)
 
             with pytest.raises(BTClibValueError, match="non positive w: "):
-                mult_fixed_window(1, ec.GJ, ec, -w)
+                _mult_fixed_window(1, ec.GJ, ec, -w, cached=False)
 
     ec = ec23_31
     for w in range(1, 10):
         for k1 in range(ec.n):
-            K1 = mult_fixed_window(k1, ec.GJ, ec, w)
-            assert ec.jac_equality(K1, mult_jac(k1, ec.GJ, ec))
+            K1 = _mult_fixed_window(k1, ec.GJ, ec, w, cached=False)
+            assert ec.jac_equality(K1, _mult_jac(k1, ec.GJ, ec))
 
 
 def test_signed_odd_digits() -> None:
@@ -379,10 +392,10 @@ def test_signed_odd_multiples() -> None:
     """The table against the multiplications of the digits that index it."""
     for ec in (ec23_31, secp256k1):
         for w in range(1, 6):
-            T = signed_odd_multiples(ec.GJ, ec, w)
+            T = _signed_odd_multiples(ec.GJ, ec, w)
             assert len(T) == 2**w
             for d in range(-(2**w - 1), 2**w, 2):
-                expected = mult_jac(d % ec.n, ec.GJ, ec)
+                expected = _mult_jac(d % ec.n, ec.GJ, ec)
                 assert ec.jac_equality(T[(d + 2**w - 1) // 2], expected), (d, w)
 
 
@@ -427,10 +440,10 @@ def test_regular_window_addition_count_is_the_same_for_every_scalar() -> None:
     fixed = set()
     for m in scalars:
         ec.additions = 0
-        mult_regular_window(m, secp256k1.GJ, ec)
+        _mult_regular_window(m, secp256k1.GJ, ec, w=4)
         regular.add(ec.additions)
         ec.additions = 0
-        mult_fixed_window(m, secp256k1.GJ, ec)
+        _mult_fixed_window(m, secp256k1.GJ, ec, w=4, cached=False)
         fixed.add(ec.additions)
 
     assert len(regular) == 1, regular
@@ -441,33 +454,33 @@ def test_mult_regular_window() -> None:
     """Check the regular-window mult on boundaries and oversized scalars."""
     for w in range(1, MAX_W):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(mult_regular_window(0, ec.GJ, ec, w), INFJ)
-            assert ec.jac_equality(mult_regular_window(0, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_regular_window(0, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_regular_window(0, INFJ, ec, w), INFJ)
 
-            assert ec.jac_equality(mult_regular_window(1, INFJ, ec, w), INFJ)
-            assert ec.jac_equality(mult_regular_window(1, ec.GJ, ec, w), ec.GJ)
+            assert ec.jac_equality(_mult_regular_window(1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_regular_window(1, ec.GJ, ec, w), ec.GJ)
 
-            PJ = mult_regular_window(2, ec.GJ, ec, w)
+            PJ = _mult_regular_window(2, ec.GJ, ec, w)
             assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-            PJ = mult_regular_window(ec.n - 1, ec.GJ, ec, w)
+            PJ = _mult_regular_window(ec.n - 1, ec.GJ, ec, w)
             assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-            assert ec.jac_equality(mult_regular_window(ec.n - 1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_regular_window(ec.n - 1, INFJ, ec, w), INFJ)
 
             assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(mult_regular_window(ec.n, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_regular_window(ec.n, ec.GJ, ec, w), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
-                mult_regular_window(-1, ec.GJ, ec, w)
+                _mult_regular_window(-1, ec.GJ, ec, w)
 
             with pytest.raises(BTClibValueError, match="non positive w: "):
-                mult_regular_window(1, ec.GJ, ec, -w)
+                _mult_regular_window(1, ec.GJ, ec, -w)
 
     ec = ec23_31
     for w in range(1, 10):
         for k1 in range(ec.n):
-            K1 = mult_regular_window(k1, ec.GJ, ec, w)
-            assert ec.jac_equality(K1, mult_jac(k1, ec.GJ, ec))
+            K1 = _mult_regular_window(k1, ec.GJ, ec, w)
+            assert ec.jac_equality(K1, _mult_jac(k1, ec.GJ, ec))
 
     # a scalar of more bits than the group has, which is the one case where
     # the digit count is the scalar's own again: the answer is still the
@@ -475,7 +488,7 @@ def test_mult_regular_window() -> None:
     ec = secp256k1
     for m in (ec.n, ec.n + 1, 2 * ec.n, 1 << 300):
         assert ec.jac_equality(
-            mult_regular_window(m, ec.GJ, ec), mult_jac(m, ec.GJ, ec)
+            _mult_regular_window(m, ec.GJ, ec, w=4), _mult_jac(m, ec.GJ, ec)
         ), m
 
 
@@ -483,41 +496,45 @@ def test_mult_fixed_window_cached() -> None:
     """Check the cached fixed-window mult on boundary scalars and widths."""
     for _ in range(1, MAX_W):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(mult_fixed_window_cached(0, ec.GJ, ec), INFJ)
-            assert ec.jac_equality(mult_fixed_window_cached(0, INFJ, ec), INFJ)
+            assert ec.jac_equality(_mult_fixed_window_cached(0, ec.GJ, ec, w=4), INFJ)
+            assert ec.jac_equality(_mult_fixed_window_cached(0, INFJ, ec, w=4), INFJ)
 
-            assert ec.jac_equality(mult_fixed_window_cached(1, INFJ, ec), INFJ)
-            assert ec.jac_equality(mult_fixed_window_cached(1, ec.GJ, ec), ec.GJ)
+            assert ec.jac_equality(_mult_fixed_window_cached(1, INFJ, ec, w=4), INFJ)
+            assert ec.jac_equality(_mult_fixed_window_cached(1, ec.GJ, ec, w=4), ec.GJ)
 
-            PJ = mult_fixed_window_cached(2, ec.GJ, ec)
+            PJ = _mult_fixed_window_cached(2, ec.GJ, ec, w=4)
             assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-            PJ = mult_fixed_window_cached(ec.n - 1, ec.GJ, ec)
+            PJ = _mult_fixed_window_cached(ec.n - 1, ec.GJ, ec, w=4)
             assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-            assert ec.jac_equality(mult_fixed_window_cached(ec.n - 1, INFJ, ec), INFJ)
+            assert ec.jac_equality(
+                _mult_fixed_window_cached(ec.n - 1, INFJ, ec, w=4), INFJ
+            )
 
             assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(mult_fixed_window_cached(ec.n, ec.GJ, ec), INFJ)
-            assert ec.jac_equality(mult_mont_ladder(ec.n, INFJ, ec), INFJ)
+            assert ec.jac_equality(
+                _mult_fixed_window_cached(ec.n, ec.GJ, ec, w=4), INFJ
+            )
+            assert ec.jac_equality(_mult_mont_ladder(ec.n, INFJ, ec), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
-                mult_fixed_window_cached(-1, ec.GJ, ec)
+                _mult_fixed_window_cached(-1, ec.GJ, ec, w=4)
 
             with pytest.raises(BTClibValueError, match="non positive w: "):
-                mult_fixed_window_cached(1, ec.GJ, ec, -1)
+                _mult_fixed_window_cached(1, ec.GJ, ec, -1)
 
     ec = ec23_31
     for w in range(1, 10):
         for k1 in range(ec.n):
-            K1 = mult_fixed_window_cached(k1, ec.GJ, ec, w)
-            assert ec.jac_equality(K1, mult_jac(k1, ec.GJ, ec))
+            K1 = _mult_fixed_window_cached(k1, ec.GJ, ec, w)
+            assert ec.jac_equality(K1, _mult_jac(k1, ec.GJ, ec))
 
 
 def test_assorted_jac_mult() -> None:
     """Check the double and multi mults exhaustively against sums of mults."""
     ec = ec23_31
     H = second_generator(ec)
-    HJ = jac_from_aff(H)
+    HJ = _jac_from_aff(H)
     for k1 in range(ec.n):
         K1J = _mult(k1, ec.GJ, ec)
         for k2 in range(ec.n):
@@ -582,32 +599,35 @@ def test_mult_on_a_characteristic_7_curve() -> None:
 
     INFJ is (7, 0, 0), so p == 7 is where that arbitrary x reduces to
     zero and add_jac's doubling test can mistake the identity for the
-    other operand (issue 171). Before it was fixed, mult_jac answered
-    wrong for 6 of the 13 scalars here, the ladder and mult_recursive_jac
+    other operand (issue 171). Before it was fixed, _mult_jac answered
+    wrong for 6 of the 13 scalars here, the ladder and _mult_recursive_jac
     for 12 of 13, and _double_mult for 100 of the 169 coefficient pairs;
     the two fixed windows happened not to, every scalar of a curve this
     small fitting in one base-16 digit -- which is why the reference here
-    is mult_aff, the one multiplication that forms no Jacobian point at
+    is _mult_aff, the one multiplication that forms no Jacobian point at
     all.
     """
     ec = Curve(7, 0, 3, (1, 2), 13, 1, False)
+    # named pairs rather than the functions alone: three of them take a
+    # window width, which carries no default now, and a partial has no
+    # __name__ for the assertion to report
     variants = (
-        _mult,
-        mult_jac,
-        mult_recursive_jac,
-        mult_mont_ladder,
-        mult_base_3,
-        mult_fixed_window,
-        mult_fixed_window_cached,
-        mult_regular_window,
+        ("_mult", _mult),
+        ("_mult_jac", _mult_jac),
+        ("_mult_recursive_jac", _mult_recursive_jac),
+        ("_mult_mont_ladder", _mult_mont_ladder),
+        ("_mult_base_3", _mult_base_3),
+        ("_mult_fixed_window", partial(_mult_fixed_window, w=4, cached=False)),
+        ("_mult_fixed_window_cached", partial(_mult_fixed_window_cached, w=4)),
+        ("_mult_regular_window", partial(_mult_regular_window, w=4)),
     )
     for k in range(ec.n):
-        expected = mult_aff(k, ec.G, ec)
-        for mult_f in variants:
-            assert ec.aff_from_jac(mult_f(k, ec.GJ, ec)) == expected, mult_f.__name__
+        expected = _mult_aff(k, ec.G, ec)
+        for name, mult_f in variants:
+            assert ec.aff_from_jac(mult_f(k, ec.GJ, ec)) == expected, name
         for j in range(ec.n):
             shamir = _double_mult(k, ec.GJ, j, ec.GJ, ec)
-            assert ec.aff_from_jac(shamir) == mult_aff(k + j, ec.G, ec), (k, j)
+            assert ec.aff_from_jac(shamir) == _mult_aff(k + j, ec.G, ec), (k, j)
 
 
 def _sum_of_mults(
@@ -636,7 +656,7 @@ def test_multi_mult_w_NAF() -> None:
     does.
     """
     for ec in (low_card_curves["ec13_11"], ec23_31):
-        HJ = jac_from_aff(second_generator(ec))
+        HJ = _jac_from_aff(second_generator(ec))
         # MAX_W by name rather than the 5 it is today: it is the widest
         # window the dispatch ever asks for, and a test that stops one
         # short of the tuning constant stops covering it the moment the
@@ -688,7 +708,7 @@ def test_multi_mult_agrees_across_curves() -> None:
     """
     rnd = random.Random(0x2AC0FFEE)
     for ec in all_curves.values():
-        HJ = jac_from_aff(second_generator(ec))
+        HJ = _jac_from_aff(second_generator(ec))
         points = [ec.GJ, HJ, _mult(3, ec.GJ, ec)]
         scalars = [rnd.randrange(ec.n) for _ in points]
         expected = _sum_of_mults(scalars, points, ec)
@@ -710,7 +730,7 @@ def test_multi_mult_dispatch() -> None:
     would still pass, testing the other branch twice.
     """
     ec = ec23_31
-    HJ = jac_from_aff(second_generator(ec))
+    HJ = _jac_from_aff(second_generator(ec))
     rnd = random.Random(0x175212)
     for size in (BOS_COSTER_THRESHOLD - 1, BOS_COSTER_THRESHOLD):
         points = [ec.GJ if i % 2 else HJ for i in range(size)]
@@ -761,7 +781,7 @@ def test_multi_mult_distant_magnitudes() -> None:
     finish on the third, and this test would say so by not returning.
     """
     ec = secp256k1
-    HJ = jac_from_aff(second_generator(ec))
+    HJ = _jac_from_aff(second_generator(ec))
     for scalars in ([10**6, 1], [1, 10**6], [ec.n - 1, 1], [ec.n - 1, ec.n - 2]):
         expected = _sum_of_mults(scalars, [ec.GJ, HJ], ec)
         assert ec.jac_equality(_multi_mult(scalars, [ec.GJ, HJ], ec), expected)
@@ -773,13 +793,13 @@ def test_multi_mult_distant_magnitudes() -> None:
 def test_jac_equality() -> None:
     """Check jac_equality on equal representations and on unequal points."""
     ec = ec23_31
-    assert ec.jac_equality(ec.GJ, jac_from_aff(ec.G))
+    assert ec.jac_equality(ec.GJ, _jac_from_aff(ec.G))
 
     # q in [2, n-1], as the difference with ec.GJ is checked below
     q = 2
-    Q = mult_aff(q, ec.G, ec)
+    Q = _mult_aff(q, ec.G, ec)
     QJ = _mult(q, ec.GJ, ec)
-    assert ec.jac_equality(QJ, jac_from_aff(Q))
+    assert ec.jac_equality(QJ, _jac_from_aff(Q))
     assert not ec.jac_equality(QJ, ec.negate_jac(QJ))
     assert not ec.jac_equality(QJ, ec.GJ)
 

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -43,10 +43,10 @@ from btclib.curves.curve import (
     _y_even,
 )
 
-# cached_multiples and jac_from_aff are implementation helpers of
+# _cached_multiples and _jac_from_aff are implementation helpers of
 # curve_group, not part of what btclib.curves exports: they are taken from the
 # module that defines them
-from btclib.curves.curve_group import cached_multiples, jac_from_aff, mult_jac
+from btclib.curves.curve_group import _cached_multiples, _jac_from_aff, _mult_jac
 from btclib.ecc import second_generator
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.number_theory import mod_inv, mod_sqrt
@@ -231,7 +231,7 @@ def test_curves_with_n_above_p() -> None:
         ec = low_card_curves[name]
         # every point of the curve, x below n, so nothing to reduce
         for q in range(1, ec.n):
-            x_K = ec.x_aff_from_jac(mult_jac(q, ec.GJ, ec))
+            x_K = ec.x_aff_from_jac(_mult_jac(q, ec.GJ, ec))
             assert x_K < ec.n
             assert x_K % ec.n == x_K
 
@@ -302,14 +302,14 @@ def test_aff_jac_conversions() -> None:
     for ec in all_curves.values():
         # just a point, not INF
         Q = ec.G
-        QJ = jac_from_aff(Q)
+        QJ = _jac_from_aff(Q)
         assert ec.aff_from_jac(QJ) == Q
         x_Q = ec.x_aff_from_jac(QJ)
         assert Q[0] == x_Q
         y_Q = ec.y_aff_from_jac(QJ)
         assert Q[1] == y_Q
 
-        assert ec.aff_from_jac(jac_from_aff(INF)) == INF
+        assert ec.aff_from_jac(_jac_from_aff(INF)) == INF
 
         with pytest.raises(BTClibValueError, match="INF has no x-coordinate"):
             ec.x_aff_from_jac(INFJ)
@@ -367,7 +367,7 @@ def test_add_double_aff_jac() -> None:
     for ec in all_curves.values():
         # just a point, not INF
         Q = ec.G
-        QJ = jac_from_aff(Q)
+        QJ = _jac_from_aff(Q)
 
         # add Q and G
         R = ec.add_aff(Q, ec.G)
@@ -410,12 +410,12 @@ def _jac_spellings(ec: CurveGroup, P: Point | None) -> list[JacPoint]:
     (x*z^2, y*z^3, z) is the same affine point for every z != 0, and
     add_jac compares coordinates that only a common frame makes
     comparable, so one frame would not exercise the comparison. Infinity
-    is any Z == 0 triple: the INFJ constant, what `jac_from_aff` turns
+    is any Z == 0 triple: the INFJ constant, what `_jac_from_aff` turns
     the affine INF into, and the all-zero triple that `jac_equality`
     reads as equal to everything.
     """
     if P is None:
-        return [INFJ, jac_from_aff(INF), (0, 0, 0)]
+        return [INFJ, _jac_from_aff(INF), (0, 0, 0)]
     return [(P[0] * z * z % ec.p, P[1] * z**3 % ec.p, z) for z in (1, 2)]
 
 
@@ -462,7 +462,7 @@ def test_add_jac_infinity_is_not_a_doubling() -> None:
 
     add_jac's doubling test compares affine coordinates, and Z == 0
     leaves X and Y free to be anything at all: INFJ is (7, 0, 0) and
-    `jac_from_aff(INF)` is (5, 0, 0), those x-coordinates picked for
+    `_jac_from_aff(INF)` is (5, 0, 0), those x-coordinates picked for
     being invalid rather than for being zero. On a curve of
     characteristic 7 or 5 they reduce to zero, the test reads "same x,
     same y" and doubles -- issue 171, where P + INFJ answered 2*P. The
@@ -473,7 +473,7 @@ def test_add_jac_infinity_is_not_a_doubling() -> None:
         Curve(5, 2, 1, (0, 1), 7, 1, False),
         secp256k1,
     ):
-        for infinity in (INFJ, jac_from_aff(INF), (0, 0, 0)):
+        for infinity in (INFJ, _jac_from_aff(INF), (0, 0, 0)):
             assert ec.aff_from_jac(ec.add_jac(ec.GJ, infinity)) == ec.G
             assert ec.aff_from_jac(ec.add_jac(infinity, ec.GJ)) == ec.G
             assert ec.add_jac(infinity, infinity)[2] == 0
@@ -678,7 +678,7 @@ def test_curve_equality() -> None:
     assert mult(3, None, secp256k1_bis) == mult(3)
 
     # equal curves are equal lru_cache keys, so they share the entries
-    assert cached_multiples(secp256k1.GJ, secp256k1_bis) is cached_multiples(
+    assert _cached_multiples(secp256k1.GJ, secp256k1_bis) is _cached_multiples(
         secp256k1.GJ, secp256k1
     )
 
@@ -779,7 +779,7 @@ def test_negate() -> None:
         assert ec.add(Q, minus_Q) == INF
 
         # Jacobian coordinates
-        QJ = jac_from_aff(Q)
+        QJ = _jac_from_aff(Q)
         minus_QJ = ec.negate_jac(QJ)
         assert ec.jac_equality(ec.add_jac(QJ, minus_QJ), INFJ)
 

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -1348,7 +1348,7 @@ def test_verify_with_another_hash_function_on_both_arithmetics(
     The two must not disagree, about a valid signature or an invalid one,
     and least of all about the infinity point: a libsecp256k1 pubkey is
     never the identity, so the K that is INF is answered on this side of
-    the boundary -- from the z == 0 of `jac_from_aff`, in the same line
+    the boundary -- from the z == 0 of `_jac_from_aff`, in the same line
     that answered it before.
     """
     msg = b"a message to sign"

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -16,7 +16,7 @@ from btclib.alias import INF, Point, String
 from btclib.bip32 import BIP32KeyData
 from btclib.curves import bytes_from_point, curve_group, double_mult, mult, secp256k1
 from btclib.curves.curve import CURVES, Curve
-from btclib.curves.curve_group import jac_from_aff
+from btclib.curves.curve_group import _jac_from_aff
 from btclib.ecc import second_generator, ssa
 from btclib.ecc.bip340_nonce import bip340_nonce_
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
@@ -317,7 +317,7 @@ def test_low_cardinality() -> None:
     for ec in test_curves:
         for q in range(1, ec.n // 2):  # all possible private keys
             q_fixed, x_Q = ssa.gen_keys(q, ec)
-            QJ = jac_from_aff((x_Q, ec.y_even(x_Q)))
+            QJ = _jac_from_aff((x_Q, ec.y_even(x_Q)))
             sig: ssa.Sig | None = None
             while sig is None:
                 try:
@@ -371,7 +371,7 @@ def test_assert_as_valid_rejects_the_odd_y_twin_of_a_correct_k() -> None:
     """
     ec = secp256k1
     q, x_Q = ssa.gen_keys()
-    QJ = jac_from_aff((x_Q, ec.y_even(x_Q)))
+    QJ = _jac_from_aff((x_Q, ec.y_even(x_Q)))
     k, r = ssa.gen_keys()  # k's point has even y, by gen_keys' own normalization
     e = 5
 


### PR DESCRIPTION
The eighteen multiplications of curve_group and the six of curve_group_2
take a point they assume to be on the curve and check nothing, so a
malformed one is answered with a point rather than refused: the one shape
of missing validation that produces a wrong answer instead of an
exception. Each carries a leading underscore now, and curve_group_2's
__all__ is empty as a result, which is the answer for a module with
nothing public of its own.

Validating inside each was the alternative and is the wrong fix: they
exist to be measured against each other, so a check in each would be
measured with the arithmetic. mult, double_mult and multi_mult already
call require_on_curve on every point on every path, libsecp256k1 dispatch
included, and btclib.curves already declined to export the variants; the
underscore finishes that decision in the one place a caller could still
reach them, and states it in the name rather than in a paragraph. What
stays open is named rather than claimed shut: the private name is still
importable, so the wrong-answer path is narrower and not closed.

Nine of them carried a default -- w=4 on seven, with cached=False,
scalar_len=0 and regular=True beside it -- which a private signature may
not, so each call site states the width it used to inherit.
curve_group._mult is a function rather than an alias of
_mult_regular_window for that reason, carrying _MULT_W; curve.py gains
_ENDOMORPHISM_W and _DOUBLE_MULT_W, two constants and not one because
they are two algorithms, a window of the endomorphism's half-length
scalars not being a window of an interleaved wNAF's full-length ones.
Each sits next to the caller that chose it, as _MULTI_MULT_W does. The
two docstrings that justified w=4 as "the default" say w=4, there being
no default to name.

CurveGroup's six group-law methods have the same gap and are not part of
this: aff_from_jac, jac_equality, add_jac, double_jac, add_aff and
double_aff are methods on a public class rather than names in an __all__,
and ecc/dsa.py calls two of them across the curves -> ecc boundary, which
makes them a decision of their own. signed_odd_digits stays public,
validating m, w and size in full.

Gates, all green locally: `uv run pytest` at 25971 passed with coverage
100.00%, `uv run pre-commit run --all-files`, and the sphinx -W build.

Closes https://github.com/btclib-org/btclib/issues/728

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make curve point multiplication variants private implementation details while keeping the public mult/double_mult/multi_mult APIs unchanged and validated.

Enhancements:
- Add leading underscores and remove exports for internal point arithmetic helpers in curve_group and curve_group_2, including making curve_group_2 export nothing via __all__.
- Introduce explicit window-width constants used by mult and double_mult, removing default parameters from private multiplication helpers and requiring callers to pass widths explicitly.
- Refine CurveGroup equality and caching behavior comments to reflect use with the now-private cached multiples helpers.

Documentation:
- Document the privatization of individual point multiplication variants and the expectation to use mult/double_mult/multi_mult in CHANGELOG and HISTORY, including rationale around validation and API design.

Tests:
- Update curve, curve_group, curve_group_2, ECC, and SSA/DSA tests to import and exercise the newly-private helper names, passing explicit window widths where needed and confirming the public API surface remains limited to the intended curve operations.
- Adjust all_test and curve_test to assert the curated btclib.curves __all__ and to rely on private helper imports for implementation-level checks.