### PR TITLE
Give every btclib exception one base to catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1300,6 +1300,37 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`BTClibException`, one name to catch for everything btclib raises**
+  (issue #743). `btclib.exceptions` says its classes "exist only to tell
+  an exception raised by btclib from one raised by any other code", and
+  could not do it: telling them apart took a tuple of three --
+  `BTClibValueError`, `BTClibTypeError`, `BTClibRuntimeError` -- that a
+  caller had to keep in step with this hierarchy. Those three now inherit
+  the new base, and the eleven classes under them get it transitively.
+
+  Inherited *beside* the built-in and not instead of it, which is the half
+  that matters: `BTClibValueError` is a `ValueError` as it always was, so
+  every `except ValueError` already written keeps catching what it caught.
+  That is the standard library's own shape -- `json.JSONDecodeError` is a
+  `ValueError` -- and what requests, sqlalchemy and httpx give up by
+  deriving their bases from `Exception` alone, which leaves an `except
+  ValueError` not catching their value errors.
+
+  It is caught and never raised: every raise is one of the three, and
+  which one answers what the base cannot carry -- whether the value was
+  wrong, the type was, or neither was and a check failed anyway. A caller
+  with something to do about that names the specific class.
+  `BTClibUserWarning` stays out, a warning being filtered rather than
+  caught: with `filterwarnings = ["error"]` an `except BTClibException`
+  would otherwise catch a call that worked.
+
+  The docstring says what is not yet true, rather than promising it: issue
+  #744 counts the public functions still letting a native `KeyError`,
+  `IndexError` or `OverflowError` through, so catching this class catches
+  most of what the library raises and not all of it. The test that will
+  close that gap wants a single predicate to assert, which is why the base
+  lands before the fixes rather than after them.
+
 - **BIP85 deterministic entropy from a BIP32 keychain** (issue #644), as
   `btclib.bip85`. `entropy_from_der_path` is the derivation itself -- a
   fully hardened path off a root key, then

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -8,6 +8,28 @@ These exist only to tell an exception raised by btclib from one raised by
 any other code: each derives from the built-in that says what kind of
 failure it is, and adds nothing to it.
 
+`BTClibException` is what makes that telling apart a single `except`
+rather than a tuple of three a caller has to keep in step with this
+hierarchy. It is inherited *beside* the built-in and not instead of it,
+which is the half that matters: `BTClibValueError` is a `ValueError` as
+it always was, so code catching the built-in keeps catching what it
+caught, and `json.JSONDecodeError` is the standard library doing the
+same. Libraries that give up the built-in -- requests, sqlalchemy and
+httpx among them -- leave an `except ValueError` not catching their value
+errors, which is the cost this avoids by inheriting from both.
+
+It is caught and never raised: every raise below is one of the three, and
+which one answers a question the base cannot carry -- whether the value
+was wrong, the type was, or neither was and a check failed anyway. A
+caller with something to do about that difference names the specific
+class; `except BTClibException` is for the caller who only needs to know
+it came from here.
+
+That every failure of btclib's *is* one is not yet true: issue #744
+counts the public functions still letting a native `KeyError`,
+`IndexError` or `OverflowError` through, and until that is closed this
+class catches most of what the library raises rather than all of it.
+
 So a caller is usually better off catching the regular ValueError,
 TypeError or RuntimeError, and does not lose anything by doing so.
 
@@ -40,6 +62,7 @@ from __future__ import annotations
 from typing import Any
 
 __all__ = [
+    "BTClibException",
     "BTClibRuntimeError",
     "BTClibTypeError",
     "BTClibUserWarning",
@@ -58,15 +81,25 @@ __all__ = [
 ]
 
 
-class BTClibValueError(ValueError):
+class BTClibException(Exception):
+    """Anything btclib raised, whatever kind of failure it is.
+
+    The one name to catch for a caller who handles the standard library's
+    exceptions anyway and needs to know which came from here. Never
+    raised: the three below it are, and each says which kind of failure
+    it was.
+    """
+
+
+class BTClibValueError(BTClibException, ValueError):
     """A value no valid input could carry; the library's usual refusal."""
 
 
-class BTClibTypeError(TypeError):
+class BTClibTypeError(BTClibException, TypeError):
     """An input of a type no conversion accepts: a caller error."""
 
 
-class BTClibRuntimeError(RuntimeError):
+class BTClibRuntimeError(BTClibException, RuntimeError):
     """A check that failed on valid inputs, e.g. a failed verification."""
 
 
@@ -330,4 +363,10 @@ class BTClibUserWarning(UserWarning):
     The test suite relies on it too: `filterwarnings = ["error"]` is only
     worth having if the places that provoke a btclib warning silence that
     warning and nothing else.
+
+    Not a `BTClibException`, though it comes from btclib as much as any
+    of them: a warning is not a failure and is not caught but filtered,
+    so an `except BTClibException` sweeping one up -- which
+    `filterwarnings = ["error"]` is enough to make happen -- would catch
+    a call that worked as if it had not.
     """

--- a/tests/exceptions_test.py
+++ b/tests/exceptions_test.py
@@ -23,7 +23,12 @@ from typing import Any
 
 import pytest
 
+from btclib import exceptions
 from btclib.exceptions import (
+    BTClibException,
+    BTClibRuntimeError,
+    BTClibTypeError,
+    BTClibUserWarning,
     BTClibValueError,
     FetchError,
     HttpError,
@@ -159,6 +164,77 @@ def test_an_exception_adding_nothing_round_trips_too(error: BaseException) -> No
         assert type(back) is type(error)
         assert str(back) == str(error)
         assert back.args == error.args
+
+
+def test_every_exception_of_the_module_is_one_base_to_catch() -> None:
+    """`except BTClibException` is what tells a btclib failure from any other.
+
+    The classes are found rather than listed, so one added to the module
+    is one this covers: a new exception that forgot the base would be a
+    failure a caller catching it could not catch, and nothing else in the
+    suite would say so.
+
+    `BTClibUserWarning` is the exception, and the assertion says which way:
+    a warning is filtered, not caught, so it stays out of the class an
+    `except` names.
+    """
+    classes = [
+        getattr(exceptions, name)
+        for name in exceptions.__all__
+        if isinstance(getattr(exceptions, name), type)
+    ]
+    assert len(classes) == len(exceptions.__all__), "a non-class in __all__"
+
+    warnings = [c for c in classes if issubclass(c, Warning)]
+    assert warnings == [BTClibUserWarning]
+
+    for cls in classes:
+        if cls is BTClibUserWarning:
+            assert not issubclass(cls, BTClibException)
+            continue
+        assert issubclass(cls, BTClibException), f"{cls.__name__} is not catchable"
+
+
+@pytest.mark.parametrize(
+    "cls, builtin",
+    [
+        (BTClibValueError, ValueError),
+        (BTClibTypeError, TypeError),
+        (BTClibRuntimeError, RuntimeError),
+    ],
+    ids=["ValueError", "TypeError", "RuntimeError"],
+)
+def test_the_base_is_inherited_beside_the_builtin_not_instead_of_it(
+    cls: type[BTClibException], builtin: type[Exception]
+) -> None:
+    """The half that keeps every `except ValueError` already written working.
+
+    requests, sqlalchemy and httpx derive their bases from `Exception`
+    alone, so an `except ValueError` does not catch their value errors.
+    Asserted on the subclasses too, since they are what modules raise:
+    inheriting the base transitively must not cost them the built-in.
+    """
+    assert issubclass(cls, builtin)
+    assert issubclass(cls, BTClibException)
+    for sub in cls.__subclasses__():
+        assert issubclass(sub, builtin), f"{sub.__name__} lost {builtin.__name__}"
+        assert issubclass(sub, BTClibException)
+
+
+def test_the_base_carries_no_behaviour_of_its_own() -> None:
+    """It adds a name to catch and nothing else, which is the whole design.
+
+    A base that composed a message, or took a field, would be a second
+    thing to keep true in every subclass -- and the four subclasses that
+    do carry a field compose in `__str__` for the pickling reason the
+    module docstring gives, which a base doing its own would undo.
+    """
+    assert BTClibException.__init__ is Exception.__init__
+    assert BTClibException.__str__ is Exception.__str__
+    error = BTClibValueError("bad")
+    assert str(error) == "bad"
+    assert error.args == ("bad",)
+    assert type(pickle.loads(pickle.dumps(error))) is BTClibValueError  # noqa: S301
 
 
 def _raise_http_error() -> None:


### PR DESCRIPTION
btclib.exceptions says its classes "exist only to tell an exception
raised by btclib from one raised by any other code", and could not do it:
telling them apart took a tuple of three -- BTClibValueError,
BTClibTypeError, BTClibRuntimeError -- that a caller had to keep in step
with this hierarchy. Those three inherit BTClibException now, and the
eleven classes under them get it transitively.

Inherited beside the built-in and not instead of it, which is the half
that matters: BTClibValueError is a ValueError as it always was, so every
`except ValueError` already written keeps catching what it caught. That
is the standard library's own shape -- json.JSONDecodeError is a
ValueError -- and what requests, sqlalchemy and httpx give up by deriving
their bases from Exception alone, which leaves an `except ValueError` not
catching their value errors.

The base is caught and never raised: every raise is one of the three, and
which one answers what the base cannot carry -- whether the value was
wrong, the type was, or neither was and a check failed anyway.
BTClibUserWarning stays out, a warning being filtered rather than caught:
with `filterwarnings = ["error"]` an `except BTClibException` would
otherwise catch a call that worked.

The docstring says what is not yet true rather than promising it: issue
744 counts the public functions still letting a native KeyError,
IndexError or OverflowError through, so catching this class catches most
of what the library raises and not all of it. The test that will close
that gap wants one predicate to assert, which is why the base lands
before the fixes rather than after them.

Three tests, finding the classes rather than listing them: that every
name in __all__ is a BTClibException with BTClibUserWarning the named
exception, that each of the three keeps its built-in and so does every
subclass, and that the base adds no __init__ or __str__ of its own --
which the four field-carrying subclasses would have to undo, composing in
__str__ for the pickling reason the module docstring gives.

Gates, all green locally: `uv run pytest` at 26077 passed with coverage
100.00%, `uv run pre-commit run --all-files`, and the sphinx -W build.

Closes https://github.com/btclib-org/btclib/issues/743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a common BTClibException base to allow callers to catch all btclib failures with a single exception type while preserving existing built-in exception behavior.

New Features:
- Add BTClibException as a shared base class for btclib-specific error types to enable unified exception handling.

Enhancements:
- Make BTClibValueError, BTClibTypeError, BTClibRuntimeError and their subclasses inherit BTClibException alongside their respective built-in exceptions.
- Document the new exception base and its intended usage and limitations in the exceptions module docstring and changelog.
- Keep BTClibUserWarning separate from BTClibException to avoid treating warnings as failures when catching btclib exceptions.

Tests:
- Add tests to verify every exported btclib exception (except BTClibUserWarning) derives from BTClibException, that built-in exception relationships are preserved, and that BTClibException introduces no custom behavior.