### PR TITLE
The script number zero is the empty vector (#746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1741,6 +1741,38 @@ documented at release-notes length in the first place, and are still in
   `serialize` writes; the docstring says the rule and the test pins it,
   over the whole set of values that could have been written otherwise.
 
+- **the script number zero is the empty vector** (issue #746).
+  `encode_num(0)` wrote `b"\x00"` where Core's `CScriptNum::serialize`
+  returns the empty vector, and zero was the only value where the two
+  disagreed. Not a spelling: `b"\x00"` is not a minimally encoded script
+  number, so the interpreter refuses it as one under MINIMALDATA --
+  `(vch.back() & 0x7f) == 0` with nothing before it is what Core's
+  `CScriptNum` throws on, and `_to_num(b"\x00", MINIMALDATA, 4)` is what
+  this library answers `non-minimal encoding of 0: 00`. So
+  `serialize([0])` wrote `0100`, a push btclib's own engine will not
+  read as a number, and warned "consider using OP_0" as if the op code
+  were merely one byte shorter.
+
+  `encode_num(0)` is `b""` and `decode_num(b"")` is `0`, which are
+  `CScriptNum::serialize` and `CScriptNum::set_vch`; `serialize([0])` is
+  therefore OP_0, by the same path as every other value, a zero-length
+  push being that op code already. The engine had written Core's
+  function a second time to get around this -- `_from_num` was `b"" if x
+  == 0 else encode_num(x)`, with a matching empty-element branch in
+  `_to_num` -- and both are gone, every call site of the wrapper now
+  calling `encode_num`. The warning goes for zero and stays for the rest,
+  there being nothing shorter left to suggest, and it names
+  `op_int(command)` rather than interpolating the number: for -1 it read
+  "consider using OP_-1 instead", which is no op code.
+
+  `decode_num` keeps reading `00` and `80` as zero -- refusing them is
+  the interpreter's rule, and `_to_num` is where MINIMALDATA is known.
+  What follows from the pair being Core's is that
+  `miniscript.from_script` no longer reads a `0100` push as the number
+  0: a `thresh` whose threshold is written that way closes no fragment
+  where it used to be refused for the threshold's value, both being a
+  refusal and the second being the accurate one.
+
 ### Descriptors and miniscript
 
 - **An invalid output is refused, not answered about** (#691). `index_of`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -121,6 +121,19 @@ full year, short month, short day (YYYY-M-D)
   index=0)`, which re-validates by default -- the same function
   `BIP32KeyData(...)` still takes, and still defaulting to `True`.
 
+- **the script number zero is the empty vector.** `encode_num(0)` was
+  `b"\x00"` and is `b""`; `decode_num(b"")` was a `BTClibValueError` and
+  is `0`; and `script.serialize([0])`, which pushes what `encode_num`
+  writes, was `0100` and is `00` -- OP_0, with no "consider using OP_0"
+  warning left to raise. A caller pinning any of those bytes has one
+  substitution to make, and a caller reading a script number back has one
+  refusal fewer to catch. `push_int(0)`, `op_int(0)` and the engine are
+  unchanged, all three having answered OP_0 and the empty vector all
+  along. The reason to act rather than to keep the old spelling: `0100`
+  is not a minimally encoded script number, so the interpreter refuses
+  it as one wherever MINIMALDATA is in force -- btclib's own engine
+  included.
+
 ### The bindings are now `btclib_secp256k1`
 
 - **The secp256k1 bindings were renamed, and btclib requires the new

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -16,12 +16,7 @@ from btclib.exceptions import BTClibRuntimeError, BTClibValueError, ScriptError
 from btclib.script import sig_hash
 from btclib.script.engine import script_op_codes
 from btclib.script.engine.flags import ScriptFlag
-from btclib.script.engine.script_op_codes import (
-    _MAX_NUM_SIZE,
-    ScriptOp,
-    _from_num,
-    _to_num,
-)
+from btclib.script.engine.script_op_codes import _MAX_NUM_SIZE, ScriptOp, _to_num
 from btclib.script.limits import (
     MAX_OPS_PER_SCRIPT,
     MAX_PUBKEYS_PER_MULTISIG,
@@ -37,7 +32,7 @@ from btclib.script.script import (
 from btclib.script.script import serialize as serialize_script
 from btclib.script.sig_hash import SIG_HASH_TYPES, PrecomputedTxData
 from btclib.tx.tx import Tx
-from btclib.utils import bytesio_from_binarydata
+from btclib.utils import bytesio_from_binarydata, encode_num
 
 __all__ = [
     "DISABLED_OP_CODES",
@@ -557,7 +552,7 @@ def _run_ops(  # noqa: C901, PLR0912
                 hash_types,
             )
             check_nullfail(flags, result, [signature], "OP_CHECKSIG")
-            stack.append(_from_num(int(result)))
+            stack.append(encode_num(int(result)))
 
         elif op == "OP_CHECKMULTISIG":
             # Core's order, and it is the order that makes the two
@@ -606,7 +601,7 @@ def _run_ops(  # noqa: C901, PLR0912
         elif op == "OP_CHECKSEQUENCEVERIFY":
             script_op_codes.op_checksequenceverify(stack, tx, i, flags)
         elif op[3:].isdigit():
-            stack.append(_from_num(int(op[3:])))
+            stack.append(encode_num(int(op[3:])))
         elif op == "OP_CODESEPARATOR":
             codesep_offset = op_code_stops[script_index]
         elif op == "OP_IF":

--- a/btclib/script/engine/script_op_codes.py
+++ b/btclib/script/engine/script_op_codes.py
@@ -118,16 +118,10 @@ def _to_num(element: bytes, flags: ScriptFlag, max_size: int) -> int:
         raise BTClibValueError("non-minimal encoding of zero")
     if len(element) > max_size:
         raise BTClibValueError(f"number longer than {max_size} bytes: {len(element)}")
-    if element == b"":
-        return 0
     x = decode_num(element)
-    if minimaldata and _from_num(x) != element:
+    if minimaldata and encode_num(x) != element:
         raise BTClibValueError(f"non-minimal encoding of {x}: {element.hex()}")
     return x
-
-
-def _from_num(x: int) -> bytes:
-    return b"" if x == 0 else encode_num(x)
 
 
 def _to_bool(element: bytes) -> bool:
@@ -381,7 +375,7 @@ def op_swap(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> Non
 
 def op_1negate(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Push the number -1."""
-    stack.append(_from_num(-1))
+    stack.append(encode_num(-1))
 
 
 def op_verify(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -439,7 +433,7 @@ def op_checkmultisigverify(
 
 def op_size(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Push the byte length of the top element, leaving it in place."""
-    stack.append(_from_num(len(stack[-1])))
+    stack.append(encode_num(len(stack[-1])))
 
 
 def op_ripemd160(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -470,25 +464,25 @@ def op_hash256(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> 
 def op_1add(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop a number and push it incremented by one."""
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(a + 1))
+    stack.append(encode_num(a + 1))
 
 
 def op_1sub(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop a number and push it decremented by one."""
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(a - 1))
+    stack.append(encode_num(a - 1))
 
 
 def op_negate(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop a number and push its negation."""
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(-a))
+    stack.append(encode_num(-a))
 
 
 def op_abs(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop a number and push its absolute value."""
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(abs(a)))
+    stack.append(encode_num(abs(a)))
 
 
 def op_not(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -512,14 +506,14 @@ def op_add(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None
     """Pop two numbers and push their sum."""
     b = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(a + b))
+    stack.append(encode_num(a + b))
 
 
 def op_sub(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop two numbers and push the deeper one minus the top one."""
     b = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(a - b))
+    stack.append(encode_num(a - b))
 
 
 def op_booland(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -625,14 +619,14 @@ def op_min(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None
     """Pop two numbers and push the smaller."""
     b = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(min(a, b)))
+    stack.append(encode_num(min(a, b)))
 
 
 def op_max(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop two numbers and push the larger."""
     b = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(max(a, b)))
+    stack.append(encode_num(max(a, b)))
 
 
 def op_within(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -673,7 +667,7 @@ def op_ifdup(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> No
 
 def op_depth(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Push the number of elements on the stack."""
-    stack.append(_from_num(len(stack)))
+    stack.append(encode_num(len(stack)))
 
 
 def op_nip(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -18,7 +18,7 @@ from btclib.script import sig_hash
 from btclib.script.engine import script_op_codes
 from btclib.script.engine.flags import ScriptFlag
 from btclib.script.engine.script import EVALUATED_WHEN_UNEXECUTED
-from btclib.script.engine.script_op_codes import ScriptOp, _from_num
+from btclib.script.engine.script_op_codes import ScriptOp
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
 from btclib.script.op_codes_tapscript import OP_CODE_NAMES
 from btclib.script.script_pub_key import type_and_payload
@@ -27,7 +27,7 @@ from btclib.script.taproot import parse
 from btclib.script.taproot import serialize as serialize_script
 from btclib.tx.tx import Tx
 from btclib.tx.tx_out import TxOut
-from btclib.utils import bytesio_from_binarydata
+from btclib.utils import bytesio_from_binarydata, encode_num
 
 __all__ = [
     "OPERATIONS",
@@ -176,7 +176,7 @@ def op_checksig(
     # because Core charges it for a passing upgradable key too
     elif ScriptFlag.DISCOURAGE_UPGRADABLE_PUBKEYTYPE in flags:
         raise BTClibValueError(f"upgradable public key type: {len(pub_key)} bytes")
-    stack.append(_from_num(int(bool(signature))))
+    stack.append(encode_num(int(bool(signature))))
     return budget
 
 
@@ -323,7 +323,7 @@ def _run_ops(  # noqa: C901, PLR0912
         elif op == "OP_CHECKSEQUENCEVERIFY":
             script_op_codes.op_checksequenceverify(stack, tx, i, flags)
         elif op[3:].isdigit():
-            stack.append(_from_num(int(op[3:])))
+            stack.append(encode_num(int(op[3:])))
         elif op == "OP_CODESEPARATOR":
             codesep_pos = script_index
         elif op == "OP_IF":

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -349,11 +349,13 @@ def push_int(i: int) -> str:
 
 
 def _serialize_int_command(command: int) -> bytes:
-    if -1 <= command <= 16:
+    if -1 <= command <= 16 and command != 0:
         # not a DeprecationWarning: nothing is going away, the push is
-        # merely one byte longer than the op code that means the same
+        # merely one byte longer than the op code that means the same.
+        # Zero is not among them: its encoding is the empty vector, so
+        # the push of it is OP_0 already and there is nothing to suggest
         warn(
-            f"consider using OP_{command} instead",
+            f"consider using {op_int(command)} instead",
             BTClibUserWarning,
             stacklevel=2,
         )
@@ -449,6 +451,11 @@ def serialize(script: Sequence[Command]) -> bytes:
     bytes and is warned about for exactly this. `push_int` is what
     writes a number the shortest way there is, and what every caller in
     this library that means one uses.
+
+    Zero is where the two coincide and the warning therefore stops: the
+    empty vector is what `encode_num` writes for it, and the push of an
+    empty vector is OP_0, so `serialize([0])` is the op code -- as Core's
+    `CScript() << 0` is -- with nothing shorter left to suggest.
     """
     r: list[bytes] = []
     for command in script:

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -310,13 +310,12 @@ def decode_num(data: bytes) -> int:
     * 0x01 is 1
     * 0x81 is -1
 
-    Therefore, there are two representations of zero:
-
-    * 0x00 is "positive" zero
-    * 0x80 is "negative" zero
-
-    Positive zero is also represented by a null-length byte vector,
-    which is considered the canonical one.
+    Zero has three spellings, and this reads all three: the empty vector
+    that `encode_num` writes and Core's `CScriptNum::set_vch` answers 0
+    for, 0x00 -- "positive" zero -- and 0x80, "negative" zero. Only the
+    first is minimal; refusing the other two belongs to the reader that
+    knows whether MINIMALDATA is in force, which is the engine's
+    `_to_num`, and not here.
 
     Not bounded the way `encode_num` is: this is the reader, and its two
     callers ask different things of it. The engine's `_to_num` caps an
@@ -327,7 +326,7 @@ def decode_num(data: bytes) -> int:
     """
     length = len(data)
     if length == 0:
-        raise BTClibValueError("empty byte string")
+        return 0
     i = int.from_bytes(data, byteorder="little", signed=False)
     if data[-1] >= 0x80:  # negative number
         # mask for all but the highest bit
@@ -355,13 +354,14 @@ def encode_num(i: int) -> bytes:
     * 0x01 is 1
     * 0x81 is -1
 
-    Therefore, there are two representations of zero:
-
-    * 0x00 is "positive" zero
-    * 0x80 is "negative" zero
-
-    Positive zero is also represented by a null-length byte vector,
-    which is considered the canonical one.
+    Zero is the empty vector, which is Core's `CScriptNum::serialize`
+    and is the only spelling of it the interpreter reads back as a
+    number: 0x00 and 0x80 -- "positive" and "negative" zero -- decode to
+    zero and are refused as operands under MINIMALDATA, `(vch.back() &
+    0x7f) == 0` with nothing before it being what Core's `CScriptNum`
+    throws on. A push of the empty vector is OP_0, so the shortest
+    command and the encoded number agree here and nowhere else (issue
+    #646).
 
     The number is a CScriptNum, i.e. an int64, and a Python int outside
     that range is refused rather than encoded: what it would write is a
@@ -379,6 +379,8 @@ def encode_num(i: int) -> bytes:
         err_msg += f", not in [{_MIN_SCRIPT_NUM}, {_MAX_SCRIPT_NUM}]"
         raise BTClibValueError(err_msg)
 
+    if i == 0:
+        return b""
     # i.bit_length() bits, plus a sign bit
     n_bits = i.bit_length() + 1
     # The number of bytes necessary to accommodate n_bits

--- a/tests/block/mining_test.py
+++ b/tests/block/mining_test.py
@@ -77,7 +77,7 @@ def test_a_mined_block_is_a_block() -> None:
 
     header = mine(candidate)
     assert header is not None
-    assert header.nonce == 373
+    assert header.nonce == 278
     assert header.hash <= header.target
     header.assert_valid_pow(REGTEST_POW_LIMIT_BITS)
 
@@ -152,12 +152,12 @@ def test_a_bounded_search_can_find_nothing() -> None:
     transactions = [_coinbase(1)]
     candidate = candidate_block_header(_PREVIOUS, transactions, _TIME, _EASY_BITS)
 
-    # the nonce that solves this one is 53, so a search of 53 -- nonces
-    # 0 to 52 -- stops one short of it
-    assert mine(candidate, 53) is None
-    solved = mine(candidate, 54)
+    # the nonce that solves this one is 126, so a search of 126 --
+    # nonces 0 to 125 -- stops one short of it
+    assert mine(candidate, 126) is None
+    solved = mine(candidate, 127)
     assert solved is not None
-    assert solved.nonce == 53
+    assert solved.nonce == 126
 
     # a mainnet-grade target is not found either, and the bound is what
     # makes that a return rather than a hang

--- a/tests/descriptors/miniscript_test.py
+++ b/tests/descriptors/miniscript_test.py
@@ -600,6 +600,10 @@ REFUSED_SCRIPTS = [
     ("51ac", "ill-typed miniscript"),
     ("87", "closes no fragment"),
     ("510087", "invalid thresh.. threshold"),
+    # the same threshold pushed as data rather than as OP_0: zero is the
+    # empty vector, so a push of one zero byte is not the number and the
+    # script closes no thresh at all
+    ("51010087", "closes no fragment"),
     # a script that is two expressions and not one
     ("515193", "closes no fragment"),
     # every op code that must be there and is not

--- a/tests/script/script_test.py
+++ b/tests/script/script_test.py
@@ -138,7 +138,11 @@ def test_a_data_command_is_never_a_numeric_op_code() -> None:
     # the only value in the set for which reaching for the op code would
     # change what lands on the stack, and not merely how it is spelled
     assert serialize([b"\x00"]) == b"\x01\x00"
-    assert serialize_non_canonical([0]) == b"\x01\x00"
+
+    # the integer zero is not that push: its encoding is the empty
+    # vector, whose push is OP_0, so the data and the op code coincide
+    # and the warning the rest of the range gets has nothing to say
+    assert serialize([0]) == BYTE_FROM_OP_CODE_NAME["OP_0"]
 
     # what parse hands back for such a push is its hex, and serializing
     # that writes the push it read: the round trip is what a substitution
@@ -308,6 +312,7 @@ def test_regressions() -> None:
         ["AAAA"],
         [""],
         [b""],
+        [0],
         ["OP_0"],
         ["OP_1NEGATE"],
         [0x81],
@@ -317,11 +322,12 @@ def test_regressions() -> None:
         serialized = serialize(s)
         assert serialize(parse(serialized)) == serialized
 
-    # the three regressions that serialize() warns about, kept apart from
+    # the two regressions that serialize() warns about, kept apart from
     # the others so that the warning is asserted rather than ignored: a
     # simplefilter("ignore") around the loop above would hide it, and
-    # with it any other warning the loop raises
-    non_canonical: list[ScriptList] = [[1], [0], [-1]]
+    # with it any other warning the loop raises. Zero is not one of them
+    # any more, OP_0 being what its empty encoding is pushed as
+    non_canonical: list[ScriptList] = [[1], [-1]]
     for s in non_canonical:
         serialized = serialize_non_canonical(s)
         assert serialize(parse(serialized)) == serialized
@@ -338,10 +344,12 @@ def test_null_serialization() -> None:
     assert parse(serialize([b""])) == ["OP_0"]
     assert parse(serialize([b" "])) == ["20"]
 
-    # 0 and 16 have a one-byte op code, so pushing them as data warns
-    assert serialize_non_canonical([0]) == b"\x01\x00"
-    assert parse(serialize_non_canonical([0])) == ["00"]
+    # zero is the empty vector, so pushing it as data is OP_0 and warns
+    # not: the op code and the push are the same byte
+    assert serialize([0]) == b"\x00"
+    assert parse(serialize([0])) == ["OP_0"]
 
+    # 16 has a one-byte op code the data push is not, so it warns
     assert serialize_non_canonical([16]) == b"\x01\x10"
     assert parse(serialize_non_canonical([16])) == ["10"]
 
@@ -369,9 +377,10 @@ def test_integer_serialization() -> None:
     """Verify integers parse back as data, warned only in [0, 16]."""
     assert parse(b"\x00") == ["OP_0"]
 
-    # [0, 16] is exactly the range with a shorter op code form, so every
-    # serialize() below warns; from 17 on, none does
-    assert serialize_non_canonical([0]) != b"\x00"
+    # [1, 16] is exactly the range with a shorter op code form, so every
+    # serialize() below warns; from 17 on, none does, and zero is the op
+    # code itself
+    assert serialize([0]) == b"\x00"
     for i in range(1, 17):
         serialized_int = serialize_non_canonical([i])
         assert [hex_string(i)] == parse(serialized_int)

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -390,11 +390,14 @@ def test_serialization() -> None:
     script: ScriptList = ["OP_SUCCESS80", b"\x01\x01\x01"]
     assert parse(serialize(script)) == script
 
-    # -1 and [0, 16] are the integers with a one-byte op code, so every
-    # serialize() below pushes data where an op code would do and warns
+    # -1 and [1, 16] are the integers whose one-byte op code the data
+    # push is not, so every serialize() below pushes data where an op
+    # code would do and warns; zero's encoding is the empty vector, so
+    # its push is that op code and it warns not
     assert parse(serialize_non_canonical([-1], serialize)) == ["81"]
-    for x in range(17):
+    for x in range(1, 17):
         assert parse(serialize_non_canonical([x], serialize)) == [f"{x:02X}"]
+    assert parse(serialize([0])) == ["OP_0"]
 
     for x in range(17, 100):
         assert parse(serialize([x])) == [f"{x:02X}"]

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -149,10 +149,12 @@ def test_int_from_bits() -> None:
 
 def test_encode_num() -> None:
     """Round-trip script numbers across sign, zero and length boundaries."""
-    with pytest.raises(BTClibValueError, match="empty byte string"):
-        decode_num(b"")
-
-    # different representations of zero
+    # zero is the empty vector, as Core's CScriptNum::serialize writes it
+    # and its set_vch reads it back, and the only spelling the
+    # interpreter accepts as a number: the engine's `_to_num` refuses the
+    # other two under MINIMALDATA, which is where that rule belongs
+    assert encode_num(0) == b""
+    assert decode_num(b"") == 0
     assert decode_num(b"\x00") == 0  # "positive" zero
     assert decode_num(b"\x80") == 0  # "negative" zero
 


### PR DESCRIPTION
Closes <https://github.com/btclib-org/btclib/issues/746>.

## The finding

`encode_num(0)` wrote `b"\x00"`. Core's `CScriptNum::serialize` — the
same function — returns the empty vector, and zero was the only value
where the two disagreed.

That is not a choice of spelling. `b"\x00"` is not a minimally encoded
script number, so the interpreter refuses it as one wherever MINIMALDATA
is in force: Core's `CScriptNum(vch, fRequireMinimal)` throws
`non-minimally encoded script number` when `(vch.back() & 0x7f) == 0`
with nothing before it, and this library says the same thing in its own
words —

```python
>>> _to_num(b"\x00", ScriptFlag.MINIMALDATA, 4)
BTClibValueError: non-minimal encoding of 0: 00
>>> _to_num(b"", ScriptFlag.MINIMALDATA, 4)
0
```

So `serialize([0])` wrote `0100`, a push btclib's own engine will not
read as a number, and warned `consider using OP_0` as though the op code
were merely one byte shorter.

This is not #646 revisited. There the finding was that an int command is
data and is written as a length-prefixed push whatever the value, which
is Core's split and is right; for -1 and for 1 to 16 that push carries a
*valid, minimally encoded* script number in a command one byte longer
than the op code. Zero is the one value where what it carries is not a
script number at all.

## The change

`encode_num(0)` is `b""` and `decode_num(b"")` is `0` — Core's
`CScriptNum::serialize` and `CScriptNum::set_vch`. `serialize([0])` is
therefore OP_0, reached by the same path as every other value, a
zero-length push being that op code already.

The engine had written Core's function a second time to get around this:

```python
def _from_num(x: int) -> bytes:
    return b"" if x == 0 else encode_num(x)
```

That wrapper is gone, with the matching empty-element branch in
`_to_num`, and every call site now calls `encode_num`. Two workarounds
disappearing is the evidence the fix is at the right level.

The warning goes for zero and stays for the rest, there being nothing
shorter left to suggest — and it now names `op_int(command)` instead of
interpolating the number: for -1 it read `consider using OP_-1 instead`,
which is no op code.

`decode_num` keeps reading `00` and `80` as zero. Refusing them is the
interpreter's rule, and `_to_num` is where MINIMALDATA is known.

## What it changes for a caller

A HISTORY.md breaking-changes bullet, the "before" checked against the
`v2023.7.12` tag, where `encode_num` was the same code. `push_int(0)`,
`op_int(0)` and the engine are unchanged, all three having answered OP_0
and the empty vector all along.

One consequence worth naming: `miniscript.from_script` no longer reads a
`0100` push as the number 0, so a `thresh` whose threshold is written
that way closes no fragment where it used to be refused for the
threshold's value — both a refusal, the second the accurate one. A test
vector pins it beside the OP_0 spelling.

Three tests pinned the old answer and now pin the new one, and two
mining tests carry a nonce derived from a coinbase whose extranonce is
`encode_num(0)`, so their nonces were re-derived: 373 → 278 and 53 → 126.

## Gates

`uv run pytest` (26254 passed, 100% coverage ratchet included),
`uv run pre-commit run --all-files`, and the sphinx `-W` build, all green
locally, on the rebase onto main that carries #740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align script number zero encoding and interpretation with Bitcoin Core by treating zero as the empty vector, simplifying numeric handling and warnings across the scripting and miniscript engines.

Bug Fixes:
- Fix non-minimal encoding of script number zero so numeric pushes and interpreter rules are consistent under MINIMALDATA.
- Correct miniscript threshold parsing so a data push of 0100 is no longer misread as numeric zero and now properly rejected as closing no fragment.
- Update mining tests to reflect changed nonces derived from coinbases that previously used the old zero encoding.

Enhancements:
- Unify numeric serialization in the script engines by removing the bespoke _from_num wrapper and having all op codes use encode_num directly.
- Adjust integer serialization warnings so only values with strictly shorter op-code encodings (-1 and 1–16, excluding 0) emit suggestions, referencing op_int(command) rather than interpolated numeric names.
- Extend decode_num to accept the empty vector as zero while leaving minimal-encoding enforcement to the script engine, matching Core’s CScriptNum behavior.

Documentation:
- Document the new canonical encoding of script number zero and its impact on serialize([0]) and related APIs in CHANGELOG.md and HISTORY.md.

Tests:
- Update and add script, taproot, miniscript, utils, and mining tests to pin the new zero encoding behavior, warning semantics, and revised mining nonces.