### PR TITLE
Build both affine coordinates from one inverse of Z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1817,6 +1817,40 @@ documented at release-notes length in the first place, and are still in
   landed on the bindings' `main` before any release carries it, which is
   what the entry above this one already moved this tree's requirement to
   track.
+- **`aff_from_jac` inverts once, where it inverted twice.** x is X/Z^2
+  and y is Y/Z^3, and the two denominators were inverted separately --
+  two extended Euclids for one point. Z^-1 gives both: Z^-2 is a
+  multiplication away from it and Z^-3 another, and an inverse costs
+  what about a hundred products cost.
+
+  The conversion is where scalar multiplication ends, so it is what
+  `mult` and `double_mult` pay once per call on every curve the bindings
+  do not answer. Measured against `3f7873db` on Python 3.14.6, best of
+  15 alternating rounds, with the order of the two sides alternating too
+  and three cases that make no conversion at all as the noise detector:
+
+  | | two inverses | one inverse | |
+  | --- | ---: | ---: | ---: |
+  | `aff_from_jac`, random z | 49.00 us | 25.10 us | **1.95x** |
+  | `aff_from_jac`, z == 1 | 0.837 us | 0.484 us | **1.73x** |
+  | `mult`, secp256r1 | 1003 us | 977 us | 1.03x |
+  | `mult`, ec23_31 | 8.21 us | 7.78 us | 1.05x |
+  | `dsa.assert_as_valid`, secp256r1 | 1264 us | 1266 us | 1.00x |
+  | `dsa.assert_as_valid`, secp256k1 | 20.7 us | 20.7 us | 1.00x |
+  | control, `mult` secp256k1 | 8.23 us | 8.27 us | 0.99x |
+
+  A 256-bit multiplication is a thousand microseconds of doublings and
+  additions with one conversion at the end, so halving the conversion
+  moves it by what the table says and no more. Signature verification
+  does not appear because it makes no conversion: `dsa` and `ssa` verify
+  in Jacobian coordinates and ask `x_aff_from_jac` for the one
+  coordinate they compare.
+
+  `x_aff_from_jac` and `y_aff_from_jac` still invert Z^2 and Z^3
+  directly: for a single coordinate that is the same one inverse, and
+  the power wanted is the one inverted. Their docstrings said they made
+  one inversion where `aff_from_jac` made two, which is no longer what
+  tells them apart; each now says what it does not compute.
 
 ### The public API and the module layout
 

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -647,11 +647,13 @@ def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> J
     it answers the z == 0 both functions already recognize, so each still
     raises what it raised before, from the same line.
 
-    The two conversions in cost 0.39 us each on the z == 1 that a parsed
-    key and a lifted r arrive as, and a shortcut for that case -- the
-    affine point being the same pair of coordinates, no inversion at all
-    -- saves 0.75 us of the 28. Not worth a branch, and neither is the
-    caller's own mod_inv(1) on the way back out, 0.14 us.
+    The two conversions in are one modular inversion each on the z == 1
+    that a parsed key and a lifted r arrive as, and a shortcut for that
+    case -- the affine point being the same pair of coordinates, no
+    inversion at all -- saves both of them, 3% of the 28 us the call
+    costs. Not worth a branch, and neither is the caller's own
+    mod_inv(1) on the way back out, the same inversion again on the
+    cheapest operand it has.
     """
     if not _libsecp256k1_applicable(ec, None):
         return _double_mult_w_NAF(u, HJ, v, QJ, ec, _DOUBLE_MULT_W)

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -241,7 +241,7 @@ class CurveGroup:
         raise BTClibTypeError("not a Jacobian point")
 
     def aff_from_jac(self, Q: JacPoint) -> Point:
-        """Return the affine point: two modular inversions.
+        """Return the affine point: one modular inversion.
 
         The input point is assumed to be on the curve; infinity comes
         back as INF, its affine spelling.
@@ -249,14 +249,21 @@ class CurveGroup:
         if Q[2] == 0:  # Infinity point in Jacobian coordinates
             return INF
 
-        Z2 = Q[2] * Q[2]
-        x = Q[0] * mod_inv(Z2, self.p)
-        y = Q[1] * mod_inv(Z2 * Q[2], self.p)
-        return x % self.p, y % self.p
+        # x is X/Z^2 and y is Y/Z^3, and both powers are built from one
+        # inverse: Z^-2 is a product away from Z^-1, and Z^-3 another.
+        # Inverting Z^2 and Z^3 separately is two extended Euclids where
+        # this is one and two multiplications, and an inverse costs what
+        # a hundred products cost
+        p = self.p
+        z_inv = mod_inv(Q[2], p)
+        z_inv2 = z_inv * z_inv % p
+        return Q[0] * z_inv2 % p, Q[1] * z_inv2 % p * z_inv % p
 
     def x_aff_from_jac(self, Q: JacPoint) -> int:
-        """Return the affine x alone: one modular inversion, not two.
+        """Return the affine x alone, without the products y costs.
 
+        One inversion, as `aff_from_jac`, of Z^2 rather than of Z: the
+        power x wants is the one inverted, so nothing is rebuilt from it.
         The input point is assumed to be on the curve; infinity has no
         x and is refused.
         """
