### PR TITLE
Advertise BIP85 where a reader looks for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2492,6 +2492,21 @@ documented at release-notes length in the first place, and are still in
   format of its own; the direction that was refused for being ambiguous is
   the one that stays refused.
 
+### Documentation and the website
+
+- **The feature list advertises BIP85**, which it had not: README.md is
+  the btclib.org homepage and the PyPI long description, so the list
+  under "Included features are" is where a reader learns what is here,
+  and the only two mentions of `bip85` in that file were in the module
+  layout underneath it. `docs/proposals/cli.md` had the converse gap and
+  the same cause: its command tree is `__all__` minus the recorded
+  exclusions, and a published module of eleven names appeared in neither
+  its Phase 2 inventory nor that list. It carries the `bip85` group now,
+  and one decision the group is the first to raise -- `BIP85DRNG` is a
+  reader over a stream, so `drng-from-der-path` and
+  `rsa-drng-from-root-key` return a value that nothing in the output
+  rules prints until a length is named.
+
 ### Tests
 
 - **The 88 high-s vectors are pinned, not assumed** (#695). Every vector

--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ Included features are:
   key versions (xprv, yprv, zprv, Yprv, Zprv, tprv, uprv, vprv, and Uprv)
   with corresponding mapping to
   p2pkh/p2sh, p2wpkh-p2sh, p2wpkh, p2wsh-p2sh, p2wsh and p2tr addresses
+- [BIP85](https://github.com/bitcoin/bips/blob/master/bip-0085.mediawiki)
+  deterministic entropy: one root key behind many wallets, a hardened
+  path saying which, and each application taking what it needs of the 512
+  bits it reaches — a BIP39 mnemonic, the Bitcoin Core `hdseed` WIF, an
+  xprv, raw bytes, a base64 or base85 password, dice rolls, and the
+  SHAKE256 stream an RSA key generator reads
 - [BIP352](https://github.com/bitcoin/bips/blob/master/bip-0352.mediawiki)
   silent payments: one reusable bech32m address, and a different taproot
   output for every payment to it — the sender's outputs, the receiver's

--- a/docs/proposals/cli.md
+++ b/docs/proposals/cli.md
@@ -559,6 +559,12 @@ bip32         rootxprv-from-seed  xpub-from-xprv  derive
 slip132       address-from-xkey  address-from-xpub  p2pkh-xkey
               p2wpkh-xkey  p2wpkh-p2sh-xkey
 bip44         address-from-der-path
+bip85         entropy-from-der-path  mnemonic-from-root-key
+              wif-from-root-key  xprv-from-root-key
+              bytes-entropy-from-root-key  rolls-from-root-key
+              base64-password-from-root-key
+              base85-password-from-root-key
+              drng-from-der-path  rsa-drng-from-root-key
 mnemonic bip39
               mnemonic-from-entropy  entropy-from-mnemonic
               seed-from-mnemonic  mxprv-from-mnemonic
@@ -581,6 +587,13 @@ mnemonic      collect-rolls  bin-str-entropy-from-rolls
 module already prompts with `input()` and already has the T201 exemption
 that says so. It is the exception the rest of the design is measured
 against, not a precedent.
+
+`bip85` is where the class rule above meets a type with no text form of
+its own. `BIP85DRNG` is a reader over a SHAKE256 stream, so its receiver
+is the 64 entropy bytes as hex and its one method is `read`; and
+`drng-from-der-path` and `rsa-drng-from-root-key` return that reader
+rather than a value, which no rule in "Output, streams and exit codes"
+prints. The decision below is how much of the stream a command squeezes.
 
 ### Phase 3: signatures, PSBT, the script engine
 
@@ -765,6 +778,12 @@ repository, not this one, releases and versions.
    function. Either the CLI keeps a private one — the only CLI-only
    vocabulary in the design — or `btclib.hashes` grows one, which the
    library itself could then use in its own error messages.
+1. **What does a command that returns a stream print?** BIP85's DRNG is
+   the first published type that is neither a value nor a dataclass:
+   `btclib bip85 drng-from-der-path` has nothing to print until a length
+   is named. Either those two commands take a `--num-bytes`, which is an
+   option no parameter of the function corresponds to, or the group
+   exposes `BIP85DRNG.read` alone and the path is spelled twice.
 1. **Is `--json` off by default, or on?** Off reads better for a human
    and pipes better for `$(...)`; on gives a script one shape everywhere.
 1. **Does `fetch` get a write path?** `broadcast` is one method, and it


### PR DESCRIPTION
Two places that should have named BIP85 after
https://github.com/btclib-org/btclib/pull/741 and
https://github.com/btclib-org/btclib/pull/751 landed
https://github.com/btclib-org/btclib/issues/644, and did not.

**1. README.md's feature list.** That file is the btclib.org homepage and
the PyPI long description, so the list under "Included features are" is
where a reader learns what the library holds — BIP32, BIP39, Electrum,
SLIP39, BIP44, SLIP132, BIP352 and the rest each have their bullet. The
only two mentions of `bip85` in the file were in the module layout
underneath the list. It has its bullet now, beside SLIP132, naming what
each application hands back.

**2. `docs/proposals/cli.md`.** The converse gap, same cause: that
document's rule is that the command tree is `__all__` minus the recorded
exclusions, and its exclusion table is empty, so a published module of
eleven names is eleven commands. `bip85` appeared in neither the Phase 2
inventory nor that table. The group is in the inventory now.

One decision comes with it, recorded rather than settled, in the
document's own "The decisions this needs" list: `BIP85DRNG` is a reader
over a SHAKE256 stream, so its receiver is the 64 entropy bytes and its
one method is `read` — and `drng-from-der-path` and
`rsa-drng-from-root-key` return that reader, which is neither a value
nor a dataclass and so is printed by no rule in "Output, streams and
exit codes" until a length is named. Either the two commands take a
`--num-bytes` that no parameter of the function corresponds to, or the
group exposes `BIP85DRNG.read` alone and the path is spelled twice.

Nothing here changes behaviour: three files of prose, and a CHANGELOG
bullet under a "Documentation and the website" group for this release.

Filed alongside https://github.com/btclib-org/btclib/issues/759, which is
the other thing BIP85 left open — btclib now converts dice to entropy and
entropy to dice in two modules that say nothing about each other, and one
of the two computes bits per roll with a float that stops being exact at
2**49 - 1.

**Gates**, all run locally on this branch:

- `uv run pytest` — 26455 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0

## Summary by Sourcery

Document BIP85 support prominently in user-facing docs and record its CLI implications.

Documentation:
- Add BIP85 to the README feature list with a description of its deterministic entropy use cases.
- Include the bip85 command group and its subcommands in the CLI proposal Phase 2 inventory, noting the DRNG output-stream decision.
- Document in the CLI design that BIP85DRNG-based commands return a stream and require a decision on how much of it to print.

Chores:
- Record these documentation updates and the outstanding BIP85 CLI output decision under a new "Documentation and the website" section in the changelog.