### PR TITLE
Say how to take a profile of the suite, and how to read one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2950,6 +2950,27 @@ documented at release-notes length in the first place, and are still in
   refuses the same substitution in the same place: typeshed's `hmac.new`
   rejects a SHAKE as a digestmod, and derives `HASHXOF` from `HASH` only
   through a `type: ignore[override]`.
+- **`tests/README.md` says how to take a profile and how to read one.**
+  The commands it carried took the suite's defaults with them, and every
+  one of those defaults is wrong under a profiler: `-n auto` runs the
+  tests in child processes cProfile never sees, leaving the parent it
+  does measure waiting on them; `--cov` charges coverage's callback to
+  whichever function is running under it; and pytest-randomly reorders
+  the run, so two profiles of the same tree are not comparable.
+  `-n0 --no-cov -p no:randomly` is what the section passes now, with
+  `python -m pstats` beside it for the caller attribution that neither
+  `-s time` nor `-s cumtime` prints.
+
+  Reading one needs the rest of the section. The self time is dominated
+  by the Jacobian point arithmetic of `curves/curve_group.py`, and it is
+  there because `python_path_test.py` patches the delegation away and
+  because the low-cardinality tests run curves `_libsecp256k1_applicable`
+  refuses -- the fallback, and not what a user's secp256k1 call reaches.
+  `double_jac` is charged for being called rather than for what it does,
+  as `isinstance` and `len` are. `time.sleep` high in that column is
+  `subprocess._wait`, the tests that shell out. And the cost of a single
+  call is a sort cProfile does not offer, so something expensive in each
+  of a handful of calls ranks nowhere.
 
   `n_size` is the pinned length, and any length above it is the same
   test: `challenge_` reads the leftmost `nlen` bits, and a SHAKE's output

--- a/tests/README.md
+++ b/tests/README.md
@@ -209,10 +209,43 @@ the number describes the machine rather than pytest.
 
 ## Profiling
 
-Profiling can be obtained with:
-
 ```shell
-uv run python -m cProfile -s time -m pytest
-uv run python -m cProfile -s cumtime -m pytest
-uv run python -m cProfile -o btclib.prof -m pytest
+uv run python -m cProfile -o btclib.prof -m pytest \
+    -n0 --no-cov -p no:randomly
+uv run python -m pstats btclib.prof   # sort time, stats 30, callers add_jac
 ```
+
+Every flag after `-m pytest` undoes something `addopts` asked for, and
+none of them is decoration. `-n0` because xdist runs the tests in child
+processes while cProfile measures the parent, which then reports the
+suite as time spent waiting on them. `--no-cov` because coverage's
+callback is charged to whichever function is running under it. `-p
+no:randomly` because two profiles are comparable only if the order that
+produced them was.
+
+`-s time` and `-s cumtime` in place of `-o` sort the run and keep
+nothing. Saving the file answers both sorts from one run, and answers
+what neither of them asks — who called the expensive function, which is
+the browser's `callers` on the second line.
+
+What to know before reading one:
+
+- **the point arithmetic of `curves/curve_group.py` dominates the self
+  time**, and what drives it is the two places that ask for the
+  arithmetic the bindings do not do: `python_path_test.py` patches the
+  delegation away on purpose, and the low-cardinality tests of `dsa` and
+  `ssa` run toy curves `_libsecp256k1_applicable` refuses by definition.
+  The profile therefore ranks the fallback, and a change meant for what
+  a user's secp256k1 call reaches has to be measured on a run that is
+  not denying it the bindings.
+- **a wrapper is billed for being called.** `double_jac` does nothing but
+  call the helper beneath it, and every one of those calls is charged to
+  it; `isinstance`, `len` and `list.append` are the same entry from the
+  other side, large because everything calls them.
+- **`time.sleep` high in the self time is not work**: it is
+  `subprocess._wait`, the tests that shell out, and `callers` is what
+  says so rather than guesswork.
+- **cost per call is a sort the profile does not offer**, and the sort by
+  self time buries it: something called a handful of times can be
+  expensive in each of them and rank nowhere. Read `ncalls` beside
+  `tottime`, or divide one by the other.


### PR DESCRIPTION
`tests/README.md`'s profiling section listed three cProfile commands and
nothing else. Each of them took the suite's `addopts` defaults with it,
and every one of those defaults is wrong under a profiler:

- `-n auto` runs the tests in child processes cProfile never sees, so the
  parent it does measure is mostly waiting on them
- `--cov` charges coverage's callback to whichever function runs under it
- pytest-randomly reorders the run, so two profiles of the same tree are
  not comparable

One command now, with `-n0 --no-cov -p no:randomly`, and `python -m
pstats` beside it for the caller attribution neither `-s time` nor `-s
cumtime` prints.

The section then says how to read the result, the top of it being the
misleading part. The self time is dominated by the Jacobian point
arithmetic of `curves/curve_group.py`, which is there because
`python_path_test.py` patches the delegation away and because the
low-cardinality tests run curves `_libsecp256k1_applicable` refuses — the
fallback path, not the one a user's secp256k1 call reaches. `double_jac`
is billed for being called rather than for what it does, as `isinstance`
and `len` are. `time.sleep` high in that column is `subprocess._wait`,
the tests that shell out. And cost per call is a sort cProfile does not
offer, so something expensive in each of a handful of calls ranks
nowhere.

No wall clock and no count, for the reason the section above it already
states.

Gates: `pre-commit run --files tests/README.md CHANGELOG.md`,
`pytest tests/release_notes_test.py`, and the `-W` sphinx build, all
green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document how to profile the test suite and interpret cProfile output, adjusting commands and guidance so profiles reflect meaningful performance data.

Documentation:
- Update tests/README.md profiling section to use a single cProfile command compatible with the suite’s defaults and to explain how to read the resulting stats, including common pitfalls and interpretation of key entries.
- Add release note describing the new profiling guidance and rationale for the adjusted pytest flags and use of pstats.