### PR TITLE
Index an affine table, and add to it as one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2091,6 +2091,48 @@ documented at release-notes length in the first place, and are still in
   with the bindings applicable, `mult` has returned before reaching it.
   `double_mult` and `multi_mult` do not rescale, their coefficients being
   a verification's and public.
+- **The tables a windowed multiplication indexes are affine** (issue
+  #801). `add_jac` adds two Jacobian points, and in a windowed
+  multiplication one of the two is always a table entry. `add_jac_aff`
+  takes that one as a `Point` -- the precondition in the signature rather
+  than in a sentence nothing checks -- and five of the sixteen products
+  become multiplications by one: the entry's two powers of Z, the two
+  that put the accumulator in its frame, and one factor of the answer's
+  Z. libsecp256k1 keeps its tables the same way and states
+  `secp256k1_gej_add_ge_var` as 8 mul and 3 sqr against the 12 and 4 of
+  `secp256k1_gej_add_var`.
+
+  What the table costs is one modular inversion, `aff_from_jac_batch`
+  sharing it across the entries: at w=4 one extended Euclid and some
+  forty products, against five saved on each of the ~63 additions a
+  256-bit scalar makes. The inversion is a function of the point and not
+  of the scalar, so a multiplication that is regular in its scalar stays
+  regular in it. Measured against `1bb77121` on Python 3.14.6, best of
+  seven alternating rounds, with a doubling as the noise detector:
+
+  | | Jacobian | affine | |
+  | --- | ---: | ---: | ---: |
+  | `_mult`, secp256k1 | 729 us | 681 us | **1.07x** |
+  | `_mult`, secp256r1 | 809 us | 765 us | **1.06x** |
+  | `_mult_endomorphism_secp256k1` | 547 us | 522 us | **1.05x** |
+  | `_double_mult_w_NAF`, secp256r1 | 1004 us | 933 us | **1.08x** |
+  | `_double_mult_endomorphism_secp256k1` | 755 us | 711 us | **1.06x** |
+  | `_multi_mult`, 16 scalars | 4257 us | 3753 us | **1.13x** |
+  | control, `double_jac` | 1.66 us | 1.66 us | 1.00x |
+
+  Every loop that builds a table takes it: the regular windows of `_mult`
+  and `_double_mult_regular_window`, and the interleaved wNAFs of
+  `_double_mult_w_NAF` and `_multi_mult_w_NAF`. `add_jac` stays what
+  `_double_mult`'s Shamir-Strauss table and every caller outside those
+  loops adds with, and every case it answers `add_jac_aff` answers the
+  same way -- infinity through a stand-in and a selection at the end,
+  spelled `R[1] == 0` because that is what infinity is in affine
+  coordinates. A new test compares the two over every pair of points of
+  every low-cardinality curve, which is where those cases are reached.
+
+  `_signed_odd_multiples` is gone, `_signed_odd_multiples_aff` being what
+  the regular windows index; `_odd_multiples` stays, the affine table
+  being built on it. The negation costs the same either way, `(x, p - y)`.
 
 ### The public API and the module layout
 

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -479,6 +479,55 @@ class CurveGroup:
         # here, which is the whole point of it
         return ((X, Y, Z), R, Q, INFJ)[(Q[2] == 0) + 2 * (R[2] == 0)]
 
+    def add_jac_aff(self, Q: JacPoint, R: Point) -> JacPoint:
+        """Return the sum of a Jacobian point and an affine one, branch-free.
+
+        `add_jac` with the second operand's Z known to be one, which is
+        what an affine point is: five of the sixteen products become
+        multiplications by one -- R's two powers of Z, the two that put Q
+        in R's frame, and one factor of the answer's Z. libsecp256k1 keeps
+        its tables in affine coordinates for exactly this and states
+        `secp256k1_gej_add_ge_var` as 8 mul and 3 sqr against the 12 and 4
+        of `secp256k1_gej_add_var`.
+
+        The affine operand is a Point and not a JacPoint whose Z happens
+        to be one, so the precondition is in the signature rather than in
+        a sentence nothing checks.
+
+        The input points are assumed to be on the curve. Every case
+        `add_jac` answers is answered here the same way and for the same
+        reasons, which its comments carry: infinity through a stand-in and
+        a selection at the end, spelled `R[1] == 0` because that is what
+        infinity is in affine coordinates, and the doubling and the sum
+        that is infinity through the one branch on V.
+        """
+        QS = (Q, self._stand_in_q)[Q[2] == 0]
+        RS = (R, self._stand_in_r)[R[1] == 0]
+
+        p = self.p
+        QZ2 = QS[2] * QS[2] % p
+        QZ3 = QZ2 * QS[2] % p
+
+        # M and T are Q's coordinates as they stand: R's frame is the
+        # affine one, so putting Q in it is what QZ2 and QZ3 already did
+        M = QS[0]
+        T = QS[1]
+        V = (RS[0] * QZ2 - M) % p
+        W = (RS[1] * QZ3 - T) % p
+
+        if V == 0 and Q[2] and R[1]:
+            return self._double_jac_helper(Q, QZ2) if W == 0 else INFJ
+
+        V2 = V * V % p
+        V3 = V2 * V % p
+        MV2 = M * V2 % p
+
+        X = (W * W - V3 - 2 * MV2) % p
+        Y = (W * (MV2 - X) - T * V3) % p
+        Z = V * QS[2] % p
+
+        return ((X, Y, Z), (R[0], R[1], 1), Q, INFJ)[(Q[2] == 0) + 2 * (R[1] == 0)]
+
     def double_jac(self, Q: JacPoint) -> JacPoint:
         """Return twice the Jacobian point, assumed to be on the curve."""
         # Z^2 is what the a*Z^4 term is built from and the only thing that
@@ -941,23 +990,42 @@ def _odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
     return T
 
 
-def _signed_odd_multiples(Q: JacPoint, ec: CurveGroup, w: int) -> list[JacPoint]:
-    """Return the 2^w multiples a signed odd width-w digit names.
+def _odd_multiples_aff(Q: JacPoint, ec: CurveGroup, w: int) -> list[Point]:
+    """Return `_odd_multiples` in affine coordinates, one inversion for all.
+
+    What it buys is the loop that indexes it: `add_jac_aff` makes five
+    products fewer than `add_jac` on every addition, and a windowed
+    multiplication makes one addition per window. What it costs is one
+    extended Euclid, `aff_from_jac_batch` sharing it across the entries --
+    at w=4 one inverse and some forty products, against five saved on each
+    of the ~63 additions a 256-bit scalar makes.
+
+    The inversion is a function of the point and not of the scalar, so a
+    multiplication that is regular in its scalar stays regular in it.
+    """
+    return ec.aff_from_jac_batch(_odd_multiples(Q, ec, w))
+
+
+def _signed_odd_multiples_aff(Q: JacPoint, ec: CurveGroup, w: int) -> list[Point]:
+    """Return the 2^w multiples a signed odd width-w digit names, affine.
 
     -(2^w - 1)*Q first and (2^w - 1)*Q last, so the digit d of
-    signed_odd_digits picks entry (d + 2^w - 1) // 2 and nothing has to
-    test its sign, where the wNAF loops negate an entry of `_odd_multiples`
-    on the fly under an `if`. Cheaper, too, and not only regular: 2^(w-1)
-    modular subtractions once -- 8 of them at w=4 -- against the one per
-    negative digit the loop would make, which is half of the 64 digits a
-    256-bit scalar has at that width.
+    `signed_odd_digits` picks entry (d + 2^w - 1) // 2 and nothing has to
+    test its sign, where the wNAF loops negate an entry of
+    `_odd_multiples_aff` on the fly under an `if`. Cheaper, too, and not
+    only regular: 2^(w-1) modular subtractions once -- 8 of them at w=4 --
+    against the one per negative digit the loop would make, which is half
+    of the 64 digits a 256-bit scalar has at that width.
 
-    The table it is built on is `_odd_multiples(Q, ec, w + 1)`: a regular
-    digit reaches 2^w - 1 where a width-w NAF digit stops at 2^(w-1) - 1,
-    so the table is twice as long as that recoding's for the same window.
+    The table it is built on is `_odd_multiples_aff(Q, ec, w + 1)`: a
+    regular digit reaches 2^w - 1 where a width-w NAF digit stops at
+    2^(w-1) - 1, so the table is twice as long as that recoding's for the
+    same window. The negation is one modular subtraction in affine
+    coordinates as it is in Jacobian ones, `(x, p - y)`, so nothing is
+    paid for the entries being affine here rather than there.
     """
-    T = _odd_multiples(Q, ec, w + 1)
-    return [ec.negate_jac(P) for P in reversed(T)] + T
+    T = _odd_multiples_aff(Q, ec, w + 1)
+    return [ec.negate(P) for P in reversed(T)] + T
 
 
 def _mult_mont_ladder(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
@@ -1150,17 +1218,17 @@ def _mult_regular_window(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoin
     # all, and m + n would be the same point only for a point whose order
     # it is -- which the group this multiplies in cannot say
     digits = signed_odd_digits(m | 1, w, size)
-    T = _signed_odd_multiples(Q, ec, w)
+    T = _signed_odd_multiples_aff(Q, ec, w)
     offset = (1 << w) - 1
 
     # a table entry, the top digit being positive, and never infinity
-    R = T[(digits[-1] + offset) // 2]
+    R = _jac_from_aff(T[(digits[-1] + offset) // 2])
     for digit in digits[-2::-1]:
         # multiple 'double'
         for _ in range(w):
             R = ec.double_jac(R)
         # and 'add', on every digit: there is no zero one to skip
-        R = ec.add_jac(R, T[(digit + offset) // 2])
+        R = ec.add_jac_aff(R, T[(digit + offset) // 2])
     # the parity correction, made whatever the parity so that it cannot be
     # read off the clock: one addition of infinity, which by the same
     # property costs what the addition of -Q costs. It is also what
@@ -1326,7 +1394,7 @@ def _multi_mult_w_NAF(
         return INFJ
 
     nafs = [_wNAF_of_m(n, w) for n, _ in pairs]
-    tables = [_odd_multiples(PJ, ec, w) for _, PJ in pairs]
+    tables = [_odd_multiples_aff(PJ, ec, w) for _, PJ in pairs]
 
     R = INFJ
     for j in range(max(len(naf) for naf in nafs) - 1, -1, -1):
@@ -1335,8 +1403,8 @@ def _multi_mult_w_NAF(
             # a scalar shorter than the longest one has run out of digits
             if j < len(naf) and naf[j] != 0:
                 d = naf[j]
-                QJ = T[(d - 1) // 2] if d > 0 else ec.negate_jac(T[(-d - 1) // 2])
-                R = ec.add_jac(R, QJ)
+                P = T[(d - 1) // 2] if d > 0 else ec.negate(T[(-d - 1) // 2])
+                R = ec.add_jac_aff(R, P)
     return R
 
 

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -103,9 +103,10 @@ from btclib.alias import INFJ, JacPoint
 from btclib.curves.curve_group import (
     CurveGroup,
     _convert_number_to_base,
+    _jac_from_aff,
     _multi_mult_w_NAF,
-    _odd_multiples,
-    _signed_odd_multiples,
+    _odd_multiples_aff,
+    _signed_odd_multiples_aff,
     _wNAF_of_m,
     signed_odd_digits,
 )
@@ -302,21 +303,23 @@ def _double_mult_w_NAF(
     vs = _wNAF_of_m(v, w)
 
     # one table of odd multiples per point, the same curve_group's
-    # interleaved _multi_mult_w_NAF builds for each of its own
-    TH = _odd_multiples(HJ, ec, w)
-    TQ = _odd_multiples(QJ, ec, w)
+    # interleaved _multi_mult_w_NAF builds for each of its own, and in
+    # affine coordinates for the same reason: one inversion a table
+    # against five products on every addition that indexes it
+    TH = _odd_multiples_aff(HJ, ec, w)
+    TQ = _odd_multiples_aff(QJ, ec, w)
 
     R = INFJ
     for j in range(max(len(us), len(vs)) - 1, -1, -1):
         R = ec.double_jac(R)
         if j < len(us) and us[j] != 0:
             d = us[j]
-            T = TH[(d - 1) // 2] if d > 0 else ec.negate_jac(TH[(-d - 1) // 2])
-            R = ec.add_jac(R, T)
+            T = TH[(d - 1) // 2] if d > 0 else ec.negate(TH[(-d - 1) // 2])
+            R = ec.add_jac_aff(R, T)
         if j < len(vs) and vs[j] != 0:
             d = vs[j]
-            T = TQ[(d - 1) // 2] if d > 0 else ec.negate_jac(TQ[(-d - 1) // 2])
-            R = ec.add_jac(R, T)
+            T = TQ[(d - 1) // 2] if d > 0 else ec.negate(TQ[(-d - 1) // 2])
+            R = ec.add_jac_aff(R, T)
     return R
 
 
@@ -374,18 +377,20 @@ def _double_mult_regular_window(
     us = signed_odd_digits(u | 1, w, size)
     vs = signed_odd_digits(v | 1, w, size)
 
-    TH = _signed_odd_multiples(HJ, ec, w)
-    TQ = _signed_odd_multiples(QJ, ec, w)
+    TH = _signed_odd_multiples_aff(HJ, ec, w)
+    TQ = _signed_odd_multiples_aff(QJ, ec, w)
     offset = (1 << w) - 1
 
     # the accumulator starts at the sum of two table entries, so infinity
     # is out of the loop here too
-    R = ec.add_jac(TH[(us[-1] + offset) // 2], TQ[(vs[-1] + offset) // 2])
+    R = ec.add_jac_aff(
+        _jac_from_aff(TH[(us[-1] + offset) // 2]), TQ[(vs[-1] + offset) // 2]
+    )
     for du, dv in zip(us[-2::-1], vs[-2::-1], strict=True):
         for _ in range(w):
             R = ec.double_jac(R)
-        R = ec.add_jac(R, TH[(du + offset) // 2])
-        R = ec.add_jac(R, TQ[(dv + offset) // 2])
+        R = ec.add_jac_aff(R, TH[(du + offset) // 2])
+        R = ec.add_jac_aff(R, TQ[(dv + offset) // 2])
     # and the two parity corrections, each made whatever the parity
     R = ec.add_jac(R, (INFJ, ec.negate_jac(HJ))[not u & 1])
     return ec.add_jac(R, (INFJ, ec.negate_jac(QJ))[not v & 1])

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -9,8 +9,8 @@ from functools import partial
 
 import pytest
 
-from btclib.alias import INF, INFJ, JacPoint
-from btclib.curves import Curve, CurveGroup, secp256k1
+from btclib.alias import INF, INFJ, JacPoint, Point
+from btclib.curves import Curve, CurveGroup, find_all_points, secp256k1
 
 # the mult_* variants under test, and the helpers they are built on, come
 # from the module that defines them: btclib.curves exports mult,
@@ -37,7 +37,7 @@ from btclib.curves.curve_group import (
     _multi_mult_bos_coster,
     _multi_mult_w_NAF,
     _multiples,
-    _signed_odd_multiples,
+    _signed_odd_multiples_aff,
     signed_odd_digits,
 )
 from btclib.ecc import second_generator
@@ -389,15 +389,36 @@ def test_signed_odd_digits_properties() -> None:
                 assert sum(d << (w * i) for i, d in enumerate(digits)) == m
 
 
-def test_signed_odd_multiples() -> None:
+def test_signed_odd_multiples_aff() -> None:
     """The table against the multiplications of the digits that index it."""
     for ec in (ec23_31, secp256k1):
         for w in range(1, 6):
-            T = _signed_odd_multiples(ec.GJ, ec, w)
+            T = _signed_odd_multiples_aff(ec.GJ, ec, w)
             assert len(T) == 2**w
             for d in range(-(2**w - 1), 2**w, 2):
-                expected = _mult_jac(d % ec.n, ec.GJ, ec)
-                assert ec.jac_equality(T[(d + 2**w - 1) // 2], expected), (d, w)
+                expected = ec.aff_from_jac(_mult_jac(d % ec.n, ec.GJ, ec))
+                assert T[(d + 2**w - 1) // 2] == expected, (d, w)
+
+
+def test_add_jac_aff_answers_add_jac_on_every_pair() -> None:
+    """The mixed sum against the general one, exhaustively.
+
+    Every point of every low-cardinality curve as the affine operand,
+    infinity included, against every point of the subgroup as the
+    Jacobian one, whose Z is a real one rather than the 1 an affine point
+    converts to. The two are the same formula with the second operand's Z
+    known to be one, so what holds add_jac's branch-free infinity
+    handling and its one branch on V correct holds this one's too -- and
+    these curves are where both are reached at all.
+    """
+    for ec in low_card_curves.values():
+        points = [*find_all_points(ec), INF]
+        jac = [_jac_from_aff(P) for P in points]
+        jac += [_mult_jac(k, ec.GJ, ec) for k in range(ec.n)]
+        for PJ in jac:
+            for R in points:
+                mixed = ec.add_jac_aff(PJ, R)
+                assert ec.jac_equality(ec.add_jac(PJ, _jac_from_aff(R)), mixed)
 
 
 class _CountingGroup(CurveGroup):
@@ -418,6 +439,14 @@ class _CountingGroup(CurveGroup):
     def add_jac(self, Q: JacPoint, R: JacPoint) -> JacPoint:
         self.additions += 1
         return super().add_jac(Q, R)
+
+    def add_jac_aff(self, Q: JacPoint, R: Point) -> JacPoint:
+        # counted beside add_jac and not apart from it: what the test
+        # below is about is how many additions a scalar costs, and the
+        # regular window indexes an affine table where the fixed one it is
+        # measured against indexes a Jacobian one
+        self.additions += 1
+        return super().add_jac_aff(Q, R)
 
 
 def test_regular_window_addition_count_is_the_same_for_every_scalar() -> None:


### PR DESCRIPTION
add_jac adds two Jacobian points, and in a windowed multiplication one of
the two is always a table entry. add_jac_aff takes that one as a Point --
the precondition in the signature rather than in a sentence nothing
checks -- and five of the sixteen products become multiplications by one:
the entry's two powers of Z, the two that put the accumulator in its
frame, and one factor of the answer's Z. libsecp256k1 keeps its tables
the same way and states gej_add_ge_var as 8 mul and 3 sqr against the 12
and 4 of gej_add_var.

What the table costs is one modular inversion, aff_from_jac_batch sharing
it across the entries: at w=4 one extended Euclid and some forty
products, against five saved on each of the ~63 additions a 256-bit
scalar makes. The inversion is a function of the point and not of the
scalar, so a multiplication that is regular in its scalar stays regular
in it.

Measured against 1bb77121 on Python 3.14.6, best of seven alternating
rounds, with a doubling as the noise detector:

                                          Jacobian    affine
  _mult, secp256k1                           729 us    681 us   1.07x
  _mult, secp256r1                           809 us    765 us   1.06x
  _mult_endomorphism_secp256k1               547 us    522 us   1.05x
  _double_mult_w_NAF, secp256r1             1004 us    933 us   1.08x
  _double_mult_endomorphism_secp256k1        755 us    711 us   1.06x
  _multi_mult, 16 scalars                   4257 us   3753 us   1.13x
  control, double_jac                       1.66 us   1.66 us   1.00x

Every loop that builds a table takes it: the regular windows of _mult and
_double_mult_regular_window, and the interleaved wNAFs of
_double_mult_w_NAF and _multi_mult_w_NAF. add_jac stays what
_double_mult's Shamir-Strauss table and every caller outside those loops
adds with, and every case it answers add_jac_aff answers the same way --
infinity through a stand-in and a selection at the end, spelled
R[1] == 0 because that is what infinity is in affine coordinates. A test
compares the two over every pair of points of every low-cardinality
curve, which is where those cases are reached at all.

_signed_odd_multiples is gone, _signed_odd_multiples_aff being what the
regular windows index; _odd_multiples stays, the affine table being built
on it. The negation costs the same either way, (x, p - y).

Closes #801

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce mixed Jacobian–affine addition and switch windowed scalar multiplication tables to affine coordinates for performance and regularity.

New Features:
- Add add_jac_aff for branch-free addition of a Jacobian point with an affine point.
- Add affine odd-multiples table helpers used by windowed and wNAF-based scalar multiplication routines.

Enhancements:
- Refactor regular-window and wNAF scalar multiplication to index affine tables and use mixed Jacobian–affine addition, reducing per-addition field multiplications.
- Update double-multiplication helpers in curve_group_2 to use affine tables and mixed addition for both regular-window and wNAF variants.
- Extend the counting CurveGroup to track add_jac_aff calls alongside add_jac for scalar-regularity tests.

Documentation:
- Document the affine table strategy, performance impact, and add_jac_aff behavior in the CHANGELOG, including benchmark results.

Tests:
- Replace signed_odd_multiples tests with signed_odd_multiples_aff tests that compare against affine conversions of scalar multiples.
- Add exhaustive tests that verify add_jac_aff matches add_jac over all relevant point pairs on low-cardinality curves.
- Adjust multi-scalar multiplication and double-multiplication tests to cover the new affine-table and mixed-addition behavior.