### PR TITLE
Ask for twenty-one jobs a commit, not thirty-nine

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,14 +3,14 @@ name: codeql
 
 # the static analysis GitHub runs on its side, moved into the tree.
 #
-# It ran from default setup, a repository setting, which made it the one
-# required check whose definition no diff could review: every other check
-# in main's rule is a file here, with its actions pinned to commit SHAs
-# that a pull request can be read for. A setting is edited in a browser by
-# whoever holds the token, leaves no history a reviewer sees, and cannot
-# be branched -- so the analysis that looks for injected expressions and
-# unsafe checkouts in these very workflows was itself the part of CI
-# nobody could audit.
+# A repository setting is edited in a browser by whoever holds the token,
+# leaves no history a reviewer sees, and cannot be branched -- so while
+# default setup held this analysis, the thing that looks for injected
+# expressions and unsafe checkouts in these very workflows was itself the
+# one part of CI no diff could review. It is a file now, with its actions
+# pinned to commit SHAs a pull request can be read for, which is the
+# property that had to hold whether or not it gates: the `on:` block below
+# is where it stopped gating, and why.
 #
 # What the setting held is reproduced rather than invented. Read from the
 # API while it still held it -- the same command answers
@@ -40,44 +40,42 @@ name: codeql
 # "CodeQL analyses from advanced configurations cannot be processed when
 # the default setup is enabled". Both jobs below are therefore red rather
 # than absent while the setting is on, so the branch rule stops naming
-# `CodeQL` before the setting goes off and names the aggregate after.
+# `CodeQL` before the setting goes off rather than after.
 
 on:
+  # main and the schedule below, and no pull_request trigger: this analysis
+  # is the one gate that was worth trading for the queue it held. GitHub
+  # Free gives an organization twenty concurrent jobs, a commit used to ask
+  # for thirty-nine, and this workflow's three of them were held while a
+  # pull request waited for a slot -- so the analysis now lands on the merge
+  # commit rather than before it, and the aggregate below is no longer a
+  # required check on main. REPOSITORY.md's "Required checks on main" is
+  # where that rule is written down, and dropping the context there is a
+  # token operation that had to come first.
+  # What still reads a branch before it merges is lint.yml: zizmor is a
+  # pre-commit hook and reads exactly these files for an injected
+  # expression, which is the finding this workflow would otherwise be alone
+  # in making. What is deferred by a merge is the rest -- the python
+  # queries, and whatever zizmor does not model -- and the window is the
+  # time between a merge and the next run of this workflow, which for main
+  # is that merge itself.
+  # No `paths` filter, on either trigger: a filter buys nothing now that
+  # nothing waits on the answer, and it would have to name every path a
+  # query reads
   push:
-    # main only: a push to a branch that has an open pull request would
-    # run this workflow twice, once per event, and the two runs land in
-    # different concurrency groups (refs/heads/<branch> against
-    # refs/pull/N/merge) so neither cancels the other. The pull_request
-    # run is the one worth keeping, because it analyses the merge commit
-    # and is the only run a fork's pull request produces at all.
-    # main keeps a trigger of its own because a merge creates a commit
-    # that is not the one the pull request analysed, and because code
-    # scanning compares a pull request's alerts against the default
-    # branch's: without a run here every alert on every branch reads as
-    # new
+    # a merge creates a commit that no pull request analysed, and code
+    # scanning compares a branch's alerts against the default branch's, so
+    # without a run here there is no baseline for any other run to be read
+    # against
     branches: [main]
-  pull_request:
-    # ready_for_review, so a pull request marked ready gets the run the
-    # draft condition below withheld while it was a draft: the default
-    # types do not include it, and without it a readied pull request
-    # would wait for its next push to be checked at all
-    types: [opened, reopened, synchronize, ready_for_review]
-    # no `paths` filter, on either trigger: the aggregate at the end of
-    # this file is a required check on main, and a required check that
-    # never runs blocks a merge where a skipped one satisfies it -- the
-    # same trade integration.yml makes, and for the same reason. Every
-    # pull request pays it, documentation-only ones included, and what
-    # that costs was read off the runs default setup produced rather than
-    # guessed: a mean of 40 seconds for the actions job and 72 for the
-    # python one, the command in the aggregate's comment below
   schedule:
     # Tuesdays, 04:23 UTC. Not on the hour: GitHub queues scheduled
     # workflows across every repository that asked for the same minute,
     # and the run can be dropped outright when the queue is long.
     # Tuesday is a day nothing else here asks for -- links Monday, latest
-    # and macos Wednesday, Dependabot Thursday, integration Friday, and
-    # the mutation session Sunday -- so a failure notification still names
-    # the workflow by the day it arrived; and it is the day
+    # and macos Wednesday, Dependabot Thursday, integration Friday, windows
+    # Saturday and the mutation session Sunday -- so a failure notification
+    # still names the workflow by the day it arrived; and it is the day
     # btclib-secp256k1 and bitcoin-core-rpc analyse on, so "did CodeQL
     # go red anywhere" has one morning to read rather than three. Weekly, as
     # default setup was: what a scheduled analysis catches is a query