@@ -267,8 +274,10 @@ class CurveGroup:
         return (Q[0] * mod_inv(Z2, self.p)) % self.p
 
     def y_aff_from_jac(self, Q: JacPoint) -> int:
-        """Return the affine y alone: one modular inversion, not two.
+        """Return the affine y alone, without the product x costs.
 
+        One inversion, as `aff_from_jac`, of Z^3 rather than of Z, for
+        the same reason `x_aff_from_jac` inverts Z^2.
         The input point is assumed to be on the curve; infinity has no
         y and is refused.
         """
@@ -301,8 +310,10 @@ class CurveGroup:
         """
         self.require_on_curve(Q1)
         self.require_on_curve(Q2)
-        # no Jacobian coordinates here as aff_from_jac would cost 2 mod_inv
-        # while add_aff costs only one mod_inv
+        # affine arithmetic, and it is not the inversion that decides it:
+        # aff_from_jac makes one, add_aff makes one. The products decide,
+        # and reaching this sum through Jacobian coordinates and back
+        # makes more of them than add_aff does
         return self.add_aff(Q1, Q2)
 
     def add_jac(self, Q: JacPoint, R: JacPoint) -> JacPoint:


### PR DESCRIPTION
`aff_from_jac` inverted two denominators to convert one point: x is
X/Z^2 and y is Y/Z^3, and each power was handed to its own extended
Euclid. Z^-1 answers both — Z^-2 is a multiplication away from it, Z^-3
another — and an inverse costs what about a hundred products cost.

```python
p = self.p
z_inv = mod_inv(Q[2], p)
z_inv2 = z_inv * z_inv % p
return Q[0] * z_inv2 % p, Q[1] * z_inv2 % p * z_inv % p
```

## Measured

Against `3f7873db` on Python 3.14.6, best of 15 alternating rounds, with
the order of the two sides alternating as well — run second in every
round and a side is measured on a warmer machine than its rival — and
three cases that make no conversion at all as the noise detector.

| | two inverses | one inverse | | conversions |
| --- | ---: | ---: | ---: | ---: |
| `aff_from_jac`, random z | 49.00 us | 25.10 us | **1.95x** | 1 |
| `aff_from_jac`, z == 1 | 0.837 us | 0.484 us | **1.73x** | 1 |
| `mult`, secp256r1 | 1003 us | 977 us | 1.03x | 1 |
| `mult`, ec23_31 | 8.21 us | 7.78 us | 1.05x | 1 |
| `dsa.assert_as_valid`, secp256r1 | 1264 us | 1266 us | 1.00x | 0 |
| `dsa.assert_as_valid`, secp256k1 | 20.7 us | 20.7 us | 1.00x | 0 |
| control, `mult` secp256k1 | 8.23 us | 8.27 us | 0.99x | 0 |

The last column is the conversions each case makes per operation,
counted rather than assumed: the three at zero are the ones the change
cannot touch, and they are what says the rest is signal. The conversion
halves; what pays for it is one call at the end of every scalar
multiplication the bindings do not answer, so a 256-bit `mult` moves by
a few per cent and no more.

Verification does not appear because it makes no conversion at all:
`dsa` and `ssa` verify in Jacobian coordinates and ask `x_aff_from_jac`
for the single coordinate they compare.

## Three comments stated the old count

- `add` gave two inversions against `add_aff`'s one as the reason it
  stays affine. Both are one now, so the reason is the products, and it
  is still affine.
- `x_aff_from_jac` and `y_aff_from_jac` said "one modular inversion, not
  two", which no longer tells them from this one: each says what it does
  not compute.
- `_jac_double_mult` priced its two conversions in, and the caller's
  `mod_inv(1)` on the way back out, at the two-inversion figures.

## Gates

`uv run pytest` green, 26711 passed, coverage 100.00% against the
`fail_under` of 100; `pre-commit run --all-files` green; the `-W` sphinx
build green.

Independent of https://github.com/btclib-org/btclib/pull/780, which
makes the inverse itself cheaper in `btclib/number_theory.py`: different
file, no conflict, and neither removes the work the other does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize Jacobian-to-affine point conversion to use a single modular inversion and update related documentation and comments to reflect the new cost model and rationale.

Enhancements:
- Reduce `aff_from_jac` to one modular inversion by reusing the inverse of Z to derive both affine coordinates.
- Clarify docstrings for `x_aff_from_jac` and `y_aff_from_jac` to describe their relationship to `aff_from_jac` and what each computes.
- Update comments in `add` and `_jac_double_mult` to reflect the new inversion counts and performance considerations.
- Document the performance impact of the new `aff_from_jac` implementation in the changelog with measured benchmarks.