### PR TITLE
Sum a size from the field widths instead of measuring a copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1171,6 +1171,45 @@ documented at release-notes length in the first place, and are still in
   None means "verify every signature this input holds". One implementation
   of a signature check, for the role that has a request and for the caller
   that has none.
+- **A size is summed from the field widths, not measured on a copy of
+  the bytes** (issue #785). `Block.size` and `Block.stripped_size` were
+  `len(self.serialize(...))`, and `Block.weight` asked for both, so
+  validating a block built the whole block three times over to read
+  three integers: `assert_valid_length` takes the stripped size and
+  `assert_valid_weight` takes the weight, which is the other two. For
+  block 481,824 that is close to a megabyte allocated and dropped, three
+  times, per `assert_valid` -- and `Block.__init__` calls `assert_valid`,
+  so parsing one pays it.
+
+  `_serialized_size` beside each `serialize` answers the same question by
+  addition: `var_int._size` and `var_bytes._size` for the widths a codec
+  writes, then `OutPoint`, `TxIn`, `TxOut`, `Witness`, `BlockHeader`,
+  `Tx` and `Block` each summing what their own serialization would have
+  written. It is what Core does in `GetSerializeSize`, which serializes
+  into a `SizeComputer` -- a stream whose `write` adds to a counter
+  rather than to a buffer.
+
+  Two ways of computing one quantity can drift apart, and a size that is
+  wrong by a byte is a consensus answer that is wrong, so the pair is
+  held together by tests rather than by care:
+  `test_the_size_and_the_serialization_agree` compares them on every
+  block vector in the tree and on a segwit transaction and a legacy one,
+  and `var_int`'s own compares the width with the encoding on both sides
+  of each threshold, under hypothesis and at the boundaries by name.
+
+  Measured against `98931dd1` on Python 3.14.6, best of 11 alternating
+  rounds, order of the two sides alternating too, with a case that
+  computes no size as the noise detector:
+
+  | | serialized | summed | |
+  | --- | ---: | ---: | ---: |
+  | `Block.weight`, block 481,824 | 8880 us | 3612 us | **2.46x** |
+  | `Tx.weight`, a segwit transaction | 18.23 us | 8.70 us | **2.10x** |
+  | control, `hash256` | 3.50 us | 3.50 us | 1.00x |
+
+  Not a cache: `Tx` and `Block` are mutable dataclasses, so a stored
+  length is a field that goes stale the first time a caller appends an
+  input.
 
 ### Curves, signatures and keys
 

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -115,10 +115,25 @@ class Block:
     header: BlockHeader
     transactions: list[Tx]
 
+    def _serialized_size(self, include_witness: bool) -> int:
+        """Return what serialize writes, without writing it.
+
+        `Tx._serialized_size` says why the sizes are summed rather than
+        measured on the bytes; a block is where it matters, being what
+        `assert_valid` bounds three times over -- once for the length
+        and twice for the weight -- each of which built a copy of the
+        whole block to take its length.
+        """
+        return (
+            self.header._serialized_size()
+            + var_int._size(len(self.transactions))
+            + sum(t._serialized_size(include_witness) for t in self.transactions)
+        )
+
     @property
     def size(self) -> int:
         """Return the serialized size, witnesses included."""
-        return len(self.serialize(check_validity=False))
+        return self._serialized_size(include_witness=True)
 
     @property
     def stripped_size(self) -> int:
@@ -129,7 +144,7 @@ class Block:
         left out, which is the serialization the witness discount is
         expressed against and what `getblock` reports under this name.
         """
-        return len(self.serialize(include_witness=False, check_validity=False))
+        return self._serialized_size(include_witness=False)
 
     @property
     def weight(self) -> int:

--- a/btclib/block/block_header.py
+++ b/btclib/block/block_header.py
@@ -401,6 +401,23 @@ class BlockHeader:
         if not 0 <= self.nonce <= 0xFFFFFFFF:
             raise BTClibValueError(f"invalid nonce: {hex(self.nonce)}")
 
+    def _serialized_size(self) -> int:
+        """Return what serialize writes, without writing it.
+
+        The eighty bytes of a header, taken from the fields rather than
+        stated: `assert_valid` is what fixes the two hashes and the bits
+        at their widths, and this is asked by callers that pass
+        `check_validity=False`.
+        """
+        return (
+            4
+            + len(self.previous_block_hash)
+            + len(self.merkle_root)
+            + 4
+            + len(self.bits)
+            + 4
+        )
+
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return a BlockHeader binary serialization."""
         if check_validity:

--- a/btclib/script/witness.py
+++ b/btclib/script/witness.py
@@ -91,6 +91,12 @@ class Witness:
         """Build a Witness from the dict shape to_dict writes."""
         return cls(dict_["stack"], check_validity=check_validity)
 
+    def _serialized_size(self) -> int:
+        """Return what serialize writes, without writing it."""
+        return var_int._size(len(self.stack)) + sum(
+            var_bytes._size(w) for w in self.stack
+        )
+
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the serialization of the Witness."""
         if check_validity:

--- a/btclib/tx/out_point.py
+++ b/btclib/tx/out_point.py
@@ -125,6 +125,10 @@ class OutPoint:
         """Build an OutPoint from the dict shape to_dict writes."""
         return cls(dict_["txid"], dict_["vout"], check_validity=check_validity)
 
+    def _serialized_size(self) -> int:
+        """Return what serialize writes, without writing it."""
+        return len(self.tx_id) + 4
+
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the 36 bytes serialization of the OutPoint."""
         if check_validity:

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -138,10 +138,39 @@ class Tx:  # noqa: PLW1641
         hash256_ = hash256(serialized_)
         return hash256_[::-1]
 
+    def _serialized_size(self, include_witness: bool) -> int:
+        """Return what serialize writes, without writing it.
+
+        The sum of the widths, field by field, and no bytes built: a
+        caller that wants a length gets one, where `len(serialize(...))`
+        answered it with a copy of the whole transaction -- of the whole
+        block, for the rules that bound a block by its size. It is
+        Core's `GetSerializeSize`, which serializes into a
+        `SizeComputer`: a stream whose write adds to a counter.
+
+        Two ways of computing one quantity can disagree, and a size that
+        is wrong by a byte is a consensus answer that is wrong, so this
+        mirrors `serialize` line for line and
+        `test_the_size_and_the_serialization_agree` holds the two
+        together over every vector the suite carries.
+        """
+        segwit = include_witness and self.is_segwit()
+
+        size = 4 + 4  # version and lock_time
+        if segwit:
+            size += len(_SEGWIT_MARKER)
+        size += var_int._size(len(self.vin))
+        size += sum(tx_in._serialized_size() for tx_in in self.vin)
+        size += var_int._size(len(self.vout))
+        size += sum(tx_out._serialized_size() for tx_out in self.vout)
+        if segwit:
+            size += sum(tx_in.script_witness._serialized_size() for tx_in in self.vin)
+        return size
+
     @property
     def size(self) -> int:
         """Return the transaction size."""
-        return len(self.serialize(include_witness=True, check_validity=False))
+        return self._serialized_size(include_witness=True)
 
     @property
     def vsize(self) -> int:
@@ -154,9 +183,9 @@ class Tx:  # noqa: PLW1641
     @property
     def weight(self) -> int:
         """Return the BIP141 weight: 3x the stripped size plus the size."""
-        no_wit = len(self.serialize(include_witness=False, check_validity=False)) * 3
-        wit = len(self.serialize(include_witness=True, check_validity=False))
-        return no_wit + wit
+        return 3 * self._serialized_size(include_witness=False) + self._serialized_size(
+            include_witness=True
+        )
 
     @property
     def sig_op_count(self) -> int:

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -178,6 +178,14 @@ class TxIn:
             check_validity=check_validity,
         )
 
