### PR TITLE
Invert a sequence with one extended Euclid, not one each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2031,6 +2031,42 @@ documented at release-notes length in the first place, and are still in
   window has 253 against 71. It is also what `curves.mult` runs on
   secp256k1 for the arguments the bindings decline; every other curve
   gets the row above it.
+- **`mod_inv_batch` inverts a whole sequence with one extended Euclid**
+  (issue #800). Montgomery's trick, which libsecp256k1 spells
+  `secp256k1_fe_inv_all_var`: the running products `a[0]`, `a[0]*a[1]`,
+  ... are formed, the last of them is inverted once, and the individual
+  inverses are peeled back off it. So n inverses cost one inverse and
+  3(n-1) products, where an inverse modulo secp256k1's p is 7.4 us and a
+  product is 0.25.
+
+  `CurveGroup.aff_from_jac_batch` is the plural of `aff_from_jac` built
+  on it -- infinity keeps its place in the list and is not in the batch,
+  having no Z to invert -- and `_aff_from_z_inv` is the two products a
+  conversion is once the inverse is in hand, which the singular and the
+  plural now share. Measured against `70899b51` on Python 3.14.6, best of
+  seven alternating rounds:
+
+  | | one each | batched | |
+  | --- | ---: | ---: | ---: |
+  | 4 inverses mod p | 31.8 us | 10.6 us | **3.01x** |
+  | 16 inverses mod p | 136 us | 20.9 us | **6.50x** |
+  | 64 inverses mod p | 535 us | 59.2 us | **9.04x** |
+  | 4 points to affine | 38.2 us | 14.7 us | **2.59x** |
+  | 16 points to affine | 154 us | 37.0 us | **4.17x** |
+  | `dsa.recover_pub_keys_`, secp256r1 | 4881 us | 4871 us | 1.00x |
+
+  The last row is the honest one: `recover_pub_keys_` is the only caller
+  in the tree today, a candidate on secp256r1 is two Python
+  multiplications, and two candidates at 2.4 ms each leave the ~8 us
+  saved a fifth of a percent. It is where the plural is exercised, not
+  where it pays; what pays is a table of point multiples brought to
+  `Z == 1`, which is issue #801.
+
+  A product is invertible only if every factor is, so one element without
+  an inverse fails the batch: the error then names that element, in
+  `mod_inv`'s own message, rather than the product a caller never formed.
+  An empty sequence is not an error, being what a caller that filtered
+  its own input is left with.
 
 ### The public API and the module layout
 

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -20,7 +20,7 @@ from math import ceil
 
 from btclib.alias import INF, INFJ, Integer, JacPoint, Point
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.number_theory import mod_inv, mod_sqrt
+from btclib.number_theory import mod_inv, mod_inv_batch, mod_sqrt
 from btclib.utils import hex_string, int_from_integer
 
 __all__ = [
@@ -257,13 +257,33 @@ class CurveGroup:
         if Q[2] == 0:  # Infinity point in Jacobian coordinates
             return INF
 
+        return self._aff_from_z_inv(Q, mod_inv(Q[2], self.p))
+
+    def aff_from_jac_batch(self, Qs: Sequence[JacPoint]) -> list[Point]:
+        """Return the affine points: one modular inversion for all of them.
+
+        `aff_from_jac` over a sequence, with `mod_inv_batch` in place of
+        the one inverse each: the conversion is two products a point once
+        the inverse is in hand, so a caller holding several Jacobian
+        points pays one extended Euclid instead of one per point.
+
+        The input points are assumed to be on the curve. Infinity is not
+        in the batch, having no Z to invert, and comes back as INF where
+        it stood.
+        """
+        inverses = iter(mod_inv_batch([Q[2] for Q in Qs if Q[2]], self.p))
+        return [
+            INF if Q[2] == 0 else self._aff_from_z_inv(Q, next(inverses)) for Q in Qs
+        ]
+
+    def _aff_from_z_inv(self, Q: JacPoint, z_inv: int) -> Point:
         # x is X/Z^2 and y is Y/Z^3, and both powers are built from one
         # inverse: Z^-2 is a product away from Z^-1, and Z^-3 another.
         # Inverting Z^2 and Z^3 separately is two extended Euclids where
         # this is one and two multiplications, and an inverse costs what
-        # a hundred products cost
+        # a hundred products cost -- which is also why the inverse itself
+        # is the caller's, one of them being what the batch above shares
         p = self.p
-        z_inv = mod_inv(Q[2], p)
         z_inv2 = z_inv * z_inv % p
         return Q[0] * z_inv2 % p, Q[1] * z_inv2 % p * z_inv % p
 

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -1183,7 +1183,9 @@ def recover_pub_keys_(
     c = challenge_(msg_hash, sig.ec, hf)  # 1.5
 
     QJs = _recover_pub_keys_(c, sig.r, sig.s, sig.ec, lower_s=False)
-    return [sig.ec.aff_from_jac(QJ) for QJ in QJs]
+    # the candidates converted together: one extended Euclid for the list
+    # where one per candidate is what the loop above would have paid
+    return sig.ec.aff_from_jac_batch(QJs)
 
 
 def recover_pub_keys(msg: Octets, sig: Sig | Octets, hf: HashF = sha256) -> list[Point]:

--- a/btclib/number_theory.py
+++ b/btclib/number_theory.py
@@ -17,12 +17,15 @@ with the following modifications:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.utils import hex_string, is_integer
 
 __all__ = [
     "legendre_symbol",
     "mod_inv",
+    "mod_inv_batch",
     "mod_sqrt",
     "tonelli",
     "xgcd",
@@ -109,6 +112,56 @@ def mod_inv(a: int, m: int) -> int:
         err_msg += " mod "
         err_msg += f"{hex_string(m)}" if m > 0xFFFFFFFF else f"{m}"
         raise BTClibValueError(err_msg) from None
+
+
+def mod_inv_batch(a: Sequence[int], m: int) -> list[int]:
+    """Return the inverse of every element of a (mod m), in its order.
+
+    m does not have to be a prime, and every element has to be invertible
+    modulo it, as `mod_inv` requires of its one operand.
+
+    Montgomery's trick, which libsecp256k1 spells `secp256k1_fe_inv_all_var`:
+    the running products a[0], a[0]*a[1], ..., a[0]*...*a[n-1] are formed,
+    the last of them is inverted once, and the individual inverses are
+    peeled back off it. So n inverses cost one inverse and 3(n-1)
+    products, where n calls to `mod_inv` are n extended Euclids -- an
+    inverse modulo a 256-bit prime being some thirty times a product.
+
+    An empty sequence has no inverses and is not an error: it is what a
+    caller that filtered its own input is left with.
+    """
+    _assert_valid_modulus(m)
+    for x in a:
+        _assert_valid_operand(x)
+
+    if not a:
+        return []
+
+    # the running products, the last of which is the one to invert
+    acc: list[int] = []
+    product = 1
+    for x in a:
+        product = product * x % m
+        acc.append(product)
+
+    try:
+        inv = pow(product, -1, m)
+    except ValueError:
+        # a product is invertible only if every factor is, so at least one
+        # element is not: inverting them one at a time reaches it and
+        # answers `mod_inv`'s own message, naming the operand rather than
+        # the product a caller never formed
+        return [mod_inv(x, m) for x in a]
+
+    # and peeled back off it, from the last element to the first: the
+    # inverse of the whole product times the product of everything before
+    # element i is the inverse of element i
+    inverses = [0] * len(a)
+    for i in range(len(a) - 1, 0, -1):
+        inverses[i] = inv * acc[i - 1] % m
+        inv = inv * a[i] % m
+    inverses[0] = inv
+    return inverses
 
 
 def legendre_symbol(a: int, p: int) -> int:

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -812,3 +812,24 @@ def test_INF() -> None:
         secp256k1.y(INF[0])
     with pytest.raises(BTClibValueError, match="invalid x-coordinate: "):
         secp256k1.y(INF[0] + secp256k1.n)
+
+
+def test_aff_from_jac_batch_is_aff_from_jac_over_a_sequence() -> None:
+    """The batch answers what the conversions one at a time answer.
+
+    Infinity keeps its place in the list and is not in the batch, having
+    no Z to invert: what a caller gets back is as long as what it passed,
+    which is what makes the answer indexable beside the input.
+    """
+    for ec in all_curves.values():
+        QJs = [_mult(k, ec.GJ, ec) for k in (1, 2, 3, ec.n - 1)]
+        assert ec.aff_from_jac_batch(QJs) == [ec.aff_from_jac(QJ) for QJ in QJs]
+
+        # infinity first, last and in between, so that the peeling back
+        # off the running products starts and stops beside one
+        mixed = [INFJ, QJs[0], INFJ, INFJ, QJs[1], INFJ]
+        assert ec.aff_from_jac_batch(mixed) == [ec.aff_from_jac(QJ) for QJ in mixed]
+
+        # nothing to invert at all, and nothing to convert at all
+        assert ec.aff_from_jac_batch([INFJ, INFJ]) == [INF, INF]
+        assert ec.aff_from_jac_batch([]) == []

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -40,7 +40,7 @@ from btclib.exceptions import BTClibTypeError
 from btclib.fee import FeeRate, fee_from_vsize
 from btclib.hashes import merkle_root_from_branch, sha256
 from btclib.mnemonic.entropy import bin_str_entropy_from_wordlist_indexes
-from btclib.number_theory import mod_inv
+from btclib.number_theory import mod_inv, mod_inv_batch
 from btclib.script import input_script_sig, sig_hash
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from btclib.utils import bytes_from_octets, encode_num, is_integer
@@ -120,6 +120,8 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     ("word-list index", lambda v: bin_str_entropy_from_wordlist_indexes([v], 2048)),
     ("modular operand", lambda v: mod_inv(v, 7)),
     ("modulus", lambda v: mod_inv(3, v)),
+    ("modular operand in a batch", lambda v: mod_inv_batch([3, v], 7)),
+    ("modulus of a batch", lambda v: mod_inv_batch([3], v)),
     ("taproot leaf index", lambda v: input_script_sig(None, _SCRIPT_TREE, v)),
     (
         "sig_hash input index",
@@ -187,6 +189,7 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert bech32.encode("bc", [1]) == b"bc1pdg93mv"
     assert bin_str_entropy_from_wordlist_indexes([1], 2048) == "00000000001"
     assert mod_inv(3, 7) == 5
+    assert mod_inv_batch([3, 2], 7) == [5, 4]
     assert input_script_sig(None, _SCRIPT_TREE, 0)[0] == ["OP_1"]
     assert len(sig_hash.taproot(_tx(), 0, _PREVOUTS, 1, 0, b"", b"")) == 32
     assert encode_num(1) == b"\x01"

--- a/tests/number_theory_test.py
+++ b/tests/number_theory_test.py
@@ -11,7 +11,14 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.number_theory import legendre_symbol, mod_inv, mod_sqrt, tonelli, xgcd
+from btclib.number_theory import (
+    legendre_symbol,
+    mod_inv,
+    mod_inv_batch,
+    mod_sqrt,
+    tonelli,
+    xgcd,
+)
 
 primes = [
     2,
@@ -232,3 +239,52 @@ def test_mod_sqrt_squares_back(a: int, p: int) -> None:
     assert root * root % p == a % p
     # the other root, p - root, is a root too: a square has two
     assert (p - root) * (p - root) % p == a % p
+
+
+def test_mod_inv_batch_is_mod_inv_over_a_sequence() -> None:
+    """The batch answers what the inverses one at a time answer.
+
+    The first and last elements included, which is where the peeling
+    back off the running products stops and starts, and the empty
+    sequence, which has no inverses and is not an error.
+    """
+    for m in (7, 97, 2**521 - 1):
+        values = [1, 2, m - 1, 3, m - 2]
+        assert mod_inv_batch(values, m) == [mod_inv(v, m) for v in values]
+        assert mod_inv_batch([2], m) == [mod_inv(2, m)]
+    assert mod_inv_batch([], 7) == []
+
+
+def test_mod_inv_batch_names_the_element_that_has_no_inverse() -> None:
+    """A product is invertible only if every factor is.
+
+    So the batch fails whenever one element does, and names that element
+    as `mod_inv` does rather than the product a caller never formed.
+    """
+    with pytest.raises(BTClibValueError, match="no inverse for 0 mod 7"):
+        mod_inv_batch([1, 2, 0, 3], 7)
+    with pytest.raises(BTClibValueError, match="no inverse for 3 mod 9"):
+        mod_inv_batch([2, 3], 9)
+
+    # the arguments are checked as every other function of the module
+    # checks its own, a bool being no integer and zero no modulus
+    for value in (2.0, True, None):
+        with pytest.raises(BTClibTypeError, match="not an integer: "):
+            mod_inv_batch([1, value], 7)  # type: ignore[list-item]
+    for m in (0, -7, 3.0, False):
+        with pytest.raises((BTClibTypeError, BTClibValueError)):
+            mod_inv_batch([1], m)  # type: ignore[arg-type]
+
+
+@given(values=st.lists(st.integers(), max_size=8), m=st.integers(min_value=2))
+def test_mod_inv_batch_inverts(values: list[int], m: int) -> None:
+    """Every inverse multiplies its element back to one, or none does."""
+    if any(math.gcd(v % m, m) != 1 for v in values):
+        with pytest.raises(BTClibValueError, match="no inverse"):
+            mod_inv_batch(values, m)
+        return
+    inverses = mod_inv_batch(values, m)
+    assert len(inverses) == len(values)
+    for v, inverse in zip(values, inverses, strict=True):
+        assert 0 <= inverse < m
+        assert v * inverse % m == 1


### PR DESCRIPTION
Montgomery's trick, which libsecp256k1 spells fe_inv_all_var: the running
products a[0], a[0]*a[1], ... are formed, the last of them is inverted
once, and the individual inverses are peeled back off it. n inverses cost
one inverse and 3(n-1) products, an inverse modulo secp256k1's p being
7.4 us and a product 0.25.

number_theory.mod_inv_batch is that, validating its arguments as its
neighbours there do. CurveGroup.aff_from_jac_batch is the plural of
aff_from_jac built on it, with infinity keeping its place in the list and
staying out of the batch, having no Z to invert; _aff_from_z_inv is the
two products a conversion is once the inverse is in hand, which the
singular and the plural now share rather than each spelling out.

Measured against 70899b51 on Python 3.14.6, best of seven alternating
rounds:

                                        one each     batched
  4 inverses mod p                       31.8 us     10.6 us   3.01x
  16 inverses mod p                       136 us     20.9 us   6.50x
  64 inverses mod p                       535 us     59.2 us   9.04x
  4 points to affine                     38.2 us     14.7 us   2.59x
  16 points to affine                     154 us     37.0 us   4.17x
  dsa.recover_pub_keys_, secp256r1       4881 us     4871 us   1.00x

The last row is the honest one. recover_pub_keys_ is the only caller in
the tree today, a candidate on secp256r1 is two Python multiplications,
and two candidates at 2.4 ms each leave the 8 us saved a fifth of a
percent: it is where the plural is exercised, not where it pays. What
pays is a table of point multiples brought to Z == 1, which is #801.

A product is invertible only if every factor is, so one element without
an inverse fails the batch, and the error names that element in
mod_inv's own message rather than the product a caller never formed. An
empty sequence is not an error, being what a caller that filtered its own
input is left with.

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce batched modular inversion and affine conversion to reduce the number of extended Euclid calls when processing sequences of values and curve points.

New Features:
- Add mod_inv_batch to compute modular inverses for a sequence of operands in one batch while preserving order and handling empty inputs.
- Add CurveGroup.aff_from_jac_batch to convert multiple Jacobian points to affine coordinates using a shared batched inversion and preserving INF positions.

Enhancements:
- Refactor affine conversion logic into a shared helper _aff_from_z_inv used by both singular and batched Jacobian-to-affine conversions.
- Extend integer policy tests and error-path coverage to include batched modular inversion scenarios.

Documentation:
- Document mod_inv_batch, aff_from_jac_batch, and associated performance characteristics and error behavior in the changelog entry.

Tests:
- Add unit and property-based tests for mod_inv_batch, including success cases, empty input, non-invertible elements, and invalid arguments.
- Add tests ensuring aff_from_jac_batch matches aff_from_jac over sequences, correctly handles INF points, and supports empty batches.