### PR TITLE
Split both coefficients through the endomorphism in double_mult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1226,6 +1226,48 @@ documented at release-notes length in the first place, and are still in
   `mod_sqrt` squares back to compare with a is the same question the
   symbol was asked. The non-square half of its inputs pays that squaring
   and an exception in place of the symbol, and measures the same 78 us.
+- **The Python `double_mult` splits both coefficients through the GLV
+  endomorphism on secp256k1**. `mult` has had algorithm 3.77 since the
+  endomorphism went in, and `double_mult` did not: it ran two full-length
+  interleaved wNAFs where the single multiplication ran two 128-bit
+  halves. `_double_mult_endomorphism_secp256k1` splits both coefficients
+  and hands the four halves to the interleaved wNAF that already shares
+  one doubling per bit position among any number of scalars, so ~256
+  doublings become ~128, at the price of two more tables of odd multiples
+  and the two field multiplications the endomorphism's images cost.
+  0.812 ms against 1.024, measured over 30 random pairs of 256-bit
+  coefficients in alternating rounds; w=4 as before, w=5 measuring the
+  same and the smaller table deciding.
+
+  The interleaved wNAF and not the regular windows, which is the choice
+  `mult` makes the other way round: a verification's coefficients are
+  public, where a `mult`'s scalar is a private key or a nonce, and the
+  regular form exists to spend 16% for a cost that does not vary with the
+  secret.
+
+  Who sees it is every secp256k1 double multiplication the bindings do not
+  answer, which is what the Python path is: a zero coefficient or an
+  infinity, and -- with the bindings patched off, the way the suite holds
+  them against the Python arithmetic -- every verification of the curve.
+  The suite spends 1.839 s there against 2.386 s, the two measured on one
+  tree over the same 2498 calls. The other three catalogued curves with the endomorphism,
+  secp160k1, secp192k1 and secp224k1, are not given one: their lattice
+  basis would have to be computed rather than secp256k1's reused, and
+  measured over the suite they make no Python `double_mult` call at all.
+
+  What it cost is one dispatch, `curve._double_mult_python`, shared by
+  `double_mult` and `_jac_double_mult` so that one place decides which
+  double multiplication a curve gets. It tests the curve rather than
+  asking `_libsecp256k1_applicable`, the same test today and not the same
+  question: the bindings patched off must leave the endomorphism arm
+  standing, or the suite would be comparing them against the generic
+  double-and-add of every other curve. That is a second `Curve.__eq__` per
+  call, 0.394 us where the curve is not secp256k1 -- 8% of a
+  low-cardinality double multiplication, two tenths of a second of the
+  suite, and the alternative is a copy of the dispatch per caller.
+  `_endomorphism_split_secp256k1` is the decomposition and the sign
+  handling, extracted so that the two multiplications share them rather
+  than each carrying a copy.
 
 - **The bits a digit holds are counted in integers** (issue #759).
   `bin_str_entropy_from_rolls` and `collect_rolls` computed

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -48,6 +48,7 @@ from btclib.curves.curve_group import (
     _multi_mult,
 )
 from btclib.curves.curve_group_2 import (
+    _double_mult_endomorphism_secp256k1,
     _double_mult_w_NAF,
     _mult_endomorphism_secp256k1,
 )
@@ -551,11 +552,13 @@ def _libsecp256k1_multi_mult(scalars: Sequence[int], points: Sequence[Point]) ->
     )
 
 
-# the widths mult and double_mult hand the two variants below them; the
+# the widths mult and double_mult hand the variants below them; the
 # measurement behind each is in the docstring of the function it is passed
-# to, and they are two constants rather than one because they are two
-# algorithms: a window of the GLV endomorphism's half-length scalars is
-# not a window of an interleaved wNAF's full-length ones
+# to, and they are two constants rather than one because what a window is
+# measured on is the length of the scalars in it: the GLV endomorphism's
+# halves take the first, whether one coefficient was split into two of
+# them or two into four, and an interleaved wNAF's full-length
+# coefficients take the second
 _ENDOMORPHISM_W = 4
 _DOUBLE_MULT_W = 4
 
@@ -604,6 +607,41 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
     return ec.aff_from_jac(R)
 
 
