### PR TITLE
Spell the tangent law in the a the curve has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1998,6 +1998,39 @@ documented at release-notes length in the first place, and are still in
   the power wanted is the one inverted. Their docstrings said they made
   one inversion where `aff_from_jac` made two, which is no longer what
   tells them apart; each now says what it does not compute.
+- **The tangent law stops multiplying by an `a` that is zero** (issue
+  #799). `_double_jac_helper` built `3*X^2 + a*Z^4` whatever `a` was, and
+  `double_jac` formed the `Z^2` that term is built from and that nothing
+  else in the formula reads. Of the catalogued curves the `k1` family has
+  `a == 0`, and there both squarings are spent to add zero; most of the
+  rest have `a == p - 3`, where `3*(X - Z^2)*(X + Z^2)` is the same value
+  for one product instead of two squarings and a multiplication.
+  libsecp256k1 carries the first spelling alone, secp256k1's `a` being
+  zero, and states its doubling as 3 mul and 4 sqr against the 12 and 4
+  of its addition.
+
+  Which spelling to run is decided in `__init__`, `a` being the curve's
+  and a curve not changing, rather than by a test inside a function a
+  multiplication calls 253 times. The tests are on the curve and not on
+  the point, so a given curve still makes the same operations for every
+  point of it, which is what the regular window is for. Measured against
+  `70899b51` on Python 3.14.6, best of seven alternating rounds, with the
+  addition as the noise detector:
+
+  | | generic | specialized | |
+  | --- | ---: | ---: | ---: |
+  | `double_jac`, secp256k1 | 1.94 us | 1.69 us | **1.15x** |
+  | `double_jac`, secp256r1 | 2.28 us | 1.96 us | **1.16x** |
+  | `_mult`, secp256k1 | 829 us | 758 us | **1.09x** |
+  | `_mult`, secp256r1 | 941 us | 833 us | **1.13x** |
+  | `_mult_endomorphism_secp256k1` | 609 us | 576 us | **1.06x** |
+  | control, `add_jac` | 2.88 us | 2.89 us | 1.00x |
+
+  The endomorphism moves least because it is the one that already halved
+  the doublings, 126 of them against 79 additions where the plain regular
+  window has 253 against 71. It is also what `curves.mult` runs on
+  secp256k1 for the arguments the bindings decline; every other curve
+  gets the row above it.
 
 ### The public API and the module layout
 

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -142,6 +142,14 @@ class CurveGroup:
             raise BTClibValueError("zero discriminant")
         self._a = a
         self._b = b
+        # which spelling of the tangent law _double_jac_helper runs. The
+        # curve decides it and a curve does not change, so it is decided
+        # here rather than by a test inside the function a multiplication
+        # calls 253 times: the a*Z^4 term is zero for the k1 family, and
+        # for the a == p - 3 of most catalogued curves it is a difference
+        # of two squares that costs one product instead of three
+        self._a_is_zero = a == 0
+        self._a_is_minus_3 = a == p - 3
         # what add_jac feeds its formula in place of an operand at
         # infinity: any value does, the arithmetic on it being thrown
         # away, as long as it is the size of a real coordinate -- which is
@@ -424,18 +432,36 @@ class CurveGroup:
 
     def double_jac(self, Q: JacPoint) -> JacPoint:
         """Return twice the Jacobian point, assumed to be on the curve."""
-        return self._double_jac_helper(Q, Q[2] * Q[2] % self.p)
+        # Z^2 is what the a*Z^4 term is built from and the only thing that
+        # needs it, so a curve whose a is zero is handed a value the
+        # helper never reads rather than a squaring and its reduction
+        QZ2 = 0 if self._a_is_zero else Q[2] * Q[2] % self.p
+        return self._double_jac_helper(Q, QZ2)
 
     def _double_jac_helper(self, Q: JacPoint, QZ2: int) -> JacPoint:
-        # QZ2 is Q[2]^2 reduced mod p, which add_jac has already formed.
-        # The tangent law has no case to tell apart -- a point is never
-        # exceptional to itself -- so this is the whole of it: no test on
-        # Q, one sequence of operations for every point of the curve, and
-        # the same one for a secret point as for a public one. Which is
-        # also what lets add_jac call it on every addition
+        # QZ2 is Q[2]^2 reduced mod p, which add_jac has already formed;
+        # a curve whose a is zero never reads it, and double_jac above
+        # does not form it. The tangent law has no case to tell apart -- a
+        # point is never exceptional to itself -- so this is the whole of
+        # it: no test on Q, one sequence of operations for every point of
+        # the curve, and the same one for a secret point as for a public
+        # one. Which is also what lets add_jac call it on every addition
         p = self.p
         QY2 = Q[1] * Q[1] % p
-        W = (3 * Q[0] * Q[0] + self._a * QZ2 * QZ2) % p
+        # the a*Z^4 term, in the spelling this curve's a allows: the tests
+        # are on the curve and not on the point, so the operations a given
+        # curve makes are still the same for every point of it.
+        # libsecp256k1 carries the first spelling alone, secp256k1's a
+        # being zero, and states the doubling it makes as 3 mul and 4 sqr
+        # against the 12 and 4 of its addition
+        if self._a_is_zero:
+            W = 3 * Q[0] * Q[0] % p
+        elif self._a_is_minus_3:
+            # 3*(X - Z^2)*(X + Z^2) is 3*X^2 - 3*Z^4, one product where
+            # the general spelling below has two squarings and a product
+            W = 3 * (Q[0] - QZ2) * (Q[0] + QZ2) % p
+        else:
+            W = (3 * Q[0] * Q[0] + self._a * QZ2 * QZ2) % p
         V = 4 * Q[0] * QY2 % p
         X = (W * W - 2 * V) % p
         Y = (W * (V - X) - 8 * QY2 * QY2) % p


### PR DESCRIPTION
_double_jac_helper built 3*X^2 + a*Z^4 whatever a was, and double_jac
formed the Z^2 that term is built from and that nothing else in the
formula reads. The k1 family of the catalogue has a == 0, and there both
squarings are spent to add zero; most of the rest have a == p - 3, where
3*(X - Z^2)*(X + Z^2) is the same value for one product instead of three.

libsecp256k1 carries the first spelling alone, secp256k1's a being zero,
and states the doubling it makes as 3 mul and 4 sqr against the 12 and 4
of its addition.

Which spelling to run is decided in __init__, a being the curve's and a
curve not changing, rather than by a test inside a function a
multiplication calls 253 times. The tests are on the curve and not on the
point, so a given curve still makes the same operations for every point
of it, which is what the regular window is for.

Measured against 70899b51 on Python 3.14.6, best of seven alternating
rounds, with the addition as the noise detector:

                                        generic   specialized
  double_jac, secp256k1                  1.94 us      1.69 us   1.15x
  double_jac, secp256r1                  2.28 us      1.96 us   1.16x
  _mult, secp256k1                        829 us       758 us   1.09x
  _mult, secp256r1                        941 us       833 us   1.13x
  _mult_endomorphism_secp256k1            609 us       576 us   1.06x
  control, add_jac                       2.88 us      2.89 us   1.00x

The endomorphism moves least because it is the one that already halved
the doublings, 126 of them against 79 additions where the plain regular
window has 253 against 71. Both spellings answer the same point on every
curve of the catalogue.

Closes #799

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize Jacobian point doubling by specializing the tangent law for curves with a = 0 and a = p - 3, avoiding unnecessary computations and improving scalar multiplication performance.

Bug Fixes:
- Ensure the Jacobian doubling tangent law skips the a·Z^4 term when the curve parameter a is zero.

Enhancements:
- Add curve-level flags to select an efficient tangent law variant, reducing multiplications and squarings for common curves.
- Refine double_jac to avoid computing Z² when it is unused, keeping the operation sequence uniform across points.

Documentation:
- Document the optimized tangent law behavior, its curve-parameter specializations, and the measured performance improvements in the changelog.