### PR TITLE
Run the HWI integration tests against a Trezor emulator

### DIFF
--- a/.github/actions/install-bitcoind/action.yml
+++ b/.github/actions/install-bitcoind/action.yml
@@ -1,0 +1,76 @@
+---
+# The two jobs of integration.yml both need a node, and a checksum
+# duplicated is a checksum that drifts: the one that is raised is the one
+# somebody was reading, and the other stays on the release before it
+# while its job keeps reporting green. A composite action is the only
+# thing GitHub Actions offers to say this once -- there are no yaml
+# anchors across jobs -- so the download, the verification and the
+# unpacking live here and the version is an input.
+#
+# Referenced by path (`uses: ./.github/actions/install-bitcoind`) and not
+# by commit SHA, which is the rule for every third-party action: this one
+# is the repository's own file, read from the same commit as the workflow
+# that calls it, so there is no owner who could move it.
+name: Install bitcoind
+description: >-
+  Download a pinned Bitcoin Core release, check its published sha256 and
+  answer with the path of the daemon.
+
+inputs:
+  version:
+    description: 'The release to download, "31.1" rather than "v31.1"'
+    required: true
+  sha256:
+    description: The sha256 of that release's x86_64 linux tarball
+    required: true
+
+# an output rather than a line appended to GITHUB_ENV, which is what a
+# job would write for itself: an action is called with values it does not
+# choose, and a file that becomes the environment of every later step is
+# the one place where a crafted input would be more than a failed
+# download -- zizmor's github-env audit is about exactly that. The caller
+# names the path where it needs it
+outputs:
+  path:
+    description: The path of the bitcoind this installed
+    value: ${{ steps.install.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    # the release tarball rather than a package or a third-party action:
+    # ubuntu's archive carries no bitcoind, and an action would be a
+    # fourth party between this job and a binary whose checksum is
+    # published and attested. --fail so an html error page is not
+    # unpacked as a tarball, and the checksum before the unpacking, not
+    # after
+    - name: Install bitcoind
+      id: install
+      shell: bash
+      # through the environment rather than interpolated into the script:
+      # an input is caller-controlled text, and `${{ }}` in a run body is
+      # pasted in before bash reads a line of it
+      env:
+        BITCOIND_VERSION: ${{ inputs.version }}
+        BITCOIND_SHA256: ${{ inputs.sha256 }}
+      run: |
+        base="https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION"
+        tarball="bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz"
+        # --proto/--proto-redir: --location follows redirects, and a
+        # redirect to http:// would be followed too. The checksum below
+        # protects the integrity either way, so this is not a hole it
+        # closes -- it is the download refusing to leave https at all
+        curl --proto '=https' --proto-redir '=https' \
+          --fail --silent --show-error --location --retry 3 \
+          --output "$tarball" "$base/$tarball"
+        echo "$BITCOIND_SHA256  $tarball" | sha256sum --check --strict
+        # the daemon alone: the tarball carries the cli, the wallet tool
+        # and the gui's libraries, and the tests speak rpc
+        tar -xzf "$tarball" "bitcoin-$BITCOIND_VERSION/bin/bitcoind"
+        daemon="$PWD/bitcoin-$BITCOIND_VERSION/bin/bitcoind"
+        echo "path=$daemon" >> "$GITHUB_OUTPUT"
+        # what answered, in the log of the run that used it: a green run
+        # whose node version is only in a workflow file is one nobody can
+        # date, and the version string carries the build the sha256
+        # pinned
+        "$daemon" -version | head -n 1

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,12 +16,16 @@ name: integration
 # must not -- that rule lives outside the repository and names its checks
 # as literal strings.
 #
-# The HWI half of `tests/integration/` does not run here and skips with
-# its reason: it needs a device to press a button on, or an emulator to
-# stand in for one, which is a service to pin and keep working rather
-# than a tarball to download. Issue #529 is where that is decided; what
-# runs against the actual HWI command line meanwhile is tests/hwi_test.py,
-# whose stand-in device is a subprocess answering HWI's own json.
+# The HWI half of `tests/integration/` is the second job, and it needs a
+# device: a pinned Trezor emulator stands in for one, with a pinned HWI
+# in an interpreter of its own. That job is not on a pull request, which
+# is the whole difference between the two -- it can go red on a firmware
+# release, on data.trezor.io, or on an emulator that stopped starting
+# headless, so it is asked on the schedule and on demand, where the run
+# is read by somebody who wanted the answer, rather than in front of a
+# review that has nothing to do with it. What checks the HWI command line
+# on every commit stays tests/hwi_test.py, whose stand-in device is a
+# subprocess answering HWI's own json.
 
 on:
   schedule:
@@ -68,9 +72,22 @@ on:
     # which is what 36 seconds of work buys
 
 # least privilege for the GITHUB_TOKEN: nothing here writes, and the
-# tarball is fetched from bitcoincore.org, which does not know this token
+# tarballs are fetched from bitcoincore.org and data.trezor.io, neither of
+# which knows this token
 permissions:
   contents: read
+
+# the node both jobs run, here rather than in either of them: the release
+# under test, and the sha256 of its linux tarball as four independent
+# guix builders attested it in bitcoin-core/guix.sigs. Pinned rather than
+# resolved to "latest": a run that installs whatever is newest reports
+# the day Core released rather than the day btclib changed, and the
+# version that answered is then unknowable from a green run. Raising it
+# is a commit, with the new sha read from the same place
+env:
+  BITCOIND_VERSION: "31.1"
+  BITCOIND_SHA256: >-
+    b80d9c3e04da78fb6f0569685673418cf686fadba9042d926d13fb87ff503f9e
 
 # cancel superseded runs. Named literally rather than through
 # github.workflow, as everywhere else here: in a called workflow that
@@ -95,17 +112,6 @@ jobs:
     # -- so this bounds the download and the failure cases rather than
     # the work
     timeout-minutes: 20
-    env:
-      # the release under test, and the sha256 of its linux tarball as
-      # four independent guix builders attested it in
-      # bitcoin-core/guix.sigs. Pinned rather than resolved to "latest":
-      # a run that installs whatever is newest reports the day Core
-      # released rather than the day btclib changed, and the version that
-      # answered is then unknowable from a green run. Raising it is a
-      # commit, with the new sha read from the same place
-      BITCOIND_VERSION: "31.1"
-      BITCOIND_SHA256: >-
-        b80d9c3e04da78fb6f0569685673418cf686fadba9042d926d13fb87ff503f9e
     steps:
       # every action is pinned to a commit SHA, the tag in the comment: a
       # tag, let alone a branch, is a name its owner can move
@@ -120,41 +126,22 @@ jobs:
           # the wheels uv.lock pins do not change between runs, so the
           # cache is the difference between a download and a copy
           enable-cache: true
-      # the release tarball rather than a package or a third-party action:
-      # ubuntu's archive carries no bitcoind, and an action would be a
-      # fourth party between this job and a binary whose checksum is
-      # published and attested. --fail so an html error page is not
-      # unpacked as a tarball, and the checksum before the unpacking, not
-      # after
+      # the repository's own composite action, which the emulator job
+      # calls with the same two values: the reasoning for the download is
+      # in the file
       - name: Install bitcoind
-        run: |
-          base="https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION"
-          tarball="bitcoin-$BITCOIND_VERSION-x86_64-linux-gnu.tar.gz"
-          # --proto/--proto-redir: --location follows redirects, and a
-          # redirect to http:// would be followed too. The checksum below
-          # protects the integrity either way, so this is not a hole it
-          # closes -- it is the download refusing to leave https at all
-          curl --proto '=https' --proto-redir '=https' \
-            --fail --silent --show-error --location --retry 3 \
-            --output "$tarball" "$base/$tarball"
-          echo "$BITCOIND_SHA256  $tarball" | sha256sum --check --strict
-          # the daemon alone: the tarball carries the cli, the wallet tool
-          # and the gui's libraries, and the tests speak rpc
-          tar -xzf "$tarball" "bitcoin-$BITCOIND_VERSION/bin/bitcoind"
-          echo "BTCLIB_BITCOIND=$PWD/bitcoin-$BITCOIND_VERSION/bin/bitcoind" \
-            >> "$GITHUB_ENV"
-      # what answered, in the log of the run that used it: a green run
-      # whose node version is only in this file is one nobody can date,
-      # and the version string carries the build the sha256 above pinned
-      - name: Record the node version
-        run: |
-          "$BTCLIB_BITCOIND" -version | head -n 1
+        id: bitcoind
+        uses: ./.github/actions/install-bitcoind
+        with:
+          version: ${{ env.BITCOIND_VERSION }}
+          sha256: ${{ env.BITCOIND_SHA256 }}
       # the same command tests/README.md documents, with the binary named
       # rather than found on PATH. The junit report is for the step below,
       # the run itself being read from the log
       - name: Run the integration tests
         env:
           BTCLIB_INTEGRATION: "1"
+          BTCLIB_BITCOIND: ${{ steps.bitcoind.outputs.path }}
         run: |
           uv run --locked --no-default-groups --group test \
             pytest tests/integration --junitxml=integration.xml
@@ -195,4 +182,245 @@ jobs:
           if-no-files-found: error
           # long enough to compare a run with the one before it, short
           # enough that a weekly job does not accumulate a year of xml
+          retention-days: 90
+
+  hwi-emulator:
+    name: HWI against a Trezor emulator
+    # not on a pull request, where the job above runs and is required:
+    # this one drives a device somebody else builds, publishes and
+    # releases, so a red run is more often trezor's day than the branch's
+    # -- and it is exactly the shape of check that gets ignored when it
+    # sits next to a review. The schedule asks it weekly with the node,
+    # the push to main asks it of the commit a merge created, and the
+    # dispatch button is how a branch touching btclib/hwi.py gets the
+    # answer before it lands: `gh workflow run integration.yml --ref
+    # <branch>` runs that branch's copy of this file
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-latest
+    # the tests are seconds; the emulator, HWI and the node are a few
+    # minutes of downloading and installing, and this bounds the failure
+    # cases -- an emulator that starts and never answers is the one that
+    # would otherwise hold a runner
+    timeout-minutes: 30
+    env:
+      # the emulator, and the sha256 of the binary trezor publishes.
+      # T2T1 is the Trezor Model T, whose emulator HWI's own test suite
+      # runs, and the version is a released firmware rather than a build
+      # of a branch: `common/releases.json` in trezor/trezor-firmware is
+      # what says which versions exist per model, and the binary of each
+      # is under emulators-new/<model>/ at the url below.
+      #
+      # 2.9.4 rather than the newest: from 2.12.2 the emulator links
+      # SDL3, which ubuntu's archive does not carry yet, and HWI's own
+      # CI builds core/v2.9.6 -- so this is the newest released firmware
+      # that is both installable here and inside the range upstream
+      # tests. Raising it is a commit, with the new sha read from the
+      # same url
+      TREZOR_MODEL: T2T1
+      TREZOR_VERSION: "2.9.4"
+      TREZOR_SHA256: >-
+        a286b20cd33f2fbff30cc46f16c756a25e7cbeaeab9714913746d6826b923c08
+      # the seed the emulator is loaded with: HWI's test suite uses it,
+      # trezor's device tests before it, and it is published in both. An
+      # emulator has no secure element and no owner, so this is a test
+      # fixture and not a key -- what it must never be is a mnemonic
+      # anybody generated for use
+      TREZOR_MNEMONIC: >-
+        alcohol woman abuse must during monitor noble actual mixed trade
+        anger aisle
+      # HWI declares ^3.9,<3.13 and is run as a program rather than
+      # imported (btclib/hwi.py says why, and issue #469 why there is no
+      # extra), so it gets an interpreter of its own here: uv fetches
+      # 3.12, and nothing about the environment the tests run in changes
+      HWI_VERSION: "3.2.0"
+      HWI_PYTHON: "3.12"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # see the checkout of the test-py job in test.yml
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+      # the signing test spends a regtest coin, so this job needs the
+      # node the one above needs, from the same pin
+      - name: Install bitcoind
+        id: bitcoind
+        uses: ./.github/actions/install-bitcoind
+        with:
+          version: ${{ env.BITCOIND_VERSION }}
+          sha256: ${{ env.BITCOIND_SHA256 }}
+      # what the emulator is linked against, and patchelf to make it
+      # runnable at all: the published binary is built under nix, so its
+      # interpreter and its RUNPATH name /nix/store paths that exist on
+      # no ubuntu. libjpeg62 is the soname SDL2_image was built against
+      # and is not the libjpeg ubuntu installs by default; libusb is
+      # HWI's, which loads it by name at import for the transports this
+      # job does not use
+      - name: Install what the emulator needs
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            libjpeg62 libsdl2-2.0-0 libsdl2-image-2.0-0 libusb-1.0-0 \
+            patchelf
+      # the same shape as the node's download: pinned version, published
+      # checksum, https that cannot be redirected off https
+      - name: Install the Trezor emulator
+        run: |
+          base="https://data.trezor.io/dev/firmware/releases/emulators-new"
+          name="trezor-emu-core-$TREZOR_MODEL-v$TREZOR_VERSION"
+          curl --proto '=https' --proto-redir '=https' \
+            --fail --silent --show-error --location --retry 3 \
+            --output trezor-emulator "$base/$TREZOR_MODEL/$name"
+          echo "$TREZOR_SHA256  trezor-emulator" | sha256sum --check --strict
+          chmod +x trezor-emulator
+          # the loader ubuntu has, and no RUNPATH, so the libraries
+          # installed above are the ones found
+          patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 \
+            --remove-rpath trezor-emulator
+      # in an environment of its own, and named by path: BTCLIB_HWI is
+      # split on spaces, which is how the flags of a command reach it,
+      # and --emulators is what makes HWI look at 127.0.0.1:21324 at all.
+      # btclib passes that flag to `enumerate` itself, and to nothing
+      # else -- every other command is selected by fingerprint -- so it
+      # belongs here rather than in the test
+      - name: Install HWI
+        run: |
+          uv venv --python "$HWI_PYTHON" hwi-env
+          uv pip install --python hwi-env/bin/python "hwi==$HWI_VERSION"
+          echo "BTCLIB_HWI=$PWD/hwi-env/bin/hwi --emulators" >> "$GITHUB_ENV"
+          hwi-env/bin/hwi --version
+      # the emulator, then the seed, and both versions in the log: what a
+      # green run is evidence about is a firmware and an HWI, and neither
+      # is readable from this file six months later.
+      #
+      # The seed goes in over DebugLink, which is also how the button
+      # gets pressed: HWI opens a udp path with TrezorClientDebugLink
+      # rather than the ordinary client, and that one answers a
+      # ButtonRequest itself. That is what BTCLIB_HWI_SIGN guards
+      # against, and why it can be set here -- there is no screen and
+      # nobody in front of it.
+      #
+      # trezorlib comes from HWI's own vendored copy rather than from
+      # PyPI: it is the library that will talk to this emulator half a
+      # second later, so a protocol it accepts is one HWI accepts
+      - name: Start the emulator and load its seed
+        run: |
+          mkdir -p emulator-profile
+          TREZOR_PROFILE_DIR="$PWD/emulator-profile" SDL_VIDEODRIVER=dummy \
+            ./trezor-emulator > emulator.log 2>&1 &
+          echo "EMULATOR_PID=$!" >> "$GITHUB_ENV"
+          hwi-env/bin/python - <<'PY'
+          import os
+          import socket
+          import sys
+          import time
+
+          from hwilib.devices.trezorlib.debuglink import (
+              TrezorClientDebugLink,
+              load_device_by_mnemonic,
+          )
+          from hwilib.devices.trezorlib.transport.udp import UdpTransport
+
+          # the ping the firmware's own wait_for_emulator.py sends, and
+          # the answer that says the udp transport is up
+          deadline = time.monotonic() + 60
+          sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+          sock.connect(("127.0.0.1", 21324))
+          sock.settimeout(0.5)
+          while True:
+              try:
+                  sock.send(b"PINGPING")
+                  if sock.recv(8) == b"PONGPONG":
+                      break
+              # every failure before it is listening is the same one:
+              # nothing is bound to the port yet, so the datagram is
+              # refused or the answer times out
+              except OSError:
+                  pass
+              if time.monotonic() > deadline:
+                  sys.exit("::error::the emulator did not answer in 60 s")
+              time.sleep(0.1)
+
+          client = TrezorClientDebugLink(UdpTransport.enumerate()[0])
+          client.init_device()
+          features = client.features
+          version = ".".join(
+              str(part)
+              for part in (
+                  features.major_version,
+                  features.minor_version,
+                  features.patch_version,
+              )
+          )
+          revision = features.revision.hex() if features.revision else "none"
+          print(f"{features.model} firmware {version}, revision {revision}")
+          load_device_by_mnemonic(
+              client=client,
+              mnemonic=os.environ["TREZOR_MNEMONIC"],
+              pin="",
+              passphrase_protection=False,
+              label="btclib",
+          )
+          PY
+      # the module tests/README.md documents, with both switches set and
+      # the node from the step above. Only that module: the regtest tests
+      # beside it are the other job's, and running them again here would
+      # report a Core failure twice
+      - name: Run the HWI integration tests
+        env:
+          BTCLIB_INTEGRATION: "1"
+          BTCLIB_HWI_SIGN: "1"
+          BTCLIB_BITCOIND: ${{ steps.bitcoind.outputs.path }}
+        run: |
+          uv run --locked --no-default-groups --group test \
+            pytest tests/integration/hwi_device_test.py --junitxml=hwi.xml
+      # the same guard the node job carries, for the same reason: every
+      # one of these tests skips itself when a switch is off or when
+      # enumerate answers something other than one usable device, so a
+      # job whose emulator stopped being seen would pass while asking HWI
+      # nothing
+      - name: Fail if the device tests did not run
+        run: |
+          uv run --locked --no-default-groups --group test python - <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          cases = ET.parse("hwi.xml").getroot().iter("testcase")
+          ran = [one for one in cases
+                 if "hwi_device" in one.get("classname", "")]
+          skipped = [one for one in ran if one.find("skipped") is not None]
+          for one in skipped:
+              reason = one.find("skipped").get("message", "")
+              print(f"::error::{one.get('name')} skipped: {reason}")
+          if not ran or skipped:
+              print(f"::error::{len(ran)} device tests, {len(skipped)} skipped")
+              sys.exit(1)
+          print(f"{len(ran)} device tests ran against the emulator")
+          PY
+      # before the upload, so the log is complete and the runner is not
+      # tearing down a process that still holds the file. Both guards
+      # matter: a step that failed before the emulator started leaves
+      # EMULATOR_PID unset, and `kill 0` -- what a default would spell --
+      # signals the whole process group, this shell included
+      - name: Stop the emulator
+        if: always()
+        run: |
+          if [ -n "${EMULATOR_PID:-}" ]; then
+            kill "$EMULATOR_PID" || true
+          fi
+      # the emulator's own log beside the report: a device that refused
+      # says so there and nowhere else, the psbt failure and the button
+      # that was never pressed looking alike from pytest
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hwi-emulator-report
+          path: |
+            hwi.xml
+            emulator.log
+          if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -368,7 +368,14 @@ jobs:
       # the module tests/README.md documents, with both switches set and
       # the node from the step above. Only that module: the regtest tests
       # beside it are the other job's, and running them again here would
-      # report a Core failure twice
+      # report a Core failure twice.
+      #
+      # -n0 because there is one device. pyproject.toml's addopts pass
+      # `-n auto`, which is right for everything else here and wrong for
+      # a signer: three workers are three HWI processes on one udp port,
+      # and the one that finds the emulator mid-exchange waits for an
+      # answer to somebody else's command until btclib's timeout ends it.
+      # Measured, and it is displayaddress that lost the race
       - name: Run the HWI integration tests
         env:
           BTCLIB_INTEGRATION: "1"
@@ -376,7 +383,7 @@ jobs:
           BTCLIB_BITCOIND: ${{ steps.bitcoind.outputs.path }}
         run: |
           uv run --locked --no-default-groups --group test \
-            pytest tests/integration/hwi_device_test.py --junitxml=hwi.xml
+            pytest tests/integration/hwi_device_test.py -n0 --junitxml=hwi.xml
       # the same guard the node job carries, for the same reason: every
       # one of these tests skips itself when a switch is off or when
       # enumerate answers something other than one usable device, so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,42 @@ documented at release-notes length in the first place, and are still in
   raise `FileNotFoundError` from an unpacked sdist, where
   `mutation_counts_test.py` had been excluded for exactly that. MANIFEST.in
   and `[tool.check-manifest]` name all four now.
+- **The HWI integration tests run unattended, against a Trezor
+  emulator** (#529). `integration.yml` gains a second job beside the
+  regtest one: it downloads the Model T emulator trezor publishes for
+  firmware 2.9.4, checks its sha256, installs HWI 3.2.0 in an
+  interpreter of its own — HWI declares `^3.9,<3.13`, which is why
+  `btclib/hwi.py` runs it as a program — loads the seed HWI's own test
+  suite uses, and runs `tests/integration/hwi_device_test.py` with both
+  switches on. So the three questions only a device can answer — whether
+  HWI accepts the path spelling `getxpub` is given, the descriptor
+  `displayaddress` is given, and the psbt `signtx` reads — are asked of
+  a real HWI on a schedule, where what ran against a stand-in on every
+  commit is the process contract.
+
+  `BTCLIB_HWI_SIGN` can be set there, and that is the part that is not
+  obvious: HWI opens a udp path with `TrezorClientDebugLink` rather than
+  its ordinary client, and that one answers the ButtonRequest itself, so
+  the button press the switch guards against needs nobody. Three things
+  the job costs. The published emulator is built under nix, so its
+  interpreter and RUNPATH name paths no ubuntu has and `patchelf` is what
+  makes it run; 2.9.4 rather than the newest, because from 2.12.2 the
+  emulator links SDL3, which ubuntu's archive does not carry, and HWI's
+  own CI builds core/v2.9.6. And it is not a pull request check: a
+  firmware release or an unreachable `data.trezor.io` is not the branch's
+  fault, so it runs weekly, on a push to `main` and on
+  `gh workflow run integration.yml --ref <branch>`, which is how a branch
+  touching `btclib/hwi.py` gets the answer before it lands. Physical
+  devices stay manual, as issue #524 said they should.
+- **The node both jobs need is installed by one file**,
+  `.github/actions/install-bitcoind`, this repository's first composite
+  action: the download, the checksum and the unpacking were about to be
+  a second copy, and a duplicated pin is one that drifts — the copy
+  somebody raises is the one they were reading, and the other keeps
+  reporting green against the release before it. Referenced by path
+  rather than by commit SHA, which every third-party action here is: it
+  is read from the same commit as the workflow calling it, so there is
+  no owner who could move it.
 - **The bindings are required from their `main` rather than from a
   release**, which is what `bitcoin-core-rpc` already was: a direct
   reference to `btclib-org/btclib-secp256k1@main` in place of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,7 +248,7 @@ read by every checkout of this repository.
 | --- | --- | --- |
 | `test` | pull request, push | 4 platforms × 7 interpreters |
 | `lint`, `docs` | pull request, push | — |
-| `integration` | pull request, push | a regtest node |
+| `integration` | pull request, push | a regtest node, a Trezor emulator |
 | `website` | pull request, push, on website files | — |
 | `codeql` | pull request, push, Tuesday | 2 languages |
 | `macos` | Wednesday, a release | 2 macOS images × 7 interpreters |
@@ -539,8 +539,34 @@ BTCLIB_INTEGRATION=1 BTCLIB_BITCOIND=/path/to/bitcoind \
 A step after it reads that report and fails the job if a regtest test
 skipped: pytest exits 0 for a module that skipped itself, so a job whose
 fixture stopped finding the node would stay green while asking Core
-nothing. The HWI tests skip there by design, needing a device or an
-emulator, and are not counted.
+nothing. The HWI tests skip there by design and are not counted; the
+second job is theirs.
+
+`HWI against a Trezor emulator` is that job, and it gates nothing: it
+downloads a pinned emulator binary from `data.trezor.io` beside the same
+node, checks its sha256, installs a pinned HWI in an interpreter of its
+own — HWI declares `^3.9,<3.13`, and `btclib/hwi.py` says why it is a
+program here rather than a dependency — loads the seed HWI's own suite
+uses over DebugLink, and runs:
+
+```shell
+BTCLIB_INTEGRATION=1 BTCLIB_HWI_SIGN=1 \
+    BTCLIB_HWI="/path/to/hwi --emulators" \
+    BTCLIB_BITCOIND=/path/to/bitcoind \
+    uv run --locked --no-default-groups --group test \
+    pytest tests/integration/hwi_device_test.py --junitxml=hwi.xml
+```
+
+`BTCLIB_HWI_SIGN` can be set because HWI opens a udp device with
+`TrezorClientDebugLink`, which answers the button request itself. The
+job is not on a pull request: a firmware release, an unreachable
+`data.trezor.io` or an emulator that stopped starting headless is
+trezor's day rather than the branch's, so it runs weekly, on a push to
+`main`, and on `gh workflow run integration.yml --ref <branch>` — which
+is how a branch touching `btclib/hwi.py` is checked before it lands.
+Both jobs install the node through `.github/actions/install-bitcoind`,
+the repository's own composite action, so the release and its checksum
+are pinned once.
 
 The documentation, which the `Build the documentation` job of `docs.yml`
 runs with this same command, as read the docs does. `-W` is what makes an

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -554,8 +554,11 @@ BTCLIB_INTEGRATION=1 BTCLIB_HWI_SIGN=1 \
     BTCLIB_HWI="/path/to/hwi --emulators" \
     BTCLIB_BITCOIND=/path/to/bitcoind \
     uv run --locked --no-default-groups --group test \
-    pytest tests/integration/hwi_device_test.py --junitxml=hwi.xml
+    pytest tests/integration/hwi_device_test.py -n0 --junitxml=hwi.xml
 ```
+
+`-n0` because there is one device: `addopts` passes `-n auto`, and three
+workers are three HWI processes on one udp port.
 
 `BTCLIB_HWI_SIGN` can be set because HWI opens a udp device with
 `TrezorClientDebugLink`, which answers the button request itself. The

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -26,12 +26,20 @@ workflows with a job named the same thing produce one ambiguous check.
 | `test: every job passed` | `test.yml`, aggregate over the matrix |
 | `Lint and type-check` | `lint.yml`, its only job |
 | `Build the documentation` | `docs.yml`, its only job |
-| `Regtest against Bitcoin Core` | `integration.yml`, its only job |
+| `Regtest against Bitcoin Core` | `integration.yml`, its regtest job |
 | `codeql: every job passed` | `codeql.yml`, aggregate over the languages |
 
-A workflow with one job needs no aggregate: the job *is* the context, which
-is why three of the five are job names. The day one of them grows a second
-job, an aggregate and a change to this rule are what that costs.
+A workflow needs an aggregate when every one of its jobs has to gate: the
+matrix of `test.yml` and the languages of `codeql.yml` are the two, and a
+context naming one cell of either would leave the rest outside the rule.
+Where a single job is what gates, that job *is* the context, which is why
+three of the five are job names — and why `integration.yml` naming a
+second job changed nothing here: `HWI against a Trezor emulator` runs
+beside the regtest one and must not gate, an emulator being a service to
+keep working rather than a claim about the branch, so the context stays
+the name of the job that does. What a second job would cost is a rename:
+a workflow whose *whole* answer becomes required needs an aggregate, and
+this table with it.
 
 `Build the documentation` is named on its own on purpose: a rule naming
 `Lint and type-check` alone would leave a red docs build outside the

--- a/tests/README.md
+++ b/tests/README.md
@@ -79,12 +79,19 @@ The HWI tests need a device as well, and a second switch for the one that
 asks it to sign:
 
 ```shell
-BTCLIB_INTEGRATION=1 BTCLIB_HWI=hwi BTCLIB_HWI_SIGN=1 uv run pytest tests/integration
+BTCLIB_INTEGRATION=1 BTCLIB_HWI=hwi BTCLIB_HWI_SIGN=1 \
+    uv run pytest tests/integration/hwi_device_test.py -n0
 ```
 
 `BTCLIB_HWI` is the executable, split on spaces, so an emulator is
 reached with `BTCLIB_HWI="hwi --emulators"`. Nothing there is
 destructive: enumerate, an xpub, an address on a screen, a signature.
+
+`-n0` because there is one device. `addopts` passes `-n auto`, which is
+right for the rest of the suite and wrong here: three workers are three
+HWI processes on one device, and the one that reaches it mid-exchange
+waits for an answer to somebody else's command until btclib's timeout
+ends it.
 
 These tests are outside the coverage ratchet, which `pyproject.toml`
 says where it omits them: the ratchet measures what an ordinary run

--- a/tests/README.md
+++ b/tests/README.md
@@ -91,11 +91,20 @@ says where it omits them: the ratchet measures what an ordinary run
 executes, and a body that skips itself would be an uncovered line at
 every commit rather than a defect.
 
-The regtest flow does run unattended: the `integration` workflow
-downloads a pinned Core release weekly and on demand, and fails if a
-regtest test skipped rather than ran. The HWI half does not — a device
-or an emulator is a thing to keep working rather than a tarball to
-download, which is issue #529.
+Both halves run unattended, in a job each of the `integration` workflow,
+and each job fails if its tests skipped rather than ran. The regtest one
+downloads a pinned Core release on every pull request and weekly. The
+HWI one downloads a pinned Trezor emulator and a pinned HWI, loads the
+seed HWI's own suite uses, and runs this module with both switches set:
+an emulator reached over udp is driven through DebugLink, which answers
+the confirmation a person would press, so even the signing test needs
+nobody. It is not on a pull request — a firmware release or an emulator
+that stopped starting headless is not the branch's fault — so it runs
+weekly, on a push to `main`, and on demand:
+
+```shell
+gh workflow run integration.yml --ref <branch>
+```
 
 ## There is no `slow` marker, and that is a measurement
 

--- a/tests/integration/hwi_device_test.py
+++ b/tests/integration/hwi_device_test.py
@@ -25,6 +25,16 @@ reached: `hwi --emulators`. Signing is asked for only where
 `BTCLIB_HWI_SIGN` says so, because a device that signs is a device
 somebody is standing in front of, pressing a button.
 
+One emulator is what CI brings, which is issue #529 and not a change of
+that rule: the `HWI against a Trezor emulator` job of `integration.yml`
+downloads a pinned Trezor Model T binary and loads the seed HWI's own
+suite uses, and it sets `BTCLIB_HWI_SIGN` because there is nobody to
+press anything -- HWI opens a udp device with `TrezorClientDebugLink`,
+which answers the button request itself. What that job cannot answer is
+whether a device with a secure element, a screen and firmware of its own
+agrees, so the vendors it does not run stay what they were: bring your
+own.
+
 Nothing here is destructive: enumerate, an xpub, an address on a screen.
 Setup, wipe, restore, backup and the PIN flows are deliberately outside
 this and outside `btclib.hwi` altogether.

--- a/tests/integration/hwi_device_test.py
+++ b/tests/integration/hwi_device_test.py
@@ -17,13 +17,16 @@ own binary, image and udev rules, and vendoring that is the "large
 security and maintenance surface unrelated to btclib's Bitcoin
 primitives" the issue rules out. So the switches are two:
 
-    BTCLIB_INTEGRATION=1 BTCLIB_HWI=hwi uv run pytest tests/integration
+    BTCLIB_INTEGRATION=1 BTCLIB_HWI=hwi uv run pytest -n0 tests/integration
 
 with `BTCLIB_HWI` naming the executable -- `hwi`, a path, or a command
 with flags of its own, split on spaces, which is how an emulator is
 reached: `hwi --emulators`. Signing is asked for only where
 `BTCLIB_HWI_SIGN` says so, because a device that signs is a device
-somebody is standing in front of, pressing a button.
+somebody is standing in front of, pressing a button. `-n0` because there
+is one device: `addopts` passes `-n auto`, and three workers are three
+HWI processes reaching for it at once, where the one that arrives
+mid-exchange waits out btclib's timeout.
 
 One emulator is what CI brings, which is issue #529 and not a change of
 that rule: the `HWI against a Trezor emulator` job of `integration.yml`


### PR DESCRIPTION
## What this changes

Closes <https://github.com/btclib-org/btclib/issues/529>.

`tests/integration/hwi_device_test.py` needed a device, so nothing ran
it unattended: what CI checked on every commit was the process contract,
against the stand-in of `tests/hwi_test.py`. Whether a real HWI accepts
the path spelling `getxpub` is given, the descriptor `displayaddress` is
given and the psbt `signtx` reads was asked by whoever had hardware on
the desk.

`integration.yml` gains a second job, `HWI against a Trezor emulator`:

- the Model T (`T2T1`) emulator trezor publishes for firmware 2.9.4,
  with its sha256 pinned the way the Core tarball's is. It is built
  under nix, so `patchelf` is what makes it run on an ubuntu runner, and
  2.9.4 rather than the newest because from 2.12.2 the emulator links
  SDL3, which ubuntu's archive does not carry, while HWI's own CI builds
  `core/v2.9.6`
- HWI 3.2.0 in an interpreter of its own — it declares `^3.9,<3.13`,
  which is why `btclib/hwi.py` runs it as a program and why
  <https://github.com/btclib-org/btclib/issues/469> refused an extra
- the seed HWI's own test suite uses, loaded over DebugLink with HWI's
  vendored trezorlib, and the firmware version, revision and `hwi
  --version` printed into the job log
- both switches on, `BTCLIB_HWI_SIGN` included: HWI opens a udp path
  with `TrezorClientDebugLink` rather than its ordinary client, and that
  one answers the ButtonRequest itself, so the button press the switch
  guards against needs nobody

It is not a pull request check. A firmware release, an unreachable
`data.trezor.io` or an emulator that stopped starting headless is not
the branch's fault, so it runs weekly beside the node, on a push to
`main`, and on `gh workflow run integration.yml --ref <branch>` — which
is how a branch touching `btclib/hwi.py` gets the answer before it
lands. Physical-device signing stays manual, as
<https://github.com/btclib-org/btclib/issues/524> said it should.

Two things came with it:

- the signing test spends a regtest coin, so this job needs the node
  too. The download moved into `.github/actions/install-bitcoind`, this
  repository's first composite action: a duplicated checksum is one that
  drifts, the copy somebody raises being the one they were reading. It
  answers with the path as an output rather than appending to
  `GITHUB_ENV`, which zizmor's `github-env` audit is about
- `-n0` for this module, in the workflow and in the documented command.
  `addopts` passes `-n auto`, which is right for the rest of the suite
  and wrong for a signer — measured, not guessed: the first run of the
  job sent the three tests to three workers, and `displayaddress` waited
  out btclib's 120 s timeout while another process held the device

## How it was verified

The job itself, dispatched on this branch, which is the only way to run
it before it reaches `main`:

- <https://github.com/btclib-org/btclib/actions/runs/31704669235> — the
  first attempt: emulator up, seed loaded, `hwi 3.2.0`, `T firmware
  2.9.4, revision ccf73fd0`, two tests passed and `displayaddress`
  timed out on the parallel workers
- <https://github.com/btclib-org/btclib/actions/runs/31705252101> — with
  `-n0`: `3 passed in 12.72s`, and the guard step reporting `3 device
  tests ran against the emulator`. `Regtest against Bitcoin Core` is
  green in both, which is the composite action doing what the inline
  steps did

Locally: `uv run pre-commit run --all-files` clean, `uv run pytest`
25971 passed, and the sphinx build with `-W`.

## Checks

- [x] `uv run pre-commit run --all-files` is clean (ruff, mypy strict,
      markdownlint, the copyright notice, `uv.lock`)
- [x] `uv run pytest` passes
- [x] `CHANGELOG.md` has an entry, if a user would notice the change;
      `HISTORY.md` too, if it is one a user has to act on

## Anything the reviewer should know

- The emulator job is one device family. A Ledger through Speculos, or
  a Coldcard simulator, is the same shape of job and a second pin to
  keep working; this closes #529 with the one upstream tests, and the
  rest stays "bring your own", as the module docstring says.
- Not touched, and adjacent: the header of `integration.yml` still says
  the workflow "gates nothing" and "does not appear in main's required
  checks, and must not", while `Regtest against Bitcoin Core` is
  required on `main` and the `pull_request` block below says so. One of
  the two paragraphs is stale, and which one is the maintainer's call
  rather than this pull request's.

## Summary by Sourcery

Add unattended HWI integration testing against a pinned Trezor emulator and centralize bitcoind installation for integration workflows.

New Features:
- Introduce an HWI integration job that runs tests against a Trezor Model T emulator with a pinned HWI version on scheduled, main, and manual dispatch runs.

Enhancements:
- Refactor integration workflow to share pinned bitcoind version and checksum via env and a reusable composite action instead of per-job scripting.
- Document the new HWI emulator job, its invocation, and the single-worker requirement for device tests in CONTRIBUTING, tests/README, and CHANGELOG entries.
- Clarify hwi_device_test usage by enforcing `-n0` for device-backed tests and describing how CI uses the Trezor emulator and DebugLink-based signing.

CI:
- Extend integration.yml with a non-PR HWI emulator job that provisions the Trezor emulator, HWI, and bitcoind, runs hwi_device_test.py, and fails if device tests are skipped.
- Add a composite GitHub Action to install a pinned Bitcoin Core release and expose the bitcoind path as an output for reuse by integration jobs.