### PR TITLE
Write the script number zero as no bytes, the way Core does (#746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1741,6 +1741,36 @@ documented at release-notes length in the first place, and are still in
   `serialize` writes; the docstring says the rule and the test pins it,
   over the whole set of values that could have been written otherwise.
 
+- **zero is the empty byte vector, in both directions** (issue #746).
+  `encode_num(0)` wrote `b"\x00"` where Core's `CScriptNum::serialize`
+  returns an empty vector, and `decode_num(b"")` raised "empty byte
+  string" where Core's `set_vch` answers 0. Zero was the only value where
+  the two libraries disagreed, and the disagreement was not cosmetic:
+  `b"\x00"` is not a minimally encoded script number, so the interpreter
+  refuses it as one wherever MINIMALDATA is in force -- Core's
+  `CScriptNum(vch, fRequireMinimal)` on "non-minimally encoded script
+  number", and btclib's own engine on "non-minimal encoding of 0: 00". So
+  `serialize([0])` wrote the push `0100`, carrying a number this library
+  would not read back, where Core's `CScript() << 0` writes OP_0.
+
+  It writes that OP_0 now, and by the ordinary path rather than a case of
+  its own: a zero-length push is OP_0's byte already, which is what
+  issue #646's test calls the one place the two spellings coincide. The
+  warning goes with it for zero alone -- with nothing shorter to suggest,
+  "consider using OP_0 instead" would name what was just written -- and
+  stays from 1 to 16 and at -1, where the push really is one byte longer
+  than the op code.
+
+  The engine had `CScriptNum::serialize` written a second time to work
+  around this, `_from_num` being `b"" if x == 0 else encode_num(x)` and
+  `_to_num` carrying the matching empty-element branch; both are gone,
+  `encode_num` and `decode_num` now being the pair the engine needed.
+  `miniscript._script_number` stops reading a `0100` push back as the
+  number 0, which is what Core's miniscript parser refuses. Visible in
+  the tests too: two mined blocks in `tests/block/mining_test.py` carry a
+  coinbase whose extranonce is `encode_num(0)`, so the nonces solving
+  them moved.
+
 ### Descriptors and miniscript
 
 - **An invalid output is refused, not answered about** (#691). `index_of`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -121,6 +121,20 @@ full year, short month, short day (YYYY-M-D)
   index=0)`, which re-validates by default -- the same function
   `BIP32KeyData(...)` still takes, and still defaulting to `True`.
 
+- **the script number zero is no bytes at all.** `utils.encode_num(0)`
+  returns `b""` where it returned `b"\x00"`, and `utils.decode_num(b"")`
+  returns 0 where it raised `BTClibValueError("empty byte string")`:
+  Core's `CScriptNum::serialize` and `set_vch`, which is what the rest of
+  this library already had to work around. Two things move with them.
+  `script.serialize([0])` is the single byte OP_0 rather than the push
+  `0100`, so a caller pinning those bytes -- a script, a coinbase
+  script_sig, a txid over either -- gets a different answer; and that
+  call no longer warns "consider using OP_0 instead", there being nothing
+  shorter left to suggest. `b"\x00"` still decodes to zero, being a
+  non-minimal spelling of it and not an invalid one, which is why the
+  interpreter refuses it as a number under MINIMALDATA and why writing it
+  was the defect.
+
 ### The bindings are now `btclib_secp256k1`
 
 - **The secp256k1 bindings were renamed, and btclib requires the new

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -16,12 +16,7 @@ from btclib.exceptions import BTClibRuntimeError, BTClibValueError, ScriptError
 from btclib.script import sig_hash
 from btclib.script.engine import script_op_codes
 from btclib.script.engine.flags import ScriptFlag
-from btclib.script.engine.script_op_codes import (
-    _MAX_NUM_SIZE,
-    ScriptOp,
-    _from_num,
-    _to_num,
-)
+from btclib.script.engine.script_op_codes import _MAX_NUM_SIZE, ScriptOp, _to_num
 from btclib.script.limits import (
     MAX_OPS_PER_SCRIPT,
     MAX_PUBKEYS_PER_MULTISIG,
@@ -37,7 +32,7 @@ from btclib.script.script import (
 from btclib.script.script import serialize as serialize_script
 from btclib.script.sig_hash import SIG_HASH_TYPES, PrecomputedTxData
 from btclib.tx.tx import Tx
-from btclib.utils import bytesio_from_binarydata
+from btclib.utils import bytesio_from_binarydata, encode_num
 
 __all__ = [
     "DISABLED_OP_CODES",
@@ -557,7 +552,7 @@ def _run_ops(  # noqa: C901, PLR0912
                 hash_types,
             )
             check_nullfail(flags, result, [signature], "OP_CHECKSIG")
-            stack.append(_from_num(int(result)))
+            stack.append(encode_num(int(result)))
 
         elif op == "OP_CHECKMULTISIG":
             # Core's order, and it is the order that makes the two
@@ -606,7 +601,7 @@ def _run_ops(  # noqa: C901, PLR0912
         elif op == "OP_CHECKSEQUENCEVERIFY":
             script_op_codes.op_checksequenceverify(stack, tx, i, flags)
         elif op[3:].isdigit():
-            stack.append(_from_num(int(op[3:])))
+            stack.append(encode_num(int(op[3:])))
         elif op == "OP_CODESEPARATOR":
             codesep_offset = op_code_stops[script_index]
         elif op == "OP_IF":

--- a/btclib/script/engine/script_op_codes.py
+++ b/btclib/script/engine/script_op_codes.py
@@ -118,16 +118,10 @@ def _to_num(element: bytes, flags: ScriptFlag, max_size: int) -> int:
         raise BTClibValueError("non-minimal encoding of zero")
     if len(element) > max_size:
         raise BTClibValueError(f"number longer than {max_size} bytes: {len(element)}")
-    if element == b"":
-        return 0
     x = decode_num(element)
-    if minimaldata and _from_num(x) != element:
+    if minimaldata and encode_num(x) != element:
         raise BTClibValueError(f"non-minimal encoding of {x}: {element.hex()}")
     return x
-
-
-def _from_num(x: int) -> bytes:
-    return b"" if x == 0 else encode_num(x)
 
 
 def _to_bool(element: bytes) -> bool:
@@ -381,7 +375,7 @@ def op_swap(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> Non
 
 def op_1negate(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Push the number -1."""
-    stack.append(_from_num(-1))
+    stack.append(encode_num(-1))
 
 
 def op_verify(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -439,7 +433,7 @@ def op_checkmultisigverify(
 
 def op_size(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Push the byte length of the top element, leaving it in place."""
-    stack.append(_from_num(len(stack[-1])))
+    stack.append(encode_num(len(stack[-1])))
 
 
 def op_ripemd160(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -470,25 +464,25 @@ def op_hash256(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> 
 def op_1add(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop a number and push it incremented by one."""
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(a + 1))
+    stack.append(encode_num(a + 1))
 
 
 def op_1sub(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop a number and push it decremented by one."""
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(a - 1))
+    stack.append(encode_num(a - 1))
 
 
 def op_negate(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop a number and push its negation."""
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(-a))
+    stack.append(encode_num(-a))
 
 
 def op_abs(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop a number and push its absolute value."""
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(abs(a)))
+    stack.append(encode_num(abs(a)))
 
 
 def op_not(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -512,14 +506,14 @@ def op_add(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None
     """Pop two numbers and push their sum."""
     b = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(a + b))
+    stack.append(encode_num(a + b))
 
 
 def op_sub(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop two numbers and push the deeper one minus the top one."""
     b = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(a - b))
+    stack.append(encode_num(a - b))
 
 
 def op_booland(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -625,14 +619,14 @@ def op_min(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None
     """Pop two numbers and push the smaller."""
     b = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(min(a, b)))
+    stack.append(encode_num(min(a, b)))
 
 
 def op_max(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Pop two numbers and push the larger."""
     b = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
     a = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-    stack.append(_from_num(max(a, b)))
+    stack.append(encode_num(max(a, b)))
 
 
 def op_within(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
@@ -673,7 +667,7 @@ def op_ifdup(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> No
 
 def op_depth(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:
     """Push the number of elements on the stack."""
-    stack.append(_from_num(len(stack)))
+    stack.append(encode_num(len(stack)))
 
 
 def op_nip(stack: list[bytes], altstack: list[bytes], flags: ScriptFlag) -> None:

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -18,7 +18,7 @@ from btclib.script import sig_hash
 from btclib.script.engine import script_op_codes
 from btclib.script.engine.flags import ScriptFlag
 from btclib.script.engine.script import EVALUATED_WHEN_UNEXECUTED
-from btclib.script.engine.script_op_codes import ScriptOp, _from_num
+from btclib.script.engine.script_op_codes import ScriptOp
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
 from btclib.script.op_codes_tapscript import OP_CODE_NAMES
 from btclib.script.script_pub_key import type_and_payload
@@ -27,7 +27,7 @@ from btclib.script.taproot import parse
 from btclib.script.taproot import serialize as serialize_script
 from btclib.tx.tx import Tx
 from btclib.tx.tx_out import TxOut
-from btclib.utils import bytesio_from_binarydata
+from btclib.utils import bytesio_from_binarydata, encode_num
 
 __all__ = [
     "OPERATIONS",
@@ -176,7 +176,7 @@ def op_checksig(
     # because Core charges it for a passing upgradable key too
     elif ScriptFlag.DISCOURAGE_UPGRADABLE_PUBKEYTYPE in flags:
         raise BTClibValueError(f"upgradable public key type: {len(pub_key)} bytes")
-    stack.append(_from_num(int(bool(signature))))
+    stack.append(encode_num(int(bool(signature))))
     return budget
 
 
@@ -323,7 +323,7 @@ def _run_ops(  # noqa: C901, PLR0912
         elif op == "OP_CHECKSEQUENCEVERIFY":
             script_op_codes.op_checksequenceverify(stack, tx, i, flags)
         elif op[3:].isdigit():
-            stack.append(_from_num(int(op[3:])))
+            stack.append(encode_num(int(op[3:])))
         elif op == "OP_CODESEPARATOR":
             codesep_pos = script_index
         elif op == "OP_IF":

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -338,9 +338,10 @@ def push_int(i: int) -> str:
     are written the same way and serialize differently.
 
     `serialize` reaches the same bytes from the integer itself for
-    everything above 16, and warns for -1 to 16 that the op code is one
-    byte shorter: this is that op code, so the warning is the caller
-    being told to write this instead. Minimal because the consumers are:
+    everything above 16, and warns for -1 to 16 -- 0 excepted, where the
+    two spellings are the same byte -- that the op code is one byte
+    shorter: this is that op code, so the warning is the caller being
+    told to write this instead. Minimal because the consumers are:
     `miniscript.from_script` refuses a push written the long way, and the
     interpreter refuses it too under MINIMALDATA, so a number pushed with
     a byte to spare is a script that reads as nothing and may not spend.
@@ -349,7 +350,10 @@ def push_int(i: int) -> str:
 
 
 def _serialize_int_command(command: int) -> bytes:
-    if -1 <= command <= 16:
+    # zero excepted: `encode_num` writes it as no bytes at all, so the
+    # push of it is the single byte OP_0 already and there is nothing
+    # shorter to suggest -- the warning would name what was just written
+    if -1 <= command <= 16 and command != 0:
         # not a DeprecationWarning: nothing is going away, the push is
         # merely one byte longer than the op code that means the same
         warn(
@@ -449,6 +453,12 @@ def serialize(script: Sequence[Command]) -> bytes:
     bytes and is warned about for exactly this. `push_int` is what
     writes a number the shortest way there is, and what every caller in
     this library that means one uses.
+
+    The integer 0 is the one exception, and it needs no exception in the
+    code: `encode_num` writes it as no bytes at all, so its minimal push
+    is the single byte OP_0 -- which is what Core's `CScript() << 0`
+    writes, and what the interpreter reads back as a number, `0100`
+    being a push MINIMALDATA refuses (issue #746).
     """
     r: list[bytes] = []
     for command in script:

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -310,13 +310,16 @@ def decode_num(data: bytes) -> int:
     * 0x01 is 1
     * 0x81 is -1
 
-    Therefore, there are two representations of zero:
+    Therefore, there are three spellings of zero, and all three decode
+    to it:
 
-    * 0x00 is "positive" zero
-    * 0x80 is "negative" zero
+    * the null-length byte vector, the canonical one and the only
+      minimally encoded one, which is what `encode_num` writes
+    * 0x00, "positive" zero
+    * 0x80, "negative" zero
 
-    Positive zero is also represented by a null-length byte vector,
-    which is considered the canonical one.
+    The first is Core's `CScriptNum::set_vch` answering 0 for an empty
+    vector rather than refusing it (issue #746).
 
     Not bounded the way `encode_num` is: this is the reader, and its two
     callers ask different things of it. The engine's `_to_num` caps an
@@ -327,7 +330,7 @@ def decode_num(data: bytes) -> int:
     """
     length = len(data)
     if length == 0:
-        raise BTClibValueError("empty byte string")
+        return 0
     i = int.from_bytes(data, byteorder="little", signed=False)
     if data[-1] >= 0x80:  # negative number
         # mask for all but the highest bit
@@ -355,13 +358,12 @@ def encode_num(i: int) -> bytes:
     * 0x01 is 1
     * 0x81 is -1
 
-    Therefore, there are two representations of zero:
-
-    * 0x00 is "positive" zero
-    * 0x80 is "negative" zero
-
-    Positive zero is also represented by a null-length byte vector,
-    which is considered the canonical one.
+    Zero is the null-length byte vector, as Core's
+    `CScriptNum::serialize` writes it: 0x00 and 0x80 decode to zero too,
+    and neither is minimally encoded, so the interpreter refuses either
+    as a number wherever MINIMALDATA is in force -- and a zero-length
+    push is OP_0's byte already, which is what `serialize([0])` writes
+    through this (issue #746).
 
     The number is a CScriptNum, i.e. an int64, and a Python int outside
     that range is refused rather than encoded: what it would write is a
@@ -378,6 +380,9 @@ def encode_num(i: int) -> bytes:
         err_msg = f"script number out of range: {i}"
         err_msg += f", not in [{_MIN_SCRIPT_NUM}, {_MAX_SCRIPT_NUM}]"
         raise BTClibValueError(err_msg)
+
+    if i == 0:
+        return b""
 
     # i.bit_length() bits, plus a sign bit
     n_bits = i.bit_length() + 1

--- a/tests/block/mining_test.py
+++ b/tests/block/mining_test.py
@@ -77,7 +77,7 @@ def test_a_mined_block_is_a_block() -> None:
 
     header = mine(candidate)
     assert header is not None
-    assert header.nonce == 373
+    assert header.nonce == 278
     assert header.hash <= header.target
     header.assert_valid_pow(REGTEST_POW_LIMIT_BITS)
 
@@ -152,12 +152,12 @@ def test_a_bounded_search_can_find_nothing() -> None:
     transactions = [_coinbase(1)]
     candidate = candidate_block_header(_PREVIOUS, transactions, _TIME, _EASY_BITS)
 
-    # the nonce that solves this one is 53, so a search of 53 -- nonces
-    # 0 to 52 -- stops one short of it
-    assert mine(candidate, 53) is None
-    solved = mine(candidate, 54)
+    # the nonce that solves this one is 126, so a search of 126 -- nonces
+    # 0 to 125 -- stops one short of it
+    assert mine(candidate, 126) is None
+    solved = mine(candidate, 127)
     assert solved is not None
-    assert solved.nonce == 53
+    assert solved.nonce == 126
 
     # a mainnet-grade target is not found either, and the bound is what
     # makes that a return rather than a hang

--- a/tests/script/__init__.py
+++ b/tests/script/__init__.py
@@ -18,6 +18,10 @@ def serialize_non_canonical(
 ) -> bytes:
     """Serialize a number in [-1, 16] as data, asserting the warning.
 
+    Zero excepted: its push is OP_0's byte already, so `serialize` writes
+    it without a word and calling this for it would fail on the missing
+    warning (issue #746).
+
     Both serializers suggest the one-byte op code that means the same,
     and the tests calling this push the number as data on purpose;
     `serializer` says which of the two is under test. Asserting the

--- a/tests/script/script_test.py
+++ b/tests/script/script_test.py
@@ -138,7 +138,11 @@ def test_a_data_command_is_never_a_numeric_op_code() -> None:
     # the only value in the set for which reaching for the op code would
     # change what lands on the stack, and not merely how it is spelled
     assert serialize([b"\x00"]) == b"\x01\x00"
-    assert serialize_non_canonical([0]) == b"\x01\x00"
+
+    # and the *integer* 0 is a number, not that byte: `encode_num` writes
+    # it as no bytes, so it takes the same road every other integer takes
+    # and lands on the empty push, which is OP_0 (issue #746)
+    assert serialize([0]) == BYTE_FROM_OP_CODE_NAME["OP_0"]
 
     # what parse hands back for such a push is its hex, and serializing
     # that writes the push it read: the round trip is what a substitution
@@ -312,16 +316,17 @@ def test_regressions() -> None:
         ["OP_1NEGATE"],
         [0x81],
         ["81"],
+        [0],
     ]
     for s in script_list:
         serialized = serialize(s)
         assert serialize(parse(serialized)) == serialized
 
-    # the three regressions that serialize() warns about, kept apart from
+    # the two regressions that serialize() warns about, kept apart from
     # the others so that the warning is asserted rather than ignored: a
     # simplefilter("ignore") around the loop above would hide it, and
     # with it any other warning the loop raises
-    non_canonical: list[ScriptList] = [[1], [0], [-1]]
+    non_canonical: list[ScriptList] = [[1], [-1]]
     for s in non_canonical:
         serialized = serialize_non_canonical(s)
         assert serialize(parse(serialized)) == serialized
@@ -338,10 +343,14 @@ def test_null_serialization() -> None:
     assert parse(serialize([b""])) == ["OP_0"]
     assert parse(serialize([b" "])) == ["20"]
 
-    # 0 and 16 have a one-byte op code, so pushing them as data warns
-    assert serialize_non_canonical([0]) == b"\x01\x00"
-    assert parse(serialize_non_canonical([0])) == ["00"]
+    # the integer 0 is written as OP_0 and warns not: encode_num writes
+    # it as no bytes at all, so its minimal push is that op code's byte
+    # (issue #746)
+    assert serialize([0]) == b"\x00"
+    assert parse(serialize([0])) == ["OP_0"]
 
+    # 16 has a one-byte op code and a number of its own to push, so
+    # pushing it as data warns
     assert serialize_non_canonical([16]) == b"\x01\x10"
     assert parse(serialize_non_canonical([16])) == ["10"]
 
@@ -366,12 +375,16 @@ def test_op_int_serialization() -> None:
 
 
 def test_integer_serialization() -> None:
-    """Verify integers parse back as data, warned only in [0, 16]."""
+    """Verify integers parse back as data, warned only in [1, 16]."""
     assert parse(b"\x00") == ["OP_0"]
 
-    # [0, 16] is exactly the range with a shorter op code form, so every
+    # the integer 0 is the OP_0 Core's `CScript() << 0` writes, and the
+    # only value in [0, 16] whose push is the op code rather than one
+    # byte longer than it (issue #746)
+    assert serialize([0]) == b"\x00"
+
+    # [1, 16] is what is left with a shorter op code form, so every
     # serialize() below warns; from 17 on, none does
-    assert serialize_non_canonical([0]) != b"\x00"
     for i in range(1, 17):
         serialized_int = serialize_non_canonical([i])
         assert [hex_string(i)] == parse(serialized_int)

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -390,11 +390,17 @@ def test_serialization() -> None:
     script: ScriptList = ["OP_SUCCESS80", b"\x01\x01\x01"]
     assert parse(serialize(script)) == script
 
-    # -1 and [0, 16] are the integers with a one-byte op code, so every
-    # serialize() below pushes data where an op code would do and warns
+    # -1 and [1, 16] are the integers whose push is one byte longer than
+    # the op code meaning the same, so every serialize() below pushes
+    # data where an op code would do and warns
     assert parse(serialize_non_canonical([-1], serialize)) == ["81"]
-    for x in range(17):
+    for x in range(1, 17):
         assert parse(serialize_non_canonical([x], serialize)) == [f"{x:02X}"]
+
+    # 0 is not among them: encode_num writes it as no bytes, so its push
+    # is OP_0's own byte and there is nothing to warn about (issue #746)
+    assert serialize([0]) == b"\x00"
+    assert parse(serialize([0])) == ["OP_0"]
 
     for x in range(17, 100):
         assert parse(serialize([x])) == [f"{x:02X}"]

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -305,6 +305,34 @@ def test_ifdup_casts_to_bool() -> None:
     verify_script(script_bytes, [], 0, tx, 0, NO_FLAGS, False, True)
 
 
+def test_a_serialized_zero_is_a_number_the_interpreter_reads() -> None:
+    """What `serialize` writes for 0, the engine reads back as 0.
+
+    Which it did not: `encode_num(0)` was a single 0x00, so
+    `serialize([0])` wrote the push `0100` -- accepted as *data* by
+    CheckMinimalPush, and refused as a *number* by the very next op code
+    that reads one, both here and in Core (issue #746). It is OP_0 now,
+    by the ordinary path, a zero-length push being that op code's byte.
+    """
+    tx = Tx(check_validity=False)
+
+    # 0, OP_1ADD, OP_1, OP_NUMEQUAL: the number goes in through serialize
+    # and comes out through _to_num, with MINIMALDATA judging it
+    script_bytes = serialize([0, "OP_1ADD", "OP_1", "OP_NUMEQUAL"])
+    assert script_bytes == b"\x00\x8b\x51\x9c"
+    verify_script(script_bytes, [], 0, tx, 0, ScriptFlag.MINIMALDATA, False, True)
+
+    # the push it used to write, one byte longer and unspendable under a
+    # flag every relay path sets
+    non_minimal = b"\x01\x00" + script_bytes[1:]
+    with pytest.raises(ScriptError, match="non-minimal encoding of 0: 00"):
+        verify_script(non_minimal, [], 0, tx, 0, ScriptFlag.MINIMALDATA, False, True)
+
+    # a script number all the same where nothing asks for minimality,
+    # which is why the old spelling passed the vectors it passed
+    verify_script(non_minimal, [], 0, tx, 0, NO_FLAGS, False, True)
+
+
 @pytest.mark.parametrize(
     "script, message",
     [

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -149,10 +149,11 @@ def test_int_from_bits() -> None:
 
 def test_encode_num() -> None:
     """Round-trip script numbers across sign, zero and length boundaries."""
-    with pytest.raises(BTClibValueError, match="empty byte string"):
-        decode_num(b"")
-
-    # different representations of zero
+    # the three spellings of zero, and the null-length one is canonical:
+    # it is what encode_num writes, so the round trip closes at zero the
+    # way it closes everywhere else (issue #746)
+    assert encode_num(0) == b""
+    assert decode_num(b"") == 0
     assert decode_num(b"\x00") == 0  # "positive" zero
     assert decode_num(b"\x80") == 0  # "negative" zero
 
@@ -189,6 +190,26 @@ def test_encode_num() -> None:
     # 16 bits + sign bit = 17 bits = 3 byte (plus 1 byte for length)
     i = 0b1111111111111111
     assert len(encode_num(i)) == 3
+
+
+def test_zero_is_the_empty_vector_core_writes() -> None:
+    """Zero is no bytes at all, in both directions (issue #746).
+
+    Core's `CScriptNum::serialize` returns an empty vector for zero and
+    its `set_vch` answers zero for one, and the pair has to be that way
+    round: a single 0x00 is not a minimally encoded script number, so the
+    interpreter refuses it as one wherever MINIMALDATA is in force, and a
+    serializer writing it would be writing a number nothing can read
+    back.
+    """
+    assert encode_num(0) == b""
+    assert decode_num(b"") == 0
+
+    # what makes the other two spellings non-minimal is exactly this:
+    # they decode to zero and re-encode to something shorter
+    for non_minimal in (b"\x00", b"\x80"):
+        assert decode_num(non_minimal) == 0
+        assert encode_num(decode_num(non_minimal)) != non_minimal
 
 
 def test_encode_num_is_bounded_by_the_int64_of_a_script_number() -> None:


### PR DESCRIPTION
`encode_num(0)` returned `b"\x00"` where Core's `CScriptNum::serialize`
returns an empty vector, and `decode_num(b"")` raised where Core's
`set_vch` answers 0. Zero was the only value where the two disagreed,
and the disagreement was not cosmetic: `b"\x00"` is not a minimally
encoded script number, so the interpreter refuses it as one wherever
MINIMALDATA is in force -- Core on "non-minimally encoded script
number", btclib's own engine on "non-minimal encoding of 0: 00". So
`serialize([0])` wrote the push `0100`, carrying a number this library
would not read back, where `CScript() << 0` writes OP_0.

It writes that OP_0 now, and through the ordinary path rather than a
case of its own: a zero-length push is OP_0's byte already, which is
what issue #646's test calls the one place the two spellings coincide.
The warning goes with it for zero alone -- with nothing shorter to
suggest, "consider using OP_0 instead" would name what was just written
-- and stays at -1 and from 1 to 16, where the push really is one byte
longer than the op code.

The engine had `CScriptNum::serialize` written a second time to work
around this, `_from_num` being `b"" if x == 0 else encode_num(x)` and
`_to_num` carrying the matching empty-element branch. Both are gone,
`encode_num` and `decode_num` being the pair the engine always needed;
`miniscript._script_number` stops reading a `0100` push back as the
number 0, which is what Core's miniscript parser refuses.

Source-breaking, so HISTORY.md carries it: a caller pinning the bytes of
a script, a coinbase script_sig or a txid over either gets a different
answer, and the two mined blocks of `tests/block/mining_test.py` are
that -- their coinbase carries an extranonce of `encode_num(0)`, so the
nonces solving them moved.

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align script number zero encoding/decoding and script serialization with Bitcoin Core, making zero a canonical empty byte vector and updating interpreter, serialization behavior, and tests accordingly.

Bug Fixes:
- Fix non-minimal encoding of script number zero that caused MINIMALDATA failures and scripts that could not be interpreted as numbers.
- Correct mining tests whose expected nonces changed due to the new canonical encoding of zero in coinbase scripts.

Enhancements:
- Make encode_num/decode_num treat zero as an empty byte vector in both directions, matching Core’s CScriptNum semantics.
- Simplify the script engine by removing custom zero-handling helpers and consistently using encode_num for numeric pushes.
- Adjust script serialization and warning logic so integer 0 is serialized as OP_0 without emitting non-canonical encoding warnings.
- Update miniscript and taproot serialization/parsing behavior to respect the canonical empty-vector representation of zero.
- Extend and adjust tests to cover zero’s canonical encoding, interpreter behavior under MINIMALDATA, and updated serialization semantics.

Documentation:
- Document the new canonical encoding of script number zero and its impact in CHANGELOG.md and HISTORY.md, including source-breaking effects on script bytes and txids.

Tests:
- Update and expand script, utils, engine, taproot, and mining tests to reflect zero-as-empty-vector semantics and ensure compatibility with Core’s behavior.