### PR TITLE
Say what the published workflow does, on the day it does it

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -22,10 +22,11 @@ on:
     # workflows across every repository that asked for the same minute, and
     # the run can be dropped outright when the queue is long.
     # First among the weekday sentinels: whether an external page still
-    # resolves is the least volatile of the four questions this week
-    # asks, published.yml (Tuesday), latest.yml (Wednesday) and
-    # Dependabot (Thursday) each asking something that changes more
-    # often than the last
+    # resolves is the least volatile of the questions this week asks --
+    # latest.yml (Wednesday) and Dependabot (Thursday) each ask something
+    # that changes more often than the last. published.yml asks the
+    # quietest of them all and asks it monthly, its subject being an
+    # artifact already released and therefore fixed
     - cron: "17 4 * * 1"
   # the escape hatch, and the way to check a branch before merging a
   # documentation change that adds links

--- a/.github/workflows/published.yml
+++ b/.github/workflows/published.yml
@@ -35,18 +35,20 @@ name: published
 
 on:
   schedule:
-    # Tuesday, a minute that is not the hour: everything scheduled on the
-    # hour queues together, and a run that waits is a run whose failure
-    # is noticed later. The day after links.yml's Monday: a fixed,
-    # already-released artifact is checked here, before latest.yml asks
-    # the more volatile question of what the newest dependency does to a
-    # tree not yet released.
+    # The first of the month, at a minute that is not the hour: everything
+    # scheduled on the hour queues together, and a run that waits is a run
+    # whose failure is noticed later. Monthly and not weekly because the
+    # subject does not change: an already-released artifact is fixed, and
+    # what can move under it -- a new interpreter, an index serving a file
+    # that does not match its own hash -- moves on nobody's week. The one
+    # moment the answer can change is a release, and that is a call from
+    # release.yml rather than a day on the calendar.
     # Only the default branch schedules workflows, so on any other branch
     # this is reachable through the dispatch below alone
     - cron: "31 4 1 * *"
   # after a release, which is the one moment this workflow's answer can
-  # change: RELEASING.md documented dispatching it by hand right there, and
-  # a call does not forget. Called by release.yml rather than triggered by
+  # change: a call does not forget, where RELEASING.md's step is a verdict
+  # to read. Called by release.yml rather than triggered by
   # workflow_run, which zizmor rates a dangerous trigger and rightly -- it
   # runs the default branch's copy with the token of a push nobody reviewed
   # -- where a call runs inside the release that gated it. The caller passes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,18 @@ documented at release-notes length in the first place, and are still in
   and would fail without it. `/en/stable/` is the last release either way,
   which is what makes the backfill not worth doing.
 
+- **The release documentation says what the release workflow does.** Three
+  places described a `published` workflow that has moved on: RELEASING.md
+  asked for a dispatch by hand after the release, where `release.yml` calls
+  the workflow with the tag and waits for the index to serve that version
+  -- so the step is a verdict to read, and a dispatch is for a question
+  between runs; and it, along with the workflow's own schedule comment and
+  links.yml's list of weekday sentinels, called the run weekly and put it
+  on a Tuesday, where the cron says the first of the month. Prose only, and
+  the two workflow files change in their comments alone: an instruction
+  nobody needs and a day that is not the day are read as facts by whoever
+  finds them, and there is nothing in a run to say otherwise.
+
 ### Packaging, linting and CI
 
 - **A tag is refused unless the default branch contains its commit**

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -413,16 +413,20 @@ word, and step 1 asks it of both.
    Attested with the distribution files, so `gh attestation verify` below
    covers it too.
 
-1. Dispatch the `published` workflow (Actions → published → Run workflow)
-   and expect it green: no checkout, so it resolves to what PyPI actually
-   serves rather than to a source tree. It checks a BIP39 vector against
-   the twenty-five `_data/` files a wheel missing one would still install
-   and import cleanly, and a BIP340 vector besides -- both fixed forever,
-   so neither needs an edit after a release the way a version-pinned
-   assertion would. From then on it runs weekly on its own, and a failure
-   means the outside world moved, not this repository — a new interpreter
-   release, PyPI serving a file that does not match its own hash — which
-   is why it is a workflow of its own rather than a job of this one.
+1. Read the release run's `published` job, which is this workflow called
+   with the tag rather than a dispatch to remember: it has no checkout, so
+   it resolves to what PyPI actually serves rather than to a source tree,
+   and it waits for the version the tag names before installing anything,
+   so it cannot pass by testing the release before it. It checks a BIP39
+   vector against the `_data/` files a wheel missing one would still
+   install and import cleanly, and a BIP340 vector besides — both fixed
+   forever, so neither needs an edit after a release the way a
+   version-pinned assertion would. From then on it runs monthly on its
+   own, and a failure means the outside world moved, not this repository —
+   a new interpreter release, PyPI serving a file that does not match its
+   own hash — which is why it is a workflow of its own rather than a job
+   of this one. Actions → published → Run workflow is for asking between
+   those runs, with no particular version in mind.
 
 1. Open the next cycle: set a generic next version without the day
    (e.g. after 2026.8.4, use 2026.9) in pyproject.toml, and start a new


### PR DESCRIPTION
Prose only: the two workflow files change in their comments alone, so
nothing here can turn a run red.

Three places described a `published` workflow that has moved on.

**RELEASING.md asked for a dispatch by hand** after the release, where
`release.yml` calls the workflow with the tag and that call waits for the
index to serve the version before installing anything. So the step becomes
a verdict to read, and Actions → published → Run workflow is what asks the
same question between runs, with no version in mind. The workflow's header
already said as much about the caller; its schedule comment did not.

**That schedule comment put the run on a Tuesday**, "the day after
links.yml's Monday", and links.yml's own list of weekday sentinels named it
there too. `cron: "31 4 1 * *"` is the first of the month, and monthly is
right for what this workflow asks: an already-released artifact is fixed,
what moves under it — a new interpreter, an index serving a file that does
not match its own hash — moves on nobody's week, and the one moment the
answer can change is a release, which is a call and not a day.

CONTRIBUTING.md's workflow table was already right (`published` | monthly,
a release), which is why it is not in the diff.

Local gates: `pre-commit run --all-files`, `pytest` (26253 passed) and the
`sphinx -W` build, all green.

## Summary by Sourcery

Clarify how the `published` workflow is triggered and when it runs, aligning documentation and workflow comments with the current release process and schedule.

CI:
- Revise comments in `.github/workflows/published.yml` to document its monthly schedule, rationale for the timing, and invocation from `release.yml` instead of manual workflow dispatch.
- Update comments in `.github/workflows/links.yml` to reflect that `published.yml` now runs monthly and asks the least volatile question among the scheduled checks.

Documentation:
- Update RELEASING.md to describe `published` as a job in the release workflow, emphasizing its tag-based call, monthly cadence, and role as a post-release verdict rather than a manual dispatch.
- Extend CHANGELOG.md to record the corrections to release documentation and workflow commentary around the `published` job’s schedule and triggering.
- Adjust links in release documentation prose to distinguish between scheduled runs and manual dispatches of the `published` workflow.