+def _double_mult_python(
+    u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve
+) -> JacPoint:
+    """Return u*HJ + v*QJ in Python, through the endomorphism if there is one.
+
+    The arm `double_mult` and `_jac_double_mult` share, so that one place
+    decides which double multiplication a curve gets and both reach the
+    same one. On secp256k1 that is the GLV split of both coefficients,
+    which is to `_double_mult_w_NAF` what `_mult_endomorphism_secp256k1`
+    is to `_mult`: the same answer for ~128 doublings instead of ~256.
+
+    Dispatched on the curve having the endomorphism, not on
+    `_libsecp256k1_applicable` -- the same test today, and not the same
+    question. `mult` says why at length: patching the bindings off is how
+    python_path_test.py holds them against the Python arithmetic, and a
+    dispatch spelled the other way would answer that test with the generic
+    interleaved wNAF every other curve runs instead of with secp256k1's
+    own fastest path.
+
+    Which makes this the second curve comparison of the call, the guard
+    above having asked `_libsecp256k1_applicable` the first: 0.394 us on a
+    curve that is not secp256k1, the frame and `Curve.__eq__`'s two
+    _eq_key tuples together, where the identical object short-circuits on
+    identity. That is 8% of a low-cardinality double multiplication and
+    two tenths of a second of the suite, spent for the same reason
+    _double_mult_w_NAF spends about 3 us a call there: what the saving
+    would buy is a fraction of a second, and what it would cost is a
+    second copy of the dispatch, one per caller, free to drift. `mult`
+    makes the same two comparisons for the same reason.
+    """
+    if ec == secp256k1:
+        return _double_mult_endomorphism_secp256k1(u, HJ, v, QJ, ec, _ENDOMORPHISM_W)
+    return _double_mult_w_NAF(u, HJ, v, QJ, ec, _DOUBLE_MULT_W)
+
+
 def double_mult(
     u: Integer, H: Point, v: Integer, Q: Point, ec: Curve = secp256k1
 ) -> Point:
