### PR TITLE
Read a psbt one map at a time, out of a stream (#647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -598,6 +598,78 @@ documented at release-notes length in the first place, and are still in
 
 ### Transactions, blocks and PSBT
 
+- **A psbt can be read a map at a time, out of a stream** (#647).
+  `btclib.psbt.PsbtView` is that reader, beside `Psbt` and not instead of
+  it: `Psbt.parse` reads every map before anything can be inspected or
+  signed, so a psbt whose inputs each carry the previous transaction they
+  spend costs all of them at once, and a signer with less memory than that
+  cannot read the psbt at all. A view walks the stream once to learn where
+  each map begins and reads one when it is asked for it, which is
+  `diybitcoinhardware/embit`'s `psbtview.PSBTView` idea and its audience:
+  hardware wallets and airgapped signers. What it offers is the global
+  fields, `input` and `output` one map at a time, the transaction being
+  built, the outputs being spent and both sig_hashes; what it does not is
+  any of the roles that rewrite a psbt, the stream being read-only, so a
+  signer assembles its own answer out of the maps it was handed and
+  `PsbtIn.serialize` writes each.
+
+  It holds the global map, an integer per map saying where that map
+  starts, and -- once a sig_hash is asked for -- the unsigned transaction,
+  the output each input spends, and `sig_hash.PrecomputedTxData`: BIP143
+  and BIP341 commit every input to all three, so signing N inputs hashes
+  the whole transaction once rather than N times, which is issue #164's
+  arithmetic for a psbt whose N inputs are exactly what does not fit. What
+  it therefore never holds is two input maps at once, and that is where a
+  psbt's size is -- a witness utxo is an amount and a script, a
+  non-witness utxo is a whole transaction, and the derivation paths, leaf
+  scripts and signatures of every input are as large as the wallet that
+  wrote them. Measured rather than asserted: a test counts the octets read
+  from the stream and reads none of the large utxo it does not ask for.
+
+  The stream must not change while a view is alive, and the module
+  docstring says so at length rather than leaving it implicit, embit's own
+  docstring being where that candour comes from: a view answers from the
+  bytes that were there when it read them, nothing re-reads a map to check
+  that it still says what it said, and an amount or a script that changes
+  between two reads is a sig_hash committing to a transaction the signer
+  was never shown -- a time-of-check to time-of-use attack rather than a
+  stale read. So a psbt on removable or untrusted storage is copied into
+  memory the caller controls first, and a stream that has legitimately
+  changed is read by building a new view.
+
+  A view takes any seekable binary stream, a file object as much as a
+  `BytesIO`, which is wider than `alias.BinaryData` on purpose: a `parse`
+  consumes what it is given, so a `BytesIO` is all it can want, while a
+  view over a `BytesIO` holds the whole psbt in memory and answers the
+  question it exists for with "buy more memory". Octets are taken too and
+  read as one whole psbt, what follows the last map in them being refused.
+  It is not a `parse` classmethod, and the docstring records that as a
+  decision: what it returns is not the psbt those bytes encode but a
+  handle on the stream holding it, and the second is only valid while the
+  first is unchanged.
+
+  Every question about what a psbt's bytes mean is the object model's,
+  imported rather than restated -- which type byte is a field of which
+  version, what the global map holds, what fields each version requires of
+  a map, what the transaction being built is, what a sig_hash commits to.
+  So five answers in `psbt.py` that were written inside a loop over a
+  whole psbt are now written per map beside it: `_tx_in` and `_tx_out`,
+  `_read_tx_in` and `_read_tx_out`, `_assert_valid_utxo`, `_spent_outputs`
+  and the two sig_hash bodies. `_lock_time` takes the pairs of required
+  lock times rather than the inputs, those two fields being all of an
+  input BIP370's algorithm depends on, so a caller with one input at a
+  time streams them past it. The suite holds the two readers to each other
+  over every psbt it has, valid and invalid: the globals, each map, the
+  transaction, its lock time, the outputs spent and both sig_hashes. One
+  published psbt is refused for a different reason by each, and the test
+  names it -- BIP174's two-octet `PSBT_IN_SIGHASH_TYPE` key carries 104
+  octets after its last map as well, and a view walks the maps before it
+  parses any of them.
+
+  `utils.read_exactly` now annotates its stream `BinaryIO` where it said
+  `BytesIO`: `.read` is the whole of what a short read is about, so a file
+  object is as much an answer there, and a view is the one reader in this
+  library that does not consume the stream it is handed.
 - **Three psbt entries took a psbt unasked** (#692, under the rule of #684).
   `combine` merged the maps and returned a psbt with neither the inputs nor
   the result validated anywhere, so an invalid psbt in gave an invalid psbt

--- a/btclib/psbt/__init__.py
+++ b/btclib/psbt/__init__.py
@@ -11,6 +11,13 @@ which plays the role over a `KeyManager`'s answers, and the size
 estimation a fee rate is applied to. `musig2` is named as a module, being
 the BIP373 role rather than one function, the way btclib.ecc names dsa.
 
+`PsbtView` is the same psbt read a map at a time out of a stream, for a
+signer with less memory than the psbt takes (issue #647). It is beside
+`Psbt` and not another way to spell it: it reads, where every role above
+rewrites, and what it hands back is the psbt's maps one by one rather
+than the psbt. Its module docstring states what it holds between calls
+and what a stream that changes underneath it costs.
+
 `assert_signatures_only` is the check that belongs before `combine` when
 the psbt being merged came from somebody else. BIP174 gives the Combiner
 no such role -- it takes the union of what it is given and may resolve a
@@ -65,6 +72,7 @@ from btclib.psbt.psbt import (
 from btclib.psbt.psbt_in import PsbtIn
 from btclib.psbt.psbt_out import PsbtOut
 from btclib.psbt.psbt_size import SolutionSizer, estimated_input_sizes
+from btclib.psbt.psbt_view import PsbtView
 
 __all__ = [
     "InputSolver",
@@ -72,6 +80,7 @@ __all__ = [
     "Psbt",
     "PsbtIn",
     "PsbtOut",
+    "PsbtView",
     "SolutionSizer",
     "assert_signatures_only",
     "assert_signed",

--- a/btclib/psbt/psbt.py
+++ b/btclib/psbt/psbt.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import base64
 import secrets
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, fields
 from math import ceil
@@ -227,7 +227,15 @@ def _assert_valid_version(version: int) -> None:
         raise BTClibValueError(f"invalid psbt version: {version}")
 
 
-def _lock_time(inputs: Sequence[PsbtIn], fallback_lock_time: int | None) -> int:
+def _required_lock_times(psbt_in: PsbtIn) -> tuple[int | None, int | None]:
+    """Return the two lock times the input requires, a height and a time."""
+    return psbt_in.required_height_lock_time, psbt_in.required_time_lock_time
+
+
+def _lock_time(
+    required: Iterable[tuple[int | None, int | None]],
+    fallback_lock_time: int | None,
+) -> int:
     """Return the lock time of the transaction these inputs make.
 
     BIP370's "Determining Lock Time", which is the whole of it: with no
@@ -244,55 +252,64 @@ def _lock_time(inputs: Sequence[PsbtIn], fallback_lock_time: int | None) -> int:
     A psbt where one input requires a height and another a time has no
     answer at all, one nLockTime being one number of one kind, and that
     is a psbt this refuses rather than resolves.
+
+    The pairs are `_required_lock_times` of each input, in order, and not
+    the inputs themselves: those two fields are all of an input this
+    answer depends on, so a caller holding one input at a time can stream
+    them past -- which is what `btclib.psbt.psbt_view` does, and what
+    taking a sequence of inputs would have cost it.
     """
-    requiring = [
-        psbt_in
-        for psbt_in in inputs
-        if psbt_in.required_height_lock_time is not None
-        or psbt_in.required_time_lock_time is not None
-    ]
+    requiring = [pair for pair in required if pair != (None, None)]
     if not requiring:
         return fallback_lock_time or 0
 
-    if all(psbt_in.required_height_lock_time is not None for psbt_in in requiring):
+    if all(height is not None for height, _ in requiring):
         # the heights are not None by the test above, which mypy cannot see
-        return max(
-            cast(int, psbt_in.required_height_lock_time) for psbt_in in requiring
-        )
-    if all(psbt_in.required_time_lock_time is not None for psbt_in in requiring):
-        return max(cast(int, psbt_in.required_time_lock_time) for psbt_in in requiring)
+        return max(cast(int, height) for height, _ in requiring)
+    if all(time is not None for _, time in requiring):
+        return max(cast(int, time) for _, time in requiring)
 
     err_msg = "no lock time satisfies every input: "
     err_msg += "a height is required by one and a time by another"
     raise BTClibValueError(err_msg)
 
 
-def _unsigned_tx(psbt: Psbt, *, zeroed_sequences: bool) -> Tx:
-    """Return the transaction a psbt's fields describe.
+def _tx_in(psbt_in: PsbtIn, *, zeroed_sequence: bool) -> TxIn:
+    """Return the transaction input one psbt input describes.
 
-    check_validity=False throughout, and Psbt.assert_valid is what
-    checks the result: a psbt's transaction is a template -- BIP174
+    check_validity=False, and Psbt.assert_valid is what checks the
+    transaction these make: a psbt's transaction is a template -- BIP174
     lists two psbts with no inputs as valid (issue 170) -- and every
     element of it is validated where it is held.
 
-    zeroed_sequences=True is BIP370's "Unique Identification": the
+    zeroed_sequence=True is BIP370's "Unique Identification": the
     sequence is an Updater's to change, so the transaction that
     identifies a psbt is the one with every sequence set to 0, which is
     neither the final sequence nor the input's own.
     """
-    vin = [
-        TxIn(
-            psbt_in.prev_out,
-            b"",
-            0 if zeroed_sequences else _sequence(psbt_in),
-            check_validity=False,
-        )
-        for psbt_in in psbt.inputs
-    ]
-    vout = [
-        TxOut(psbt_out.amount or 0, psbt_out.script_pub_key, check_validity=False)
-        for psbt_out in psbt.outputs
-    ]
+    return TxIn(
+        psbt_in.prev_out,
+        b"",
+        0 if zeroed_sequence else _sequence(psbt_in),
+        check_validity=False,
+    )
+
+
+def _tx_out(psbt_out: PsbtOut) -> TxOut:
+    """Return the transaction output one psbt output describes."""
+    return TxOut(psbt_out.amount or 0, psbt_out.script_pub_key, check_validity=False)
+
+
+def _unsigned_tx(psbt: Psbt, *, zeroed_sequences: bool) -> Tx:
+    """Return the transaction a psbt's fields describe.
+
+    One `_tx_in` per input and one `_tx_out` per output, which is where
+    what each of the two says about the transaction is written down: a
+    caller reading the maps one at a time -- `btclib.psbt.psbt_view` --
+    builds the same transaction out of the same two answers.
+    """
+    vin = [_tx_in(psbt_in, zeroed_sequence=zeroed_sequences) for psbt_in in psbt.inputs]
+    vout = [_tx_out(psbt_out) for psbt_out in psbt.outputs]
     return Tx(psbt.tx_version, psbt.lock_time, vin, vout, check_validity=False)
 
 
@@ -424,6 +441,37 @@ def _settle_globals(
             raise BTClibValueError(f"malformed psbt: missing {name}")
 
 
+def _assert_unsigned(tx: Tx) -> None:
+    """Raise unless the transaction a version 0 psbt carries is unsigned.
+
+    Asked of that transaction alone, this being the only door such a
+    transaction comes through: a psbt built from the fields has no
+    script_sig to carry, `Psbt.tx` writing an empty one.
+    """
+    if any(tx_in.script_sig or tx_in.script_witness for tx_in in tx.vin):
+        raise BTClibValueError("non empty script_sig or witness")
+
+
+def _read_tx_in(psbt_in: PsbtIn, tx_in: TxIn) -> None:
+    """Write what the unsigned transaction says about one input into it.
+
+    The outpoint it spends and its sequence, which is the whole of it,
+    and the inverse of `_tx_in`. The sequence is written even when it is
+    the final one: a version 0 transaction states a sequence for every
+    input, so keeping the value rather than the absence is what makes
+    the round trip exact.
+    """
+    psbt_in.previous_tx_id = tx_in.prev_out.tx_id
+    psbt_in.output_index = tx_in.prev_out.vout
+    psbt_in.sequence = tx_in.sequence
+
+
+def _read_tx_out(psbt_out: PsbtOut, tx_out: TxOut) -> None:
+    """Write what the unsigned transaction says about one output into it."""
+    psbt_out.amount = tx_out.value
+    psbt_out.script_pub_key = tx_out.script_pub_key.script
+
+
 def _read_unsigned_tx(
     tx: Tx, inputs: Sequence[PsbtIn], outputs: Sequence[PsbtOut]
 ) -> None:
@@ -435,16 +483,11 @@ def _read_unsigned_tx(
     about an output into the output map, after which nothing has to read
     it again. `Psbt.tx` puts it back together on the way out.
 
-    The sequence is written even when it is the final one: a version 0
-    transaction states a sequence for every input, so keeping the value
-    rather than the absence is what makes the round trip exact.
-
-    That the transaction is unsigned is checked here, this being the
-    only door such a transaction comes through: a psbt built from the
-    fields has no script_sig to carry, `Psbt.tx` writing an empty one.
+    Per map by `_read_tx_in` and `_read_tx_out`, which is what a caller
+    holding one map at a time asks instead: `btclib.psbt.psbt_view`
+    completes the map it has just read without the two lists this needs.
     """
-    if any(tx_in.script_sig or tx_in.script_witness for tx_in in tx.vin):
-        raise BTClibValueError("non empty script_sig or witness")
+    _assert_unsigned(tx)
 
     # one map per input and one per output, which `parse` gets from the
     # transaction itself and a caller of `from_tx` may not: strict=True
@@ -460,13 +503,10 @@ def _read_unsigned_tx(
         raise BTClibValueError(err_msg)
 
     for psbt_in, tx_in in zip(inputs, tx.vin, strict=True):
-        psbt_in.previous_tx_id = tx_in.prev_out.tx_id
-        psbt_in.output_index = tx_in.prev_out.vout
-        psbt_in.sequence = tx_in.sequence
+        _read_tx_in(psbt_in, tx_in)
 
     for psbt_out, tx_out in zip(outputs, tx.vout, strict=True):
-        psbt_out.amount = tx_out.value
-        psbt_out.script_pub_key = tx_out.script_pub_key.script
+        _read_tx_out(psbt_out, tx_out)
 
 
 def _assert_modifiable(psbt: Psbt, *, inputs: bool) -> None:
@@ -526,6 +566,28 @@ def _assert_valid_input_fields(psbt_in: PsbtIn, version: int, i: int) -> None:
         if value is not None:
             err_msg = f"input {i}: {name} is not allowed in a v0 psbt"
             raise BTClibValueError(err_msg)
+
+
+def _assert_valid_utxo(psbt_in: PsbtIn) -> None:
+    """Raise unless a non-witness utxo is the transaction the outpoint names.
+
+    Two questions about one field, both of them about the input alone,
+    which is why a caller reading one input at a time can ask them --
+    `btclib.psbt.psbt_view` does, on the map it has just read.
+
+    The transaction has to be the one the outpoint's tx_id names, and the
+    outpoint has to name one of its outputs: an index past its vout is an
+    IndexError to everything that reads the spent output --
+    `_signable_payload`, the Finalizer's sig_hash -- where malformed
+    input owes the caller a BTClibValueError.
+    """
+    non_witness_utxo = psbt_in.non_witness_utxo
+    if non_witness_utxo is None:
+        return
+    if non_witness_utxo.id != psbt_in.previous_tx_id:
+        raise BTClibValueError("mismatched non-witness utxo / outpoint tx_id")
+    if (psbt_in.output_index or 0) >= len(non_witness_utxo.vout):
+        raise BTClibValueError("outpoint vout out of range for the non-witness utxo")
 
 
 def _assert_valid_output_fields(psbt_out: PsbtOut, version: int, i: int) -> None:
@@ -696,7 +758,10 @@ class Psbt:
         unsigned transaction's nLockTime being read into the fallback.
         _lock_time is the algorithm.
         """
-        return _lock_time(self.inputs, self.fallback_lock_time)
+        return _lock_time(
+            (_required_lock_times(psbt_in) for psbt_in in self.inputs),
+            self.fallback_lock_time,
+        )
 
     @property
     def tx(self) -> Tx:
@@ -908,26 +973,8 @@ class Psbt:
         # kinds is refused here, by _lock_time
         self.tx.assert_valid(unsigned_template=True)
 
-        if any(
-            psbt_in.non_witness_utxo
-            and psbt_in.non_witness_utxo.id != psbt_in.previous_tx_id
-            for psbt_in in self.inputs
-        ):
-            err_msg = "mismatched non-witness utxo / outpoint tx_id"
-            raise BTClibValueError(err_msg)
-
-        # the outpoint names one of that transaction's outputs, and the
-        # tx_id check above does not say so: an index past its vout is an
-        # IndexError to everything that reads the spent output --
-        # _signable_payload, the Finalizer's sig_hash -- where malformed
-        # input owes the caller a BTClibValueError
-        if any(
-            psbt_in.non_witness_utxo
-            and (psbt_in.output_index or 0) >= len(psbt_in.non_witness_utxo.vout)
-            for psbt_in in self.inputs
-        ):
-            err_msg = "outpoint vout out of range for the non-witness utxo"
-            raise BTClibValueError(err_msg)
+        for psbt_in in self.inputs:
+            _assert_valid_utxo(psbt_in)
 
         assert_valid_hd_key_paths(self.hd_key_paths)
         assert_valid_unknown(self.unknown)
@@ -1770,6 +1817,27 @@ _PUSH_32 = 0x20
 _OP_CHECKSIG = 0xAC
 
 
+def _spent_outputs(inputs: Iterable[PsbtIn]) -> list[TxOut]:
+    """Return the output each of these inputs spends, in order.
+
+    An input carrying no utxo raises, which is `prevouts`' rule and says
+    why. The inputs are an iterable rather than a psbt's list because
+    that is all the answer needs: a caller reading one input at a time --
+    `btclib.psbt.psbt_view` -- streams them past, and the whole previous
+    transaction of a non-witness utxo is dropped as soon as the one
+    output being spent is out of it.
+    """
+    outs: list[TxOut] = []
+    for i, psbt_in in enumerate(inputs):
+        prev_out = _prev_out(psbt_in)
+        if prev_out is None:
+            err_msg = f"no utxo for input {i}: a taproot signature commits "
+            err_msg += "to the amount and script of every input"
+            raise BTClibValueError(err_msg)
+        outs.append(prev_out)
+    return outs
+
+
 def prevouts(psbt: Psbt) -> list[TxOut]:
     """Return the output each input of the psbt spends.
 
@@ -1783,15 +1851,37 @@ def prevouts(psbt: Psbt) -> list[TxOut]:
     # which makes this the list that most wants to have been checked
     psbt.assert_valid()
 
-    outs: list[TxOut] = []
-    for i, psbt_in in enumerate(psbt.inputs):
-        prev_out = _prev_out(psbt_in)
-        if prev_out is None:
-            err_msg = f"no utxo for input {i}: a taproot signature commits "
-            err_msg += "to the amount and script of every input"
-            raise BTClibValueError(err_msg)
-        outs.append(prev_out)
-    return outs
+    return _spent_outputs(psbt.inputs)
+
+
+def _taproot_sig_hash(
+    psbt_in: PsbtIn,
+    tx: Tx,
+    vin_i: int,
+    spent: list[TxOut],
+    leaf_hash: bytes,
+    hash_type: int | None,
+    precomputed: sig_hash.PrecomputedTxData | None,
+) -> bytes:
+    """Return BIP341's message for one input, from what one input says.
+
+    `taproot_sig_hash` is this over a whole psbt and states the rules;
+    what the arguments beyond those add is a caller that holds the
+    transaction and the spent outputs already -- `psbt_view` builds both
+    from a stream -- and, with them, the transaction-wide hashes BIP341
+    commits every input to, so that signing N inputs hashes the
+    transaction once and not N times.
+
+    `precomputed=None` is a single call, which hashes only what its hash
+    type commits to; a caller passing one must have built it from this
+    very transaction, which is `sig_hash.PrecomputedTxData`'s own rule.
+    """
+    if hash_type is None:
+        hash_type = psbt_in.sig_hash_type or DEFAULT
+    ext = leaf_hash + b"\x00" + _NO_CODESEP.to_bytes(4, "little") if leaf_hash else b""
+    return sig_hash.taproot(
+        tx, vin_i, spent, hash_type, int(bool(ext)), b"", ext, precomputed
+    )
 
 
 def taproot_sig_hash(
@@ -1813,12 +1903,14 @@ def taproot_sig_hash(
     one, and a signer cannot invent what the spender will put on the
     stack.
     """
-    leaf_hash = bytes_from_octets(leaf_hash)
-    if hash_type is None:
-        hash_type = psbt.inputs[vin_i].sig_hash_type or DEFAULT
-    ext = leaf_hash + b"\x00" + _NO_CODESEP.to_bytes(4, "little") if leaf_hash else b""
-    return sig_hash.taproot(
-        psbt.tx, vin_i, prevouts(psbt), hash_type, int(bool(ext)), b"", ext
+    return _taproot_sig_hash(
+        psbt.inputs[vin_i],
+        psbt.tx,
+        vin_i,
+        prevouts(psbt),
+        bytes_from_octets(leaf_hash),
+        hash_type,
+        precomputed=None,
     )
 
 
@@ -2015,6 +2107,34 @@ def _sig_hash_from_psbt_in(
     return sig_hash.legacy(script, tx, vin_i, hash_type)
 
 
+def _ecdsa_sig_hash(
+    psbt_in: PsbtIn, tx: Tx, vin_i: int, hash_type: int | None
+) -> bytes:
+    """Return the hash an ECDSA spend of one input signs, from that input.
+
+    `ecdsa_sig_hash` is this over a whole psbt and states the rules; what
+    this is is those rules asked of one input and the transaction being
+    built, which is what a caller reading the maps one at a time holds --
+    `btclib.psbt.psbt_view`.
+    """
+    if hash_type is None:
+        hash_type = ALL if psbt_in.sig_hash_type is None else psbt_in.sig_hash_type
+    assert_valid_hash_type(hash_type)
+    if hash_type == DEFAULT:
+        raise BTClibValueError("SIGHASH_DEFAULT is not an ECDSA sig_hash type")
+
+    if is_p2tr(_spent_script(psbt_in)):
+        err_msg = f"input {vin_i} is taproot: its message is taproot_sig_hash's"
+        raise BTClibValueError(err_msg)
+
+    msg_hash = _sig_hash_from_psbt_in(psbt_in, tx, vin_i, hash_type)
+    if msg_hash is None:
+        err_msg = f"input {vin_i} does not say what is being signed: "
+        err_msg += "no utxo, no redeem script, or no witness script"
+        raise BTClibValueError(err_msg)
+    return msg_hash
+
+
 def ecdsa_sig_hash(psbt: Psbt, vin_i: int, *, hash_type: int | None = None) -> bytes:
     """Return the hash an ECDSA spend of one input signs.
 
@@ -2040,23 +2160,7 @@ def ecdsa_sig_hash(psbt: Psbt, vin_i: int, *, hash_type: int | None = None) -> b
     role may sign, verify or finalize.
     """
     psbt.assert_valid()
-    psbt_in = psbt.inputs[vin_i]
-    if hash_type is None:
-        hash_type = ALL if psbt_in.sig_hash_type is None else psbt_in.sig_hash_type
-    assert_valid_hash_type(hash_type)
-    if hash_type == DEFAULT:
-        raise BTClibValueError("SIGHASH_DEFAULT is not an ECDSA sig_hash type")
-
-    if is_p2tr(_spent_script(psbt_in)):
-        err_msg = f"input {vin_i} is taproot: its message is taproot_sig_hash's"
-        raise BTClibValueError(err_msg)
-
-    msg_hash = _sig_hash_from_psbt_in(psbt_in, psbt.tx, vin_i, hash_type)
-    if msg_hash is None:
-        err_msg = f"input {vin_i} does not say what is being signed: "
-        err_msg += "no utxo, no redeem script, or no witness script"
-        raise BTClibValueError(err_msg)
-    return msg_hash
+    return _ecdsa_sig_hash(psbt.inputs[vin_i], psbt.tx, vin_i, hash_type)
 
 
 class KeyManager(Protocol):

--- a/btclib/psbt/psbt_view.py
+++ b/btclib/psbt/psbt_view.py
@@ -1,0 +1,472 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""A psbt read from a stream one map at a time, for a signer with no room.
+
+`Psbt` is the whole object: `Psbt.parse` reads every map before anything
+can be inspected or signed, so a psbt whose inputs carry a previous
+transaction each costs all of them at once. A `PsbtView` reads the same
+psbt out of a seekable stream and keeps no map at all -- it walks the
+stream once to learn where each one begins, and reads one when it is
+asked for it. `diybitcoinhardware/embit` calls the same idea
+`psbtview.PSBTView` and states its audience, which is this one: hardware
+wallets and airgapped signers, where the psbt can be larger than the
+memory available to hold it (issue #647).
+
+This is a reader, beside `Psbt` and not instead of it. Most callers want
+the object model -- combining, finalizing, extracting and `sign` all
+rewrite a psbt, and none of that is here. What is here is what a Signer
+needs before it signs: the global fields, one input or output map at a
+time, and the two messages a signature commits to. The signer's answer is
+its own to assemble, one `PsbtIn` per input it signed and
+`PsbtIn.serialize` how each is written, the stream this reads from being
+read-only.
+
+What it holds, exactly. At construction: the global map, which is the
+transaction version and the counts, the xpubs, and in a version 0 psbt
+the unsigned transaction; and one integer per input and output map, being
+where in the stream it starts. Asked for a sig_hash it builds two more
+things and keeps them, because BIP143 and BIP341 commit every input to
+them: the unsigned transaction, and the output each input spends -- read
+one input at a time, so that the *previous transaction* a non-witness
+utxo carries is dropped as soon as the one output being spent is out of
+it. With them it keeps `sig_hash.PrecomputedTxData`, the five 32-byte
+hashes BIP341 commits to, so that signing N inputs hashes the whole
+transaction once instead of N times (issue #164 for the whole-object
+half of the same arithmetic).
+
+What it therefore never holds is two input maps at once, which is where a
+psbt's size is: a witness utxo is an amount and a script, a non-witness
+utxo is a whole transaction, and the derivation paths, leaf scripts and
+signatures of every input are each as large as the wallet that wrote
+them.
+
+**The stream must not change while the view is alive.** A view answers
+from the bytes that are there when it reads them, and it reads on
+request: nothing re-reads a map to check that it says what it said, and
+nothing invalidates what has already been read. So a stream that changes
+under a view is a view that gives two answers to one question -- and, if
+what changed is an amount or a script, a sig_hash committing to a
+transaction the signer was never shown, which is a time-of-check to
+time-of-use attack and not merely a stale read. embit's own docstring
+gives the same warning about an SD card, whose controller answers each
+read separately. A caller reading a psbt from removable or untrusted
+storage copies it into memory it controls first; a caller whose stream
+has legitimately changed builds a new view, there being no way to refresh
+one.
+
+The stream is any seekable binary one -- a file object as much as a
+`BytesIO` -- which is wider than `alias.BinaryData`, and deliberately: a
+`parse` consumes what it is given, so a `BytesIO` is all it can want,
+while a view over a `BytesIO` holds the whole psbt in memory and answers
+the question this module exists for with "buy more memory". Octets are
+taken too, and read as one whole psbt: what follows the last map in them
+is refused, where what follows in a caller's stream is the caller's.
+
+Not a `parse` classmethod, for the same reason it is not a dataclass: what
+this returns is not the psbt those bytes encode but a handle on the stream
+holding it, and the two are not interchangeable -- the second is only
+valid while the first is unchanged. The properties `Psbt.parse` owes its
+caller are still checked where they are about the bytes: the walk at
+construction refuses a truncated psbt, one map at a time, and
+`PsbtIn.parse` reads each map from exactly the octets the walk bounded.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from io import BytesIO
+from typing import BinaryIO, cast
+
+from btclib import var_int
+from btclib.alias import Octets
+from btclib.bip32 import HdKeyPaths, assert_valid_hd_key_paths, decode_hd_key_paths
+from btclib.exceptions import BTClibValueError
+from btclib.psbt.psbt import (
+    PSBT_MAGIC_BYTES,
+    _assert_map_count,
+    _assert_unsigned,
+    _assert_valid_input_fields,
+    _assert_valid_output_fields,
+    _assert_valid_utxo,
+    _assert_valid_version,
+    _ecdsa_sig_hash,
+    _global_version,
+    _lock_time,
+    _parse_global_map,
+    _read_tx_in,
+    _read_tx_out,
+    _required_lock_times,
+    _settle_globals,
+    _spent_outputs,
+    _taproot_sig_hash,
+    _tx_in,
+    _tx_out,
+)
+from btclib.psbt.psbt_in import PsbtIn
+from btclib.psbt.psbt_out import PsbtOut
+from btclib.psbt.psbt_utils import (
+    assert_valid_unknown,
+    decode_dict_bytes_bytes,
+    deserialize_map,
+)
+from btclib.script.sig_hash import PrecomputedTxData
+from btclib.tx import Tx, TxOut
+from btclib.tx.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
+from btclib.utils import assert_no_trailing, bytes_from_octets, read_exactly
+
+__all__ = [
+    "PsbtView",
+]
+
+# every question about what a psbt's bytes mean is imported above and none
+# of it is restated here: which type byte is a field of which version,
+# what the global map holds, which fields each version requires of a map,
+# what the transaction being built is, what a sig_hash commits to. A view
+# reads the same psbts `Psbt` does, so a rule it answered on its own would
+# be a second psbt format -- one that could accept what `Psbt.parse`
+# refuses, and sign what `Psbt` would not
+
+# what a compact size is at its longest: the 0xff prefix and eight octets
+_MAX_VAR_INT_SIZE = 9
+
+
+def _read_var_int(stream: BinaryIO) -> int:
+    """Return the compact size at the stream's cursor, consuming just it.
+
+    `var_int.parse` reads from a `BytesIO` or from octets, and this stream
+    is neither, so it is handed the nine octets a compact size cannot
+    exceed and the cursor is then put where the encoding it read ends.
+    `var_int.serialize` is what says where that is: only the shortest
+    encoding of a number is a var_int at all, so the length of the number
+    written back is the length of what was read -- which keeps the
+    prefix-to-width table in the one module that has it.
+    """
+    start = stream.tell()
+    value = var_int.parse(stream.read(_MAX_VAR_INT_SIZE))
+    stream.seek(start + len(var_int.serialize(value)))
+    return value
+
+
+def _skip_map(stream: BinaryIO) -> int:
+    """Return where the map at the stream's cursor ends, reading no value.
+
+    The 0x00 separator included, so the answer is where the next map
+    begins. Only the lengths are read and the cursor is moved over the
+    keys and the values, which is what makes a walk over every map of a
+    psbt cost no memory; a length reaching past the end of the stream
+    leaves nothing for the next one to read, so a truncated psbt is
+    refused here rather than believed.
+
+    A stream with nothing left at all is the commonest such truncation --
+    a psbt declaring more maps than it carries -- and it is refused with
+    `deserialize_map`'s own words, that being the same malformation read
+    one map earlier.
+    """
+    if not stream.read(1):
+        raise BTClibValueError("malformed psbt: at least a map is missing")
+    stream.seek(-1, 1)
+
+    while True:
+        # a zero-length key is the separator, which is the same byte
+        # `deserialize_map` stops at and the same reading of it
+        key_size = _read_var_int(stream)
+        if key_size == 0:
+            return stream.tell()
+        stream.seek(key_size, 1)
+        stream.seek(_read_var_int(stream), 1)
+
+
+def _assert_index(i: int, count: int, what: str) -> None:
+    """Refuse an index no map of this psbt has.
+
+    A negative one included, where a list would take it as counting from
+    the end: this is a position in a stream, and the map before the first
+    is the global one, which is not an input.
+    """
+    if not 0 <= i < count:
+        raise BTClibValueError(f"invalid {what} index: {i}, the psbt has {count}")
+
+
+class PsbtView:
+    """A read-only view of one psbt in a seekable stream.
+
+    The global fields are attributes, being the whole of what is read
+    eagerly; `input` and `output` read one map from the stream each time
+    they are called, `tx` and `prevouts` what a transaction is built out
+    of, and `ecdsa_sig_hash` and `taproot_sig_hash` the two messages a
+    Signer signs. The module docstring says what is kept between calls,
+    and what a stream that changes underneath costs.
+    """
+
+    stream: BinaryIO
+    offset: int
+    version: int
+    tx_version: int
+    fallback_lock_time: int | None
+    tx_modifiable: int | None
+    input_count: int
+    output_count: int
+    hd_key_paths: HdKeyPaths
+    unknown: dict[bytes, bytes]
+    signed_message: bytes | None
+
+    def __init__(self, data: BinaryIO | Octets) -> None:
+        stream: BinaryIO = (
+            BytesIO(bytes_from_octets(data)) if isinstance(data, (bytes, str)) else data
+        )
+        if not stream.seekable():
+            err_msg = "a psbt view needs a seekable stream: it reads a map "
+            err_msg += "when it is asked for it, not in the order they arrive"
+            raise BTClibValueError(err_msg)
+        self.stream = stream
+        # where the psbt starts, which is where the caller's cursor is: a
+        # psbt read out of a stream carrying more than the psbt is what a
+        # stream is for, so nothing here assumes the stream begins with one
+        self.offset = stream.tell()
+
+        if stream.read(len(PSBT_MAGIC_BYTES)) != PSBT_MAGIC_BYTES:
+            raise BTClibValueError("malformed psbt: missing magic bytes")
+
+        global_map = deserialize_map(self._read_map())
+        # the version before the rest of the map and before every map after
+        # it, as in `Psbt.parse`: what a type byte means is version
+        # dependent, and a map has no order to put the version first in
+        version = _global_version(global_map)
+        _assert_valid_version(version)
+        tx, globals_, hd_key_paths, unknown, signed_message = _parse_global_map(
+            global_map, version
+        )
+        _settle_globals(tx, globals_, version)
+
+        self.version = version
+        self.tx_version = cast(int, globals_["tx_version"])
+        self.fallback_lock_time = globals_["fallback_lock_time"]
+        self.tx_modifiable = globals_["tx_modifiable"]
+        self.input_count = cast(int, globals_["input_count"])
+        self.output_count = cast(int, globals_["output_count"])
+        self.hd_key_paths = decode_hd_key_paths(hd_key_paths)
+        self.unknown = dict(sorted(decode_dict_bytes_bytes(unknown).items()))
+        self.signed_message = signed_message
+        assert_valid_hd_key_paths(self.hd_key_paths)
+        assert_valid_unknown(self.unknown)
+
+        # the same bound `Psbt.parse` applies, and for the same reason one
+        # step further along: what is allocated per declared map here is
+        # the offset of a map that may not be there
+        _assert_map_count(self.input_count, MAX_TX_IN_COUNT, "input")
+        _assert_map_count(self.output_count, MAX_TX_OUT_COUNT, "output")
+
+        if tx is not None:
+            _assert_unsigned(tx)
+        # version 0's unsigned transaction is in the psbt's own bytes, and
+        # is the only place its outpoints, sequences, amounts and scripts
+        # are: it is what a map read below is completed from. In version 2
+        # those live in the maps and there is no such transaction, which is
+        # why the two names below start as the same object and only one of
+        # them is ever built -- `_built_tx` puts a version 2 one together
+        self._global_tx = tx
+        self._tx = tx
+        self._prevouts: list[TxOut] | None = None
+        self._precomputed_data: PrecomputedTxData | None = None
+
+        # one walk, reading no map: after it the stream is on the octet
+        # after the psbt, which is where `parse` leaves it too
+        offsets = [stream.tell()]
+        for _ in range(self.input_count + self.output_count):
+            offsets.append(_skip_map(stream))
+        self._offsets = offsets
+
+        if isinstance(data, (bytes, str)):
+            # octets are one whole psbt and a stream is the caller's:
+            # btclib/utils.py states the rule both halves read. The cast is
+            # this branch's own premise -- octets are what the stream above
+            # was built from, so it is the BytesIO it was wrapped in
+            assert_no_trailing(data, cast(BytesIO, self.stream), "psbt")
+
+    def _read_map(self) -> bytes:
+        """Return the octets of the map at the cursor, its separator included.
+
+        The stream is left after the map, so this is how a psbt is walked;
+        the octets are handed to whoever parses them, which is what keeps
+        one parser per map rather than a second one reading a stream.
+        """
+        start = self.stream.tell()
+        end = _skip_map(self.stream)
+        self.stream.seek(start)
+        return read_exactly(self.stream, end - start, "psbt map")
+
+    def _map_bytes(self, n: int) -> bytes:
+        """Return the octets of map n, the inputs first as a psbt writes."""
+        start, end = self._offsets[n], self._offsets[n + 1]
+        self.stream.seek(start)
+        return read_exactly(self.stream, end - start, f"psbt map {n}")
+
+    def input(self, i: int, *, check_validity: bool = True) -> PsbtIn:
+        """Return input i, read from the stream now and held by nothing.
+
+        Complete whatever the version: a version 0 psbt keeps the outpoint
+        and the sequence of every input in its unsigned transaction, so
+        this input's are written into the map that does not carry them,
+        exactly as `Psbt.parse` does for all of them at once.
+
+        check_validity asks of the map what `Psbt.assert_valid` asks of
+        every input -- the fields this version requires of it, and the
+        previous transaction being the one the outpoint names -- which are
+        the questions about one input alone. What it cannot ask is the
+        rest: this is one map, and a psbt is valid or not as a whole.
+        """
+        _assert_index(i, self.input_count, "input")
+        psbt_in = PsbtIn.parse(
+            self._map_bytes(i),
+            psbt_version=self.version,
+            check_validity=check_validity,
+        )
+        if self._global_tx is not None:
+            _read_tx_in(psbt_in, self._global_tx.vin[i])
+        if check_validity:
+            _assert_valid_input_fields(psbt_in, self.version, i)
+            _assert_valid_utxo(psbt_in)
+        return psbt_in
+
+    def output(self, i: int, *, check_validity: bool = True) -> PsbtOut:
+        """Return output i, read from the stream now and held by nothing.
+
+        The output maps follow the input maps in a psbt, so this seeks
+        past every input; `input` says what `check_validity` covers and
+        what it cannot.
+        """
+        _assert_index(i, self.output_count, "output")
+        psbt_out = PsbtOut.parse(
+            self._map_bytes(self.input_count + i),
+            psbt_version=self.version,
+            check_validity=check_validity,
+        )
+        if self._global_tx is not None:
+            _read_tx_out(psbt_out, self._global_tx.vout[i])
+        if check_validity:
+            _assert_valid_output_fields(psbt_out, self.version, i)
+        return psbt_out
+
+    @property
+    def lock_time(self) -> int:
+        """Return the lock time of the transaction being built.
+
+        BIP370's, which `_lock_time` is the algorithm of: the inputs are
+        streamed past it, one at a time, being read for the two fields it
+        asks about and dropped. A version 0 psbt states it once, in its
+        unsigned transaction, and none of its inputs may require one --
+        `_assert_valid_input_fields` is where such an input is refused,
+        when the map it is in is read.
+        """
+        if self._tx is not None:
+            # version 0 states it in the transaction it carries, and a
+            # version 2 transaction already built computed it while it was
+            # being built: either way the walk below would reach the number
+            # that is already in hand
+            return self._tx.lock_time
+        return _lock_time(
+            (_required_lock_times(self.input(i)) for i in range(self.input_count)),
+            self.fallback_lock_time,
+        )
+
+    def _built_tx(self) -> Tx:
+        """Return the transaction the maps describe, reading them once.
+
+        The version 2 half of `tx`: every input map says an outpoint, a
+        sequence and its required lock times, and every output map an
+        amount and a script, so one walk holds a `TxIn` and a `TxOut` per
+        map -- the transaction itself -- and no map.
+        """
+        vin = []
+        required = []
+        for i in range(self.input_count):
+            psbt_in = self.input(i)
+            vin.append(_tx_in(psbt_in, zeroed_sequence=False))
+            required.append(_required_lock_times(psbt_in))
+        vout = [_tx_out(self.output(i)) for i in range(self.output_count)]
+        lock_time = _lock_time(required, self.fallback_lock_time)
+        return Tx(self.tx_version, lock_time, vin, vout, check_validity=False)
+
+    def _transaction(self) -> Tx:
+        """Return the view's own unsigned transaction, built once and kept."""
+        if self._tx is None:
+            self._tx = self._built_tx()
+        return self._tx
+
+    def _spent(self) -> list[TxOut]:
+        """Return the view's own list of spent outputs, read once and kept."""
+        if self._prevouts is None:
+            self._prevouts = _spent_outputs(
+                self.input(i) for i in range(self.input_count)
+            )
+        return self._prevouts
+
+    def _precomputed(self) -> PrecomputedTxData:
+        """Return the transaction-wide hashes BIP341 commits every input to.
+
+        Computed once for the whole transaction and kept, which is what
+        makes signing an input cost one input's worth of work: the
+        alternative is Θ(N²) hashing over a psbt whose N inputs are
+        exactly what does not fit in memory.
+        """
+        if self._precomputed_data is None:
+            self._precomputed_data = PrecomputedTxData(
+                self._transaction(), self._spent()
+            )
+        return self._precomputed_data
+
+    @property
+    def tx(self) -> Tx:
+        """Return the unsigned transaction this psbt is of.
+
+        A copy, as `Psbt.tx` is one: what is written into it is written
+        into nothing -- not into the stream, which this cannot write, and
+        not into what the next sig_hash commits to.
+        """
+        return deepcopy(self._transaction())
+
+    def prevouts(self) -> list[TxOut]:
+        """Return the output each input spends, `psbt.prevouts` over a stream.
+
+        A copy, for the reason `tx` is one. An input carrying no utxo
+        raises: a taproot signature commits to the amount and script of
+        every input, so one missing utxo leaves the whole transaction
+        unsignable rather than one input of it.
+        """
+        return deepcopy(self._spent())
+
+    def ecdsa_sig_hash(self, vin_i: int, *, hash_type: int | None = None) -> bytes:
+        """Return the hash an ECDSA spend of one input signs.
+
+        `psbt.ecdsa_sig_hash` over a stream, and the same rules: the type
+        the input asks for by default, SIGHASH_ALL when it asks for none,
+        and SIGHASH_DEFAULT refused. The input is read now and the
+        transaction is the one built once, so nothing is held past the
+        answer but what the module docstring lists.
+        """
+        return _ecdsa_sig_hash(self.input(vin_i), self._transaction(), vin_i, hash_type)
+
+    def taproot_sig_hash(
+        self, vin_i: int, *, leaf_hash: Octets = b"", hash_type: int | None = None
+    ) -> bytes:
+        """Return the hash a taproot spend of one input signs.
+
+        `psbt.taproot_sig_hash` over a stream, and the same rules: BIP341
+        for a key path spend, BIP342 for the script path a tapleaf hash
+        names, the type the input asks for by default and SIGHASH_DEFAULT
+        when it asks for none, and an empty annex. What the stream buys is
+        the precomputation: the whole-transaction hashes are the same for
+        every input, so they are built once and this is where they are
+        handed over.
+        """
+        return _taproot_sig_hash(
+            self.input(vin_i),
+            self._transaction(),
+            vin_i,
+            self._spent(),
+            bytes_from_octets(leaf_hash),
+            hash_type,
+            precomputed=self._precomputed(),
+        )

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from io import BytesIO
-from typing import Any
+from typing import Any, BinaryIO
 
 from btclib.alias import BinaryData, Integer, Octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -130,7 +130,7 @@ def bytesio_from_binarydata(stream: BinaryData) -> BytesIO:
     return stream
 
 
-def read_exactly(stream: BytesIO, size: int, what: str) -> bytes:
+def read_exactly(stream: BinaryIO, size: int, what: str) -> bytes:
     """Return size octets from the stream, or raise: a short read is truncation.
 
     `BytesIO.read` answers with whatever is left when the buffer holds
@@ -141,6 +141,13 @@ def read_exactly(stream: BytesIO, size: int, what: str) -> bytes:
 
     `what` names the field in the error message, the caller knowing which
     one it was reading and the stream not.
+
+    `BinaryIO` and not the `BytesIO` of `alias.BinaryData`: `.read` is
+    the whole of what a short read is about, so a file object is as much
+    an answer here as a buffer, and `btclib.psbt.psbt_view` reads from
+    one -- a view over a psbt is the one reader in this library that does
+    not consume the stream it is given, so it does not need one the rest
+    of the library can also `getbuffer()`.
     """
     data = stream.read(size)
     if len(data) != size:

--- a/docs/source/btclib.psbt.rst
+++ b/docs/source/btclib.psbt.rst
@@ -46,6 +46,13 @@ btclib.psbt.psbt\_utils module
    :members:
    :show-inheritance:
 
+btclib.psbt.psbt\_view module
+-----------------------------
+
+.. automodule:: btclib.psbt.psbt_view
+   :members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -757,6 +757,41 @@ single-key segwit input, build the witness yourself as the previous
 section does — two stack items, signature then public key — and use
 ``verify_transaction`` to check the result.
 
+**A psbt too large to hold.** Everything above reads the whole psbt into
+memory first, which for a psbt whose inputs each carry the previous
+transaction they spend is all of them at once. ``PsbtView`` reads the same
+psbt out of a seekable stream — a file as much as a ``BytesIO`` — and
+keeps no map at all: it learns where each one begins and reads one when
+it is asked for it.
+
+>>> from io import BytesIO
+>>> from btclib.psbt import PsbtView
+>>> view = PsbtView(BytesIO(psbt.serialize()))
+>>> view.input_count, view.output_count
+(1, 1)
+>>> view.input(0).witness_utxo.value
+600000000
+>>> view.ecdsa_sig_hash(0) == msg_hash
+True
+
+It is a reader: the stream is never written, so a signer assembles its own
+answer out of the maps the view hands it, one ``PsbtIn`` per input signed.
+
+>>> from btclib.psbt import PsbtIn
+>>> psbt_in = view.input(0)
+>>> psbt_in.partial_sigs = {pub_key: der + b"\x01"}
+>>> answer = PsbtIn.parse(psbt_in.serialize())
+>>> answer.partial_sigs == psbt.inputs[0].partial_sigs
+True
+
+What it holds between calls is in the module docstring of
+:mod:`btclib.psbt.psbt_view`, and so is the one rule using it imposes:
+the stream must not change while the view is alive. A view answers from
+the bytes that were there when it read them, and an amount or a script
+that changes between two reads is a sighash committing to a transaction
+the signer was never shown — so a psbt on removable or untrusted storage
+is copied into memory you control before it is viewed.
+
 Where to go next
 ----------------
 

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -188,7 +188,14 @@ CHILD_MODULES = {
     },
     "btclib.psbt": {
         "groups": ["musig2"],
-        "unpublished": ["psbt", "psbt_in", "psbt_out", "psbt_size", "psbt_utils"],
+        "unpublished": [
+            "psbt",
+            "psbt_in",
+            "psbt_out",
+            "psbt_size",
+            "psbt_utils",
+            "psbt_view",
+        ],
     },
     "btclib.script": {
         "groups": ["engine", "sig_hash", "taproot"],
@@ -503,6 +510,7 @@ def test_psbt_exports_the_format_not_its_plumbing() -> None:
         "Psbt",
         "PsbtIn",
         "PsbtOut",
+        "PsbtView",
         "SolutionSizer",
         "assert_signatures_only",
         "assert_signed",

--- a/tests/psbt/__init__.py
+++ b/tests/psbt/__init__.py
@@ -2,4 +2,42 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""Non-regression tests for btclib.psbt."""
+"""Non-regression tests for btclib.psbt.
+
+The vector loaders live here rather than in one of the test modules
+because two of them read the same files: `psbt_test.py` holds the object
+model to the published psbts, and `psbt_view_test.py` holds the streaming
+reader to the object model over the very same list. `tests/__init__.py`
+says why shared test code is a package `__init__` at every level.
+"""
+
+from typing import Any
+
+import pytest
+
+from tests import load, vector_id
+
+
+def psbt_cases(fname: str, kind: str) -> list[dict[str, Any]]:
+    """Return the `kind` cases of a psbt vector file, as they are written.
+
+    What each case holds depends on the kind: an encoded psbt always, an
+    error message where the case is one to refuse, the lock time BIP370
+    publishes for it where the case is about that.
+    """
+    cases: list[dict[str, Any]] = load("psbt", "_data", fname)[kind]
+    return cases
+
+
+def psbt_vectors(fname: str, kind: str) -> list[Any]:
+    """Return those cases as parametrize arguments, named by description.
+
+    The description is the id because a bare "case 7 failed" is not a
+    report: as a test id it is there for free, with no print-and-raise
+    wrapper around the decode and no interpolation into the message of
+    every assert -- and for the cases that pass as well.
+    """
+    return [
+        pytest.param(test_vector, id=vector_id(index, test_vector["description"]))
+        for index, test_vector in enumerate(psbt_cases(fname, kind), 1)
+    ]

--- a/tests/psbt/psbt_test.py
+++ b/tests/psbt/psbt_test.py
@@ -63,24 +63,11 @@ from btclib.script.taproot import input_script_sig, tree_helper
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from btclib.tx.limits import MAX_TX_IN_COUNT, MAX_TX_OUT_COUNT
-from tests import load, vector_id
+from tests import load
 from tests.conftest import JsonGolden
+from tests.psbt import psbt_vectors
 
 # first tests are part of the official BIP174 test vectors
-
-
-def psbt_vectors(fname: str, kind: str) -> list[Any]:
-    """Return the `kind` cases of a psbt vector file, named by description.
-
-    The description is the id because a bare "case 7 failed" is not a
-    report: as a test id it is there for free, with no print-and-raise
-    wrapper around the decode and no interpolation into the message of
-    every assert -- and for the cases that pass as well.
-    """
-    return [
-        pytest.param(test_vector, id=vector_id(index, test_vector["description"]))
-        for index, test_vector in enumerate(load("psbt", "_data", fname)[kind], 1)
-    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/psbt/psbt_view_test.py
+++ b/tests/psbt/psbt_view_test.py
@@ -1,0 +1,564 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Tests for the `btclib.psbt.psbt_view` module.
+
+A view answers about a stream what `Psbt` answers about an object, so the
+first tests are that the two agree, on every psbt the suite has: the
+globals, each map, the transaction being built, its lock time, the
+outputs being spent and both sig_hashes, over the BIP174, BIP370, BIP371
+and BIP373 vectors, and over the invalid psbts of those files and of
+btclib's own. What the rest of the file is about is where a view is not
+the object -- what it refuses one map later, what it reads and what it
+leaves in the stream -- and each of those names the property rather than
+the psbt it uses.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from btclib import var_int
+from btclib.exceptions import BTClibValueError
+from btclib.psbt import Psbt, PsbtView, ecdsa_sig_hash, taproot_sig_hash
+from btclib.psbt.psbt import prevouts
+from btclib.psbt.psbt_view import _read_var_int
+from btclib.script import sig_hash
+from btclib.tx import OutPoint, Tx, TxIn, TxOut
+from tests.psbt import psbt_cases, psbt_vectors
+
+_BIP_FILES = (
+    "bip174_test_vectors.json",
+    "bip370_test_vectors.json",
+    "bip371_test_vectors.json",
+    "bip373_test_vectors.json",
+)
+
+# every valid psbt the suite has, whatever BIP published it: what a view
+# is held to is the object model's own answers, so the psbts to hold it to
+# are all of them rather than two or three chosen here
+_VALID = [
+    vector for fname in _BIP_FILES for vector in psbt_vectors(fname, "valid psbts")
+]
+_VALID_CASES = [
+    case for fname in _BIP_FILES for case in psbt_cases(fname, "valid psbts")
+]
+
+# and every invalid one, btclib's own file included, that being where the
+# psbts nobody published are. `btclib_test_vectors.json` has no valid
+# psbts, which is why the two lists are not one comprehension over one
+# tuple of file names
+_INVALID_FILES = (*_BIP_FILES, "btclib_test_vectors.json")
+_INVALID = [
+    vector
+    for fname in _INVALID_FILES
+    for vector in psbt_vectors(fname, "invalid psbts")
+]
+_INVALID_CASES = [
+    case for fname in _INVALID_FILES for case in psbt_cases(fname, "invalid psbts")
+]
+
+# the one invalid psbt a view refuses for another reason than `Psbt.parse`
+# does, with the reason: BIP174 published it for the two-octet
+# PSBT_IN_SIGHASH_TYPE key in its second input map, and it carries 104
+# octets after its last map as well. A view walks the maps before it parses
+# any of them, so what it reports is the trailing data -- the same psbt
+# refused, for something that is true of it
+_REFUSED_EARLIER = "PSBT with invalid input sig_hash type typed key"
+
+
+def _raw(vector: dict[str, Any]) -> bytes:
+    """Return the octets of a vector's psbt."""
+    return base64.b64decode(vector["encoded psbt"])
+
+
+def _named(fragment: str) -> bytes:
+    """Return the octets of the valid psbt whose description holds this."""
+    return _raw(next(case for case in _VALID_CASES if fragment in case["description"]))
+
+
+def _answer(question: Callable[..., Any], *args: Any) -> Any:
+    """Return what the question answers, or the message it refuses with.
+
+    The two readers are compared on the psbts that are valid and on the
+    psbts that are not, so "raises this" has to be a value: without it
+    every assertion below would hold only where both sides answered.
+    """
+    try:
+        return question(*args)
+    except BTClibValueError as e:
+        return str(e)
+
+
+def _read_everything(view: PsbtView) -> None:
+    """Ask a view for everything it can be asked, in a signer's order.
+
+    The transaction first, that being what a signer shows before it reads
+    a key: for a version 2 psbt it reads every map to build it, and for a
+    version 0 one it is the transaction the psbt carries, so the maps are
+    then read by the loops below.
+    """
+    assert view.tx.version == view.tx_version
+    for i in range(view.input_count):
+        view.input(i)
+    for i in range(view.output_count):
+        view.output(i)
+
+
+@pytest.mark.parametrize("test_vector", _VALID)
+def test_the_view_reads_what_the_object_reads(test_vector: dict[str, Any]) -> None:
+    """A view and a `Psbt` answer the same questions about the same psbt.
+
+    check_validity=False on the object, and no `assert_valid` anywhere:
+    one of these vectors is BIP370's psbt whose inputs require a height
+    and a time both, which has no transaction at all, so `_answer` is
+    what keeps that case a comparison rather than an exclusion.
+    """
+    raw = _raw(test_vector)
+    psbt = Psbt.parse(raw, check_validity=False)
+    view = PsbtView(raw)
+
+    assert view.version == psbt.version
+    assert view.tx_version == psbt.tx_version
+    assert view.fallback_lock_time == psbt.fallback_lock_time
+    assert view.tx_modifiable == psbt.tx_modifiable
+    assert view.signed_message == psbt.signed_message
+    assert view.hd_key_paths == psbt.hd_key_paths
+    assert view.unknown == psbt.unknown
+    assert view.input_count == len(psbt.inputs)
+    assert view.output_count == len(psbt.outputs)
+    assert _answer(lambda: view.lock_time) == _answer(lambda: psbt.lock_time)
+    assert _answer(lambda: view.tx) == _answer(lambda: psbt.tx)
+
+    for i in range(view.input_count):
+        assert view.input(i, check_validity=False) == psbt.inputs[i]
+        assert _answer(view.ecdsa_sig_hash, i) == _answer(ecdsa_sig_hash, psbt, i)
+        assert _answer(view.taproot_sig_hash, i) == _answer(taproot_sig_hash, psbt, i)
+    for i in range(view.output_count):
+        assert view.output(i, check_validity=False) == psbt.outputs[i]
+
+
+@pytest.mark.parametrize("test_vector", _VALID)
+def test_the_outputs_being_spent_are_the_objects(test_vector: dict[str, Any]) -> None:
+    """`prevouts` read one input at a time is `prevouts` read whole.
+
+    Its own test because the object's answer needs the psbt to be valid --
+    `prevouts` validates before it reads, a taproot signature committing
+    to every input's amount and script -- while a view validates one map
+    at a time and never the whole. So this one is checked, where the test
+    above compares the two readers on psbts the object model refuses as
+    well.
+    """
+    raw = _raw(test_vector)
+    assert _answer(PsbtView(raw).prevouts) == _answer(prevouts, Psbt.parse(raw))
+
+
+@pytest.mark.parametrize("test_vector", _INVALID)
+def test_the_view_refuses_what_the_object_refuses(test_vector: dict[str, Any]) -> None:
+    """Every psbt `Psbt.parse` refuses, a view refuses too.
+
+    Not always at the same moment: a view reads a map when it is asked
+    for it, so a malformation inside one is found when that map is read
+    and not at construction. What this asserts is that reading the whole
+    psbt through the view reaches the same refusal, with the message the
+    vector file records -- and `_REFUSED_EARLIER` names the one case where
+    a view has a different true thing to say first.
+    """
+    if test_vector["description"] == _REFUSED_EARLIER:
+        with pytest.raises(BTClibValueError, match="104 bytes after the psbt"):
+            PsbtView(_raw(test_vector))
+        return
+
+    with pytest.raises(BTClibValueError) as excinfo:
+        _read_everything(PsbtView(_raw(test_vector)))
+    assert test_vector["error message"] in str(excinfo.value)
+
+
+def test_a_psbt_is_read_from_a_file(tmp_path: Path) -> None:
+    """The stream a view is for: one the psbt was never held whole from.
+
+    `alias.BinaryData` is a `BytesIO`, which is the psbt in memory with an
+    object model still to be built on top of it; a file is the case a view
+    exists for, so it is a case the tests have to run. The taproot
+    sig_hash because it is the answer that commits to every input, and so
+    the one that has to have read the whole file to be right.
+    """
+    raw = _named("P2TR key only input with internal key and its")
+    path = tmp_path / "unsigned.psbt"
+    path.write_bytes(raw)
+
+    with path.open("rb") as file_:
+        view = PsbtView(file_)
+        from_file = [view.taproot_sig_hash(i) for i in range(view.input_count)]
+        assert view.input(0) == PsbtView(raw).input(0)
+        assert view.tx == PsbtView(raw).tx
+
+    in_memory = PsbtView(raw)
+    assert from_file == [
+        in_memory.taproot_sig_hash(i) for i in range(in_memory.input_count)
+    ]
+
+
+def test_a_stream_may_carry_more_than_the_psbt() -> None:
+    """A view starts where the cursor is and stops after the last map.
+
+    Which is `parse`'s half of the same contract, and what makes a psbt
+    readable out of a stream carrying something else as well: here the
+    something else is a second psbt, read by a second view from where the
+    first one left the stream.
+    """
+    first = _named("PSBT with one P2PKH input. Outputs are empty")
+    second = _named("1 input, 2 output PSBTv2, required fields only")
+    stream = BytesIO(b"before" + first + second + b"after")
+    stream.seek(len(b"before"))
+
+    view = PsbtView(stream)
+    assert view.offset == len(b"before")
+    assert stream.tell() == len(b"before") + len(first)
+    assert view.input(0) == Psbt.parse(first).inputs[0]
+
+    stream.seek(len(b"before") + len(first))
+    second_view = PsbtView(stream)
+    assert second_view.version == 2
+    assert stream.tell() == len(b"before") + len(first) + len(second)
+    assert second_view.input(0) == Psbt.parse(second).inputs[0]
+
+
+def test_octets_are_one_whole_psbt() -> None:
+    """What follows the last map in octets is refused, hex string included."""
+    raw = _named("PSBT with one P2PKH input. Outputs are empty")
+    assert PsbtView(raw).input_count == 1
+
+    for trailing in (b"\x00", b"junk"):
+        with pytest.raises(BTClibValueError, match="bytes after the psbt"):
+            PsbtView(raw + trailing)
+        with pytest.raises(BTClibValueError, match="bytes after the psbt"):
+            PsbtView((raw + trailing).hex())
+
+
+def test_no_prefix_of_a_psbt_is_a_view() -> None:
+    """Every truncation is refused, at every offset.
+
+    The parse contract's first property, asked of the walk a view is built
+    by: the maps are not read, but where each of them ends is, so a psbt
+    that stops in the middle of one has nowhere for the next to start.
+    """
+    raw = _named("1 input, 2 output updated PSBTv2, with all PSBTv2 fields")
+    for size in range(len(raw)):
+        with pytest.raises(BTClibValueError):
+            PsbtView(raw[:size])
+
+
+def _large_utxo() -> Tx:
+    """Return a transaction large enough that not reading it is measurable.
+
+    A non-witness utxo is a whole previous transaction, which is what
+    makes a psbt larger than the maps a signer needs from it: a thousand
+    outputs here, so that "the view did not read it" is a statement about
+    tens of kilobytes rather than about rounding.
+    """
+    return Tx(
+        1,
+        0,
+        [TxIn(OutPoint("11" * 32, 0), b"\x51", 0xFFFFFFFF)],
+        [TxOut(1000, b"\x51" * 32) for _ in range(1000)],
+    )
+
+
+def _psbt_with_a_large_utxo() -> tuple[bytes, int]:
+    """Return such a psbt, and the size of the utxo its first input holds."""
+    prev_tx = _large_utxo()
+    tx = Tx(
+        2,
+        0,
+        [TxIn(OutPoint(prev_tx.id, i), b"", 0xFFFFFFFF) for i in range(3)],
+        [TxOut(500, b"\x51" * 22)],
+    )
+    psbt = Psbt.from_tx(tx)
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    return psbt.serialize(), len(prev_tx.serialize(include_witness=False))
+
+
+class _CountingStream(BytesIO):
+    """A BytesIO that remembers how many octets have been read from it."""
+
+    def __init__(self, initial_bytes: bytes) -> None:
+        super().__init__(initial_bytes)
+        self.read_count = 0
+
+    def read(self, size: int | None = -1, /) -> bytes:
+        data = super().read(size)
+        self.read_count += len(data)
+        return data
+
+
+def test_only_the_maps_asked_for_are_read() -> None:
+    """The property the whole module is for, counted in octets.
+
+    A view reads the global map, the lengths of every map after it, and
+    then whichever map it is asked for; `Psbt.parse` reads the psbt. So a
+    caller asking for the two small inputs of the psbt below never reads
+    the large utxo of the first, and the count says so -- where the object
+    model has read every octet before it can answer anything.
+    """
+    raw, utxo_size = _psbt_with_a_large_utxo()
+
+    stream = _CountingStream(raw)
+    view = PsbtView(stream)
+    view.input(1)
+    view.input(2)
+    view.output(0)
+    assert stream.read_count < utxo_size
+
+    stream = _CountingStream(raw)
+    Psbt.parse(stream)
+    assert stream.read_count > utxo_size
+
+
+def test_a_map_is_read_again_rather_than_kept() -> None:
+    """Two reads of one input are two objects, so neither of them is held.
+
+    What a view keeps between calls is in its module docstring, and a map
+    is not on that list: an input handed to a caller is theirs to change,
+    and changing it changes nothing the next caller of the same view sees.
+    """
+    view = PsbtView(_named("PSBT with one P2PKH input. Outputs are empty"))
+    first, second = view.input(0), view.input(0)
+    assert first == second
+    assert first is not second
+
+    first.sig_hash_type = 0x81
+    assert view.input(0) == second
+
+
+def _psbt_with_taproot_inputs(count: int = 3) -> bytes:
+    """Return a psbt of `count` taproot inputs, which no vector file has.
+
+    Every published taproot psbt has one input, and one input is exactly
+    the case that cannot tell a hash computed per input from a hash
+    computed once: BIP341 commits each of them to the amounts and scripts
+    of all of them.
+    """
+    script_pub_key = b"\x51\x20" + b"\x01" * 32  # OP_1 <32 bytes>, a p2tr output
+    tx = Tx(
+        2,
+        0,
+        [TxIn(OutPoint(f"{i + 1:064x}", i), b"", 0xFFFFFFFF) for i in range(count)],
+        [TxOut(1000, script_pub_key)],
+    )
+    psbt = Psbt.from_tx(tx)
+    for i, psbt_in in enumerate(psbt.inputs):
+        psbt_in.witness_utxo = TxOut(2000 + i, script_pub_key)
+    return psbt.serialize()
+
+
+def test_the_transaction_wide_hashes_are_computed_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Signing N inputs hashes the whole transaction once, not N times.
+
+    BIP341 commits every input to the same five hashes over the whole
+    transaction, so a psbt whose inputs are what does not fit in memory is
+    exactly the psbt that must not hash them once per input (issue #164 is
+    the same arithmetic for the object model). Counted rather than timed,
+    and the answers are asserted to be the object model's: a
+    precomputation that changed one of them would be an optimization
+    around the wrong hash.
+    """
+    raw = _psbt_with_taproot_inputs()
+    psbt = Psbt.parse(raw)
+    view = PsbtView(raw)
+    built = 0
+
+    def counted(tx: Tx, spent: list[TxOut]) -> sig_hash.PrecomputedTxData:
+        nonlocal built
+        built += 1
+        return sig_hash.PrecomputedTxData(tx, spent)
+
+    monkeypatch.setattr("btclib.psbt.psbt_view.PrecomputedTxData", counted)
+
+    for i in range(view.input_count):
+        assert view.taproot_sig_hash(i) == taproot_sig_hash(psbt, i)
+
+    assert view.input_count == 3
+    assert built == 1
+
+
+def test_the_transaction_and_the_outputs_spent_are_copies() -> None:
+    """What `tx` and `prevouts` hand back is not what the next answer uses.
+
+    `Psbt.tx` promises the same thing by computing the transaction at
+    every access; a view keeps one, so a copy is where the promise is kept
+    -- and it is worth keeping, a sig_hash built from a caller's edit
+    being a signature over a transaction nobody agreed to. A `TxOut` is
+    frozen, so what is written below is what a caller still can write: a
+    field of the transaction, and an element of either list.
+    """
+    view = PsbtView(_psbt_with_taproot_inputs())
+    before = view.taproot_sig_hash(0)
+    elsewhere = TxOut(1, b"\x51")
+
+    tx = view.tx
+    tx.lock_time += 1
+    tx.vout[0] = elsewhere
+    spent = view.prevouts()
+    spent[0] = elsewhere
+
+    assert view.tx.lock_time != tx.lock_time
+    assert view.tx.vout[0] != elsewhere
+    assert view.prevouts()[0] != elsewhere
+    assert view.taproot_sig_hash(0) == before
+
+
+def test_an_index_no_map_of_this_psbt_has_is_refused() -> None:
+    """A position in a stream, so counting from the end is not one.
+
+    Zero included, by the psbt with no inputs and no outputs BIP174
+    publishes as valid: an empty psbt has no map 0 either.
+    """
+    view = PsbtView(_named("PSBT with one P2PKH input. Outputs are empty"))
+    for index in (-1, view.input_count):
+        with pytest.raises(BTClibValueError, match="invalid input index"):
+            view.input(index)
+    for index in (-1, view.output_count):
+        with pytest.raises(BTClibValueError, match="invalid output index"):
+            view.output(index)
+
+    empty = PsbtView(_named("0 inputs and 0 outputs"))
+    assert (empty.input_count, empty.output_count) == (0, 0)
+    with pytest.raises(BTClibValueError, match="the psbt has 0"):
+        empty.input(0)
+    with pytest.raises(BTClibValueError, match="the psbt has 0"):
+        empty.output(0)
+
+
+def test_a_stream_that_cannot_seek_is_refused() -> None:
+    """A view reads a map when it is asked for it, which is a seek.
+
+    Refused at construction and with what it needs said: without the
+    check, the first seek fails from underneath the library, and for a
+    pipe or a socket it fails with the psbt already half read.
+    """
+
+    class Pipe(BytesIO):
+        def seekable(self) -> bool:
+            return False
+
+    with pytest.raises(BTClibValueError, match="needs a seekable stream"):
+        PsbtView(Pipe(_named("PSBT with one P2PKH input. Outputs are empty")))
+
+
+def test_the_magic_bytes_are_the_whole_header() -> None:
+    """The five octets, the 0xff included, as `Psbt.parse` asks for them."""
+    raw = _named("PSBT with one P2PKH input. Outputs are empty")
+    with pytest.raises(BTClibValueError, match="missing magic bytes"):
+        PsbtView(b"psbt\x00" + raw[5:])
+    with pytest.raises(BTClibValueError, match="missing magic bytes"):
+        PsbtView(b"")
+
+
+def test_a_map_is_validated_when_it_is_read_and_not_before() -> None:
+    """`check_validity` is per map, which is the only place a view can ask.
+
+    Which fields a version requires of a map is a question about that map
+    alone, so it is asked when the map is read; BIP370's two psbts below
+    are invalid for exactly that reason, and unchecked they are read back
+    as the maps they are -- an input with no outpoint, an output with no
+    amount.
+    """
+    missing_txid = next(
+        case
+        for case in _INVALID_CASES
+        if "missing PSBT_IN_PREVIOUS_TXID" in case["description"]
+    )
+    view = PsbtView(_raw(missing_txid))
+    with pytest.raises(
+        BTClibValueError, match="input 0: missing PSBT_IN_PREVIOUS_TXID"
+    ):
+        view.input(0)
+    assert view.input(0, check_validity=False).previous_tx_id == b""
+
+    missing_amount = next(
+        case
+        for case in _INVALID_CASES
+        if "missing PSBT_OUT_AMOUNT" in case["description"]
+    )
+    view = PsbtView(_raw(missing_amount))
+    with pytest.raises(BTClibValueError, match="output 0: missing PSBT_OUT_AMOUNT"):
+        view.output(0)
+    assert view.output(0, check_validity=False).amount is None
+
+
+def _psbt_with_a_mismatched_utxo(*, wrong_id: bool) -> bytes:
+    """Return a psbt whose non-witness utxo is not what its outpoint names."""
+    prev_tx = Tx(1, 0, [TxIn(OutPoint("22" * 32, 0), b"\x51", 0)], [TxOut(9, b"\x51")])
+    tx_id = "11" * 32 if wrong_id else prev_tx.id
+    tx = Tx(
+        2, 0, [TxIn(OutPoint(tx_id, 0 if wrong_id else 7), b"", 0)], [TxOut(1, b"\x51")]
+    )
+    psbt = Psbt.from_tx(tx, check_validity=False)
+    psbt.inputs[0].non_witness_utxo = prev_tx
+    return psbt.serialize(check_validity=False)
+
+
+@pytest.mark.parametrize(
+    "wrong_id, err_msg",
+    [
+        (True, "mismatched non-witness utxo / outpoint tx_id"),
+        (False, "outpoint vout out of range for the non-witness utxo"),
+    ],
+)
+def test_the_utxo_of_an_input_is_the_transaction_its_outpoint_names(
+    err_msg: str, *, wrong_id: bool
+) -> None:
+    """Both halves of that, asked of one input rather than of the psbt.
+
+    `Psbt.assert_valid` asks them of every input, which a view cannot;
+    what it can do is ask them of the map it has just read, and an
+    outpoint naming an output the transaction does not have is the case
+    that would otherwise be an IndexError out of the sig_hash.
+    """
+    view = PsbtView(_psbt_with_a_mismatched_utxo(wrong_id=wrong_id))
+    with pytest.raises(BTClibValueError, match=err_msg):
+        view.input(0)
+
+
+def test_a_lock_time_no_transaction_can_have_is_refused() -> None:
+    """One input requiring a height and another a time, read one at a time.
+
+    BIP370's own psbt, and the answer `Psbt.lock_time` gives it: the
+    inputs stream past `_lock_time` rather than reaching it as a list, so
+    what this pins is that streaming them reaches the same refusal.
+    """
+    case = next(
+        case
+        for case in psbt_cases("bip370_test_vectors.json", "lock time psbts")
+        if case["lock time"] is None
+    )
+    view = PsbtView(_raw(case))
+    with pytest.raises(BTClibValueError, match="no lock time satisfies every input"):
+        _ = view.lock_time
+
+
+@pytest.mark.parametrize("value", [0, 0xFC, 0xFD, 0xFFFF, 0x1_0000, var_int.MAX_SIZE])
+def test_a_compact_size_is_read_and_no_more_than_it(value: int) -> None:
+    """The one number a view reads with no `BytesIO` under it.
+
+    A key or a value longer than 252 octets carries a prefix, and the
+    cursor has to be left on the octet after the number rather than after
+    the window it was read out of: an off-by-one there misreads every map
+    that follows. The psbts above exercise the one-octet form thousands of
+    times over, and these are the two prefixed forms a length can reach --
+    the third needs a number above `var_int.MAX_SIZE`, which is not a
+    length any psbt has.
+    """
+    stream = BytesIO(var_int.serialize(value) + b"tail")
+    assert _read_var_int(stream) == value
+    assert stream.read() == b"tail"


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/647

`Psbt.parse` reads every map before anything can be inspected or signed,
so a psbt whose inputs each carry the previous transaction they spend
costs all of them at once, and a signer with less memory than that cannot
read the psbt at all. `btclib.psbt.PsbtView` walks a seekable stream once
to learn where each map begins and reads one when it is asked for it —
[`diybitcoinhardware/embit`](https://github.com/diybitcoinhardware/embit/blob/eb6104fd/src/embit/psbtview.py)'s
`psbtview.PSBTView` idea, and its audience: hardware wallets and
airgapped signers.

## What it is

A reader beside `Psbt`, not another way to spell it. It offers the global
fields, `input` and `output` one map at a time, the transaction being
built, the outputs being spent, and both sig_hashes. The roles that
rewrite a psbt — Combiner, Finalizer, Extractor, `sign` — are not here,
the stream being read-only: a signer assembles its own answer out of the
maps it was handed, `PsbtIn.serialize` writing each. That is the issue's
"scope the first version to reading".

```python
with path.open("rb") as file_:          # a file, not only a BytesIO
    view = PsbtView(file_)
    psbt_in = view.input(0)             # one map, read now, held by nothing
    msg_hash = view.taproot_sig_hash(0)
```

## What it holds, and what it never holds

The global map, an integer per map saying where that map starts, and —
once a sig_hash is asked for — the unsigned transaction, the output each
input spends, and `sig_hash.PrecomputedTxData`, which BIP143 and BIP341
commit *every* input to. So signing N inputs hashes the transaction once
rather than N times, which is issue #164's arithmetic for the psbt whose
N inputs are exactly what does not fit; that is the issue's "reuse
btclib's existing BIP341 midstate computation rather than duplicating
it", and the reuse is literal — `sig_hash.taproot`'s own `precomputed`
argument.

What it never holds is two input maps at once, and that is where a psbt's
size is. Measured rather than asserted: a test counts the octets read
from the stream and reads none of the large utxo it did not ask for.

## The TOCTOU contract

The module docstring states it at length rather than leaving it implicit,
as the issue asks: a view answers from the bytes that were there when it
read them, nothing re-reads a map to check that it still says what it
said, and nothing invalidates what has been read. An amount or a script
that changes between two reads is a sig_hash committing to a transaction
the signer was never shown. So the stream must not change while the view
is alive; a psbt on removable or untrusted storage is copied into memory
the caller controls first, and a stream that has legitimately changed is
read by building a new view.

## One implementation, two readers

Every question about what a psbt's bytes mean stays the object model's,
imported rather than restated — which type byte is a field of which
version, what the global map holds, what each version requires of a map,
what the transaction being built is, what a sig_hash commits to. Five
answers in `psbt.py` that were written inside a loop over a whole psbt
are now written per map beside it (`_tx_in`/`_tx_out`,
`_read_tx_in`/`_read_tx_out`, `_assert_valid_utxo`, `_spent_outputs`, and
the two sig_hash bodies), and `_lock_time` takes the pairs of required
lock times rather than the inputs — those two fields being all of an
input BIP370's algorithm depends on, so a caller with one input at a time
streams them past it.

`utils.read_exactly` annotates its stream `BinaryIO` where it said
`BytesIO`: `.read` is the whole of what a short read is about, and a view
is the one reader here that does not consume the stream it is given.
That is also why a view's stream type is wider than `alias.BinaryData` —
a view over a `BytesIO` holds the whole psbt in memory and answers the
question it exists for with "buy more memory".

## Tests

The suite holds the two readers to each other over every psbt it has:
BIP174, BIP370, BIP371 and BIP373 valid vectors — globals, each map, the
transaction, its lock time, the outputs spent and both sig_hashes — and
the invalid vectors of those four files plus btclib's own, where reading
the psbt through the view has to reach the same refusal with the same
message. One published psbt is refused for a different reason by each,
and the test names it: BIP174's two-octet `PSBT_IN_SIGHASH_TYPE` key
carries 104 octets after its last map as well, and a view walks the maps
before it parses any of them.

Beside that: a psbt read from a file, a psbt inside a stream that carries
two, every truncation refused, the octet counting above, the copies `tx`
and `prevouts` hand back, the midstates built once with the answers
asserted to be the object model's, a multi-input taproot psbt no vector
file has, and the per-map validity `check_validity` gates.

Gates run locally: `uv run pytest` (100.00%, 26253 passed), `uv run
pre-commit run --all-files`, the sphinx `-W` build, and the suite on 3.10.
The guide gains a worked example, which `tests/docs_examples_test.py`
executes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce PsbtView as a stream-based, map-at-a-time PSBT reader for low-memory signers and integrate it with existing PSBT parsing, transaction building, and sig-hash utilities.

New Features:
- Add PsbtView to read PSBTs one map at a time from seekable binary streams, exposing globals, per-input/per-output maps, the unsigned transaction, prevouts, and both sig-hashes.
- Support reading PSBTs directly from files or generic BinaryIO streams, and treating raw octets as a single complete PSBT.

Enhancements:
- Refactor PSBT transaction construction, lock-time computation, utxo validation, prevouts collection, and sig-hash helpers into per-map utilities that can be reused by both Psbt and PsbtView.
- Adjust lock time computation to operate on iterable pairs of required lock times, enabling streaming over inputs.
- Update utils.read_exactly to accept BinaryIO instead of BytesIO, allowing use with file streams.
- Export PsbtView from btclib.psbt and document its behavior and TOCTOU considerations in the changelog and psbt module docs.

Documentation:
- Update PSBT documentation and the guide to describe PsbtView, its streaming semantics, TOCTOU constraints, and usage examples.
- Add detailed changelog entry explaining PsbtView, its design rationale, memory model, and interaction with existing PSBT utilities.

Tests:
- Add extensive PsbtView test suite covering equivalence with Psbt over all valid/invalid vectors, streaming behavior, truncation and trailing-data handling, large UTXO read-count measurement, taproot precomputation reuse, and per-map validity checks.
- Refactor shared PSBT vector-loading helpers into tests/psbt/__init__.py for reuse by both Psbt and PsbtView tests.
- Extend docs examples tests to cover the new PsbtView usage where applicable.

Chores:
- Update tests/all_test.py exports and unpublished module list to include the new psbt_view module and PsbtView symbol.