+    def _serialized_size(self) -> int:
+        """Return what serialize writes, without writing it.
+
+        The witness is not counted here, for the reason serialize does
+        not write it: Tx puts every witness after the outputs.
+        """
+        return self.prev_out._serialized_size() + var_bytes._size(self.script_sig) + 4
+
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the wire serialization: prev_out, script_sig, sequence.
 

--- a/btclib/tx/tx_out.py
+++ b/btclib/tx/tx_out.py
@@ -145,6 +145,10 @@ class TxOut:
             value, ScriptPubKey(script_bin, network), check_validity=check_validity
         )
 
+    def _serialized_size(self) -> int:
+        """Return what serialize writes, without writing it."""
+        return 8 + var_bytes._size(self.script_pub_key.script)
+
     def serialize(self, *, check_validity: bool = True) -> bytes:
         """Return the wire serialization: the value, then the script.
 

--- a/btclib/var_bytes.py
+++ b/btclib/var_bytes.py
@@ -28,6 +28,18 @@ def parse(stream: BinaryData, forbid_zero_size: bool = False) -> bytes:
     return result
 
 
+def _size(octets: Octets) -> int:
+    """Return the width `serialize` writes, without writing it.
+
+    The coercion is `serialize`'s and is not skipped: a hex string is
+    half its own length in bytes, and reading `len` off the string would
+    answer twice the width for the one input the codec accepts as text.
+    What it does not do is build the concatenation.
+    """
+    size = len(bytes_from_octets(octets))
+    return var_int._size(size) + size
+
+
 def serialize(octets: Octets) -> bytes:
     """Return the var_int(len(octets)) + octets serialization of octets."""
     bytes_ = bytes_from_octets(octets)

--- a/btclib/var_int.py
+++ b/btclib/var_int.py
@@ -90,6 +90,28 @@ def parse(stream: BinaryData, max_size: int = MAX_SIZE) -> int:
     return i
 
 
+def _size(i: int) -> int:
+    """Return the width `serialize` writes for i, without writing it.
+
+    The four thresholds below are `serialize`'s own, and a test asserts
+    the two agree on both sides of each: a size and a serialization that
+    disagree are a consensus answer that is wrong by a byte.
+
+    Private, and unvalidated as a private twin is: every caller hands it
+    the length of a list or of a byte string, which is the non-negative
+    integer `serialize` checks for. The range `serialize` refuses is
+    unreachable from there -- a count that large counts more items than
+    the block holding them could carry.
+    """
+    if i < 0xFD:
+        return 1
+    if i <= 0xFFFF:
+        return 3
+    if i <= 0xFFFFFFFF:
+        return 5
+    return 9
+
+
 def serialize(i: int) -> bytes:
     """Return the var_int bytes encoding of an integer.
 

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -1407,3 +1407,38 @@ def test_a_declared_transaction_count_is_bounded_by_what_a_block_holds() -> None
 
     with pytest.raises(BTClibValueError, match="var_int too big"):
         Block.parse(header + var_int.serialize(maximum + 1), check_validity=False)
