### PR TITLE
Refuse an implicit encoding at the gate, not on Saturday

### DIFF
--- a/.github/scripts/check_vendored_vectors.py
+++ b/.github/scripts/check_vendored_vectors.py
@@ -160,7 +160,7 @@ def _latest_commit(repo: str, path: str) -> tuple[str, str] | None:
         ],
         capture_output=True,
         check=True,
-        text=True,
+        encoding="utf-8",
     )
     commits = json.loads(result.stdout)
     if not commits:
@@ -227,7 +227,7 @@ def _open_issue_number() -> str | None:
         ],
         capture_output=True,
         check=True,
-        text=True,
+        encoding="utf-8",
     )
     issues = json.loads(result.stdout)
     return str(issues[0]["number"]) if issues else None

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -454,6 +454,26 @@ repos:
         args: [--fix]
       - id: ruff-format
         name: ruff format (in place fixes)
+  # the other half of pyproject.toml's unspecified-encoding, which reads
+  # `open` and the pathlib and tempfile spellings and stops there. A child
+  # process decoded through `text=True` takes the locale's encoding by
+  # exactly the same rule -- what a test asserts then depends on what
+  # Windows decoded the child's stdout as -- and no linter here has an
+  # opinion on that keyword.
+  # `encoding=` is what the call wanted anyway: passing it puts subprocess
+  # in text mode, so the fix is one keyword in place of another and never
+  # a mode change.
+  # A literal keyword rather than a call-shaped pattern, because pygrep is
+  # line based and every such call here spans several lines. It costs
+  # nothing to be that blunt: there is no reason to write `text=True` that
+  # `encoding="utf-8"` does not answer
+  - repo: local
+    hooks:
+      - id: decoded-subprocess-encoding
+        name: a decoded subprocess names its encoding, not text=True
+        language: pygrep
+        entry: '\b(text|universal_newlines)=True'
+        files: \.py$
   # not the mirrors-mypy hook: it injects --ignore-missing-imports, which
   # turns an unresolved (or misspelled) import into Any, the opposite of
   # strict, and it type checks in an isolated environment, where every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -244,6 +244,32 @@ documented at release-notes length in the first place, and are still in
 
 ### Packaging, linting and CI
 