@@ -86,8 +84,9 @@ on:
     # Cron runs from the default branch only, so this asks nothing until
     # it reaches main; elsewhere the dispatch below is the way in
     - cron: "23 4 * * 2"
-  # the escape hatch: an analysis on demand for a branch whose pull
-  # request is not open yet
+  # the escape hatch, and with no pull_request trigger above it is the only
+  # way to analyse a branch before it is merged: worth reaching for on one
+  # that touches a workflow, which is what the actions queries read
   workflow_dispatch:
 
 # least privilege for the GITHUB_TOKEN: everything running in a job
@@ -98,7 +97,8 @@ on:
 permissions:
   contents: read
 
-# cancel superseded runs on the same branch/PR.
+# cancel superseded runs on the same branch, which is main or whatever a
+# dispatch names.
 # The group is named literally rather than with github.workflow, which in
 # a called workflow is the caller's name: nothing calls this one today,
 # and the expression would be a trap for whatever does
@@ -113,12 +113,10 @@ jobs:
     # reader into the log to find out which half broke -- and so the two
     # run in parallel, which is what default setup did too
     name: Analyze ${{ matrix.language }}
-    # a draft pull request is work in progress: every push to one spends
-    # runners on a tree its author is not asking anyone to review yet.
-    # The gate below carries the same condition, so a draft skips
-    # uniformly and the gate does not read that skip as a job that should
-    # have run
-    if: ${{ !github.event.pull_request.draft }}
+    # no draft condition, where every job of test.yml carries one: this
+    # workflow no longer runs on a pull request at all, so there is no draft
+    # to skip and `github.event.pull_request.draft` is an expression that
+    # could only read empty here
     runs-on: ubuntu-latest
     # far above what either language needs; what it bounds is a hung job
     # holding a runner for six hours
@@ -192,30 +190,29 @@ jobs:
           # rather than starting again
           category: "/language:${{ matrix.language }}"
 
-  # the single check main's branch protection requires from this
-  # workflow, and it exists because that rule names its checks as literal
-  # strings, stored outside the repository. The matrix above produces one
-  # check per language, so naming those directly would mean a rule to
-  # edit -- in a setting no pull request can review -- every time the
-  # matrix moves, and a name that stops being produced becomes a required
-  # check that never reports, which blocks every merge until somebody
-  # remembers where the rule lives.
-  # This job depends on the matrix instead, so the rule names one thing
-  # that never changes and adding a language here is enough to gate on it
+  # one answer to read per commit rather than one per language, which is
+  # what this job is for now that main's branch protection does not require
+  # it -- REPOSITORY.md's table is where that changed, and why. Kept rather
+  # than deleted because the name is then still produced: requiring this
+  # workflow again is a patch to the rule and nothing in the tree, which is
+  # the half of the exchange that cannot be made in a pull request.
+  # The matrix above produces one check per language, and a rule naming
+  # those directly would mean a setting to edit -- one no pull request can
+  # review -- every time the matrix moves. This job depends on the matrix
+  # instead, so adding a language is enough to be covered by it
   codeql-passed:
-    # the name and not the id is what branch protection matches, and it
-    # carries the workflow on purpose: a context is keyed by name alone,
-    # so two workflows with a job named "every job passed" would produce
-    # one ambiguous check. The pattern, and the reasoning behind every
-    # line of it, is test.yml's own aggregate
+    # the name is what branch protection matches, and it carries the
+    # workflow on purpose: a context is keyed by name alone, so two
+    # workflows with a job named "every job passed" would produce one
+    # ambiguous check. The pattern, and the reasoning behind every line of
+    # it, is test.yml's own aggregate -- which is still required, so the two
+    # names must not converge
     name: "codeql: every job passed"
     needs: [analyze]
     # not success(): a job whose dependencies failed is skipped, and a
-    # skipped check reports "skipped", which branch protection counts as
-    # satisfied. The gate has to run to be able to fail.
-    # And the draft condition the matrix carries, so a draft skips
-    # uniformly rather than tripping the skip check below
-    if: ${{ always() && !github.event.pull_request.draft }}
+    # skipped check reports "skipped", which reads as satisfied wherever a
+    # check is read at all. The gate has to run to be able to fail
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,13 +219,17 @@ jobs:
     name: Run the docs workflow
     uses: ./.github/workflows/docs.yml
 
-  # and the platform the merge gate does not wait for: macos.yml runs
+  # and the two platforms the merge gate does not wait for: each runs
   # weekly, so a regression there could otherwise sit on main until the
-  # Wednesday after the tag. Cheap in work and the slowest call here in wall
+  # morning after the tag. Cheap in work and the slowest calls here in wall
   # clock, which a release is the one place worth paying for
   macos:
     name: Run the macos workflow
     uses: ./.github/workflows/macos.yml
+
+  windows:
+    name: Run the windows workflow
+    uses: ./.github/workflows/windows.yml
 
   build:
     name: Build the wheel and the sdist
