### PR TITLE
Say which minimal `serialize` means, data being data (#646)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1586,6 +1586,34 @@ documented at release-notes length in the first place, and are still in
   valid range and not the one asked for, which would be a caller's
   arithmetic reported as a successful import of something else.
 
+- **`serialize` says which minimal it means** (issue #646). "Data is
+  always the minimal push, per BIP62" reads as the minimal *command*,
+  which would make a bytes command holding the single byte `0x01` come
+  out as OP_1; what it has always meant, and now says, is the minimal
+  push *operator* -- the narrowest of the four widths -- with the data
+  pushed by length whatever it is. Which is Core's split: its
+  `AppendDataSize` writes a length for whatever vector it is handed, and
+  `push_int64` -- reached from a `CScriptNum` and from an integer, never
+  from a byte vector -- is the only thing that reaches for OP_0,
+  OP_1NEGATE or OP_1..OP_16. Only the caller knows whether bytes mean a
+  number, so `push_int` is where one that means a number says so, and
+  the integer command warns that it is one byte longer than the op code.
+
+  Not a gap left open: every place in this library that pushes a number
+  already calls `push_int` or `op_int`, and three readers positively
+  require the current spelling, each measuring a push against what
+  `serialize` writes for its data --
+  `engine.script_op_codes.check_minimal_push`,
+  `miniscript._assert_minimal_push` and, differently,
+  `engine.script.calculate_script_code`, which builds the needle
+  FindAndDelete searches for as Core builds it, `CScript() << vchSig`. A
+  push of the single byte `0x00` is the one Core's `CheckMinimalPush`
+  accepts as data of one byte where OP_0 pushes no bytes at all, so it is
+  also the one value for which the substitution would change what lands
+  on the stack rather than how it is spelled. Nothing changes in what
+  `serialize` writes; the docstring says the rule and the test pins it,
+  over the whole set of values that could have been written otherwise.
+
 ### Descriptors and miniscript
 
 - **An invalid output is refused, not answered about** (#691). `index_of`

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -377,6 +377,29 @@ def _serialize_bytes_command(command: bytes) -> bytes:
     According to standardness rules (BIP62) the minimum possible
     PUSHDATA operator must be used.
 
+    The minimal push *operator*, and never the one-byte op code that
+    pushes the same value: a bytes command holding the single byte 0x01
+    is written ``0101``, as every other one-byte push is, and not OP_1
+    (issue #646). Core's own split, and for Core's reason: its
+    `AppendDataSize` writes a length for whatever vector it is handed,
+    and `push_int64` -- reached from `CScriptNum` and from an integer,
+    never from a byte vector -- is the only thing that reaches for OP_0,
+    OP_1NEGATE or OP_1..OP_16. It has to be that way here too, because
+    only the caller knows whether those bytes mean a number: `push_int`
+    is where one that means a number says so, and `op_int` is the op
+    code it names.
+
+    Three readers depend on it, each measuring a push against what this
+    writes for its data: `engine.script_op_codes.check_minimal_push`,
+    `miniscript._assert_minimal_push`, and -- differently --
+    `engine.script.calculate_script_code`, which builds the needle
+    FindAndDelete searches for as Core builds it, `CScript() << vchSig`.
+    A one-byte push of 0x00 is what the first two hand this, Core's
+    `CheckMinimalPush` accepting it as data of one byte where OP_0
+    pushes no bytes at all; substituting the op code would refuse the
+    push Core accepts, and would have FindAndDelete search for bytes the
+    script code cannot hold.
+
     All four widths, OP_PUSHDATA4 included, because what parse reads
     serialize must be able to write back: a push over 520 bytes is one
     the stack cannot hold, i.e. a script no one can spend, and not one
@@ -416,9 +439,16 @@ def serialize(script: Sequence[Command]) -> bytes:
     where a one-byte op code means the same, and a refusal outside the
     int64 a script number is -- a string is an op code name, an
     UNKNOWN_OP_CODE_n byte, or hex data, and bytes are data; data is
-    always the minimal push, per BIP62. What parse returns round-trips,
-    ERROR_COMMAND excepted, that marker being a place in the bytes
-    rather than an instruction.
+    always the minimal push operator, per BIP62. What parse returns
+    round-trips, ERROR_COMMAND excepted, that marker being a place in
+    the bytes rather than an instruction.
+
+    The minimal *operator* and not the minimal *command*: data is data,
+    so the bytes 0x01 are pushed with a length of one and not with OP_1,
+    and the same goes for an integer command, which is the number's
+    bytes and is warned about for exactly this. `push_int` is what
+    writes a number the shortest way there is, and what every caller in
+    this library that means one uses.
     """
     r: list[bytes] = []
     for command in script:

--- a/tests/script/script_test.py
+++ b/tests/script/script_test.py
@@ -111,6 +111,42 @@ def test_serialize_bytes_command() -> None:
     assert len(serialize([b])) == (length + 1) + 3
 
 
+def test_a_data_command_is_never_a_numeric_op_code() -> None:
+    """Verify the values with an op code are still pushed as data.
+
+    The set Core's `CheckMinimalPush` names -- the empty push, 1 to 16
+    and 0x81 -- is the set with a one-byte op code of its own, and
+    `serialize` reaches for none of them from a bytes command, a hex
+    string or an integer: data is data, and `push_int` is where a caller
+    that means a number says so (issue #646). The empty push is the one
+    place the two spellings are the same byte, a zero-length push being
+    OP_0 already.
+    """
+    assert serialize([b""]) == BYTE_FROM_OP_CODE_NAME["OP_0"]
+    for i in range(1, 17):
+        assert serialize([bytes([i])]) == bytes([1, i])
+        assert serialize([bytes([i]).hex()]) == bytes([1, i])
+        assert serialize_non_canonical([i]) == bytes([1, i])
+        assert serialize([push_int(i)]) == BYTE_FROM_OP_CODE_NAME[f"OP_{i}"]
+    assert serialize([b"\x81"]) == b"\x01\x81"
+    assert serialize_non_canonical([-1]) == b"\x01\x81"
+    assert serialize([push_int(-1)]) == BYTE_FROM_OP_CODE_NAME["OP_1NEGATE"]
+
+    # a push of one zero byte is data of one byte, which is what Core's
+    # CheckMinimalPush measures it as: OP_0 pushes no bytes at all, so
+    # the two are not the same push and this one is minimal already --
+    # the only value in the set for which reaching for the op code would
+    # change what lands on the stack, and not merely how it is spelled
+    assert serialize([b"\x00"]) == b"\x01\x00"
+    assert serialize_non_canonical([0]) == b"\x01\x00"
+
+    # what parse hands back for such a push is its hex, and serializing
+    # that writes the push it read: the round trip is what a substitution
+    # would break, silently and for every one-byte push in a script
+    assert parse(b"\x01\x01") == ["01"]
+    assert serialize(parse(b"\x01\x01")) == b"\x01\x01"
+
+
 def test_add_and_eq() -> None:
     """Verify Script + Script concatenates and refuses raw bytes."""
     script_1 = serialize(["OP_2", "OP_3", "OP_ADD", "OP_5"])


### PR DESCRIPTION
Closes <https://github.com/btclib-org/btclib/issues/646>.

The issue asked which of two readings is right, and named the first
step: whether any code path here builds a byte-vector push for a value
in `{b"", b"\x00", b"\x01".."\x10", b"\x81"}` without going through the
int path. Answer, measured rather than argued: none does, and three
readers positively require the current spelling.

## How it was measured

`_serialize_bytes_command` was instrumented to record every one-byte
command in that set together with the btclib frames above it, and the
whole suite was run (26031 tests). Everything reaching it from inside
the library is one of three call sites; everything else is a test
pushing such a value on purpose.

- `engine.script_op_codes.check_minimal_push` compares
  `serialize([data])[0]` with the op code the script actually used.
  Core's vectors 516, 946, 1182 and 1191 hand it a one-byte push of
  `0x00`, which Core's `CheckMinimalPush` accepts as data of one byte —
  `data.size() <= 75 → opcode == data.size()`. Substituting OP_0 there
  would refuse the push Core accepts, and would be a different stack
  element besides: OP_0 pushes no bytes at all.
- `miniscript._assert_minimal_push` does the same for the scripts
  `from_script` reads.
- `engine.script.calculate_script_code` builds the needle FindAndDelete
  searches for with `serialize([signature])`, mirroring Core's
  `FindAndDelete(scriptCode, CScript() << vchSig)`. Core's vectors 592
  and 593 pass a one-byte signature. A substitution would search for
  `51` where Core searches for `0101`, in a consensus preimage.

Miniscript's `_ONE_PUSH` never reaches a serializer: miniscript is
allowed in the `wsh()` and `tr()` contexts only, so its satisfactions
are witness stacks, where no push operator is written at all.

## What Core does

The split is Core's, verbatim in `src/script/script.h`: `AppendDataSize`
writes a length for whatever vector it is handed, and `push_int64` —
reached from `CScriptNum` and from an integer, never from a byte vector
— is the only thing that reaches for OP_0, OP_1NEGATE or OP_1..OP_16.
btclib draws the same line: `push_int` is where a caller that means a
number says so, and an integer command warns that the op code is one
byte shorter.

## The change

Documentation and a test, no behavior change:

- `serialize`'s docstring says the minimal push *operator* and not the
  minimal *command*, which is the sentence the issue read the other way;
- `_serialize_bytes_command`'s carries Core's split and the three
  readers that depend on it;
- `test_a_data_command_is_never_a_numeric_op_code` pins the whole set,
  from a bytes command, a hex string and an integer alike, together with
  the `push_int` spelling of each and the `parse`/`serialize` round trip
  a substitution would break.

## Gates

`uv run pytest` (26032 passed, coverage ratchet included),
`uv run pre-commit run --all-files`, and the sphinx `-W` build, all
green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify that script serialization uses the minimal push operator width for data rather than numeric opcodes, aligning behavior with Bitcoin Core and explicitly documenting this invariant.

Enhancements:
- Expand serialize and _serialize_bytes_command docstrings to explain the distinction between data pushes and numeric opcodes and reference the Core-inspired split.

Documentation:
- Document the clarified minimal push semantics for serialize in the changelog, including the correspondence with Bitcoin Core’s AppendDataSize/push_int64 behavior.

Tests:
- Add a regression test ensuring data, hex strings, and integers are serialized as data pushes rather than numeric opcodes for the special values with dedicated opcodes, and that parse/serialize round-trips remain unchanged.