### PR TITLE
Name the encoding where a test reads a source file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2781,6 +2781,26 @@ documented at release-notes length in the first place, and are still in
 
 ### Tests
 
+- **Every test that reads a source file names its encoding.** Four
+  `read_text()` calls took the locale's, which is UTF-8 on the runners this
+  suite is usually read on and cp1252 on the Windows ones: the walk in
+  `input_validation_test.py` parses every module under `btclib/`, one of
+  them has a typographic quote in a docstring, and 0x9d is a byte cp1252
+  maps to nothing. Twelve of the fourteen Windows cells therefore ended in
+  a collection error with every other test passed, and the two that did not
+  are the PyPy ones, which collected the module and ran its 132 tests: what
+  a locale answers is the interpreter's to decide, which is the argument for
+  never asking it. The pair in
+  `input_validation_test.py`, `flags_test.py`'s engine scan and
+  `hwi_test.py`'s recorded argv now all pass `encoding="utf-8"`. Nothing
+  else in `btclib`, `tests` or `.github/scripts` opens a file without
+  one, measured with a rule ruff has in preview:
+
+  ```shell
+  uv run ruff check --isolated --preview --select PLW1514 \
+      btclib tests .github/scripts
+  ```
+
 - **`python_path_test.py` leaves the arithmetic delegated.** It patches
   the bindings off for `dsa` and `ssa`, which is what puts the Python
   verdict in front of the vendored consensus vectors, and no longer for

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -300,7 +300,7 @@ def last_argv(hwi: list[str]) -> list[str]:
     adapter would have built.
     """
     recorded = Path(hwi[-1]).with_suffix(".argv.json")
-    return json.loads(recorded.read_text())  # type: ignore[no-any-return]
+    return json.loads(recorded.read_text(encoding="utf-8"))  # type: ignore[no-any-return]
 
 
 def test_the_network_is_the_chain_hwi_is_told(tmp_path: Path) -> None:

--- a/tests/input_validation_test.py
+++ b/tests/input_validation_test.py
@@ -198,7 +198,7 @@ def _drivable() -> dict[str, list[str]]:
     found: dict[str, list[str]] = {}
     for path in sorted(_LIBRARY.rglob("*.py")):
         module = ".".join(path.relative_to(_LIBRARY.parent).with_suffix("").parts)
-        for node in ast.parse(path.read_text()).body:
+        for node in ast.parse(path.read_text(encoding="utf-8")).body:
             if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
                 continue
             positional = [*node.args.posonlyargs, *node.args.args]
@@ -271,7 +271,7 @@ def test_the_vocabulary_is_the_libraries_input_types() -> None:
     in_alias_py: set[str] = set()
     annotated: set[str] = set()
     for path in sorted(_LIBRARY.rglob("*.py")):
-        tree = ast.parse(path.read_text())
+        tree = ast.parse(path.read_text(encoding="utf-8"))
         names = {
             node.targets[0].id
             for node in tree.body

--- a/tests/script_engine/flags_test.py
+++ b/tests/script_engine/flags_test.py
@@ -33,7 +33,8 @@ def flags_named_in_the_engine() -> set[str]:
     for path in sorted(ENGINE_DIR.glob("*.py")):
         if path.name == "flags.py":
             continue  # where they are defined, not where they are checked
-        names |= set(re.findall(r"ScriptFlag\.([A-Z0-9_]+)", path.read_text()))
+        source = path.read_text(encoding="utf-8")
+        names |= set(re.findall(r"ScriptFlag\.([A-Z0-9_]+)", source))
     return names
 
 


### PR DESCRIPTION
Fixes the `windows.yml` failure in
https://github.com/btclib-org/btclib/actions/runs/31745314171 — twelve of
fourteen cells, all with **every other test passed**.

Four `read_text()` calls took the locale's encoding, which is UTF-8 on the
runners this suite is usually read on and cp1252 on the Windows ones. The
walk in `tests/input_validation_test.py` parses every module under `btclib/`,
`btclib/bip32/bip32.py:392` has a typographic quote in a docstring, and 0x9d
is a byte cp1252 maps to nothing — so the module failed to *collect*, four
times, once per xdist worker that reached it.

The two cells that passed are the PyPy ones, which collected the module and
ran its 132 tests: what a locale answers is the interpreter's to decide,
which is the argument for never asking it.

## Reproduced without Windows

On the tree before this commit, a US-ASCII locale is the same defect:

```shell
LC_ALL=C PYTHONCOERCECLOCALE=0 uv run python -X utf8=0 -c "
import ast, pathlib
for p in sorted(pathlib.Path('btclib').rglob('*.py')): ast.parse(p.read_text())"
# UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 ... btclib/b58.py
```

With this commit, the three touched files pass under that same locale, 201
tests.

## Nothing else opens a file without one

Measured to zero across `btclib`, `tests` and `.github/scripts`, with the
rule ruff has in preview:

```shell
uv run ruff check --isolated --preview --select PLW1514 \
    btclib tests .github/scripts
```

## What is *not* the guard against the next one

`PYTHONWARNDEFAULTENCODING=1` looks like it should be, `filterwarnings =
["error"]` already being in `addopts`. It is inherited by every subprocess a
test spawns, so `tests/mutation_counts_test.py` and `tests/imports_test.py`
fail on what the child wrote rather than on what they assert — measured, two
failures. A source-level test in the shape of `input_validation_test.py`
would be the guard that works; it is not in this pull request.

Local gates: `uv run pre-commit run --all-files` and `uv run pytest` (26711
passed, coverage ratchet met), both exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure tests that read source files explicitly use UTF-8 encoding to avoid locale-dependent failures, particularly on Windows runners.

Documentation:
- Document in the changelog that all tests reading source files now specify UTF-8 encoding and that the suite was hardened against locale-dependent decoding issues.

Tests:
- Update input validation, script engine flag scanning, and HWI argv tests to read source files with encoding="utf-8" instead of relying on the locale.
- Verify that no other files in btclib, tests, or .github/scripts open files without an explicit encoding, using ruff’s PLW1514 rule as a guard.