@@ -415,7 +419,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI
-    needs: [test, lint, docs, macos, build]
+    needs: [test, lint, docs, macos, windows, build]
     if: github.event_name == 'workflow_dispatch' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -439,7 +443,7 @@ jobs:
 
   publish-pypi:
     name: Publish to PyPI
-    needs: [test, lint, docs, macos, build]
+    needs: [test, lint, docs, macos, windows, build]
     if: github.event_name == 'push' && github.repository == 'btclib-org/btclib'
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,12 +63,7 @@ jobs:
   # what the matrix buys: every (os, architecture, interpreter) triple
   # selects a different published wheel of btclib_secp256k1, each with
   # its own compiled libsecp256k1 inside, and the pure Python code meets a
-  # distinct hashlib and OpenSSL.
-  # windows-11-arm needs no special handling, and that is worth a word:
-  # which architecture the interpreter targets there is up to the runner
-  # image, native arm64 for the versions it caches and emulated x86-64
-  # for the ones uv has to download, and the wheel is selected for the
-  # interpreter rather than for the host, so either one links
+  # distinct hashlib and OpenSSL
   suite:
     name: Run the suite on ${{ matrix.python }}, ${{ matrix.os }}
     # a draft pull request is work in progress: every push to one spends
@@ -81,24 +76,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # four, and macos.yml carries the other two: on one run of the
-        # full six every macOS cell waited 29.4 and 23.2 minutes on average
-        # for a runner, against 0.5 to 1.6 here, so two rows of twelve set
-        # most of the wait of a pull request -- 45 jobs, 93 minutes of work
-        # and 399 minutes of queueing. What they sample is a platform this
-        # library has no branch for, which is worth a week rather than
-        # worth a review's patience
+        # two, and macos.yml and windows.yml carry the other four, each with
+        # its measurement in its own header: what a platform row costs a
+        # pull request is the wait for a runner, and what it buys is a
+        # standard library under code this library writes no
+        # platform-conditional branch in. The two cheapest and fastest rows
+        # stay, because something has to run the suite before a merge; the
+        # rest answer weekly and before a release
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
-          - windows-latest
-          - windows-11-arm
         # 3.14t is the free-threaded interpreter, and it is in the matrix
         # for what it installs as much as for what it runs: the bindings
         # ship a py3-none dynamic wheel for it, and nothing else here
         # exercises a build without the GIL. python-build-standalone has a
-        # freethreaded build for all six platforms below, so it needs no
-        # exclusion.
+        # freethreaded build for every platform this repository runs, the
+        # two here and the four of macos.yml and windows.yml, so it needs no
+        # exclusion of its own.
         # no pypy3.10, and PyPy is still tested: hypothesis ships
         # compiled wheels from 6.160 on and publishes none for pypy3.10, so
         # uv falls back to its sdist, whose maturin build needs a PyO3 that
@@ -114,6 +108,17 @@ jobs:
           - "3.14"
           - "3.14t"
           - "pypy3.11"
+        # the one cell the coverage job below already is: same runner image,
+        # same interpreter, the same suite, and the only difference is the
+        # instrumentation. Running both asks one question twice and holds two
+        # of the twenty concurrent jobs GitHub Free gives an organization,
+        # which is what a pull request's wall clock is made of here. Nothing
+        # else in the matrix is excluded: that job is pinned to this pair,
+        # for the reason its own comment gives, so this is the only overlap
+        # there can be
+        exclude:
+          - os: ubuntu-latest
+            python: "3.14"
     # far above what a run of the suite needs: what it bounds is a hung
     # job holding a runner for six hours
     timeout-minutes: 30
@@ -165,7 +170,10 @@ jobs:
   # The number is a gate rather than a report: fail_under, in
   # tool.coverage.report, fails this job on a regression. It needs no
   # secret and no third party, and it applies to every run, where a
