### PR TITLE
Read pyproject by regex on 3.10, and unpin what the wheel asks by branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,13 +285,20 @@ jobs:
       # The lock arrives as constraints and not as requirements: a
       # requirements file installs the bindings whether or not the wheel
       # asks for them, so a wheel declaring nothing would pass. A
-      # constraint pins and requests no package, which leaves
-      # the wheel's metadata doing the work while pinning the outcome to
-      # what uv.lock resolved -- the commit, for a direct reference -- and
-      # pinning it is what keeps a required check deterministic, since
-      # unpinned uv takes whatever the branch is at, and a commit pushed
-      # this morning would redden every open pull request, none of which
-      # caused it.
+      # constraint pins and requests no package, which leaves the wheel's
+      # metadata doing the work while pinning the outcome to what uv.lock
+      # resolved.
+      # Every package but the two direct references, which is what
+      # --no-emit-package is for here: the lock exports those as the
+      # commit it resolved, the wheel asks for `main`, and uv unifies a
+      # branch with a commit only while the branch is still at it --
+      # after which it refuses the two urls as conflicting and the job
+      # fails on nothing this repository did. Those branches are where
+      # this tree's own dependencies are developed, so they move on their
+      # own schedule, and a pin that has to be refreshed within the hour
+      # is not determinism. Unpinned, this step resolves what a user
+      # installing the wheel today resolves, which is the question it
+      # asks; the rest of the workflow runs --locked and is unaffected.
       # Whether the newest bindings still work is asked on a schedule by
       # latest.yml, and again by the release workflow before it publishes.
       # The assertions are three, because each catches what the others
@@ -306,6 +313,8 @@ jobs:
       - name: Smoke-test the wheel, with the dependencies its metadata asks for
         run: |
           uv export --locked --no-dev --no-emit-project --no-hashes \
+            --no-emit-package btclib-secp256k1 \
+            --no-emit-package bitcoin-core-rpc \
             -o "$RUNNER_TEMP"/constraints.txt
           cd "$RUNNER_TEMP"
           uv venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,35 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **`main` is green again, after two failures of one run that have