+
+
+@pytest.mark.parametrize(
+    "fname",
+    [
+        "block_1.bin",
+        "block_170.bin",
+        "block_200000.bin",
+        "block_481824.bin",
+        "block_481824_complete.bin",
+    ],
+)
+def test_the_size_and_the_serialization_agree(fname: str) -> None:
+    """The summed widths are the bytes, witnesses in and witnesses out.
+
+    `Block.size` and `Block.stripped_size` add the widths up rather than
+    take the length of a serialization, so there are two ways of
+    computing one quantity and they can drift apart. What is measured
+    here is what `assert_valid_length` and `assert_valid_weight` bound,
+    so a byte of disagreement is a block accepted or refused wrongly.
+    """
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as file_:
+        block = Block.parse(file_.read())
+
+    for include_witness in (True, False):
+        assert block._serialized_size(include_witness) == len(
+            block.serialize(include_witness, check_validity=False)
+        )
+
+    assert block.size == len(block.serialize(check_validity=False))
+    assert block.stripped_size == len(
+        block.serialize(include_witness=False, check_validity=False)
+    )
+    assert block.weight == 3 * block.stripped_size + block.size

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -928,3 +928,38 @@ def test_a_declared_input_or_output_count_is_bounded_before_allocation() -> None
     # the first input's short read is what answers instead
     with pytest.raises(BTClibValueError, match="not enough data for the outpoint"):
         Tx.parse(version + var_int.serialize(MAX_TX_IN_COUNT))
+
+
+def test_the_size_and_the_serialization_agree() -> None:
+    """The summed widths are the bytes, for a segwit transaction and not.
+
+    `Tx.size` and `Tx.weight` add the widths up rather than take the
+    length of a serialization: two ways of computing one quantity, and
+    the block rules are checked against the sizes. The segwit case is
+    the one with fields the stripped serialization leaves out -- the
+    marker, the flag and every witness -- so it is where the two
+    spellings have something to disagree about.
+    """
+    fname = "d4f3c2c3c218be868c77ae31bedb497e2f908d6ee5bbbe91e4933e6da680c970.bin"
+    filename = Path(__file__).parent / "_data" / fname
+    with filename.open("rb") as binary_file_:
+        segwit = Tx.parse(binary_file_.read())
+    assert segwit.is_segwit()
+
+    legacy = Tx(
+        version=1,
+        lock_time=0,
+        vin=[TxIn(OutPoint(b"\x01" * 32, 0), b"\x02" * 253, 0xFFFFFFFF)],
+        vout=[TxOut(1000, ScriptPubKey(b"\x03" * 25))],
+    )
+    assert not legacy.is_segwit()
+
+    for tx in (segwit, legacy):
+        for include_witness in (True, False):
+            assert tx._serialized_size(include_witness) == len(
+                tx.serialize(include_witness, check_validity=False)
+            )
+        assert tx.size == len(tx.serialize(include_witness=True, check_validity=False))
+        assert tx.weight == 3 * len(
+            tx.serialize(include_witness=False, check_validity=False)
+        ) + len(tx.serialize(include_witness=True, check_validity=False))

--- a/tests/var_bytes_test.py
+++ b/tests/var_bytes_test.py
@@ -57,3 +57,13 @@ def test_forbid_zero_size(octets: bytes) -> None:
     else:
         with pytest.raises(BTClibRuntimeError, match="zero size"):
             var_bytes.parse(serialized, forbid_zero_size=True)