@@ -623,7 +661,7 @@ def double_mult(
 
     HJ = _jac_from_aff(H)
     QJ = _jac_from_aff(Q)
-    R = _double_mult_w_NAF(u, HJ, v, QJ, ec, _DOUBLE_MULT_W)
+    R = _double_mult_python(u, HJ, v, QJ, ec)
     return ec.aff_from_jac(R)
 
 
@@ -654,7 +692,7 @@ def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> J
     caller's own mod_inv(1) on the way back out, 0.14 us.
     """
     if not _libsecp256k1_applicable(ec, None):
-        return _double_mult_w_NAF(u, HJ, v, QJ, ec, _DOUBLE_MULT_W)
+        return _double_mult_python(u, HJ, v, QJ, ec)
 
     R = double_mult(u, ec.aff_from_jac(HJ), v, ec.aff_from_jac(QJ), ec)
     return _jac_from_aff(R)

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -1214,9 +1214,14 @@ def _multi_mult_w_NAF(
     55.1 at w=6). In milliseconds over 10 scalars: 7.81 at w=4, 7.27 at
     w=5, 7.38 at w=6, 8.68 at w=7.
 
-    No GLV splitting of the scalars, which would halve the doublings on
+    No GLV splitting of its own, which would halve the doublings on
     secp256k1: the split is curve-specific, this function serves every
-    curve, and the doublings it would halve are already shared.
+    curve, and with many scalars the doublings it would halve are already
+    shared. A caller that has only two of them has the opposite balance,
+    and curve_group_2's _double_mult_endomorphism_secp256k1 is that
+    caller: it splits both coefficients itself and hands the four halves
+    here, so the split lives with the curve that has it and the
+    interleaving stays one implementation.
 
     The input points are assumed to be on curve, the scalar coefficients
     are assumed to have been reduced mod n if appropriate (e.g. cyclic

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -15,6 +15,7 @@ The implemented algorithms are:
     - Interleaved-wNAF double multiplication (HMV algorithm 3.51)
     - Regular-window double multiplication
     - GLV endomorphism multiplication for secp256k1 (HMV algorithm 3.77)
+    - GLV endomorphism double multiplication for secp256k1
 
 References:
     - https://en.wikipedia.org/wiki/Elliptic_curve_point_multiplication
@@ -72,6 +73,7 @@ from btclib.alias import INFJ, JacPoint
 from btclib.curves.curve_group import (
     CurveGroup,
     _convert_number_to_base,
+    _multi_mult_w_NAF,
     _odd_multiples,
     _signed_odd_multiples,
     _wNAF_of_m,
@@ -225,16 +227,17 @@ def _double_mult_w_NAF(
     additions drop from one per bit to ~2/(w+1) per bit, the negative
     digits costing only an on-the-fly negation.
 
-    This is the one the library calls: `curves.double_mult`, `dsa` and
-    `ssa` verification and public key recovery all reach it, which on
-    secp256k1 means every signature the bindings do not answer -- another
-    curve, another hash function, a caller-supplied nonce, or the test
-    suite holding the Python path against them. Measured over random
-    256-bit coefficients, best of seven: 1.03 ms against the 1.53 ms of
-    curve_group's _double_mult, which stays as the reference the tests
-    compare this against. w=5 measures 0.99 ms and w=3 1.10, so the w=4
-    `curve.py` passes is within 4% of the best window and its table is
-    half the size of w=5's.
+    This is the one the library calls on every curve without the GLV
+    endomorphism: `curves.double_mult`, `dsa` and `ssa` verification and
+    public key recovery all reach it through `curve`'s
+    _double_mult_python, which sends secp256k1 to
+    _double_mult_endomorphism_secp256k1 instead -- four half-length
+    coefficients where this takes two full-length ones, and 0.81 ms where
+    this is 1.02. Measured over random 256-bit coefficients, best of
+    seven: 1.03 ms against the 1.53 ms of curve_group's _double_mult,
+    which stays as the reference the tests compare this against. w=5
+    measures 0.99 ms and w=3 1.10, so the w=4 `curve.py` passes is within
+    4% of the best window and its table is half the size of w=5's.
 
     The gap over _double_mult is the wider since add_jac stopped
     shortcutting infinity: fewer additions is worth the more when an
@@ -420,6 +423,35 @@ def _multiplier_decomposer(m: int) -> tuple[int, int]:
 _HALF_LEN = 128
 
 
+def _endomorphism_split_secp256k1(
+    m: int, Q: JacPoint, ec: CurveGroup
+) -> tuple[int, JacPoint, int, JacPoint]:
+    """Return (m1, P, m2, K) with m1*P + m2*K == m*Q and both halves short.
+
+    The half of algorithm 3.77 that is not the double multiplication:
+    `_multiplier_decomposer`'s two signed halves, the endomorphism's image
+    of Q, and the signs moved off the coefficients and onto the points.
+    Both multiplications built on it want exactly this, and the sign
+    handling is what neither should own a second copy of.
+
+    m1 and m2 come back non-negative, which is what the double
+    multiplications require; the caller owes them nothing else.
+    """
+    m1, m2 = _multiplier_decomposer(m)
+
+    K = ((Q[0] * _BETA) % ec.p), Q[1], Q[2]  # K = lambda*Q, direct calculation
+
+    # the decomposition is signed on purpose -- balance is what makes the
+    # halves short -- and the sign belongs to the point: -m1*Q is m1*(-Q),
+    # one modular negation of a y-coordinate. Negated whatever the sign and
+    # selected afterwards, rather than under an `if`: the sign of a half is
+    # a bit of the scalar, and a modular subtraction is what a branch on it
+    # would put on the clock
+    P = (Q, ec.negate_jac(Q))[m1 < 0]
+    K = (K, ec.negate_jac(K))[m2 < 0]
+    return abs(m1), P, abs(m2), K
+
+
 def _mult_endomorphism_secp256k1(
     m: int, Q: JacPoint, ec: CurveGroup, w: int, regular: bool
 ) -> JacPoint:
@@ -448,7 +480,9 @@ def _mult_endomorphism_secp256k1(
     `curves.mult` is a private key or a nonce in every caller btclib has,
     and 16% of a multiplication that libsecp256k1 answers in 13 us is not
     what this path is for. Both stay: the wNAF is what verification wants,
-    its coefficients being public, and `double_mult` reaches it directly.
+    its coefficients being public, and verification arrives at
+    `_double_mult_endomorphism_secp256k1` below, which splits two
+    coefficients rather than one and interleaves the four halves.
 
     w=4 by measurement for both: the regular windows give 0.610 ms at
     w=5, and the wNAFs 0.527 at w=3 and 0.510 at w=5, which is w=4's own
@@ -457,20 +491,54 @@ def _mult_endomorphism_secp256k1(
     if m < 0:
         raise BTClibValueError(f"negative m: {hex(m)}")
 
-    m1, m2 = _multiplier_decomposer(m)
-
-    K = ((Q[0] * _BETA) % ec.p), Q[1], Q[2]  # K = lambda*Q, direct calculation
-
-    # the decomposition is signed on purpose -- balance is what makes the
-    # halves short -- and the sign belongs to the point: -m1*Q is m1*(-Q),
-    # one modular negation of a y-coordinate. Negated whatever the sign and
-    # selected afterwards, rather than under an `if`: the sign of a half is
-    # a bit of the scalar, and a modular subtraction is what a branch on it
-    # would put on the clock
-    P = (Q, ec.negate_jac(Q))[m1 < 0]
-    K = (K, ec.negate_jac(K))[m2 < 0]
-    m1, m2 = abs(m1), abs(m2)
+    m1, P, m2, K = _endomorphism_split_secp256k1(m, Q, ec)
 
     if regular:
         return _double_mult_regular_window(m1, P, m2, K, ec, w, _HALF_LEN)
     return _double_mult_w_NAF(m1, P, m2, K, ec, w)
+
+
+def _double_mult_endomorphism_secp256k1(
+    u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: CurveGroup, w: int
+) -> JacPoint:
+    """Double scalar multiplication (u*H + v*Q) through the endomorphism.
+
+    Algorithm 3.77 for two coefficients: each is split into a pair of
+    half-length halves over its own point and the endomorphism's image of
+    it, and the four terms go through one interleaved wNAF, which shares
+    one doubling per bit position among all of them. So the ~256 doublings
+    the two full-length coefficients need become the ~128 of four halves,
+    at the price of two more tables of odd multiples and the two field
+    multiplications the images cost.
+
+    That trade is the whole of the gain, and it is the same one
+    `_mult_endomorphism_secp256k1` makes for a single coefficient: 0.81 ms
+    against `_double_mult_w_NAF`'s 1.02, measured over 30 random pairs of
+    256-bit coefficients, best of three, alternating the two so that
+    neither is always warm. Both answer the same point on every pair the
+    tests compare, boundary coefficients and infinities included.
+
+    The interleaved wNAF rather than the regular windows: the coefficients
+    of a double multiplication are public, being a verification's, which is
+    the same reason `curve.double_mult` reaches `_double_mult_w_NAF`
+    directly and not through `_mult_endomorphism_secp256k1`'s regular
+    default. A scalar that is a secret goes through `mult`.
+
+    w=4 by measurement over the same pairs: 0.88 ms at w=3, 0.81 at w=4,
+    0.82 at w=5, 0.91 at w=6 -- so w=4 and w=5 measure the same and the
+    smaller table decides, as it does for `_double_mult_w_NAF`.
+
+    The input points are assumed to be on curve. Either coefficient may be
+    zero and either point may be infinity: the interleaved wNAF drops a
+    zero half rather than building a table it would never index, and the
+    empty sum is infinity, which is what the term of a zero coefficient
+    contributes.
+    """
+    if u < 0:
+        raise BTClibValueError(f"negative first coefficient: {hex(u)}")
+    if v < 0:
+        raise BTClibValueError(f"negative second coefficient: {hex(v)}")
+
+    u1, U1, u2, U2 = _endomorphism_split_secp256k1(u, HJ, ec)
+    v1, V1, v2, V2 = _endomorphism_split_secp256k1(v, QJ, ec)
+    return _multi_mult_w_NAF([u1, u2, v1, v2], [U1, U2, V1, V2], ec, w)

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -355,6 +355,7 @@ def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
         (curve_group, "_cached_multiples"),
         (curve_group, "_jac_from_aff"),
         (curve_group, "_multiples"),
+        (curve_group_2, "_double_mult_endomorphism_secp256k1"),
         (curve_group_2, "_mult_endomorphism_secp256k1"),
         (curve_group_2, "_mult_sliding_window"),
         (curve_group_2, "_mult_w_NAF"),

--- a/tests/curves/curve_group_2_test.py
+++ b/tests/curves/curve_group_2_test.py
@@ -18,6 +18,7 @@ from btclib.curves.curve_group_2 import (
     _HALF_LEN,
     _LAM,
     _N,
+    _double_mult_endomorphism_secp256k1,
     _double_mult_regular_window,
     _double_mult_w_NAF,
     _mult_endomorphism_secp256k1,
@@ -219,6 +220,66 @@ def test_double_mult_w_NAF() -> None:
         _double_mult_w_NAF(1, ec.GJ, -1, ec.GJ, ec, w=4)
     with pytest.raises(BTClibValueError, match="non positive w: "):
         _double_mult_w_NAF(1, ec.GJ, 1, ec.GJ, ec, 0)
+
+
+def test_double_mult_endomorphism_secp256k1() -> None:
+    """The GLV double mult against the Shamir-Strauss one it replaces.
+
+    secp256k1 only, the endomorphism being its own, so there is no
+    low-cardinality curve to be exhaustive over and the pairs are chosen
+    instead: the boundaries, the two cube roots whose decompositions are
+    the lattice identities, and the 2^127 line issue #215 was about, where
+    a decomposition reduced mod p rather than mod n starts answering
+    wrongly. A coefficient at or above n is reduced by the decomposer, so
+    the reference is taken on the residue.
+
+    Every w, not only the one `curve.py` passes: w=1 collapses each table
+    to the point itself and is where an off-by-one in the interleaving
+    would show.
+    """
+    ec = secp256k1
+    HJ = ec.GJ
+    QJ = _mult(3, ec.GJ, ec)
+
+    def dm(u: int, v: int, H: JacPoint, Q: JacPoint, w: int = 4) -> JacPoint:
+        return _double_mult_endomorphism_secp256k1(u, H, v, Q, ec, w)
+
+    pairs = [
+        (0, 0),
+        (0, 1),
+        (1, 0),
+        (1, 1),
+        (1, 2),
+        (1, _N - 1),
+        (_N - 1, 1),
+        (_N - 1, _N - 2),
+        ((1 << 127) - 1, 1 << 127),  # the last scalar the mod-p split survived
+        ((1 << 128) - 1, (1 << 128) - 1),  # all four halves negative
+        (_LAM, _N - _LAM),  # (0, 1) and (0, -1): the endomorphism itself
+        (_N, _N + 42),  # reduced mod n before anything else
+    ] + [(secrets.randbelow(_N), secrets.randbelow(_N)) for _ in range(8)]
+    for u, v in pairs:
+        expected = _double_mult(u % _N, HJ, v % _N, QJ, ec)
+        for w in (1, 2, 4, 5):
+            assert ec.jac_equality(dm(u, v, HJ, QJ, w), expected), (u, v, w)
+
+    # infinity on either side, and the coefficient that contributes nothing:
+    # what `curves.double_mult` sends down this path on secp256k1, the
+    # bindings taking no zero scalar and no infinity
+    for u, v in ((7, 5), (0, 5), (7, 0), (0, 0)):
+        for H, Q in ((INFJ, QJ), (HJ, INFJ), (INFJ, INFJ)):
+            assert ec.jac_equality(dm(u, v, H, Q), _double_mult(u, H, v, Q, ec)), (u, v)
+
+    # the same point twice, and a sum that lands on infinity
+    assert ec.jac_equality(dm(7, 5, HJ, HJ), _double_mult(7, HJ, 5, HJ, ec))
+    assert ec.jac_equality(dm(3, _N - 3, HJ, HJ), INFJ)
+
+    with pytest.raises(BTClibValueError, match="negative first coefficient: "):
+        dm(-1, 1, HJ, QJ)
+    with pytest.raises(BTClibValueError, match="negative second coefficient: "):
+        dm(1, -1, HJ, QJ)
+    with pytest.raises(BTClibValueError, match="non positive w: "):
+        dm(1, 1, HJ, QJ, 0)
 
 
 def test_double_mult_regular_window() -> None:


### PR DESCRIPTION
`mult` has run HMV algorithm 3.77 on secp256k1 since the GLV endomorphism
went in. `double_mult` did not: it ran two full-length interleaved wNAFs
where the single multiplication ran two 128-bit halves, so the Python path
paid ~256 doublings for what ~128 answer.

`_double_mult_endomorphism_secp256k1` splits both coefficients and hands
the four halves to `_multi_mult_w_NAF`, which already shares one doubling
per bit position among any number of scalars. The interleaving is
therefore not written a second time — the split lives with the curve that
has it, the interleaving stays one implementation.

## Measured

Rebased on `d7f3fdf1`, so the numbers are against a base that already has
https://github.com/btclib-org/btclib/pull/780.

| | `_double_mult_w_NAF` | endomorphism | |
| --- | ---: | ---: | ---: |
| 30 random 256-bit pairs | 1.024 ms | 0.812 ms | **1.26x** |
| the suite's secp256k1 arm, 2498 calls | 2.386 s | 1.839 s | **1.30x** |

The two suite figures are one tree, not two: an env var forces the
pre-change arm, so the same 2498 calls are timed both ways in the same
run. `w` stays 4 — 0.88 ms at w=3, 0.81 at w=4, 0.82 at w=5, 0.91 at w=6,
so w=4 and w=5 measure the same and the smaller table decides, as it
already does for `_double_mult_w_NAF`.

The interleaved wNAF and not the regular windows, which is the choice
`mult` makes the other way round: a verification's coefficients are
public, where a `mult`'s scalar is a private key or a nonce, and the
regular form exists to spend 16% for a cost that does not vary with the
secret.

## Who sees it

Every secp256k1 double multiplication the bindings do not answer, which
is what the Python path is: a zero coefficient, an infinity, and — with
the bindings patched off, the way the suite holds them against the Python
arithmetic — every verification of the curve. `curve.py`'s own comment
already frames that path as "the reference implementation the test suite
holds the bindings against, and the GLV endomorphism is its fastest
form"; this is that sentence applied to the second multiplication.

`secp160k1`, `secp192k1` and `secp224k1` have the endomorphism too —
`a == 0`, `p` and `n` both `1 mod 3` — and are deliberately not given
one: their lattice basis would have to be computed rather than
secp256k1's reused, and instrumenting the whole suite finds they make no
Python `double_mult` call at all.

## What it cost

One dispatch, `curve._double_mult_python`, shared by `double_mult` and
`_jac_double_mult` so that one place decides which double multiplication
a curve gets. It tests the curve rather than asking
`_libsecp256k1_applicable` — the same test today, not the same question —
because the bindings patched off must leave the endomorphism arm
standing, or the suite would compare them against the generic
double-and-add of every other curve. `mult` is spelled the same way and
says why at length.

That is a second `Curve.__eq__` per call: 0.394 us where the curve is not
secp256k1, 8% of a low-cardinality double multiplication and about two
tenths of a second of the suite. Spent for the reason
`_double_mult_w_NAF` already spends about 3 us a call there — what the
saving buys is a fraction of a second, what it costs is one copy of the
dispatch per caller, free to drift.

`_endomorphism_split_secp256k1` is the decomposition and the sign
handling, extracted so both multiplications share one copy rather than
each carrying its own.

## Correctness

`test_double_mult_endomorphism_secp256k1` compares against
`curve_group._double_mult`, the Shamir-Strauss loop the other two double
multiplications are already tested against: the boundaries, both cube
roots whose decompositions are the lattice identities, the 2^127 line
issue #215 was about, coefficients at and above `n`, every combination of
infinity on either side, the same point twice, a sum landing on infinity,
and eight random pairs — each at w of 1, 2, 4 and 5, w=1 being where the
tables collapse to the points themselves.

Beyond that, every test that patches the bindings off now runs
verification through this function, which is the cross-check that
matters: `dsa`, `ssa`, `bms`, `sec_point`, `wycheproof` and the taproot
suites all compare the Python arithmetic against libsecp256k1's answers.

Three docstrings stated what `double_mult` runs and now state it
correctly: `_double_mult_w_NAF`'s, `_mult_endomorphism_secp256k1`'s, and
`_multi_mult_w_NAF`'s "no GLV splitting", which now has the caller that
does the splitting for it.

## Gates

`uv run pytest` (26712 passed, coverage at 100%), `uv run pre-commit run
--all-files`, and the sphinx `-W` build, all green locally, and the suite
re-run after the rebase.

## Summary by Sourcery

Optimize Python secp256k1 double scalar multiplication by routing it through a new GLV endomorphism-based implementation that splits both coefficients, sharing the split logic between single and double multiplications and updating docs/tests accordingly.

New Features:
- Add `_double_mult_endomorphism_secp256k1` to perform secp256k1 double scalar multiplication using GLV endomorphism and interleaved wNAF.
- Introduce `_double_mult_python` dispatcher so `double_mult` and `_jac_double_mult` select endomorphism-based or generic double multiplication per curve.
- Expose shared `_endomorphism_split_secp256k1` helper for GLV coefficient decomposition used by both single and double multiplications.

Enhancements:
- Route secp256k1 Python `double_mult` calls through the endomorphism path, reducing doublings and improving verification performance.
- Clarify and update docstrings for `_double_mult_w_NAF`, `_mult_endomorphism_secp256k1`, and `_multi_mult_w_NAF` to describe the new splitting and usage.
- Export the new endomorphism double-mult implementation through the curve API module for consistency.

Documentation:
- Update CHANGELOG and internal documentation to describe the GLV-based secp256k1 double multiplication behavior, performance characteristics, and routing through the new dispatcher.

Tests:
- Add `test_double_mult_endomorphism_secp256k1` to validate the new GLV double multiplication against Shamir-Strauss across edge cases, random inputs, multiple windows, and infinity handling.
- Extend export tests to ensure the new endomorphism double-mult helper is available from the curve group module.