### PR TITLE
Add a benchmark for pure-Python arithmetic vs libsecp256k1 bindings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -494,13 +494,15 @@ repos:
   # dispatch is the only thing that runs it, and strict mode is the whole of
   # what reads it in between. A bound method used as a truth value is what
   # that buys -- in a script of checks, a check that cannot fail.
-  # scripts/ joins it for the same reason: nothing collects
-  # benchmark_libraries.py either, a manual run being the whole of what
-  # exercises it. It imports five untyped third-party packages the `bench`
-  # group installs and this command's `--group lint --group test` does
-  # not, so pyproject.toml's [[tool.mypy.overrides]] declares
-  # ignore_missing_imports for exactly those five -- unresolved either way,
-  # with or without the group, so the group is not what this command needs
+  # scripts/ joins it for the same reason: no test collects either script
+  # there, a manual run being the whole of what exercises benchmark.py and
+  # benchmark_libraries.py alike. The latter imports five untyped
+  # third-party packages the `bench` group installs and this command's
+  # `--group lint --group test` does not, so pyproject.toml's
+  # [[tool.mypy.overrides]] declares ignore_missing_imports for exactly
+  # those five -- unresolved either way, with or without the group, so the
+  # group is not what this command needs. The former has no third-party
+  # dependency to begin with, so nothing there needs that override
   - repo: local
     hooks:
       - id: mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,10 @@ ignore = [
     "tests/generate_sbom_test.py",
     "tests/mutation_counts_test.py",
     "tests/verify_dist_contents_test.py",
+    # a developer's own tool, run by hand against a checkout rather than
+    # against an install: it needs no third-party dependency, but it is no
+    # more part of the distributed package than the website above is
+    "scripts/**",
 ]
 
 [tool.pytest.ini_options]
@@ -770,6 +774,12 @@ ignore = [
     "S101", # assert
     "T201", # print
 ]
+# the pure-Python-vs-bindings benchmark: T201, whose whole output is the
+# timings a developer ran it to see, print being the only interface a
+# script run by hand has; and S101, each assert there being the guard
+# against timing a call that silently stopped agreeing with the other
+# implementation, the one thing a benchmark cannot afford to do quietly
+"scripts/benchmark.py" = ["T201", "S101"]
 # the D rules are not here: a public test function, fixture or method
 # states what it verifies -- the property, the vector, the failure
 # mode -- under the same docstring gate as the library's public

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,163 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Timings of btclib's own two arithmetic paths, side by side.
+
+btclib delegates secp256k1 point operations to the btclib_secp256k1
+bindings -- curves.curve.mult and ecc.dsa.sign_/ecc.ssa.sign_ for
+secp256k1 with sha256 -- and falls back to the pure Python arithmetic of
+curves/curve_group.py for every other curve, a zero scalar, the point at
+infinity, and everything else the bindings decline. This times point
+multiplication and ECDSA/BIP340 sign and verify through both paths, on
+one fixed key and message.
+
+The point is not a number to quote: the two paths answer the same
+equations, one in C and one in Python, and what this shows is an order
+of magnitude, the same one curve.py's own docstrings already measure in
+passing next to the code they describe. Nothing here repeats a
+measurement or discards an outlier.
+
+The pure Python side is reached by turning btclib's own dispatch off,
+which `python_arithmetic_only` below does and says why: every one of the
+timed functions asks `_libsecp256k1_applicable` first and would
+otherwise answer from the bindings, the very path the other half of this
+script already timed.
+
+Not part of the test suite and not run by CI: nothing here is a
+correctness check, and `tests/script_engine/python_path_test.py` already
+is one, over the vendored consensus vectors rather than a synthetic
+message. No third-party dependency either -- btclib_secp256k1 is already
+a dependency of btclib itself.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import Any, cast
+
+from btclib.curves import curve
+from btclib.ecc import dsa, ssa
+from btclib.hashes import reduce_to_hlen
+from btclib.to_pub_key import pub_keyinfo_from_prv_key
+
+prvkey = 1
+pubkey = pub_keyinfo_from_prv_key(prvkey)[0]
+xonly_pubkey = pubkey[1:]
+msg_hash = reduce_to_hlen(b"Satoshi Nakamoto")
+scalar = 12345
+
+# both signed while the bindings are still the default, and
+# deterministically: grind=False takes dsa.sign_'s plain RFC6979 nonce
+# with no low-r search, and a fixed aux replaces ssa.sign_'s random
+# default, so the pure Python path below can be checked against the very
+# same signature instead of a fresh, unrelated one
+dsa_sig = dsa.sign_(msg_hash, prvkey, grind=False)
+ssa_sig = ssa.sign_(msg_hash, prvkey, aux=bytes(32))
+
+
+def python_arithmetic_only() -> None:
+    """Turn btclib's libsecp256k1 dispatch off, in every namespace.
+
+    `_libsecp256k1_applicable` is imported by name into `ecc.dsa`,
+    `ecc.ssa` and `curves.curve`: patching one leaves the other two
+    delegating, so a partial patch would still measure C in a row meant
+    to measure Python -- dsa's and ssa's own verification calls into
+    curve's double multiplication underneath whichever implementation
+    answers the boundary check first.
+
+    Called once, after the fixtures above are signed: they go through
+    the bindings too, and there is no reason to slow those down.
+
+    Cast to Any rather than assigned directly: mypy sees the loop
+    variable as a plain module, none of the three concrete modules in
+    particular, and a plain module has no `_libsecp256k1_applicable` of
+    its own to assign.
+    """
+    for module in (dsa, ssa, curve):
+        cast(Any, module)._libsecp256k1_applicable = lambda *_: False
+
+
+def mult_bindings() -> None:
+    """Time point multiplication through the libsecp256k1 bindings."""
+    curve.mult(scalar)
+
+
+def mult_python() -> None:
+    """Time point multiplication through the pure Python arithmetic."""
+    curve.mult(scalar)
+
+
+def dsa_sign_bindings() -> None:
+    """Time ECDSA signing through the libsecp256k1 bindings."""
+    assert dsa.sign_(msg_hash, prvkey, grind=False) == dsa_sig
+
+
+def dsa_sign_python() -> None:
+    """Time ECDSA signing through btclib's pure Python arithmetic."""
+    assert dsa.sign_(msg_hash, prvkey, grind=False) == dsa_sig
+
+
+def dsa_verify_bindings() -> None:
+    """Time ECDSA verification through the libsecp256k1 bindings."""
+    assert dsa.verify_(msg_hash, pubkey, dsa_sig)
+
+
+def dsa_verify_python() -> None:
+    """Time ECDSA verification through btclib's pure Python arithmetic."""
+    assert dsa.verify_(msg_hash, pubkey, dsa_sig)
+
+
+def ssa_sign_bindings() -> None:
+    """Time BIP340 signing through the libsecp256k1 bindings."""
+    assert ssa.sign_(msg_hash, prvkey, aux=bytes(32)) == ssa_sig
+
+
+def ssa_sign_python() -> None:
+    """Time BIP340 signing through btclib's pure Python arithmetic."""
+    assert ssa.sign_(msg_hash, prvkey, aux=bytes(32)) == ssa_sig
+
+
+def ssa_verify_bindings() -> None:
+    """Time BIP340 verification through the libsecp256k1 bindings."""
+    assert ssa.verify_(msg_hash, xonly_pubkey, ssa_sig)
+
+
+def ssa_verify_python() -> None:
+    """Time BIP340 verification through btclib's pure Python arithmetic."""
+    assert ssa.verify_(msg_hash, xonly_pubkey, ssa_sig)
+
+
+def benchmark(func: Callable[[], None], mult: int = 1) -> None:
+    """Call `func` 1000 * `mult` times and print the seconds per 1000.
+
+    `mult` is per function rather than shared: the pure Python path
+    measured here is slower than the bindings by more than one order of
+    magnitude, so one loop count for both would either take too long on
+    the Python side or measure the bindings against the resolution of
+    the clock.
+    """
+    # perf_counter and not time(): the wall clock can step backwards
+    # under an NTP correction, and a benchmark is the one place that
+    # shows up as a negative duration
+    start = time.perf_counter()
+    for _ in range(1000 * mult):
+        func()
+    end = time.perf_counter()
+    print(f"{func.__name__:<19}: {((end - start) / mult):.6f}")
+
+
+benchmark(mult_bindings, 100)
+benchmark(dsa_sign_bindings, 100)
+benchmark(dsa_verify_bindings, 100)
+benchmark(ssa_sign_bindings, 100)
+benchmark(ssa_verify_bindings, 100)
+
+python_arithmetic_only()
+
+benchmark(mult_python, 1)
+benchmark(dsa_sign_python, 1)
+benchmark(dsa_verify_python, 1)
+benchmark(ssa_sign_python, 1)
+benchmark(ssa_verify_python, 1)


