### PR TITLE
Judge the vectors with the Python verdict, not the Python arithmetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2781,6 +2781,24 @@ documented at release-notes length in the first place, and are still in
 
 ### Tests
 
+- **`python_path_test.py` leaves the arithmetic delegated.** It patches
+  the bindings off for `dsa` and `ssa`, which is what puts the Python
+  verdict in front of the vendored consensus vectors, and no longer for
+  `curves.curve`, which is one layer further down: that third patch sent
+  the `double_mult` of `_assert_as_valid_` and the two square roots that
+  lift a key and answer for an r into Python as well, on every vector of
+  the module -- 1.02 ms against 28 µs for the multiplication, 75 µs
+  against 2.9 and 2.4 for the roots, and the module 8.6x of what it now
+  costs, the largest single item in the suite by a wide margin. What it
+  bought was a comparison `tests/curves/curve_test.py` already makes
+  against the bindings, and makes on a chosen spread of inputs rather
+  than on whatever these vectors happen to carry:
+  `test_libsecp256k1_arbitrary_point` for the multiplications,
+  `test_x_coordinate_lift` for the roots. What the module is for is
+  untouched, both #129 defects being `Sig.parse` and `point_from_octets`
+  -- neither of them arithmetic, and both still on the path the two
+  remaining patches open. Coverage is unchanged.
+
 - **The input-validation rule has a gate, and the gate enumerates by
   running** (issues #743, #744). `tests/input_validation_test.py` holds
   every public module-level function whose required parameters are all

--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -10,7 +10,7 @@ these vectors otherwise: a defect in them is unreachable rather than
 absent. Issue #129 found two hiding exactly there, each accepting a
 transaction the data calls invalid.
 
-This module is the bindings-less configuration, without the packaging:
+This module is the bindings-less verification, without the packaging:
 the two symbols the engine imports from the bindings are replaced by the
 Python implementations and the same vector sets run again through them,
 so a disagreement between the two implementations about the *verdict*
@@ -35,7 +35,7 @@ from typing import Any
 
 import pytest
 
-from btclib.curves import curve, point_from_octets
+from btclib.curves import point_from_octets
 from btclib.ecc import dsa, ssa
 from btclib.exceptions import BTClibValueError
 from btclib.script.engine import script as engine_script
@@ -78,16 +78,27 @@ def python_verification(monkeypatch: pytest.MonkeyPatch) -> None:
     secp256k1 with sha256 straight back to them -- the very dispatch that
     makes the Python path unreachable in the first place.
 
-    A third patch, one curve deeper, is what keeps the arithmetic Python
-    too: `dsa._assert_as_valid_` and `ssa._assert_as_valid_` reach the
-    `double_mult` of `curves.curve`, which delegates any point of
-    secp256k1 to the bindings. Without it the verdict below would still be
-    the Python implementation's, and the multiplication under it would not
-    -- a bindings-less configuration in name only.
+    The arithmetic under the verdict stays delegated: no third patch on
+    `curves.curve`, whose dispatch is what `dsa._assert_as_valid_` and
+    `ssa._assert_as_valid_` reach for a `double_mult` and for the two
+    square roots that lift a key and answer for an r. Patching it off
+    would send those down the Python path on every vector below, at the
+    ratios `curves/curve.py` states beside each of them, and would buy a
+    comparison `tests/curves/curve_test.py` already makes against the
+    bindings -- `test_libsecp256k1_arbitrary_point` for the
+    multiplications, `test_x_coordinate_lift` for the roots -- on a
+    chosen spread of inputs rather than on whatever these vectors happen
+    to carry.
+
+    So the line is drawn where the second implementation is otherwise
+    unreached: `Sig.parse`, the hybrid prefix `point_from_octets` takes
+    only when asked, and the parity and the x comparison
+    `_assert_as_valid_` makes -- which is where both #129 defects were.
+    The field and group arithmetic under all of that is the bindings',
+    as it is everywhere else.
     """
     monkeypatch.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
     monkeypatch.setattr(ssa, "_libsecp256k1_applicable", lambda *_: False)
-    monkeypatch.setattr(curve, "_libsecp256k1_applicable", lambda *_: False)
     monkeypatch.setattr(engine_script, "_libsecp256k1_dsa_verify", python_dsa_verify)
     monkeypatch.setattr(engine_tapscript, "_libsecp256k1_ssa_verify", python_ssa_verify)
 


### PR DESCRIPTION
`tests/script_engine/python_path_test.py` patched the bindings off in
three places. Two of them are what the module is for: the engine's own
reference to the bindings' verify, and `btclib.ecc`'s dispatch. Together
they put `Sig.parse`, the hybrid prefix `point_from_octets` takes only
when asked, and the parity and x comparison of `_assert_as_valid_` in
front of the vendored consensus vectors — which is where
https://github.com/btclib-org/btclib/issues/129 found two defects, both
of them there and neither of them arithmetic.

The third patch, on `curves.curve`, went a layer further down: it sent
the `double_mult` under that verdict and the two square roots that lift
a key and answer for an `r` into Python as well, on every vector of the
module. Profiled, that is essentially the whole of its cost — 1.02 ms
against 28 µs for the multiplication, 75 µs against 2.9 and 2.4 for the
roots, at ~21k verifications.

What it bought is a comparison
[`tests/curves/curve_test.py`](tests/curves/curve_test.py) already makes
against the bindings, and makes deterministically rather than on
whatever these vectors happen to carry:
`test_libsecp256k1_arbitrary_point` for the multiplications,
`test_x_coordinate_lift` for the roots.

Measured, dropping it:

| | before | after |
|---|---|---|
| the module, serial | 28.5s | **3.3s** |
| the suite, wall clock | 27.1s | **22.0s** |
| coverage | 100% | 100% |
| outcomes | 5185 passed | 5185 passed |

The module was 41.8% of the suite's test CPU, the largest single item by
a wide margin.

The fixture docstring said the third patch was what kept this from being
"a bindings-less configuration in name only"; it now says where the line
is drawn and why — the verdict and the parsing are Python here, the
field and group arithmetic under them is the bindings', as everywhere
else — and the module docstring says "bindings-less verification" rather
than "configuration".

Gates run locally: `uv run pytest` (100% coverage), `uv run pre-commit
run --all-files`, and the sphinx `-W` build, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Limit python_path_test to exercising Python-based verdict and parsing while keeping field and group arithmetic delegated to libsecp256k1 bindings, improving test performance without changing coverage or outcomes.

Documentation:
- Clarify python_path_test module and fixture docstrings to describe bindings-less verification rather than configuration and to document the boundary between Python verdict logic and bindings-backed arithmetic.

Tests:
- Adjust python_path_test fixture to stop patching curves.curve so only dsa/ssa verdict and parsing run via Python while curve arithmetic stays in the bindings, removing redundant comparison already covered by curve_test.

Chores:
- Document the performance impact and rationale for unpatching curves.curve in CHANGELOG, noting unchanged coverage and test outcomes.