### PR TITLE
Refuse an unmerged tag, check what the archives contain, ship an SBOM

### DIFF
--- a/.github/scripts/generate_sbom.py
+++ b/.github/scripts/generate_sbom.py
@@ -1,0 +1,314 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Write a CycloneDX bill of materials for a built wheel and sdist.
+
+A release says where its files came from -- PEP 740 attestations on the
+index, a build provenance attestation over the copies attached to the
+GitHub release -- and said nothing about what is *in* them. This is the
+second half: one CycloneDX 1.6 document naming the distribution, its
+licence, the two files and their digests, and every dependency their
+metadata declares.
+
+**The wheel's metadata is the source, not pyproject.toml.** They agree on
+a release and not in a rehearsal, where the `build` job appends
+`.dev<run number>` to the version before building: the document has to
+describe the files beside it, so it reads the archive it is given. Which
+also means the only version it can report for a dependency is the one the
+metadata pins, and that is deliberate -- what a user's installer resolves
+is not a fact about these files, so a resolved version recorded here would
+be a claim the wheel does not make. A requirement pinned with `==` gets a
+`version`; anything else gets the specifier as a property and no version.
+
+**It is reproducible, like the files it describes.** The timestamp is
+`SOURCE_DATE_EPOCH`, which the `build` job exports from the commit date
+for the wheel and the sdist normalizer, and the serial number is a UUID5
+over the purl and the two digests -- so a rebuild of a tag writes the same
+bytes here too, and the attestation over the release assets covers this
+file as well. Nothing is read from the clock, and nothing is random:
+`uuid4` would make a rebuild differ in the one field nobody could check.
+
+Run it on a freshly built dist directory, after `uv build` and after the
+sdist normalizer, whose rewrite changes the digest this records:
+
+    uv run --no-project --python 3.14 \
+        .github/scripts/generate_sbom.py dist/ sbom/
+
+The output is named `<distribution>-<version>.cdx.json` after the wheel,
+so the workflow does not have to know the version -- which in a rehearsal
+it does not. RELEASING.md has the command that regenerates it from a tag
+and verifies it against the attestation.
+"""
+
+from __future__ import annotations
+
+import datetime
+import hashlib
+import json
+import os
+import re
+import sys
+import zipfile
+from email import message_from_bytes
+from email.message import Message
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+from uuid import NAMESPACE_URL, uuid5
+
+# PEP 508, cut down to the two forms a distribution's `Requires-Dist` takes
+# here: a name with a version specifier, and a name with a direct
+# reference. Anything else is refused rather than guessed at -- a
+# requirement this cannot read is a dependency the document would omit in
+# silence, which is the one failure a bill of materials must not have
+REQUIREMENT = re.compile(
+    r"""
+    ^(?P<name>[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?)   # the name
+    (?:\[(?P<extras>[^][]+)\])?                             # its extras
+    (?:\s*@\s*(?P<url>[^\s;]+)                              # a direct reference
+      |(?P<specifier>[^;]*))                                # or a specifier
+    (?:\s*;\s*(?P<marker>.+))?$                             # its environment marker
+    """,
+    re.VERBOSE,
+)
+
+# one `==` and one version, which is the only specifier that names a
+# version rather than a range of them
+PINNED = re.compile(r"^==\s*(?P<version>[^,\s]+)$")
+
+# how the labels of pyproject.toml's `[project.urls]` map onto the
+# externalReference types CycloneDX defines. A label with no mapping is
+# recorded as "other" rather than dropped: the document is a description,
+# and losing a url because the vocabulary has no word for it is worse than
+# saying "other"
+REFERENCE_TYPES = {
+    "changelog": "release-notes",
+    "documentation": "documentation",
+    "download": "distribution",
+    "homepage": "website",
+    "issues": "issue-tracker",
+    "repository": "vcs",
+}
+
+
+def canonical_name(name: str) -> str:
+    """Return the PEP 503 normalized form of a distribution name."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def file_hash(path: Path) -> str:
+    """Return the SHA-256 of a file, read a megabyte at a time."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def wheel_metadata(wheel: Path) -> Message:
+    """Return the parsed METADATA of a wheel."""
+    with zipfile.ZipFile(wheel) as archive:
+        names = [
+            name for name in archive.namelist() if name.endswith(".dist-info/METADATA")
+        ]
+        if len(names) != 1:
+            msg = f"{wheel.name} carries {len(names)} dist-info/METADATA members"
+            raise SystemExit(msg)
+        return message_from_bytes(archive.read(names[0]))
+
+
+def purl(name: str, version: str | None, url: str | None) -> str:
+    """Return the package url of a PyPI distribution, qualified by its vcs."""
+    reference = f"pkg:pypi/{canonical_name(name)}"
+    if version is not None:
+        reference += f"@{version}"
+    if url is not None:
+        # percent-encoded, the qualifier value being part of a url itself:
+        # the `git+https://...@main` of a direct reference carries the two
+        # characters that would otherwise end the qualifier
+        reference += f"?vcs_url={quote(url, safe='')}"
+    return reference
+
+
+def component(requirement: str) -> dict[str, Any]:
+    """Return the component one `Requires-Dist` line describes."""
+    match = REQUIREMENT.match(requirement.strip())
+    if match is None:
+        msg = f"cannot read the requirement {requirement!r}"
+        raise SystemExit(msg)
+
+    specifier = (match["specifier"] or "").strip()
+    pinned = PINNED.match(specifier)
+    version = pinned["version"] if pinned is not None else None
+    marker = match["marker"]
+    reference = purl(match["name"], version, match["url"])
+
+    entry: dict[str, Any] = {
+        "type": "library",
+        "bom-ref": reference,
+        "name": canonical_name(match["name"]),
+        "purl": reference,
+        # an extra names a dependency the wheel asks for only when the
+        # extra is; nothing else in a marker makes a requirement optional
+        # to a bill of materials, an interpreter version being a condition
+        # on where it installs rather than on whether it is needed
+        "scope": (
+            "optional" if marker is not None and "extra ==" in marker else "required"
+        ),
+        # the line as the metadata carries it, which is the whole of what
+        # this document knows about the dependency: the fields above are a
+        # reading of it, and the reading is checkable against it
+        "properties": [{"name": "btclib:requires-dist", "value": requirement}],
+    }
+    if version is not None:
+        entry["version"] = version
+    if match["extras"] is not None:
+        entry["properties"].append({"name": "btclib:extras", "value": match["extras"]})
+    if match["url"] is not None:
+        entry["externalReferences"] = [{"type": "vcs", "url": match["url"]}]
+    return entry
+
+
+def timestamp(epoch: int) -> str:
+    """Return the epoch as the UTC ISO 8601 instant CycloneDX asks for."""
+    # `isoformat` spells the zone "+00:00" and the schema's own examples
+    # end in "Z"; both are valid ISO 8601 and one of them is what every
+    # other tool writes
+    when = datetime.datetime.fromtimestamp(epoch, datetime.timezone.utc)
+    return when.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def distribution_reference(path: Path) -> dict[str, Any]:
+    """Return the externalReference for one of the distribution files."""
+    return {
+        "type": "distribution",
+        # the name alone, and no url: the file is published to PyPI and
+        # attached to a GitHub release, so a url here would name one of
+        # the two copies and read as the authoritative one
+        "url": path.name,
+        "hashes": [{"alg": "SHA-256", "content": file_hash(path)}],
+    }
+
+
+def build_sbom(wheel: Path, sdist: Path, epoch: int) -> dict[str, Any]:
+    """Return the CycloneDX document describing the two files."""
+    metadata = wheel_metadata(wheel)
+    name = metadata["Name"]
+    version = metadata["Version"]
+    if name is None or version is None:
+        msg = f"{wheel.name} declares no Name or no Version"
+        raise SystemExit(msg)
+    reference = purl(name, version, None)
+
+    references = [distribution_reference(wheel), distribution_reference(sdist)]
+    for entry in metadata.get_all("Project-URL", []):
+        label, _, url = entry.partition(", ")
+        references.append(
+            {"type": REFERENCE_TYPES.get(label, "other"), "url": url, "comment": label}
+        )
+
+    root: dict[str, Any] = {
+        "type": "library",
+        "bom-ref": reference,
+        "name": canonical_name(name),
+        "version": version,
+        "purl": reference,
+        # no component-level `hashes`: the component is two files with two
+        # digests, and a hash over both would be a number nothing else can
+        # recompute. The digests are on the two references above, where a
+        # verifier can check each against the file it has
+        "externalReferences": references,
+    }
+    summary = metadata["Summary"]
+    if summary is not None:
+        root["description"] = summary
+    # PEP 639, which is what pyproject.toml's `license = "MIT"` writes:
+    # a SPDX expression, and CycloneDX takes one as such rather than as a
+    # licence name it would have to match against a list
+    expression = metadata["License-Expression"]
+    if expression is not None:
+        root["licenses"] = [{"expression": expression}]
+    requires_python = metadata["Requires-Python"]
+    if requires_python is not None:
+        root["properties"] = [
+            {"name": "btclib:requires-python", "value": requires_python}
+        ]
+
+    components = sorted(
+        (
+            component(requirement)
+            for requirement in metadata.get_all("Requires-Dist", [])
+        ),
+        key=lambda entry: str(entry["bom-ref"]),
+    )
+    serial = f"{reference}:{file_hash(wheel)}:{file_hash(sdist)}"
+    return {
+        "$schema": "http://cyclonedx.org/schema/bom-1.6.schema.json",
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        # derived and not random, so that a rebuild of a tag writes this
+        # file byte for byte as the release did
+        "serialNumber": f"urn:uuid:{uuid5(NAMESPACE_URL, serial)}",
+        "version": 1,
+        "metadata": {
+            "timestamp": timestamp(epoch),
+            "tools": {
+                "components": [
+                    {"type": "application", "name": ".github/scripts/generate_sbom.py"}
+                ]
+            },
+            "component": root,
+        },
+        "components": components,
+        "dependencies": [
+            {"ref": reference, "dependsOn": [entry["bom-ref"] for entry in components]},
+            *({"ref": entry["bom-ref"], "dependsOn": []} for entry in components),
+        ],
+    }
+
+
+def one_of(directory: Path, pattern: str) -> Path:
+    """Return the single file in the directory matching the pattern."""
+    matches = sorted(directory.glob(pattern))
+    if len(matches) != 1:
+        found = ", ".join(match.name for match in matches) if matches else "none"
+        msg = f"{directory}: expected one {pattern}, found {found}"
+        raise SystemExit(msg)
+    return matches[0]
+
+
+def main(argv: list[str]) -> int:
+    """Write the bill of materials of one dist directory into another."""
+    if len(argv) != 3:
+        print(f"usage: {argv[0]} <dist directory> <output directory>", file=sys.stderr)  # noqa: T201
+        return 2
+
+    epoch = os.environ.get("SOURCE_DATE_EPOCH")
+    if epoch is None:
+        # not a default of "now", for normalize_sdist.py's reason: a
+        # default makes the document differ from the released one, and
+        # whoever finds that out is the one person who cannot fix it
+        print("SOURCE_DATE_EPOCH is not set", file=sys.stderr)  # noqa: T201
+        return 1
+
+    dist_dir = Path(argv[1])
+    wheel = one_of(dist_dir, "*.whl")
+    sdist = one_of(dist_dir, "*.tar.gz")
+    sbom = build_sbom(wheel, sdist, int(epoch))
+
+    # named after the wheel's own first two fields, {distribution} and
+    # {version}, so the caller needs to know neither -- which in a
+    # rehearsal, where the version carries a `.dev<run number>` the
+    # workflow patched in, it does not
+    distribution, version = wheel.name.split("-")[:2]
+    output = Path(argv[2]) / f"{distribution}-{version}.cdx.json"
+    output.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(sbom, indent=2, sort_keys=True)
+    output.write_text(f"{text}\n", encoding="utf-8")
+    print(f"wrote {output}")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/scripts/verify_dist_contents.py
+++ b/.github/scripts/verify_dist_contents.py
@@ -1,0 +1,338 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Check a built wheel and sdist against an allowlist of their members.
+
+`twine check`, `check-wheel-contents` and `pyroma` read the *metadata* of
+a distribution file: whether it is syntactically valid, whether the long
+description renders, whether the classifiers and urls are the ones a
+package should declare. None of them reads the members, so what is in the
+archive was checked by nothing -- and the archive is what a user installs.
+
+Three questions, one per section below.
+
+**What may be in there.** The wheel gets a strict allowlist, it being what
+lands on `sys.path`: Python source under `btclib/`, `btclib/py.typed`,
+whatever sits in a `_data/` directory, and the `.dist-info` metadata
+setuptools writes. Anything else fails, which is what makes a `.pth` file,
+a stray top-level module and a bundled shared object all one rule rather
+than three.
+
+The sdist gets a structural check instead, and not an extension allowlist,
+because MANIFEST.in already is one: `recursive-include tests *.json` is
+the statement of what a vendored vector may be, and a second copy of it
+here would be one more edit per vector while catching nothing that file
+lets through. What this adds is what MANIFEST.in cannot say -- that every
+member is under the archive's own root directory, that every member is a
+regular file or a directory (a tar can carry a symlink, a hardlink or a
+device node, where a zip cannot), that no directory holds the metadata of
+some *other* distribution, and which files may sit at the root, where
+MANIFEST.in's `include *.md` and `include *.yaml` ship whatever lands
+beside them.
+
+**What may never be in there**, whichever archive: a short list of
+suffixes and names, checked against every member including the ones the
+`_data/` amnesty above admits by directory rather than by extension. It is
+belt and braces for the wheel and the only rule of its kind for the sdist.
+
+**What has to be in there.** `uv build` builds the sdist and then the
+wheel from it, so the two carry the same `btclib/` payload, and comparing
+them is a completeness check with nothing to keep in step: a data file the
+tree has and the wheel does not is issue #393, and this is its pre-publish
+half -- check-manifest gates the tree against the sdist, this gates the
+sdist against the wheel, and #393's own smoke test gates what PyPI serves.
+`py.typed` is named on its own because PEP 561 makes its absence silent:
+the package installs, imports and type checks as `Any`.
+
+Every offending member is reported rather than the first: a policy failure
+is usually a class of files, and a build is hundreds of members.
+
+Run it on a freshly built dist directory, after `uv build`:
+
+    uv run --no-project --python 3.14 \
+        .github/scripts/verify_dist_contents.py dist/
+
+The `dist` job of test.yml runs it on every pull request and the `build`
+job of release.yml on what it is about to publish, which are the same
+command on two trees.
+"""
+
+from __future__ import annotations
+
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+
+# no distribution file of this project carries any of these, and each is
+# something an installed wheel would *run* or a packaging accident would
+# bundle: a `.pth` executes at interpreter startup, before the first
+# import; the four native suffixes are a compiled extension, which this
+# project has none of -- the secp256k1 bindings are a separate
+# distribution, resolved at install time and never vendored; a `.pyc` is
+# a compiled module whose source nobody reviewed; and an archive inside
+# an archive is a nested distribution, i.e. a second package installing
+# with the first
+FORBIDDEN_SUFFIXES = (
+    ".dll",
+    ".dylib",
+    ".egg",
+    ".exe",
+    ".pth",
+    ".pyc",
+    ".pyd",
+    ".so",
+    ".tar.gz",
+    ".whl",
+    ".zip",
+)
+
+# the two names Python imports for their side effects alone, at startup,
+# from the root of site-packages. Both end in `.py`, so the wheel's
+# allowlist would admit either under `btclib/` -- inert there, and named
+# here because the rule is about the name and not about where it happens
+# to be harmless
+FORBIDDEN_NAMES = ("sitecustomize.py", "usercustomize.py")
+
+# what setuptools writes into `.dist-info`, and no more. `entry_points.txt`
+# is deliberately absent: pyproject.toml declares no `[project.scripts]`,
+# and an entry point is a code path a user runs without importing anything,
+# so one appearing here is a packaging change that has to be read
+WHEEL_METADATA_FILES = frozenset({"METADATA", "RECORD", "WHEEL", "top_level.txt"})
+
+# the members without which the wheel is broken in a way that installs
+# cleanly: `py.typed` for PEP 561, the metadata for `btclib.__version__`
+# (issue #150), and `__init__.py` because a wheel with no package at all
+# is the shape a misconfigured `packages.find` produces
+WHEEL_REQUIRED = frozenset({"btclib/__init__.py", "btclib/py.typed"})
+
+# the directories of the sdist, which is the development tree: the package,
+# its suite, the documentation sources, and the metadata setuptools
+# generates beside them
+SDIST_DIRECTORIES = frozenset({"btclib", "btclib.egg-info", "docs", "tests"})
+
+# the files that may sit at the root of the sdist. MANIFEST.in ships these
+# by glob -- `include *.md`, `include *.yaml`, `include *.jsonc` -- so a
+# new file beside them is shipped without a packaging decision being made;
+# this is where that decision is recorded. A dotted name is here because
+# the lint gate has to be runnable from an unpacked sdist, which is
+# MANIFEST.in's own reason for carrying it
+SDIST_ROOT_SUFFIXES = (".jsonc", ".md", ".toml", ".yaml")
+SDIST_ROOT_NAMES = frozenset(
+    {
+        ".python-version",
+        ".secrets.baseline",
+        "COPYRIGHT",
+        "LICENSE",
+        "MANIFEST.in",
+        "PKG-INFO",
+        "setup.cfg",
+        "uv.lock",
+    }
+)
+
+# generated metadata, and nothing else, under `btclib.egg-info/`
+SDIST_EGG_INFO_NAMES = frozenset({"PKG-INFO"})
+SDIST_EGG_INFO_SUFFIXES = (".txt",)
+
+# the sdist is broken without these in a way that is not obvious either:
+# PKG-INFO is the metadata PyPI reads off the archive, and pyproject.toml
+# is what makes it buildable at all
+SDIST_REQUIRED = frozenset({"PKG-INFO", "pyproject.toml"})
+
+
+def forbidden_reason(path: str) -> str | None:
+    """Say why this member may never be in a distribution file, or None."""
+    name = path.rsplit("/", 1)[-1]
+    if name in FORBIDDEN_NAMES:
+        return f"is {name}, which Python imports at startup"
+    for suffix in FORBIDDEN_SUFFIXES:
+        if path.endswith(suffix):
+            return f"carries the forbidden suffix {suffix}"
+    if "__pycache__" in path.split("/"):
+        return "is under __pycache__"
+    return None
+
+
+def wheel_member_reason(path: str, dist_info: str) -> str | None:
+    """Say why this wheel member is not on the allowlist, or None."""
+    forbidden = forbidden_reason(path)
+    if forbidden is not None:
+        return forbidden
+    if path.startswith(f"{dist_info}/"):
+        relative = path[len(dist_info) + 1 :]
+        if relative in WHEEL_METADATA_FILES or relative.startswith("licenses/"):
+            return None
+        return f"is under {dist_info}/ and is not one of its files"
+    if not path.startswith("btclib/"):
+        return "is neither package code nor package metadata"
+    if path.endswith(".py") or path == "btclib/py.typed" or "/_data/" in path:
+        return None
+    return "is under btclib/ and is neither Python source nor a _data file"
+
+
+def verify_wheel(wheel: Path) -> tuple[list[str], set[str]]:
+    """Return the wheel's complaints and its `btclib/` payload."""
+    # the file name is what carries the version, canonically: a wheel is
+    # named {distribution}-{version}-{python}-{abi}-{platform}.whl, so the
+    # first two fields are read from there rather than from the metadata
+    # the check below is about to judge
+    distribution, version = wheel.name.split("-")[:2]
+    dist_info = f"{distribution}-{version}.dist-info"
+
+    with zipfile.ZipFile(wheel) as archive:
+        # a zip may carry an entry per directory; setuptools writes none,
+        # and a wheel that starts to is not a policy change
+        members = [name for name in archive.namelist() if not name.endswith("/")]
+
+    complaints = [
+        f"{wheel.name}: {name} {reason}"
+        for name in members
+        for reason in [wheel_member_reason(name, dist_info)]
+        if reason is not None
+    ]
+    required = WHEEL_REQUIRED | {f"{dist_info}/{name}" for name in WHEEL_METADATA_FILES}
+    complaints += [
+        f"{wheel.name}: {name} is missing" for name in sorted(required - set(members))
+    ]
+    payload = {name for name in members if name.startswith("btclib/")}
+    return complaints, payload
+
+
+def sdist_shape_reason(member: tarfile.TarInfo, root: str) -> str | None:
+    """Say why this sdist member is not a plain path under the root."""
+    path = member.name
+    if not (member.isfile() or member.isdir()):
+        return f"is neither a regular file nor a directory (type {member.type!r})"
+    if path.startswith("/") or ".." in path.split("/"):
+        return "is not a relative path within the archive"
+    if path != root and not path.startswith(f"{root}/"):
+        return f"is outside the archive's own {root}/ directory"
+    return forbidden_reason(path)
+
+
+def sdist_root_reason(name: str, *, is_dir: bool) -> str | None:
+    """Say why this member at the root of the sdist is not allowed."""
+    if is_dir:
+        if name in SDIST_DIRECTORIES:
+            return None
+        return "is a directory the sdist does not ship"
+    if name in SDIST_ROOT_NAMES or name.endswith(SDIST_ROOT_SUFFIXES):
+        return None
+    return "is a root file the sdist does not ship"
+
+
+def sdist_nested_reason(parts: list[str], *, is_dir: bool) -> str | None:
+    """Say why this member below the sdist's root is not allowed."""
+    # the metadata of another distribution, vendored or left behind by a
+    # build in the tree the sdist was made from. `btclib.egg-info` is this
+    # project's own, and one of the root directories above
+    for part in parts[1:]:
+        if part.endswith((".dist-info", ".egg-info")):
+            return f"holds the metadata of another distribution, {part}"
+    if parts[0] not in SDIST_DIRECTORIES:
+        return "is not under one of the directories the sdist ships"
+    if is_dir or parts[0] != "btclib.egg-info":
+        return None
+    if parts[-1] in SDIST_EGG_INFO_NAMES or parts[-1].endswith(SDIST_EGG_INFO_SUFFIXES):
+        return None
+    return "is under btclib.egg-info/ and is not metadata"
+
+
+def sdist_member_reason(member: tarfile.TarInfo, root: str) -> str | None:
+    """Say why this sdist member fails the structural check, or None."""
+    shape = sdist_shape_reason(member, root)
+    if shape is not None:
+        return shape
+    relative = member.name[len(root) :].strip("/")
+    if not relative:
+        return None
+    parts = relative.split("/")
+    if len(parts) == 1:
+        return sdist_root_reason(relative, is_dir=member.isdir())
+    return sdist_nested_reason(parts, is_dir=member.isdir())
+
+
+def verify_sdist(sdist: Path) -> tuple[list[str], set[str]]:
+    """Return the sdist's complaints and its `btclib/` payload."""
+    # {name}-{version}.tar.gz, so the root directory the members sit under
+    # is the file's own name without the extension
+    root = sdist.name[: -len(".tar.gz")]
+
+    with tarfile.open(sdist, "r:gz") as archive:
+        members = archive.getmembers()
+
+    complaints = [
+        f"{sdist.name}: {member.name} {reason}"
+        for member in members
+        for reason in [sdist_member_reason(member, root)]
+        if reason is not None
+    ]
+    files = {
+        member.name[len(root) :].strip("/") for member in members if member.isfile()
+    }
+    complaints += [
+        f"{sdist.name}: {name} is missing" for name in sorted(SDIST_REQUIRED - files)
+    ]
+    payload = {name for name in files if name.startswith("btclib/")}
+    return complaints, payload
+
+
+def one_of(dist_dir: Path, pattern: str) -> tuple[Path | None, list[str]]:
+    """Return the single file matching the pattern, and any complaint."""
+    # exactly one, not the newest of several: a stale artifact from an
+    # earlier build in the same directory is precisely what a check on
+    # the published files must not skip over
+    matches = sorted(dist_dir.glob(pattern))
+    if len(matches) == 1:
+        return matches[0], []
+    found = ", ".join(match.name for match in matches) if matches else "none"
+    return None, [f"{dist_dir}: expected one {pattern}, found {found}"]
+
+
+def verify(dist_dir: Path) -> list[str]:
+    """Return every complaint about the wheel and the sdist in dist_dir."""
+    wheel, complaints = one_of(dist_dir, "*.whl")
+    sdist, sdist_complaints = one_of(dist_dir, "*.tar.gz")
+    complaints += sdist_complaints
+    if wheel is None or sdist is None:
+        return complaints
+
+    wheel_complaints, wheel_payload = verify_wheel(wheel)
+    sdist_complaints, sdist_payload = verify_sdist(sdist)
+    complaints += wheel_complaints + sdist_complaints
+
+    # the wheel is built from the sdist, so the two carry one payload; a
+    # difference either way is a file that reaches a user installing from
+    # source and not one installing the wheel, or the reverse
+    complaints += [
+        f"{sdist.name} ships {name}, {wheel.name} does not"
+        for name in sorted(sdist_payload - wheel_payload)
+    ]
+    complaints += [
+        f"{wheel.name} ships {name}, {sdist.name} does not"
+        for name in sorted(wheel_payload - sdist_payload)
+    ]
+    if not complaints:
+        print(f"{wheel.name} and {sdist.name} carry what they may and no more")  # noqa: T201
+        print(f"one payload of {len(wheel_payload)} files, in both")  # noqa: T201
+    return complaints
+
+
+def main(argv: list[str]) -> int:
+    """Verify the wheel and the sdist of the directory named on the line."""
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <dist directory>", file=sys.stderr)  # noqa: T201
+        return 2
+
+    complaints = verify(Path(argv[1]))
+    for complaint in complaints:
+        # the workflow annotation, so a failure is readable from the run
+        # summary rather than only from the log
+        print(f"::error::{complaint}", file=sys.stderr)  # noqa: T201
+    return 1 if complaints else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,15 +31,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # what a version cannot survive being wrong about, checked before
-  # anything is built and long before anything is uploaded: a version is
-  # consumed by the upload that carries it, and can then only be yanked.
+  # what a tag cannot survive being wrong about, checked before anything is
+  # built and long before anything is uploaded: a version is consumed by
+  # the upload that carries it, and can then only be yanked.
   # A minute of checking, ahead of an hour of building.
   # The rehearsal runs this too, so a mismatch cannot wait for release day
-  # to surface; only the tag comparison is release-only, there being no
-  # tag to compare against otherwise
+  # to surface; only the checks about the tag itself are release-only,
+  # there being no tag to ask about otherwise
   version-check:
-    name: Check the declared versions
+    name: Check the tag and the declared versions
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -52,6 +52,44 @@ jobs:
         with:
           # see the checkout of the test-py job in test.yml
           persist-credentials: false
+          # the whole history, where every other checkout in these
+          # workflows takes the default single commit: the ancestry check
+          # below has nothing to answer with otherwise, and it is also what
+          # puts origin/<default branch> in this checkout at all. Only this
+          # job pays for it, and it pays once per release
+          fetch-depth: 0
+      # a tag is a name that can point anywhere, and nothing else in this
+      # workflow asks where: every check below reads the tree the tag names
+      # rather than where that tree came from. So a tag pushed from a stale
+      # worktree, or from a branch whose pull request is still open, or from
+      # a commit squashed away on its way into the default branch, would
+      # publish code no review ever approved and no branch contains --
+      # which is issue #574's failure mode one pipeline over, a build
+      # running something unreachable from where it is supposed to be.
+      # `git merge-base --is-ancestor` is the whole of the question.
+      # Release-only, like the two checks below and for the same reason: a
+      # rehearsal is dispatched from a branch on purpose, that being what
+      # it is for.
+      # The default branch is read from the event rather than written as
+      # `main`: this is the one check whose subject is that branch, so it
+      # has to keep meaning what it says the day the name changes
+      - name: Check that the tag is merged into the default branch (release only)
+        if: github.event_name == 'push'
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if ! git rev-parse --verify --quiet "origin/$DEFAULT_BRANCH" >/dev/null; then
+            msg="fetch-depth: 0 on the checkout above is what puts it there"
+            echo "::error::origin/$DEFAULT_BRANCH is not in this checkout; $msg"
+            exit 1
+          fi
+          commit=$(git rev-parse HEAD)
+          if ! git merge-base --is-ancestor "$commit" "origin/$DEFAULT_BRANCH"; then
+            msg="a release is tagged on a commit that branch contains"
+            echo "::error::$commit is not an ancestor of $DEFAULT_BRANCH; $msg"
+            exit 1
+          fi
+          echo "$commit is an ancestor of $DEFAULT_BRANCH"
       # caching off in this workflow, unlike every other: a cache entry is
       # written by whichever run populated it, and read here through the
       # scoping that gives a tag push the caches of the default branch. This
@@ -301,6 +339,33 @@ jobs:
           uv run --no-project --python 3.14 \
             .github/scripts/normalize_sdist.py dist/
           sha256sum dist/*
+      # what the packaging checks of the dist job do not look at: the
+      # members of the two archives. They read metadata -- whether it is
+      # valid, whether the long description renders, whether the
+      # classifiers are the ones a package should declare -- and the
+      # allowlist in the script is about what is *in* the files. It runs in
+      # that job too, so a pull request is told before a tag is; here it
+      # judges the files that get uploaded, which in a rehearsal are a
+      # different version built from a re-locked tree.
+      # After the normalizer rather than before: that rewrites member
+      # metadata, and this reads member names
+      - name: Check what the distribution files contain
+        run: |
+          uv run --no-project --python 3.14 \
+            .github/scripts/verify_dist_contents.py dist/
+      # and what nothing said at all: what the files contain, as a document
+      # rather than as a check. The bill of materials is reproducible for
+      # the reason the two steps above are -- SOURCE_DATE_EPOCH is its
+      # timestamp and the two digests its serial number -- so a rebuild of
+      # the tag writes this file too, and the attest job below signs it
+      # beside the distribution files.
+      # Into a directory of its own and not dist/: that directory is
+      # uploaded as the artifact the publish jobs hand to an index, and an
+      # index takes distribution files
+      - name: Write the bill of materials
+        run: |
+          uv run --no-project --python 3.14 \
+            .github/scripts/generate_sbom.py dist/ sbom/
       # before anything is installed, and that ordering is the point: the
       # step below runs third-party code -- a `.pth` file in a dependency
       # executes at interpreter startup, before the first import -- while
@@ -313,6 +378,13 @@ jobs:
         with:
           name: dist
           path: dist/
+      # an artifact of its own, for the reason the step that writes it gives:
+      # the two jobs that download `dist` hand every file in it to an index
+      - name: Upload the bill of materials
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom
+          path: sbom/
       # dist-py installs a wheel too, but not this one: it builds its own
       # copy, on another runner and -- in a rehearsal -- from another
       # version, the step above having patched pyproject.toml and
@@ -413,7 +485,10 @@ jobs:
   # the copies on the index, while the copies attached to the GitHub release
   # below carry nothing. This job signs them, and the digests are the
   # index's own, the dist artifact being downloaded here rather than
-  # rebuilt.
+  # rebuilt. The bill of materials is signed with them, and for the same
+  # reason: it is attached to that release too, so leaving it out would be
+  # the gap this job exists to close, reopened for the one asset that says
+  # what the others contain.
   # A job of its own rather than two more permissions on github-release:
   # this workflow elevates one job at a time, and the one that writes
   # releases has no reason to also hold an OIDC token. It is not in the
@@ -429,7 +504,7 @@ jobs:
   # release day, where a failure lands after PyPI has the files and the tag
   # can no longer be moved
   attest:
-    name: Attest the distribution files
+    name: Attest the release assets
     needs: [publish-pypi, publish-testpypi]
     # always(), the other publish job being skipped rather than run, and a
     # skipped job is one `needs` treats as failed
@@ -449,18 +524,27 @@ jobs:
         with:
           name: dist
           path: dist/
+      # into a directory of its own, as in the job below and for the same
+      # reason: the dist/* glob has to stay the distribution files
+      - name: Download the bill of materials
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
+          path: sbom/
       # actions/attest and not the attest-build-provenance wrapper around
       # it: as of v4 the wrapper is a composite that does nothing but call
       # this, and its own README sends new callers here. No predicate input
       # is what selects SLSA build provenance.
-      # One attestation, both files: the statement carries every subject the
-      # glob matched, so verifying either the wheel or the sdist against the
-      # bundle below works
-      - name: Attest the distribution files
+      # One attestation, every file: the statement carries every subject the
+      # globs matched, so verifying the wheel, the sdist or the bill of
+      # materials against the bundle below works
+      - name: Attest the release assets
         id: attest
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
-          subject-path: dist/*
+          subject-path: |
+            dist/*
+            sbom/*
       # the bundle is the signed statement itself, and the job below
       # attaches it to the release: that is what lets `gh attestation verify
       # --bundle` read it from disk instead of from the attestations API,
@@ -508,13 +592,18 @@ jobs:
         with:
           name: dist
           path: dist/
-      # into a directory of its own, so that the dist/* glob below stays the
-      # distribution files and nothing else
+      # each into a directory of its own, so that the dist/* glob below
+      # stays the distribution files and nothing else
       - name: Download the attestation bundle
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: attestation
           path: attestation/
+      - name: Download the bill of materials
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: sbom
+          path: sbom/
       - name: Create the GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -537,11 +626,14 @@ jobs:
           # distribution files' own names do
           bundle="$GITHUB_REF_NAME.attestation.jsonl"
           cp attestation/attestation.jsonl "$bundle"
+          # the bill of materials needs no renaming, unlike the bundle: it
+          # carries the version in its own name, the distribution files
+          # being where it took it from
           if [ -s "$RUNNER_TEMP/notes.md" ]; then
-            gh release create "$GITHUB_REF_NAME" dist/* "$bundle" \
+            gh release create "$GITHUB_REF_NAME" dist/* sbom/* "$bundle" \
               --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/notes.md"
           else
             echo "::warning::HISTORY.md has no $GITHUB_REF_NAME section"
-            gh release create "$GITHUB_REF_NAME" dist/* "$bundle" \
+            gh release create "$GITHUB_REF_NAME" dist/* sbom/* "$bundle" \
               --title "$GITHUB_REF_NAME" --generate-notes
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -236,6 +236,26 @@ jobs:
       # the lint workflow
       - name: Build the distribution files
         run: uv build
+      # what the three checks below do not look at: the members of the two
+      # archives, which is what a user installs. The allowlist and the
+      # reasoning are in the script; release.yml's build job runs the same
+      # command on the files it is about to publish, and this is the copy
+      # that answers before a tag rather than after one.
+      # --no-project, so it runs on the interpreter uv already fetched and
+      # installs nothing: the script imports the standard library only
+      - name: Check what the distribution files contain
+        run: |
+          uv run --no-project --python 3.14 \
+            .github/scripts/verify_dist_contents.py dist/
+      # and the bill of materials release.yml attaches to a release. Written
+      # here and thrown away, into $RUNNER_TEMP rather than the workspace:
+      # what this gates is that the script still reads a real wheel, which
+      # otherwise nothing would say until a tag ran it for the first time
+      - name: Write the bill of materials
+        run: |
+          SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) \
+            uv run --no-project --python 3.14 \
+            .github/scripts/generate_sbom.py dist/ "$RUNNER_TEMP"/sbom/
       # the same validation PyPI applies on upload: broken metadata, or a
       # README that does not render, cannot be fixed by reuploading
       - name: Check the metadata and the long description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,6 +192,86 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **A tag is refused unless the default branch contains its commit**
+  (#650). Every other check in `version-check` reads the tree the tag
+  names and none asked where that tree came from, so a tag pushed from a
+  stale worktree, from a branch whose pull request is still open, or from
+  the pre-squash commit of one that landed -- which the squash leaves on
+  no branch at all -- would have published code no review approved and
+  `main` does not contain. `git merge-base --is-ancestor` against
+  `github.event.repository.default_branch` is the whole of it, before the
+  version comparison and long before anything is built; the checkout of
+  that job takes `fetch-depth: 0`, where every other checkout in these
+  workflows takes the default single commit, because otherwise there is no
+  ancestry to answer with and no `origin/<default branch>` to answer
+  against. Release-only, like the two checks beside it: a rehearsal is
+  dispatched from a branch on purpose. It is issue #574's failure mode one
+  pipeline over -- a build running something unreachable from where it is
+  supposed to be -- and `embit`'s `release.yml` guards it the same way.
+- **What the distribution files contain is checked against an allowlist**
+  (#649). `twine check --strict`, `check-wheel-contents` and `pyroma --min
+  10` all read metadata; nothing read the members, and the members are
+  what a user installs. `.github/scripts/verify_dist_contents.py` holds
+  the allowlist, and the `dist` job of `test.yml` runs it on every pull
+  request while the `build` job of `release.yml` runs it on the files it
+  is about to publish -- the same command on two trees, which in a
+  rehearsal are two versions. Three questions, and the asymmetry between
+  the two archives is the substance of it. The wheel gets a strict
+  allowlist, being what lands on `sys.path`: Python source under
+  `btclib/`, `py.typed`, whatever sits in a `_data/` directory, and the
+  `.dist-info` metadata setuptools writes -- so a `.pth` file, a stray
+  top-level module, a bundled shared object and an `entry_points.txt`
+  nothing declared are one rule and not four. The sdist gets a structural
+  check instead of an extension allowlist, because MANIFEST.in already is
+  one and a second copy here would be an edit per vendored vector while
+  catching nothing that file lets through; what it adds is what MANIFEST.in
+  cannot say -- that every member is under the archive's own root, that
+  every member is a regular file or a directory (a tar can carry a symlink,
+  a hardlink or a device node, where a zip cannot), that no directory holds
+  another distribution's metadata, and which files may sit at the root,
+  where `include *.md` and `include *.yaml` ship whatever lands beside
+  them. And the completeness half, which needs nothing kept in step:
+  `uv build` builds the sdist and then the wheel from it, so the two carry
+  one `btclib/` payload and the check is that they do, member by member,
+  with no list of names to maintain here. Measured on a real build: the
+  two sets are equal today, in both directions.
+  A data file in the tree and not in the wheel is #393, so
+  check-manifest gates the tree against the sdist, this gates the sdist
+  against the wheel, and #393's own smoke test gates what PyPI serves.
+  `py.typed` is required by name because PEP 561 makes its absence silent.
+  Every offending member is reported rather than the first. A policy
+  document beside the script was the alternative, as `embit` has, and the
+  allowlist is in the script instead: two copies of a list are one that
+  can be wrong.
+- **Each release carries a CycloneDX bill of materials** (#648),
+  `btclib-<version>.cdx.json`, attached to the GitHub release beside the
+  distribution files and covered by the same attestation -- a bill of
+  materials whose provenance nobody can check says only what whoever wrote
+  it wanted said, which is the gap #557 closed for the other assets.
+  `.github/scripts/generate_sbom.py` writes it from the *built wheel* and
+  not from pyproject.toml: the two agree on a release and not in a
+  rehearsal, where the version carries a `.dev<run number>` the build job
+  patched in, and the document has to describe the files beside it. Which
+  also decides what it can say about a dependency -- the requirement as
+  published, so a component gets a `version` where that requirement is a
+  `==` pin and none where it is a floor, a resolution recorded here being
+  a claim the wheel does not make. It is reproducible like the files it
+  describes: `SOURCE_DATE_EPOCH` is the timestamp and a UUID5 over the purl
+  and the two digests is the serial number, so a rebuild of the tag writes
+  the same bytes and RELEASING.md's rebuild command verifies it with a
+  third `gh attestation verify`. Validated once against the published
+  CycloneDX 1.6 schema and its two `$ref` files, rather than a validator
+  installed in the release path. Hand-written, where the official
+  `cyclonedx-py` takes an environment or a requirements file as its
+  subject: neither is these two archives, and the build job installs
+  nothing before the artifact it publishes is uploaded.
+- **The sdist ships no test whose subject it omits.** What
+  `.github/scripts` holds is not shipped, and three of the four tests that
+  load a script from there by path were in the archive --
+  `check_vendored_vectors_test.py` was, and every one of its tests would
+  raise `FileNotFoundError` from an unpacked sdist, where
+  `mutation_counts_test.py` had been excluded for exactly that. MANIFEST.in
+  and `[tool.check-manifest]` name all four now.
 - **The bindings are required from their `main` rather than from a
   release**, which is what `bitcoin-core-rpc` already was: a direct
   reference to `btclib-org/btclib-secp256k1@main` in place of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -323,7 +323,12 @@ written out here even though addopts already carries it, this being the
 job's command verbatim.
 
 The `dist` job, which inspects what would be published and then
-installs it. The last commands ask for the wheel and nothing else, so
+installs it. The first two commands after the build read the *members* of
+the two archives, which the three that follow do not: an allowlist of what
+may be in a wheel and an sdist, and the bill of materials a release
+attaches — written here into a temporary directory and thrown away, this
+being the copy that says the script still reads a real wheel. The last
+commands ask for the wheel and nothing else, so
 what pulls btclib_secp256k1 in is the `Requires-Dist` the wheel
 carries; the lock arrives as constraints, which pin without
 requesting a package — a commit, for a direct reference — so nothing
@@ -334,6 +339,10 @@ the wheel:
 
 ```shell
 uv build
+uv run --no-project --python 3.14 \
+    .github/scripts/verify_dist_contents.py dist/
+SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct) uv run --no-project \
+    --python 3.14 .github/scripts/generate_sbom.py dist/ "$(mktemp -d)"
 uv run --locked --only-group build twine check --strict dist/*
 uv run --locked --only-group build check-wheel-contents dist/*.whl
 uv run --locked --only-group build pyroma --min 10 dist/*.tar.gz
@@ -351,9 +360,11 @@ cd "$tmp" && uv venv &&
         dsa.sign(b'btclib', 1))"
 ```
 
-The checks the `release` workflow runs before building anything:
+The checks the `release` workflow runs before building anything, the
+first of them being where the tag came from rather than what it says:
 
 ```shell
+git merge-base --is-ancestor HEAD origin/main
 uv lock --check
 uv version --short
 ```
@@ -379,6 +390,10 @@ produce the same wheel, the second why they produce the same sdist:
 export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 uv run --no-project --python 3.14 .github/scripts/normalize_sdist.py dist/
 ```
+
+The bill of materials that job writes is reproducible for the same reason,
+that variable being its timestamp, so a rebuild verifies against the
+attestation exactly as the two distribution files do.
 
 RELEASING.md's "Rebuild a release from its tag" has them in the order a
 verifier runs them, with the `gh attestation verify` that gives the

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -37,14 +37,18 @@ recursive-include tests *.csv
 recursive-include tests *.json
 recursive-include tests *.md
 recursive-include tests *.py
-# except the one whose subject the sdist does not carry: the mutation
-# workflow's counter lives under .github, which is not shipped, so that test
-# in an sdist is three fixture errors and a failing subprocess rather than a
-# test. Excluded here because the include above did add it -- unlike the
+# except the ones whose subject the sdist does not carry: what
+# .github/scripts holds is not shipped, so each of these in an sdist is a
+# fixture error or a failing subprocess rather than a test -- the loading
+# by path that every one of them does raises FileNotFoundError there.
+# Excluded here because the include above did add them -- unlike the
 # website's files, whose absence is check-manifest's configuration and not
-# this file's; [tool.check-manifest] ignore names this one too, a tracked
+# this file's; [tool.check-manifest] ignore names them too, a tracked
 # file the sdist omits being exactly what that tool reports
+exclude tests/check_vendored_vectors_test.py
+exclude tests/generate_sbom_test.py
 exclude tests/mutation_counts_test.py
+exclude tests/verify_dist_contents_test.py
 recursive-exclude tests *.pyc
 recursive-include tests *.txt
 # the Apache-2.0 text of C2SP/wycheproof, whose vectors sit beside it: an

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -326,6 +326,14 @@ word, and step 1 asks it of both.
    is the guard doing its job. The `git show` above is the same check one
    step earlier, where it costs nothing.
 
+   The commit has to be one `main` contains, and `version-check` refuses
+   the tag otherwise: `git merge-base --is-ancestor` against the default
+   branch is the first thing it asks, before it has read a version at all.
+   What that catches is the other half of the same mistake — the right
+   version on a commit nobody merged, a branch whose pull request is still
+   open, or the pre-squash commit of one that landed, which the squash left
+   on no branch at all.
+
 1. The workflow builds the full matrix and the distribution files, then
    pauses at the `pypi` environment for the review "One-time setup"
    describes. Approve it. That approval is not the point of no return:
@@ -338,7 +346,8 @@ word, and step 1 asks it of both.
    already built, rather than the whole matrix again. The upload itself
    is the point of no return, PyPI accepting no file name twice even
    after deletion; the GitHub release follows it, with the distribution
-   files attached, `<tag>.attestation.jsonl` beside them, and the
+   files attached, `btclib-<version>.cdx.json` and
+   `<tag>.attestation.jsonl` beside them, and the
    HISTORY.md section as its body. Read those notes
    once it lands: a run that logs
    `HISTORY.md has no v<version> section` generated them from the merged
@@ -378,6 +387,17 @@ word, and step 1 asks it of both.
      pypi-attestations verify pypi <file> \
      --repository https://github.com/btclib-org/btclib
    ```
+
+1. Read the bill of materials attached to the release,
+   `btclib-<version>.cdx.json`: a CycloneDX 1.6 document naming the
+   distribution, its licence, the two files with their SHA-256, and one
+   component per dependency the wheel's metadata declares. What is worth
+   reading rather than assuming is that list — it is `Requires-Dist` as
+   published, so a `git+https://` still in it is a release that should not
+   have got this far, and each component carries a `version` only where the
+   requirement is a `==` pin, a floor being a range and not a version.
+   Attested with the distribution files, so `gh attestation verify` below
+   covers it too.
 
 1. Dispatch the `published` workflow (Actions → published → Run workflow)
    and expect it green: no checkout, so it resolves to what PyPI actually
@@ -427,12 +447,21 @@ export SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)
 uv build
 uv run --no-project --python 3.14 \
   .github/scripts/normalize_sdist.py dist/
+uv run --no-project --python 3.14 \
+  .github/scripts/generate_sbom.py dist/ sbom/
 repo=btclib-org/btclib
 gh attestation verify dist/btclib-<version>-py3-none-any.whl \
   --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
 gh attestation verify dist/btclib-<version>.tar.gz \
   --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
+gh attestation verify sbom/btclib-<version>.cdx.json \
+  --repo "$repo" --signer-workflow "$repo/.github/workflows/release.yml"
 ```
+
+The bill of materials is rebuilt with them and verified like them: its
+timestamp is `SOURCE_DATE_EPOCH` and its serial number is derived from the
+two digests, so it is the same bytes as the released copy — which is the
+only reason a third `gh attestation verify` can pass at all.
 
 Two things bound that guarantee, and both are worth knowing before reading
 a mismatch as tampering:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,10 +69,20 @@ gh attestation verify btclib-<version>-py3-none-any.whl \
 than accepting any attestation this repository has. The signed statement
 is attached to the release as well, as `<tag>.attestation.jsonl`, so
 `--bundle <tag>.attestation.jsonl` runs the same check reading it from
-disk instead of asking GitHub for it; one attestation covers the wheel
-and the sdist both. Either file can also be rebuilt from its tag and
+disk instead of asking GitHub for it; one attestation covers every asset
+of the release. Either file can also be rebuilt from its tag and
 verified without being downloaded at all, the build being reproducible:
 RELEASING.md has that command and the bounds on it.
+
+A CycloneDX 1.6 bill of materials is attached beside them,
+`btclib-<version>.cdx.json`: the two files with their SHA-256, the
+licence, and one component per dependency the wheel's metadata declares.
+It is generated from the built wheel rather than from the source tree, so
+it describes the files it is attached to, and it is covered by the same
+attestation — a bill of materials whose provenance nobody can check says
+only what whoever wrote it wanted said. What it records of a dependency is
+the requirement as published, so a component carries a version only where
+that requirement is an exact pin.
 
 ## Limitations, not vulnerabilities
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,11 +178,14 @@ ignore = [
     # .secrets.baseline, which it does carry, because the lint gate is
     # runnable from an unpacked sdist
     ".lycheeignore",
-    # the test of the mutation workflow's counter, whose subject is under
+    # the tests of what .github/scripts holds, whose subject is under
     # .github and therefore not shipped either. The suite an sdist carries
     # has to be runnable from it, and a test whose subject is absent is not
-    # a test but four errors; MANIFEST.in excludes it and says the same
+    # a test but a fixture error; MANIFEST.in excludes them and says the same
+    "tests/check_vendored_vectors_test.py",
+    "tests/generate_sbom_test.py",
     "tests/mutation_counts_test.py",
+    "tests/verify_dist_contents_test.py",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/generate_sbom_test.py
+++ b/tests/generate_sbom_test.py
@@ -1,0 +1,417 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the bill-of-materials writer of `.github/scripts`.
+
+The script reads a wheel's `METADATA` and the bytes of the two
+distribution files, and nothing else -- no clock, no network, no source
+tree -- so the wheels here are synthetic and carry the metadata each test
+is about. The sdist is a file with content: only its digest is read.
+
+Two properties are worth more than the field-by-field assertions, and are
+what the release pipeline depends on. The document validates against the
+CycloneDX 1.6 JSON schema, checked once against the published schema and
+its two `$ref` files -- not asserted here, that would need the schema
+vendored and a validator installed for one test. And it is reproducible:
+`test_the_document_is_the_same_bytes_twice` is the one that fails if a
+clock or a `uuid4` ever reaches it, which would leave a rebuilt release
+differing from the published one in the one field nobody could check.
+
+The script is loaded by path, `.github/scripts` being no package.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import runpy
+import sys
+import zipfile
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "generate_sbom.py"
+
+# an instant in August 2026, as SOURCE_DATE_EPOCH carries one: seconds
+_EPOCH = 1786407122
+_METADATA = """Metadata-Version: 2.4
+Name: btclib
+Version: 2026.9
+Summary: A library for 'bitcoin cryptography'
+License-Expression: MIT
+Project-URL: homepage, https://btclib.org
+Requires-Python: >=3.10
+"""
+
+
+@pytest.fixture
+def script() -> ModuleType:
+    """Return the script, imported by path."""
+    spec = importlib.util.spec_from_file_location("generate_sbom", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_dist(
+    directory: Path,
+    *,
+    requirements: tuple[str, ...] = (),
+    metadata: str = _METADATA,
+    members: tuple[str, ...] = ("btclib-2026.9.dist-info/METADATA",),
+    version: str = "2026.9",
+) -> tuple[Path, Path]:
+    """Write a wheel carrying this metadata, and an sdist beside it."""
+    text = metadata + "".join(f"Requires-Dist: {r}\n" for r in requirements)
+    wheel = directory / f"btclib-{version}-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        for member in members:
+            archive.writestr(member, text)
+    sdist = directory / f"btclib-{version}.tar.gz"
+    sdist.write_bytes(b"an sdist, read for its digest alone")
+    return wheel, sdist
+
+
+def sbom(script: ModuleType, directory: Path, **kwargs: Any) -> dict[str, Any]:
+    """Return the document for a dist directory written on the spot."""
+    wheel, sdist = write_dist(directory, **kwargs)
+    document: dict[str, Any] = script.build_sbom(wheel, sdist, _EPOCH)
+    return document
+
+
+def test_the_document_describes_the_distribution(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """The root component is btclib, at the version the wheel declares."""
+    document = sbom(script, tmp_path)
+
+    assert document["bomFormat"] == "CycloneDX"
+    assert document["specVersion"] == "1.6"
+    assert document["metadata"]["timestamp"] == "2026-08-11T00:12:02Z"
+    component = document["metadata"]["component"]
+    assert component["name"] == "btclib"
+    assert component["version"] == "2026.9"
+    assert component["purl"] == "pkg:pypi/btclib@2026.9"
+    assert component["licenses"] == [{"expression": "MIT"}]
+    assert component["description"] == "A library for 'bitcoin cryptography'"
+    assert component["properties"] == [
+        {"name": "btclib:requires-python", "value": ">=3.10"}
+    ]
+    # no component-level hash, the component being two files
+    assert "hashes" not in component
+
+
+def test_the_two_files_are_named_with_their_digests(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """One externalReference per distribution file, carrying its SHA-256."""
+    document = sbom(script, tmp_path)
+
+    references = document["metadata"]["component"]["externalReferences"]
+    distributions = [r for r in references if r["url"].startswith("btclib-2026.9")]
+    assert [r["url"] for r in distributions] == [
+        "btclib-2026.9-py3-none-any.whl",
+        "btclib-2026.9.tar.gz",
+    ]
+    for reference in distributions:
+        (digest,) = reference["hashes"]
+        assert digest["alg"] == "SHA-256"
+        assert len(digest["content"]) == 64
+
+
+def test_a_project_url_becomes_a_reference_of_its_kind(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """The labels of `[project.urls]` map onto CycloneDX's own vocabulary."""
+    metadata = _METADATA + "Project-URL: repository, https://github.com/o/r\n"
+    document = sbom(script, tmp_path, metadata=metadata)
+
+    references = document["metadata"]["component"]["externalReferences"]
+    assert {"type": "website", "url": "https://btclib.org", "comment": "homepage"} in (
+        references
+    )
+    assert {
+        "type": "vcs",
+        "url": "https://github.com/o/r",
+        "comment": "repository",
+    } in references
+
+
+def test_a_label_with_no_mapping_is_recorded_as_other(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A url is never dropped for want of a word for what it is."""
+    metadata = _METADATA + "Project-URL: pull_requests, https://example.org/pulls\n"
+    document = sbom(script, tmp_path, metadata=metadata)
+
+    references = document["metadata"]["component"]["externalReferences"]
+    assert {
+        "type": "other",
+        "url": "https://example.org/pulls",
+        "comment": "pull_requests",
+    } in references
+
+
+def test_a_pinned_requirement_carries_its_version(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """`==` is the one specifier that names a version rather than a range."""
+    document = sbom(script, tmp_path, requirements=("btclib_secp256k1==0.8.0",))
+
+    (component,) = document["components"]
+    assert component["name"] == "btclib-secp256k1"
+    assert component["version"] == "0.8.0"
+    assert component["purl"] == "pkg:pypi/btclib-secp256k1@0.8.0"
+    assert component["scope"] == "required"
+    assert component["properties"] == [
+        {"name": "btclib:requires-dist", "value": "btclib_secp256k1==0.8.0"}
+    ]
+
+
+def test_a_floor_carries_no_version(script: ModuleType, tmp_path: Path) -> None:
+    """A range is not a version, and what the wheel declares is a range.
+
+    Which is the shape every release carries: RELEASING.md replaces each
+    direct reference with a `>=` floor before the tag, and what an
+    installer then resolves is not a fact about these files.
+    """
+    document = sbom(script, tmp_path, requirements=("btclib_secp256k1>=0.8.0",))
+
+    (component,) = document["components"]
+    assert "version" not in component
+    assert component["purl"] == "pkg:pypi/btclib-secp256k1"
+    assert component["properties"] == [
+        {"name": "btclib:requires-dist", "value": "btclib_secp256k1>=0.8.0"}
+    ]
+
+
+def test_a_direct_reference_carries_its_vcs_url(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """Between releases each sibling is a `git+https://...@main` reference."""
+    url = "git+https://github.com/btclib-org/btclib-secp256k1.git@main"
+    document = sbom(script, tmp_path, requirements=(f"btclib_secp256k1 @ {url}",))
+
+    (component,) = document["components"]
+    assert component["externalReferences"] == [{"type": "vcs", "url": url}]
+    # percent-encoded, the `+` and the `@` of the url being the two
+    # characters that would otherwise end a purl qualifier
+    assert component["purl"] == (
+        "pkg:pypi/btclib-secp256k1?vcs_url=git%2Bhttps%3A%2F%2Fgithub.com"
+        "%2Fbtclib-org%2Fbtclib-secp256k1.git%40main"
+    )
+
+
+def test_an_extra_makes_a_requirement_optional(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A dependency the wheel asks for only when an extra is asked for."""
+    requirement = 'coverage>=7; extra == "test"'
+    document = sbom(script, tmp_path, requirements=(requirement,))
+
+    (component,) = document["components"]
+    assert component["scope"] == "optional"
+
+
+def test_a_marker_that_is_not_an_extra_leaves_it_required(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """An interpreter version says where a dependency installs, not whether."""
+    document = sbom(script, tmp_path, requirements=('tomli; python_version < "3.11"',))
+
+    (component,) = document["components"]
+    assert component["scope"] == "required"
+
+
+def test_the_extras_of_a_requirement_are_recorded(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A name with extras keeps them, the purl having no field for them."""
+    document = sbom(script, tmp_path, requirements=("requests[socks]>=2",))
+
+    (component,) = document["components"]
+    assert {"name": "btclib:extras", "value": "socks"} in component["properties"]
+
+
+def test_the_dependency_graph_names_every_component(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """The root depends on each, and each on nothing: one level, declared."""
+    document = sbom(
+        script,
+        tmp_path,
+        requirements=("bitcoin-core-rpc==1.0", "btclib_secp256k1==2.0"),
+    )
+
+    refs = [component["bom-ref"] for component in document["components"]]
+    root, *leaves = document["dependencies"]
+    assert root == {"ref": "pkg:pypi/btclib@2026.9", "dependsOn": refs}
+    assert leaves == [{"ref": ref, "dependsOn": []} for ref in refs]
+
+
+def test_the_components_are_sorted(script: ModuleType, tmp_path: Path) -> None:
+    """Sorted by reference, so the metadata's own order cannot move them."""
+    document = sbom(
+        script, tmp_path, requirements=("zope.interface==7.0", "attrs==25.0")
+    )
+
+    assert [c["name"] for c in document["components"]] == ["attrs", "zope-interface"]
+
+
+def test_a_requirement_the_script_cannot_read_stops_it(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """Refused rather than guessed at.
+
+    A dependency the document omits in silence is the one failure a bill of
+    materials must not have.
+    """
+    with pytest.raises(SystemExit, match="cannot read the requirement"):
+        sbom(script, tmp_path, requirements=("== 1.0",))
+
+
+@pytest.mark.parametrize(
+    "members, expected",
+    [
+        ((), "carries 0 dist-info/METADATA members"),
+        (
+            ("a-1.dist-info/METADATA", "b-2.dist-info/METADATA"),
+            "carries 2 dist-info/METADATA members",
+        ),
+    ],
+)
+def test_a_wheel_without_exactly_one_metadata_stops_it(
+    script: ModuleType, tmp_path: Path, members: tuple[str, ...], expected: str
+) -> None:
+    """One wheel is one distribution, and its metadata is one member."""
+    with pytest.raises(SystemExit, match=expected):
+        sbom(script, tmp_path, members=members)
+
+
+def test_metadata_with_no_name_stops_it(script: ModuleType, tmp_path: Path) -> None:
+    """A wheel whose metadata is missing the two fields that identify it."""
+    with pytest.raises(SystemExit, match="declares no Name or no Version"):
+        sbom(script, tmp_path, metadata="Metadata-Version: 2.4\n")
+
+
+def test_metadata_with_no_summary_or_licence_omits_them(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """Every optional field is optional, rather than reported as empty."""
+    metadata = "Metadata-Version: 2.4\nName: btclib\nVersion: 2026.9\n"
+    document = sbom(script, tmp_path, metadata=metadata)
+
+    component = document["metadata"]["component"]
+    assert "description" not in component
+    assert "licenses" not in component
+    assert "properties" not in component
+
+
+def test_main_says_how_to_be_called_when_it_is_not(
+    script: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Two directories, no more and no fewer."""
+    assert script.main(["prog", "dist"]) == 2
+    err = capsys.readouterr().err
+    assert err == "usage: prog <dist directory> <output directory>\n"
+
+
+def test_main_refuses_to_run_without_source_date_epoch(
+    script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No default of "now", for normalize_sdist.py's reason.
+
+    A default makes the document differ from the released one, and whoever
+    found that out is the one person who could not fix it.
+    """
+    monkeypatch.delenv("SOURCE_DATE_EPOCH", raising=False)
+
+    assert script.main(["prog", str(tmp_path), str(tmp_path)]) == 1
+
+
+@pytest.mark.parametrize("pattern", ["*.whl", "*.tar.gz"])
+def test_main_refuses_a_dist_directory_that_is_not_one_pair(
+    script: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    pattern: str,
+) -> None:
+    """A stale artifact beside the fresh one is not silently skipped over."""
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
+    write_dist(tmp_path)
+    write_dist(tmp_path, version="2026.8")
+    (
+        tmp_path
+        / f"btclib-2026.8{'.tar.gz' if pattern == '*.whl' else '-py3-none-any.whl'}"
+    ).unlink()
+
+    with pytest.raises(SystemExit, match=f"expected one {pattern.replace('*', '.')}"):
+        script.main(["prog", str(tmp_path), str(tmp_path / "sbom")])
+
+
+def test_main_names_the_file_after_the_wheel(
+    script: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The caller passes a directory and needs to know no version.
+
+    Which in a rehearsal it does not: the `build` job patches a
+    `.dev<run number>` into the version before building, so the name the
+    workflow would have to construct is not the one in pyproject.toml.
+    """
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
+    write_dist(tmp_path, version="2026.9.dev7")
+    output = tmp_path / "sbom"
+
+    assert script.main(["prog", str(tmp_path), str(output)]) == 0
+
+    written = output / "btclib-2026.9.dev7.cdx.json"
+    assert f"wrote {written}" in capsys.readouterr().out
+    assert json.loads(written.read_text(encoding="utf-8"))["specVersion"] == "1.6"
+
+
+def test_the_document_is_the_same_bytes_twice(
+    script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reproducibility the release assets and their attestation want.
+
+    Everything here is derived: the timestamp from `SOURCE_DATE_EPOCH`,
+    the serial number from the purl and the two digests. A clock or a
+    `uuid4` reaching either is what this fails on.
+    """
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
+    write_dist(tmp_path, requirements=("btclib_secp256k1>=0.8.0",))
+
+    first, second = (tmp_path / "one", tmp_path / "two")
+    assert script.main(["prog", str(tmp_path), str(first)]) == 0
+    assert script.main(["prog", str(tmp_path), str(second)]) == 0
+
+    name = "btclib-2026.9.cdx.json"
+    assert (first / name).read_bytes() == (second / name).read_bytes()
+
+
+def test_the_main_guard_runs_the_script_as___main__(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cover `if __name__ == "__main__":` without a subprocess.
+
+    `runpy.run_path` executes the file fresh with `__name__` set to
+    `"__main__"` in this interpreter, this project collecting no coverage
+    from a child one.
+    """
+    monkeypatch.setenv("SOURCE_DATE_EPOCH", str(_EPOCH))
+    write_dist(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["prog", str(tmp_path), str(tmp_path / "sbom")])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(_SCRIPT), run_name="__main__")
+
+    assert excinfo.value.code == 0

--- a/tests/verify_dist_contents_test.py
+++ b/tests/verify_dist_contents_test.py
@@ -1,0 +1,396 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the distribution-content check of `.github/scripts`.
+
+What CI can show is that a real build passes: the `dist` job of test.yml
+runs the script on every pull request, and the `build` job of release.yml
+on the files it is about to publish. What CI cannot show is that anything
+*fails* -- a wheel with a shared object in it is not something a workflow
+can produce on purpose -- so the archives here are synthetic, one member
+planted per rule, and the assertion is the complaint.
+
+The script is loaded by path, `.github/scripts` being no package, as the
+mutation-counter and vendored-vector tests do. It has no dataclass, so
+registering the module before `exec_module` is not needed here.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import runpy
+import sys
+import tarfile
+import zipfile
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "verify_dist_contents.py"
+
+_VERSION = "1.0"
+_ROOT = f"btclib-{_VERSION}"
+_DIST_INFO = f"btclib-{_VERSION}.dist-info"
+
+# the smallest pair that passes: the package, one data file, the metadata
+# setuptools writes, and the licences it copies
+_PAYLOAD = ("btclib/__init__.py", "btclib/py.typed", "btclib/_data/mainnet.json")
+_WHEEL_MEMBERS = (
+    *_PAYLOAD,
+    f"{_DIST_INFO}/METADATA",
+    f"{_DIST_INFO}/RECORD",
+    f"{_DIST_INFO}/WHEEL",
+    f"{_DIST_INFO}/top_level.txt",
+    f"{_DIST_INFO}/licenses/LICENSE",
+)
+_SDIST_MEMBERS = (
+    *_PAYLOAD,
+    "PKG-INFO",
+    "pyproject.toml",
+    "README.md",
+    "uv.lock",
+    ".python-version",
+    "btclib.egg-info/PKG-INFO",
+    "btclib.egg-info/SOURCES.txt",
+    "docs/index.rst",
+    "tests/btclib_test.py",
+)
+_SDIST_DIRECTORIES = ("btclib", "btclib/_data", "btclib.egg-info", "docs", "tests")
+
+
+@pytest.fixture
+def script() -> ModuleType:
+    """Return the script, imported by path."""
+    spec = importlib.util.spec_from_file_location("verify_dist_contents", _SCRIPT)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_wheel(
+    directory: Path,
+    *,
+    extra: tuple[str, ...] = (),
+    omit: tuple[str, ...] = (),
+    version: str = _VERSION,
+) -> Path:
+    """Write a wheel carrying the default members, plus and minus these."""
+    path = directory / f"btclib-{version}-py3-none-any.whl"
+    with zipfile.ZipFile(path, "w") as archive:
+        for name in (*(m for m in _WHEEL_MEMBERS if m not in omit), *extra):
+            archive.writestr(name, "content")
+    return path
+
+
+def write_sdist(
+    directory: Path,
+    *,
+    extra: tuple[str, ...] = (),
+    omit: tuple[str, ...] = (),
+    raw: tuple[str, ...] = (),
+    specials: tuple[tarfile.TarInfo, ...] = (),
+) -> Path:
+    """Write an sdist: the default members, plus and minus, raw, special.
+
+    `extra` and `omit` name members relative to the archive's own root
+    directory, `raw` names them verbatim -- which is how a member outside
+    that root is planted -- and `specials` are `TarInfo` objects passed
+    through, for the member types a tar can carry and a zip cannot.
+    """
+    path = directory / f"{_ROOT}.tar.gz"
+    with tarfile.open(path, "w:gz") as archive:
+        for name in ("", *(f"/{d}" for d in _SDIST_DIRECTORIES)):
+            info = tarfile.TarInfo(f"{_ROOT}{name}")
+            info.type = tarfile.DIRTYPE
+            archive.addfile(info)
+        names = (
+            *(f"{_ROOT}/{m}" for m in _SDIST_MEMBERS if m not in omit),
+            *(f"{_ROOT}/{m}" for m in extra),
+            *raw,
+        )
+        for name in names:
+            info = tarfile.TarInfo(name)
+            info.size = len(b"content")
+            archive.addfile(info, io.BytesIO(b"content"))
+        for info in specials:
+            archive.addfile(info)
+    return path
+
+
+def one_complaint(script: ModuleType, directory: Path) -> str:
+    """Verify the directory, asserting there is exactly one complaint."""
+    (complaint,) = script.verify(directory)
+    return str(complaint)
+
+
+def test_a_clean_pair_passes(
+    script: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Nothing to complain about, and the payload is reported once."""
+    write_wheel(tmp_path)
+    write_sdist(tmp_path)
+
+    assert script.verify(tmp_path) == []
+
+    out = capsys.readouterr().out
+    assert "carry what they may and no more" in out
+    assert f"one payload of {len(_PAYLOAD)} files, in both" in out
+
+
+@pytest.mark.parametrize(
+    "member, expected",
+    [
+        # the limit of the `_data/` amnesty, which admits by directory and
+        # not by extension
+        ("btclib/_data/libsecp256k1.so", "carries the forbidden suffix .so"),
+        ("btclib/_data/vectors.tar.gz", "carries the forbidden suffix .tar.gz"),
+        ("btclib/sitecustomize.py", "is sitecustomize.py, which Python imports"),
+        ("btclib/usercustomize.py", "is usercustomize.py, which Python imports"),
+        (
+            "btclib/__pycache__/utils.cpython-314.pyc",
+            "carries the forbidden suffix .pyc",
+        ),
+        # a `.py` the allowlist would otherwise take, in the one place a
+        # wheel must not put one
+        ("stray.py", "is neither package code nor package metadata"),
+        ("btclib/curves/notes.rst", "is neither Python source nor a _data file"),
+        (f"{_DIST_INFO}/entry_points.txt", "is not one of its files"),
+        (f"{_DIST_INFO}/nested/METADATA", "is not one of its files"),
+    ],
+)
+def test_a_planted_wheel_member_is_named(
+    script: ModuleType, tmp_path: Path, member: str, expected: str
+) -> None:
+    """One member per rule, and the complaint says which rule it broke."""
+    write_wheel(tmp_path, extra=(member,))
+    write_sdist(tmp_path)
+
+    complaints = script.verify(tmp_path)
+
+    assert any(expected in complaint for complaint in complaints)
+
+
+@pytest.mark.parametrize(
+    "member", ["btclib/py.typed", "btclib/__init__.py", f"{_DIST_INFO}/RECORD"]
+)
+def test_a_missing_wheel_member_is_named(
+    script: ModuleType, tmp_path: Path, member: str
+) -> None:
+    """PEP 561's marker, the package itself and the metadata are required.
+
+    Each is absent in a way that installs and imports cleanly: a wheel
+    with no `py.typed` type checks as `Any`, and one with no metadata
+    reports `btclib.__version__` as "unknown" (issue #150).
+    """
+    write_wheel(tmp_path, omit=(member,))
+    write_sdist(tmp_path, omit=(member,))
+
+    complaints = script.verify(tmp_path)
+
+    assert any(f"{member} is missing" in complaint for complaint in complaints)
+
+
+@pytest.mark.parametrize(
+    "extra, omit, raw, expected",
+    [
+        ((".editorconfig",), (), (), "is a root file the sdist does not ship"),
+        (
+            ("benchmarks/timing.py",),
+            (),
+            (),
+            "is not under one of the directories the sdist ships",
+        ),
+        (
+            ("tests/vendored.dist-info/METADATA",),
+            (),
+            (),
+            "holds the metadata of another distribution",
+        ),
+        (
+            ("btclib.egg-info/build.log",),
+            (),
+            (),
+            "is under btclib.egg-info/ and is not metadata",
+        ),
+        (("tests/_data/wheel.whl",), (), (), "carries the forbidden suffix .whl"),
+        ((), (), ("elsewhere/setup.py",), "is outside the archive's own"),
+        ((), (), (f"{_ROOT}/../escape.py",), "is not a relative path"),
+        ((), (), ("/etc/passwd",), "is not a relative path"),
+        ((), ("PKG-INFO",), (), "PKG-INFO is missing"),
+        ((), ("pyproject.toml",), (), "pyproject.toml is missing"),
+    ],
+)
+def test_a_planted_sdist_member_is_named(
+    script: ModuleType,
+    tmp_path: Path,
+    extra: tuple[str, ...],
+    omit: tuple[str, ...],
+    raw: tuple[str, ...],
+    expected: str,
+) -> None:
+    """One member per structural rule, and the complaint names the rule."""
+    # the wheel omits what the sdist omits, so that the two payloads still
+    # agree and the complaint under test is the only one
+    write_wheel(tmp_path, omit=omit)
+    write_sdist(tmp_path, extra=extra, omit=omit, raw=raw)
+
+    complaints = script.verify(tmp_path)
+
+    assert any(expected in complaint for complaint in complaints)
+
+
+@pytest.mark.parametrize(
+    "directory, expected",
+    [
+        ("benchmarks", "is a directory the sdist does not ship"),
+        # the one case the forbidden suffixes do not reach: an empty
+        # bytecode directory is a directory member and no `.pyc`
+        ("btclib/__pycache__", "is under __pycache__"),
+    ],
+)
+def test_a_directory_member_is_judged_too(
+    script: ModuleType, tmp_path: Path, directory: str, expected: str
+) -> None:
+    """A directory with no file under it is a member in its own right."""
+    info = tarfile.TarInfo(f"{_ROOT}/{directory}")
+    info.type = tarfile.DIRTYPE
+    write_wheel(tmp_path)
+    write_sdist(tmp_path, specials=(info,))
+
+    complaints = script.verify(tmp_path)
+
+    assert any(expected in complaint for complaint in complaints)
+
+
+def test_a_member_that_is_not_a_file_or_a_directory_is_named(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A symlink is a member type a tar can carry and a zip cannot.
+
+    Which is the whole reason the sdist is checked for it and the wheel is
+    not: what a symlink in an sdist points at is decided when it is
+    unpacked, so it is the one member whose content is not in the archive.
+    """
+    info = tarfile.TarInfo(f"{_ROOT}/tests/link.py")
+    info.type = tarfile.SYMTYPE
+    info.linkname = "../../../etc/passwd"
+    write_wheel(tmp_path)
+    write_sdist(tmp_path, specials=(info,))
+
+    complaints = script.verify(tmp_path)
+
+    assert any("is neither a regular file nor a directory" in c for c in complaints)
+
+
+def test_a_payload_the_wheel_drops_is_named(script: ModuleType, tmp_path: Path) -> None:
+    """A data file in the sdist and not in the wheel, which is issue #393."""
+    write_wheel(tmp_path)
+    write_sdist(tmp_path, extra=("btclib/_data/testnet.json",))
+
+    assert "ships btclib/_data/testnet.json" in one_complaint(script, tmp_path)
+
+
+def test_a_payload_only_the_wheel_has_is_named(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """And the other direction: a file the sdist, hence the tree, lacks."""
+    write_wheel(tmp_path, extra=("btclib/_data/testnet.json",))
+    write_sdist(tmp_path)
+
+    assert "ships btclib/_data/testnet.json" in one_complaint(script, tmp_path)
+
+
+def test_a_directory_entry_in_the_wheel_is_not_a_member(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """A zip may carry an entry per directory; setuptools writes none."""
+    write_wheel(tmp_path, extra=("btclib/curves/",))
+    write_sdist(tmp_path)
+
+    assert script.verify(tmp_path) == []
+
+
+@pytest.mark.parametrize("pattern", ["*.whl", "*.tar.gz"])
+def test_no_artifact_of_a_kind_is_named(
+    script: ModuleType, tmp_path: Path, pattern: str
+) -> None:
+    """A dist directory with only one of the two is not half checked."""
+    if pattern == "*.tar.gz":
+        write_wheel(tmp_path)
+    else:
+        write_sdist(tmp_path)
+
+    assert f"expected one {pattern}, found none" in one_complaint(script, tmp_path)
+
+
+def test_a_second_artifact_of_a_kind_is_named(
+    script: ModuleType, tmp_path: Path
+) -> None:
+    """Two wheels are refused rather than the newer one being picked.
+
+    A stale artifact from an earlier build in the same directory is
+    precisely what a check on the files about to be published must not
+    skip over -- and it is the file the *other* one that gets uploaded.
+    """
+    write_wheel(tmp_path)
+    write_wheel(tmp_path, version="0.9")
+    write_sdist(tmp_path)
+
+    complaints = script.verify(tmp_path)
+
+    assert any("expected one *.whl, found" in complaint for complaint in complaints)
+
+
+def test_main_says_how_to_be_called_when_it_is_not(
+    script: ModuleType, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No dist directory, or two of them, is the usage rather than a crash."""
+    assert script.main(["prog"]) == 2
+    assert capsys.readouterr().err == "usage: prog <dist directory>\n"
+
+
+def test_main_annotates_every_complaint_and_fails(
+    script: ModuleType, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Each complaint is a workflow annotation, so the run summary has it."""
+    write_wheel(tmp_path, extra=("stray.py",))
+    write_sdist(tmp_path, extra=(".editorconfig",))
+
+    assert script.main(["prog", str(tmp_path)]) == 1
+
+    err = capsys.readouterr().err
+    assert "::error::" in err
+    assert err.count("::error::") == 2
+
+
+def test_main_passes_on_a_clean_pair(script: ModuleType, tmp_path: Path) -> None:
+    """The exit code a green workflow step reads."""
+    write_wheel(tmp_path)
+    write_sdist(tmp_path)
+
+    assert script.main(["prog", str(tmp_path)]) == 0
+
+
+def test_the_main_guard_runs_the_script_as___main__(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Cover `if __name__ == "__main__":` without a subprocess.
+
+    This project collects no coverage from a child interpreter, so a real
+    subprocess would leave the guard as uncovered as it is in
+    `mutation_counts.py`. `runpy.run_path` executes the file fresh with
+    `__name__` set to `"__main__"` in this one.
+    """
+    write_wheel(tmp_path)
+    write_sdist(tmp_path)
+    monkeypatch.setattr(sys, "argv", ["prog", str(tmp_path)])
+
+    with pytest.raises(SystemExit) as excinfo:
+        runpy.run_path(str(_SCRIPT), run_name="__main__")
+
+    assert excinfo.value.code == 0


### PR DESCRIPTION
Three gaps in the release pipeline, each one thing nothing looked at:
where the tag came from, what is inside the files it builds, and what
those files declare.

## Where the tag came from — [#650](https://github.com/btclib-org/btclib/issues/650)

Every check in `version-check` reads the tree the tag names and none asked
where that tree came from, so a tag pushed from a stale worktree, from a
branch whose pull request is still open, or from the pre-squash commit of
one that landed — which the squash leaves on no branch at all — would
publish code no review approved and `main` does not contain.
`git merge-base --is-ancestor` against
`github.event.repository.default_branch` answers it, first in the job and
release-only, a rehearsal being dispatched from a branch on purpose.

The job's checkout takes `fetch-depth: 0`, where every other checkout in
these workflows takes the default single commit: without it there is no
ancestry to answer with, and no `origin/<default branch>` to answer
against — checkout fetches `+refs/heads/*:refs/remotes/origin/*` at that
depth and nothing at the default, read in `ref-helper.ts` at the pinned
commit rather than assumed. A missing ref is told apart from a missing
ancestor, so the error names the cause.

## What is inside them — [#649](https://github.com/btclib-org/btclib/issues/649)

`twine check --strict`, `check-wheel-contents` and `pyroma --min 10` read
metadata; the members of the two archives were read by nothing, and the
members are what a user installs.
`.github/scripts/verify_dist_contents.py` is the allowlist, run by the
`dist` job of `test.yml` on every pull request and by the `build` job of
`release.yml` on the files it is about to publish.

The asymmetry between the two archives is the substance of it.

- **the wheel gets a strict allowlist**, being what lands on `sys.path`:
  Python source under `btclib/`, `py.typed`, whatever sits in a `_data/`
  directory, and the `.dist-info` metadata setuptools writes — so a `.pth`
  file, a stray top-level module, a bundled shared object and an
  `entry_points.txt` nothing declared are one rule and not four
- **the sdist gets a structural check** instead of an extension allowlist,
  because MANIFEST.in already is one and a second copy would be an edit per
  vendored vector while catching nothing that file lets through. What it
  adds is what MANIFEST.in cannot say: every member under the archive's own
  root, every member a regular file or a directory (a tar carries a
  symlink, a hardlink and a device node, where a zip cannot), no directory
  holding another distribution's metadata, and which files may sit at the
  root, where `include *.md` and `include *.yaml` ship whatever lands
  beside them
- **and the completeness half**, which needs nothing kept in step: `uv
  build` builds the sdist and then the wheel from it, so the two carry one
  `btclib/` payload and the check is that they do, member by member. A data
  file in the tree and not in the wheel is
  [#393](https://github.com/btclib-org/btclib/issues/393), so
  check-manifest gates the tree against the sdist, this gates the sdist
  against the wheel, and #393's own smoke test gates what PyPI serves.
  Measured on a real build: the two payloads are equal, in both directions

`py.typed` is required by name, PEP 561 making its absence silent. Every
offending member is reported, not the first. `embit` keeps a policy
document beside its script; the allowlist is in the script here, two copies
of a list being one that can be wrong.

## What they declare — [#648](https://github.com/btclib-org/btclib/issues/648)

`.github/scripts/generate_sbom.py` writes one CycloneDX 1.6 document per
release, attached to the GitHub release and covered by the same
attestation — a bill of materials whose provenance nobody can check says
only what whoever wrote it wanted said, which is the gap
[#557](https://github.com/btclib-org/btclib/issues/557) closed for the
other assets.

It reads the built wheel and not pyproject.toml: the two agree on a release
and not in a rehearsal, where the version carries a `.dev<run number>` the
build job patched in, and the document has to describe the files beside it.
Which also decides what it can say about a dependency — the requirement as
published, so a component gets a `version` where that requirement is a `==`
pin and none where it is a floor, a resolution recorded here being a claim
the wheel does not make.

It is reproducible like the files it describes: `SOURCE_DATE_EPOCH` is the
timestamp and a UUID5 over the purl and the two digests is the serial
number, so a rebuild of the tag writes the same bytes and RELEASING.md's
rebuild command verifies it with a third `gh attestation verify`. Written
into an artifact of its own and not into `dist/`, which the publish jobs
hand to an index whole. Validated once against the published CycloneDX 1.6
schema and its two `$ref` files, rather than a validator installed in the
release path. Hand-written, where the official `cyclonedx-py` takes an
environment or a requirements file as its subject: neither is these two
archives, and the build job installs nothing before the artifact it
publishes is uploaded.

## [#557](https://github.com/btclib-org/btclib/issues/557) is already closed, by
## [`5f2fdbc1`](https://github.com/btclib-org/btclib/commit/5f2fdbc1705c50b6602207447b99c11ba4cc48ac)

Nothing in this branch is for it. `release.yml`'s `attest` job does what
that issue asked — `actions/attest` over `dist/*`, in a job of its own
rather than as two more permissions on `github-release`, which is the
placement the issue said to decide deliberately — and the signed bundle is
attached to the release as `<tag>.attestation.jsonl` besides. SECURITY.md
carries the `gh attestation verify` command and CHANGELOG.md the entry. It
is open only because the commit did not say `Closes`; it can be closed
naming that commit.

What this branch does for it is keep it closed: the bill of materials is a
new release asset, and an unattested one would have reopened exactly that
gap for the file that says what the others contain. So `attest` signs
`sbom/*` with `dist/*`, under one statement.

## Found on the way

Three of the four tests that load a script from `.github/scripts` by path
were in the sdist, which carries no `.github` at all, so every test in
`tests/check_vendored_vectors_test.py` would raise `FileNotFoundError` from
an unpacked one — where `tests/mutation_counts_test.py` had been excluded
for exactly that. MANIFEST.in and `[tool.check-manifest]` name all four
now.

## Tests

Both scripts are tested, because what CI can show is that a real build
passes and what it cannot show is that anything fails — a wheel with a
shared object in it is not something a workflow produces on purpose. The
archives in the two new test modules are synthetic, one member planted per
rule, and the reproducibility of the document is the assertion that fails
if a clock or a `uuid4` ever reaches it.

## Gates, run locally

- `uv run pytest` — 26031 passed, coverage 100.00%, the ratchet met
- `uv run pre-commit run --all-files` — every hook, actionlint and zizmor
  included
- `sphinx-build -W --keep-going` — build succeeded
- both scripts against a real `uv build` of this branch, and the resulting
  document validated against the published CycloneDX 1.6 schema: 0 errors

## Summary by Sourcery

Enforce release-tag integrity, validate built distribution contents, and generate and attest a reproducible CycloneDX SBOM as part of the release and test workflows.

Enhancements:
- Add a release-time check that refuses tags whose commit is not contained in the repository’s default branch.
- Extend release and test workflows to verify wheel and sdist members against an explicit policy and to ensure their payloads match.
- Introduce a reproducible CycloneDX 1.6 SBOM generated from built artifacts, store it as a separate artifact, and include it among attested and released assets.
- Update contributor, releasing, changelog, and security documentation to describe the new tag ancestry check, distribution content verification, and SBOM generation and verification flow.

CI:
- Modify release and test GitHub Actions workflows to run the new tag ancestry check, distribution-content verification, SBOM generation, and to attest and publish the SBOM alongside distribution files.

Documentation:
- Document the tag-ancestry safeguard, the SBOM asset and its verification, and the stricter sdist contents policy in RELEASING.md, CONTRIBUTING.md, CHANGELOG.md, and SECURITY.md.

Tests:
- Add unit tests for the SBOM generator script, including dependency modelling, error handling, and reproducibility guarantees.
- Add unit tests for the distribution-content verification script, covering allowed/forbidden members, structural sdist rules, payload completeness checks, and CLI behaviour.

Chores:
- Exclude tests whose subject resides under .github/scripts from the sdist via pyproject configuration so the packaged test suite is runnable from the sdist.