### PR TITLE
Resolve a network name in one place, rather than index NETWORKS raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1525,6 +1525,42 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`network_from_name` is the one place a network name becomes a
+  `Network`** (issue #744), and fourteen call sites that indexed
+  `NETWORKS[network]` raw go through it. A name no network has was a bare
+  `KeyError`, which is a `LookupError`: no `except BTClibValueError`
+  written against this library caught it, so a caller filtering bad input
+  saw an exception nothing told it to expect. It is a `BTClibValueError`
+  naming the five now, and a non-string is a `BTClibTypeError` where
+  `network.strip()` used to raise `AttributeError`.
+
+  The call sites are `b58`'s `wif_from_prv_key` and `address_from_h160`,
+  `b32`'s `address_from_witness`, `to_prv_key.prv_keyinfo_from_prv_key`,
+  `to_pub_key`'s `pub_keyinfo_from_pub_key` and
+  `pub_keyinfo_from_prv_key`, the three `mxprv_from_mnemonic(s)` of
+  `bip39`, `electrum` and `slip39`, `bip85`, `descriptors.key_expression`
+  and `ecc.bms` -- and, through them, `p2pkh`, `p2sh`, `p2wpkh`, `p2wsh`,
+  `p2tr`, `p2wpkh_p2sh`, `p2wsh_p2sh`, `pub_keyinfo_from_key` and
+  `fingerprint`, which add no check of their own and are correct once
+  their root is.
+
+  **A name in any case, and spaced how it likes, is accepted where it used
+  to be refused.** `alias.py` said every `network: str` parameter runs
+  through `strip().lower()`; only `network.py`'s own three lookups did, so
+  `b32.address_from_witness(0, prog, "MAINNET")` raised where
+  `xpubversions_from_network("MAINNET")` worked. One converter is what
+  makes the promise true rather than repeated -- and that paragraph of
+  `alias.py`, along with its claim that a misspelled field name "matches
+  no network, so the lookup answers None", is corrected: it does not, and
+  it now raises.
+
+  `networks_from_key_value` refuses a `key` naming no field of `Network`
+  rather than scanning for it, `getattr` having raised `AttributeError`.
+  Answering `[]` was the alternative and is worse: a typo in a field name
+  would read as a fact about the prefix. `_NETWORK_FIELDS` is built from
+  `dataclasses.fields(Network)`, so it is `alias.NetworkField`'s Literal
+  at run time, for the callers mypy never sees.
+
 - **`BTClibException`, one name to catch for everything btclib raises**
   (issue #743). `btclib.exceptions` says its classes "exist only to tell
   an exception raised by btclib from one raised by any other code", and

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,19 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **a bad network name raises `BTClibValueError`, not `KeyError`.**
+  Every function taking a `network: str` -- `b58.p2pkh`, `b32.p2wpkh`,
+  `to_pub_key.fingerprint`, `bip39.mxprv_from_mnemonic` and the rest --
+  refused an unknown name with a bare `KeyError`, which is a
+  `LookupError` and so not caught by an `except BTClibValueError`. Code
+  catching `KeyError` around one of these has to catch
+  `BTClibValueError` instead; code already catching `BTClibValueError`
+  starts working. A non-string name is a `BTClibTypeError` where it was
+  an `AttributeError`. Nothing that worked stops working: the same call
+  with a good name is unchanged, and a name in the wrong case or with
+  spaces around it -- `"MAINNET"` to `b32.address_from_witness` -- is
+  accepted now where it used to raise.
+
 - **the individual point multiplications are private.** `from
   btclib.curves.curve_group import mult_jac` is an `ImportError` now, and
   so is every other variant of `curve_group` and `curve_group_2`: the

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -177,10 +177,12 @@ ScriptType = Literal[
 
 # A field name of network.Network, which the three *_from_key_value
 # lookups take as a str and resolve with getattr. The most fragile of
-# these vocabularies, and so a parameter type: a misspelled field name
-# matches no network, so the lookup answers None -- "no network carries
-# this prefix" -- where a misspelled network name at least raises
-# KeyError at the indexing. network_test.py checks the members against
+# these vocabularies, and so a parameter type: mypy holds a caller to
+# these seventeen, and `network._NETWORK_FIELDS` is the same vocabulary
+# at run time, for the callers mypy never sees -- a name outside it is a
+# BTClibValueError there rather than the AttributeError getattr would
+# raise, and rather than the empty list that would read as a fact about
+# the prefix. network_test.py checks the members against
 # dataclasses.fields(Network), the one thing mypy cannot check about a
 # name resolved with getattr.
 #
@@ -211,9 +213,12 @@ NetworkField = Literal[
 #
 # Still not a parameter type, and issue #216 is where that is decided: the
 # `network: str` parameters accept a name with spaces around it and in any
-# case -- `network.strip().lower()` is what they run it through -- so the
+# case -- `network.network_from_name` is what they run it through -- so the
 # set they take is wider than these five spellings, and narrowing the
 # annotation without dropping that tolerance would reject calls that work.
+# One converter and not a `strip().lower()` per call site, which is what
+# left b32 and the mnemonic modules indexing NETWORKS raw and refusing the
+# tolerance this paragraph promised (issue #744).
 # It names the five for a caller who wants mypy to hold them to it;
 # network.py annotates with it the tuple of names it loads, which is what
 # keeps this list equal to the data

--- a/btclib/b32.py
+++ b/btclib/b32.py
@@ -58,7 +58,7 @@ from btclib.alias import Octets, String
 from btclib.bech32 import decode, encode
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
-from btclib.network import NETWORKS, network_from_key_value
+from btclib.network import NETWORKS, network_from_key_value, network_from_name
 from btclib.to_pub_key import Key, pub_keyinfo_from_key
 from btclib.utils import bytes_from_octets
 
@@ -152,7 +152,7 @@ def address_from_witness(
     wit_ver: int, wit_prg: Octets, network: str = "mainnet"
 ) -> str:
     """Encode a bech32 native segwit address from the witness."""
-    hrp = NETWORKS[network].hrp
+    hrp = network_from_name(network).hrp
     return _address_from_witness(wit_ver, wit_prg, hrp)
 
 

--- a/btclib/b58.py
+++ b/btclib/b58.py
@@ -24,7 +24,7 @@ from btclib.base58 import decode as b58decode
 from btclib.base58 import encode as b58encode
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
-from btclib.network import NETWORKS, network_from_key_value
+from btclib.network import network_from_key_value, network_from_name
 from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
 from btclib.to_pub_key import Key, pub_keyinfo_from_key
 from btclib.utils import bytes_from_octets
@@ -51,10 +51,10 @@ def wif_from_prv_key(
     network = net if network is None else network
     compressed = compr if compressed is None else compressed
 
-    ec = NETWORKS[network].curve
+    ec = network_from_name(network).curve
     payload = b"".join(
         [
-            NETWORKS[network].wif,
+            network_from_name(network).wif,
             q.to_bytes(ec.n_size, byteorder="big", signed=False),
             b"\x01" if compressed else b"",
         ]
@@ -79,9 +79,9 @@ def address_from_h160(
     # spell it makes that a cast at every call site rather than a
     # message from here
     if script_type == "p2sh":
-        prefix = NETWORKS[network].p2sh
+        prefix = network_from_name(network).p2sh
     elif script_type == "p2pkh":
-        prefix = NETWORKS[network].p2pkh
+        prefix = network_from_name(network).p2pkh
     else:
         raise BTClibValueError(f"invalid script type: {script_type}")
 

--- a/btclib/bip85.py
+++ b/btclib/bip85.py
@@ -66,7 +66,7 @@ from btclib.bip32.der_path import (
 from btclib.exceptions import BTClibValueError
 from btclib.mnemonic.bip39 import mnemonic_from_entropy
 from btclib.mnemonic.mnemonic import Mnemonic
-from btclib.network import NETWORKS, network_from_xkeyversion
+from btclib.network import network_from_name, network_from_xkeyversion
 from btclib.utils import bytes_from_octets
 
 __all__ = [
@@ -305,7 +305,7 @@ def xprv_from_root_key(root_key: BIP32Key, index: int = 0) -> str:
     entropy = _entropy_from_der_path(xkey, f"m/{_PURPOSE}h/32h/{index}h")
     network = network_from_xkeyversion(xkey.version)
     derived = BIP32KeyData(
-        version=NETWORKS[network].bip32_prv,
+        version=network_from_name(network).bip32_prv,
         depth=0,
         parent_fingerprint=b"\x00" * 4,
         index=0,

--- a/btclib/descriptors/key_expression.py
+++ b/btclib/descriptors/key_expression.py
@@ -50,7 +50,7 @@ from btclib.curves import secp256k1
 from btclib.curves.sec_point import bytes_from_point
 from btclib.ecc.musig2 import key_agg, key_sort
 from btclib.exceptions import BTClibValueError
-from btclib.network import NETWORKS
+from btclib.network import network_from_name
 from btclib.to_pub_key import point_from_pub_key, pub_keyinfo_from_key
 from btclib.utils import bytes_from_octets
 
@@ -174,7 +174,7 @@ class KeyExpression:
             if not musig_path:
                 return aggregate
             synthetic = BIP32KeyData(
-                version=NETWORKS[network].bip32_pub,
+                version=network_from_name(network).bip32_pub,
                 depth=0,
                 parent_fingerprint=b"\x00" * 4,
                 index=0,

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -124,7 +124,7 @@ from btclib.ecc import dsa
 from btclib.ecc.dsa import _libsecp256k1_recover_sec_
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import hash160, magic_message, reduce_to_hlen
-from btclib.network import NETWORKS
+from btclib.network import network_from_name
 from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
 from btclib.utils import assert_no_trailing, bytesio_from_binarydata
 
@@ -266,7 +266,7 @@ def gen_keys(
     if prv_key is None:
         if network is None:
             network = "mainnet"
-        ec = NETWORKS[network].curve
+        ec = network_from_name(network).curve
         # q in the range [1, ec.n-1]
         prv_key = 1 + secrets.randbelow(ec.n - 1)
 

--- a/btclib/mnemonic/bip39.py
+++ b/btclib/mnemonic/bip39.py
@@ -73,7 +73,7 @@ from btclib.mnemonic.mnemonic import (
     mnemonic_from_indexes,
     normalize_mnemonic,
 )
-from btclib.network import NETWORKS
+from btclib.network import network_from_name
 
 __all__ = [
     "entropy_from_mnemonic",
@@ -302,5 +302,5 @@ def mxprv_from_mnemonic(
 ) -> str:
     """Return BIP32 root master extended private key from BIP39 mnemonic."""
     seed = seed_from_mnemonic(mnemonic, passphrase or "", verify_checksum)
-    version = NETWORKS[network].bip32_prv
+    version = network_from_name(network).bip32_prv
     return rootxprv_from_seed(seed, version)

--- a/btclib/mnemonic/electrum.py
+++ b/btclib/mnemonic/electrum.py
@@ -81,7 +81,7 @@ from btclib.mnemonic.mnemonic import (
     indexes_from_mnemonic,
     mnemonic_from_indexes,
 )
-from btclib.network import NETWORKS
+from btclib.network import network_from_name
 from btclib.to_prv_key import int_from_prv_key
 
 __all__ = [
@@ -571,10 +571,10 @@ def mxprv_from_mnemonic(
     version, seed = _seed_from_mnemonic(mnemonic, passphrase or "")
 
     if version == "standard":
-        xversion = NETWORKS[network].bip32_prv
+        xversion = network_from_name(network).bip32_prv
         return rootxprv_from_seed(seed, xversion)
     if version == "segwit":
-        xversion = NETWORKS[network].slip132_p2wpkh_prv
+        xversion = network_from_name(network).slip132_p2wpkh_prv
         rootxprv = rootxprv_from_seed(seed, xversion)
         return derive(rootxprv, _HARDENED_OFFSET)  # "m/0h"
     err_msg = f"unmanaged electrum mnemonic version: {version}"

--- a/btclib/mnemonic/slip39.py
+++ b/btclib/mnemonic/slip39.py
@@ -68,7 +68,7 @@ from btclib.mnemonic.mnemonic import (
     indexes_from_mnemonic,
     mnemonic_from_indexes,
 )
-from btclib.network import NETWORKS
+from btclib.network import network_from_name
 from btclib.utils import bytes_from_octets
 
 __all__ = [
@@ -661,5 +661,5 @@ def mxprv_from_mnemonics(
     between the two: SLIP-0039 backs up the seed itself.
     """
     seed = master_secret_from_mnemonics(mnemonics, passphrase or "")
-    version = NETWORKS[network].bip32_prv
+    version = network_from_name(network).bip32_prv
     return rootxprv_from_seed(seed, version)

--- a/btclib/network.py
+++ b/btclib/network.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
 from pathlib import Path
 from types import MappingProxyType
 from typing import Any
@@ -51,6 +51,7 @@ __all__ = [
     "Network",
     "curve_from_xkeyversion",
     "network_from_key_value",
+    "network_from_name",
     "network_from_xkeyversion",
     "network_type_from_key_value",
     "network_type_from_network",
@@ -324,6 +325,12 @@ for _net in _network_names:
 # callers do with it, and all four are what a mapping is
 NETWORKS: Mapping[str, Network] = MappingProxyType(_networks)
 
+# what a `key: NetworkField` may name, off the dataclass rather than off
+# alias.NetworkField's Literal: the Literal is what mypy holds a caller
+# to, and this is the same vocabulary at run time, for the callers mypy
+# never sees. network_test.py asserts the two are the same set
+_NETWORK_FIELDS = frozenset(field.name for field in fields(Network))
+
 
 # Everything below is derived from NETWORKS, in one pass over it, because
 # every one of these questions is "which network carries these bytes" asked
@@ -419,7 +426,17 @@ def networks_from_key_value(
     unhashable one with a TypeError where the comparison answers "no
     network carries this". Five networks and one `getattr` each is what
     that costs.
+
+    A `key` that names no field of Network is refused rather than scanned
+    for: `getattr` would raise `AttributeError`, which is neither a
+    `ValueError` nor something a caller of this library is told to catch,
+    and answering `[]` instead -- "no network carries this prefix" -- would
+    be worse, a typo in a field name reading as a fact about the prefix.
     """
+    if key not in _NETWORK_FIELDS:
+        err_msg = f"unknown network field: '{key}'"
+        err_msg += f"; it must be one of {sorted(_NETWORK_FIELDS)}"
+        raise BTClibValueError(err_msg)
     return [
         network_str
         for network_str, network in NETWORKS.items()
@@ -458,10 +475,45 @@ def network_type_from_key_value(
     return NETWORKS[networks[0]].network_type if networks else None
 
 
+def _validated_network_name(network: str) -> str:
+    """Return the name of a network, normalized, or refuse it.
+
+    `strip().lower()` is the tolerance issue #216 decided to keep, and the
+    reason `alias.NetworkName` is not the annotation of a `network`
+    parameter: the set accepted is wider than the five spellings it
+    names.
+    """
+    if not isinstance(network, str):
+        raise BTClibTypeError(f"not a network name: {network!r}")
+    name = network.strip().lower()
+    if name not in NETWORKS:
+        err_msg = f"unknown network: '{network}'"
+        err_msg += f"; it must be one of {sorted(NETWORKS)}"
+        raise BTClibValueError(err_msg)
+    return name
+
+
+def network_from_name(network: str = "mainnet") -> Network:
+    """Return the Network a name names, in any case and spaced how it likes.
+
+    The one place a `network: str` becomes a `Network`, and what every
+    caller of a network name should reach for rather than indexing
+    `NETWORKS` itself: a name no network has is refused here, where
+    `NETWORKS[network]` answers a bare `KeyError`. That matters beyond
+    tidiness, `KeyError` being a `LookupError` -- so no `except
+    BTClibValueError` written against this library catches it, and a
+    caller filtering bad input sees an exception nothing told it to
+    expect.
+
+    `NETWORKS` stays exported for a caller iterating the five, which is a
+    different question from resolving one name.
+    """
+    return NETWORKS[_validated_network_name(network)]
+
+
 def network_type_from_network(network: str = "mainnet") -> NetworkType:
     """Return the "main"/"test" type of a network name."""
-    network = network.strip().lower()
-    return NETWORKS[network].network_type
+    return network_from_name(network).network_type
 
 
 def xpubversions_from_network(network: str = "mainnet") -> list[bytes]:
@@ -471,12 +523,12 @@ def xpubversions_from_network(network: str = "mainnet") -> list[bytes]:
     or trimming the answer is not editing the table every other lookup
     reads.
     """
-    return list(_XPUB_VERSIONS[network.strip().lower()])
+    return list(_XPUB_VERSIONS[_validated_network_name(network)])
 
 
 def xprvversions_from_network(network: str = "mainnet") -> list[bytes]:
     """Return every xprv version of the network, BIP32 and SLIP132."""
-    return list(_XPRV_VERSIONS[network.strip().lower()])
+    return list(_XPRV_VERSIONS[_validated_network_name(network)])
 
 
 def xpubversion_from_xprvversion(xprvversion: bytes) -> bytes:

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -16,8 +16,8 @@ from btclib.exceptions import (
     NotAPrvKeyError,
 )
 from btclib.network import (
-    NETWORKS,
     network_from_key_value,
+    network_from_name,
     network_from_xkeyversion,
     xprvversions_from_network,
 )
@@ -97,7 +97,7 @@ def int_from_prv_key(prv_key: PrvKey, ec: Curve = secp256k1) -> int:
 
 def _q_if_network_and_ec_match(q: int, network: str, ec: Curve) -> int:
     # q has been validated on the xprv/wif network
-    ec2 = NETWORKS[network].curve
+    ec2 = network_from_name(network).curve
     if ec != ec2:
         raise BTClibValueError(f"ec / network ({network}) mismatch")
     return q
@@ -127,7 +127,7 @@ def _wif_network(prefix: bytes, network: str | None) -> str:
     # reject a signet WIF as "not a signet wif: prefix 0xef" --
     # naming the very prefix signet asks for (issue #207).
     # _prv_keyinfo_from_xprv below makes the same membership check
-    if prefix != NETWORKS[network].wif:
+    if prefix != network_from_name(network).wif:
         raise InvalidPrvKeyError(f"not a {network} wif: prefix 0x{prefix.hex()}")
     # the declared network, not the lookup's guess: for a caller who
     # said "signet" the answer is signet, and it is the one that ends
@@ -198,7 +198,7 @@ def _prv_keyinfo_from_wif(
     # is a fault in a WIF: InvalidPrvKeyError, which the format-guessing
     # callers let through instead of trying the input as something else
     net = _wif_network(payload[:1], network)
-    ec = NETWORKS[net].curve
+    ec = network_from_name(net).curve
     prv_key, compr = _wif_prv_key_and_compression(payload, ec.n_size, compressed)
 
     q = int.from_bytes(prv_key, byteorder="big")
@@ -296,7 +296,7 @@ def prv_keyinfo_from_prv_key(
     """
     compr = True if compressed is None else compressed
     net = "mainnet" if network is None else network
-    ec = NETWORKS[net].curve
+    ec = network_from_name(net).curve
 
     if isinstance(prv_key, int):
         q = prv_key

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -22,8 +22,8 @@ from btclib.curves.sec_point import _sec_from_octets
 from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import (
-    NETWORKS,
     curve_from_xkeyversion,
+    network_from_name,
     network_from_xkeyversion,
     xpubversions_from_network,
 )
@@ -84,7 +84,7 @@ def point_from_key(key: Key, ec: Curve = secp256k1) -> Point:
     except BTClibValueError:
         pass
     else:
-        if ec != NETWORKS[net].curve:
+        if ec != network_from_name(net).curve:
             raise BTClibValueError("Curve mismatch")
         return mult(q, ec.G, ec)
 
@@ -184,7 +184,7 @@ def pub_keyinfo_from_pub_key(
     """Return the pub key tuple (SEC-bytes, network) from a public key."""
     compr = True if compressed is None else compressed
     net = "mainnet" if network is None else network
-    ec = NETWORKS[net].curve
+    ec = network_from_name(net).curve
 
     if isinstance(pub_key, tuple):
         return bytes_from_point(pub_key, ec, compr), net
@@ -215,7 +215,7 @@ def pub_keyinfo_from_prv_key(
 ) -> PubkeyInfo:
     """Return the pub key tuple (SEC-bytes, network) from a private key."""
     q, net, compr = prv_keyinfo_from_prv_key(prv_key, network, compressed)
-    ec = NETWORKS[net].curve
+    ec = network_from_name(net).curve
     return bytes_from_prv_key_int(q, ec, compr), net
 
 

--- a/tests/b32_test.py
+++ b/tests/b32_test.py
@@ -199,20 +199,23 @@ def test_invalid_address() -> None:
 def test_invalid_address_enc() -> None:
     """Test whether address encoding fails on invalid input."""
     invalid_address_enc = [
-        ("MAINNET", 0, 20, "'MAINNET'"),
+        ("nosuchnet", 0, 20, "unknown network"),
         ("mainnet", 0, 21, "invalid size: "),
         ("mainnet", 17, 32, "invalid witness version: "),
         ("mainnet", 1, 1, "invalid size: "),
         ("mainnet", 16, 41, "invalid size: "),
     ]
 
-    network, wit_ver, length, err_msg = invalid_address_enc[0]
-    with pytest.raises(KeyError, match=err_msg):
-        b32.address_from_witness(wit_ver, "0A" * length, network)
-
-    for network, wit_ver, length, err_msg in invalid_address_enc[1:]:
+    for network, wit_ver, length, err_msg in invalid_address_enc:
         with pytest.raises(BTClibValueError, match=err_msg):
             b32.address_from_witness(wit_ver, "0A" * length, network)
+
+    # "MAINNET" is not among them any more: the case and space tolerance
+    # alias.py documents for every `network: str` is now applied here as
+    # well, where NETWORKS[network] used to be indexed raw (issue #744)
+    assert b32.address_from_witness(0, "0A" * 20, " MainNet ") == (
+        b32.address_from_witness(0, "0A" * 20, "mainnet")
+    )
 
 
 def test_address_witness() -> None:

--- a/tests/network_test.py
+++ b/tests/network_test.py
@@ -17,6 +17,7 @@ from btclib.network import (
     Network,
     curve_from_xkeyversion,
     network_from_key_value,
+    network_from_name,
     network_from_xkeyversion,
     network_type_from_key_value,
     network_type_from_network,
@@ -106,9 +107,18 @@ def test_space_and_caps() -> None:
     net = " MainNet "
     assert xpubversions_from_network(net), f"unknown network: {net}"
 
-    with pytest.raises(KeyError):
+    # a BTClibValueError and not the bare KeyError of an unguarded
+    # NETWORKS[...]: a LookupError is not caught by an `except
+    # BTClibValueError` written against this library (issue #744)
+    with pytest.raises(BTClibValueError, match="unknown network"):
         net = " MainNet2 "
         xpubversions_from_network(net)
+
+    with pytest.raises(BTClibValueError, match="unknown network"):
+        xprvversions_from_network("nosuchnet")
+
+    with pytest.raises(BTClibTypeError, match="not a network name"):
+        xpubversions_from_network(42)  # type: ignore[arg-type]
 
 
 def test_numbers_of_networks() -> None:
@@ -299,7 +309,7 @@ def test_network_type_from_network() -> None:
     assert network_type_from_network(" MainNet ") == "main"
     for name in ("testnet", "regtest", "signet", "testnet4"):
         assert network_type_from_network(name) == "test"
-    with pytest.raises(KeyError):
+    with pytest.raises(BTClibValueError, match="unknown network"):
         network_type_from_network("nosuchnet")
 
 
@@ -351,3 +361,51 @@ def test_the_literal_vocabularies_name_the_data() -> None:
     """
     assert set(get_args(NetworkField)) == {field.name for field in fields(Network)}
     assert set(get_args(NetworkName)) == set(NETWORKS)
+
+
+def test_a_network_name_no_network_has_is_refused() -> None:
+    """`network_from_name` is the one place a name becomes a Network.
+
+    A BTClibValueError and not the bare KeyError of `NETWORKS[name]`:
+    KeyError is a LookupError, so a caller filtering bad input with an
+    `except BTClibValueError` -- which is what this library's own
+    docstrings tell it to write -- did not catch it (issue #744). The
+    message names the five, a typo being the case it exists for.
+    """
+    for name in NETWORKS:
+        assert network_from_name(name) is NETWORKS[name]
+    # the tolerance issue #216 decided to keep
+    assert network_from_name(" MainNet ") is NETWORKS["mainnet"]
+    assert network_from_name() is NETWORKS["mainnet"]
+
+    with pytest.raises(BTClibValueError, match="unknown network"):
+        network_from_name("nosuchnet")
+    with pytest.raises(BTClibValueError, match="mainnet"):
+        network_from_name("")
+    with pytest.raises(BTClibTypeError, match="not a network name"):
+        network_from_name(42)  # type: ignore[arg-type]
+    with pytest.raises(BTClibTypeError, match="not a network name"):
+        network_from_name(None)  # type: ignore[arg-type]
+
+
+def test_a_field_no_network_has_is_refused_rather_than_scanned_for() -> None:
+    """A misspelled field name is not the fact that no network carries it.
+
+    `getattr` raised AttributeError, and answering `[]` instead would have
+    been worse: `alias.py` claimed that was the behaviour -- "a misspelled
+    field name matches no network, so the lookup answers None" -- which
+    would make a typo read as a statement about the prefix (issue #744).
+    """
+    err_msg = "unknown network field"
+    for key in ("nosuchfield", "", "Curve", "datadir"):
+        with pytest.raises(BTClibValueError, match=err_msg):
+            networks_from_key_value(key, b"\x00")  # type: ignore[arg-type]
+        with pytest.raises(BTClibValueError, match=err_msg):
+            network_from_key_value(key, b"\x00")  # type: ignore[arg-type]
+        with pytest.raises(BTClibValueError, match=err_msg):
+            network_type_from_key_value(key, b"\x00")  # type: ignore[arg-type]
+
+    # every field of the dataclass is one, which is the set the run-time
+    # check is built from and the one NetworkField names for mypy
+    for field in fields(Network):
+        assert networks_from_key_value(field.name, object()) == []  # type: ignore[arg-type]


### PR DESCRIPTION
A name no network has was a bare KeyError, which is a LookupError: no
`except BTClibValueError` written against this library caught it, so a
caller filtering bad input saw an exception nothing told it to expect.
network_from_name is the one place a `network: str` becomes a Network
now, and the fourteen call sites that indexed NETWORKS[network] go
through it.

b58's wif_from_prv_key and address_from_h160, b32's
address_from_witness, to_prv_key.prv_keyinfo_from_prv_key, to_pub_key's
pub_keyinfo_from_pub_key and pub_keyinfo_from_prv_key, the three
mxprv_from_mnemonic(s) of bip39, electrum and slip39, bip85,
descriptors.key_expression and ecc.bms -- and, through them, p2pkh,
p2sh, p2wpkh, p2wsh, p2tr, p2wpkh_p2sh, p2wsh_p2sh, pub_keyinfo_from_key
and fingerprint, which add no check of their own and are correct once
their root is. A non-string name is a BTClibTypeError where
network.strip() used to raise AttributeError.

A name in any case, and spaced how it likes, is accepted where it used
to be refused. alias.py said every `network: str` parameter runs through
strip().lower(); only network.py's own three lookups did, so
b32.address_from_witness(0, prog, "MAINNET") raised where
xpubversions_from_network("MAINNET") worked. One converter is what makes
that promise true rather than repeated, and the paragraph claiming it is
corrected with the code.

networks_from_key_value refuses a `key` naming no field of Network
rather than scanning for it, getattr having raised AttributeError.
Answering [] was the alternative and is worse: a typo in a field name
would read as a fact about the prefix -- which is what alias.py claimed
happened, and did not. _NETWORK_FIELDS comes from
dataclasses.fields(Network), so it is alias.NetworkField's Literal at run
time, for the callers mypy never sees.

Two tests asserted the old behaviour and assert the new one: network_test
on the KeyError, and b32_test on "MAINNET" being refused -- which was the
inconsistency, not the rule.

The first slice of issue 744's census. Twelve of its places answer a
malformed input with a wrong answer and no exception at all, and are the
more urgent work; they are unrelated fixes and are not in this.

Gates, all green locally: `uv run pytest` at 26087 passed with coverage
100.00%, `uv run pre-commit run --all-files`, and the sphinx -W build.

Part of https://github.com/btclib-org/btclib/issues/744

The first of https://github.com/btclib-org/btclib/issues/744's slices. It followed https://github.com/btclib-org/btclib/pull/748 and https://github.com/btclib-org/btclib/pull/755 in a stack; both merged while this was being written, so it is rebased onto `main` and stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Normalize and centralize resolution of network names across the library so invalid or mistyped names raise btclib-specific exceptions instead of raw KeyError, and align runtime behaviour with documented alias and network vocabularies.

Bug Fixes:
- Ensure unknown or malformed network names consistently raise BTClibValueError/BTClibTypeError instead of leaking bare KeyError or AttributeError to callers.
- Fix inconsistency where some functions accepted case/space-variant network names while others rejected them, applying documented normalization uniformly.

Enhancements:
- Introduce network_from_name as the single entry point for resolving string network names to Network objects and update existing call sites to use it.
- Add runtime validation of network field keys via a dataclass-derived field set so misspelled field names are rejected explicitly rather than silently returning no matches.

Documentation:
- Update alias, HISTORY, and CHANGELOG documentation to describe the new network name resolution behaviour, tightened error semantics, and the runtime validation of network field names.

Tests:
- Extend and adjust network and b32 tests to cover the new error types, name normalization behaviour, and validation of network field keys against the dataclass fields.