+  nothing to do with each other.** `tests/build_system_test.py` read
+  pyproject.toml with `tomllib`, which is standard library from 3.11 up
+  and the floor here is 3.10: the module failed to collect on the four
+  3.10 cells of the matrix and passed everywhere else, so the pull
+  request that added it (#754) merged with every other cell green. It
+  reads the `[build-system]` table by regex now, anchored on the header
+  and stopping at the next one, which is what `tests/copyright_test.py`
+  already does with the same file and for the same reason; both tests
+  assert what they asserted before.
+
+  The `dist` job's smoke test is the other one, and what it failed on was
+  a design that could only hold for as long as nothing moved. It installs
+  the wheel with `uv.lock` exported as constraints, and the wheel asks
+  for `btclib_secp256k1` and `bitcoin-core-rpc` from their repositories'
+  `main` while the export pins the commit the lock resolved: uv unifies a
+  branch with a commit while the branch is still at it, and refuses the
+  two urls as conflicting once it is not. Both repositories had moved, so
+  the job failed here and in every open pull request, none of which
+  caused it -- and a lock refresh would only have bought the time until
+  the next push, which for `bitcoin-core-rpc` was fifteen minutes.
+  The export now passes `--no-emit-package` for those two, which is the
+  whole of the fix: everything else stays pinned to the lock, and the two
+  direct references resolve the way a user installing this wheel resolves
+  them. Nothing here is left unasked -- `uv run --locked` is what the
+  rest of the workflow runs, and whether the newest bindings still work
+  is `latest.yml`'s weekly question and the release workflow's before it
+  publishes.
+
 - **The package-content policy is stated where an unpacked sdist carries
   it** (#735, #734). `docs/source/package-content-policy.md` says what
   may be in the wheel and the sdist, what may never be, and what has to

--- a/tests/build_system_test.py
+++ b/tests/build_system_test.py
@@ -24,6 +24,16 @@ and what is checked: one requirement, named setuptools, bounded from
 below and nothing else -- which is also how a direct reference to a url,
 an extra and an environment marker are refused, each of them a way to
 name a package that resolves to somebody else's code.
+
+Regex rather than `tomllib` for the two keys wanted out of
+pyproject.toml: the floor here is 3.10, and `tomllib` is 3.11, so a test
+module importing it fails to collect on the oldest interpreter the
+matrix runs, with every other cell green. `tests/copyright_test.py` reads
+the same file the same way and for the same reason; once 3.10 is dropped,
+both can parse it. What the regex costs is that it reads text and not a
+table, so it is anchored on the `[build-system]` header and stops at the
+next one: a `requires` belonging to some `[tool.*]` below is a different
+key, and a second build requirement is what has to be seen.
 """
 
 from __future__ import annotations
@@ -31,21 +41,38 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-import tomllib
-
 _PYPROJECT = Path(__file__).parents[1] / "pyproject.toml"
 
 # a name, `>=` and a release: no `@ <url>`, no `[extra]`, no `; marker`
 _LOWER_BOUND = re.compile(r"setuptools>=[0-9]+(?:\.[0-9]+)*")
 
-# the table pip and uv build with, read at import: the file is the
-# project's own and a test module that cannot read it has nothing to say
-_BUILD_SYSTEM = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))["build-system"]
+# the table pip and uv build with, up to whichever table follows it
+_TABLE = re.compile(r"^\[build-system\]$(.*?)(?=^\[)", re.MULTILINE | re.DOTALL)
+_REQUIRES = re.compile(r"^requires\s*=\s*\[(.*?)\]", re.MULTILINE | re.DOTALL)
+_BACKEND = re.compile(r'^build-backend\s*=\s*"(.*?)"', re.MULTILINE)
+_QUOTED = re.compile(r'"(.*?)"')
+
+
+def _build_system() -> str:
+    """Return the text of pyproject.toml's `[build-system]` table.
+
+    Called at import: the file is the project's own and a test module
+    that cannot read it has nothing to say.
+    """
+    text = _PYPROJECT.read_text(encoding="utf-8")
+    match = _TABLE.search(text)
+    assert match, "pyproject.toml has no [build-system] table"
+    return match.group(1)
+
+
+_BUILD_SYSTEM = _build_system()
 
 
 def test_the_build_requires_setuptools_and_nothing_else() -> None:
     """One requirement, and a lower bound is the whole of what it says."""
-    (requirement,) = _BUILD_SYSTEM["requires"]
+    match = _REQUIRES.search(_BUILD_SYSTEM)
+    assert match, "[build-system] declares no requires"
+    (requirement,) = _QUOTED.findall(match.group(1))
 
     assert _LOWER_BOUND.fullmatch(requirement)
 
@@ -57,4 +84,7 @@ def test_the_backend_is_the_declarative_one() -> None:
     imports the file and runs it, which is the install-time hook the
     package-content policy is about, one stage earlier and in the build.
     """
-    assert _BUILD_SYSTEM["build-backend"] == "setuptools.build_meta"
+    match = _BACKEND.search(_BUILD_SYSTEM)
+    assert match, "[build-system] declares no build-backend"
+
+    assert match.group(1) == "setuptools.build_meta"


### PR DESCRIPTION
`main` has been red since 8c8c0426, on two failures of one run that have
nothing to do with each other.

**`tests/build_system_test.py` imported `tomllib`**, which is standard
library from 3.11 up while the floor here is 3.10: the module failed to
collect on the four 3.10 cells of the matrix and passed on every other
one, so the pull request that added it (#754) merged with the rest of
the matrix green. It reads the `[build-system]` table by regex now,
anchored on the header and stopping at the next one, which is what
`tests/copyright_test.py` does with the same file and for the same
reason. Both tests assert what they asserted before.

**The `dist` job's smoke test pinned what the wheel names by branch.** It
exports `uv.lock` as constraints and installs the wheel against them; the
wheel asks for `btclib_secp256k1` and `bitcoin-core-rpc` from their
repositories' `main`, the export pins the commit the lock resolved, and
uv unifies a branch with a commit only while the branch is still at it.
Both had moved, so the two urls were refused as conflicting -- here and
in every open pull request, none of which caused it. A lock refresh buys
the time until the next push, which for `bitcoin-core-rpc` was fifteen
minutes between one `ls-remote` and the next, so the export passes
`--no-emit-package` for those two instead: everything else stays pinned
to the lock, and the two direct references resolve what a user installing
this wheel resolves. `uv run --locked` is unaffected, and whether the
newest bindings still work stays `latest.yml`'s weekly question.

Verified locally: `uv run pytest` (100% coverage), every pre-commit hook,
`sphinx-build -W`, the fixed test module under 3.10, and the smoke test
reproduced by hand against a wheel built from this tree.

## Summary by Sourcery

Restore CI green by making build-system tests compatible with Python 3.10 and adjusting the dist smoke test to avoid brittle pinning of git-based dependencies.

Enhancements:
- Update build-system tests to read pyproject.toml via regex instead of tomllib so they run on the supported Python 3.10 floor.

CI:
- Change the dist job's smoke test to export constraints without pinning btclib_secp256k1 and bitcoin-core-rpc to specific commits, letting those direct references resolve against their branches while keeping other dependencies locked.

Documentation:
- Document the CI and packaging fixes and their rationale in the changelog.