### PR DESCRIPTION
## Summary

- Adds `scripts/benchmark.py`, timing point multiplication and ECDSA/BIP340
  sign and verify through both of btclib's own paths -- the libsecp256k1
  bindings and the pure-Python fallback -- on one fixed key and message.
- The pure-Python side is reached by turning `_libsecp256k1_applicable`
  off in `ecc.dsa`, `ecc.ssa` and `curves.curve`, the same monkeypatch
  `btclib-secp256k1`'s own `scripts/benchmark.py` already uses.
- Each timed function asserts its result agrees with a signature or
  verification produced once up front, so a divergence between the two
  paths fails loudly instead of being timed silently.
- Not gated, not part of the pytest suite, no new dependency:
  `btclib_secp256k1` is already a dependency of btclib itself.
- `scripts/` is excluded from the sdist (`[tool.check-manifest]`) and
  brought into the mypy hook's scope, alongside `.github/scripts`.

Closes https://github.com/btclib-org/btclib/issues/816

## Test plan

- [x] `uv run pre-commit run --all-files` (every hook passes)
- [x] `uv run pytest` (26732 passed, 100.00% coverage)
- [x] `uv run --locked --no-default-groups --group docs sphinx-build -W
      --keep-going -b html docs/source docs/build/html` (build succeeded)
- [x] `uv run python scripts/benchmark.py` runs and prints ten timings,
      bindings and pure-Python side by side

## Summary by Sourcery

Add a standalone benchmark script to compare btclib's libsecp256k1 bindings against the pure-Python arithmetic path for core secp256k1 operations, and wire scripts into existing tooling without affecting distributed artifacts or tests.

New Features:
- Introduce a scripts/benchmark.py tool to measure performance of point multiplication and ECDSA/BIP340 sign/verify across libsecp256k1 bindings and the pure-Python fallback.

Enhancements:
- Include the scripts directory in the strict mypy pre-commit hook to type-check developer scripts alongside library and test code.
- Exclude scripts/ from the source distribution and configure per-file static-analysis rule exemptions for the benchmark script to allow printing and asserts appropriate for a hand-run tool.

CI:
- Adjust pre-commit mypy configuration comments and scope to cover both .github/scripts and scripts directories.