+
+
+def test_the_size_and_the_serialization_agree() -> None:
+    """`_size` is what `serialize` writes, the hex spelling included.
+
+    The string case is the one a length cannot be read off: `len` of
+    "deadbeef" is eight and the codec writes four bytes and a prefix.
+    """
+    for octets in (b"", b"\x00", b"\xff" * 0xFC, b"\xff" * 0xFD, "deadbeef"):
+        assert var_bytes._size(octets) == len(var_bytes.serialize(octets))

--- a/tests/var_int_test.py
+++ b/tests/var_int_test.py
@@ -214,3 +214,25 @@ def test_truncated_encoding_is_rejected(i: int) -> None:
         err_msg = "not enough binary data for var_int"
         with pytest.raises(BTClibValueError, match=err_msg):
             var_int.parse(encoded[:length], max_size=0xFFFFFFFFFFFFFFFF)
+
+
+@given(i=st.integers(min_value=0, max_value=0xFFFFFFFFFFFFFFFF))
+def test_the_size_and_the_encoding_agree(i: int) -> None:
+    """`_size` answers what `serialize` would have written."""
+    assert var_int._size(i) == len(var_int.serialize(i))
+
+
+def test_the_size_agrees_at_every_width_boundary() -> None:
+    """Both sides of each threshold, which is where an off-by-one lands."""
+    for i in (
+        0,
+        1,
+        0xFC,
+        0xFD,
+        0xFFFF,
+        0x10000,
+        0xFFFFFFFF,
+        0x100000000,
+        0xFFFFFFFFFFFFFFFF,
+    ):
+        assert var_int._size(i) == len(var_int.serialize(i))


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/785.

`Block.size` and `Block.stripped_size` were `len(self.serialize(...))`,
and `Block.weight` asks for both, so validating a block built the whole
block three times over to read three integers: `assert_valid_length`
takes the stripped size, `assert_valid_weight` takes the weight, which
is the other two. For block 481,824 that is close to a megabyte
allocated and dropped, three times, per `assert_valid` — and
`Block.__init__` calls `assert_valid`, so parsing one pays it.

`_serialized_size` beside each `serialize` answers by addition:
`var_int._size` and `var_bytes._size` for the widths a codec writes,
then `OutPoint`, `TxIn`, `TxOut`, `Witness`, `BlockHeader`, `Tx` and
`Block` each summing what their own serialization would have written.
It is Core's `GetSerializeSize`, which serializes into a `SizeComputer`
— a stream whose `write` adds to a counter rather than to a buffer.

## The drift is what the tests are for

Two ways of computing one quantity can disagree, and a size that is
wrong by a byte is a consensus answer that is wrong. So the pair is held
together by tests rather than by care:

- `test_the_size_and_the_serialization_agree` in
  `tests/block/block_test.py`, over all five block vectors, witnesses in
  and witnesses out;
- the same name in `tests/tx/tx_test.py`, over a segwit transaction and
  a legacy one — the segwit case being the one with fields the stripped
  serialization leaves out;
- `var_int`'s own, comparing the width with the encoding under
  hypothesis and at both sides of every threshold by name;
- `var_bytes`', including the hex-string spelling, which is the input a
  length cannot be read off.

## Measured

Against `98931dd1` on Python 3.14.6, best of 11 alternating rounds, the
order of the two sides alternating as well, with a case that computes no
size as the noise detector:

| | serialized | summed | |
| --- | ---: | ---: | ---: |
| `Block.weight`, block 481,824 | 8880 us | 3612 us | **2.46x** |
| `Tx.weight`, a segwit transaction | 18.23 us | 8.70 us | **2.10x** |
| control, `hash256` | 3.50 us | 3.50 us | 1.00x |

Not a cache: `Tx` and `Block` are mutable dataclasses, so a stored
length is a field that goes stale the first time a caller appends an
input.

## Gates

`uv run pytest` green, 26721 passed, coverage 100.00% against the
`fail_under` of 100; `pre-commit run --all-files` green; the `-W` sphinx
build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Compute block and transaction size and weight by summing serialization field widths instead of measuring serialized byte copies, with tests ensuring equivalence between the two calculations.

Bug Fixes:
- Eliminate redundant full-block and full-transaction serializations when validating size and weight, avoiding off-by-one consensus errors through verified size computations.

Enhancements:
- Introduce _serialized_size helpers across core data structures (var_int, var_bytes, OutPoint, TxIn, TxOut, Witness, BlockHeader, Tx, Block) to provide efficient, allocation-free size calculations.
- Add property implementations for Block and Tx size and weight that rely on summed field widths for performance and consistency with Core’s GetSerializeSize approach.

Documentation:
- Document the new size-computation approach and its performance impact in the changelog, including rationale and benchmark results.

Tests:
- Add tests that assert summed widths match actual serialized lengths for blocks, transactions (segwit and legacy), var_int, and var_bytes, including boundary and hypothesis-based checks to guard against drift between size and serialization implementations.