### PR TITLE
Split a descriptor at its delimiters, not at every character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2660,6 +2660,31 @@ documented at release-notes length in the first place, and are still in
   `checksum()` runs on every descriptor parse and serialization and the
   fix is a net simplification, not because the polymod loop is the actual
   cost and a different algorithm.
+- **`_split_arguments` stops at the delimiters instead of reading every
+  character** (issue #786). `for i, char in enumerate(arguments)` brought
+  the whole descriptor into bytecode where five characters decide
+  anything, and `re.finditer` over `[(){},]` skips the rest in C. Same
+  splits, same refusal of an unbalanced bracket, same message, and the
+  key origin brackets still uncounted on purpose.
+
+  What makes it worth more than one scan of one string is `_parse_tree`
+  above it: a tr() branch is split, and each of its branches is split
+  again, so a character near a leaf is read once per level above it.
+  Measured against `98931dd1` on Python 3.14.6, best of 15 alternating
+  rounds, order of the two sides alternating too, with a case that
+  parses nothing as the noise detector:
+
+  | | per character | delimiters | |
+  | --- | ---: | ---: | ---: |
+  | `_split_arguments`, the 5000-deep tree | 7436 us | 2324 us | **3.20x** |
+  | `parse`, the same tree (refused at 129) | 1.106 s | 0.452 s | **2.45x** |
+  | `parse`, a tree at the depth bound | 17.27 us | 8.49 us | **2.03x** |
+  | `parse`, a plain `wpkh` | 43.96 us | 41.42 us | 1.06x |
+  | control, `hash256` | 0.78 us | 0.76 us | 1.02x |
+
+  A descriptor with no tree in it is one call over a short string and
+  does not move; the trees `tests/descriptors/descriptors_test.py`
+  bounds at `taproot.MAX_TREE_DEPTH` are what the factor is for.
 
 ### Wallets
 

--- a/btclib/descriptors/key_expression.py
+++ b/btclib/descriptors/key_expression.py
@@ -58,6 +58,11 @@ __all__ = ["KeyExpression", "PrvKeys"]
 
 _FINGERPRINT = re.compile(r"[0-9a-fA-F]{8}")
 _HEX = re.compile(r"[0-9a-fA-F]*")
+# what `_split_arguments` stops at, compiled once here rather than
+# handed to `re.finditer` as a pattern string per call: the cache that
+# would answer for it is a dict lookup on that string, which a function
+# called once per branch of a tr() tree makes for nothing
+_DELIMITERS = re.compile(r"[(){},]")
 
 # what `parse` hands back beside the descriptor, and what expansion takes
 # when a hardened step needs it: the extended private key each extended
@@ -303,16 +308,22 @@ def _split_arguments(arguments: str) -> list[str]:
     depth = 0
     start = 0
     result = []
-    for i, char in enumerate(arguments):
+    # the loop is over the delimiters and not over the string: every
+    # other character decides nothing, and `re` skips them in C. What
+    # makes that worth writing is the recursion above -- `_parse_tree`
+    # splits a branch and splits each of its branches again, so a
+    # character deep in a tr() tree is walked once per level above it
+    for match in _DELIMITERS.finditer(arguments):
+        char = match[0]
         if char in "({":
             depth += 1
         elif char in ")}":
             depth -= 1
             if depth < 0:
                 raise BTClibValueError(f"unbalanced brackets: {arguments}")
-        elif char == "," and depth == 0:
-            result.append(arguments[start:i])
-            start = i + 1
+        elif depth == 0:  # a comma, the only other character matched
+            result.append(arguments[start : match.start()])
+            start = match.end()
     if depth:
         raise BTClibValueError(f"unbalanced brackets: {arguments}")
     result.append(arguments[start:])


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/786.

`_split_arguments` walked the argument string one character at a time,
where five characters decide anything and every other one decides
nothing. A compiled `[(){},]` finds them in C:

```python
for match in _DELIMITERS.finditer(arguments):
    char = match[0]
```

The loop body is what it was — same splits, same refusal of an
unbalanced bracket, same message, and the key origin brackets still
uncounted on purpose, so that a bracket written wrong reaches the key
expression parser.

## Measured

One scan of one string would not be worth the change; `_parse_tree`
above it is. It splits a `tr()` branch and splits each of that branch's
branches again, so a character near a leaf is read once per level above
it.

Against `98931dd1` on Python 3.14.6, best of 15 alternating rounds, the
order of the two sides alternating as well, with a case that parses
nothing as the noise detector:

| | per character | delimiters | |
| --- | ---: | ---: | ---: |
| `_split_arguments`, the 5000-deep tree | 7436 us | 2324 us | **3.20x** |
| `parse`, the same tree (refused at 129) | 1.106 s | 0.452 s | **2.45x** |
| `parse`, a tree at the depth bound | 17.27 us | 8.49 us | **2.03x** |
| `parse`, a plain `wpkh` | 43.96 us | 41.42 us | 1.06x |
| control, `hash256` | 0.78 us | 0.76 us | 1.02x |

A descriptor with no tree in it does not move — one call over a short
string — and the last two rows are the same number twice. The trees are
the ones `test_tr_tree_depth_is_bounded` builds, at
`taproot.MAX_TREE_DEPTH` and well past it.

The equivalence was checked before the timing, on both sides of every
case measured plus `a,b,c`, the empty string, `a(b,c),d`, `{a,b},c` and
the four unbalanced spellings.

## Gates

`uv run pytest` green, 26712 passed, coverage 100.00% against the
`fail_under` of 100; `pre-commit run --all-files` green; the `-W` sphinx
build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize descriptor argument splitting to scan only delimiter characters while preserving existing parsing behavior and error handling.

Enhancements:
- Improve `_split_arguments` performance by iterating over precompiled delimiter matches instead of every character, reducing repeated work in recursive tree parsing.
- Introduce a shared precompiled delimiter regex for key expression parsing to avoid per-call pattern compilation overhead.

Documentation:
- Document the `_split_arguments` delimiter-based optimization and its measured performance impact in the changelog.