### PR TITLE
Format every BIP85 application, and run every vector the BIP publishes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -202,10 +202,12 @@ repos:
         name: detect-secrets (credentials of other systems)
         # the test data of a signing library is private keys by the
         # hundred, published upstream and vendored to be compared against,
-        # so four json files account for 430 findings on their own: three
-        # vector files, and one golden file whose 18 are the same accident
-        # -- ACCA is one of the AWS key prefixes and is also four hex
-        # digits, so any run of upper-case hex holding it matches.
+        # so a handful of json files account for nearly every finding in
+        # the tree: three vector files, one golden file whose findings are
+        # the same accident -- ACCA is one of the AWS key prefixes and is
+        # also four hex digits, so any run of upper-case hex holding it
+        # matches -- and BIP85's vectors, where it is a field name rather
+        # than a value, the BIP printing a password as DERIVED PWD.
         # They are recorded in .secrets.baseline as already reviewed rather
         # than excluded from the scan: an exclusion makes a file blind for
         # good, and the difference is not theoretical -- an AWS key planted

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -119,6 +119,15 @@
     }
   ],
   "results": {
+    "tests/_data/bip85_test_vectors.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/_data/bip85_test_vectors.json",
+        "hashed_secret": "92bbfe418b52275f60d39e3696e0dd67737ea7aa",
+        "is_verified": false,
+        "line_number": 70
+      }
+    ],
     "tests/block/_generated_files/block_481824.json": [
       {
         "type": "AWS Access Key",
@@ -3138,5 +3147,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-02T06:50:23Z"
+  "generated_at": "2026-08-13T15:02:38Z"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1402,22 +1402,36 @@ documented at release-notes length in the first place, and are still in
   `btclib.bip85`. `entropy_from_der_path` is the derivation itself -- a
   fully hardened path off a root key, then
   `HMAC-SHA512(key="bip-entropy-from-k", msg=k)` over the child private
-  key -- and it answers for any path, including the applications no
-  function here formats. Four of them are formatted:
+  key -- and it answers for any path, including one no function here
+  formats. Every application the BIP defines is formatted beside it:
   `mnemonic_from_root_key` (39', BIP85's ten languages and all five
   sentence lengths of its Words Table), `wif_from_root_key` (2', the
-  Bitcoin Core `hdseed`), `xprv_from_root_key` (32') and
+  Bitcoin Core `hdseed`), `xprv_from_root_key` (32'),
   `bytes_entropy_from_root_key` (128169', which the BIP calls HEX and
-  which hands back the bytes).
+  which hands back the bytes), `base64_password_from_root_key` (707764'),
+  `base85_password_from_root_key` (707785'), `rolls_from_root_key`
+  (89101') and `rsa_drng_from_root_key` (828365').
+
+  The last two read `BIP85DRNG`, which is BIP85-DRNG-SHAKE256: 64 bytes
+  are not enough for a function whose appetite is not known until it has
+  finished, so they seed a SHAKE256 stream and `read` squeezes it. RSA is
+  where that matters and where btclib stops -- the BIP defines the path
+  and the stream to feed a key generator, not how the primes are found,
+  so what comes back is the reader an RSA library is to be given. It is
+  also the one application the BIP publishes no vector for, and the
+  reason is the same: two libraries handed the same stream need not
+  agree on the key.
+
+  `rolls_from_root_key` computes the width of a roll as
+  `(sides - 1).bit_length()` where the BIP writes `ceil(log_2(sides))`,
+  which is the same number and not the same operation: a float logarithm
+  rounds at a power of two, and a roll one bit too wide is one the
+  rejection step then drops far more often than it should.
 
   The module is at the top level rather than under `btclib/bip32/`, for
   the reason `bip44` and `slip132` are: the applications need `b58` for a
   WIF and `mnemonic.bip39` for a sentence, and both of those import
-  `bip32`, which may not import them back. What is left out is the rest
-  of the BIP, and the line is BIP85-DRNG-SHAKE256: 707764' and 707785'
-  are a base64 and a base85 slice of the same 64 bytes, while 828365'
-  (RSA) and 89101' (dice) read a stream seeded with them rather than the
-  bytes themselves.
+  `bip32`, which may not import them back.
 
   Two of BIP85's own fields are not what their name reads as, and
   `tests/bip85_test.py` says so where it asserts them: application 32'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,7 +212,10 @@ for a credential that has no business being there.
 `tests/block/_generated_files/block_481824.json` is in the baseline for a
 narrower reason: `ACCA` is one of the AWS key prefixes and is also four hex
 digits, so the block's own signatures match the detector wherever a script
-is rendered as upper-case hex. Adding a vector to one of those files, or
+is rendered as upper-case hex. `tests/_data/bip85_test_vectors.json` is
+there for a third reason again, and the narrowest: the detector reads the
+field name, and BIP85 prints the password of its two password
+applications as DERIVED PWD. Adding a vector to one of those files, or
 changing what a golden file holds, means regenerating the baseline:
 
 ```shell

--- a/btclib/bip85.py
+++ b/btclib/bip85.py
@@ -25,20 +25,31 @@ the same reason: the applications below need `b58` for a WIF and
 which `btclib/bip32/` may not import back. Nothing in the library
 imports this module.
 
-Four of BIP85's applications are here -- 39' (a BIP39 mnemonic), 2' (the
-Bitcoin Core hdseed WIF), 32' (an xprv) and 128169' (raw bytes) -- and
-`entropy_from_der_path` is the derivation itself, which answers for any
-path including the ones no function here formats. What is not here is
-the rest of the BIP: 707764' and 707785' are a base64 and a base85 slice
-of the same entropy, and 828365' (RSA) and 89101' (dice) need
-BIP85-DRNG-SHAKE256, a stream of arbitrary length seeded with the 64
-bytes rather than the bytes themselves.
+`entropy_from_der_path` is the derivation itself and answers for any
+path, the applications no function here formats included. Every
+application BIP85 defines is formatted beside it: 39' (a BIP39
+mnemonic), 2' (the Bitcoin Core hdseed WIF), 32' (an xprv), 128169'
+(raw bytes, which the BIP calls HEX), 707764' and 707785' (a base64 and
+a base85 password), 89101' (dice rolls) and 828365' (RSA).
+
+The last two read BIP85-DRNG-SHAKE256 rather than the 64 bytes: a
+function whose appetite is not known in advance needs a stream, so the
+entropy seeds a SHAKE256 one and `BIP85DRNG.read` squeezes it. RSA is
+where that matters and where btclib stops: the BIP defines the path and
+the stream to feed a key generator, not how the primes are found, so
+`rsa_drng_from_root_key` hands back the reader an RSA library is to be
+given -- and no two libraries handed the same stream need agree on the
+key, which is why the BIP publishes vectors for every other application
+and none for this one.
 """
 
 from __future__ import annotations
 
 import hmac
+from base64 import b64encode, b85encode
+from hashlib import shake_256
 
+from btclib.alias import Octets
 from btclib.b58 import wif_from_prv_key
 from btclib.bip32.bip32 import (
     BIP32Key,
@@ -56,11 +67,18 @@ from btclib.exceptions import BTClibValueError
 from btclib.mnemonic.bip39 import mnemonic_from_entropy
 from btclib.mnemonic.mnemonic import Mnemonic
 from btclib.network import NETWORKS, network_from_xkeyversion
+from btclib.utils import bytes_from_octets
 
 __all__ = [
+    "BIP85DRNG",
+    "base64_password_from_root_key",
+    "base85_password_from_root_key",
     "bytes_entropy_from_root_key",
+    "drng_from_der_path",
     "entropy_from_der_path",
     "mnemonic_from_root_key",
+    "rolls_from_root_key",
+    "rsa_drng_from_root_key",
     "wif_from_root_key",
     "xprv_from_root_key",
 ]
@@ -105,6 +123,26 @@ _ENTROPY_BYTES = {12: 16, 15: 20, 18: 24, 21: 28, 24: 32}
 # the HEX application's bounds, both inclusive, as BIP85 states them
 _MIN_BYTES = 16
 _MAX_BYTES = 64
+
+# the password lengths of the two encodings, both inclusive and both the
+# BIP's. 86 is where base64 stops because the 88 characters 64 bytes
+# encode to end in the two "=" of a final group holding one byte, so a
+# slice no longer than 86 never reaches the padding
+_MIN_B64_LEN = 20
+_MAX_B64_LEN = 86
+_MIN_B85_LEN = 10
+_MAX_B85_LEN = 80
+
+# the least a die and a session of rolls can be. The BIP's own upper
+# bound of 2**32 - 1 for each is not reachable and is not written here:
+# both are hardened path levels, so what the derivation can spell stops
+# at 2**31 - 1, and `str_from_index_int` refuses the rest
+_MIN_SIDES = 2
+_MIN_ROLLS = 1
+
+# BIP85-DRNG-SHAKE256's seed size, which the BIP fixes at the HMAC's own
+# output and requires to be exactly that
+_DRNG_SEED_SIZE = 64
 
 
 def _assert_valid_der_path(indexes: list[int]) -> None:
@@ -158,6 +196,51 @@ def entropy_from_der_path(root_key: BIP32Key, der_path: DerPath) -> bytes:
     from that same key.
     """
     return _entropy_from_der_path(_key_data_from_bip32_key(root_key), der_path)
+
+
+class BIP85DRNG:
+    """BIP85-DRNG-SHAKE256: the 64 entropy bytes as a stream.
+
+    The entropy of a path is 64 bytes and no more, which is not enough
+    for a function whose appetite is not known until it has finished --
+    RSA key generation is the BIP's example. So the 64 bytes seed a
+    SHAKE256 extendable-output function, and `read` squeezes as many as
+    are asked for, each call continuing where the last one stopped.
+
+    The seed must be exactly 64 bytes, which is what the BIP requires: a
+    shorter one is a different stream that no other implementation
+    reaches, so it is refused rather than padded.
+
+    `read` is `shake_256(seed).digest(cursor + num_bytes)[cursor:]`,
+    which is a squeeze of the whole prefix each time rather than a
+    resumed one -- hashlib publishes no incremental squeeze. The output
+    is the same either way, SHAKE256's output at a given length being a
+    prefix of its output at any greater one, and that identity is also
+    what makes a stream read in small pieces equal to the same stream
+    read in one: `bipsea`, the reference implementation, reads it the
+    same way.
+    """
+
+    def __init__(self, entropy: Octets) -> None:
+        self._entropy = bytes_from_octets(entropy, _DRNG_SEED_SIZE)
+        self._cursor = 0
+
+    def read(self, num_bytes: int) -> bytes:
+        """Return the next num_bytes of the stream, and advance it."""
+        if num_bytes < 0:
+            raise BTClibValueError(f"invalid number of bytes: {num_bytes}")
+        start, self._cursor = self._cursor, self._cursor + num_bytes
+        return shake_256(self._entropy).digest(self._cursor)[start:]
+
+
+def drng_from_der_path(root_key: BIP32Key, der_path: DerPath) -> BIP85DRNG:
+    """Return the BIP85-DRNG seeded with the entropy of a path.
+
+    The path is any BIP85 path, `entropy_from_der_path`'s own rules
+    applying to it: what this adds is the stream on top of the 64 bytes,
+    for an application that needs more of them than there are.
+    """
+    return BIP85DRNG(entropy_from_der_path(root_key, der_path))
 
 
 def mnemonic_from_root_key(
@@ -253,3 +336,120 @@ def bytes_entropy_from_root_key(
     der_path = f"m/{_PURPOSE}h/128169h/{num_bytes}h/{index}h"
     entropy = _entropy_from_der_path(_key_data_from_bip32_key(root_key), der_path)
     return entropy[:num_bytes]
+
+
+def base64_password_from_root_key(
+    root_key: BIP32Key, pwd_len: int, index: int = 0
+) -> str:
+    """Return a base64 password, BIP85's application 707764'.
+
+    The path is `m/83696968h/707764h/{pwd_len}h/{index}h`: all 64 bytes
+    of the entropy are base64-encoded and the leading `pwd_len`
+    characters are the password. `pwd_len` is bounded to 20..86
+    inclusive, and the upper end is what keeps the slice clear of the
+    "=" padding those 64 bytes encode to.
+    """
+    if not _MIN_B64_LEN <= pwd_len <= _MAX_B64_LEN:
+        err_msg = f"invalid password length: {pwd_len}; "
+        err_msg += f"expected: {_MIN_B64_LEN}..{_MAX_B64_LEN}"
+        raise BTClibValueError(err_msg)
+
+    der_path = f"m/{_PURPOSE}h/707764h/{pwd_len}h/{index}h"
+    entropy = _entropy_from_der_path(_key_data_from_bip32_key(root_key), der_path)
+    return b64encode(entropy).decode("ascii")[:pwd_len]
+
+
+def base85_password_from_root_key(
+    root_key: BIP32Key, pwd_len: int, index: int = 0
+) -> str:
+    """Return a base85 password, BIP85's application 707785'.
+
+    The path is `m/83696968h/707785h/{pwd_len}h/{index}h`: all 64 bytes
+    of the entropy are base85-encoded and the leading `pwd_len`
+    characters are the password. `pwd_len` is bounded to 10..80
+    inclusive.
+
+    The alphabet is the one `base64.b85encode` writes, which is
+    RFC1924's; the BIP names no alphabet and its vector is in this one.
+    """
+    if not _MIN_B85_LEN <= pwd_len <= _MAX_B85_LEN:
+        err_msg = f"invalid password length: {pwd_len}; "
+        err_msg += f"expected: {_MIN_B85_LEN}..{_MAX_B85_LEN}"
+        raise BTClibValueError(err_msg)
+
+    der_path = f"m/{_PURPOSE}h/707785h/{pwd_len}h/{index}h"
+    entropy = _entropy_from_der_path(_key_data_from_bip32_key(root_key), der_path)
+    return b85encode(entropy).decode("ascii")[:pwd_len]
+
+
+def rolls_from_root_key(
+    root_key: BIP32Key, rolls: int, sides: int = 6, index: int = 0
+) -> list[int]:
+    """Return dice rolls, BIP85's application 89101'.
+
+    The path is `m/83696968h/89101h/{sides}h/{rolls}h/{index}h` -- the
+    sides before the rolls, where this signature takes the rolls first,
+    a die having a customary number of sides and a session no customary
+    length. Each roll is in `0..sides-1`, which is what BIP85 defines
+    and what a caller printing them as a die's faces adds one to.
+
+    The rolls are read off the DRNG rather than off the 64 bytes: enough
+    of them exhaust any fixed entropy, and a trial landing at or beyond
+    `sides` is skipped rather than folded, so that every face stays
+    equally likely.
+
+    Nothing bounds `rolls` from above here beyond what a path level can
+    hold, and the wait is the caller's: a session is `rolls` reads of a
+    stream and takes as long as it takes.
+    """
+    if rolls < _MIN_ROLLS:
+        raise BTClibValueError(f"invalid number of rolls: {rolls}")
+    if sides < _MIN_SIDES:
+        raise BTClibValueError(f"invalid number of sides: {sides}")
+
+    der_path = f"m/{_PURPOSE}h/89101h/{sides}h/{rolls}h/{index}h"
+    drng = drng_from_der_path(root_key, der_path)
+
+    # ceil(log2(sides)) as an integer operation, where BIP85 writes it as
+    # a logarithm: `math.log(sides, 2)` is a float, and its rounding at a
+    # power of two is the difference between a roll of the right width
+    # and one bit too many
+    bits_per_roll = (sides - 1).bit_length()
+    bytes_per_roll = -(-bits_per_roll // 8)
+    excess_bits = 8 * bytes_per_roll - bits_per_roll
+
+    history: list[int] = []
+    while len(history) < rolls:
+        trial = int.from_bytes(drng.read(bytes_per_roll), byteorder="big")
+        # the most significant bits are the roll, which is what the BIP
+        # trims to; a trial the die has no face for is dropped
+        trial >>= excess_bits
+        if trial < sides:
+            history.append(trial)
+    return history
+
+
+def rsa_drng_from_root_key(
+    root_key: BIP32Key, key_bits: int, key_index: int = 0, sub_key: int | None = None
+) -> BIP85DRNG:
+    """Return the DRNG of an RSA key, BIP85's application 828365'.
+
+    The path is `m/83696968h/828365h/{key_bits}h/{key_index}h`, with a
+    further `{sub_key}h` level for the GPG sub-keys the BIP allocates:
+    0' encrypts, 1' authenticates, 2' signs, and the key at `key_index`
+    itself is the one that certifies.
+
+    What comes back is the stream, not a key: BIP85 says an RSA
+    generator should take the DRNG as its source of randomness and says
+    nothing about how the primes are found, so the key belongs to
+    whatever library is handed this reader. btclib generates no RSA key
+    and the BIP publishes no vector for one.
+
+    A GPG key built this way has one more rule the BIP states and this
+    cannot enforce: the creation date must be UNIX Epoch timestamp
+    1231006505, the fingerprint being a function of it.
+    """
+    der_path = f"m/{_PURPOSE}h/828365h/{key_bits}h/{key_index}h"
+    if sub_key is not None:
+        der_path += f"/{sub_key}h"
+    return drng_from_der_path(root_key, der_path)

--- a/tests/_data/README.md
+++ b/tests/_data/README.md
@@ -649,15 +649,19 @@ pulled  2026-08-13
 behind  0 revisions; that commit is the tip of the path
 ```
 
-Verdict: **transcribed**, and not complete. Every value in our copy
-appears verbatim in the pinned text — the master root key, the two
-entropy cases of the specification's own section with the derived key of
-each, the three BIP39 mnemonics, the hdseed WIF, the xprv and the 64 hex
-bytes — and what is left out is the applications `btclib/bip85.py` does
-not implement: BIP85-DRNG-SHAKE256's 80-byte read, the base64 and base85
-passwords of 707764' and 707785', and the dice rolls of 89101'. RSA
-(828365') publishes no vector to leave out. That module's docstring says
-why each is absent from it.
+Verdict: **transcribed**, complete. Every value in our copy appears
+verbatim in the pinned text, and every vector the BIP publishes is in
+our copy: the master root key, the two entropy cases of the
+specification's own section with the derived key of each, the 80-byte
+BIP85-DRNG read, the three BIP39 mnemonics, the hdseed WIF, the xprv,
+the 64 hex bytes, the base64 and base85 passwords, and the ten dice
+rolls. `tests/bip85_test.py` runs all of them.
+
+RSA (828365') is the one application with no vector here, because the
+BIP publishes none for it: it defines the path and says the key
+generator should read BIP85-DRNG, leaving how the primes are found to
+whatever library generates the key. `btclib.bip85` stops at the same
+place, so there is nothing further to compare against.
 
 Two of the BIP's fields are not what their name reads as, and
 `tests/bip85_test.py` asserts them as the BIP prints them rather than as

--- a/tests/_data/bip85_test_vectors.json
+++ b/tests/_data/bip85_test_vectors.json
@@ -52,5 +52,39 @@
       "num_bytes": 64,
       "derived_entropy": "492db4698cf3b73a5a24998aa3e9d7fa96275d85724a91e71aa2d645442f878555d078fd1f1f67e368976f04137b1f7a0d19232136ca50c44614af72b5582a5c"
     }
+  ],
+  "drng": [
+    {
+      "path": "m/83696968'/0'/0'",
+      "derived_key": "cca20ccb0e9a90feb0912870c3323b24874b0ca3d8018c4b96d0b97c0e82ded0",
+      "derived_entropy": "efecfbccffea313214232d29e71563d941229afb4338c21f9517c41aaa0d16f00b83d2a09ef747e7a64e8e2bd5a14869e693da66ce94ac2da570ab7ee48618f7",
+      "num_bytes": 80,
+      "drng": "b78b1ee6b345eae6836c2d53d33c64cdaf9a696487be81b03e822dc84b3f1cd883d7559e53d175f243e4c349e822a957bbff9224bc5dde9492ef54e8a439f6bc8c7355b87a925a37ee405a7502991111"
+    }
+  ],
+  "pwd_base64": [
+    {
+      "path": "m/83696968'/707764'/21'/0'",
+      "pwd_len": 21,
+      "derived_entropy": "74a2e87a9ba0cdd549bdd2f9ea880d554c6c355b08ed25088cfa88f3f1c4f74632b652fd4a8f5fda43074c6f6964a3753b08bb5210c8f5e75c07a4c2a20bf6e9",
+      "derived_pwd": "dKLoepugzdVJvdL56ogNV"
+    }
+  ],
+  "pwd_base85": [
+    {
+      "path": "m/83696968'/707785'/12'/0'",
+      "pwd_len": 12,
+      "derived_entropy": "f7cfe56f63dca2490f65fcbf9ee63dcd85d18f751b6b5e1c1b8733af6459c904a75e82b4a22efff9b9e69de2144b293aa8714319a054b6cb55826a8e51425209",
+      "derived_pwd": "_s`{TW89)i4`"
+    }
+  ],
+  "dice": [
+    {
+      "path": "m/83696968'/89101'/6'/10'/0'",
+      "sides": 6,
+      "rolls": 10,
+      "derived_entropy": "5e41f8f5d5d9ac09a20b8a5797a3172b28c806aead00d27e36609e2dd116a59176a738804236586f668da8a51b90c708a4226d7f92259c69f64c51124b6f6cd2",
+      "derived_rolls": "1,0,0,2,0,1,5,5,2,4"
+    }
   ]
 }

--- a/tests/bip85_test.py
+++ b/tests/bip85_test.py
@@ -18,9 +18,11 @@ name reads:
 - for application 39' it is the entropy already truncated to what the
   sentence encodes, so 16, 24 and 32 bytes rather than 64.
 
-The applications btclib does not implement are the reason four of the
-BIP's vector groups are not in that file: BIP85-DRNG, the two password
-encodings, and the dice rolls, which the module docstring accounts for.
+Every vector the BIP publishes is in that file and asserted here. The
+one application with none is RSA, which is the one btclib does not
+generate a key for: what `rsa_drng_from_root_key` hands back is the
+stream the BIP says to feed a key generator, and the assertions below
+reach no further than the path it is seeded from.
 """
 
 from __future__ import annotations
@@ -32,9 +34,15 @@ import pytest
 from btclib.bip32 import BIP32KeyData, derive, rootxprv_from_seed, xpub_from_xprv
 from btclib.bip85 import (
     _LANGUAGE_INDEXES,
+    BIP85DRNG,
+    base64_password_from_root_key,
+    base85_password_from_root_key,
     bytes_entropy_from_root_key,
+    drng_from_der_path,
     entropy_from_der_path,
     mnemonic_from_root_key,
+    rolls_from_root_key,
+    rsa_drng_from_root_key,
     wif_from_root_key,
     xprv_from_root_key,
 )
@@ -205,6 +213,144 @@ def test_a_slip132_root_still_emits_an_xprv() -> None:
     assert xprv_from_root_key(yprv) == xprv_from_root_key(xprv)
 
 
+@pytest.mark.parametrize("vector", **_ids("drng"))
+def test_the_drng_stream(vector: dict[str, Any]) -> None:
+    """BIP85-DRNG-SHAKE256, at the path of the entropy vectors."""
+    drng = drng_from_der_path(_ROOT, vector["path"])
+    assert drng.read(vector["num_bytes"]).hex() == vector["drng"]
+
+
+@pytest.mark.parametrize("vector", **_ids("drng"))
+def test_the_stream_does_not_depend_on_how_it_is_read(
+    vector: dict[str, Any],
+) -> None:
+    """A read is a squeeze of a prefix, so the pieces are the whole.
+
+    Which is what the dice application relies on: it reads one roll at a
+    time, and the rolls have to be the stream a single read of the same
+    length would have given.
+    """
+    whole = bytes.fromhex(vector["drng"])
+    drng = drng_from_der_path(_ROOT, vector["path"])
+    pieces = b"".join(drng.read(n) for n in (1, 0, 31, 48))
+    assert pieces == whole
+    assert len(pieces) == vector["num_bytes"]
+
+
+@pytest.mark.parametrize("vector", **_ids("pwd_base64"))
+def test_base64_password_application(vector: dict[str, Any]) -> None:
+    """Application 707764': all 64 bytes encoded, then sliced."""
+    entropy = entropy_from_der_path(_ROOT, vector["path"])
+    assert entropy.hex() == vector["derived_entropy"]
+
+    pwd = base64_password_from_root_key(_ROOT, vector["pwd_len"])
+    assert pwd == vector["derived_pwd"]
+    assert len(pwd) == vector["pwd_len"]
+
+
+@pytest.mark.parametrize("vector", **_ids("pwd_base85"))
+def test_base85_password_application(vector: dict[str, Any]) -> None:
+    """Application 707785', in the alphabet the BIP's vector is in."""
+    entropy = entropy_from_der_path(_ROOT, vector["path"])
+    assert entropy.hex() == vector["derived_entropy"]
+
+    pwd = base85_password_from_root_key(_ROOT, vector["pwd_len"])
+    assert pwd == vector["derived_pwd"]
+    assert len(pwd) == vector["pwd_len"]
+
+
+def test_a_password_is_a_prefix_of_the_longest_one() -> None:
+    """Only where the length is the same: it is a path level too.
+
+    The slice is of an encoding of the entropy of a path that spells the
+    length, so two lengths are two derivations and not one password cut
+    in two places -- which is what keeps a longer password from
+    disclosing a shorter one.
+    """
+    assert (
+        base64_password_from_root_key(_ROOT, 20)
+        != (base64_password_from_root_key(_ROOT, 86)[:20])
+    )
+    assert (
+        base85_password_from_root_key(_ROOT, 10)
+        != (base85_password_from_root_key(_ROOT, 80)[:10])
+    )
+
+
+@pytest.mark.parametrize("pwd_len", [20, 86])
+def test_the_base64_bounds_are_inclusive(pwd_len: int) -> None:
+    """86 is where the padding of those 64 bytes would start."""
+    pwd = base64_password_from_root_key(_ROOT, pwd_len)
+    assert len(pwd) == pwd_len
+    assert "=" not in pwd
+
+
+@pytest.mark.parametrize("pwd_len", [10, 80])
+def test_the_base85_bounds_are_inclusive(pwd_len: int) -> None:
+    """10 and 80 are the two ends BIP85 states."""
+    assert len(base85_password_from_root_key(_ROOT, pwd_len)) == pwd_len
+
+
+@pytest.mark.parametrize("vector", **_ids("dice"))
+def test_dice_application(vector: dict[str, Any]) -> None:
+    """Application 89101': ten rolls of a six-sided die.
+
+    The vector is what makes the rejection branch load-bearing: a byte
+    whose top three bits are 6 or 7 is no face of a six-sided die, and
+    the ten rolls below are what the stream gives once those are
+    dropped.
+    """
+    rolls = rolls_from_root_key(_ROOT, vector["rolls"], vector["sides"])
+    assert ",".join(str(roll) for roll in rolls) == vector["derived_rolls"]
+    assert all(0 <= roll < vector["sides"] for roll in rolls)
+
+
+@pytest.mark.parametrize("sides", [2, 6, 8, 20, 62, 256, 257])
+def test_a_roll_is_a_face_of_the_die(sides: int) -> None:
+    """Whatever the die, including the powers of two either side of 8.
+
+    `ceil(log2(sides))` is where a float logarithm would put a roll one
+    bit too wide, and a roll too wide is one the rejection above drops
+    far too often rather than a wrong answer -- so the width is asserted
+    through the rolls it produces.
+    """
+    rolls = rolls_from_root_key(_ROOT, 32, sides)
+    assert len(rolls) == 32
+    assert all(0 <= roll < sides for roll in rolls)
+
+
+def test_the_rsa_drng_is_the_stream_of_its_path() -> None:
+    """The path BIP85 allocates, sub-key level included.
+
+    btclib generates no RSA key and the BIP publishes no vector for one,
+    so what is asserted is the derivation: the reader is the one the
+    path seeds, and the four GPG sub-keys are four different streams.
+    """
+    key_bits, key_index = 1024, 0
+    path = f"m/83696968h/828365h/{key_bits}h/{key_index}h"
+    assert rsa_drng_from_root_key(_ROOT, key_bits).read(32) == (
+        drng_from_der_path(_ROOT, path).read(32)
+    )
+
+    streams = {
+        rsa_drng_from_root_key(_ROOT, key_bits, key_index, sub_key).read(32)
+        for sub_key in (0, 1, 2)
+    }
+    assert len(streams) == 3
+    assert rsa_drng_from_root_key(_ROOT, key_bits, key_index, 0).read(32) == (
+        drng_from_der_path(_ROOT, f"{path}/0h").read(32)
+    )
+
+
+def test_the_drng_seed_is_exactly_64_bytes() -> None:
+    """What BIP85 requires of the input, and what read refuses."""
+    with pytest.raises(BTClibValueError, match="invalid size: 32 bytes"):
+        BIP85DRNG(bytes(32))
+
+    with pytest.raises(BTClibValueError, match="invalid number of bytes: -1"):
+        BIP85DRNG(bytes(64)).read(-1)
+
+
 def test_a_public_root_key_is_refused() -> None:
     """Every level is hardened, so there is nothing to derive publicly."""
     xpub = xpub_from_xprv(_ROOT)
@@ -241,6 +387,24 @@ def test_an_application_parameter_outside_its_table() -> None:
 
     with pytest.raises(BTClibValueError, match="invalid number of bytes: 65"):
         bytes_entropy_from_root_key(_ROOT, 65)
+
+    with pytest.raises(BTClibValueError, match="invalid password length: 19"):
+        base64_password_from_root_key(_ROOT, 19)
+
+    with pytest.raises(BTClibValueError, match="invalid password length: 87"):
+        base64_password_from_root_key(_ROOT, 87)
+
+    with pytest.raises(BTClibValueError, match="invalid password length: 9"):
+        base85_password_from_root_key(_ROOT, 9)
+
+    with pytest.raises(BTClibValueError, match="invalid password length: 81"):
+        base85_password_from_root_key(_ROOT, 81)
+
+    with pytest.raises(BTClibValueError, match="invalid number of rolls: 0"):
+        rolls_from_root_key(_ROOT, 0)
+
+    with pytest.raises(BTClibValueError, match="invalid number of sides: 1"):
+        rolls_from_root_key(_ROOT, 10, 1)
 
 
 def test_an_index_no_path_level_can_hold() -> None:


### PR DESCRIPTION
Completes https://github.com/btclib-org/btclib/issues/644, which
https://github.com/btclib-org/btclib/pull/741 closed with four of BIP85's
applications formatted and four left out. The four left out were the ones
reading a stream rather than the 64 entropy bytes, or an encoding rather
than a bitcoin type. Both lines are gone.

- **`BIP85DRNG`** is BIP85-DRNG-SHAKE256: the 64 bytes seed a SHAKE256
  stream and `read` squeezes as far as it is asked to, each call
  continuing where the last stopped. `read` squeezes the whole prefix
  each time — hashlib publishes no incremental squeeze — and the output
  is the same either way, SHAKE256's output at a length being a prefix
  of its output at any greater one. That identity is also what makes a
  stream read in pieces equal to the same stream read at once, which the
  dice rolls depend on and which a test asserts against the BIP's own
  80-byte vector.
- **`base64_password_from_root_key`** (707764') and
  **`base85_password_from_root_key`** (707785') encode all 64 bytes and
  slice the leading `pwd_len` characters, bounded 20..86 and 10..80 as
  the BIP bounds them. base64's upper end is what keeps the slice clear
  of the padding those 64 bytes encode to, which a test asserts.
- **`rolls_from_root_key`** (89101') reads the DRNG one roll at a time
  and drops a trial the die has no face for. The width of a roll is
  `(sides - 1).bit_length()` where the BIP writes `ceil(log_2(sides))`:
  the same number, not the same operation — a float logarithm rounds at
  a power of two, and a roll one bit too wide is one the rejection then
  drops far more often than it should.
- **`rsa_drng_from_root_key`** (828365') builds the path, GPG sub-key
  level and all, and hands back the reader. It stops there because the
  BIP does: the key generator is to read the DRNG, and how it finds its
  primes is the generator's. That is also why it is the one application
  with no vector — two libraries handed the same stream need not agree
  on the key — and the docstring carries the BIP's other GPG rule, the
  creation date fixed at UNIX Epoch 1231006505.

**Vectors.** Every vector BIP85 publishes is now vendored and asserted:
the DRNG read, the two passwords and the ten dice rolls join what
`tests/_data/bip85_test_vectors.json` already held, every value checked
to appear verbatim in the pinned `bip-0085.mediawiki` at `97781eae`, and
the entry in `tests/_data/README.md` now reads **transcribed**, complete.

**One hook needed maintenance.** The BIP prints a password as DERIVED
PWD, which detect-secrets reads as a secret keyword, so
`.secrets.baseline` records that line as reviewed — regenerated with the
command CONTRIBUTING.md documents. The hook's comment and that
paragraph name the third file and its reason, the two already there
being high-entropy vectors and an AWS-prefix accident.

**Gates**, all run locally on this branch:

- `uv run pytest` — 26272 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html` — build succeeded

## Summary by Sourcery

Format all remaining BIP85 applications and vendor/assert all published BIP85 test vectors, including DRNG, password, dice, and RSA stream paths.

New Features:
- Expose a BIP85DRNG SHAKE256-based stream seeded from BIP85 entropy paths and a helper drng_from_der_path.
- Add base64_password_from_root_key and base85_password_from_root_key helpers to derive BIP85 password applications 707764' and 707785'.
- Add rolls_from_root_key to derive dice roll sequences for BIP85 application 89101'.
- Add rsa_drng_from_root_key to derive the DRNG stream for BIP85 RSA application 828365', including optional GPG sub-key paths.

Enhancements:
- Update the BIP85 changelog and module documentation to describe all applications, the DRNG stream, and the dice roll width calculation.
- Clarify test data documentation to state that all BIP85 vectors are fully transcribed and exercised, and explain the absence of RSA key vectors.

CI:
- Adjust detect-secrets configuration and CONTRIBUTING notes to document BIP85 vector files as reviewed test data and explain their presence in the secrets baseline.

Tests:
- Extend bip85_test to cover DRNG behavior, password derivations, dice roll properties, RSA DRNG path derivation, and parameter validation for new applications.
- Expand tests/_data/bip85_test_vectors.json with all remaining BIP85 vectors (DRNG, passwords, dice rolls) and assert them against the specification.

Chores:
- Regenerate .secrets.baseline to account for BIP85 test vector additions and updated detect-secrets behavior.