### PR TITLE
Give each release a documentation URL of its own, and a check for it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -637,3 +637,45 @@ jobs:
             gh release create "$GITHUB_REF_NAME" dist/* sbom/* "$bundle" \
               --title "$GITHUB_REF_NAME" --generate-notes
           fi
+
+  # the sentinel on the documentation, which nothing was watching: read the
+  # docs activates and builds a new release tag from an automation rule of
+  # its own (REPOSITORY.md's "Read the Docs" section), and a build that
+  # never starts fails nothing -- a site answering 200 serves the last build
+  # that succeeded, for as long as that takes somebody to notice. Two
+  # releases went out undocumented that way, which is issue #574.
+  # The rendered URL and not the v3 API, which is the reverse of what
+  # `published` above does with PyPI's: read the docs throttles an
+  # unauthenticated caller to five requests a minute and warns that
+  # requests from a cloud provider are blocked outright without a token, so
+  # asking the API from a runner would mean storing a credential for a
+  # check that gates nothing. /en/<tag>/ is CDN-served, answers 404 for a
+  # version that is inactive or has no successful build, and is the URL a
+  # reader follows anyway.
+  # Release-only, a rehearsal never being tagged; after version-check, so a
+  # tag it refuses produces one verdict and not two; and nothing needs it:
+  # a late documentation build is not a reason to withhold a wheel, and the
+  # fix for a red run here is a build on their side, not a moved tag
+  documented:
+    name: Check read the docs built the tag
+    needs: version-check
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Wait for the tag's documentation to be served
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          url="https://btclib.readthedocs.io/en/${TAG}/"
+          for attempt in $(seq 30); do
+            if curl -sf --max-time 10 -o /dev/null "$url"; then
+              echo "${url} is served"
+              exit 0
+            fi
+            echo "attempt ${attempt}: ${url} is not served yet"
+            sleep 30
+          done
+          echo "::error::${url} was never served: read the builds page on" \
+            "https://app.readthedocs.org/projects/btclib/builds/"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,32 @@ documented at release-notes length in the first place, and are still in
   lives and `OutPoint` and `TxIn` are the classes it holds for, so the new
   paragraph points at it instead of restating it.
 
+- **Each new release gets a documentation URL of its own, and a check that
+  says so.** btclib.readthedocs.io was serving neither of the last two
+  releases: `latest` followed a branch this repository no longer has, so
+  every push was answered without a build being triggered, and the site
+  kept the last build that had succeeded -- a placeholder version, from a
+  commit squashed away months earlier. That is issue #574, and the half of
+  it that is settings is now written down: `latest` follows `main`,
+  `stable` is the newest release tag, and an automation rule activates each
+  new tag, which is what makes `/en/v<version>/` exist and stay that
+  version rather than becoming the next one. REPOSITORY.md's "Read the
+  Docs" section is where they live, that file being the whole of what
+  cannot be recovered by reading the tree.
+  The other half is a job: `release.yml`'s `documented` waits for the
+  tag's page to be served and is red if it never is, where until now
+  nothing failed when a build never started. It polls the rendered URL and
+  not the v3 API, which the `published` job's PyPI check is the reverse of:
+  read the docs throttles an unauthenticated caller to five requests a
+  minute and blocks cloud-provider addresses outright without a token, so
+  asking the API from a runner would mean keeping a credential for a check
+  that gates nothing. It starts with the next release and reaches no
+  release behind it: a rule applies to the versions created after it, so
+  `v2026.8.9` has no page of its own and is not getting one, and anything
+  before `v2026.8.7` could not have one — a build needs `.readthedocs.yaml`
+  and would fail without it. `/en/stable/` is the last release either way,
+  which is what makes the backfill not worth doing.
+
 ### Packaging, linting and CI
 
 - **A tag is refused unless the default branch contains its commit**

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ kramdown having hard_wrap off. -->
 [![test workflow status](https://github.com/btclib-org/btclib/actions/workflows/test.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/test.yml)
 [![lint workflow status](https://github.com/btclib-org/btclib/actions/workflows/lint.yml/badge.svg)](https://github.com/btclib-org/btclib/actions/workflows/lint.yml)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/btclib-org/btclib/main.svg)](https://results.pre-commit.ci/latest/github/btclib-org/btclib/main)
-[![documentation build](https://readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
+[![documentation build](https://app.readthedocs.org/projects/btclib/badge/?version=latest)](https://btclib.readthedocs.io)
 
 [![GitHub repository: btclib-org/btclib](https://img.shields.io/badge/GitHub-btclib--org%2Fbtclib-181717?logo=github)](https://github.com/btclib-org/btclib/)
 [![slack: btclib_dev](https://img.shields.io/badge/slack-btclib_dev-white.svg?logo=slack)](https://bbt-training.slack.com/messages/C01CCJ85AES)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -250,13 +250,16 @@ word, and step 1 asks it of both.
    runs neither**.
 
    Then verify the
-   [read the docs](https://readthedocs.org/projects/btclib/builds/)
+   [read the docs](https://app.readthedocs.org/projects/btclib/builds/)
    build, and that [the website](https://btclib.org) and the
    [documentation](https://btclib.readthedocs.io/en/latest/) render
    correctly. Read the *builds* page and not only the rendered one: a
    site that answers 200 may be serving the last build that succeeded,
    which for three years was v2023.7.12's — the webhook had been
    refusing every delivery with a 400 and nobody was told (issue #484).
+   This is the half no check covers: `latest` is the tip of `main`, so
+   nothing names a version to ask about. The tag's own build is asked
+   about, by the `documented` job below.
 
    Two things about that pull request, both of them before the button
    rather than after it.
@@ -354,6 +357,17 @@ word, and step 1 asks it of both.
    pull requests instead — the fallback `version-check` exists to make
    unreachable, not a second way to write release notes — and they are
    worth replacing by hand if it ever fires.
+
+1. Read the `documented` job rather than the site: read the docs activates
+   and builds a new release tag from the automation rule REPOSITORY.md
+   records, and that job waits for
+   `https://btclib.readthedocs.io/en/<tag>/` to be served and is red if it
+   never is. Green means the release has a permanent URL of its own, which
+   is the one to link when the version is named anywhere. Red means the
+   build is missing and
+   [the builds page](https://app.readthedocs.org/projects/btclib/builds/)
+   says why: nothing about the publication depends on it, so the fix is a
+   build on their side and never a moved tag.
 
 1. Install what was just published into an environment of its own,
    then exercise something that touches the shipped data rather than

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -396,6 +396,65 @@ records for `btclib.org` and the `https_enforced` certificate hang off it.
 The file is what Pages reads on each build, so deleting it from the tree
 un-sets the setting on the next push.
 
+## Read the Docs, which is btclib.readthedocs.io
+
+**The published documentation is a project on Read the Docs**, `btclib` on
+<https://app.readthedocs.org/projects/btclib/>. `.readthedocs.yaml` says
+how a build runs; *which* versions run it is settings there, and nothing
+in the tree records them:
+
+```shell
+curl -s https://app.readthedocs.org/api/v3/projects/btclib/ \
+  | python3 -c 'import json, sys; p = json.load(sys.stdin); \
+      print(p["default_branch"], p["default_version"])'
+# main latest
+```
+
+- **`latest` follows the default branch, which is `main`.** That setting is
+  Read the Docs' own and not GitHub's, so renaming the branch here leaves
+  it pointing at one that no longer exists — and a push to a branch no
+  version follows is *accepted*, answered with `{"build_triggered": false,
+  "versions": []}`, which is a green delivery and a site frozen at its last
+  build (issue #574).
+- **`stable` is the highest semantic-version tag**, chosen by Read the Docs
+  and moved by it on each release, pre-releases excluded. It takes no
+  setting and no rule, and it is what `/en/stable/` serves.
+- **An automation rule activates each new release tag**: Admin → Automation
+  Rules, match `SemVer versions`, version type `Tag`, action `Activate
+  version`. A tag is created inactive otherwise, which is a 404 on
+  `/en/v<version>/`; with the rule each release keeps a URL that stays that
+  release rather than becoming the next one. It applies to versions created
+  after it, so a tag pushed before it stays inactive until activated by
+  hand.
+- **`default_version` is `latest`**, so the root of the site serves the
+  development tip, declaring the placeholder version `pyproject.toml`
+  carries between releases. `stable` is the alternative, and what the
+  choice decides is which of the two a reader arriving with no version in
+  mind is given.
+
+Tags older than the rule are mostly not activatable rather than merely not
+activated: a build needs `.readthedocs.yaml`, which reaches back to
+`v2026.8.7` alone, so an older tag answers with a failed build instead of
+with the documentation of 2023. None was backfilled, `v2026.8.9` — which
+could have been — included, so `/en/v<version>/` starts at the first tag
+pushed after the rule and there is nothing behind it. `/en/stable/` is the
+last release either way, which is what makes the backfill skippable.
+
+**The webhook has to carry a secret.** A delivery from one that does not is
+refused with 400 and the reason in the body, which GitHub records in the
+hook's delivery log and reports nowhere else:
+
+```shell
+gh api repos/btclib-org/btclib/hooks \
+  --jq '.[] | [.config.url, (.config.secret != null), .last_response.code]'
+# ["https://app.readthedocs.org/api/v2/webhook/btclib/331149/",true,200]
+```
+
+A hook added here by hand has no secret and cannot be given one that Read
+the Docs knows. The one that works was issued by the project's integration
+page, and that is also how it is replaced: delete the integration there
+and add it again, rather than editing the hook on this side.
+
 ## Plan-gated settings
 
 Some settings cannot be enabled and fail silently: secret scanning's


### PR DESCRIPTION
btclib.readthedocs.io was serving neither of the last two releases.
`latest` followed `master`, a branch this repository no longer has, so
every push was accepted and triggered nothing —
`{"build_triggered": false, "versions": []}` is a green delivery — and the
site kept the last build that had succeeded: a placeholder version, from a
commit squashed away months earlier.

The settings half is done on Read the Docs and recorded here, in a new
`## Read the Docs` section of REPOSITORY.md, that file being the whole of
what cannot be recovered by reading the tree: `latest` on `main`, `stable`
on the newest release tag — which Read the Docs chooses and moves by
itself — and an automation rule (`SemVer versions` / `Tag` / `Activate
version`) that makes `/en/v<version>/` exist and keeps it that release
rather than the next one.

That URL starts at the first tag pushed under the rule, nothing behind it
having been backfilled: `v2026.8.9` could have been and was not, and a tag
before `v2026.8.7` could not be, a build needing `.readthedocs.yaml`, which
reaches back no further. `/en/stable/` is the last release either way,
which is what makes the backfill skippable.

The rest is a job, because nothing failed when a build never started and
the check was a person reading a page. `release.yml`'s `documented` waits
for the tag's own page to be served and is red if it never is. It polls
the rendered URL and not the v3 API, the reverse of what `published` does
with PyPI's: Read the Docs throttles an unauthenticated caller to five
requests a minute and blocks cloud-provider addresses outright without a
token, so asking the API from a runner would mean keeping a credential for
a check that gates nothing. Both branches of that loop were exercised
against the live site before pushing — `/en/stable/` passes, an inactive
version fails.

RELEASING.md's release-day step shrinks to what is left for a person, and
the links that pointed at the old host follow the project to
app.readthedocs.org, the README badge with them.

Local gates: `pre-commit run --all-files`, `pytest` (26032 passed, the
coverage ratchet included) and the `sphinx -W` build, all green.

Closes #574