-  # coveralls.io upload happens only on a pull request
+  # coveralls.io upload happens only on a pull request.
+  # It is also the (3.14, ubuntu-latest) cell of the matrix above, which is
+  # why that pair is excluded there: a suite that passes is what this job
+  # reports before it reads a number, so the pair needs no job of its own
   coverage:
     name: Measure coverage, gated at 100%
     if: ${{ !github.event.pull_request.draft }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,125 @@
+---
+name: windows
+
+# the second platform the merge gate does not wait for, and it is here for
+# the reason macos.yml is, measured on this repository rather than assumed.
+# GitHub Free gives an organization twenty concurrent jobs, and a commit used
+# to ask for thirty-nine: measured over a working afternoon, the repository
+# sat at nineteen or twenty running jobs for 1375 of 2100 seconds, so a pull
+# request's wall clock was set by waiting for a slot and not by the suite.
+# The fourteen Windows cells were 2357 of the 3556 seconds of matrix work per
+# commit -- windows-11-arm alone 1250, the slowest row and the one with the
+# longest queue -- and they also carry the largest fixed cost per cell, some
+# 50 to 75 seconds of checkout, uv and wheel build against 17 on ubuntu.
+# Moving them here took a commit from 66 runner-minutes to 25. To re-derive:
+#
+#     id=$(gh run list --workflow=test.yml --limit 1 \
+#         --json databaseId --jq '.[0].databaseId')
+#     gh api "repos/$GITHUB_REPOSITORY/actions/runs/$id/jobs?per_page=100"
+#
+# What these cells buy is what macos.yml's comment says of its own: there is
+# no platform-conditional branch in this library -- no sys.platform and no
+# sys.version_info anywhere, which is the property the coverage job of
+# test.yml records from the other side -- so every cell walks the same lines.
+# What runs here is the standard library under them, the published
+# btclib_secp256k1 wheel for each interpreter, and the one path separator
+# and line ending this library never sees otherwise.
+#
+# windows-11-arm needs no special handling, and that is worth a word: which
+# architecture the interpreter targets there is up to the runner image,
+# native arm64 for the versions it caches and emulated x86-64 for the ones
+# uv has to download, and the wheel is selected for the interpreter rather
+# than for the host, so either one links.
+#
+# A workflow of its own rather than a row in macos.yml, which is the same
+# design that file argues for itself: one variable each, so a red cell names
+# a platform. On its own morning too, and that is this workflow's whole
+# point -- macos.yml and latest.yml already share Wednesday, and fourteen
+# more jobs against twenty slots would rebuild on that morning the queue
+# this file exists to take out of a pull request.
+#
+# It gates no commit and no merge -- a Windows regression sits on main for at
+# most a week -- but release.yml calls it, so one cannot be published
+
+on:
+  schedule:
+    # Saturday, the one day nothing else here asks for -- the mutation
+    # session Sunday, links Monday, codeql Tuesday, latest and macos
+    # Wednesday, Dependabot Thursday, integration Friday -- so a failure
+    # notification still names the workflow by the day it arrived, which is
+    # the convention codeql.yml states at its own cron. A minute that is not
+    # the hour, as every schedule here, so the run does not queue behind
+    # everything else cron starts; 19 is unused by the others.
+    # Only the default branch schedules workflows, so on any other branch
+    # this is reachable through the dispatch below alone
+    - cron: "19 4 * * 6"
+  # lets release.yml gate a publication on this platform too, which is what
+  # keeps a weekly sentinel from being the only thing that ever asks
+  workflow_call:
+  # the escape hatch: the platform on demand, for a branch that touches a
+  # path, a line ending or anything a subprocess reaches
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: everything running in a job
+# (actions, dependencies) can read the token, so it must not be able to
+# write to the repository
+permissions:
+  contents: read
+
+# cancel superseded runs: the subject here is the commit, which a newer one
+# supersedes. Named literally rather than with github.workflow, which in a
+# called workflow is the caller's name -- release.yml calls this one
+# alongside test.yml, and with that expression the two would share a group
+# and cancel each other
+concurrency:
+  group: windows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  suite-windows:
+    name: Run the suite on ${{ matrix.python }}, ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # every cell to the end: which interpreter fails on which image is the
+      # whole answer, and stopping at the first one hides the rest
+      fail-fast: false
+      matrix:
+        # the two images test.yml no longer carries. Both, and not the
+        # newest alone: what differs between them is the architecture the
+        # interpreter and the bindings wheel target
+        os:
+          - windows-latest
+          - windows-11-arm
+        # the interpreter set test.yml runs, unchanged: this workflow moves
+        # the platform and nothing else, so a difference between the two is
+        # attributable to the platform
+        python:
+          - "3.10"
+          - "3.11"
+          - "3.12"
+          - "3.13"
+          - "3.14"
+          - "3.14t"
+          - "pypy3.11"
+    # far above what a run of the suite needs, and it bounds a hung job
+    # rather than a slow one: the queueing this workflow exists to move
+    # happens before a job starts and is not counted here
+    timeout-minutes: 30
+    steps:
+      # the three steps of test.yml's suite job, and each `with:` there
+      # carries the reason for itself
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+          python-version: ${{ matrix.python }}
+      # --no-cov for the reason test.yml's suite job gives beside its own
+      # step: this matrix carries the same PyPy cells behind the same
+      # timeout, and the coverage job there is the one place the number is
+      # measured and gated
+      - name: Run pytest
+        run: uv run --locked --no-default-groups --group test pytest --no-cov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,33 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **A pull request asks for twenty-one jobs instead of thirty-nine**, and
+  the number that decided it is not a wall clock but a ceiling: GitHub Free
+  gives an organization twenty concurrent jobs. Measured over a working
+  afternoon of eight branches, the repository sat at nineteen or twenty
+  running jobs for 1375 of 2100 seconds, 328 jobs asked for and 552
+  runner-minutes to drain, so a pull request's wall clock was the wait for
+  a slot; a run of `test.yml` spent 476 to 1083 seconds of it, against 65
+  to 320 seconds of work in its slowest cell. Three changes, and each is
+  the same trade -- an answer moved off the review path, none dropped:
+    - the fourteen Windows cells become `windows.yml`, weekly on Saturday
+    and called by `release.yml`, exactly as `macos.yml` already holds the
+    macOS ones and for the reason its header gives. They were 2357 of the
+    3556 seconds of matrix work per commit, `windows-11-arm` alone 1250 --
+    the slowest row, the longest queue, and some 50 to 75 seconds of fixed
+    cost per cell against 17 on ubuntu.
+    - `codeql.yml` loses its `pull_request` trigger and keeps `main` and its
+    Tuesday schedule, so `codeql: every job passed` is no longer one of
+    main's required checks -- four now, and REPOSITORY.md is where the
+    rule and the `gh api` patch that dropped the context are written down.
+    What still reads a branch before it merges is `zizmor`, a pre-commit
+    hook, which audits these workflows for an injected expression on every
+    pull request as part of a check that does gate.
+    - the `(3.14, ubuntu-latest)` cell of `test.yml`'s matrix is excluded,
+    because the `coverage` job beside it is that cell: same image, same
+    interpreter, the same suite, and the only difference is the
+    instrumentation.
+
 - **`tests/build_system_test.py` collects on 3.10** (#767), where it read
   pyproject.toml with `tomllib` -- standard library from 3.11 up, and the
   floor here is 3.10: the module failed to collect on the four 3.10 cells

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,29 +239,45 @@ read by every checkout of this repository.
 
 | workflow | when | what it varies |
 | --- | --- | --- |
-| `test` | pull request, push | 4 platforms × 7 interpreters |
+| `test` | pull request, push | 2 platforms × 7 interpreters |
 | `lint`, `docs` | pull request, push | — |
 | `integration` | pull request, push | a node, two device emulators |
 | `website` | pull request, push, on website files | — |
-| `codeql` | pull request, push, Tuesday | 2 languages |
+| `codeql` | push to main, Tuesday | 2 languages |
+| `windows` | Saturday, a release | 2 Windows images × 7 interpreters |
 | `macos` | Wednesday, a release | 2 macOS images × 7 interpreters |
 | `latest` | Wednesday | platforms sampled, deps upgraded |
 | `links`, `mutation` | weekly | — |
 | `vendored-vectors` | monthly | upstream's vectors |
 | `published` | monthly, a release | what PyPI serves |
-| `release` | a tag | calls test, lint, docs, macos, published |
+| `release` | a tag | calls test, lint, docs, macos, windows, published |
 
 The first four rows are what a merge waits for, and between them they report
-the five required checks: `lint` and `docs` share a row and report one
-each. macOS is not among them on purpose: it is the platform whose runners
-queue — 29.4 and 23.2 minutes of mean wait against 0.5 to 1.6 elsewhere, on
-a run of 45 jobs that spent 93 minutes working and 399 waiting — so it
-answers weekly, and before a release, rather than before a review. `macos`
-and `latest` share a morning half an hour apart, which is what makes the
-pair readable: red in both is the platform, red in `latest` alone is the
-upgrade. Every workflow in the table also takes `workflow_dispatch`, the
-gates included: a branch whose pull request is not open yet has no other way
-to ask.
+the four required checks: `lint` and `docs` share a row and report one each.
+
+What the other rows have in common is that a pull request does not wait for
+them, and the reason is one number: GitHub Free gives an organization twenty
+concurrent jobs. A commit used to ask for thirty-nine, and a repository at
+that ceiling spends a pull request's wall clock waiting for a slot rather
+than running the suite — measured over a working afternoon, nineteen or
+twenty jobs were running for 1375 of 2100 seconds. So a platform row earns
+its place before a review only if it is cheap to wait for: macOS queued 29.4
+and 23.2 minutes on average against 0.5 to 1.6 elsewhere, and the fourteen
+Windows cells were 2357 of the 3556 seconds of matrix work per commit, the
+slowest rows and the longest queues. Both answer weekly and before a
+release instead, which is a regression sitting on `main` for at most a week
+against every review paying for it. `codeql` is there for the same
+arithmetic, with `zizmor` in `lint` still reading these workflows on every
+pull request; REPOSITORY.md has that trade in full.
+
+`macos` and `latest` share a morning half an hour apart, which is what makes
+the pair readable: red in both is the platform, red in `latest` alone is the
+upgrade. `windows` takes a morning of its own, Saturday being the day
+nothing else here asks for — fourteen jobs beside those two would rebuild on
+Wednesday the queue this arrangement exists to remove. Every workflow in the
+table also takes `workflow_dispatch`, the gates included: a branch whose
+pull request is not open yet has no other way to ask, and for `codeql` and
+the two platform workflows it is the only way to ask about a branch at all.
 
 ### Reproducing what CI runs
 
@@ -297,10 +313,15 @@ touching `.venv`. The command is what CI runs, verbatim, and CI has no
 `--no-cov` is the matrix asking about the platform and not about the
 number: it undoes the `--cov` addopts carries, so what a cell reports is
 whether that (os, architecture, interpreter) triple passes. The job below
-is where coverage is measured, and `macos.yml` passes the flag for the
-same reason. `latest.yml` does not: it runs no PyPy cell and has no
-coverage job of its own, so the ratchet meeting an upgraded coverage.py
-is one of the things that workflow exists to find out.
+is where coverage is measured, and `macos.yml` and `windows.yml` pass the
+flag for the same reason. `latest.yml` does not: it runs no PyPy cell and
+has no coverage job of its own, so the ratchet meeting an upgraded
+coverage.py is one of the things that workflow exists to find out.
+
+One pair is missing from that matrix, `(3.14, ubuntu-latest)`, and the
+coverage job below is it: same image, same interpreter, same suite, and the
+only difference is the instrumentation. Reproducing that cell is therefore
+the coverage command rather than this one.
 
 The `coverage` job, gated by `fail_under` in pyproject.toml:
 
@@ -644,9 +665,11 @@ something already known to the world.
 The only check with no local equivalent is `codeql`: the analysis needs the
 CodeQL bundle and a database, which is a download rather than a `uv`
 command, so `.github/workflows/codeql.yml` is where it is configured and
-GitHub's runners are where it happens. Its findings appear under the
-Security tab, and `REPOSITORY.md` has why the workflow is in the tree at
-all.
+GitHub's runners are where it happens. It is also the one check no pull
+request runs — `workflow_dispatch` is how a branch asks — so its findings
+arrive under the Security tab after a merge rather than before it, and
+`REPOSITORY.md` has both why the workflow is in the tree and what that
+timing was traded for.
 
 ### The website
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,14 +13,14 @@ rehearsal against TestPyPI. A rehearsal is never tagged.
 
 **A workflow GitHub has not registered cannot be dispatched, and it
 registers one only once its file has reached the default branch.** That
-makes `release.yml`, `latest.yml` and `published.yml` — `schedule` and
-`workflow_dispatch` only, so nothing else ever triggers them — answer
-`gh: Not Found (HTTP 404)` until the release pull request is merged. It
-bites once, on the first release after any of them is written, and it
-inverts the order below: the TestPyPI rehearsal and the `latest` run
-that this file asks for *before* the merge can only happen after it,
-still before the tag. It also means such a workflow reaches `main`
-having never run, which is how `published.yml` shipped a
+makes `release.yml`, `latest.yml`, `published.yml`, `macos.yml` and
+`windows.yml` — `schedule` and `workflow_dispatch` only, so nothing else
+ever triggers them — answer `gh: Not Found (HTTP 404)` until the release
+pull request is merged. It bites once, on the first release after any of
+them is written, and it inverts the order below: the TestPyPI rehearsal
+and the `latest` run that this file asks for *before* the merge can only
+happen after it, still before the tag. It also means such a workflow
+reaches `main` having never run, which is how `published.yml` shipped a
 `windows-11-arm` cell that failed at setup.
 
 ## Which version string is which

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -19,7 +19,7 @@ aggregate job at the end of `test.yml` that `needs` the matrix; a new job in
 carries the workflow because a context is keyed by name alone: two
 workflows with a job named the same thing produce one ambiguous check.
 
-`main` requires five checks, and only five:
+`main` requires four checks, and only four:
 
 | Check | Produced by |
 | --- | --- |
@@ -27,19 +27,17 @@ workflows with a job named the same thing produce one ambiguous check.
 | `Lint and type-check` | `lint.yml`, its only job |
 | `Build the documentation` | `docs.yml`, its only job |
 | `Regtest against Bitcoin Core` | `integration.yml`, its regtest job |
-| `codeql: every job passed` | `codeql.yml`, aggregate over the languages |
 
 A workflow needs an aggregate when every one of its jobs has to gate: the
-matrix of `test.yml` and the languages of `codeql.yml` are the two, and a
-context naming one cell of either would leave the rest outside the rule.
-Where a single job is what gates, that job *is* the context, which is why
-three of the five are job names — and why `integration.yml` naming a
-second job changed nothing here: `HWI against a Trezor emulator` runs
-beside the regtest one and must not gate, an emulator being a service to
-keep working rather than a claim about the branch, so the context stays
-the name of the job that does. What a second job would cost is a rename:
-a workflow whose *whole* answer becomes required needs an aggregate, and
-this table with it.
+matrix of `test.yml` is the one, and a context naming one cell of it would
+leave the rest outside the rule. Where a single job is what gates, that job
+*is* the context, which is why three of the four are job names — and why
+`integration.yml` naming a second job changed nothing here: `HWI against a
+Trezor emulator` runs beside the regtest one and must not gate, an emulator
+being a service to keep working rather than a claim about the branch, so
+the context stays the name of the job that does. What a second job would
+cost is a rename: a workflow whose *whole* answer becomes required needs an
+aggregate, and this table with it.
 
 `Build the documentation` is named on its own on purpose: a rule naming
 `Lint and type-check` alone would leave a red docs build outside the
@@ -50,26 +48,33 @@ moving a job is free and renaming one is not — the pull request that renames
 a required check stops producing the old name and never produces one the
 rule is waiting for.
 
-`Regtest against Bitcoin Core` is the newest of the five, and it is here
+`Regtest against Bitcoin Core` is the newest of the four, and it is here
 because its cost was measured rather than assumed: 36 seconds of work for a
 disposable regtest node, which is less than the matrix it runs beside. It
 answers the one claim the recorded vectors cannot make. `integration.yml`
 therefore carries no `paths` filter: a required check that never runs blocks
 a merge, where a skipped one satisfies it.
 
-`codeql: every job passed` is the only one of the five whose predecessor was
-not a file at all. Code scanning ran from default setup, a repository
-setting, which made the check that reads these workflows for an injected
-expression the one part of CI no diff could review — while every other check
-is a workflow with its actions pinned to commit SHAs. `codeql.yml` holds it
-now, one job per language and an aggregate over them, for the reason
-`test.yml` has one; the section below has how the switch was thrown, because
-the two cannot be exchanged in either order without a step that blocks
-every merge.
+`codeql: every job passed` is not among them, and that is the one place a
+check was traded for the wait it cost. GitHub Free gives an organization
+twenty concurrent jobs; a commit here asked for thirty-nine, and measured
+over a working afternoon the repository sat at nineteen or twenty running
+jobs for 1375 of 2100 seconds — so a pull request's wall clock was the wait
+for a slot and not the work. `codeql.yml` now runs on `main` and on its
+schedule, the analysis landing on the merge commit rather than ahead of it,
+and it still produces that aggregate: the name is available, so requiring it
+again is a patch to the rule and nothing in the tree.
 
-Renaming a required check is the one change that cannot be made in a pull
-request, so the rule moves first, against the branch, and the pull request
-that renames the job reports the name the rule now wants:
+What still reads a branch before it merges is the workflow half of the same
+question: `zizmor` is a pre-commit hook, so `lint.yml` audits these very
+files for an injected expression on every pull request, and that check is
+required. What a merge now defers is the rest of the analysis, for the time
+between that merge and the next run — which for `main` is the merge itself.
+
+Renaming or dropping a required check is the one change that cannot be made
+in a pull request: the workflow in the branch stops producing the name while
+the rule outside still waits for it, so nothing merges. The rule moves
+first, against the branch, and the pull request follows:
 
 ```shell
 branch=repos/btclib-org/btclib/branches/main
@@ -80,14 +85,13 @@ gh api -X PATCH "$branch"/protection/required_status_checks --input - <<'JSON'
     {"context": "test: every job passed", "app_id": 15368},
     {"context": "Lint and type-check", "app_id": 15368},
     {"context": "Build the documentation", "app_id": 15368},
-    {"context": "Regtest against Bitcoin Core", "app_id": 15368},
-    {"context": "codeql: every job passed", "app_id": 15368}
+    {"context": "Regtest against Bitcoin Core", "app_id": 15368}
   ]
 }
 JSON
 ```
 
-**`checks` and not `contexts`, and that is not a style.** All five are
+**`checks` and not `contexts`, and that is not a style.** All four are
 bound to the app that produces them — 15368, Actions — so nothing else
 reporting one of those names can satisfy it. `contexts` has no field for
 an app, so a `PATCH` sending it replaces the bound list with an unbound
@@ -131,16 +135,19 @@ default setup is enabled
 ```
 
 So while the setting is on, the analysing jobs and the aggregate are red
-rather than absent — which is why the exchange has an order. These five
-steps are the order that never leaves `main` unmergeable, and 1, 2 and 5
-are a token rather than a pull request, so only a human can perform them:
+rather than absent — which is why the exchange has an order. These four
+steps are the order that never leaves `main` unmergeable, and 1 and 2 are a
+token rather than a pull request, so only a human can perform them:
 
 1. patch the rule to drop the `CodeQL` context, every other one staying;
 1. disable default setup;
 1. re-run the pull request's checks: the upload that was refused is
    accepted now, so `codeql: every job passed` goes green;
-1. merge;
-1. patch the rule to add `codeql: every job passed`.
+1. merge.
+
+There is no fifth step adding `codeql: every job passed` to the rule, and
+the section above is why: that context is not required, so what the rule
+holds is what step 1 leaves it with.
 
 Step 2 is what makes the setting let go of the analysis. It is not the
 command that enabled default setup and there is no need to keep that one:
@@ -173,50 +180,18 @@ gh api -X PATCH \
   -F state=not-configured
 ```
 
-Steps 1 and 5 patch the `checks` array rather than `contexts`, so that the
+Step 1 patches the `checks` array rather than `contexts`, so that the
 bindings the rule already has survive the edit, and **a JSON body on stdin
 is what that takes**: `-f` sends every value as a string and the endpoint
-answers 422 for a string `app_id`. Step 1:
-
-```shell
-branch=repos/btclib-org/btclib/branches/main
-gh api -X PATCH "$branch"/protection/required_status_checks --input - <<'JSON'
-{
-  "strict": true,
-  "checks": [
-    {"context": "test: every job passed", "app_id": 15368},
-    {"context": "Regtest against Bitcoin Core", "app_id": 15368},
-    {"context": "Lint and type-check", "app_id": 15368},
-    {"context": "Build the documentation", "app_id": 15368}
-  ]
-}
-JSON
-```
-
-Step 5 is that body with one entry added, and every entry carries its app
-because every one of these checks is an Actions check — the `CodeQL` this
-replaces was the exception, the app producing it not being Actions:
-
-```shell
-branch=repos/btclib-org/btclib/branches/main
-gh api -X PATCH "$branch"/protection/required_status_checks --input - <<'JSON'
-{
-  "strict": true,
-  "checks": [
-    {"context": "test: every job passed", "app_id": 15368},
-    {"context": "Regtest against Bitcoin Core", "app_id": 15368},
-    {"context": "codeql: every job passed", "app_id": 15368},
-    {"context": "Lint and type-check", "app_id": 15368},
-    {"context": "Build the documentation", "app_id": 15368}
-  ]
-}
-JSON
-```
+answers 422 for a string `app_id`. Its body is the four-check one the
+section above carries, every entry naming its app because every one of these
+is an Actions check — the `CodeQL` it drops was the exception, the app
+producing it not being Actions.
 
 ## Branch protection
 
 `main` is the only branch, and everything reaches it through a pull
-request: the five checks above with `strict`, one approving review,
+request: the four checks above with `strict`, one approving review,
 `dismiss_stale_reviews`, **required signatures**, linear history, no force
 pushes, no deletions, `required_conversation_resolution`, and
 `enforce_admins` *off* — an administrator can bypass all of it.


### PR DESCRIPTION
GitHub Free gives an organization twenty concurrent jobs, and this repository
asked for thirty-nine on every commit. Measured over a working afternoon of
eight branches, it sat at nineteen or twenty running jobs for 1375 of 2100
seconds — 328 jobs asked for, 552 runner-minutes to drain — so a pull
request's wall clock was the wait for a slot and not the work: 476 to 1083
seconds for a run of `test.yml`, against 65 to 320 seconds in its slowest
cell.

Three answers move off the review path, none is dropped.

| | runner-minutes a commit | jobs |
| --- | --- | --- |
| before | 66 | 39 |
| after | 23 | 21 |

- **the fourteen Windows cells become `windows.yml`**, weekly on Saturday and
  called by `release.yml`, exactly as `macos.yml` already holds the macOS ones
  and for the reason its header gives. They were 2357 of the 3556 seconds of
  matrix work per commit, `windows-11-arm` alone 1250 — the slowest row, the
  longest queue, and some 50 to 75 seconds of fixed cost per cell against 17
  on ubuntu.
- **`codeql.yml` loses its `pull_request` trigger** and keeps `main` and its
  Tuesday schedule, so the analysis lands on the merge commit rather than
  ahead of it. What still reads a branch before it merges is `zizmor`, a
  pre-commit hook, which audits these very workflows for an injected
  expression as part of a check that does gate.
- **the `(3.14, ubuntu-latest)` cell of `test.yml`'s matrix is excluded**,
  because the `coverage` job beside it *is* that cell: same image, same
  interpreter, the same suite, and the only difference is the instrumentation.

## This needs the branch rule patched first

`codeql: every job passed` is a required check on `main`, and this branch
stops producing it — so nothing merges until the rule drops that context.
That half cannot be made in a pull request. REPOSITORY.md carries the table
and the command, now four checks:

```shell
branch=repos/btclib-org/btclib/branches/main
gh api -X PATCH "$branch"/protection/required_status_checks --input - <<'JSON'
{
  "strict": true,
  "checks": [
    {"context": "test: every job passed", "app_id": 15368},
    {"context": "Lint and type-check", "app_id": 15368},
    {"context": "Build the documentation", "app_id": 15368},
    {"context": "Regtest against Bitcoin Core", "app_id": 15368}
  ]
}
JSON
```

`windows.yml` also reaches `main` having never run — `schedule`,
`workflow_call` and `workflow_dispatch` only, so GitHub cannot dispatch it
until its file is on the default branch. RELEASING.md already states that
trap and now names this file among the ones it applies to; a dispatch right
after the merge is what confirms the matrix.

Local gates, all green: `uv run pre-commit run --all-files`, the sphinx build
with `-W`, and `uv run pytest` at 26711 passed with the coverage ratchet met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reduce CI load and required checks by moving Windows test matrix to a separate scheduled workflow, adjusting CodeQL to run only on main and its schedule, and trimming redundant test matrix cells.

New Features:
- Add a dedicated windows.yml workflow to run the Windows test matrix weekly and during releases.

Enhancements:
- Update test.yml to run Linux-only matrices for PRs and pushes, excluding the cell duplicated by the coverage job.
- Extend release.yml to invoke the new Windows workflow and gate publishing on its completion.
- Clarify CI and branch protection behavior in CONTRIBUTING.md, REPOSITORY.md, RELEASING.md, and CHANGELOG.md regarding required checks and scheduled workflows.

CI:
- Change codeql.yml triggers so analyses run on pushes to main, weekly schedule, and manual dispatch only, and ensure its aggregate job is no longer a required check.
- Adjust concurrency and permissions comments across workflows to reflect the new CI structure and scheduling.
- Document and apply the updated branch protection rule that drops the CodeQL aggregate check from main's required checks.

Documentation:
- Update contributor, repository, releasing, and changelog documentation to describe the new job counts, platform workflows, CodeQL timing, and branch protection requirements.

Tests:
- Refine the test matrix to focus PR runs on the most efficient platforms while coverage continues to gate on a single Linux cell.