### PR TITLE
Switch off the analysis nobody could read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The generated Code Quality analysis is off** (issue #788). A second
+  CodeQL run that no file in this tree declares — `Analyze (python)` and
+  `Analyze (ruby)`, on every pull request and every push to `main` — took
+  two of the twenty concurrent jobs GitHub Free gives an organization, on
+  top of the twenty-one a pull request asks for on purpose, and produced
+  nothing anybody read: there is no `code-quality/alerts` endpoint and no
+  `code-quality/analyses`, both 404, so the repository's Code quality tab
+  is the only place those queries have ever spoken. `Analyze (ruby)` had
+  no Ruby to read either — Pages serves btclib.org from `main`'s root, so
+  a `Gemfile` sits beside the package and autodetection saw a Ruby
+  project, which is why `codeql.yml` excludes Ruby from its own matrix.
+  REPOSITORY.md gains the section and the endpoint that reports and sets
+  it, `code-quality/setup`: not `code-scanning/default-setup`, and not the
+  Actions API, which answers 422 for a workflow the repository does not
+  own.
+
 - **`integration.yml` says which of its jobs gates** (#736). Its header
   claimed the workflow gates nothing and "must not" appear in main's
   required checks, which two paragraphs of the same file, three of

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -160,7 +160,8 @@ section tells you to read. A generated
 running `Analyze (ruby)` and `Analyze (python)`, but it uploads *code
 quality* results now — `ruby.quality.sarif` in its log, where the security
 analysis produced `python.sarif` and `actions.sarif`. Code quality is a
-separate setting, and `code-scanning/default-setup` does not report it:
+separate setting with an endpoint of its own, the section below, and
+`code-scanning/default-setup` reports nothing about it:
 
 ```shell
 gh api repos/btclib-org/btclib/actions/workflows \
@@ -187,6 +188,57 @@ answers 422 for a string `app_id`. Its body is the four-check one the
 section above carries, every entry naming its app because every one of these
 is an Actions check — the `CodeQL` it drops was the exception, the app
 producing it not being Actions.
+
+## Code quality
+
+The analysis the section above leaves behind, and it is off. Its setting
+is not `code-scanning/default-setup`, and the Actions API refuses to be
+the way in — `actions/workflows/<id>/disable` answers 422, `Unable to
+disable this workflow`, a generated workflow not being one this repository
+owns. The endpoint that reports it is the one that sets it:
+
+```shell
+gh api repos/btclib-org/btclib/code-quality/setup
+# {"state":"not-configured","languages":["python","ruby"], ...}
+
+gh api -X PATCH repos/btclib-org/btclib/code-quality/setup \
+  -F state=not-configured
+```
+
+What decided it is the concurrency ceiling and not the queries. GitHub
+Free gives an organization twenty concurrent jobs, a pull request here
+asks for twenty-one on purpose, and `Analyze (python)` and `Analyze
+(ruby)` were two more on every pull request and every push to `main` —
+`Code Quality: PR #N` in the run list, 80 seconds and 32.
+
+What they produced in exchange cannot be read from here at all. There is
+no `code-quality/alerts` and no `code-quality/analyses`, both 404, and a
+quality upload appears in neither of the endpoints that do answer: the
+alert list is empty, and every analysis is `codeql.yml`'s own, by
+category.
+
+```shell
+gh api "repos/btclib-org/btclib/code-scanning/alerts?per_page=100" \
+  --jq length
+gh api "repos/btclib-org/btclib/code-scanning/analyses?per_page=100" \
+  --jq '[.[] | .category] | unique'
+```
+
+So the repository's Code quality tab is the only place the python quality
+queries have ever spoken — the run log lists them one by one as they
+evaluate — and nothing outside a browser can say what they said, which is
+most of the reason nobody read them.
+
+`Analyze (ruby)` is the plainest half of it: there is no Ruby in this
+library. Pages serves btclib.org from `main`'s root, so a `Gemfile` sits
+beside the package and autodetection reads a Ruby project; `codeql.yml`
+excludes Ruby from its own matrix for that same reason.
+
+`state=configured` is the way back, and the argument for it is that these
+queries are a class of finding nothing else here makes: ruff, mypy and the
+two spell checkers are the cover, and they are not the same questions. The
+trade against them is above, and it is the ceiling, so a fleet that is not
+waiting for slots is what would change it.
 
 ## Branch protection
 


### PR DESCRIPTION
Closes https://github.com/btclib-org/btclib/issues/788.

**One command has to be run before this merges**, and it is the one the
issue asked somebody to find. The setting is neither
`code-scanning/default-setup` nor anything the Actions API will disable
(422, `Unable to disable this workflow`); it is:

```shell
gh api -X PATCH repos/btclib-org/btclib/code-quality/setup \
  -F state=not-configured
```

I could not run it from here — writes to that endpoint are refused by this
session's permission classifier — so `REPOSITORY.md` describing the
setting as off becomes true when you run it. `gh api
repos/btclib-org/btclib/code-quality/setup` is the check, and
`state=configured` is the way back.

## What the decision rests on

- **Cost**: two of the twenty concurrent jobs GitHub Free gives an
  organization, on every pull request and every push to `main`, on top of
  the twenty-one https://github.com/btclib-org/btclib/pull/777 left a pull
  request asking for on purpose. 80 seconds of python and 32 of ruby.
- **Output, read as far as an API can read it**: `code-quality/alerts` and
  `code-quality/analyses` are both 404. The alert list is empty and every
  analysis is `codeql.yml`'s own — `/language:python` and
  `/language:actions`. The Code quality tab in the browser is the whole of
  the audience, which is most of the reason nobody has been in it.
- **`Analyze (ruby)`**: there is no Ruby here. Pages serves btclib.org
  from `main`'s root, so a `Gemfile` sits beside the package and
  autodetection reads a Ruby project — the same reason `codeql.yml`
  excludes Ruby from its own matrix.

The argument the issue raised for keeping it is in the new section rather
than dropped: these queries are a class of finding ruff, mypy and the two
spell checkers do not make, and what refuses them is the ceiling, so a
fleet that is not waiting for slots is what would change the answer.

Gates: `uv run pre-commit run --all-files` exit 0, `uv run pytest
tests/release_notes_test.py` 3 passed. Prose only, so no wait on CI.

The same setting is `configured` on `btclib-secp256k1` and
`bitcoin-core-rpc`, python-only there; their pull requests follow.

## Summary by Sourcery

Document disabling the generated GitHub Code Quality analysis and its configuration endpoint, explaining the rationale and impact on repository workflows.

Documentation:
- Add a dedicated REPOSITORY.md section describing the GitHub Code Quality setup endpoint, its disabled state, and the reasoning around concurrency limits and unread results.
- Update CHANGELOG.md to record that the generated Code Quality analysis has been switched off and to outline why it was disabled and how it can be re-enabled.