### PR TITLE
Delegate mod_inv's extended Euclid to CPython (#779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1174,6 +1174,38 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **`mod_inv` delegates its extended Euclid to CPython** (issue #779).
+  `pow(a, -1, m)` is `long_invmod`, the same algorithm `xgcd` runs with
+  the second cofactor dropped -- CPython carries that loop as a comment
+  above the C -- so the inverse is no longer interpreted a division step
+  at a time. Modulo secp256k1's `p` or `n` it is 2.5x, and modulo a
+  low-cardinality curve's order 5.8x, measured in alternating rounds
+  against `pow(v, 3, m)` as the case the change cannot touch. Where that
+  shows is affine arithmetic, which pays one inverse per addition:
+  `_mult_aff` on secp256r1 went from 5178 us to 2184 us. The Jacobian
+  path pays one at the end of a multiplication and moves 3%, and
+  secp256k1 with sha256 and a library nonce does not move at all, never
+  reaching this function.
+
+  Nothing about the properties changed: both spellings are variable-time
+  and branch on the operand, which `SECURITY.md` publishes about the
+  Python path. safegcd would be the constant-time answer and is the wrong
+  trade here -- in bytecode its 256 divsteps lose to one C call, the
+  batching into 62-bit transition matrices being what makes it fast in
+  libsecp256k1 and what its own document declines to explain; and
+  `_mult_aff`, `_mult_jac` and the wNAF branch on the scalar anyway, so a
+  constant-time inverse would close one leak of several and cost speed.
+
+  What `pow` does not carry is this module's error contract, so the two
+  validations stay and the refusal is rebuilt rather than chained: a
+  non-invertible operand is a bare `ValueError` naming neither operand,
+  where `mod_inv` names both in hex; a modulus of zero is another one,
+  which `except BTClibValueError` does not catch; a negative modulus
+  `pow` accepts, answering a negative residue; and a bool reaches it as
+  the integer it subclasses. `xgcd` is unchanged, still exported and
+  still tested as the Bezout identity it is named after -- it stops
+  being what `mod_inv` is built on, and stays what it was.
+
 - **The bits a digit holds are counted in integers** (issue #759).
   `bin_str_entropy_from_rolls` and `collect_rolls` computed
   `math.floor(math.log2(dice_sides))`, which is exact until `2**49 - 1`:

--- a/btclib/number_theory.py
+++ b/btclib/number_theory.py
@@ -58,10 +58,11 @@ def _assert_valid_modulus(m: int) -> None:
 
 # every public function here checks its own arguments, rather than five
 # private twins doing the work unchecked for the ones that call each
-# other: a pair of isinstance calls is a fraction of a percent of the
-# arithmetic it stands in front of, an inverse modulo a 256-bit prime
-# being an extended Euclid, so the re-checking mod_sqrt does through
-# tonelli and legendre_symbol costs less than five more names would
+# other: a pair of isinstance calls is a small fraction of the arithmetic
+# it stands in front of, an inverse modulo a 256-bit prime being an
+# extended Euclid even when C runs it, so the re-checking mod_sqrt does
+# through tonelli and legendre_symbol costs less than five more names
+# would
 
 
 def xgcd(a: int, b: int) -> tuple[int, int, int]:
@@ -85,20 +86,29 @@ def mod_inv(a: int, m: int) -> int:
 
     m does not have to be a prime.
 
-    Based on Extended Euclidean Algorithm, see:
-    - https://en.wikibooks.org/wiki/Algorithm_Implementation/Mathematics/Extended_Euclidean_algorithm
+    `pow(a, -1, m)` is an Extended Euclidean Algorithm too -- CPython's
+    `long_invmod`, which is the loop `xgcd` runs with the second cofactor
+    dropped -- so this delegates the same algorithm to C rather than
+    interpreting it, and that is the whole of why it is called. It is not
+    a constant-time inverse and neither was the bytecode one; SECURITY.md
+    publishes the Python path as variable-time.
+
+    What `pow` does not carry is this module's contract, so the checks
+    stay above it and the message below it: a non-invertible operand
+    leaves `pow` as a bare `ValueError` naming neither operand, and
+    rebuilding the message says more than chaining that one would.
     """
     _assert_valid_operand(a)
     _assert_valid_modulus(m)
-    a %= m
-    g, x, _ = xgcd(a, m)
-    if g == 1:
-        return x % m
-    err_msg = "no inverse for "
-    err_msg += f"{hex_string(a)}" if a > 0xFFFFFFFF else f"{a}"
-    err_msg += " mod "
-    err_msg += f"{hex_string(m)}" if m > 0xFFFFFFFF else f"{m}"
-    raise BTClibValueError(err_msg)
+    try:
+        return pow(a, -1, m)
+    except ValueError:
+        a %= m
+        err_msg = "no inverse for "
+        err_msg += f"{hex_string(a)}" if a > 0xFFFFFFFF else f"{a}"
+        err_msg += " mod "
+        err_msg += f"{hex_string(m)}" if m > 0xFFFFFFFF else f"{m}"
+        raise BTClibValueError(err_msg) from None
 
 
 def legendre_symbol(a: int, p: int) -> int:


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/779.

`pow(a, -1, m)` is `long_invmod`, which CPython carries as a comment
above the C: the loop `xgcd` runs, with the second cofactor dropped. So
this is not a different algorithm, only the same one stopping being
interpreted a division step at a time.

## Measured

Against `dbaa5080` on Python 3.14.6, alternating A/B rounds with a case
the change cannot touch as the noise detector.

| | `xgcd` | `pow(a, -1, m)` | |
| --- | ---: | ---: | ---: |
| inverse mod secp256k1 `p` | 22.95 us | 9.25 us | **2.48x** |
| inverse mod secp256k1 `n` | 23.00 us | 9.26 us | **2.48x** |
| inverse mod 7 | 0.327 us | 0.056 us | **5.83x** |
| control, `pow(v, 3, m)` | 0.491 us | 0.503 us | 1.02x |
| `_mult_aff`, secp256r1 | 5178 us | 2184 us | **2.37x** |
| `mult`, secp256r1, Jacobian | 993 us | 965 us | 1.03x |
| `dsa.assert_as_valid`, secp256k1 | 20.3 us | 20.2 us | 1.01x |
| control, `mult` secp256k1 | 8.2 us | 8.2 us | 1.01x |
| the suite, `uv run pytest` | 19.53-20.04 s | 17.34-18.54 s | **~8%** |

Affine arithmetic is where the factor lands, paying one inverse per
addition — every curve but secp256k1, and the low-cardinality curves the
suite runs on. The Jacobian path pays one at the end of a multiplication
and barely moves; secp256k1 with sha256 and a library nonce does not
move at all, never reaching this function.

## What was kept

`pow` answers a different way in four places, so both validations stay
and the refusal is rebuilt rather than chained:

- a non-invertible operand is `ValueError: base is not invertible for the
  given modulus`, naming neither operand, where `mod_inv` names both in
  hex
- `pow(3, -1, 0)` is a bare `ValueError`, which `except BTClibValueError`
  does not catch
- a negative modulus `pow` accepts, answering a negative residue
- `pow(True, -1, 7)` answers `1`, a bool being an int

The first two are the reasons `_assert_valid_modulus`'s docstring
already gives, and it names `pow` for the second.

`xgcd` is untouched: still in `__all__`, still covered by
`test_xgcd_is_bezout`. It stops being what `mod_inv` is built on and
stays what it was.

## Equivalence

Every `a` in `[-m, 2m]` for every `m` in `1..199`, comparing answers and
refusals: 0 divergences, the non-invertible cases and `m == 1` included.
The existing tests cover the change with no addition — `test_mod_inv`
inverts every residue of every modulus up to 100, `test_mod_inv_inverts`
is the property version.

## Gates

`uv run pytest` (26711 passed, coverage at 100%), `uv run pre-commit run
--all-files`, and the sphinx `-W` build, all green locally.

## Not in this PR

safegcd, which https://github.com/btclib-org/btclib/issues/779 argues
against on both counts: slower in bytecode, and constant time is not
something one inverse can deliver while `_mult_aff`, `_mult_jac` and the
wNAF branch on the scalar. GLV is separate work on `mult`.

## Summary by Sourcery

Delegate modular inverse computation to CPython’s built‑in `pow(a, -1, m)` while preserving btclib’s validation and error semantics.

Enhancements:
- Refine `mod_inv` to use CPython’s extended Euclidean implementation via `pow(a, -1, m)` instead of the local `xgcd` loop, keeping argument validation and custom error messages intact.
- Clarify documentation in `number_theory.py` around argument checking and the relationship between `mod_inv`, extended Euclid, and CPython’s implementation.

Documentation:
- Document the `mod_inv` change and its performance/security trade‑offs in the changelog, including impact on affine arithmetic and confirmation that `xgcd` remains unchanged.