### PR TITLE
Refuse the type at the coercion, not three modules later (#776)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2001,6 +2001,70 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **Five coercions trusted their annotation** (issue #776), and the
+  input-validation gate held fifty-nine public functions open on them.
+  Each takes "anything convertible", handles the `str` spelling and
+  passed everything else through untouched, so the value failed later
+  and somewhere else: a native `TypeError` or `AttributeError` about a
+  builtin, out of a module the caller never called. It is the bug issue
+  #744 fixed in `bytes_from_octets`, five times over.
+
+  `base58.decode` reached `len(v)` with whatever it was handed, and
+  every key and address converter in the library decodes there, which is
+  why one line accounted for more than half the list -- `b58.p2pkh`,
+  `b32.p2wpkh`, `bip32.derive`, all of `bip85` and all of `slip132`,
+  both `to_prv_key` converters and all four of `to_pub_key`'s among
+  them. `bip32.der_path`'s `_indexes_from_der_path` handed a float to
+  `list()`, which answers "'float' object is not iterable";
+  `b32.has_segwit_prefix` assumed bytes in the `else` of its one line;
+  `curves.curve_group.is_on_curve` asked `len` of what is not sized.
+
+  `utils.bytesio_from_binarydata` did not raise at all: it returned its
+  argument unchanged, so a `None` came back a `None` and the six `parse`
+  functions above it failed on `.read` or on `.getbuffer`. It wraps
+  octets in a `BytesIO` now and hands a `BytesIO` back as it came, what
+  is neither being `bytes_from_octets`'s to refuse. A file object is
+  neither, and was never more than half accepted: it has no
+  `getbuffer()`, which `psbt.psbt_utils.deserialize_map` asks the result
+  for. `read_exactly` is still the one that takes any `BinaryIO`, and
+  `psbt.psbt_view` still reads a psbt out of an open file through it.
+
+  `utils.str_from_string` is the `String` half of `bytes_from_octets`,
+  and the four places that spelled that coercion out by hand now call
+  it: `bech32._decode`, `b32.has_segwit_prefix`,
+  `b32.witness_from_address` and `silent_payments.keys_from_address`. It
+  takes text or ascii bytes and refuses the rest, which is what the two
+  address functions needed *before* their length bound -- `len` of a
+  float is a complaint about a builtin, where the codec below would have
+  named the argument -- and it carries to all four the non-ascii refusal
+  that only `bech32` had, a `UnicodeDecodeError` being outside the
+  contract a caller is told to catch.
+
+  `script.script_pub_key.address` answered `""` for a `None`, which is
+  the answer a nulldata output has: the coercion runs before the
+  truthiness now, so an argument that is no script is refused rather
+  than reported as a script that has no address. `tx_or_psbt_from_any`
+  and `script.taproot.serialize` are the last two, one reaching `.split`
+  and the other subscripting what it was given.
+
+  **What moves for a caller**: the class is narrower and the control
+  flow identical, `BTClibTypeError` being a `TypeError` and
+  `BTClibValueError` a `ValueError`. `to_prv_key`'s WIF and xkey
+  attempts catch a `TypeError` beside the `ValueError` now, as its two
+  "it must be octets" fallbacks already did, so an argument of the wrong
+  type still ends as "not a private key" and not as the first format's
+  refusal. A `bytearray` or a `memoryview` is accepted wherever a
+  `String` is, `base58.decode` and `str_from_string` taking the buffers
+  `bytes_from_octets` takes.
+
+  What the gate still holds open is one function, and it is not a
+  coercion: `ecc.dleq.verify_proof` answers False for a pub key that is
+  no point, `to_pub_key` refusing one as a `BTClibValueError` whatever
+  was wrong with it. That is what keeps a boolean verification total,
+  which is issue #745's decision and issue #143's test -- `dsa.verify`
+  answers False for a private key passed as a public one -- so closing
+  that entry is reversing those rather than plugging a hole.
+
 - **`bytes_from_octets` is the whole of what `Octets` means, and it is
   total** (issue #744). It is the coercion every `Octets` parameter of
   the library runs through, and it had two holes: a hex string that is
@@ -3039,6 +3103,16 @@ documented at release-notes length in the first place, and are still in
   rules prints until a length is named.
 
 ### Tests
+
+- **The input-validation gate's own verdict is exercised** (issue #776).
+  `_classify` is the three answers a call can give -- the rule held, a
+  native exception got out and here is its class, nothing was raised at
+  all -- and it is a function of its own now rather than three branches
+  inside the walk. The middle one is why: no function under `btclib/`
+  produces a native exception any more, so as a branch it went uncovered,
+  and an unrun branch is a poor thing to be relying on the day one does.
+  `test_the_walk_names_what_escapes` provokes all three on calls whose
+  behaviour is stated there.
 
 - **Every test that reads a source file names its encoding.** Four
   `read_text()` calls took the locale's, which is UTF-8 on the runners this

--- a/btclib/alias.py
+++ b/btclib/alias.py
@@ -8,9 +8,9 @@ Octets and String below are both `bytes | str`, so mypy cannot tell
 one from the other: passing a text string where a hex-string is expected
 is a type error this file names but no checker can catch. The distinction
 is enforced at run time instead, by the converter each function calls on
-its way in -- bytes_from_octets for Octets, encode() for String -- and it
-is documented here because that is the only place it can be read as one
-piece.
+its way in -- bytes_from_octets for Octets, str_from_string for String --
+and it is documented here because that is the only place it can be read
+as one piece.
 
 Making them NewTypes would let mypy separate them, at the cost of every
 caller having to wrap its literals: Octets("deadbeef") instead of

--- a/btclib/b32.py
+++ b/btclib/b32.py
@@ -60,7 +60,7 @@ from btclib.exceptions import BTClibValueError
 from btclib.hashes import hash160, sha256
 from btclib.network import NETWORKS, network_from_key_value, network_from_name
 from btclib.to_pub_key import Key, pub_keyinfo_from_key
-from btclib.utils import bytes_from_octets
+from btclib.utils import bytes_from_octets, str_from_string
 
 __all__ = [
     "address_from_witness",
@@ -82,7 +82,7 @@ def has_segwit_prefix(addr: String) -> bool:
     The prefix alone -- hrp and the 1 separator -- is read; whether the
     rest decodes is witness_from_address's answer.
     """
-    str_addr = addr.strip().lower() if isinstance(addr, str) else addr.decode("ascii")
+    str_addr = str_from_string(addr, "address").strip().lower()
     return any(str_addr.startswith(f"{net.hrp}1") for net in NETWORKS.values())
 
 
@@ -161,15 +161,17 @@ def witness_from_address(b32addr: String) -> tuple[int, bytes, str]:
 
     The returned data structure is: version, program, network.
     """
-    if isinstance(b32addr, str):
-        b32addr = b32addr.strip()
+    # the coercion before the length, which is a fact about characters:
+    # `len` of what is neither text nor bytes is a TypeError about a
+    # builtin, where the codec below would have named the argument
+    addr = str_from_string(b32addr, "address").strip()
 
     # the 90-character bound is address semantics, deliberately not
     # enforced by the bech32 codec (Lightning strings exceed it)
-    if len(b32addr) > 90:
-        raise BTClibValueError(f"invalid bech32 address length: {len(b32addr)} > 90")
+    if len(addr) > 90:
+        raise BTClibValueError(f"invalid bech32 address length: {len(addr)} > 90")
 
-    hrp, data = decode(b32addr)
+    hrp, data = decode(addr)
 
     wit_ver = data[0]
     wit_prog = bytes(power_of_2_base_conversion(data[1:], 5, 8, False))

--- a/btclib/base58.py
+++ b/btclib/base58.py
@@ -154,13 +154,10 @@ def _b58decode_to_int(v: bytes) -> int:
 
 
 def _b58decode(v: bytes) -> bytes:
-    # bytes for what the character-by-character check took without ever
-    # saying so: any iterable of byte values. That is how a caller's
-    # garbage reaches here -- `to_prv_key` tries a WIF before it gives up,
-    # so a Point handed to it arrives as the tuple (5, 0) -- and it has to
-    # go on being refused below as characters outside the alphabet, which
-    # is a BTClibValueError, rather than as a missing method. Free on the
-    # path that matters: bytes(b) is b for a bytes object, 29 ns
+    # bytes for the buffers that are a String and are not bytes: a
+    # memoryview has neither translate nor lstrip, and a bytearray
+    # answers both in its own type. Free on the path that matters:
+    # bytes(b) is b for a bytes object, 29 ns
     v = bytes(v)
     # every alphabet byte deleted, so what is left is what is not one:
     # the same question as `any(x not in _ALPHABET for x in v)` asked in
@@ -202,6 +199,15 @@ def decode(v: String, out_size: int | None = None) -> bytes:
             v = v.encode("ascii")
         except UnicodeEncodeError as e:
             raise BTClibValueError(f"non-ascii character in base58 string: {e}") from e
+    elif not isinstance(v, (bytes, bytearray, memoryview)):
+        # what is neither went through untouched and failed on `len` below,
+        # which is a TypeError about a builtin rather than about the
+        # address that was passed. Every key and address converter in the
+        # library decodes here, so this is the one place worth saying it
+        # in. Every buffer and not `bytes` alone, as bytes_from_octets
+        # takes them
+        err_msg = f"invalid base58 string type: {type(v).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
 
     if len(v) > MAX_LENGTH:
         err_msg = f"too many base58 characters: {len(v)}, max is {MAX_LENGTH}"

--- a/btclib/bech32.py
+++ b/btclib/bech32.py
@@ -59,7 +59,7 @@ from operator import xor
 
 from btclib.alias import String
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.utils import is_integer
+from btclib.utils import is_integer, str_from_string
 
 __all__ = [
     "decode",
@@ -125,15 +125,10 @@ def _verify_checksum(hrp: str, data: list[int], m: int) -> bool:
 
 def _decode(bech: String) -> tuple[str, list[int], list[int]]:
     """Determine a bech32 string HRP, data and checksum."""
-    if isinstance(bech, bytes):
-        # bech32 is an ascii encoding, so a byte outside it is an
-        # invalid character like any other and gets the same answer:
-        # a UnicodeDecodeError let out would fly past every caller
-        # written to catch BTClibValueError
-        try:
-            bech = bech.decode("ascii")
-        except UnicodeDecodeError as e:
-            raise BTClibValueError(f"non-ascii character in bech32 string: {e}") from e
+    # bech32 is an ascii encoding, so a byte outside it is an invalid
+    # character like any other, and what is neither text nor bytes is
+    # refused here rather than reaching `rfind` as a missing method
+    text = str_from_string(bech, "bech32 string")
 
     # no 90-character limit here: that bound belongs to bitcoin
     # addresses and not to bech32, which the Lightning Network uses
@@ -141,27 +136,27 @@ def _decode(bech: String) -> tuple[str, list[int], list[int]]:
     # intended -- b32.witness_from_address enforces it, and the module
     # docstring there lists it among the rules b32 adds on top
 
-    pos = bech.rfind("1")  # find the separator between hrp and data
+    pos = text.rfind("1")  # find the separator between hrp and data
     if pos == -1:
-        raise BTClibValueError(f"no separator character: {bech}")
+        raise BTClibValueError(f"no separator character: {text}")
     if pos == 0:
-        raise BTClibValueError(f"empty HRP: {bech}")
-    if pos + 7 > len(bech):
-        raise BTClibValueError(f"too short checksum: {bech}")
+        raise BTClibValueError(f"empty HRP: {text}")
+    if pos + 7 > len(text):
+        raise BTClibValueError(f"too short checksum: {text}")
 
-    if not all(47 < ord(x) < 123 for x in bech[:pos]):
-        raise BTClibValueError(f"HRP character out of range: {bech}")
-    if bech.lower() != bech and bech.upper() != bech:
-        raise BTClibValueError(f"mixed case: {bech}")
+    if not all(47 < ord(x) < 123 for x in text[:pos]):
+        raise BTClibValueError(f"HRP character out of range: {text}")
+    if text.lower() != text and text.upper() != text:
+        raise BTClibValueError(f"mixed case: {text}")
 
-    bech = bech.lower()
-    hrp = bech[:pos]
+    text = text.lower()
+    hrp = text[:pos]
 
-    indices = [_INDEX_OF.get(x, -1) for x in bech[pos + 1 :]]
+    indices = [_INDEX_OF.get(x, -1) for x in text[pos + 1 :]]
     if -1 in indices[-6:]:
-        raise BTClibValueError(f"invalid character in checksum: {bech}")
+        raise BTClibValueError(f"invalid character in checksum: {text}")
     if -1 in indices:
-        raise BTClibValueError(f"invalid data character: {bech}")
+        raise BTClibValueError(f"invalid data character: {text}")
     data = indices
 
     return hrp, data[:-6], data[-6:]

--- a/btclib/bip32/der_path.py
+++ b/btclib/bip32/der_path.py
@@ -21,7 +21,7 @@ number spelled the one way it spells it.
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 
 from btclib.alias import Octets
 from btclib.exceptions import BTClibTypeError, BTClibValueError
@@ -235,6 +235,13 @@ def _indexes_from_der_path(der_path: Sequence[int] | int | bytes) -> list[int]:
             int.from_bytes(der_path[n : n + 4], byteorder="little", signed=False)
             for n in range(0, len(der_path), 4)
         ]
+
+    if not isinstance(der_path, Iterable):
+        # what is left went to `list()` untouched, which answers a float
+        # with "'float' object is not iterable" -- a complaint about
+        # iteration, from underneath the library, about a path
+        err_msg = f"invalid derivation path type: {type(der_path).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
 
     # an iterable of int, and of int alone: int() here would coerce a bool
     # into the index one, where the annotation already says Sequence[int]

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -528,6 +528,10 @@ class CurveGroup:
 
     def is_on_curve(self, Q: Point) -> bool:
         """Return True if the point is on the curve."""
+        # the type before the length: `len` of what is not sized is a
+        # TypeError about a builtin, where a Point is what this asks for
+        if not isinstance(Q, tuple):
+            raise BTClibTypeError(f"invalid point type: {type(Q).__name__}")
         if len(Q) != 2:
             raise BTClibValueError("point must be a tuple[int, int]")
         if Q[1] == 0:  # Infinity point in affine coordinates

--- a/btclib/exceptions.py
+++ b/btclib/exceptions.py
@@ -25,8 +25,8 @@ caller with something to do about that difference names the specific
 class; `except BTClibException` is for the caller who only needs to know
 it came from here.
 
-That every failure of btclib's *is* one is not yet true: issue #744
-counts the public functions still letting a native `KeyError`,
+That every failure of btclib's *is* one is not yet true: issue #776
+carries the public functions still letting a native `KeyError`,
 `IndexError` or `OverflowError` through, and until that is closed this
 class catches most of what the library raises rather than all of it.
 

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -69,6 +69,12 @@ def address(script_pub_key: Octets, network: str = "mainnet") -> str:
     can read the address back into the very script it came from
     (issue #251).
     """
+    # the coercion before the truthiness, which is what tells an empty
+    # script from a script that has no address: `None` is falsy just as
+    # `b""` is, so a caller passing one was answered "" -- the answer a
+    # nulldata output has, and not a word about the argument
+    script_pub_key = bytes_from_octets(script_pub_key)
+
     if script_pub_key:
         script_type, payload = type_and_payload(script_pub_key)
         if script_type in {"p2pkh", "p2sh"}:
@@ -80,7 +86,7 @@ def address(script_pub_key: Octets, network: str = "mainnet") -> str:
         if script_type == "witness_unknown":
             # the one type whose version the answer does not imply: it is
             # the op code the program follows, OP_2..OP_16 being 0x52..0x60
-            version = bytes_from_octets(script_pub_key)[0] - 0x50
+            version = script_pub_key[0] - 0x50
             return b32.address_from_witness(version, payload, network)
 
     # not script_pub_key

--- a/btclib/script/taproot.py
+++ b/btclib/script/taproot.py
@@ -79,6 +79,12 @@ def serialize(script: ScriptList) -> bytes:
     by exactly one bytes command, appended raw -- what follows an
     OP_SUCCESS need not be a script, so it round-trips unparsed.
     """
+    if not isinstance(script, list):
+        # what is not a list reached the reversal and the `pop` below
+        # untouched, so a None was "not subscriptable" and a str was a
+        # str with no `pop` -- neither of them a word about the script
+        raise BTClibTypeError(f"invalid tapscript type: {type(script).__name__}")
+
     r: list[bytes] = []
     script = script[::-1]
     while script:

--- a/btclib/silent_payments.py
+++ b/btclib/silent_payments.py
@@ -77,7 +77,7 @@ from btclib.script.witness import Witness
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import PubKey, point_from_pub_key
 from btclib.tx.out_point import OutPoint
-from btclib.utils import bytes_from_octets, is_integer
+from btclib.utils import bytes_from_octets, is_integer, str_from_string
 
 __all__ = [
     "K_MAX",
@@ -247,13 +247,15 @@ def keys_from_address(address: String) -> tuple[Point, Point, NetworkType]:
     pay a later address. v31 is refused instead, being the version BIP352
     reserves for a change that breaks exactly that.
     """
-    if isinstance(address, str):
-        address = address.strip().lower()
-    if len(address) > _MAX_ADDRESS_SIZE:
-        err_msg = f"invalid address length: {len(address)} > {_MAX_ADDRESS_SIZE}"
+    # the coercion before the length, as in b32.witness_from_address:
+    # `len` of what is neither text nor bytes is a TypeError about a
+    # builtin, where the codec below would have named the argument
+    addr = str_from_string(address, "address").strip().lower()
+    if len(addr) > _MAX_ADDRESS_SIZE:
+        err_msg = f"invalid address length: {len(addr)} > {_MAX_ADDRESS_SIZE}"
         raise BTClibValueError(err_msg)
 
-    hrp, data = decode(address, _BECH32_M_CONST)
+    hrp, data = decode(addr, _BECH32_M_CONST)
     if hrp == _MAINNET_HRP:
         network_type: NetworkType = "main"
     elif hrp == _TESTNET_HRP:

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -188,13 +188,13 @@ def _prv_keyinfo_from_wif(
     # echoes the input, which is candidate key material -- a checksum, a
     # prefix and a size are not secret.
     #
-    # ValueError and not BTClibValueError: b58decode leaks a plain one,
-    # "byte must be in range(0, 256)", for an input that is neither str nor
-    # bytes -- a Point tuple, say. That leak is base58's to fix; whatever
-    # it is, it means this input is not a WIF
+    # both classes, as the octets branch of the two public converters
+    # catches both: what is neither a base58 string nor bytes is a
+    # TypeError, and it means here what a bad checksum means -- this input
+    # is not a WIF, and the caller is free to try it as something else
     try:
         payload = b58decode(wif)
-    except ValueError as e:
+    except (TypeError, ValueError) as e:
         raise NotAPrvKeyError(f"not a WIF ({e})") from e
 
     # from here on the version prefix says WIF, so a fault in what follows
@@ -226,10 +226,13 @@ def _prv_keyinfo_from_xprv(
     else:
         # base58, 78 bytes, and a known xkey version or not: a negative
         # answer leaves the input free to be octets or an int, so it is
-        # NotAPrvKeyError, carrying the reason rather than discarding it
+        # NotAPrvKeyError, carrying the reason rather than discarding it.
+        # Both classes, as everywhere a format is guessed here: a type the
+        # decode refuses says this is not an xkey, not that the caller is
+        # owed a TypeError from inside the guessing
         try:
             xprv = _key_data_from_bip32_key(xprv)
-        except ValueError as e:
+        except (TypeError, ValueError) as e:
             raise NotAPrvKeyError(f"not a BIP32 xkey ({e})") from e
 
     # a BIP32 key is always compressed, so a caller asking for uncompressed

--- a/btclib/tx_or_psbt.py
+++ b/btclib/tx_or_psbt.py
@@ -31,6 +31,7 @@ from btclib.alias import String
 from btclib.exceptions import BTClibValueError
 from btclib.psbt.psbt import PSBT_MAGIC_BYTES, Psbt
 from btclib.tx import Tx
+from btclib.utils import bytes_from_octets
 
 __all__ = [
     "tx_or_psbt_from_any",
@@ -76,17 +77,21 @@ def _octets_from_any(data: String) -> bytes:
     transaction begins with a four-byte version that is not printable,
     and a serialized psbt with a `0xff` that is not ascii at all.
     """
-    if isinstance(data, bytes):
-        try:
-            text = data.decode("ascii")
-        except UnicodeDecodeError:
-            return data
-        try:
-            return _octets_from_text(text)
-        except BTClibValueError:
-            return data
+    if isinstance(data, str):
+        return _octets_from_text(data)
 
-    return _octets_from_text(data)
+    # the refusal of what is neither text nor bytes is bytes_from_octets's
+    # to give, `split` below being str's and `decode` bytes'; a buffer
+    # that is not `bytes` is made one, for the same reason
+    raw = bytes(bytes_from_octets(data))
+    try:
+        text = raw.decode("ascii")
+    except UnicodeDecodeError:
+        return raw
+    try:
+        return _octets_from_text(text)
+    except BTClibValueError:
+        return raw
 
 
 def tx_or_psbt_from_any(data: String, *, check_validity: bool = True) -> Tx | Psbt:

--- a/btclib/utils.py
+++ b/btclib/utils.py
@@ -56,7 +56,7 @@ from collections.abc import Iterable
 from io import BytesIO
 from typing import Any, BinaryIO
 
-from btclib.alias import BinaryData, Integer, Octets
+from btclib.alias import BinaryData, Integer, Octets, String
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 
 __all__ = [
@@ -72,6 +72,7 @@ __all__ = [
     "int_from_json_number",
     "is_integer",
     "read_exactly",
+    "str_from_string",
 ]
 
 NoneOneOrMoreInt = int | Iterable[int] | None
@@ -137,19 +138,58 @@ def bytes_from_octets(octets: Octets, out_size: NoneOneOrMoreInt = None) -> byte
     raise BTClibValueError(err_msg)
 
 
-def bytesio_from_binarydata(stream: BinaryData) -> BytesIO:
-    """Return a BytesIO stream object from BinaryIO or Octets.
+def str_from_string(s: String, what: str) -> str:
+    """Return the text of a String, whether it came as text or as ascii bytes.
 
-    If the input is not Octets (i.e. str or bytes), then it goes
-    untouched.
+    What `bytes_from_octets` is to the other `bytes | str` alias, in the
+    direction the addresses go: an address, a WIF and an xkey are ascii,
+    so a byte outside it is an invalid character like any other and gets
+    the same answer -- a UnicodeDecodeError let out would fly past every
+    caller written to catch a BTClibValueError.
+
+    `what` names the string in both messages, the caller knowing what it
+    was reading and this not, exactly as `read_exactly` names a field.
+
+    Nothing is stripped and nothing is lowered: which of those is right
+    is the caller's to know, a message to be signed being the one String
+    whose blanks are part of it.
     """
-    if isinstance(stream, str):  # hex string
-        stream = bytes_from_octets(stream)
+    if isinstance(s, str):
+        return s
 
-    if isinstance(stream, bytes):
-        stream = BytesIO(stream)
+    if not isinstance(s, (bytes, bytearray, memoryview)):
+        # what is neither went through untouched, to fail on `len` or on
+        # a method of str that the value does not have -- a complaint
+        # about a builtin rather than about the argument
+        err_msg = f"invalid {what} type: {type(s).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
 
-    return stream
+    try:
+        return bytes(s).decode("ascii")
+    except UnicodeDecodeError as e:
+        raise BTClibValueError(f"non-ascii character in {what}: {e}") from e
+
+
+def bytesio_from_binarydata(stream: BinaryData) -> BytesIO:
+    """Return a BytesIO stream object from a BytesIO or from Octets.
+
+    A `BytesIO` is the caller's own and is handed back as it came, the
+    position it is left at being how a transaction is read out of a
+    block. Anything else is octets, and is wrapped in one.
+
+    A `BytesIO` and not any binary stream: `deserialize_map` asks the
+    result for `getbuffer()`, which a file object does not have, so
+    accepting one here would only move the failure. `read_exactly` is
+    the one that takes a `BinaryIO`, and its docstring says why.
+    """
+    if isinstance(stream, BytesIO):
+        return stream
+
+    # the refusal of what is neither a stream nor octets is
+    # bytes_from_octets's to give: what is neither used to go through
+    # untouched and be returned as it came, so `parse` answered a None
+    # with a None and the caller failed on `.read`
+    return BytesIO(bytes_from_octets(stream))
 
 
 def read_exactly(stream: BinaryIO, size: int, what: str) -> bytes:

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -758,8 +758,13 @@ def test_libsecp256k1_applicable() -> None:
 def test_is_on_curve() -> None:
     """Refuse non-tuples and out-of-range coordinates, on every curve."""
     for ec in all_curves.values():
-        with pytest.raises(BTClibValueError, match="point must be a tuple"):
+        # the type first, `len` of what is not sized being a TypeError
+        # about a builtin rather than a word about the argument
+        with pytest.raises(BTClibTypeError, match="invalid point type: str"):
             ec.is_on_curve("not a point")  # type: ignore[arg-type]
+
+        with pytest.raises(BTClibValueError, match="point must be a tuple"):
+            ec.is_on_curve((1, 2, 3))  # type: ignore[arg-type]
 
         with pytest.raises(BTClibValueError, match="x-coordinate not in 0..p-1: "):
             ec.y(ec.p)

--- a/tests/input_validation_test.py
+++ b/tests/input_validation_test.py
@@ -61,12 +61,14 @@ from __future__ import annotations
 
 import ast
 import importlib
+from collections.abc import Callable
+from functools import partial
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from btclib.exceptions import BTClibException
+from btclib.exceptions import BTClibException, BTClibValueError
 
 _LIBRARY = Path(__file__).parents[1] / "btclib"
 
@@ -115,69 +117,19 @@ _EXCLUDED: dict[str, str] = {
 
 # what issue #744's census left, by the class that escapes. Deleting a
 # line is how a fix lands, the test below failing on an entry that has
-# stopped leaking, so this cannot go stale in either direction
+# stopped leaking, so this cannot go stale in either direction.
+#
+# The one left is not a coercion trusting its annotation, which is what
+# the rest of the list was: what answers False is `to_pub_key`'s refusal
+# of anything that is not a public key, which is a BTClibValueError
+# whatever was wrong with it, and folding the type in is what keeps a
+# boolean verification total. Issue #745 is where that was settled --
+# `dsa.verify_` answers False for a private key passed as a public one,
+# which is issue #143 and a test -- so making this one raise reverses
+# that decision rather than closing a hole, and the entry stays here
+# until it is taken
 _OPEN: dict[str, str] = {
-    "btclib.b32.has_segwit_prefix": "AttributeError",
-    "btclib.b32.p2wpkh": "TypeError",
-    "btclib.b32.witness_from_address": "TypeError",
-    "btclib.b58.h160_from_address": "TypeError",
-    "btclib.b58.p2pkh": "TypeError",
-    "btclib.b58.p2wpkh_p2sh": "TypeError",
-    "btclib.b58.wif_from_prv_key": "TypeError",
-    "btclib.base58.decode": "TypeError",
-    "btclib.bech32.decode": "AttributeError",
-    "btclib.bip32.bip32.crack_prv_key": "TypeError",
-    "btclib.bip32.bip32.derive": "TypeError",
-    "btclib.bip32.bip32.xpub_from_xprv": "TypeError",
-    "btclib.bip32.der_path.bytes_from_der_path": "TypeError",
-    "btclib.bip32.der_path.hardenings_from_der_path": "TypeError",
-    "btclib.bip32.der_path.indexes_from_der_path": "TypeError",
-    "btclib.bip32.der_path.str_from_der_path": "TypeError",
-    "btclib.bip322.sign": "AttributeError",
-    "btclib.bip322.to_sign_psbt": "AttributeError",
-    "btclib.bip44.address_from_der_path": "TypeError",
-    "btclib.bip85.bytes_entropy_from_root_key": "TypeError",
-    "btclib.bip85.drng_from_der_path": "TypeError",
-    "btclib.bip85.entropy_from_der_path": "TypeError",
-    "btclib.bip85.mnemonic_from_root_key": "TypeError",
-    "btclib.bip85.wif_from_root_key": "TypeError",
-    "btclib.bip85.xprv_from_root_key": "TypeError",
-    "btclib.curves.curve.double_mult": "TypeError",
-    "btclib.curves.sec_point.bytes_from_point": "TypeError",
-    "btclib.descriptors.descriptors.account_descriptors": "TypeError",
-    "btclib.ecc.dleq.generate_proof": "TypeError",
     "btclib.ecc.dleq.verify_proof": "no exception",
-    "btclib.ecc.ecies.derive_keys": "TypeError",
-    "btclib.ecc.ellswift.create": "TypeError",
-    "btclib.ecc.musig2.individual_pub_key": "TypeError",
-    "btclib.ecc.musig2.nonce_gen": "TypeError",
-    "btclib.psbt.psbt_utils.deserialize_map": "AttributeError",
-    "btclib.script.script.parse": "AttributeError",
-    "btclib.script.script_pub_key.address": "no exception",
-    "btclib.script.sig_hash.redeem_script": "AttributeError",
-    "btclib.script.taproot.output_prvkey": "TypeError",
-    "btclib.script.taproot.output_prvkey_from_merkle_root": "TypeError",
-    "btclib.script.taproot.parse": "AttributeError",
-    "btclib.script.taproot.serialize": "TypeError",
-    "btclib.silent_payments.keys_from_address": "TypeError",
-    # the name of a BIP352 function, and detect-secrets reads any
-    # "...secret": "..." as one
-    "btclib.silent_payments.shared_secret": "TypeError",  # pragma: allowlist secret
-    "btclib.slip132.address_from_xkey": "TypeError",
-    "btclib.slip132.address_from_xpub": "TypeError",
-    "btclib.slip132.p2pkh_xkey": "TypeError",
-    "btclib.slip132.p2wpkh_p2sh_xkey": "TypeError",
-    "btclib.slip132.p2wpkh_xkey": "TypeError",
-    "btclib.to_prv_key.int_from_prv_key": "TypeError",
-    "btclib.to_prv_key.prv_keyinfo_from_prv_key": "TypeError",
-    "btclib.to_pub_key.fingerprint": "TypeError",
-    "btclib.to_pub_key.point_from_key": "TypeError",
-    "btclib.to_pub_key.pub_keyinfo_from_key": "TypeError",
-    "btclib.to_pub_key.pub_keyinfo_from_prv_key": "TypeError",
-    "btclib.tx_or_psbt.tx_or_psbt_from_any": "AttributeError",
-    "btclib.utils.bytesio_from_binarydata": "no exception",
-    "btclib.var_bytes.parse": "AttributeError",
-    "btclib.var_int.parse": "AttributeError",
 }
 
 
@@ -216,6 +168,27 @@ def _drivable() -> dict[str, list[str]]:
 _DRIVABLE = _drivable()
 
 
+def _classify(call: Callable[[], Any]) -> str | None:
+    """Return the class of what escapes the rule, or None if it holds.
+
+    The whole of the verdict, on one call, and a function of its own so
+    that the three answers can be provoked here: the middle one names a
+    native exception, and no function of the library produces one any
+    more, so as a branch inside the walk it went uncovered -- and an
+    unrun branch is a poor thing to find out about on the day something
+    does leak. `test_the_walk_names_what_escapes` is what runs it.
+    """
+    try:
+        call()
+    except BTClibException:
+        return None
+    # the class of what came out is the finding, so every one of them is
+    # caught and named rather than let out of the walk
+    except Exception as e:  # noqa: BLE001
+        return type(e).__name__
+    return "no exception"
+
+
 def _leak(dotted: str) -> str | None:
     """Return the class of what escapes the rule, or None if it holds."""
     module_name, _, name = dotted.rpartition(".")
@@ -223,15 +196,11 @@ def _leak(dotted: str) -> str | None:
     aliases = _DRIVABLE[dotted]
     for round_ in range(max(len(_MALFORMED[a]) for a in aliases)):
         args = [_MALFORMED[a][round_ % len(_MALFORMED[a])] for a in aliases]
-        try:
-            function(*args)
-        except BTClibException:
-            continue
-        # the class of what came out is the finding, so every one of them
-        # is caught and named rather than let out of the walk
-        except Exception as e:  # noqa: BLE001
-            return type(e).__name__
-        return "no exception"
+        # partial and not a lambda, which would close over the loop
+        # variables and be read on a later round
+        found = _classify(partial(function, *args))
+        if found is not None:
+            return found
     return None
 
 
@@ -320,6 +289,24 @@ def test_the_vocabulary_is_the_libraries_input_types() -> None:
         "TaprootScriptTree",
     }
     assert in_alias_py & annotated <= set(_MALFORMED) | without_a_wrong_value
+
+
+def test_the_walk_names_what_escapes() -> None:
+    """The three verdicts, on calls whose behaviour is stated here.
+
+    A walk that answered None to everything would pass every test above,
+    and the answer that says a native exception got out is the one no
+    function of the library provokes any more -- so this is where it is
+    provoked, rather than being a branch nothing runs until the day it
+    matters.
+    """
+
+    def raiser(e: Exception) -> None:
+        raise e
+
+    assert _classify(partial(raiser, BTClibValueError("refused"))) is None
+    assert _classify(partial(raiser, TypeError("from underneath"))) == "TypeError"
+    assert _classify(bool) == "no exception"
 
 
 def test_the_walk_reaches_what_it_claims() -> None:


### PR DESCRIPTION
Closes fifty-eight of the fifty-nine entries the input-validation gate
holds open in https://github.com/btclib-org/btclib/issues/776. The five
roots of §5, the seven one-offs of §6 and two of the three of §7.

## What was wrong

Each of the five is a coercion that takes "anything convertible",
handles the `str` spelling and passes everything else through
untouched, trusting the annotation. The value then fails later and
somewhere else, as a native `TypeError` or `AttributeError` about a
builtin, out of a module the caller never called. It is the bug
https://github.com/btclib-org/btclib/pull/766 fixed in
`bytes_from_octets`, five times over.

- `base58.decode` reached `len(v)` with whatever it was handed. Every
  key and address converter in the library decodes there, which is why
  one line accounted for more than half the list
- `utils.bytesio_from_binarydata` did not raise at all: it returned its
  argument unchanged, so a `None` came back a `None` and the six
  `parse` functions above it failed on `.read` or on `.getbuffer`
- `bip32.der_path`'s `_indexes_from_der_path` handed a float to `list()`
- `b32.has_segwit_prefix` assumed bytes in the `else` of its one line
- `curves.curve_group.is_on_curve` asked `len` of what is not sized

## What the fix reuses

`utils.str_from_string` is the `String` half of `bytes_from_octets`,
and the four places that spelled that coercion out by hand now call it:
`bech32._decode`, `b32.has_segwit_prefix`, `b32.witness_from_address`
and `silent_payments.keys_from_address`. Two of them needed it *before*
their length bound rather than at the codec — `len` of a float is a
complaint about a builtin, where the codec below would have named the
argument — and it carries to all four the non-ascii refusal only
`bech32` had.

## What is left, and why it is a decision rather than a fix

`ecc.dleq.verify_proof` stays in `_OPEN`, and it is not a coercion.
What answers False is `to_pub_key` refusing anything that is not a
public key as a `BTClibValueError` whatever was wrong with it, and
folding the type in is what keeps a boolean verification *total* —
which is the position https://github.com/btclib-org/btclib/issues/745
settled on, and which
https://github.com/btclib-org/btclib/issues/143's test pins:
`dsa.verify` answers False for a private key passed as a public one.

I did try the other way, and the suite refused it: making
`point_from_pub_key` raise `BTClibTypeError` broke
`test_prv_key_is_not_a_pub_key` and `test_from_pub_key`. So closing
that entry reverses #745 rather than plugging a hole, and it waits for
that call. The comment above `_OPEN` says so, in place of the line
being deleted on a reading of the code.

§8 of the issue — raising the ceiling above the 138 functions the walk
can drive — is untouched and belongs to a separate branch.

## Note on the gate itself

`_classify` is the gate's verdict as a function of its own. No function
under `btclib/` leaks a native exception any more, so the branch that
names one went uncovered by the 100% ratchet, and an unrun branch is a
poor thing to be relying on the day something does leak.
`test_the_walk_names_what_escapes` provokes all three answers.

## Gates

- `uv run pytest` — 26722 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten input validation across key/address codecs and curve utilities so invalid argument types fail early with BTClib-specific exceptions instead of leaking native errors.

New Features:
- Introduce a shared str_from_string helper to coerce String aliases (text or ascii bytes) into text for address and bech32-related functions while rejecting non-ascii and wrong types.

Bug Fixes:
- Ensure base58.decode and related key/address converters reject non-string/non-buffer inputs with BTClibTypeError instead of failing later on len or other builtins.
- Fix bytesio_from_binarydata to return a BytesIO over validated octets (or the original BytesIO) so parse helpers no longer silently propagate unsupported types like None.
- Harden tx_or_psbt_from_any input handling by routing non-str inputs through bytes_from_octets and only interpreting ascii text when appropriate, avoiding native exceptions from split/decode.
- Validate derivation path types in _indexes_from_der_path, raising BTClibTypeError for non-iterable inputs instead of relying on list() to fail.
- Coerce script_pub_key to octets before inspecting truthiness in script.script_pub_key.address so non-script inputs are refused instead of being treated as a nulldata script.
- Reject non-list tapscripts in script.taproot.serialize with BTClibTypeError rather than leaking errors from list operations.
- Enforce tuple-typed points in curves.curve_group.is_on_curve, raising BTClibTypeError for invalid point types before length and range checks.

Enhancements:
- Refine the String alias documentation to reference str_from_string as the runtime enforcer for text vs hex semantics.
- Update to_prv_key WIF/xkey converters to treat type errors from base58 decoding as "not a private key" format failures, preserving the caller-facing control flow.
- Clarify exceptions module documentation to reference issue #776 as the tracker for remaining native exceptions escaping the library.

Documentation:
- Extend the changelog with detailed notes on tightened type coercion, error-class behavior, and the one intentional non-coercion in ecc.dleq.verify_proof.
- Document the new input-validation gate behavior and its coverage via the changelog narrative.

Tests:
- Refactor the input-validation gate’s verdict logic into a dedicated _classify helper and add test_the_walk_names_what_escapes to exercise its three possible outcomes.
- Adjust curve tests to expect BTClibTypeError for invalid point types and BTClibValueError for malformed tuples, matching the new is_on_curve behavior.