### PR TITLE
A bool is an answer about a value of a declared type (#814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2215,6 +2215,57 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **A `bool` is an answer about a value of a declared type** (issue
+  #814). `script_pub_key.is_p2sh` already drew that line -- bytes that
+  are not a p2sh script are `False`, a float is a `BTClibTypeError` --
+  and the boolean verifications beside it did not: every type answered
+  `False`. Issue #745 had settled the other way, on a verification total
+  over *everything* it is handed, and the two rules could not both be
+  the library's.
+
+  The annotation wins, for three reasons. It makes the `hf` carve-out
+  #745 needed an instance of a rule instead of an exception to one: a
+  value outside `HashF` raises because it is an undeclared type, as a
+  float passed as a key does. It leaves the argument that carried #745
+  untouched, since a caller filtering signatures off the wire holds
+  bytes, and bytes are declared. And it puts the line at something
+  stated rather than at which builtin a helper happens to derive from,
+  which is the accident #745 was right to name and had no better line to
+  offer.
+
+  Measured over every boolean verification, one parameter at a time,
+  what did not already follow the rule was the pub key -- `dsa.verify`,
+  `dsa.verify_` and `ecc.dleq.verify_proof`. Every `Octets` parameter,
+  every signature, `pedersen`'s scalars, `merkle_proof`'s index, the two
+  engine adapters, `ssa`'s `BIP340PubKey` and `bms`'s and `bip322`'s
+  address already raised for a type. One converter was the whole of the
+  gap: `to_pub_key` flattened every refusal into `BTClibValueError("not
+  a public key")`, so "this key is not on the curve" and "this is not a
+  key at all" arrived as one class.
+
+  `_assert_pub_key_type` and `_assert_key_type` ask it at the top of the
+  four converters, the two unions being closed -- which is what
+  `ssa.point_from_bip340pub_key` already did, ending in exactly this
+  refusal. An int is in one list and not the other on purpose: it is a
+  private key here and never a public one, so `dsa.verify(msg, 12, sig)`
+  is refused rather than reported as a signature that did not verify.
+  That is issue #143 answered more loudly than it asked, its other five
+  spellings being a `str` or a `BIP32KeyData` and still `False`.
+
+  The rule is stated in CONTRIBUTING.md beside "Every public function
+  validates its inputs", `ecc.dsa.verify_` carries the reason, and the
+  five verifications that repeated it now point there --
+  `ecc.pedersen`, `ecc.borromean` and `ecc.dleq` were still carrying the
+  paragraph #745 declared wrong, which is the "one fact in one place"
+  half of that issue that was not carried out.
+
+  `tests/input_validation_test.py` loses `_OPEN`, which is empty: the
+  one entry left after issue #776 was `dleq.verify_proof`, and it is an
+  `_EXCLUDED` entry now, with the family reason the nine script
+  predicates carry. `_EXCLUDED` gained the ratchet `_OPEN` used to have
+  -- `test_what_is_excluded_still_needs_to_be` fails on a line that has
+  outlived its reason, which nothing checked before.
+
 - **Five coercions trusted their annotation** (issue #776), and the
   input-validation gate held fifty-nine public functions open on them.
   Each takes "anything convertible", handles the `str` spelling and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -828,6 +828,23 @@ private twin that does not validate; that twin is then what the library
 composes internally, where the inputs have already been checked and
 checking them a second time buys nothing.
 
+**A function that answers a `bool` is total over the types it declares,
+and only those.** `is_p2sh` answers False for bytes that are not a p2sh
+script, and `dsa.verify` answers False for a signature that does not
+verify: that is what the bool is for, and a caller filtering a list of
+them wants an answer and not an exception. A value of a type the
+signature does not declare is not such an answer — it is the caller's
+own mistake, it is a call mypy already refuses, and it leaves as a
+`BTClibTypeError` like any other. So `dsa.verify(msg, 12, sig)` raises,
+12 being a private key in this library and never a public one, where
+`dsa.verify(msg, "not a key", sig)` is False.
+
+The line is the annotation, and deliberately not which built-in a helper
+happens to derive from: those two coincide only by accident, which is
+what issue #745 found and this replaces. The `assert_*` twin beside each
+of these is the spelling that says *why* a value was refused, and the two
+are how a caller chooses between an answer and a reason.
+
 `check_validity=False` is not an exemption from this. It says "do not
 check *now*", not "this object is exempt from here on": these are mutable
 dataclasses whose fields are public and get reassigned in place, so

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,24 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **a verification refuses a type it does not declare, where it used to
+  answer `False`.** `dsa.verify` takes a `PubKey` -- bytes, a hex
+  string, a `BIP32KeyData` or a `Point` -- and an int is none of those:
+  in this library an int is a private key. `dsa.verify(msg, 12, sig)` is
+  a `BTClibTypeError` now where it was `False`, and so is
+  `ecc.dleq.verify_proof` with one. A key of a *declared* type that is
+  not valid is still `False` -- `dsa.verify(msg, "not a key", sig)` is
+  unchanged -- so a caller filtering signatures that arrived as bytes is
+  unaffected; what changes is a call mypy already refused.
+
+  The converters underneath moved with it, and that is the part to act
+  on: `to_pub_key`'s `point_from_pub_key`, `pub_keyinfo_from_pub_key`,
+  `point_from_key` and `pub_keyinfo_from_key` answer a `BTClibTypeError`
+  for a type no spelling of a key has, where every refusal used to be a
+  `BTClibValueError`. Code catching `TypeError` or `BTClibException`
+  keeps working; code catching `BTClibValueError` alone around one of
+  those four has to widen.
+
 - **a bad network name raises `BTClibValueError`, not `KeyError`.**
   Every function taking a `network: str` -- `b58.p2pkh`, `b32.p2wpkh`,
   `to_pub_key.fingerprint`, `bip39.mxprv_from_mnemonic` and the rest --

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -189,12 +189,8 @@ def verify(
     - s: s-values, both real (one per ring) and forged
     - pubk_rings: sequence of PubKey rings
     """
-    # ValueError and BTClibRuntimeError, not Exception: an input that is not
-    # a valid signature is False, and so is a verification that failed, but
-    # a TypeError is neither -- an hf passed as sha256() instead of sha256
-    # is a caller error: raise, rather than report an invalid signature.
-    # BTClibRuntimeError by name and not RuntimeError, because
-    # RecursionError is one and is not an answer about a signature
+    # ValueError and BTClibRuntimeError, as `ecc.dsa.verify_` catches them
+    # and for its reasons, which it states
     try:
         assert_as_valid(msg, e0, s, pubk_rings, ec, hf)
     except (ValueError, BTClibRuntimeError):

--- a/btclib/ecc/dleq.py
+++ b/btclib/ecc/dleq.py
@@ -224,10 +224,8 @@ def verify_proof(
     msg: Octets | None = None,
 ) -> bool:
     """Return True if the proof holds for A, B, C under G and msg."""
-    # ValueError and BTClibRuntimeError, not Exception, as in
-    # `btclib.ecc.ssa`: an input that is not a valid proof is False, and
-    # so is a proof that does not hold, but a TypeError is neither -- it
-    # is a caller error, and raising it is the answer
+    # ValueError and BTClibRuntimeError, as `ecc.dsa.verify_` catches them
+    # and for its reasons, which it states
     try:
         assert_proof_as_valid(A, B, C, proof, G, msg)
     except (ValueError, BTClibRuntimeError):

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -928,13 +928,23 @@ def verify_(
     signature that does not commit to that value is False as a forged one
     is: the answer is about this signature and this commitment, both.
     """
-    # ValueError and BTClibRuntimeError, not Exception: an input that is not
-    # a valid signature is False, and so is a verification that failed. A
-    # caller's own mistake is neither, and is kept out by being refused
-    # before this rather than by being excluded from the except: an hf
-    # passed as sha256() instead of sha256 leaves assert_as_valid_ as the
-    # BTClibTypeError hashes._assert_valid_hf raises, which a TypeError is,
-    # so it arrives here uncaught and reaches the caller.
+    # The comment every boolean verification in this library points at.
+    #
+    # ValueError and BTClibRuntimeError, not Exception: a value that is
+    # not a valid signature is False, and so is a verification that
+    # failed. A value of a type this function does not declare is
+    # neither, and reaches the caller: the classes that say so are
+    # TypeErrors -- `_assert_valid_hf` for an hf passed as sha256()
+    # instead of sha256, `to_pub_key` for what is no spelling of a key --
+    # and no TypeError is in the tuple below, so none of them has to be
+    # refused ahead of the try to get out.
+    #
+    # The line is the annotation, and not which built-in a helper happens
+    # to derive from: those two coincide only by accident, which is what
+    # issue #745 found, and issue #814 is where the annotation was chosen
+    # over the accident. CONTRIBUTING.md's "Every public function
+    # validates its inputs" states the rule for the library.
+    #
     # BTClibRuntimeError by name and not RuntimeError, because
     # RecursionError is one and is not an answer about a signature
     try:

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -116,12 +116,8 @@ def verify(
     r: int, v: int, commitment: Point, ec: Curve = secp256k1, hf: HashF = sha256
 ) -> bool:
     """Open the commitment and return True if valid."""
-    # ValueError and BTClibRuntimeError, not Exception: an input that is not
-    # a valid signature is False, and so is a verification that failed, but
-    # a TypeError is neither -- an hf passed as sha256() instead of sha256
-    # is a caller error: raise, rather than report an invalid signature.
-    # BTClibRuntimeError by name and not RuntimeError, because
-    # RecursionError is one and is not an answer about a signature
+    # ValueError and BTClibRuntimeError, as `ecc.dsa.verify_` catches them
+    # and for its reasons, which it states
     try:
         assert_as_valid(r, v, commitment, ec, hf)
     except (ValueError, BTClibRuntimeError):

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -250,7 +250,11 @@ def point_from_bip340pub_key(x_Q: BIP340PubKey, ec: Curve = secp256k1) -> Point:
         return x_Q, _y_even(x_Q, ec)
 
     # (tuple) Point, (dict or str) BIP32Key, or 33/65 bytes
-    with contextlib.suppress(BTClibValueError):
+    # both classes, this being a guess at the spelling: a type no public
+    # key has may still be a BIP340 one -- an int is, and is a private
+    # key to `to_pub_key` -- so the refusal that names BIP340 is the one
+    # at the end
+    with contextlib.suppress(BTClibTypeError, BTClibValueError):
         x_Q = point_from_pub_key(x_Q, ec)[0]
         return x_Q, _y_even(x_Q, ec)
     # BIP340 key as bytes or hex-string

--- a/btclib/to_pub_key.py
+++ b/btclib/to_pub_key.py
@@ -19,7 +19,7 @@ from btclib.curves import (
     secp256k1,
 )
 from btclib.curves.sec_point import _sec_from_octets
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.hashes import hash160
 from btclib.network import (
     curve_from_xkeyversion,
@@ -50,6 +50,46 @@ PubKey = bytes | str | BIP32KeyData | Point
 # usable wherever a PubKey is logically expected
 Key = int | bytes | str | BIP32KeyData | Point
 
+# the two unions at run time, with the buffers bytes_from_octets accepts
+# beside bytes. An int is in one and not the other on purpose: in this
+# library an int is a private key, and never a public one
+_PUB_KEY_TYPES = (bytes, bytearray, memoryview, str, BIP32KeyData, tuple)
+_KEY_TYPES = (int, *_PUB_KEY_TYPES)
+
+
+def _assert_pub_key_type(pub_key: PubKey) -> None:
+    """Refuse a type no spelling of a public key has.
+
+    Asked at the top of a converter, and not inferred from whichever
+    spelling failed last, which is what these two used to do: every
+    refusal was a BTClibValueError, so "this key is not on the curve"
+    and "this is not a key at all" arrived as one class.
+
+    The difference is what a boolean verification reads, and issue #814
+    is where it is stated: `dsa.verify` answers False about a value of a
+    declared type and refuses a type it does not declare, exactly as
+    `script_pub_key.is_p2sh` does. The union is closed, so the question
+    has an answer here; `ssa.point_from_bip340pub_key` ends in this same
+    refusal for the same reason.
+
+    Never echo the input: it may be private material passed by mistake,
+    which is the very confusion issue #143 is about -- an int is a
+    private key here, so it is refused as a type rather than reported as
+    a public key that does not verify.
+    """
+    if not isinstance(pub_key, _PUB_KEY_TYPES):
+        raise BTClibTypeError("not a public key")
+
+
+def _assert_key_type(key: Key) -> None:
+    """Refuse a type no spelling of a key has, private or public.
+
+    `_assert_pub_key_type`'s wider twin, for the converters that take
+    either: an int is a private key, and the two lists differ by it.
+    """
+    if not isinstance(key, _KEY_TYPES):
+        raise BTClibTypeError("not a private or public key")
+
 
 def _point_from_xpub(xpub: BIP32Key, ec: Curve) -> Point:
     """Return an elliptic curve point tuple from a xpub key."""
@@ -74,6 +114,8 @@ def point_from_key(key: Key, ec: Curve = secp256k1) -> Point:
     - SEC Octets (bytes or hex-string, with 02, 03, or 04 prefix)
     - native tuple
     """
+    _assert_key_type(key)
+
     if isinstance(key, tuple):
         return point_from_pub_key(key, ec)
     if isinstance(key, int):
@@ -93,6 +135,8 @@ def point_from_key(key: Key, ec: Curve = secp256k1) -> Point:
 
 def point_from_pub_key(pub_key: PubKey, ec: Curve = secp256k1) -> Point:
     """Return an elliptic curve point tuple from a public key."""
+    _assert_pub_key_type(pub_key)
+
     if isinstance(pub_key, tuple):
         if ec.is_on_curve(pub_key) and pub_key[1] != 0:
             return pub_key[0], pub_key[1]
@@ -152,6 +196,8 @@ def pub_keyinfo_from_key(
     key: Key, network: str | None = None, compressed: bool | None = None
 ) -> PubkeyInfo:
     """Return the pub key tuple (SEC-bytes, network) from a pub/prv key."""
+    _assert_key_type(key)
+
     if isinstance(key, tuple):
         return pub_keyinfo_from_pub_key(key, network, compressed)
     if isinstance(key, int):
@@ -182,6 +228,8 @@ def pub_keyinfo_from_pub_key(
     pub_key: PubKey, network: str | None = None, compressed: bool | None = None
 ) -> PubkeyInfo:
     """Return the pub key tuple (SEC-bytes, network) from a public key."""
+    _assert_pub_key_type(pub_key)
+
     compr = True if compressed is None else compressed
     net = "mainnet" if network is None else network
     ec = network_from_name(net).curve

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -462,24 +462,40 @@ def test_prv_key_is_not_a_pub_key() -> None:
     # which converts the key on its own
     sig_sha1 = dsa.sign(msg, prv_key_int, hf=sha1)
 
+    # the spellings a PubKey declares -- a str, a BIP32KeyData -- which
+    # carry a private key and are refused for what they hold. No
+    # `type: ignore` on these: they type check, which is the whole of
+    # what makes False the right answer for them
     for prv_key in (
-        prv_key_int,
         prv_key_hexstring,
         wif_compressed_string,
         wif_uncompressed_string,
         xprv_string,
         xprv_data,
     ):
-        assert not dsa.verify(msg, prv_key, sig)  # type: ignore[arg-type]
-        assert not dsa.verify(msg, prv_key, sig_sha1, hf=sha1)  # type: ignore[arg-type]
+        assert not dsa.verify(msg, prv_key, sig)
+        assert not dsa.verify(msg, prv_key, sig_sha1, hf=sha1)
         with pytest.raises(BTClibValueError, match="not a public key"):
-            dsa.assert_as_valid(msg, prv_key, sig)  # type: ignore[arg-type]
+            dsa.assert_as_valid(msg, prv_key, sig)
         with pytest.raises(BTClibValueError, match="not a public key"):
-            dsa.assert_as_valid(msg, prv_key, sig_sha1, hf=sha1)  # type: ignore[arg-type]
+            dsa.assert_as_valid(msg, prv_key, sig_sha1, hf=sha1)
         # neither the rejection nor its message may echo the secret
-        with pytest.raises(BTClibValueError) as excinfo:
-            dsa.assert_as_valid(msg, prv_key, sig)  # type: ignore[arg-type]
-        assert str(prv_key) not in str(excinfo.value)
+        with pytest.raises(BTClibValueError) as refusal:
+            dsa.assert_as_valid(msg, prv_key, sig)
+        assert str(prv_key) not in str(refusal.value)
+
+    # and the int, which a PubKey does not declare at all: refused as a
+    # type rather than answered False, which is issue #814's rule and the
+    # stronger half of this issue's. Somebody passing an int here meant a
+    # private key, where False reads as a signature that did not verify.
+    # `verify` refuses it as `assert_as_valid` does, a TypeError being
+    # outside the `except` that turns a refusal into False -- and the
+    # `type: ignore` these two need, where the five above need none, is
+    # the line this rule draws, written out by the type checker
+    for call in (dsa.verify, dsa.assert_as_valid):
+        with pytest.raises(BTClibTypeError, match="not a public key") as wrong_type:
+            call(msg, prv_key_int, sig)  # type: ignore[arg-type]
+        assert str(prv_key_int) not in str(wrong_type.value)
 
     # the very same key, in its public representations, still verifies
     for pub_key in (

--- a/tests/input_validation_test.py
+++ b/tests/input_validation_test.py
@@ -43,18 +43,24 @@ a valid instance the vocabulary cannot build. That is the part of issue
 what the walk does find, so a narrowing of it fails here rather than
 quietly running over less.
 
-## The three lists, and which way each ratchets
+## The two lists, and which way each ratchets
 
 - `_MALFORMED` is the vocabulary, and every name in it is a type this
   tree still declares: a rename would otherwise shrink the walk in
   silence, which `test_the_vocabulary_is_the_libraries_input_types` is
   against.
 - `_EXCLUDED` is what must not be held to the rule this way, with the
-  reason. What is in it is a family whose own comment states the design.
-- `_OPEN` is what issue #744's census left, each entry naming the class
-  that escapes. It can only shrink: `test_what_is_open_is_still_open`
-  fails on an entry that has become compliant, as RUF100 fails an unused
-  `noqa`, so a fix cannot land without deleting its line.
+  reason. What is in it is two families, each stating its own design,
+  and it ratchets the way `_OPEN` used to:
+  `test_what_is_excluded_still_needs_to_be` fails on an entry that has
+  become compliant, as RUF100 fails an unused `noqa`, so a line cannot
+  outlive the reason for it.
+
+There was a third, `_OPEN`, holding what issue #744's census left. It
+is empty and therefore gone: every function the walk drives now either
+holds the rule or is in `_EXCLUDED` with a reason. What the walk finds
+next is a red test above, to be fixed or to be excluded with a reason of
+its own -- a backlog is not a place a new finding goes to wait.
 """
 
 from __future__ import annotations
@@ -76,7 +82,7 @@ _LIBRARY = Path(__file__).parents[1] / "btclib"
 # and the tuples are read round-robin so that a function taking three
 # parameters of one type is called with three different wrong values.
 # Constants and not a strategy: what this gate reports has to be the same
-# on two runs, `_OPEN` below being read as a statement about the tree
+# on two runs, `_EXCLUDED` below being read as a statement about the tree
 _MALFORMED: dict[str, tuple[Any, ...]] = {
     "BIP32Key": (None, 1.5, "not an xkey"),
     "BinaryData": ("not hex at all", None, 1.5),
@@ -103,7 +109,22 @@ _A_PREDICATE_ANSWERS_FALSE = (
     " in script_pub_key._is_funct, which catches ValueError alone"
 )
 
+# the other family, and the same sentence one layer up: a verification
+# answers "does this proof hold", so a pub key of a declared type that
+# is no point is False, exactly as bytes that are no p2sh script are. A
+# wrong *type* does raise, `to_pub_key` refusing what is no spelling of
+# a key, which is the half of it the rule reaches. `dleq.verify_proof`
+# is the one of the family the walk can drive: the others take a
+# `Sig | Octets` the vocabulary has no wrong value for
+_A_VERIFICATION_ANSWERS_FALSE = (
+    "a boolean verification is total over the types it declares, so a pub"
+    " key that is no point is False: CONTRIBUTING.md's 'Every public"
+    " function validates its inputs' states the rule, ecc.dsa.verify_ the"
+    " reason, and issue #814 is where it was decided"
+)
+
 _EXCLUDED: dict[str, str] = {
+    "btclib.ecc.dleq.verify_proof": _A_VERIFICATION_ANSWERS_FALSE,
     "btclib.script.script_pub_key.is_nulldata": _A_PREDICATE_ANSWERS_FALSE,
     "btclib.script.script_pub_key.is_p2ms": _A_PREDICATE_ANSWERS_FALSE,
     "btclib.script.script_pub_key.is_p2pk": _A_PREDICATE_ANSWERS_FALSE,
@@ -113,23 +134,6 @@ _EXCLUDED: dict[str, str] = {
     "btclib.script.script_pub_key.is_p2wpkh": _A_PREDICATE_ANSWERS_FALSE,
     "btclib.script.script_pub_key.is_p2wsh": _A_PREDICATE_ANSWERS_FALSE,
     "btclib.script.script_pub_key.is_segwit": _A_PREDICATE_ANSWERS_FALSE,
-}
-
-# what issue #744's census left, by the class that escapes. Deleting a
-# line is how a fix lands, the test below failing on an entry that has
-# stopped leaking, so this cannot go stale in either direction.
-#
-# The one left is not a coercion trusting its annotation, which is what
-# the rest of the list was: what answers False is `to_pub_key`'s refusal
-# of anything that is not a public key, which is a BTClibValueError
-# whatever was wrong with it, and folding the type in is what keeps a
-# boolean verification total. Issue #745 is where that was settled --
-# `dsa.verify_` answers False for a private key passed as a public one,
-# which is issue #143 and a test -- so making this one raise reverses
-# that decision rather than closing a hole, and the entry stays here
-# until it is taken
-_OPEN: dict[str, str] = {
-    "btclib.ecc.dleq.verify_proof": "no exception",
 }
 
 
@@ -204,7 +208,7 @@ def _leak(dotted: str) -> str | None:
     return None
 
 
-_GATED = sorted(set(_DRIVABLE) - _EXCLUDED.keys() - _OPEN.keys())
+_GATED = sorted(set(_DRIVABLE) - _EXCLUDED.keys())
 
 
 @pytest.mark.parametrize("dotted", _GATED)
@@ -214,17 +218,17 @@ def test_a_malformed_argument_leaves_as_a_btclib_exception(dotted: str) -> None:
     assert leak is None, f"{dotted} answers a malformed argument with {leak}"
 
 
-@pytest.mark.parametrize("dotted", sorted(_OPEN))
-def test_what_is_open_is_still_open(dotted: str) -> None:
-    """A fix cannot land without deleting its line from `_OPEN`.
+@pytest.mark.parametrize("dotted", sorted(_EXCLUDED))
+def test_what_is_excluded_still_needs_to_be(dotted: str) -> None:
+    """A line of `_EXCLUDED` cannot outlive the reason for it.
 
-    The ratchet, and the reason the list is in the tree rather than in a
-    report: an entry that has become compliant fails here, so what is
-    left cannot drift the way a census read by hand did.
+    The ratchet `_OPEN` used to carry, aimed at the list that is left:
+    an entry whose function has started refusing what its reason says it
+    answers is an exemption nothing needs any more, and it fails here
+    rather than quietly keeping a function out of the walk.
     """
-    assert _leak(dotted) == _OPEN[dotted], (
-        f"{dotted} no longer answers with {_OPEN[dotted]}: delete its line"
-        " from _OPEN, or correct it to what it answers with now"
+    assert _leak(dotted) is not None, (
+        f"{dotted} now holds the rule: delete its line from _EXCLUDED"
     )
 
 
@@ -330,9 +334,7 @@ def test_the_walk_reaches_what_it_claims() -> None:
     assert "btclib.psbt.psbt.finalize" not in _DRIVABLE
 
 
-def test_every_driven_function_is_gated_excluded_or_open() -> None:
+def test_every_driven_function_is_gated_or_excluded() -> None:
     """No function leaves the run without a line saying why."""
-    assert not _EXCLUDED.keys() & _OPEN.keys()
     assert _EXCLUDED.keys() <= set(_DRIVABLE)
-    assert _OPEN.keys() <= set(_DRIVABLE)
-    assert set(_GATED) | _EXCLUDED.keys() | _OPEN.keys() == set(_DRIVABLE)
+    assert set(_GATED) | _EXCLUDED.keys() == set(_DRIVABLE)

--- a/tests/to_pub_key_test.py
+++ b/tests/to_pub_key_test.py
@@ -12,7 +12,7 @@ from btclib.alias import INF, Point
 from btclib.bip32 import BIP32KeyData, derive, rootxprv_from_seed
 from btclib.curves import bytes_from_point
 from btclib.curves.curve import CURVES
-from btclib.exceptions import BTClibValueError
+from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.to_pub_key import (
     Key,
     PubkeyInfo,
@@ -191,12 +191,37 @@ def _check_refused(api: Conversions, keys: Sequence[Key]) -> None:
     assertion is the same one either way, every refusal here being a
     BTClibValueError, so the two calls name the two vocabularies rather
     than expect two answers.
+
+    Every key here is of a type the union declares. What is not is
+    `_check_refused_as_a_type`'s, and the two are separate because the
+    difference is a promise rather than a detail.
     """
     point_from, keyinfo_from = api
     for key in keys:
         with pytest.raises(BTClibValueError):
             point_from(key)
         with pytest.raises(BTClibValueError):
+            keyinfo_from(key)
+
+
+def _check_refused_as_a_type(api: Conversions, keys: Sequence[Key]) -> None:
+    """Check the refusal of a type no spelling of a public key has.
+
+    The other half of `_check_refused`, and the difference is issue
+    #814's rule: a value of a declared type that is no key is a
+    BTClibValueError, a type the union does not declare is a
+    BTClibTypeError. That is what lets `dsa.verify` answer False for the
+    first and refuse the second, being total over what it declares.
+
+    An int is the one that matters: in this library an int is a private
+    key and never a public one, so passing one here is the very
+    confusion issue #143 is about.
+    """
+    point_from, keyinfo_from = api
+    for key in keys:
+        with pytest.raises(BTClibTypeError, match="not a public key"):
+            point_from(key)
+        with pytest.raises(BTClibTypeError, match="not a public key"):
             keyinfo_from(key)
 
 
@@ -215,9 +240,6 @@ def test_from_pub_key() -> None:
             INF,
             INF_xpub_data,
             *not_a_pub_keys,
-            q,
-            q0,
-            qn,
             *plain_prv_keys,
             xprv_data,
             xprv0_data,
@@ -226,6 +248,9 @@ def test_from_pub_key() -> None:
             *uncompressed_prv_keys,
         ],
     )
+    # the three int spellings of a private key, which `test_from_key`
+    # below accepts and this must not: an int is no PubKey at all
+    _check_refused_as_a_type(api, [q, q0, qn])
 
 
 def test_from_key() -> None:


### PR DESCRIPTION
Implements §1 of https://github.com/btclib-org/btclib/issues/814, and
reverses the position https://github.com/btclib-org/btclib/issues/745
settled on. §7 of that issue — the `check_*` rename — is deliberately
left out: it is a source-breaking rename where this is a semantics
change, and reviewing them together would hide one in the other.

## The rule

> A function that answers a `bool` is total over the types it declares,
> and only those. A value of a declared type that is not valid is
> `False`; a value of a type the signature does not declare is the
> caller's own mistake and leaves as a `BTClibTypeError`.

`script_pub_key.is_p2sh` already drew that line — bytes that are not a
p2sh script are `False`, a float raises — and it is written down in
`tests/input_validation_test.py` as the reason those nine predicates are
`_EXCLUDED`. The boolean verifications beside them did not.

## Why the annotation and not totality

- It makes the `hf` carve-out #745 needed an **instance** of a rule
  instead of an exception to one: a value outside `HashF` raises because
  it is an undeclared type, exactly as a float passed as a key does.
- The argument that carried #745 — "the shape that does not break a
  caller filtering a list of signatures" — is untouched. A caller
  filtering a list holds bytes off the wire, and `bytes` is declared.
- The line becomes something *stated*. #745 was right that "`TypeError`
  raises, `ValueError` is returned" coincide only by accident; the
  annotation is the line it had no better candidate for.

## What actually had to change

Measured by driving every boolean verification with an undeclared type
in each parameter position, **fifteen of eighteen already followed the
rule**: every `Octets` parameter, every signature, `pedersen`'s scalars,
`merkle_proof`'s index, the two engine adapters, `ssa`'s `BIP340PubKey`,
and `bms`'s and `bip322`'s address all raise for a type.

One converter was the whole of the gap. `to_pub_key` flattened every
refusal into `BTClibValueError("not a public key")`, so "this key is not
on the curve" and "this is not a key at all" arrived as one class, and
`dsa.verify`, `dsa.verify_` and `dleq.verify_proof` answered `False` to
both. `_assert_pub_key_type` and `_assert_key_type` ask the question at
the top of the four converters — the unions are closed, which is what
`ssa.point_from_bip340pub_key` already relied on.

Before → after, same probe:

```console
dsa.verify_(h, KEY, sig)      answers False  ->  RAISES
dsa.verify(m, KEY, sig)       answers False  ->  RAISES
dleq.verify_proof(A, ...)     answers False  ->  RAISES
everything else                     RAISES   ->  RAISES
```

## The cost, and issue #143

An int is in `_KEY_TYPES` and not in `_PUB_KEY_TYPES` on purpose: in this
library an int is a private key and never a public one. So
`dsa.verify(msg, 12, sig)` is refused where it was `False` — which is
https://github.com/btclib-org/btclib/issues/143 answered more loudly
than it asked, since somebody passing an int meant a private key, where
`False` reads as a signature that did not verify.

Its other five spellings are a `str` or a `BIP32KeyData`, are inside
`PubKey`, and still answer `False`. They also **lost their
`# type: ignore[arg-type]`**, where the int still needs one: that is this
rule written out by the type checker, and it is now visible in the test.

## Two things put right on the way

- `ecc/pedersen.py`, `ecc/borromean.py` and `ecc/dleq.py` were still
  carrying the paragraph #745 declared wrong, word for word. All five
  now point at `ecc.dsa.verify_`, which carries the reason, and
  CONTRIBUTING.md states the rule beside "Every public function
  validates its inputs" — the "one fact in one place" half of #745 that
  was never carried out.
- `tests/input_validation_test.py` loses `_OPEN`, which is empty:
  https://github.com/btclib-org/btclib/issues/776 left one entry,
  `dleq.verify_proof`, and it is an `_EXCLUDED` entry now under the
  family reason. `_EXCLUDED` gains the ratchet `_OPEN` had —
  `test_what_is_excluded_still_needs_to_be` fails on a line that has
  outlived its reason, which nothing checked before.

## Gates

- `uv run pytest` — 26741 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Define and enforce a rule that boolean-returning verifications are total over their declared input types and raise for undeclared types, updating key-conversion helpers, verifiers, tests, and documentation accordingly.

New Features:
- Document and adopt a library-wide rule that boolean-returning functions answer about values of declared types and raise for undeclared types.

Bug Fixes:
- Ensure `dsa.verify` and `ecc.dleq.verify_proof` raise type errors for non-public-key inputs instead of silently returning False, addressing confusion around ints as private keys (issue #143).

Enhancements:
- Tighten `to_pub_key` converters to distinguish invalid key values from unsupported input types via dedicated type checks.
- Unify boolean verification error-handling semantics across ECC modules by pointing to `ecc.dsa.verify_` as the single authoritative description.
- Clarify and strengthen the input-validation gate by removing the empty `_OPEN` backlog and making `_EXCLUDED` self-ratcheting with explicit family reasons.

Documentation:
- Update CONTRIBUTING.md, CHANGELOG.md, and HISTORY.md to describe the boolean-totality rule and the resulting behavioral changes for verifications and key converters.

Tests:
- Extend and adjust tests for key-conversion and DSA verification to cover new type vs value error behaviors and the updated input-validation ratchet.