+- **The lint gate refuses a read that names no encoding** (issue #784).
+  A call that omits it takes the locale's, which is UTF-8 wherever this
+  suite is usually read and cp1252 on Windows, where a typographic quote
+  in a docstring is a byte that maps to nothing and the module holding it
+  fails to load rather than fails a test. Windows answers on Saturday and
+  before a release, so nothing else asks in between. Two rules, because
+  one tool covers one half:
+    - `unspecified-encoding` in `pyproject.toml`, ruff's transcription of
+    pylint's PLW1514, which reads `open`, `Path.open`, `read_text`,
+    `write_text` and the tempfile factories. It is a preview rule, so it
+    goes in `extend-select` and not in `select`, which holds families and
+    reaches no preview rule through any of them; `explicit-preview-rules`
+    keeps the rest of preview out. Zero findings when it was selected.
+    - a pygrep hook refusing `text=True` and `universal_newlines=True`,
+    which is the same defect one layer out: a decoded child process takes
+    the locale's encoding too, and no linter here has an opinion on that
+    keyword. `.github/scripts/check_vendored_vectors.py`,
+    `tests/imports_test.py` and `tests/mutation_counts_test.py` pass
+    `encoding="utf-8"` instead, which puts subprocess in text mode by
+    itself.
+
+  `PYTHONWARNDEFAULTENCODING=1` is not the guard: pytest turns the warning
+  into an error, but the variable is inherited by every subprocess a test
+  spawns, and two test files then fail on what the child wrote rather than
+  on what they assert.
+
 - **A pull request asks for twenty-one jobs instead of thirty-nine**, and
   the number that decided it is not a wall clock but a ceiling: GitHub Free
   gives an organization twenty concurrent jobs. Measured over a working

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -556,10 +556,9 @@ exclude = [
 # feature, so the first line is what buys the second -- and alone it
 # would also turn on every rule ruff is still designing. The second
 # takes that back off: a preview rule then runs only where this file
-# names it exactly, and every entry of `select` below is a family, which
-# no preview rule can be reached through. The rule set stays the stable
-# one it already was; what preview changes here is only how `ignore`
-# spells its own entries
+# names it exactly, and a family name reaches none of them, which is why
+# `extend-select` below exists at all. The rule set stays the stable one
+# it already was, plus what that key spells out one rule at a time
 preview = true
 explicit-preview-rules = true
 # A, BLE, C90, FA, FIX, FLY, RSE, SLOT, T10, T20 and TID are here by
@@ -639,6 +638,21 @@ select = [
     "UP",   # pyupgrade
     "W",    # pycodestyle warnings
 ]
+# a rule and not a family, so it is here rather than in `select` above,
+# which holds families and reaches no preview rule through any of them --
+# pylint's unspecified-encoding is PLW1514 and preview is where ruff
+# keeps it.
+# It asks that `open`, `Path.open`, `read_text`, `write_text` and the
+# tempfile factories name an encoding, because a call that omits it takes
+# the locale's: UTF-8 wherever this suite is usually read, cp1252 on
+# Windows, where a typographic quote in a docstring is a byte that maps
+# to nothing and the module holding it fails to load rather than fails a
+# test. windows.yml answers on Saturday and before a release, so nothing
+# else asks in between.
+# Zero findings when it was selected, which makes it a ratchet and not a
+# cleanup. .pre-commit-config.yaml carries the other half, `text=True`
+# being the same locale-dependent decode one layer out
+extend-select = ["unspecified-encoding"]
 # named rather than coded, here and in per-file-ignores below: `select`
 # above has no choice, a family having no name of its own, but an entry
 # that suppresses a single rule can say which -- so the reason sits in

--- a/tests/imports_test.py
+++ b/tests/imports_test.py
@@ -107,7 +107,7 @@ def test_exceptions_imports_nothing_of_btclibs_and_no_client(
     # whole of what runs in it
     probe = "import btclib.exceptions, sys; print(sorted(sys.modules))"
     loaded = subprocess.run(  # noqa: S603
-        [sys.executable, "-c", probe], check=True, capture_output=True, text=True
+        [sys.executable, "-c", probe], check=True, capture_output=True, encoding="utf-8"
     ).stdout
     assert "'bitcoin_core_rpc'" not in loaded
     assert "'urllib.request'" not in loaded

--- a/tests/mutation_counts_test.py
+++ b/tests/mutation_counts_test.py
@@ -207,7 +207,7 @@ def test_the_script_reads_a_session_and_exits_on_an_unsound_one(
     done = subprocess.run(  # noqa: S603
         [sys.executable, str(_SCRIPT), str(sound)],
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         check=True,
     )
     assert "killed 3, survived 0, skipped 0" in done.stdout
@@ -216,7 +216,7 @@ def test_the_script_reads_a_session_and_exits_on_an_unsound_one(
     failed = subprocess.run(  # noqa: S603
         [sys.executable, str(_SCRIPT), str(broken)],
         capture_output=True,
-        text=True,
+        encoding="utf-8",
         check=False,
     )
     assert failed.returncode == 1


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/784.

A read that names no encoding takes the locale's: UTF-8 wherever this
suite is usually read, cp1252 on Windows, where a typographic quote in a
docstring is a byte that maps to nothing and the module holding it fails
to *load* rather than fails a test. Since
https://github.com/btclib-org/btclib/pull/777 `windows.yml` answers on
Saturday and before a release, so that class of defect has a week on
`main` with nothing asking about it.

Two rules, because one tool covers one half.

**`pyproject.toml`** selects `unspecified-encoding`, ruff's transcription
of pylint's PLW1514, which reads `open`, `Path.open`, `read_text`,
`write_text` and the tempfile factories. Zero findings when it was
selected, so it is a ratchet and not a cleanup:

```shell
uv run ruff check --no-cache btclib tests .github/scripts
```

The issue proposed a source-level `ast` walk instead, on the grounds that
a preview-only rule cannot carry a per-site `noqa` while preview is off.
That premise expired before the issue was written: d3d32f57 set `preview
= true` with `explicit-preview-rules = true`, so a preview rule now runs
where this file names it exactly and can be suppressed at a site like any
other. What is left of the choice is a rule ruff maintains against a walk
this repository would, and the reason still goes in a comment either way.

It goes in `extend-select` rather than in `select`: `select` holds
families, taplo aligns an array's trailing comments on its longest entry,
and one 22-character rule name there rewrites fourteen lines that have
nothing to do with this change.

**`.pre-commit-config.yaml`** refuses `text=True` and
`universal_newlines=True`, which is the same locale-dependent decode one
layer out — a child process's stdout — and which no rule here reads.
`check_vendored_vectors.py`, `imports_test.py` and
`mutation_counts_test.py` pass `encoding="utf-8"` instead: it puts
subprocess in text mode by itself, so the call keeps its shape and loses a
keyword.

`PYTHONWARNDEFAULTENCODING=1` stays rejected for the reason the issue
measured: pytest turns the warning into an error, but the variable is
inherited by every subprocess a test spawns, and two test files then fail
on what the child wrote rather than on what they assert.

Gates run locally, on the rebased branch: `uv run pytest` (26721 passed,
100.00% coverage), `uv run pre-commit run --all-files` (exit 0). The rule
fires on a probe calling `read_text()` with no encoding, which is the
evidence it would have caught the defect that opened the issue.

## Summary by Sourcery

Enforce explicit text encodings in both file I/O and subprocess output to prevent locale-dependent failures, particularly on Windows.

Enhancements:
- Configure ruff to enforce explicit encodings for file reads and writes via the unspecified-encoding rule.
- Add a pre-commit pygrep hook to disallow text=True and universal_newlines=True in subprocess calls, steering code toward explicit encoding usage.
- Document the new encoding-related lint and pre-commit guards in the changelog, including the rationale for avoiding PYTHONWARNDEFAULTENCODING=1.

Tests:
- Update subprocess-based tests and scripts to use encoding="utf-8" instead of text mode flags, ensuring consistent decoding across platforms.