### PR TITLE
Make bytes_from_octets the whole of what Octets means

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1658,6 +1658,43 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`bytes_from_octets` is the whole of what `Octets` means, and it is
+  total** (issue #744). It is the coercion every `Octets` parameter of
+  the library runs through, and it had two holes: a hex string that is
+  not one left through `bytes.fromhex`'s bare `ValueError`, and anything
+  that was not a `str` went through *untouched* -- so `len` of a tuple
+  of 33 ints was 33, which is how
+  `taproot.assert_valid_control_block` accepted one as a control block
+  size. Both are refused now, as `BTClibValueError` and
+  `BTClibTypeError`; every buffer is still taken, and returned as it
+  came, a read being no place to rewrite the field it reads.
+
+  The message is `bytes.fromhex`'s own, which names a position and never
+  the string. That is deliberate: an `Octets` parameter is candidate key
+  material as often as not, and `to_prv_key` puts this very message
+  inside its own "not a private key" (issue #137).
+
+  `int_from_integer` gets both through it, and `to_prv_key`'s two "it
+  must be octets" fallbacks now catch a `TypeError` beside the
+  `ValueError`, as `to_pub_key` already did: what is neither octets nor
+  a spelling of them means the same thing a wrong size does.
+
+  `mnemonic.entropy`'s five `int(x, 2)` parses and its two `int(x, 16)`
+  and `int(x)` ones are `BTClibValueError` too, and say a base rather
+  than the digits -- raw entropy being seed material, as every other
+  message in that module already assumed. `borromean.sign` checks that
+  its rings, signing indexes and nonces are of one length rather than
+  leaving it to `zip(strict=True)`, whose message named "argument 3" and
+  no parameter of the function; `strict=True` stays, as the assertion
+  that the check and the loops cannot drift apart.
+
+  **What moves for a caller**: the class is narrower and the control
+  flow identical, `BTClibValueError` being a `ValueError` and
+  `BTClibTypeError` a `TypeError`. A test or a caller matching on
+  `bytes.fromhex`'s message still matches -- it is carried through --
+  and one matching the *class* now has a btclib one to match.
+  `docs/source/guide.rst` shows the new spelling.
+
 - **Ten places in `block/`, `hashes` and `utils` asked a value what it
   is not** (issue #744): a comparison, an arithmetic operation or an
   attribute lookup on an argument nothing had checked. `"5" <= 16`,

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -33,6 +33,29 @@ full year, short month, short day (YYYY-M-D)
   spaces around it -- `"MAINNET"` to `b32.address_from_witness` -- is
   accepted now where it used to raise.
 
+- **a malformed argument raises a btclib error, not a native one.** The
+  rest of issue #744's census, and the same move the network name above
+  made: an out-of-range derivation index was an `OverflowError`, an
+  out-of-range `vin_i` an `IndexError`, a header timestamp that is no
+  datetime an `AttributeError`, a hex string that is not one a bare
+  `ValueError`. Each is a `BTClibValueError` or a `BTClibTypeError` now.
+  Code catching `ValueError` or `TypeError` keeps working, the two
+  deriving from those; code catching `OverflowError`, `IndexError` or
+  `AttributeError` around one of these has to catch `BTClibException`,
+  or one of the two builtins, instead.
+
+  Two of them are not a narrowing, and are what to act on. What is
+  neither `bytes` nor a hex `str` is a `BTClibTypeError` where
+  `bytes_from_octets` used to return it untouched -- a tuple of 33 ints
+  passed `taproot.assert_valid_control_block` as a control block size,
+  and `bin_str_entropy_from_entropy(())` was reported as zero bits. And
+  a dozen calls that answered a malformed argument with a *number*
+  refuse it: `sig_hash.taproot` with an `input_index` past the end of
+  the vin, `taproot.input_script_sig` with a negative leaf index,
+  `bech32.encode` with a negative digit, `mod_inv` with a float,
+  `int_from_json_number` with 1.5, `Psbt.weight_estimate` on an
+  incoherent psbt. CHANGELOG.md lists all twelve.
+
 - **the individual point multiplications are private.** `from
   btclib.curves.curve_group import mult_jac` is an `ImportError` now, and
   so is every other variant of `curve_group` and `curve_group_2`: the

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -21,7 +21,7 @@ from hashlib import sha256
 
 from btclib.alias import HashF, Octets, Point
 from btclib.curves import Curve, bytes_from_point, double_mult, mult, secp256k1
-from btclib.exceptions import BTClibRuntimeError
+from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.utils import bytes_from_octets, int_from_bits
 
 __all__ = [
@@ -107,15 +107,20 @@ def sign(
         for pubk_ring in pubk_rings
     ]
 
+    # one entry per ring in each of the three, checked here rather than
+    # left to the `strict=True` of the two loops below: a short ks would
+    # truncate them silently and sign a subset of the rings -- a signature
+    # over fewer rings than the caller asked for, which is the one thing a
+    # ring signature must not do quietly. zip's own message is a
+    # BTClibValueError's class with none of its content, naming "argument
+    # 3" and no parameter of this function; strict=True stays, as the
+    # assertion that this check and those loops cannot drift apart
+    if not len(pubk_rings) == len(sign_key_idx) == len(ks):
+        err_msg = f"{len(pubk_rings)} rings, {len(sign_key_idx)} signing indexes"
+        err_msg += f" and {len(ks)} nonces"
+        raise BTClibValueError(err_msg)
+
     # step 1
-    # strict=True, and it is the one zip in this package that changes what
-    # an argument does rather than documenting an invariant already checked:
-    # nothing validates that ks, sign_key_idx and pubk_rings have one entry
-    # per ring, so a short ks would truncate the loop silently and sign a
-    # subset of the rings -- a signature over fewer rings than the caller
-    # asked for, which is the one thing a ring signature must not do
-    # quietly. ValueError, and BTClibValueError is a ValueError, so a caller
-    # already catching this package's errors catches it
     for i, (pubk_ring, j_star, k) in enumerate(
         zip(pubk_rings, sign_key_idx, ks, strict=True)
     ):

--- a/btclib/mnemonic/entropy.py
+++ b/btclib/mnemonic/entropy.py
@@ -49,6 +49,27 @@ BinStr = str
 Entropy = BinStr | int | bytes
 
 
+def _int_from_bin_str(entropy: BinStr) -> int:
+    """Return the number a binary 0/1 string spells, or refuse the string.
+
+    `int(x, 2)` answers what is no binary string with the bare
+    ValueError "invalid literal for int() with base 2", which names
+    neither the parameter nor this library, and what is no string at all
+    with a bare TypeError.
+
+    Neither message carries the value, and neither does this one: raw
+    entropy is seed material, and every error in this module says a
+    length or a count and never the digits (issue #137).
+    """
+    try:
+        return int(entropy, 2)
+    except TypeError as e:
+        err_msg = f"invalid entropy type: {type(entropy).__name__}"
+        raise BTClibTypeError(err_msg) from e
+    except ValueError as e:
+        raise BTClibValueError("invalid entropy: not a binary 0/1 string") from e
+
+
 def wordlist_indexes_from_bin_str_entropy(entropy: BinStr, base: int) -> list[int]:
     """Return the digit indexes for the provided raw entropy.
 
@@ -57,7 +78,7 @@ def wordlist_indexes_from_bin_str_entropy(entropy: BinStr, base: int) -> list[in
     entropy; leading zeros are not considered redundant padding.
     """
     bits = len(entropy)
-    int_entropy = int(entropy, 2)
+    int_entropy = _int_from_bin_str(entropy)
     indexes = []
     while int_entropy:
         int_entropy, index = divmod(int_entropy, base)
@@ -175,7 +196,7 @@ def bytes_entropy_from_str(bin_str_entropy: BinStr) -> bytes:
         err_msg = f"invalid number of bits: {n_bits} instead of {_bits}"
         raise BTClibValueError(err_msg)
     nbytes = (n_bits + 7) // 8
-    int_entropy = int(bin_str_entropy, 2)
+    int_entropy = _int_from_bin_str(bin_str_entropy)
     return int_entropy.to_bytes(nbytes, byteorder="big", signed=False)
 
 
@@ -196,11 +217,18 @@ def bin_str_entropy_from_int(
     if isinstance(int_entropy, str):
         int_entropy = int_entropy.strip().lower()
         if int_entropy[:2] == "0b":
-            int_entropy = int(int_entropy, 2)
-        elif int_entropy[:2] == "0x":
-            int_entropy = int(int_entropy, 16)
+            int_entropy = _int_from_bin_str(int_entropy)
         else:
-            int_entropy = int(int_entropy)
+            # the two `int` readings left, and the same bare ValueError
+            # out of both: "invalid literal for int() with base 16",
+            # naming neither the parameter nor this library -- and
+            # carrying the digits, which the message here does not
+            base = 16 if int_entropy[:2] == "0x" else 10
+            try:
+                int_entropy = int(int_entropy, base)
+            except ValueError as e:
+                err_msg = f"invalid entropy: not a base {base} number"
+                raise BTClibValueError(err_msg) from e
 
     if int_entropy < 0:
         raise BTClibValueError(f"negative entropy: {int_entropy}")
@@ -234,7 +262,7 @@ def bin_str_entropy_from_str(str_entropy: str, bits: OneOrMoreInt = _bits) -> Bi
 
     Default bit-sizes are 128, 160, 192, 224, 256, or 512 bits.
     """
-    int(str_entropy, 2)
+    _int_from_bin_str(str_entropy)
 
     # if a single int, make it a tuple
     if isinstance(bits, int):
@@ -372,7 +400,7 @@ def bin_str_entropy_from_random(
         if len(entropy) > bits:
             # only the leftmost bits are retained
             entropy = entropy[:bits]
-        i = int(entropy, 2)
+        i = _int_from_bin_str(entropy)
 
     # XOR the current entropy with CSPRNG system entropy
     i ^= secrets.randbits(bits)

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -75,7 +75,10 @@ def int_from_prv_key(prv_key: PrvKey, ec: Curve = secp256k1) -> int:
         try:
             prv_key = bytes_from_octets(prv_key, ec.n_size)
             q = int.from_bytes(prv_key, "big")
-        except ValueError as e:
+        # both, as `to_pub_key` catches both here: what is neither octets
+        # nor a spelling of them is a TypeError, and it means the same
+        # thing as a wrong size does -- this input is not a private key
+        except (TypeError, ValueError) as e:
             # never echo the input: it is candidate key material. What the
             # reasons carry is why each format rejected it -- a checksum, a
             # prefix, a size -- none of which is secret
@@ -313,7 +316,7 @@ def prv_keyinfo_from_prv_key(
         try:
             prv_key = bytes_from_octets(prv_key, ec.n_size)
             q = int.from_bytes(prv_key, byteorder="big", signed=False)
-        except ValueError as e:
+        except (TypeError, ValueError) as e:
             # never echo the input: it is candidate key material. The
             # reasons say why each format rejected it, and none of them is
             # secret

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -86,7 +86,29 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
     and say it had checked a size.
     """
     if isinstance(octets, str):  # hex string
-        octets = bytes.fromhex(octets)
+        # `bytes.fromhex` raises a bare ValueError -- the same class the
+        # contract promises, so what was lost is only that it came from
+        # here. This is the one coercion every `Octets` parameter of the
+        # library runs through, so it is the one place worth saying it in.
+        # The message is fromhex's own, which names a position and never
+        # the string: an Octets parameter is candidate key material as
+        # often as not, and `to_prv_key` puts this very message inside its
+        # own "not a private key" (issue #137)
+        try:
+            octets = bytes.fromhex(octets)
+        except ValueError as e:
+            raise BTClibValueError(f"invalid hex string: {e}") from e
+    elif not isinstance(octets, (bytes, bytearray, memoryview)):
+        # what is neither went through untouched and reached whatever the
+        # caller went on to do with it: `len` of a tuple of 33 ints is 33,
+        # so `taproot.assert_valid_control_block` accepted one as a
+        # control block size.
+        # Every buffer and not `bytes` alone, and returned as it came:
+        # `assert_valid` is a read and must not rewrite the field it
+        # reads, which is what `bytes()` here would do to a bytearray a
+        # caller built (`tests/bip32/bip32_test.py` pins it)
+        err_msg = f"invalid octets type: {type(octets).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
 
     if out_size is None:
         return octets
@@ -290,11 +312,16 @@ def int_from_integer(i: Integer) -> int:
     if isinstance(i, str):
         i = i.strip().lower()
         if i.startswith(("0x", "-0x")):
-            return int(i, 16)
-        i = bytes.fromhex(i)
+            # the same bare ValueError bytes_from_octets names below, out
+            # of the one spelling that does not reach it
+            try:
+                return int(i, 16)
+            except ValueError as e:
+                raise BTClibValueError(f"invalid hex integer: {i!r}") from e
 
-    # must be bytes
-    return int.from_bytes(i, "big", signed=False)
+    # the hex string, and the refusal of what is neither that nor bytes,
+    # both being bytes_from_octets's to give
+    return int.from_bytes(bytes_from_octets(i), "big", signed=False)
 
 
 def hex_string(i: Integer) -> str:

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -89,7 +89,7 @@ with ``bytes.fromhex``. Passing text where hex is expected fails:
 >>> from btclib.ecc import dsa
 >>> dsa.sign("hello world", 1)
 Traceback (most recent call last):
-ValueError: non-hexadecimal number found in fromhex() arg at position 0
+btclib.exceptions.BTClibValueError: invalid hex string: non-hexadecimal number found in fromhex() arg at position 0
 
 Pass ``bytes`` when you mean text, and let the hex spelling be for
 things that are bytes:

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -14,7 +14,11 @@ import pytest
 from btclib.alias import Point
 from btclib.curves import mult, secp256k1
 from btclib.ecc import borromean, dsa
-from btclib.exceptions import BTClibRuntimeError, BTClibValueError
+from btclib.exceptions import (
+    BTClibRuntimeError,
+    BTClibTypeError,
+    BTClibValueError,
+)
 from tests.curves.curve_test import low_card_curves
 
 
@@ -46,7 +50,7 @@ def test_borromean() -> None:
     # a msg that is neither bytes nor a hex-str is a caller error, and
     # verify says so instead of answering False: catching Exception would
     # report an int msg as a failed ring signature
-    with pytest.raises(TypeError):
+    with pytest.raises(BTClibTypeError, match="invalid octets type: int"):
         borromean.verify(0, sig[0], sig[1], pubk_rings)  # type: ignore[arg-type]
 
     # a forged signature must raise, not merely return a falsy value:
@@ -212,3 +216,30 @@ def test_the_point_at_infinity_is_the_other_corner_case() -> None:
     assert not borromean.verify(
         b"\x00\x00\x00\x00", (21).to_bytes(32, "big"), [[1]], [[Q1]], ec=ec
     )
+
+
+def test_one_nonce_and_one_signing_index_per_ring() -> None:
+    """A short ks truncated the loops and signed a subset of the rings.
+
+    `zip(..., strict=True)` is what caught it, with the message "zip()
+    argument 3 is shorter than argument 1" -- a `BTClibValueError`'s
+    class carrying none of its content, naming an argument position of
+    `zip` and no parameter of `sign`. The check is `sign`'s own now, and
+    `strict=True` stays as the assertion that the two cannot drift
+    apart.
+    """
+    ring_sizes = [3, 4]
+    sign_key_idx = [2, 1]
+    key_rings = [[dsa.gen_keys() for _ in range(size)] for size in ring_sizes]
+    sign_keys = [key_rings[i][sign_key_idx[i]][0] for i in range(2)]
+    pubk_rings = [[key_rings[i][j][1] for j in range(ring_sizes[i])] for i in range(2)]
+    msg = b"Borromean ring signature"
+
+    assert borromean.sign(msg, [1, 2], sign_key_idx, sign_keys, pubk_rings)
+
+    err_msg = "2 rings, 2 signing indexes and 1 nonces"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        borromean.sign(msg, [1], sign_key_idx, sign_keys, pubk_rings)
+    err_msg = "2 rings, 1 signing indexes and 2 nonces"
+    with pytest.raises(BTClibValueError, match=err_msg):
+        borromean.sign(msg, [1, 2], sign_key_idx[:1], sign_keys, pubk_rings)

--- a/tests/ecc/der_test.py
+++ b/tests/ecc/der_test.py
@@ -37,8 +37,8 @@ def test_der_size() -> None:
 
 def test_der_deserialize() -> None:
     """Refuse each malformed DER field with its own message."""
-    err_msg = "non-hexadecimal number found "
-    with pytest.raises(ValueError, match=err_msg):
+    err_msg = "invalid hex string: non-hexadecimal number found "
+    with pytest.raises(BTClibValueError, match=err_msg):
         Sig.parse("not a sig")
 
     sig = Sig(2**255 - 4, 2**247 - 1)

--- a/tests/fetch/fetcher_test.py
+++ b/tests/fetch/fetcher_test.py
@@ -75,7 +75,7 @@ def test_tx_id_hex_takes_whatever_octets_takes() -> None:
 @pytest.mark.parametrize("tx_id", ["", "00", TX_ID + "00", "not hex at all"])
 def test_tx_id_hex_refuses_what_is_not_an_id(tx_id: str) -> None:
     """A mistyped id is the caller's error, not the remote host's 404."""
-    with pytest.raises(ValueError):
+    with pytest.raises(BTClibValueError):
         tx_id_hex(tx_id)
 
 

--- a/tests/mnemonic/entropy_test.py
+++ b/tests/mnemonic/entropy_test.py
@@ -121,7 +121,7 @@ def test_conversions() -> None:
     # `== "0x"` weakened to `>=` is what a string of only letters tells
     # apart -- "ab" sorts above "0x" and parses as hex (171) where the
     # unweakened check falls through to `int("ab")` and raises instead
-    with pytest.raises(ValueError, match="invalid literal for int"):
+    with pytest.raises(BTClibValueError, match="not a base 10 number"):
         bin_str_entropy_from_int("ab", 8)
 
     max_bits = max(_bits)
@@ -210,13 +210,16 @@ def test_exceptions() -> None:
     with pytest.raises(BTClibValueError, match=err_msg):
         bin_str_entropy_from_entropy(bytes_entropy216, 224)
 
-    with pytest.raises(BTClibValueError, match=err_msg):
+    # an empty tuple is entropy of no spelling at all, which is what it
+    # is refused as: it used to reach `len()` and be reported as zero
+    # bits, a number it never carried
+    with pytest.raises(BTClibTypeError, match="invalid octets type: tuple"):
         bin_str_entropy_from_entropy(())  # type: ignore[arg-type]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(BTClibValueError, match="not a base 10 number"):
         bin_str_entropy_from_int("not an int")
 
-    with pytest.raises(TypeError):
+    with pytest.raises(BTClibTypeError, match="invalid entropy type: int"):
         bin_str_entropy_from_str(3)  # type: ignore[arg-type]
 
     err_msg = "invalid number of bits: "
@@ -430,3 +433,24 @@ def test_bin_str_entropy_from_random() -> None:
     assert len(bin_str_entropy_from_random(512)) == 512
     with pytest.raises(BTClibValueError, match=err_msg):
         bin_str_entropy_from_random(513)
+
+
+def test_what_is_no_binary_string_is_refused_without_being_echoed() -> None:
+    """`int(x, 2)` said "invalid literal for int() with base 2" and the digits.
+
+    Raw entropy is seed material, so neither the class nor the message
+    was right: a bare ValueError naming neither the parameter nor this
+    library, carrying the very string it was handed. Every message in
+    this module says a length or a count instead.
+    """
+    for not_binary in ("0b2", "0bxyz", "0b"):
+        with pytest.raises(BTClibValueError, match="not a binary") as excinfo:
+            bin_str_entropy_from_int(not_binary)
+        # the digits stay out of the message, being seed material
+        assert not_binary not in str(excinfo.value)
+
+    for not_binary in ("2" * 128, "abc" * 43):
+        with pytest.raises(BTClibValueError, match="not a binary 0/1 string"):
+            bin_str_entropy_from_str(not_binary)
+        with pytest.raises(BTClibValueError, match="not a binary 0/1 string"):
+            wordlist_indexes_from_bin_str_entropy(not_binary, 2048)

--- a/tests/script/sig_hash_taproot_test.py
+++ b/tests/script/sig_hash_taproot_test.py
@@ -768,7 +768,7 @@ def test_the_message_extension_is_octets_like_every_other_field() -> None:
         )
 
     assert sig_hash_with(ext) == sig_hash_with(ext.hex())
-    with pytest.raises(ValueError, match="fromhex"):
+    with pytest.raises(BTClibValueError, match="invalid hex string: "):
         sig_hash_with("not hex at all")
 
 

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -271,12 +271,14 @@ def test_a_control_block_size_is_octets_and_not_characters() -> None:
         with pytest.raises(BTClibValueError, match=err_msg):
             assert_valid_control_block(wrong_size)
 
-    # a str that is no hex string reaches the size check no longer; the
-    # class is `bytes_from_octets`'s to tighten, which issue 744's last
-    # slice is about
+    # a str that is no hex string reaches the size check no longer, and
+    # what is no octets at all is refused rather than measured: `len` of
+    # a tuple of 33 ints is 33
     for not_octets in ("é" * 33, "a" * 33):
-        with pytest.raises(ValueError, match="fromhex"):
+        with pytest.raises(BTClibValueError, match="invalid hex string: "):
             assert_valid_control_block(not_octets)
+    with pytest.raises(BTClibTypeError, match="invalid octets type: tuple"):
+        assert_valid_control_block(tuple(range(33)))  # type: ignore[arg-type]
 
 
 def test_a_leaf_is_named_from_the_start_of_the_tree() -> None:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -12,6 +12,7 @@ import pytest
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.utils import (
     assert_no_trailing,
+    bytes_from_octets,
     decode_num,
     encode_num,
     hex_string,
@@ -97,8 +98,9 @@ def test_int_from_integer_reads_a_str_as_hex() -> None:
     assert int_from_integer(1234) == 1234
 
     # and an odd number of digits is not a one-digit decimal either
-    # (Python 3.14 rephrased the message bytes.fromhex raises)
-    with pytest.raises(ValueError, match="fromhex"):
+    # (the message is bytes.fromhex's own, which Python 3.14 rephrased,
+    # inside the class this library promises)
+    with pytest.raises(BTClibValueError, match="invalid hex string: "):
         int_from_integer("9")
 
 
@@ -116,7 +118,7 @@ def test_hex_string() -> None:
     # invalid hex-string: odd number of hex digits
     # (Python 3.14 rephrased the message bytes.fromhex raises)
     a_str = "1deadbeef00000000"
-    with pytest.raises(ValueError, match="fromhex"):
+    with pytest.raises(BTClibValueError, match="invalid hex string: "):
         hex_string(a_str)
 
     int_ = -1
@@ -250,3 +252,44 @@ def test_a_json_number_is_a_whole_one_or_it_is_an_error() -> None:
     for not_a_number in (None, object(), [1]):
         with pytest.raises(BTClibTypeError, match="invalid version type: "):
             int_from_json_number(not_a_number, "version")
+
+
+def test_octets_are_bytes_or_the_hex_string_of_bytes_and_nothing_else() -> None:
+    """A tuple went through untouched, to be measured as if it were octets.
+
+    `bytes_from_octets` returned anything that was not a `str`
+    unchanged, so `len` of a tuple of 33 ints was 33 and
+    `taproot.assert_valid_control_block` accepted it as a control block
+    size. Every buffer is still taken, and returned as it came: a read
+    must not rewrite the field it reads, which is what `bytes()` here
+    would do to a bytearray a caller built.
+    """
+    assert bytes_from_octets(b"\x00\x01") == b"\x00\x01"
+    assert bytes_from_octets("0001") == b"\x00\x01"
+    # every buffer, though `Octets` names only the two spellings a caller
+    # writes: what reaches this is whatever a field was built from
+    assert bytes_from_octets(bytearray(b"\x00\x01")) == b"\x00\x01"  # type: ignore[arg-type]
+    assert bytes_from_octets(memoryview(b"\x00\x01")) == b"\x00\x01"  # type: ignore[arg-type]
+    # unchanged, and not merely equal
+    buffer: object = bytes_from_octets(bytearray(b"\x00"))  # type: ignore[arg-type]
+    assert isinstance(buffer, bytearray)
+
+    for not_octets in (tuple(range(33)), [1, 2], None, 1.5):
+        with pytest.raises(BTClibTypeError, match="invalid octets type: "):
+            bytes_from_octets(not_octets)  # type: ignore[arg-type]
+        with pytest.raises(BTClibTypeError, match="invalid octets type: "):
+            int_from_integer(not_octets)  # type: ignore[arg-type]
+    # an int is an `Integer` and no `Octets`, so the two differ on it
+    assert int_from_integer(1) == 1
+    with pytest.raises(BTClibTypeError, match="invalid octets type: int"):
+        bytes_from_octets(1)  # type: ignore[arg-type]
+
+    # the hex string that is not one, in both, with the message
+    # `bytes.fromhex` gives: a position, and never the string itself
+    for not_hex in ("9", "zz", "not hex at all"):
+        with pytest.raises(BTClibValueError, match="invalid hex string: "):
+            bytes_from_octets(not_hex)
+        with pytest.raises(BTClibValueError, match="invalid hex string: "):
+            int_from_integer(not_hex)
+    with pytest.raises(BTClibValueError, match="invalid hex integer: "):
+        int_from_integer("0xzz")


### PR DESCRIPTION
The last slice of https://github.com/btclib-org/btclib/issues/744.
**Stacked on https://github.com/btclib-org/btclib/pull/765**, which is
on #764, which is on #763. Review the last commit.

The issue proposed this "possibly as a documented decision rather than a
fix". It is a fix: the decision would have been defensible for the class
alone — `BTClibValueError` *is* a `ValueError` — but not for the hole
underneath it.

## Two holes, not one

`bytes_from_octets` is the coercion every `Octets` parameter of the
library runs through.

1. **A hex string that is not one** left through `bytes.fromhex`'s bare
   `ValueError`. The class the contract promises, with nothing saying it
   came from here and no way to pin the message.
2. **Anything that was not a `str` went through untouched.** So `len` of
   a tuple of 33 ints is 33, which is exactly how
   `taproot.assert_valid_control_block` accepted one as a control block
   size ( #763 fixed the character-count half and could not fix this
   one), and how `bin_str_entropy_from_entropy(())` was reported as
   *zero bits* — a number it never carried.

## Decisions worth a reviewer's eye

- **The message is `bytes.fromhex`'s own**, carried through rather than
  replaced. It names a position and never the string, which is the
  point: an `Octets` parameter is candidate key material as often as
  not, and `to_prv_key` puts this very message inside its own "not a
  private key" (issue #137). A first draft interpolated `{octets!r}` and
  `tests/to_prv_key_test.py::test_a_mistyped_wif_is_reported_as_one`
  caught it — the suite has a test for exactly this.
- **Every buffer is taken, and returned as it came.** `bytes` alone
  would have broken
  `tests/bip32/bip32_test.py::test_assert_valid_does_not_rewrite_the_key_data`,
  which pins that a read must not coerce a `bytearray` a caller built.
  `bytearray` and `memoryview` are accepted with a `# type: ignore` at
  the call in the test: `Octets` names the two spellings a *caller*
  writes, not everything a field can hold.
- **`to_prv_key` catches `TypeError` beside `ValueError`** at its two
  "it must be octets" fallbacks, as `to_pub_key` already did: what is
  neither octets nor a spelling of them means the same thing a wrong
  size does — this input is not a private key.
- **`borromean.sign` checks the three lengths itself.** `strict=True`
  said "zip() argument 3 is shorter than argument 1", naming no
  parameter of the function; the comment above it defended the *class*,
  which was right, and left the message. The check is the function's
  now, and `strict=True` stays as the assertion that the two cannot
  drift apart.
- **HISTORY.md carries one breaking-changes bullet for all four
  slices**, not just this one. #763 and #764 turn `OverflowError` and
  `IndexError` into btclib classes and #765 an `AttributeError`; a
  caller catching those three has to act, and that is a release note
  rather than four. Say the word if you want it split per PR.

## What moves for a caller

The class is narrower and the control flow identical — `BTClibValueError`
is a `ValueError`. A test matching `bytes.fromhex`'s message still
matches. The one non-narrowing is hole 2: a non-`Octets` argument is now
a `BTClibTypeError` where it used to be no error, or an error about
something else.

Six test files stop asserting the bare class, and
`docs/source/guide.rst` shows the new spelling.

## Gates

- `uv run pytest` — 26508 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

## Summary by Sourcery

Tighten octet handling across the library so malformed or non-octet inputs are consistently rejected with btclib-specific errors and clearer messages, without exposing potentially sensitive data.

Bug Fixes:
- Ensure bytes_from_octets rejects non-hex strings and non-buffer types instead of silently passing them through, preventing incorrect control-block sizes and entropy calculations.
- Validate borromean ring signature inputs so mismatched ring, signing-index, and nonce counts raise a descriptive btclib error instead of a generic zip() ValueError.
- Normalize binary and numeric entropy parsing to raise BTClibValueError/BTClibTypeError with messages that describe the problem without echoing raw entropy values.

Enhancements:
- Make bytes_from_octets the central, total coercion for all Octets parameters, accepting bytes-like buffers and hex strings while returning btclib error types for invalid inputs.
- Refactor mnemonic entropy helpers to route binary-string parsing through a shared helper and to convert malformed base-10/16 inputs into btclib errors with explicit base information.
- Adjust int_from_integer and related callers to go through bytes_from_octets and to surface btclib error types for malformed hex integers.
- Add tests that pin the new error classes, messages, and buffer-handling semantics for octet and entropy utilities, borromean signatures, DER parsing, fetch utilities, and taproot control blocks.

Documentation:
- Update HISTORY and CHANGELOG to describe the shift from native exceptions to BTClibValueError/BTClibTypeError for malformed arguments, and note the octet-handling behavior change.
- Refresh the user guide to reflect the new octet spelling and error semantics.

Tests:
- Extend and adjust tests to expect BTClibValueError/BTClibTypeError instead of bare builtin exceptions when octet, entropy, and hex inputs are malformed, and to verify that error messages avoid echoing sensitive input data.