### PR TITLE
Refuse negative zero with the check that refuses every other one (#746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2114,6 +2114,19 @@ documented at release-notes length in the first place, and are still in
   where it used to be refused for the threshold's value, both being a
   refusal and the second being the accurate one.
 
+- **negative zero is refused by the check that refuses every other
+  non-minimal number** (issue #746). `_to_num` tested `element ==
+  b"\x80"` before anything else and raised `non-minimal encoding of
+  zero`, which was a case of its own because `encode_num(0)` was itself
+  the non-minimal `00` and could not be the yardstick. It is the empty
+  vector now, so `80` fails `encode_num(x) != element` like every other
+  over-long spelling: the special case is two lines saying what the line
+  below them already says, and it is gone. A script carrying a negative
+  zero where a number is read is refused exactly as before, and reports
+  `non-minimal encoding of 0: 80` -- the wording every other value gets.
+  A caller matching the old text has one string to update; the test
+  beside it names the value, which nothing did before.
+
 ### Descriptors and miniscript
 
 - **An invalid output is refused, not answered about** (#691). `index_of`

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -145,7 +145,10 @@ full year, short month, short day (YYYY-M-D)
   along. The reason to act rather than to keep the old spelling: `0100`
   is not a minimally encoded script number, so the interpreter refuses
   it as one wherever MINIMALDATA is in force -- btclib's own engine
-  included.
+  included. One message moves with the pair: a negative zero read as a
+  number under that flag is refused as `non-minimal encoding of 0: 80`,
+  where it read `non-minimal encoding of zero`, the general check now
+  answering for it too.
 
 ### The bindings are now `btclib_secp256k1`
 

--- a/btclib/script/engine/script_op_codes.py
+++ b/btclib/script/engine/script_op_codes.py
@@ -114,11 +114,12 @@ _MAX_LOCK_TIME_NUM_SIZE = 5
 
 def _to_num(element: bytes, flags: ScriptFlag, max_size: int) -> int:
     minimaldata = ScriptFlag.MINIMALDATA in flags
-    if minimaldata and element == b"\x80":
-        raise BTClibValueError("non-minimal encoding of zero")
     if len(element) > max_size:
         raise BTClibValueError(f"number longer than {max_size} bytes: {len(element)}")
     x = decode_num(element)
+    # one comparison covers every non-minimal spelling, negative zero
+    # included: `encode_num` writes zero as the empty vector, so `80` and
+    # `00` are both something it does not write
     if minimaldata and encode_num(x) != element:
         raise BTClibValueError(f"non-minimal encoding of {x}: {element.hex()}")
     return x

--- a/tests/script_engine/script_test.py
+++ b/tests/script_engine/script_test.py
@@ -334,6 +334,25 @@ def test_a_serialized_zero_is_a_number_the_interpreter_reads() -> None:
     verify_script(non_minimal, [], 0, tx, 0, NO_FLAGS, False, True)
 
 
+def test_negative_zero_is_refused_by_the_one_minimality_check() -> None:
+    """`80` is a non-minimal zero, and the general comparison says so.
+
+    It is the third spelling of zero and the second one MINIMALDATA
+    refuses, so what is asserted here is that one check answers for both:
+    `encode_num` writes the empty vector, which `80` is not, and no case
+    of its own is needed to reach that verdict.
+    """
+    tx = Tx(check_validity=False)
+
+    # 80, OP_1ADD, OP_1, OP_NUMEQUAL: negative zero where a number is read
+    negative_zero = b"\x01\x80\x8b\x51\x9c"
+    with pytest.raises(ScriptError, match="non-minimal encoding of 0: 80"):
+        verify_script(negative_zero, [], 0, tx, 0, ScriptFlag.MINIMALDATA, False, True)
+
+    # and zero it is, wherever nothing asks for the minimal spelling
+    verify_script(negative_zero, [], 0, tx, 0, NO_FLAGS, False, True)
+
+
 @pytest.mark.parametrize(
     "script, message",
     [


### PR DESCRIPTION
`_to_num` tested `element == b"\x80"` ahead of everything else and
raised `non-minimal encoding of zero`. That was a case of its own for a
reason that no longer holds: `encode_num(0)` was itself the non-minimal
`00`, so it could not be the yardstick a minimality check measures
against. It is the empty vector now, so `80` fails `encode_num(x) !=
element` the way every other over-long spelling does, and the special
case is two lines saying what the line below them already says.

Nothing changes about what is refused -- a negative zero read as a
number under MINIMALDATA is refused before and after -- and the wording
does: `non-minimal encoding of 0: 80`, which is what every other value
gets. A test names the value, which none did: the branch was covered by
the vendored vectors alone, so the rule was pinned by a set that would
still pass if the refusal moved somewhere weaker.

Follow-up to https://github.com/btclib-org/btclib/issues/746, which is closed: this removes what the fix there made redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align script number minimality handling so negative zero is rejected by the same general MINIMALDATA check as other non-minimal encodings, and update messaging and docs accordingly.

Bug Fixes:
- Ensure negative zero in scripts is rejected via the unified minimal-encoding comparison under MINIMALDATA rather than a dedicated special case.

Enhancements:
- Simplify script number decoding by removing the bespoke negative-zero branch and relying on the generic encode/decode minimality comparison.

Documentation:
- Document that negative zero is now reported using the standard non-minimal encoding message and that the dedicated special case has been removed in CHANGELOG and HISTORY.

Tests:
- Add a test script that exercises negative zero under MINIMALDATA and no flags to confirm consistent rejection and acceptance behavior and error wording.