### PR TITLE
Stop asking for a Legendre symbol the square root already answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1205,6 +1205,27 @@ documented at release-notes length in the first place, and are still in
   the integer it subclasses. `xgcd` is unchanged, still exported and
   still tested as the Bezout identity it is named after -- it stops
   being what `mod_inv` is built on, and stays what it was.
+- **The two square roots that asked for a Legendre symbol first stop
+  asking** (issue #783). `curve_group.y_quadratic_residue` and
+  `ellswift._try_sqrt` each ran `legendre_symbol` before `mod_sqrt`,
+  which on a 256-bit prime is not a cheap test in front of the work but
+  the work twice: the symbol is `pow(a, (p - 1) // 2, p)` and the root of
+  a p == 3 mod 4 field is `pow(a, (p + 1) // 4, p)`, one exponent the
+  size of the other. 154 us against 78 for the first, 153 against 77 for
+  the second, measured beside a modular multiplication that no change
+  touches.
+
+  `y_quadratic_residue` is `ec.y` and nothing else, for the p == 3 mod 4
+  it already requires: that root is `a ** ((p + 1) // 4)`, a power of the
+  square a and so a square itself, which leaves `p - root` the
+  non-residue, -1 being one modulo such a p. The symbol could not have
+  corrected it either way -- `legendre_symbol` answers 1 or -1, both
+  truthy, so the `p - root` branch was unreachable as written.
+
+  `_try_sqrt` returns `None` where `mod_sqrt` raises: the candidate
+  `mod_sqrt` squares back to compare with a is the same question the
+  symbol was asked. The non-square half of its inputs pays that squaring
+  and an exception in place of the symbol, and measures the same 78 us.
 
 - **The bits a digit holds are counted in integers** (issue #759).
   `bin_str_entropy_from_rolls` and `collect_rolls` computed

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -20,7 +20,7 @@ from math import ceil
 
 from btclib.alias import INF, INFJ, Integer, JacPoint, Point
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.number_theory import legendre_symbol, mod_inv, mod_sqrt
+from btclib.number_theory import mod_inv, mod_sqrt
 from btclib.utils import hex_string, int_from_integer
 
 __all__ = [
@@ -546,9 +546,13 @@ class CurveGroup:
                 f"'{hex_string(self.p)}'" if self.p > HEX_THRESHOLD else f"{self.p}"
             )
             raise BTClibValueError(err_msg)
-        root = self.y(x)
-        legendre = legendre_symbol(root, self.p)
-        return root if legendre else self.p - root
+        # for a p of this form self.y answers the residue root already:
+        # it is a ** ((p + 1) // 4), a power of the square a and so a
+        # square itself, which leaves p - root the non-residue, -1 being
+        # one modulo such a p. Asking legendre_symbol which of the two
+        # this is would spend a second exponentiation the size of the
+        # first to be told what the exponent settles
+        return self.y(x)
 
 
 def _mult_recursive_aff(m: int, Q: Point, ec: CurveGroup) -> Point:

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -54,7 +54,7 @@ from btclib.curves.curve import (
 )
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import tagged_hash
-from btclib.number_theory import legendre_symbol, mod_inv, mod_sqrt
+from btclib.number_theory import mod_inv, mod_sqrt
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import PubKey, point_from_pub_key
 from btclib.utils import bytes_from_octets
@@ -102,13 +102,16 @@ def _try_sqrt(a: int, p: int) -> int | None:
     mod_sqrt raises instead, which is the wrong shape for the map: a
     non-square is one of the branches, taken for about half the inputs,
     and not an error to phrase.
+
+    That refusal is the whole of the test, rather than a legendre_symbol
+    asked before it: mod_sqrt squares its candidate back to compare with
+    a, which is the same question answered, and on a 256-bit prime the
+    symbol is an exponentiation the size of the root's.
     """
-    a %= p
-    if a == 0:
-        return 0
-    if legendre_symbol(a, p) != 1:
+    try:
+        return mod_sqrt(a, p)
+    except BTClibValueError:
         return None
-    return mod_sqrt(a, p)
 
 
 def _xswiftec(u: int, t: int, ec: Curve) -> int:


### PR DESCRIPTION
`curve_group.y_quadratic_residue` and `ellswift._try_sqrt` each computed
`legendre_symbol` before `mod_sqrt`. That is libsecp256k1's shape without
what makes it cheap there: `secp256k1_fe_sqrt` computes no symbol at all,
it verifies its candidate by squaring, and where the question is wanted on
its own — `secp256k1_fe_is_square_var`, which its own ellswift module
calls — the answer comes from a Jacobi symbol out of the safegcd
machinery, a fraction of a square root, with `fe_sqrt` as the fallback for
the rare non-converging case.

In Python there is no such test. The symbol is `pow(a, (p - 1) // 2, p)`
and the root of a p == 3 mod 4 field is `pow(a, (p + 1) // 4, p)`: one
exponent the size of the other, so asking first is not a cheap test in
front of the work but the work twice.

| | before | after |
|---|---|---|
| `secp256k1.y_quadratic_residue` | 154 µs | **78 µs** |
| `ellswift._try_sqrt`, a square | 153 µs | **77 µs** |
| `ellswift._try_sqrt`, a non-square | 78 µs | 79 µs |
| control, one modular multiplication | 0.29 µs | 0.29 µs |

Python 3.14.6, macOS arm64, 200 random x-coordinates of secp256k1, nine
alternating rounds per case, with the modular multiplication as the case
no change can touch.

## `y_quadratic_residue` is `ec.y` and nothing else

For the p == 3 mod 4 it already requires, `mod_sqrt` returns the residue
root: it answers `a ** ((p + 1) // 4)`, a power of the square `a` and so a
square itself, which leaves `p - root` the non-residue, -1 being one
modulo such a p. Checked over 2391 roots on every p == 3 mod 4 curve of
the catalogue, no counterexample, and
[`tests/curves/curve_test.py`](tests/curves/curve_test.py) asserts the
same property on the low-cardinality curves — `quad_res in hasRoot` and
`ec.p - quad_res not in hasRoot`.

The symbol could not have corrected anything either way: `legendre_symbol`
answers 1 or -1, both truthy, so `return root if legendre else self.p -
root` took the first branch whatever it said. The theorem above is what
kept that from mattering.

## `_try_sqrt` lets the refusal be the test

The candidate `mod_sqrt` squares back to compare with `a` is the same
question the symbol was asked, so `_try_sqrt` returns `None` where
`mod_sqrt` raises. The `a %= p` and the `a == 0` early return go with it:
`mod_sqrt` reduces its own argument and answers 0 for 0 on each of its
three paths.

The non-square half of the inputs — about two candidates in three of
`_xswiftec_inv`'s loop — now pays one squaring and a raise where it paid
the symbol alone, and measures the same 78 µs.

## Not in this PR

The `y_low` item of the issue: 78 µs against the 3.65 of
`curve._y_even`, since the pair {y, p - y} is the same whichever
tiebreaker picks from it. What is not obvious is the shape — nothing
inside btclib calls `y_low`, so a `_y_low` beside `_y_even` would arrive
without a caller, and overriding `y_low` on `Curve` would be the first
bindings-delegating method override in a layer that so far delegates
through module-level functions only. Left to a decision on the issue,
which stays open for it; the addition chain and `tonelli`'s z search are
recorded there too.

Takes the two proposed fixes of
https://github.com/btclib-org/btclib/issues/783.
`mod_inv`, the third measurement in it, landed meanwhile as
https://github.com/btclib-org/btclib/pull/780.

Gates run locally, on the rebased branch: `uv run pytest` (26711 passed,
100.00% coverage), `uv run pre-commit run --all-files`, and the sphinx
`-W` build, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Remove redundant Legendre symbol checks from square root helpers to rely solely on modular square root behavior for residue detection and non-square handling.

Bug Fixes:
- Correct y_quadratic_residue to always return the curve’s existing quadratic residue root without an unreachable non-residue branch.

Enhancements:
- Simplify ellswift._try_sqrt to treat mod_sqrt failure as the non-square test instead of performing an extra Legendre symbol exponentiation.
- Streamline y_quadratic_residue to avoid a second expensive exponentiation by trusting the curve’s y computation for p ≡ 3 mod 4 primes.
- Update changelog with performance and behavioral notes for the removed Legendre symbol pre-checks.