### PR TITLE
State the package-content policy where the sdist carries it (#735, #734, #736)

### DIFF
--- a/.github/scripts/verify_dist_contents.py
+++ b/.github/scripts/verify_dist_contents.py
@@ -10,7 +10,14 @@ description renders, whether the classifiers and urls are the ones a
 package should declare. None of them reads the members, so what is in the
 archive was checked by nothing -- and the archive is what a user installs.
 
-Three questions, one per section below.
+Three questions, one per section below, and the constants that answer
+them are the policy: `docs/source/package-content-policy.md` states it in
+prose, for a reader who has an unpacked sdist -- which carries that page
+and not this file -- and for the rules no member list can carry at all.
+`tests/verify_dist_contents_test.py` compares the page against these
+constants in both directions, so neither is free to drift from the other,
+which is what makes the second copy safe rather than one more thing to
+be wrong.
 
 **What may be in there.** The wheel gets a strict allowlist, it being what
 lands on `sys.path`: Python source under `btclib/`, `btclib/py.typed`,

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -8,13 +8,22 @@ name: integration
 # question is asked: a disposable regtest bitcoind, the account export,
 # the funding, the spend and the broadcast, against Core itself.
 #
-# It gates nothing, for the reason links.yml gates nothing and the
-# mutation workflow gates nothing: what it can go red on is a release of
-# Bitcoin Core, an unreachable bitcoincore.org or a runner slow enough to
-# miss the node's startup timeout, and none of those is the branch's
-# fault. It therefore does not appear in main's required checks, and
-# must not -- that rule lives outside the repository and names its checks
-# as literal strings.
+# The two jobs below sit on either side of one line, which is what a
+# check gates for: a red run that is the branch's fault gates, and a red
+# run that is somebody else's release does not. `Regtest against Bitcoin
+# Core` is on the first side and is a required check on main -- what it
+# asks is whether Core accepts what this branch built, and the node is a
+# pinned release verified against a published sha256, so the answer is
+# about btclib. A run of it can still go red on an unreachable
+# bitcoincore.org or a runner slow enough to miss the node's startup
+# timeout; that is a re-run, and it is the price of the question. The
+# job below it is on the other side and gates nothing, for the reason
+# links.yml gates nothing and the mutation workflow gates nothing.
+#
+# Which of the two is required lives outside the repository, in main's
+# protection, and names its checks as literal strings: renaming either
+# job is therefore a change to make there first, and REPOSITORY.md has
+# the recipe and the reason it cannot be done in one pull request.
 #
 # The HWI half of `tests/integration/` is the second job, and it needs a
 # device: a pinned Trezor emulator stands in for one, with a pinned HWI
@@ -65,11 +74,11 @@ on:
     # types do not include it, and without it a readied pull request
     # would wait for its next push to be checked at all
     types: [opened, reopened, synchronize, ready_for_review]
-    # no `paths` filter any more: this workflow is a required check on
-    # main, and a required check that never runs blocks a merge where a
-    # skipped one satisfies it -- a filter and a required check cannot both
-    # be had. Every pull request pays it, documentation-only ones included,
-    # which is what 36 seconds of work buys
+    # no `paths` filter any more: the regtest job below is a required
+    # check on main, and a required check that never runs blocks a merge
+    # where a skipped one satisfies it -- a filter and a required check
+    # cannot both be had. Every pull request pays it, documentation-only
+    # ones included, which is what 36 seconds of work buys
 
 # least privilege for the GITHUB_TOKEN: nothing here writes, and the
 # tarballs are fetched from bitcoincore.org and data.trezor.io, neither of
@@ -101,10 +110,8 @@ jobs:
     name: Regtest against Bitcoin Core
     # a draft pull request is work in progress and spends no runner
     # here either: a draft is work its author is not asking anyone to
-    # a draft from one release to the next, and its runs are what
-    # read yet. The same condition lint.yml and
-    # test.yml carry, and ready_for_review is a trigger type above for
-    # the same reason
+    # read yet. The same condition lint.yml and test.yml carry, and
+    # ready_for_review is a trigger type above for the same reason
     if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     # the whole flow is seconds -- two tests, a node that answers its

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **`integration.yml` says which of its jobs gates** (#736). Its header
+  claimed the workflow gates nothing and "must not" appear in main's
+  required checks, which two paragraphs of the same file, three of
+  REPOSITORY.md and one of CONTRIBUTING.md contradict: `Regtest against
+  Bitcoin Core` has been required since the workflow was put on pull
+  requests, and the `pull_request` block forty lines below explains that
+  it carries no `paths` filter for exactly that reason. Deleting the
+  paragraph would have cost the reasoning in it, which is still why the
+  *other* job does not gate, so it says the line instead -- a red run
+  that is the branch's fault gates, a red run that is somebody else's
+  release does not -- and the two jobs are named on either side of it.
+  The `pull_request` block now says "the regtest job below", the
+  workflow not being what is required, a job being.
+
 - **Every required check names the app that produces it.** Three of the
   five carried `app_id: 15368` and `Lint and type-check` and `Build the
   documentation` carried none, which is not a weaker spelling of the same
@@ -217,6 +231,36 @@ documented at release-notes length in the first place, and are still in
   which is what makes the backfill not worth doing.
 
 ### Packaging, linting and CI
+
+- **The package-content policy is stated where an unpacked sdist carries
+  it** (#735, #734). `docs/source/package-content-policy.md` says what
+  may be in the wheel and the sdist, what may never be, and what has to
+  be; `.github/scripts/verify_dist_contents.py` goes on being the thing
+  that enforces it. Two copies of one list are one that can be wrong --
+  the page saying `.so` is forbidden while the tuple says otherwise, with
+  nothing to notice -- which is why the script was written without a
+  page: `tests/verify_dist_contents_test.py` now compares the two in both
+  directions instead, list by list against the script's own constants, so
+  the page cannot state a rule the script does not have and the script
+  cannot grow one the page does not state. `.github` is not shipped and
+  `docs/` is, so what travels with an installed sdist is the statement
+  rather than nothing.
+  The page also carries what no member list can carry, which nothing
+  checked and nothing said: no install-time execution hook, no network
+  access while the package installs, no code generated from the network
+  while a release is built. The first two are already refused by rules
+  written for other reasons -- `setup.py` is not a root file the sdist
+  ships, `entry_points.txt` is not one of the wheel's metadata files, a
+  `.pth` carries a forbidden suffix -- and the page names those rules, so
+  that trimming an allowlist to what a build happens to produce is a
+  visible choice rather than the silent loss of a guard. The third had no
+  guard at all: `[build-system] requires` is one line that puts somebody
+  else's code in the build, and `tests/build_system_test.py` is what a
+  second requirement now has to get past, with the backend beside it --
+  `setuptools.build_meta`, not the `:__legacy__` that imports and runs a
+  `setup.py`. What is *not* claimed is that a build makes no network
+  request: proving that needs a sandboxed build, and naming it as policy
+  is the honest version.
 
 - **A tag is refused unless the default branch contains its commit**
   (#650). Every other check in `version-check` reads the tree the tag

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -327,7 +327,11 @@ installs it. The first two commands after the build read the *members* of
 the two archives, which the three that follow do not: an allowlist of what
 may be in a wheel and an sdist, and the bill of materials a release
 attaches — written here into a temporary directory and thrown away, this
-being the copy that says the script still reads a real wheel. The last
+being the copy that says the script still reads a real wheel. That
+allowlist is stated in prose in
+[the package-content policy](./docs/source/package-content-policy.md),
+which the suite compares against the script's own constants, so changing
+a rule means changing both. The last
 commands ask for the wheel and nothing else, so
 what pulls btclib_secp256k1 in is the `Requires-Dist` the wheel
 carries; the lock arrives as constraints, which pin without

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,6 +84,14 @@ only what whoever wrote it wanted said. What it records of a dependency is
 the requirement as published, so a component carries a version only where
 that requirement is an exact pin.
 
+What may be inside those two files is stated in
+[the package-content policy](./docs/source/package-content-policy.md),
+and a build carrying anything else is refused before it can be published:
+an allowlist of the members of a wheel and an sdist, the suffixes and
+names neither may ever hold, and — named as policy, because no list of
+members can show them — the rules about what runs while the package is
+built and installed.
+
 ## Limitations, not vulnerabilities
 
 These are known and inherent. They are worth stating because btclib is

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ btclib documentation
    PYTHON PACKAGE <modules>
    CONTRIBUTING <contributing_link.md>
    SECURITY <security_link.md>
+   PACKAGE CONTENT POLICY <package-content-policy.md>
    HISTORY <history_link.md>
    CHANGELOG <changelog_link.md>
 

--- a/docs/source/package-content-policy.md
+++ b/docs/source/package-content-policy.md
@@ -1,0 +1,157 @@
+# The package-content policy
+
+A release publishes two files, a wheel and an sdist. This page states
+what may be in them, what may never be, and what has to be: the wheel is
+what lands on `sys.path`, the sdist is what a build starts from, and both
+are read before either is published.
+
+`.github/scripts/verify_dist_contents.py` enforces every rule down to the
+last section — the `dist` job of `test.yml` runs it on a build of every
+pull request, and the `build` job of `release.yml` on the files it is
+about to upload. The last section is the rules nothing here enforces,
+which say so one by one rather than leaving the list looking complete.
+
+The script's constants are those rules, and the paragraph introducing
+each list below names the ones the list states.
+`tests/verify_dist_contents_test.py` compares the two in both directions,
+so this page cannot state a rule the script does not have, and the script
+cannot grow a rule this page does not state. The prose around the lists
+is prose, and is checked by nobody.
+
+## What may never be in either file
+
+Checked against every member of both archives, the ones the `_data/`
+amnesty below admits by directory rather than by extension included:
+`FORBIDDEN_SUFFIXES` and `FORBIDDEN_NAMES`.
+
+- `.pth` — executed at interpreter startup, before the first import
+- `.dll`, `.dylib`, `.pyd`, `.so` — a compiled extension, which this
+    project has none of: the secp256k1 bindings are a separate
+    distribution, resolved at install time and never vendored
+- `.exe` — a program rather than an extension, and refused for the same
+    reason: nothing here is compiled, so nothing here ships a binary
+- `.pyc` — a compiled module whose source nobody reviewed
+- `.egg`, `.tar.gz`, `.whl`, `.zip` — an archive inside an archive, that
+    is, a second package installing with the first
+- `sitecustomize.py`, `usercustomize.py` — the two names Python imports
+    for their side effects alone, at startup, from the root of
+    site-packages. Both end in `.py`, which the wheel's allowlist would
+    otherwise admit under `btclib/`: the rule is about the name, not
+    about where it happens to be harmless
+
+A `__pycache__` directory is refused too, by name rather than by suffix:
+an empty one is a member in its own right and carries no `.pyc`.
+
+## What the wheel may hold
+
+An allowlist, it being what lands on `sys.path`: Python source under
+`btclib/`, `btclib/py.typed`, whatever sits in a `_data/` directory, and
+the `.dist-info` metadata setuptools writes. Anything else fails, which
+is what makes a `.pth` file, a stray top-level module and a bundled
+shared object one rule rather than three.
+
+Under `btclib-<version>.dist-info/` — `WHEEL_METADATA_FILES`, beside the
+`licenses/` directory setuptools copies `LICENSE`, `COPYRIGHT` and
+`AUTHORS.md` into:
+
+- `METADATA`, `RECORD`, `WHEEL`, `top_level.txt` — what setuptools
+    writes for a package configured as this one is
+
+`entry_points.txt` is deliberately not among them: pyproject.toml
+declares no `[project.scripts]`, and an entry point is a code path a user
+runs without importing anything, so one appearing there is a packaging
+change that has to be read.
+
+## What the sdist may hold
+
+A structural check rather than an extension allowlist, `MANIFEST.in`
+already being one: `recursive-include tests *.json` is the statement of
+what a vendored vector may be, and a second copy of it here would be one
+more edit per vector while catching nothing that file lets through. What
+this adds is what `MANIFEST.in` cannot say — that every member sits under
+the archive's own root directory, that every member is a regular file or
+a directory (a tar can carry a symlink, a hardlink or a device node,
+where a zip cannot), and that no directory holds the metadata of some
+other distribution.
+
+The directories, `SDIST_DIRECTORIES`:
+
+- `btclib` — the package
+- `tests` — its suite
+- `docs` — the documentation sources
+- `btclib.egg-info` — the metadata setuptools generates beside them
+
+The files at that root, `SDIST_ROOT_SUFFIXES` and `SDIST_ROOT_NAMES`.
+`MANIFEST.in` ships most of them by glob, `include *.md` and the two
+beside it, so a file landing at the root is shipped without a packaging
+decision being made; this is where that decision is recorded:
+
+- `.md`, `.toml`, `.yaml`, `.jsonc` — what a reader of an unpacked sdist
+    reads, and the configuration of the tools it names
+- `LICENSE`, `COPYRIGHT` — the licence and the copyright notice, which
+    `project.license-files` copies into the wheel as well
+- `PKG-INFO`, `setup.cfg` — written by setuptools while it builds the
+    archive, and not files of this tree
+- `MANIFEST.in`, `uv.lock`, `.python-version`, `.secrets.baseline` —
+    what makes an unpacked sdist buildable, and its lint gate runnable,
+    which is `MANIFEST.in`'s own reason for carrying the last two
+
+Under `btclib.egg-info/`, generated metadata and nothing else:
+`SDIST_EGG_INFO_NAMES` and `SDIST_EGG_INFO_SUFFIXES`.
+
+- `PKG-INFO`, `.txt` — what setuptools writes there; anything else is
+    the tree the archive was built in leaking into it
+
+## What has to be in there
+
+The wheel, `WHEEL_REQUIRED`, beside the metadata files above, which are
+required as well as allowed:
+
+- `btclib/__init__.py` — a wheel with no package in it at all is the
+    shape a misconfigured `packages.find` produces
+- `btclib/py.typed` — PEP 561 makes its absence silent: the package
+    installs, imports, and type checks as `Any`
+
+And the sdist, `SDIST_REQUIRED`:
+
+- `PKG-INFO` — the metadata PyPI reads off the archive
+- `pyproject.toml` — what makes the archive buildable at all
+
+The two carry one payload. `uv build` builds the sdist and then the wheel
+from it, so `btclib/` is the same set of files in both; a difference
+either way is a file that reaches a user installing from source and not
+one installing the wheel, or the reverse.
+
+## The rules nothing here enforces
+
+Three rules of the policy `diybitcoinhardware/embit` publishes beside its
+own checker are not lists of members, and no list of members can show
+them. That project does not check them either — its policy says so, in as
+many words — so what follows each here is what stands in for a check.
+
+- **No install-time execution hook.** Three shapes could carry one, and
+    each is refused by a rule above: `setup.py` is not a root file the
+    sdist ships, `entry_points.txt` is not one of the wheel's metadata
+    files, and a `.pth` carries a forbidden suffix. None of those rules
+    was written for this, which is worth knowing before trimming one to
+    what a build happens to produce: it would take a guard with it.
+    There is no `setup.py` in the tree at all — `[build-system]` names
+    `setuptools.build_meta`, the configuration is declarative, and
+    pyproject.toml has no field for a command class.
+- **No network access while the package installs.** Which follows from
+    the rule above and is not a check of its own: an installed wheel is
+    Python source and data, pip runs none of it, and the three shapes
+    that would run are the three that are refused.
+- **No code generated from the network while a release is built.**
+    `[build-system] requires` is the one line that can put somebody
+    else's code in a build here, and it is one requirement long:
+    `tests/build_system_test.py` asserts it names setuptools and nothing
+    else, so a build requirement cannot be added in silence. A diff is
+    what reads it; the test is what says a reader has to.
+
+What none of this claims is that a build made no network request.
+Proving that needs a sandboxed build, which is a different undertaking at
+a different cost, and naming it as policy is the honest version. What is
+checkable instead is the *result*: the build is reproducible from
+`SOURCE_DATE_EPOCH`, and RELEASING.md has the command that rebuilds a
+release from its tag and the bounds on it.

--- a/tests/build_system_test.py
+++ b/tests/build_system_test.py
@@ -1,0 +1,60 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Nothing but setuptools runs while a distribution is built.
+
+`docs/source/package-content-policy.md` states what may be in the wheel
+and the sdist, and `.github/scripts/verify_dist_contents.py` refuses a
+build that carries anything else -- an installed wheel therefore executes
+nothing at install time, there being no member left that could. What no
+list of members can see is the *build*: `[build-system] requires` is
+resolved into an isolated environment and every package named there runs
+code while the archives are made, so that one line is the whole of what a
+release trusts, and a diff is the only thing that reads it.
+
+Which is what this is: the line is one requirement long, and a test
+saying so is what a second one would have to go past.
+
+Not an assertion on the exact string. The floor is declared in
+pyproject.toml with the reason for it, and a copy of it here would be a
+second declaration to keep in step, failing on the day it moves for a
+reason that has nothing to do with what runs. The shape is what matters
+and what is checked: one requirement, named setuptools, bounded from
+below and nothing else -- which is also how a direct reference to a url,
+an extra and an environment marker are refused, each of them a way to
+name a package that resolves to somebody else's code.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import tomllib
+
+_PYPROJECT = Path(__file__).parents[1] / "pyproject.toml"
+
+# a name, `>=` and a release: no `@ <url>`, no `[extra]`, no `; marker`
+_LOWER_BOUND = re.compile(r"setuptools>=[0-9]+(?:\.[0-9]+)*")
+
+# the table pip and uv build with, read at import: the file is the
+# project's own and a test module that cannot read it has nothing to say
+_BUILD_SYSTEM = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["build-system"]
+
+
+def test_the_build_requires_setuptools_and_nothing_else() -> None:
+    """One requirement, and a lower bound is the whole of what it says."""
+    (requirement,) = _BUILD_SYSTEM["requires"]
+
+    assert _LOWER_BOUND.fullmatch(requirement)
+
+
+def test_the_backend_is_the_declarative_one() -> None:
+    """`setuptools.build_meta`, and not the `:__legacy__` beside it.
+
+    That one is the backend for a project configured by `setup.py`: it
+    imports the file and runs it, which is the install-time hook the
+    package-content policy is about, one stage earlier and in the build.
+    """
+    assert _BUILD_SYSTEM["build-backend"] == "setuptools.build_meta"

--- a/tests/verify_dist_contents_test.py
+++ b/tests/verify_dist_contents_test.py
@@ -11,6 +11,14 @@ on the files it is about to publish. What CI cannot show is that anything
 can produce on purpose -- so the archives here are synthetic, one member
 planted per rule, and the assertion is the complaint.
 
+The last two tests here ask a different question: whether
+`docs/source/package-content-policy.md` states the same policy. A page
+beside a script is a second copy of one list, and two copies are one that
+can be wrong -- the page saying `.so` is forbidden while the script's
+tuple says otherwise, with nothing to notice. Those two compare the page
+against the script's own constants in both directions, which is what
+makes the second copy safe rather than merely tidy.
+
 The script is loaded by path, `.github/scripts` being no package, as the
 mutation-counter and vendored-vector tests do. It has no dataclass, so
 registering the module before `exec_module` is not needed here.
@@ -20,6 +28,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import re
 import runpy
 import sys
 import tarfile
@@ -30,6 +39,7 @@ from types import ModuleType
 import pytest
 
 _SCRIPT = Path(__file__).parents[1] / ".github" / "scripts" / "verify_dist_contents.py"
+_PAGE = Path(__file__).parents[1] / "docs" / "source" / "package-content-policy.md"
 
 _VERSION = "1.0"
 _ROOT = f"btclib-{_VERSION}"
@@ -374,6 +384,95 @@ def test_main_passes_on_a_clean_pair(script: ModuleType, tmp_path: Path) -> None
     write_sdist(tmp_path)
 
     assert script.main(["prog", str(tmp_path)]) == 0
+
+
+# a code span holding the name of one of the script's constants: upper
+# case with an underscore in it, which no member name and no suffix is --
+# `METADATA` and `PKG-INFO` are values the page states, not names of
+# lists, and this is what tells the two apart
+_CONSTANT = re.compile(r"`([A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+)`")
+_CODE_SPAN = re.compile(r"`([^`]+)`")
+# what separates a rule from the reason for it, in a list item of the
+# page. An em dash, spaced: the reason is prose and names whatever it
+# needs to in code spans of its own, so a rule has to end somewhere
+_REASON = " \N{EM DASH} "
+
+
+def _rules(text: str) -> list[tuple[set[str], set[str]]]:
+    """Pair every rule list of the page with the constants above it.
+
+    A list states the constants its introducing paragraph names, and a
+    list introduced by a paragraph naming none -- the policy items no
+    check enforces, at the bottom of the page -- is not a rule list and
+    is skipped. Each item contributes the code spans before its dash.
+    """
+    rules: list[tuple[set[str], set[str]]] = []
+    # the paragraph being read, and the last one that ended: a list is
+    # introduced by the paragraph before the blank line above it
+    paragraph: list[str] = []
+    lead: list[str] = []
+    items: list[str] = []
+    # the empty line is the flush: a list ending at the last line of the
+    # file would otherwise be the one nothing compares
+    for line in (*text.splitlines(), ""):
+        if line.startswith("- "):
+            items.append(line[2:])
+        elif items and line.startswith("  "):
+            items[-1] += " " + line.strip()
+        elif items:
+            named = set(_CONSTANT.findall(" ".join(lead)))
+            if named:
+                rules.append((named, _stated(items)))
+            items, lead = [], []
+        elif line.strip():
+            paragraph.append(line)
+        elif paragraph:
+            lead, paragraph = paragraph, []
+    return rules
+
+
+def _stated(items: list[str]) -> set[str]:
+    """Every member name and suffix a rule list states."""
+    spans: set[str] = set()
+    for item in items:
+        rule, dash, _ = item.partition(_REASON)
+        assert dash, f"a rule with no reason after it: {item}"
+        spans.update(_CODE_SPAN.findall(rule))
+    return spans
+
+
+def _policy_constants(
+    script: ModuleType,
+) -> dict[str, tuple[str, ...] | frozenset[str]]:
+    """Every constant of the script that is a list of members.
+
+    Read off the module rather than named here: a rule added to the
+    script is then one the page has to state before the test below
+    passes, which is the direction a hand-written inventory would miss.
+    """
+    return {
+        name: value
+        for name, value in vars(script).items()
+        if name.isupper() and isinstance(value, (tuple, frozenset))
+    }
+
+
+def test_the_page_states_what_the_script_enforces(script: ModuleType) -> None:
+    """Every rule list on the page is its constants, exactly."""
+    constants = _policy_constants(script)
+
+    for named, stated in _rules(_PAGE.read_text(encoding="utf-8")):
+        expected = {value for name in named for value in constants.get(name, ())}
+        assert stated == expected, sorted(named)
+
+
+def test_the_page_states_every_rule_the_script_has(script: ModuleType) -> None:
+    """And no constant is left off the page, or stated twice."""
+    named = [
+        name for names, _ in _rules(_PAGE.read_text(encoding="utf-8")) for name in names
+    ]
+
+    assert sorted(named) == sorted(_policy_constants(script))
 
 
 def test_the_main_guard_runs_the_script_as___main__(


### PR DESCRIPTION
One piece of work for the three open issues, which are one decision and
its consequences: where the package-content policy lives, what it has to
say that no member list can show, and one workflow header that says the
opposite of what the repository does.

Closes https://github.com/btclib-org/btclib/issues/735
Closes https://github.com/btclib-org/btclib/issues/734
Closes https://github.com/btclib-org/btclib/issues/736

## #735 — a `docs/source/` page, with the test that makes it safe

The first of the three outcomes that issue offers, the one it calls the
only version worth having. `docs/source/package-content-policy.md`
states the policy; `.github/scripts/verify_dist_contents.py` goes on
being the thing that enforces it, unchanged but for a docstring pointing
at the page.

What keeps the second copy from being a second thing to be wrong is
`tests/verify_dist_contents_test.py`, which compares them list by list:

- the constants are read off the module rather than named in the test,
  so a rule added to the script is one the page has to state before the
  suite passes;
- every rule list on the page is compared with the constants its
  introducing paragraph names — set equality, so the page can neither
  drop a member nor invent one;
- both directions were checked by mutation before pushing: dropping
  `.exe` from the page, adding a `.rst` to a rule list, and leaving
  `SDIST_REQUIRED` unnamed each turn one of the two tests red.

`.github` is not shipped and `docs/` is, so an unpacked sdist now carries
the statement rather than nothing. SECURITY.md and CONTRIBUTING.md link
to it from the two places a reader arrives from.

## #734 — the three rules, written down, and one of them tested

The last section of the page is the non-mechanical half, each item with
what stands in for a check:

- **no install-time execution hook** — the three shapes that could carry
  one are refused by rules written for other reasons, and the page names
  them (`setup.py` is not a root file the sdist ships, `entry_points.txt`
  is not one of the wheel's metadata files, a `.pth` carries a forbidden
  suffix), so trimming an allowlist to what a build happens to produce is
  a visible choice rather than the silent loss of a guard;
- **no network access while the package installs** — which follows from
  the rule above and is not a check of its own;
- **no code generated from the network at release time** — the one door
  the issue measures as genuinely open, and it now has
  `tests/build_system_test.py`.

And the page says plainly what is not claimed: nothing here proves a
build made no network request, which needs a sandboxed build.

**One deviation from the issue, and it is deliberate.** The issue asks
for a test asserting `[build-system] requires` is exactly
`["setuptools>=77"]`. The test asserts the *shape* instead — one
requirement, named setuptools, a lower bound and nothing else — because
the literal would be a second declaration of the floor, which
pyproject.toml declares once with the reason for it, and it would go red
the day the floor moves for a reason that has nothing to do with what
runs. What the regex refuses beyond the name is what the exact string
also refused: `setuptools @ <url>`, `setuptools[extra]`, an environment
marker. A second test pins the backend to `setuptools.build_meta` rather
than the `:__legacy__` beside it, which imports and runs a `setup.py`.
Say the word and it becomes the literal.

## #736 — the header paragraph

Rewritten rather than deleted, the reasoning in it being still why the
*other* job does not gate: a red run that is the branch's fault gates, a
red run that is somebody else's release does not, with the two jobs named
on either side of the line. The `pull_request` block now says "the
regtest job below is a required check", a job being what protection names
and not a workflow.

Two things checked in the same pass, as the issue asks:

- `links.yml` and `mutation.yml` say "gates nothing" and the required
  list agrees with them — `["Lint and type-check", "Build the
  documentation", "test: every job passed", "Regtest against Bitcoin
  Core", "codeql: every job passed"]`. No change there.
- the `if:` of the regtest job carried a spliced-in line that left the
  comment saying nothing ("a draft is work its author is not asking
  anyone to / a draft from one release to the next, and its runs are what
  / read yet"); the stray line is gone. **`lint.yml` has the same kind of
  defect** at its own draft condition — the comment ends mid-sentence at
  "The exception is by base branch, and it is the release pull" — which
  is left alone here, being another file and another paragraph. Worth its
  own issue.

## Gates

`uv run pytest` green at 100.00%, `uv run pre-commit run --all-files`
exit 0, the sphinx `-W` build exit 0, and `uv build` plus the script on
the real pair — the page and the new test travel in the sdist,
`verify_dist_contents_test.py` stays excluded as MANIFEST.in says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document and enforce the package-content policy alongside existing distribution checks, and clarify CI integration workflow gating behavior.

New Features:
- Add a user-facing package-content policy page describing allowed, forbidden, and required files in wheels and sdists, plus non-member-based safety rules.

Bug Fixes:
- Align the integration workflow header and comments with actual required checks, ensuring the regtest job’s gating behavior is described accurately.

Enhancements:
- Link SECURITY and CONTRIBUTING documentation to the new package-content policy to surface packaging and install-time safety guarantees.
- Extend distribution tests to verify the policy document stays consistent with the enforcement script’s constants in both directions.
- Add build-system tests to assert that setuptools is the sole, lower-bounded build requirement and that the declarative `setuptools.build_meta` backend is used.

Documentation:
- Introduce detailed documentation of the package-content policy that explains archive contents, forbidden members, required files, and unchecked but stated safety rules.