### PR TITLE
Answer in the guide the question BIP85 is for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2620,6 +2620,24 @@ documented at release-notes length in the first place, and are still in
 
 ### Documentation and the website
 
+- **The guide by task answers the question BIP85 is for.** "One backup
+  behind many wallets" is a section of `docs/source/guide.rst` now,
+  between the mnemonic and the account: the derived BIP39 sentence, the
+  index that gives the next wallet, the word count and the language as
+  path levels rather than formatting, the `hdseed` WIF and the xprv, a
+  password and a session of dice rolls, and `entropy_from_der_path` for
+  a path no function formats. It ends on what the scheme costs -- every
+  wallet hangs off the one root key, and none of them is re-derivable
+  from anything else.
+
+  A guide section is worth more than the feature list it duplicates,
+  because `tests/docs_examples_test.py` runs it: every value on the page
+  is a doctest, so the published BIP85 vectors it shows are asserted on
+  every interpreter of the matrix rather than pasted. The examples take
+  a key of the BIP's own rather than the `rootxprv` the page already
+  carries, which is what makes them the specification's values and not
+  btclib's.
+
 - **The feature list advertises BIP85**, which it had not: README.md is
   the btclib.org homepage and the PyPI long description, so the list
   under "Included features are" is where a reader learns what is here,

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -214,6 +214,79 @@ The root extended private key is the seed run through BIP32, and
 btclib does not store that anywhere. It is a string in your process, and
 what happens to it next is entirely yours.
 
+One backup behind many wallets
+------------------------------
+
+A second wallet means a second seed, and a second seed means a second
+paper backup — which is the part of this that goes wrong. BIP85 removes
+the second backup rather than the second wallet: a fully hardened path
+off one root key derives the *entropy* another wallet is seeded from, so
+what you keep is still one root key. :mod:`btclib.bip85` is that
+derivation and the formats the BIP defines on top of it.
+
+The examples here use a key of the BIP's own rather than the
+``rootxprv`` above, so the values below are the ones the specification
+publishes:
+
+>>> from btclib import bip85
+>>> master = "xprv9s21ZrQH143K2LBWUUQRFXhucrQqBpKdRRxNVq2zBqsx8HVqFk2uYo8kmbaLLHRdqtQpUm98uKfu3vca1LqdGhUtyoFnCNkfmXRyPXLjbKb"
+>>> bip85.mnemonic_from_root_key(master)
+'girl mad pet galaxy egg matter matrix prison refuse sense ordinary nose'
+
+That is a BIP39 mnemonic like any other: type it into any wallet that
+reads one. What it is not is random — it is a function of the root key
+and the path, so it comes back the same forever, and the index is how
+you ask for the next one:
+
+>>> bip85.mnemonic_from_root_key(master, index=1).split()[:3]
+['mystery', 'car', 'occur']
+
+The length and the language are path levels too, not formatting:
+another word count is another wallet, and so is another language.
+
+>>> len(bip85.mnemonic_from_root_key(master, 24).split())
+24
+>>> bip85.mnemonic_from_root_key(master, 12, "it").split()[:2]
+['smilzo', 'opinione']
+
+A wallet that does not read BIP39 takes one of the other formats: the
+WIF is what Bitcoin Core imports as an ``hdseed``, taking the leading
+256 bits as a private key, and the xprv is a BIP32 root of its own,
+taking all 512 as a chain code and a key.
+
+>>> bip85.wif_from_root_key(master)
+'Kzyv4uF39d4Jrw2W7UryTHwZr1zQVNk4dAFyqE6BuMrMh1Za7uhp'
+>>> bip85.xprv_from_root_key(master)[:14]
+'xprv9s21ZrQH14'
+
+Not everything derived this way is a wallet. A password is a slice of
+the same entropy in base64 or base85, and dice rolls are drawn from a
+SHAKE256 stream seeded with it — useful where a die is what a wallet
+asks you for, and reproducible where a real die is not:
+
+>>> bip85.base64_password_from_root_key(master, 21)
+'dKLoepugzdVJvdL56ogNV'
+>>> bip85.rolls_from_root_key(master, 10)
+[1, 0, 0, 2, 0, 1, 5, 5, 2, 4]
+
+For a path no function here formats, ``entropy_from_der_path`` is the
+derivation itself and the truncation is yours:
+
+>>> bip85.entropy_from_der_path(master, "m/83696968h/0h/0h").hex()[:32]
+'efecfbccffea313214232d29e71563d9'
+
+RSA is where the BIP stops rather than btclib: it says a key generator
+should read BIP85's own SHAKE256 stream and says nothing about how the
+primes are found, so ``rsa_drng_from_root_key`` hands back that stream
+and the key belongs to whatever library reads it.
+
+What this costs is worth stating plainly. Every wallet derived here
+hangs off the one root key: back it up and you have backed up all of
+them; lose it and they go together, none of them being re-derivable
+from anything else. A passphrase on the BIP39 mnemonic underneath the
+root key is what changes the answer, because it changes the root key
+itself.
+
 An account, its xpub, and the addresses under it
 ------------------------------------------------
 


### PR DESCRIPTION
`docs/source/guide.rst` answers questions by task, before a reader knows
which module holds the code — "A mnemonic, and the seed underneath it",
"An account, its xpub, and the addresses under it", "Signing a message
with an address". "I do not want a second seed to back up" is one of
those questions and had no section to land on, which is the last place
BIP85 was missing after
https://github.com/btclib-org/btclib/pull/741,
https://github.com/btclib-org/btclib/pull/751 and
https://github.com/btclib-org/btclib/pull/761.

**"One backup behind many wallets"** now sits between the mnemonic and
the account: the derived BIP39 sentence, the index that gives the next
wallet, the word count and the language as path levels rather than
formatting, the `hdseed` WIF and the xprv, a password and a session of
dice rolls, and `entropy_from_der_path` for a path no function formats.
It closes on what the scheme costs — every wallet hangs off the one root
key, and none of them is re-derivable from anything else — and on where
the BIP stops rather than btclib, which is RSA.

**Why a guide section is worth more than the feature list it repeats:**
`tests/docs_examples_test.py` runs that page as doctests, so every value
shown is asserted on every interpreter of the matrix rather than pasted
and left to rot. The BIP85 vectors on the page are checked by the suite
from the day they land.

Two details worth a reviewer's eye:

- the examples bind `master` rather than reusing the page's `rootxprv`.
  The key is BIP85's own, which is what makes the outputs the values the
  specification publishes; and the page shares one namespace across its
  sections, so rebinding `rootxprv` here would have derived every later
  account, address and signature on the page from this key instead — the
  doctests caught exactly that on the first run.
- the three values that are not published vectors are the ones that
  cannot be: the mnemonic at index 1, the Italian one, and nothing else.
  Every other output on the page is BIP85's own.

**Gates**, all run locally on this branch:

- `uv run pytest` — 26550 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `uv run --locked --no-default-groups --group docs sphinx-build -W --keep-going -b html docs/source docs/build/html` — build succeeded

## Summary by Sourcery

Document BIP85 usage in the task‑oriented guide and ensure its examples are continuously validated by doctests.

Documentation:
- Add a "One backup behind many wallets" section to the guide that explains using BIP85 for deriving multiple wallets from a single root backup, including its constraints and trade‑offs.

Tests:
- Treat the new BIP85 guide examples as doctests so the published vectors and derived values are automatically checked in the documentation test suite.