### PR TITLE
Name the streaming psbt reader where every feature is named

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,9 @@ Included features are:
   [BIP371](https://github.com/bitcoin/bips/blob/master/bip-0371.mediawiki)
   and the MuSig2 ones of
   [BIP373](https://github.com/bitcoin/bips/blob/master/bip-0373.mediawiki)
+- PsbtView, the same psbt read a map at a time out of a stream, for a
+  signer with less memory than the psbt takes: the maps it is asked for,
+  the transaction being built, the outputs being spent and both sig_hashes
 - [BIP370](https://github.com/bitcoin/bips/blob/master/bip-0370.mediawiki)
   PSBT version 2, the unsigned transaction computed from the fields rather
   than carried as one: the lock time its inputs require, the identifier


### PR DESCRIPTION
Follow-up to https://github.com/btclib-org/btclib/pull/747
(https://github.com/btclib-org/btclib/issues/647).

README.md's feature list names `PsbtIn`, `PsbtOut` and `Psbt` under
BIP174, so a reader asking what btclib does with a psbt reads that list
rather than the module docstrings — and that file is btclib.org's
homepage. `PsbtView` was in neither, so the one audience it exists for, a
signer with less memory than the psbt takes, had no way to find out it is
there.

Three lines, no code. `pre-commit run --all-files` passes, MD013's 80
columns included, and `tests/docs_test.py`,
`tests/docs_examples_test.py` and `tests/release_notes_test.py` are green.
No CHANGELOG entry: the entry for the reader itself is already in
v2026.9, and this is that entry's own claim made findable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Documentation:
- Add PsbtView to the README feature list to describe the streaming PSBT reader for low-memory signers.