### PR TITLE
Move the HWI emulator jobs off pull_request entirely

### DIFF
--- a/.github/actions/install-bitcoind/action.yml
+++ b/.github/actions/install-bitcoind/action.yml
@@ -1,11 +1,11 @@
 ---
-# The two jobs of integration.yml both need a node, and a checksum
-# duplicated is a checksum that drifts: the one that is raised is the one
-# somebody was reading, and the other stays on the release before it
-# while its job keeps reporting green. A composite action is the only
-# thing GitHub Actions offers to say this once -- there are no yaml
-# anchors across jobs -- so the download, the verification and the
-# unpacking live here and the version is an input.
+# The three jobs of integration.yml and hwi-integration.yml all need a
+# node, and a checksum duplicated is a checksum that drifts: the one that
+# is raised is the one somebody was reading, and the other stays on the
+# release before it while its job keeps reporting green. A composite
+# action is the only thing GitHub Actions offers to say this once --
+# there are no yaml anchors across workflows -- so the download, the
+# verification and the unpacking live here and the version is an input.
 #
 # Referenced by path (`uses: ./.github/actions/install-bitcoind`) and not
 # by commit SHA, which is the rule for every third-party action: this one

--- a/.github/scripts/wait_for_hwi_device.py
+++ b/.github/scripts/wait_for_hwi_device.py
@@ -9,7 +9,7 @@ was started, and the two are seconds apart: Speculos has an app to load
 and a screen to draw before the first APDU is taken, and a test that
 asks in between reports no device rather than waiting. The trezor
 emulator answers a ping on its own socket, which is what
-`integration.yml` waits for there; Speculos has no such thing, so the
+`hwi-integration.yml` waits for there; Speculos has no such thing, so the
 question has to be the real one -- does `hwi enumerate` see a device
 that can be talked to.
 

--- a/.github/workflows/hwi-integration.yml
+++ b/.github/workflows/hwi-integration.yml
@@ -1,0 +1,537 @@
+---
+name: hwi-integration
+
+# The other half of `tests/integration/`'s HWI question, split out of
+# integration.yml rather than kept beside `Regtest against Bitcoin Core`
+# as a second job of it: a pinned Trezor emulator stands in for one
+# device, a pinned Ledger under Speculos for another, and a red run of
+# either is more often a firmware release, an unreachable data.trezor.io
+# or an app whose screens changed wording than it is this branch's fault
+# -- exactly the shape of check that gets ignored when it sits next to a
+# review, and that a `pull_request`-triggered workflow still lists as
+# skipped even when a job-level `if` keeps it from running. This file has
+# no `pull_request` trigger at all, so neither job appears on a pull
+# request's checks, running or skipped: the schedule asks the question
+# weekly, the push to main asks it of the commit a merge created, and the
+# dispatch button is how a branch touching btclib/hwi.py gets the answer
+# before it lands -- `gh workflow run hwi-integration.yml --ref <branch>`
+# runs that branch's copy of this file.
+#
+# Two vendors rather than one because HWI is two clients: the protobuf
+# one the Trezor speaks, and the app-2.x one behind a Ledger's wallet
+# policies and psbt exchange, and a green run of either says nothing
+# about the other. Neither gates: REPOSITORY.md's required-checks table
+# names only `Regtest against Bitcoin Core`, and an emulator is a service
+# to keep working rather than a claim about the branch. What checks the
+# HWI command line on every commit stays tests/hwi_test.py, whose
+# stand-in device is a subprocess answering HWI's own json.
+
+on:
+  schedule:
+    # the same slot integration.yml answers Friday's other half in --
+    # Fridays, 04:29 UTC, not on the hour for the reason given there
+    - cron: "29 4 * * 5"
+  push:
+    branches: [main]
+  workflow_call:
+  # the escape hatch, and how a branch is checked against a device before
+  # it lands
+  workflow_dispatch:
+
+# least privilege for the GITHUB_TOKEN: nothing here writes, and the
+# binaries and images are fetched from data.trezor.io, ghcr.io and
+# bitcoincore.org, none of which knows this token
+permissions:
+  contents: read
+
+# the node both jobs run, for the signing test each ends with: the
+# release under test, and the sha256 of its linux tarball as four
+# independent guix builders attested it in bitcoin-core/guix.sigs. Pinned
+# rather than resolved to "latest" for the reason integration.yml's own
+# copy gives; raising either is a commit, with the new sha read from the
+# same place
+env:
+  BITCOIND_VERSION: "31.1"
+  BITCOIND_SHA256: >-
+    b80d9c3e04da78fb6f0569685673418cf686fadba9042d926d13fb87ff503f9e
+
+# cancel superseded runs. Named literally rather than through
+# github.workflow, as everywhere else here: in a called workflow that
+# expression is the caller's name
+concurrency:
+  group: hwi-integration-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  hwi-emulator:
+    name: HWI against a Trezor emulator
+    runs-on: ubuntu-latest
+    # the tests are seconds; the emulator, HWI and the node are a few
+    # minutes of downloading and installing, and this bounds the failure
+    # cases -- an emulator that starts and never answers is the one that
+    # would otherwise hold a runner
+    timeout-minutes: 30
+    env:
+      # the emulator, and the sha256 of the binary trezor publishes.
+      # T2T1 is the Trezor Model T, whose emulator HWI's own test suite
+      # runs, and the version is a released firmware rather than a build
+      # of a branch: `common/releases.json` in trezor/trezor-firmware is
+      # what says which versions exist per model, and the binary of each
+      # is under emulators-new/<model>/ at the url below.
+      #
+      # 2.9.4 rather than the newest: from 2.12.2 the emulator links
+      # SDL3, which ubuntu's archive does not carry yet, and HWI's own
+      # CI builds core/v2.9.6 -- so this is the newest released firmware
+      # that is both installable here and inside the range upstream
+      # tests. Raising it is a commit, with the new sha read from the
+      # same url
+      TREZOR_MODEL: T2T1
+      TREZOR_VERSION: "2.9.4"
+      TREZOR_SHA256: >-
+        a286b20cd33f2fbff30cc46f16c756a25e7cbeaeab9714913746d6826b923c08
+      # the seed the emulator is loaded with: HWI's test suite uses it,
+      # trezor's device tests before it, and it is published in both. An
+      # emulator has no secure element and no owner, so this is a test
+      # fixture and not a key -- what it must never be is a mnemonic
+      # anybody generated for use
+      TREZOR_MNEMONIC: >-
+        alcohol woman abuse must during monitor noble actual mixed trade
+        anger aisle
+      # HWI declares ^3.9,<3.13 and is run as a program rather than
+      # imported (btclib/hwi.py says why, and issue #469 why there is no
+      # extra), so it gets an interpreter of its own here: uv fetches
+      # 3.12, and nothing about the environment the tests run in changes
+      HWI_VERSION: "3.2.0"
+      HWI_PYTHON: "3.12"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # see the checkout of the test-py job in test.yml
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+      # the signing test spends a regtest coin, so this job needs the
+      # node integration.yml's regtest job needs, from the same pin
+      - name: Install bitcoind
+        id: bitcoind
+        uses: ./.github/actions/install-bitcoind
+        with:
+          version: ${{ env.BITCOIND_VERSION }}
+          sha256: ${{ env.BITCOIND_SHA256 }}
+      # what the emulator is linked against, and patchelf to make it
+      # runnable at all: the published binary is built under nix, so its
+      # interpreter and its RUNPATH name /nix/store paths that exist on
+      # no ubuntu. libjpeg62 is the soname SDL2_image was built against
+      # and is not the libjpeg ubuntu installs by default; libusb is
+      # HWI's, which loads it by name at import for the transports this
+      # job does not use
+      - name: Install what the emulator needs
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends \
+            libjpeg62 libsdl2-2.0-0 libsdl2-image-2.0-0 libusb-1.0-0 \
+            patchelf
+      # the same shape as the node's download: pinned version, published
+      # checksum, https that cannot be redirected off https
+      - name: Install the Trezor emulator
+        run: |
+          base="https://data.trezor.io/dev/firmware/releases/emulators-new"
+          name="trezor-emu-core-$TREZOR_MODEL-v$TREZOR_VERSION"
+          curl --proto '=https' --proto-redir '=https' \
+            --fail --silent --show-error --location --retry 3 \
+            --output trezor-emulator "$base/$TREZOR_MODEL/$name"
+          echo "$TREZOR_SHA256  trezor-emulator" | sha256sum --check --strict
+          chmod +x trezor-emulator
+          # the loader ubuntu has, and no RUNPATH, so the libraries
+          # installed above are the ones found
+          patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 \
+            --remove-rpath trezor-emulator
+      # in an environment of its own, and named by path: BTCLIB_HWI is
+      # split on spaces, which is how the flags of a command reach it,
+      # and --emulators is what makes HWI look at 127.0.0.1:21324 at all.
+      # btclib passes that flag to `enumerate` itself, and to nothing
+      # else -- every other command is selected by fingerprint -- so it
+      # belongs here rather than in the test
+      - name: Install HWI
+        run: |
+          uv venv --python "$HWI_PYTHON" hwi-env
+          uv pip install --python hwi-env/bin/python "hwi==$HWI_VERSION"
+          echo "BTCLIB_HWI=$PWD/hwi-env/bin/hwi --emulators" >> "$GITHUB_ENV"
+          hwi-env/bin/hwi --version
+      # the emulator, then the seed, and both versions in the log: what a
+      # green run is evidence about is a firmware and an HWI, and neither
+      # is readable from this file six months later.
+      #
+      # The seed goes in over DebugLink, which is also how the button
+      # gets pressed: HWI opens a udp path with TrezorClientDebugLink
+      # rather than the ordinary client, and that one answers a
+      # ButtonRequest itself. That is what BTCLIB_HWI_SIGN guards
+      # against, and why it can be set here -- there is no screen and
+      # nobody in front of it.
+      #
+      # trezorlib comes from HWI's own vendored copy rather than from
+      # PyPI: it is the library that will talk to this emulator half a
+      # second later, so a protocol it accepts is one HWI accepts
+      - name: Start the emulator and load its seed
+        run: |
+          mkdir -p emulator-profile
+          TREZOR_PROFILE_DIR="$PWD/emulator-profile" SDL_VIDEODRIVER=dummy \
+            ./trezor-emulator > emulator.log 2>&1 &
+          echo "EMULATOR_PID=$!" >> "$GITHUB_ENV"
+          hwi-env/bin/python - <<'PY'
+          import os
+          import socket
+          import sys
+          import time
+
+          from hwilib.devices.trezorlib.debuglink import (
+              TrezorClientDebugLink,
+              load_device_by_mnemonic,
+          )
+          from hwilib.devices.trezorlib.transport.udp import UdpTransport
+
+          # the ping the firmware's own wait_for_emulator.py sends, and
+          # the answer that says the udp transport is up
+          deadline = time.monotonic() + 60
+          sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+          sock.connect(("127.0.0.1", 21324))
+          sock.settimeout(0.5)
+          while True:
+              try:
+                  sock.send(b"PINGPING")
+                  if sock.recv(8) == b"PONGPONG":
+                      break
+              # every failure before it is listening is the same one:
+              # nothing is bound to the port yet, so the datagram is
+              # refused or the answer times out
+              except OSError:
+                  pass
+              if time.monotonic() > deadline:
+                  sys.exit("::error::the emulator did not answer in 60 s")
+              time.sleep(0.1)
+
+          client = TrezorClientDebugLink(UdpTransport.enumerate()[0])
+          client.init_device()
+          features = client.features
+          version = ".".join(
+              str(part)
+              for part in (
+                  features.major_version,
+                  features.minor_version,
+                  features.patch_version,
+              )
+          )
+          revision = features.revision.hex() if features.revision else "none"
+          print(f"{features.model} firmware {version}, revision {revision}")
+          load_device_by_mnemonic(
+              client=client,
+              mnemonic=os.environ["TREZOR_MNEMONIC"],
+              pin="",
+              passphrase_protection=False,
+              label="btclib",
+          )
+          PY
+      # the module tests/README.md documents, with both switches set and
+      # the node from the step above. Only that module: the regtest tests
+      # beside it are integration.yml's, and running them again here
+      # would report a Core failure twice.
+      #
+      # -n0 because there is one device. pyproject.toml's addopts pass
+      # `-n auto`, which is right for everything else here and wrong for
+      # a signer: three workers are three HWI processes on one udp port,
+      # and the one that finds the emulator mid-exchange waits for an
+      # answer to somebody else's command until btclib's timeout ends it.
+      # Measured, and it is displayaddress that lost the race
+      - name: Run the HWI integration tests
+        env:
+          BTCLIB_INTEGRATION: "1"
+          BTCLIB_HWI_SIGN: "1"
+          BTCLIB_BITCOIND: ${{ steps.bitcoind.outputs.path }}
+        run: |
+          uv run --locked --no-default-groups --group test \
+            pytest tests/integration/hwi_device_test.py -n0 --junitxml=hwi.xml
+      # the same guard integration.yml's regtest job carries, for the
+      # same reason: every one of these tests skips itself when a switch
+      # is off or when enumerate answers something other than one usable
+      # device, so a job whose emulator stopped being seen would pass
+      # while asking HWI nothing
+      - name: Fail if the device tests did not run
+        run: |
+          uv run --locked --no-default-groups --group test python - <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          cases = ET.parse("hwi.xml").getroot().iter("testcase")
+          ran = [one for one in cases
+                 if "hwi_device" in one.get("classname", "")]
+          skipped = [one for one in ran if one.find("skipped") is not None]
+          for one in skipped:
+              reason = one.find("skipped").get("message", "")
+              print(f"::error::{one.get('name')} skipped: {reason}")
+          if not ran or skipped:
+              print(f"::error::{len(ran)} device tests, {len(skipped)} skipped")
+              sys.exit(1)
+          print(f"{len(ran)} device tests ran against the emulator")
+          PY
+      # before the upload, so the log is complete and the runner is not
+      # tearing down a process that still holds the file. Both guards
+      # matter: a step that failed before the emulator started leaves
+      # EMULATOR_PID unset, and `kill 0` -- what a default would spell --
+      # signals the whole process group, this shell included
+      - name: Stop the emulator
+        if: always()
+        run: |
+          if [ -n "${EMULATOR_PID:-}" ]; then
+            kill "$EMULATOR_PID" || true
+          fi
+      # the emulator's own log beside the report: a device that refused
+      # says so there and nowhere else, the psbt failure and the button
+      # that was never pressed looking alike from pytest
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hwi-emulator-report
+          path: |
+            hwi.xml
+            emulator.log
+          if-no-files-found: error
+          retention-days: 90
+
+  hwi-ledger:
+    name: HWI against a Ledger emulator
+    # the same reasons as the trezor job, and stronger here: this one
+    # compiles an app somebody else releases, in an image somebody else
+    # publishes, and confirms its screens by matching the text on them.
+    # None of that is a claim about the branch
+    runs-on: ubuntu-latest
+    # the docker pull and two app builds are the minutes; the tests
+    # themselves are the same seconds as the trezor job's
+    timeout-minutes: 45
+    env:
+      # the app, its builder image, and the emulator, each pinned.
+      #
+      # Two builds of one source tree, which is what a Ledger costs where
+      # a Trezor costs none: the coin is compiled in -- `COIN=bitcoin`
+      # gives "Bitcoin" with bech32 prefix `bc`, `COIN=bitcoin_testnet`
+      # gives "Bitcoin Test" with `tb` -- so one binary cannot answer the
+      # mainnet questions of `hwi_device_test.py` and its regtest spend
+      # both. The Trezor firmware takes the chain as an argument and does
+      # both from one image.
+      #
+      # No sha256 of an artifact to pin, either, the app being built here
+      # and not downloaded: what is pinned instead is the source tag, the
+      # builder image by digest -- the tag beside it is what that digest
+      # was -- and the SDK, which the image provides. HWI's own CI builds
+      # this same pair, and 2.5.0 with builder 5.3.17 is the combination
+      # it uses
+      LEDGER_APP_VERSION: "2.5.0"
+      LEDGER_APP_BUILDER: >-
+        ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder@sha256:036d9fd1a264a068ea20f2d0edc962ecdbf1bf5861ef75215924abd77f93bf29
+      # nanox, as HWI's suite runs the 2.x app on, and the model the
+      # speculos wheel carries a cx library for
+      SPECULOS_MODEL: nanox
+      # from PyPI, where it brings its own launcher and cx libraries and
+      # wants only qemu from the system. HWI still clones and cmakes it,
+      # pinned at 0.25.10 -- the last release supporting python 3.9,
+      # which is HWI's floor and not this repository's
+      SPECULOS_VERSION: "0.26.10"
+      HWI_VERSION: "3.2.0"
+      HWI_PYTHON: "3.12"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+      - name: Install bitcoind
+        id: bitcoind
+        uses: ./.github/actions/install-bitcoind
+        with:
+          version: ${{ env.BITCOIND_VERSION }}
+          sha256: ${{ env.BITCOIND_SHA256 }}
+      # speculos runs an ARM binary through qemu's user-mode emulation,
+      # and the wheel does not carry qemu: it execs `qemu-arm-static` off
+      # the PATH
+      - name: Install what the emulator needs
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends qemu-user-static
+      # the app, twice, in the image its SDK comes from. `git clone` on
+      # the runner rather than in the container, so the checkout is the
+      # runner's own and the container only compiles; `docker run` rather
+      # than a job `container:`, because everything else in this job
+      # wants the runner's uv and its python and not the builder's
+      - name: Build the Bitcoin app
+        run: |
+          git clone --branch "$LEDGER_APP_VERSION" --depth 1 \
+            https://github.com/LedgerHQ/app-bitcoin.git
+          docker run --rm --volume "$PWD/app-bitcoin:/app" --workdir /app \
+            "$LEDGER_APP_BUILDER" bash -c '
+              set -e
+              make DEBUG=1 COIN=bitcoin BOLOS_SDK=$NANOX_SDK
+              cp bin/app.elf /app/bitcoin.elf
+              make clean
+              make DEBUG=1 COIN=bitcoin_testnet BOLOS_SDK=$NANOX_SDK
+              cp bin/app.elf /app/bitcoin-test.elf'
+          # docker wrote them as root, and everything after this reads
+          # them as the runner
+          sudo chown "$(id -u):$(id -g)" \
+            app-bitcoin/bitcoin.elf app-bitcoin/bitcoin-test.elf
+      - name: Install HWI and Speculos
+        run: |
+          uv venv --python "$HWI_PYTHON" hwi-env
+          uv pip install --python hwi-env/bin/python "hwi==$HWI_VERSION"
+          # an environment of its own: speculos wants pyqt6 and pygame
+          # even to run headless, and none of that belongs beside the
+          # command under test
+          uv venv --python "$HWI_PYTHON" speculos-env
+          uv pip install --python speculos-env/bin/python \
+            "speculos==$SPECULOS_VERSION"
+          echo "BTCLIB_HWI=$PWD/hwi-env/bin/hwi --emulators" >> "$GITHUB_ENV"
+          hwi-env/bin/hwi --version
+          # speculos takes no --version: what it answers to is the
+          # module, and the app's own version is in the two steps below
+          speculos-env/bin/python -c \
+            'from speculos.__version__ import __version__; print(__version__)'
+      # mainnet first, because two of the three tests ask the mainnet
+      # fixture and this app is the only one that can answer them: the
+      # `bc` prefix is compiled into it, and `display_address` compares
+      # the address the device shows with the one the descriptor
+      # describes.
+      #
+      # SPECULOS_APPNAME is what the emulator reports as the running app,
+      # which is where HWI reads the version it gates its features on --
+      # 2.1.0 and above is the descriptor-and-psbt client rather than the
+      # legacy one.
+      #
+      # --automation is how a Ledger is confirmed: there is no DebugLink
+      # here, so nothing answers a ButtonRequest by itself the way the
+      # trezor emulator does. The rules match the text drawn on the
+      # screen, which makes them the fragile part of this job -- an
+      # upstream wording change is a rule that stops matching and a test
+      # that waits out btclib's timeout. `automation:DEBUG` is therefore
+      # on: the log names every screen and every rule that fired, which
+      # is the difference between diagnosing that and guessing at it.
+      #
+      # .github/speculos-automation.json is HWI's own
+      # test/data/speculos-automation.json, and it is a copy rather than
+      # a smaller file written here because the screens it answers are
+      # this app's: what a rule has to match is a string nobody can check
+      # without running the app, and upstream runs these very flows
+      # against these very versions.
+      #
+      # Vendored from commit d27d196def0b24b9f0a1a1c15cad755907583221
+      # (blob 41cc061295df2a92e11605398991c3e097f8231f, reindented here
+      # by pretty-format-json, so the rules are upstream's and the bytes
+      # are not -- `python -m json.tool` on both is how the two are
+      # compared), which is the
+      # copy that goes with app 2.5.0 and not the one released in HWI
+      # 3.2.0: that older file matches `Verify Bitcoin`, this app draws
+      # `Verify bitcoin`, and the run where that rule missed spent 120
+      # seconds waiting for a button. So the file moves with
+      # LEDGER_APP_VERSION, and raising one without re-reading the other
+      # is what a hang here will mean
+
+      - name: Start the emulator with the mainnet app
+        run: |
+          SPECULOS_APPNAME="Bitcoin:$LEDGER_APP_VERSION" \
+            speculos-env/bin/speculos --display headless --api-port 0 \
+              --model "$SPECULOS_MODEL" \
+              --automation "file:$PWD/.github/speculos-automation.json" \
+              --log-level automation:DEBUG \
+              app-bitcoin/bitcoin.elf > speculos-mainnet.log 2>&1 &
+          echo "EMULATOR_PID=$!" >> "$GITHUB_ENV"
+          uv run --locked --no-default-groups --group test \
+            python .github/scripts/wait_for_hwi_device.py
+      # every test but the spend, which needs the other app. -n0 for the
+      # reason the trezor job passes it: one device, one session
+      - name: Run the read-only device tests
+        env:
+          BTCLIB_INTEGRATION: "1"
+        run: |
+          uv run --locked --no-default-groups --group test \
+            pytest tests/integration/hwi_device_test.py -n0 \
+            -k "not signs_what_btclib_built" --junitxml=ledger-mainnet.xml
+      - name: Stop the mainnet emulator
+        run: |
+          kill "$EMULATOR_PID"
+          echo "EMULATOR_PID=" >> "$GITHUB_ENV"
+      # and the spend, against the app whose coin the regtest fixture
+      # asks for. BTCLIB_HWI_SIGN is on for the reason it is on in the
+      # trezor job: the automation file is what would otherwise be a
+      # thumb on a button
+      - name: Start the emulator with the testnet app
+        run: |
+          SPECULOS_APPNAME="Bitcoin Test:$LEDGER_APP_VERSION" \
+            speculos-env/bin/speculos --display headless --api-port 0 \
+              --model "$SPECULOS_MODEL" \
+              --automation "file:$PWD/.github/speculos-automation.json" \
+              --log-level automation:DEBUG \
+              app-bitcoin/bitcoin-test.elf > speculos-testnet.log 2>&1 &
+          echo "EMULATOR_PID=$!" >> "$GITHUB_ENV"
+          uv run --locked --no-default-groups --group test \
+            python .github/scripts/wait_for_hwi_device.py --network regtest
+      - name: Run the signing test
+        env:
+          BTCLIB_INTEGRATION: "1"
+          BTCLIB_HWI_SIGN: "1"
+          BTCLIB_BITCOIND: ${{ steps.bitcoind.outputs.path }}
+        run: |
+          uv run --locked --no-default-groups --group test \
+            pytest tests/integration/hwi_device_test.py -n0 \
+            -k signs_what_btclib_built --junitxml=ledger-testnet.xml
+      # both reports, and the same guard: three tests over the two apps,
+      # none of them skipped. A phase that ran nothing is what a
+      # deselection typo looks like, and it would otherwise be green
+      - name: Fail if the device tests did not run
+        run: |
+          uv run --locked --no-default-groups --group test python - <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          ran = []
+          for report in ("ledger-mainnet.xml", "ledger-testnet.xml"):
+              cases = ET.parse(report).getroot().iter("testcase")
+              here = [one for one in cases
+                      if "hwi_device" in one.get("classname", "")]
+              if not here:
+                  print(f"::error::{report} holds no device test")
+                  sys.exit(1)
+              ran.extend(here)
+          skipped = [one for one in ran if one.find("skipped") is not None]
+          for one in skipped:
+              reason = one.find("skipped").get("message", "")
+              print(f"::error::{one.get('name')} skipped: {reason}")
+          if len(ran) != 3 or skipped:
+              print(f"::error::{len(ran)} device tests, {len(skipped)} skipped")
+              sys.exit(1)
+          print(f"{len(ran)} device tests ran against the emulator")
+          PY
+      - name: Stop the emulator
+        if: always()
+        run: |
+          if [ -n "${EMULATOR_PID:-}" ]; then
+            kill "$EMULATOR_PID" || true
+          fi
+      # the two speculos logs are the artifact that matters here: with
+      # automation:DEBUG they carry every screen the app drew and every
+      # rule that answered it, which is where a hang is read
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: hwi-ledger-report
+          path: |
+            ledger-mainnet.xml
+            ledger-testnet.xml
+            speculos-mainnet.log
+            speculos-testnet.log
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,46 +1,37 @@
 ---
 name: integration
 
-# The suite's one part that needs a program this repository does not ship.
-# `tests/integration/` skips itself without BTCLIB_INTEGRATION, so every
-# other workflow reports those tests skipped and nothing ever asks a real
-# node whether btclib's psbt is one it will relay. This is where that
-# question is asked: a disposable regtest bitcoind, the account export,
-# the funding, the spend and the broadcast, against Core itself.
+# The suite's one part that needs a program this repository does not ship:
+# a bitcoind to talk to. `tests/integration/` skips itself without
+# BTCLIB_INTEGRATION, so every other workflow reports those tests skipped
+# and nothing ever asks a real node whether btclib's psbt is one it will
+# relay. This is where that question is asked: a disposable regtest
+# bitcoind, the account export, the funding, the spend and the broadcast,
+# against Core itself.
 #
-# The two jobs below sit on either side of one line, which is what a
-# check gates for: a red run that is the branch's fault gates, and a red
-# run that is somebody else's release does not. `Regtest against Bitcoin
-# Core` is on the first side and is a required check on main -- what it
+# `Regtest against Bitcoin Core` is a required check on main: what it
 # asks is whether Core accepts what this branch built, and the node is a
 # pinned release verified against a published sha256, so the answer is
 # about btclib. A run of it can still go red on an unreachable
 # bitcoincore.org or a runner slow enough to miss the node's startup
-# timeout; that is a re-run, and it is the price of the question. The
-# job below it is on the other side and gates nothing, for the reason
-# links.yml gates nothing and the mutation workflow gates nothing.
+# timeout; that is a re-run, and it is the price of the question.
 #
-# Which of the two is required lives outside the repository, in main's
-# protection, and names its checks as literal strings: renaming either
-# job is therefore a change to make there first, and REPOSITORY.md has
-# the recipe and the reason it cannot be done in one pull request.
+# Which workflow a required check comes from lives outside the
+# repository, in main's protection, and names it as a literal string:
+# renaming this job is therefore a change to make there first, and
+# REPOSITORY.md has the recipe and the reason it cannot be done in one
+# pull request.
 #
-# The HWI half of `tests/integration/` is the other two jobs, and it
-# needs a device: a pinned Trezor emulator stands in for one, a pinned
-# Ledger under Speculos for another, each with a pinned HWI in an
-# interpreter of its own. Two vendors rather than one because HWI is two
-# clients: the protobuf one the Trezor speaks, and the app-2.x one behind
-# a Ledger's wallet policies and psbt exchange, and a green run of either
-# says nothing about the other.
-#
-# Neither is on a pull request, which is the whole difference between
-# them and the job above -- they can go red on a firmware release, on
-# data.trezor.io, on an app whose screens changed wording, so they are
-# asked on the schedule and on demand, where the run is read by somebody
-# who wanted the answer, rather than in front of a review that has
-# nothing to do with it. What checks the HWI command line on every commit
-# stays tests/hwi_test.py, whose stand-in device is a subprocess
-# answering HWI's own json.
+# The HWI half of `tests/integration/` -- a pinned Trezor emulator and a
+# pinned Ledger under Speculos -- is `hwi-integration.yml`, a workflow of
+# its own rather than a second job here: those can go red on a firmware
+# release, on data.trezor.io, or on an app whose screens changed wording,
+# none of which is a claim this branch's review has anything to do with.
+# A job that is merely skipped on a pull request still lists there as a
+# check nobody asked about; a workflow with no `pull_request` trigger at
+# all produces no check on one, skipped or otherwise. What checks the HWI
+# command line on every commit stays tests/hwi_test.py, whose stand-in
+# device is a subprocess answering HWI's own json.
 
 on:
   schedule:
@@ -87,18 +78,17 @@ on:
     # ones included, which is what 36 seconds of work buys
 
 # least privilege for the GITHUB_TOKEN: nothing here writes, and the
-# tarballs are fetched from bitcoincore.org and data.trezor.io, neither of
-# which knows this token
+# tarball is fetched from bitcoincore.org, which does not know this token
 permissions:
   contents: read
 
-# the node both jobs run, here rather than in either of them: the release
-# under test, and the sha256 of its linux tarball as four independent
-# guix builders attested it in bitcoin-core/guix.sigs. Pinned rather than
-# resolved to "latest": a run that installs whatever is newest reports
-# the day Core released rather than the day btclib changed, and the
-# version that answered is then unknowable from a green run. Raising it
-# is a commit, with the new sha read from the same place
+# the release under test, and the sha256 of its linux tarball as four
+# independent guix builders attested it in bitcoin-core/guix.sigs. Pinned
+# rather than resolved to "latest": a run that installs whatever is
+# newest reports the day Core released rather than the day btclib
+# changed, and the version that answered is then unknowable from a green
+# run. Raising it is a commit, with the new sha read from the same place.
+# hwi-integration.yml pins the same two values for its own signing test
 env:
   BITCOIND_VERSION: "31.1"
   BITCOIND_SHA256: >-
@@ -139,7 +129,7 @@ jobs:
           # the wheels uv.lock pins do not change between runs, so the
           # cache is the difference between a download and a copy
           enable-cache: true
-      # the repository's own composite action, which the emulator job
+      # the repository's own composite action, which hwi-integration.yml
       # calls with the same two values: the reasoning for the download is
       # in the file
       - name: Install bitcoind
@@ -195,489 +185,4 @@ jobs:
           if-no-files-found: error
           # long enough to compare a run with the one before it, short
           # enough that a weekly job does not accumulate a year of xml
-          retention-days: 90
-
-  hwi-emulator:
-    name: HWI against a Trezor emulator
-    # not on a pull request, where the job above runs and is required:
-    # this one drives a device somebody else builds, publishes and
-    # releases, so a red run is more often trezor's day than the branch's
-    # -- and it is exactly the shape of check that gets ignored when it
-    # sits next to a review. The schedule asks it weekly with the node,
-    # the push to main asks it of the commit a merge created, and the
-    # dispatch button is how a branch touching btclib/hwi.py gets the
-    # answer before it lands: `gh workflow run integration.yml --ref
-    # <branch>` runs that branch's copy of this file
-    if: ${{ github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
-    # the tests are seconds; the emulator, HWI and the node are a few
-    # minutes of downloading and installing, and this bounds the failure
-    # cases -- an emulator that starts and never answers is the one that
-    # would otherwise hold a runner
-    timeout-minutes: 30
-    env:
-      # the emulator, and the sha256 of the binary trezor publishes.
-      # T2T1 is the Trezor Model T, whose emulator HWI's own test suite
-      # runs, and the version is a released firmware rather than a build
-      # of a branch: `common/releases.json` in trezor/trezor-firmware is
-      # what says which versions exist per model, and the binary of each
-      # is under emulators-new/<model>/ at the url below.
-      #
-      # 2.9.4 rather than the newest: from 2.12.2 the emulator links
-      # SDL3, which ubuntu's archive does not carry yet, and HWI's own
-      # CI builds core/v2.9.6 -- so this is the newest released firmware
-      # that is both installable here and inside the range upstream
-      # tests. Raising it is a commit, with the new sha read from the
-      # same url
-      TREZOR_MODEL: T2T1
-      TREZOR_VERSION: "2.9.4"
-      TREZOR_SHA256: >-
-        a286b20cd33f2fbff30cc46f16c756a25e7cbeaeab9714913746d6826b923c08
-      # the seed the emulator is loaded with: HWI's test suite uses it,
-      # trezor's device tests before it, and it is published in both. An
-      # emulator has no secure element and no owner, so this is a test
-      # fixture and not a key -- what it must never be is a mnemonic
-      # anybody generated for use
-      TREZOR_MNEMONIC: >-
-        alcohol woman abuse must during monitor noble actual mixed trade
-        anger aisle
-      # HWI declares ^3.9,<3.13 and is run as a program rather than
-      # imported (btclib/hwi.py says why, and issue #469 why there is no
-      # extra), so it gets an interpreter of its own here: uv fetches
-      # 3.12, and nothing about the environment the tests run in changes
-      HWI_VERSION: "3.2.0"
-      HWI_PYTHON: "3.12"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          # see the checkout of the test-py job in test.yml
-          persist-credentials: false
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          enable-cache: true
-      # the signing test spends a regtest coin, so this job needs the
-      # node the one above needs, from the same pin
-      - name: Install bitcoind
-        id: bitcoind
-        uses: ./.github/actions/install-bitcoind
-        with:
-          version: ${{ env.BITCOIND_VERSION }}
-          sha256: ${{ env.BITCOIND_SHA256 }}
-      # what the emulator is linked against, and patchelf to make it
-      # runnable at all: the published binary is built under nix, so its
-      # interpreter and its RUNPATH name /nix/store paths that exist on
-      # no ubuntu. libjpeg62 is the soname SDL2_image was built against
-      # and is not the libjpeg ubuntu installs by default; libusb is
-      # HWI's, which loads it by name at import for the transports this
-      # job does not use
-      - name: Install what the emulator needs
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends \
-            libjpeg62 libsdl2-2.0-0 libsdl2-image-2.0-0 libusb-1.0-0 \
-            patchelf
-      # the same shape as the node's download: pinned version, published
-      # checksum, https that cannot be redirected off https
-      - name: Install the Trezor emulator
-        run: |
-          base="https://data.trezor.io/dev/firmware/releases/emulators-new"
-          name="trezor-emu-core-$TREZOR_MODEL-v$TREZOR_VERSION"
-          curl --proto '=https' --proto-redir '=https' \
-            --fail --silent --show-error --location --retry 3 \
-            --output trezor-emulator "$base/$TREZOR_MODEL/$name"
-          echo "$TREZOR_SHA256  trezor-emulator" | sha256sum --check --strict
-          chmod +x trezor-emulator
-          # the loader ubuntu has, and no RUNPATH, so the libraries
-          # installed above are the ones found
-          patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 \
-            --remove-rpath trezor-emulator
-      # in an environment of its own, and named by path: BTCLIB_HWI is
-      # split on spaces, which is how the flags of a command reach it,
-      # and --emulators is what makes HWI look at 127.0.0.1:21324 at all.
-      # btclib passes that flag to `enumerate` itself, and to nothing
-      # else -- every other command is selected by fingerprint -- so it
-      # belongs here rather than in the test
-      - name: Install HWI
-        run: |
-          uv venv --python "$HWI_PYTHON" hwi-env
-          uv pip install --python hwi-env/bin/python "hwi==$HWI_VERSION"
-          echo "BTCLIB_HWI=$PWD/hwi-env/bin/hwi --emulators" >> "$GITHUB_ENV"
-          hwi-env/bin/hwi --version
-      # the emulator, then the seed, and both versions in the log: what a
-      # green run is evidence about is a firmware and an HWI, and neither
-      # is readable from this file six months later.
-      #
-      # The seed goes in over DebugLink, which is also how the button
-      # gets pressed: HWI opens a udp path with TrezorClientDebugLink
-      # rather than the ordinary client, and that one answers a
-      # ButtonRequest itself. That is what BTCLIB_HWI_SIGN guards
-      # against, and why it can be set here -- there is no screen and
-      # nobody in front of it.
-      #
-      # trezorlib comes from HWI's own vendored copy rather than from
-      # PyPI: it is the library that will talk to this emulator half a
-      # second later, so a protocol it accepts is one HWI accepts
-      - name: Start the emulator and load its seed
-        run: |
-          mkdir -p emulator-profile
-          TREZOR_PROFILE_DIR="$PWD/emulator-profile" SDL_VIDEODRIVER=dummy \
-            ./trezor-emulator > emulator.log 2>&1 &
-          echo "EMULATOR_PID=$!" >> "$GITHUB_ENV"
-          hwi-env/bin/python - <<'PY'
-          import os
-          import socket
-          import sys
-          import time
-
-          from hwilib.devices.trezorlib.debuglink import (
-              TrezorClientDebugLink,
-              load_device_by_mnemonic,
-          )
-          from hwilib.devices.trezorlib.transport.udp import UdpTransport
-
-          # the ping the firmware's own wait_for_emulator.py sends, and
-          # the answer that says the udp transport is up
-          deadline = time.monotonic() + 60
-          sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-          sock.connect(("127.0.0.1", 21324))
-          sock.settimeout(0.5)
-          while True:
-              try:
-                  sock.send(b"PINGPING")
-                  if sock.recv(8) == b"PONGPONG":
-                      break
-              # every failure before it is listening is the same one:
-              # nothing is bound to the port yet, so the datagram is
-              # refused or the answer times out
-              except OSError:
-                  pass
-              if time.monotonic() > deadline:
-                  sys.exit("::error::the emulator did not answer in 60 s")
-              time.sleep(0.1)
-
-          client = TrezorClientDebugLink(UdpTransport.enumerate()[0])
-          client.init_device()
-          features = client.features
-          version = ".".join(
-              str(part)
-              for part in (
-                  features.major_version,
-                  features.minor_version,
-                  features.patch_version,
-              )
-          )
-          revision = features.revision.hex() if features.revision else "none"
-          print(f"{features.model} firmware {version}, revision {revision}")
-          load_device_by_mnemonic(
-              client=client,
-              mnemonic=os.environ["TREZOR_MNEMONIC"],
-              pin="",
-              passphrase_protection=False,
-              label="btclib",
-          )
-          PY
-      # the module tests/README.md documents, with both switches set and
-      # the node from the step above. Only that module: the regtest tests
-      # beside it are the other job's, and running them again here would
-      # report a Core failure twice.
-      #
-      # -n0 because there is one device. pyproject.toml's addopts pass
-      # `-n auto`, which is right for everything else here and wrong for
-      # a signer: three workers are three HWI processes on one udp port,
-      # and the one that finds the emulator mid-exchange waits for an
-      # answer to somebody else's command until btclib's timeout ends it.
-      # Measured, and it is displayaddress that lost the race
-      - name: Run the HWI integration tests
-        env:
-          BTCLIB_INTEGRATION: "1"
-          BTCLIB_HWI_SIGN: "1"
-          BTCLIB_BITCOIND: ${{ steps.bitcoind.outputs.path }}
-        run: |
-          uv run --locked --no-default-groups --group test \
-            pytest tests/integration/hwi_device_test.py -n0 --junitxml=hwi.xml
-      # the same guard the node job carries, for the same reason: every
-      # one of these tests skips itself when a switch is off or when
-      # enumerate answers something other than one usable device, so a
-      # job whose emulator stopped being seen would pass while asking HWI
-      # nothing
-      - name: Fail if the device tests did not run
-        run: |
-          uv run --locked --no-default-groups --group test python - <<'PY'
-          import sys
-          import xml.etree.ElementTree as ET
-
-          cases = ET.parse("hwi.xml").getroot().iter("testcase")
-          ran = [one for one in cases
-                 if "hwi_device" in one.get("classname", "")]
-          skipped = [one for one in ran if one.find("skipped") is not None]
-          for one in skipped:
-              reason = one.find("skipped").get("message", "")
-              print(f"::error::{one.get('name')} skipped: {reason}")
-          if not ran or skipped:
-              print(f"::error::{len(ran)} device tests, {len(skipped)} skipped")
-              sys.exit(1)
-          print(f"{len(ran)} device tests ran against the emulator")
-          PY
-      # before the upload, so the log is complete and the runner is not
-      # tearing down a process that still holds the file. Both guards
-      # matter: a step that failed before the emulator started leaves
-      # EMULATOR_PID unset, and `kill 0` -- what a default would spell --
-      # signals the whole process group, this shell included
-      - name: Stop the emulator
-        if: always()
-        run: |
-          if [ -n "${EMULATOR_PID:-}" ]; then
-            kill "$EMULATOR_PID" || true
-          fi
-      # the emulator's own log beside the report: a device that refused
-      # says so there and nowhere else, the psbt failure and the button
-      # that was never pressed looking alike from pytest
-      - name: Upload the report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: hwi-emulator-report
-          path: |
-            hwi.xml
-            emulator.log
-          if-no-files-found: error
-          retention-days: 90
-
-  hwi-ledger:
-    name: HWI against a Ledger emulator
-    # the same rule as the trezor job, and the reasons are stronger here:
-    # this one compiles an app somebody else releases, in an image
-    # somebody else publishes, and confirms its screens by matching the
-    # text on them. None of that is a claim about the branch, so it is
-    # asked on the schedule and on demand and not in front of a review
-    if: ${{ github.event_name != 'pull_request' }}
-    runs-on: ubuntu-latest
-    # the docker pull and two app builds are the minutes; the tests
-    # themselves are the same seconds as the trezor job's
-    timeout-minutes: 45
-    env:
-      # the app, its builder image, and the emulator, each pinned.
-      #
-      # Two builds of one source tree, which is what a Ledger costs where
-      # a Trezor costs none: the coin is compiled in -- `COIN=bitcoin`
-      # gives "Bitcoin" with bech32 prefix `bc`, `COIN=bitcoin_testnet`
-      # gives "Bitcoin Test" with `tb` -- so one binary cannot answer the
-      # mainnet questions of `hwi_device_test.py` and its regtest spend
-      # both. The Trezor firmware takes the chain as an argument and does
-      # both from one image.
-      #
-      # No sha256 of an artifact to pin, either, the app being built here
-      # and not downloaded: what is pinned instead is the source tag, the
-      # builder image by digest -- the tag beside it is what that digest
-      # was -- and the SDK, which the image provides. HWI's own CI builds
-      # this same pair, and 2.5.0 with builder 5.3.17 is the combination
-      # it uses
-      LEDGER_APP_VERSION: "2.5.0"
-      LEDGER_APP_BUILDER: >-
-        ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder@sha256:036d9fd1a264a068ea20f2d0edc962ecdbf1bf5861ef75215924abd77f93bf29
-      # nanox, as HWI's suite runs the 2.x app on, and the model the
-      # speculos wheel carries a cx library for
-      SPECULOS_MODEL: nanox
-      # from PyPI, where it brings its own launcher and cx libraries and
-      # wants only qemu from the system. HWI still clones and cmakes it,
-      # pinned at 0.25.10 -- the last release supporting python 3.9,
-      # which is HWI's floor and not this repository's
-      SPECULOS_VERSION: "0.26.10"
-      HWI_VERSION: "3.2.0"
-      HWI_PYTHON: "3.12"
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Setup uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
-        with:
-          enable-cache: true
-      - name: Install bitcoind
-        id: bitcoind
-        uses: ./.github/actions/install-bitcoind
-        with:
-          version: ${{ env.BITCOIND_VERSION }}
-          sha256: ${{ env.BITCOIND_SHA256 }}
-      # speculos runs an ARM binary through qemu's user-mode emulation,
-      # and the wheel does not carry qemu: it execs `qemu-arm-static` off
-      # the PATH
-      - name: Install what the emulator needs
-        run: |
-          sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends qemu-user-static
-      # the app, twice, in the image its SDK comes from. `git clone` on
-      # the runner rather than in the container, so the checkout is the
-      # runner's own and the container only compiles; `docker run` rather
-      # than a job `container:`, because everything else in this job
-      # wants the runner's uv and its python and not the builder's
-      - name: Build the Bitcoin app
-        run: |
-          git clone --branch "$LEDGER_APP_VERSION" --depth 1 \
-            https://github.com/LedgerHQ/app-bitcoin.git
-          docker run --rm --volume "$PWD/app-bitcoin:/app" --workdir /app \
-            "$LEDGER_APP_BUILDER" bash -c '
-              set -e
-              make DEBUG=1 COIN=bitcoin BOLOS_SDK=$NANOX_SDK
-              cp bin/app.elf /app/bitcoin.elf
-              make clean
-              make DEBUG=1 COIN=bitcoin_testnet BOLOS_SDK=$NANOX_SDK
-              cp bin/app.elf /app/bitcoin-test.elf'
-          # docker wrote them as root, and everything after this reads
-          # them as the runner
-          sudo chown "$(id -u):$(id -g)" \
-            app-bitcoin/bitcoin.elf app-bitcoin/bitcoin-test.elf
-      - name: Install HWI and Speculos
-        run: |
-          uv venv --python "$HWI_PYTHON" hwi-env
-          uv pip install --python hwi-env/bin/python "hwi==$HWI_VERSION"
-          # an environment of its own: speculos wants pyqt6 and pygame
-          # even to run headless, and none of that belongs beside the
-          # command under test
-          uv venv --python "$HWI_PYTHON" speculos-env
-          uv pip install --python speculos-env/bin/python \
-            "speculos==$SPECULOS_VERSION"
-          echo "BTCLIB_HWI=$PWD/hwi-env/bin/hwi --emulators" >> "$GITHUB_ENV"
-          hwi-env/bin/hwi --version
-          # speculos takes no --version: what it answers to is the
-          # module, and the app's own version is in the two steps below
-          speculos-env/bin/python -c \
-            'from speculos.__version__ import __version__; print(__version__)'
-      # mainnet first, because two of the three tests ask the mainnet
-      # fixture and this app is the only one that can answer them: the
-      # `bc` prefix is compiled into it, and `display_address` compares
-      # the address the device shows with the one the descriptor
-      # describes.
-      #
-      # SPECULOS_APPNAME is what the emulator reports as the running app,
-      # which is where HWI reads the version it gates its features on --
-      # 2.1.0 and above is the descriptor-and-psbt client rather than the
-      # legacy one.
-      #
-      # --automation is how a Ledger is confirmed: there is no DebugLink
-      # here, so nothing answers a ButtonRequest by itself the way the
-      # trezor emulator does. The rules match the text drawn on the
-      # screen, which makes them the fragile part of this job -- an
-      # upstream wording change is a rule that stops matching and a test
-      # that waits out btclib's timeout. `automation:DEBUG` is therefore
-      # on: the log names every screen and every rule that fired, which
-      # is the difference between diagnosing that and guessing at it.
-      #
-      # .github/speculos-automation.json is HWI's own
-      # test/data/speculos-automation.json, and it is a copy rather than
-      # a smaller file written here because the screens it answers are
-      # this app's: what a rule has to match is a string nobody can check
-      # without running the app, and upstream runs these very flows
-      # against these very versions.
-      #
-      # Vendored from commit d27d196def0b24b9f0a1a1c15cad755907583221
-      # (blob 41cc061295df2a92e11605398991c3e097f8231f, reindented here
-      # by pretty-format-json, so the rules are upstream's and the bytes
-      # are not -- `python -m json.tool` on both is how the two are
-      # compared), which is the
-      # copy that goes with app 2.5.0 and not the one released in HWI
-      # 3.2.0: that older file matches `Verify Bitcoin`, this app draws
-      # `Verify bitcoin`, and the run where that rule missed spent 120
-      # seconds waiting for a button. So the file moves with
-      # LEDGER_APP_VERSION, and raising one without re-reading the other
-      # is what a hang here will mean
-
-      - name: Start the emulator with the mainnet app
-        run: |
-          SPECULOS_APPNAME="Bitcoin:$LEDGER_APP_VERSION" \
-            speculos-env/bin/speculos --display headless --api-port 0 \
-              --model "$SPECULOS_MODEL" \
-              --automation "file:$PWD/.github/speculos-automation.json" \
-              --log-level automation:DEBUG \
-              app-bitcoin/bitcoin.elf > speculos-mainnet.log 2>&1 &
-          echo "EMULATOR_PID=$!" >> "$GITHUB_ENV"
-          uv run --locked --no-default-groups --group test \
-            python .github/scripts/wait_for_hwi_device.py
-      # every test but the spend, which needs the other app. -n0 for the
-      # reason the trezor job passes it: one device, one session
-      - name: Run the read-only device tests
-        env:
-          BTCLIB_INTEGRATION: "1"
-        run: |
-          uv run --locked --no-default-groups --group test \
-            pytest tests/integration/hwi_device_test.py -n0 \
-            -k "not signs_what_btclib_built" --junitxml=ledger-mainnet.xml
-      - name: Stop the mainnet emulator
-        run: |
-          kill "$EMULATOR_PID"
-          echo "EMULATOR_PID=" >> "$GITHUB_ENV"
-      # and the spend, against the app whose coin the regtest fixture
-      # asks for. BTCLIB_HWI_SIGN is on for the reason it is on in the
-      # trezor job: the automation file is what would otherwise be a
-      # thumb on a button
-      - name: Start the emulator with the testnet app
-        run: |
-          SPECULOS_APPNAME="Bitcoin Test:$LEDGER_APP_VERSION" \
-            speculos-env/bin/speculos --display headless --api-port 0 \
-              --model "$SPECULOS_MODEL" \
-              --automation "file:$PWD/.github/speculos-automation.json" \
-              --log-level automation:DEBUG \
-              app-bitcoin/bitcoin-test.elf > speculos-testnet.log 2>&1 &
-          echo "EMULATOR_PID=$!" >> "$GITHUB_ENV"
-          uv run --locked --no-default-groups --group test \
-            python .github/scripts/wait_for_hwi_device.py --network regtest
-      - name: Run the signing test
-        env:
-          BTCLIB_INTEGRATION: "1"
-          BTCLIB_HWI_SIGN: "1"
-          BTCLIB_BITCOIND: ${{ steps.bitcoind.outputs.path }}
-        run: |
-          uv run --locked --no-default-groups --group test \
-            pytest tests/integration/hwi_device_test.py -n0 \
-            -k signs_what_btclib_built --junitxml=ledger-testnet.xml
-      # both reports, and the same guard: three tests over the two apps,
-      # none of them skipped. A phase that ran nothing is what a
-      # deselection typo looks like, and it would otherwise be green
-      - name: Fail if the device tests did not run
-        run: |
-          uv run --locked --no-default-groups --group test python - <<'PY'
-          import sys
-          import xml.etree.ElementTree as ET
-
-          ran = []
-          for report in ("ledger-mainnet.xml", "ledger-testnet.xml"):
-              cases = ET.parse(report).getroot().iter("testcase")
-              here = [one for one in cases
-                      if "hwi_device" in one.get("classname", "")]
-              if not here:
-                  print(f"::error::{report} holds no device test")
-                  sys.exit(1)
-              ran.extend(here)
-          skipped = [one for one in ran if one.find("skipped") is not None]
-          for one in skipped:
-              reason = one.find("skipped").get("message", "")
-              print(f"::error::{one.get('name')} skipped: {reason}")
-          if len(ran) != 3 or skipped:
-              print(f"::error::{len(ran)} device tests, {len(skipped)} skipped")
-              sys.exit(1)
-          print(f"{len(ran)} device tests ran against the emulator")
-          PY
-      - name: Stop the emulator
-        if: always()
-        run: |
-          if [ -n "${EMULATOR_PID:-}" ]; then
-            kill "$EMULATOR_PID" || true
-          fi
-      # the two speculos logs are the artifact that matters here: with
-      # automation:DEBUG they carry every screen the app drew and every
-      # rule that answered it, which is where a hang is read
-      - name: Upload the report
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: hwi-ledger-report
-          path: |
-            ledger-mainnet.xml
-            ledger-testnet.xml
-            speculos-mainnet.log
-            speculos-testnet.log
-          if-no-files-found: error
           retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ documented at release-notes length in the first place, and are still in
 
 ### Repository
 
+- **The HWI emulator jobs no longer appear on a pull request's checks.**
+  `HWI against a Trezor emulator` and `HWI against a Ledger emulator`
+  ran as jobs of `integration.yml`, guarded by `if:
+  github.event_name != 'pull_request'` so they never actually ran there
+  — but the workflow itself still triggers on `pull_request`, so GitHub
+  listed both as skipped checks on every pull request regardless, which
+  is what a reviewer sees whether or not the job did anything. The two
+  jobs move to `hwi-integration.yml`, a workflow with no `pull_request`
+  trigger at all: a workflow that never fires on that event produces no
+  check on one, skipped included. `Regtest against Bitcoin Core`, the
+  one job of the two that is a required check, stays in `integration.yml`
+  unchanged, with the same `pull_request` trigger it needs to gate a
+  merge.
+
 - **The generated Code Quality analysis is off** (issue #788). A second
   CodeQL run that no file in this tree declares — `Analyze (python)` and
   `Analyze (ruby)`, on every pull request and every push to `main` — took

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -553,15 +553,16 @@ BTCLIB_INTEGRATION=1 BTCLIB_BITCOIND=/path/to/bitcoind \
 A step after it reads that report and fails the job if a regtest test
 skipped: pytest exits 0 for a module that skipped itself, so a job whose
 fixture stopped finding the node would stay green while asking Core
-nothing. The HWI tests skip there by design and are not counted; the
-second job is theirs.
+nothing. The HWI tests skip there by design and are not counted; they are
+`hwi-integration.yml`'s, a workflow of its own rather than a second job
+here.
 
-`HWI against a Trezor emulator` is that job, and it gates nothing: it
-downloads a pinned emulator binary from `data.trezor.io` beside the same
-node, checks its sha256, installs a pinned HWI in an interpreter of its
-own — HWI declares `^3.9,<3.13`, and `btclib/hwi.py` says why it is a
-program here rather than a dependency — loads the seed HWI's own suite
-uses over DebugLink, and runs:
+`HWI against a Trezor emulator` is the first of its two jobs, and it
+gates nothing: it downloads a pinned emulator binary from
+`data.trezor.io` beside the same node, checks its sha256, installs a
+pinned HWI in an interpreter of its own — HWI declares `^3.9,<3.13`, and
+`btclib/hwi.py` says why it is a program here rather than a dependency —
+loads the seed HWI's own suite uses over DebugLink, and runs:
 
 ```shell
 BTCLIB_INTEGRATION=1 BTCLIB_HWI_SIGN=1 \
@@ -576,11 +577,13 @@ workers are three HWI processes on one udp port.
 
 `BTCLIB_HWI_SIGN` can be set because HWI opens a udp device with
 `TrezorClientDebugLink`, which answers the button request itself. The
-job is not on a pull request: a firmware release, an unreachable
-`data.trezor.io` or an emulator that stopped starting headless is
-trezor's day rather than the branch's, so it runs weekly, on a push to
-`main`, and on `gh workflow run integration.yml --ref <branch>` — which
-is how a branch touching `btclib/hwi.py` is checked before it lands.
+workflow carries no `pull_request` trigger at all: a firmware release, an
+unreachable `data.trezor.io` or an emulator that stopped starting
+headless is trezor's day rather than the branch's, and a workflow that
+never triggers on a pull request produces no check there, not even a
+skipped one — so it runs weekly, on a push to `main`, and on
+`gh workflow run hwi-integration.yml --ref <branch>`, which is how a
+branch touching `btclib/hwi.py` is checked before it lands.
 
 `HWI against a Ledger emulator` is the second of the two, and it costs
 more because a Ledger does. There is no published app binary, so the job

--- a/REPOSITORY.md
+++ b/REPOSITORY.md
@@ -31,12 +31,15 @@ workflows with a job named the same thing produce one ambiguous check.
 A workflow needs an aggregate when every one of its jobs has to gate: the
 matrix of `test.yml` is the one, and a context naming one cell of it would
 leave the rest outside the rule. Where a single job is what gates, that job
-*is* the context, which is why three of the four are job names — and why
-`integration.yml` naming a second job changed nothing here: `HWI against a
-Trezor emulator` runs beside the regtest one and must not gate, an emulator
-being a service to keep working rather than a claim about the branch, so
-the context stays the name of the job that does. What a second job would
-cost is a rename: a workflow whose *whole* answer becomes required needs an
+*is* the context, which is why three of the four are job names.
+`integration.yml` holds only the regtest job: the HWI jobs — `HWI against a
+Trezor emulator` and `HWI against a Ledger emulator` — live in
+`hwi-integration.yml`, a workflow with no `pull_request` trigger at all, so
+a firmware release or a Ledger screen that changed wording produces no
+pull-request check to ignore, required or not — a job merely skipped on a
+pull request still lists there, a workflow that never triggers on one does
+not. What a job added back to `integration.yml` would still cost is a
+rename: a workflow whose *whole* answer becomes required needs an
 aggregate, and this table with it.
 
 `Build the documentation` is named on its own on purpose: a rule naming

--- a/tests/README.md
+++ b/tests/README.md
@@ -98,16 +98,18 @@ says where it omits them: the ratchet measures what an ordinary run
 executes, and a body that skips itself would be an uncovered line at
 every commit rather than a defect.
 
-Both halves run unattended, in three jobs of the `integration` workflow,
-and each job fails if its tests skipped rather than ran. The regtest one
-downloads a pinned Core release on every pull request and weekly. The
-other two are this module against an emulator, one vendor each, and
-neither is on a pull request — a firmware release or an emulator that
-stopped starting headless is not the branch's fault — so they run
-weekly, on a push to `main`, and on demand:
+Both halves run unattended, in three jobs across two workflows, and each
+job fails if its tests skipped rather than ran. The regtest one is
+`integration.yml`'s, and downloads a pinned Core release on every pull
+request and weekly. The other two are this module against an emulator,
+one vendor each, in `hwi-integration.yml` — a workflow with no
+`pull_request` trigger at all, so a firmware release or an emulator that
+stopped starting headless never shows up as a check on a review that has
+nothing to do with it. They run weekly, on a push to `main`, and on
+demand:
 
 ```shell
-gh workflow run integration.yml --ref <branch>
+gh workflow run hwi-integration.yml --ref <branch>
 ```
 
 `HWI against a Trezor emulator` downloads a pinned Model T binary and a

--- a/tests/integration/hwi_device_test.py
+++ b/tests/integration/hwi_device_test.py
@@ -29,7 +29,7 @@ HWI processes reaching for it at once, where the one that arrives
 mid-exchange waits out btclib's timeout.
 
 Two emulators are what CI brings, which is issues #529 and #738 and not
-a change of that rule. `integration.yml` runs a pinned Trezor Model T
+a change of that rule. `hwi-integration.yml` runs a pinned Trezor Model T
 seeded with the mnemonic HWI's own suite uses, and a Ledger under
 Speculos with the Bitcoin app built from a pinned tag -- twice, the coin
 being compiled into a Ledger app, so the mainnet build answers the two


### PR DESCRIPTION
## Summary

- `HWI against a Trezor emulator` and `HWI against a Ledger emulator`
  were jobs of `integration.yml`, kept from running on a pull request
  with a job-level `if: github.event_name != 'pull_request'`. The
  workflow itself still triggers on `pull_request`, so GitHub listed
  both as skipped checks on every pull request regardless of the guard.
- They move to a new `hwi-integration.yml`, a workflow with no
  `pull_request` trigger at all: a workflow that never fires on that
  event produces no check on one, not even a skipped one.
- `Regtest against Bitcoin Core`, the one required check of the three,
  stays in `integration.yml` unchanged, with the same `pull_request`
  trigger it needs to gate a merge.
- Every prose cross-reference to the old single-file layout
  (`REPOSITORY.md`, `CONTRIBUTING.md`, `tests/README.md`, the
  `install-bitcoind` action, `wait_for_hwi_device.py`, the docstring of
  `tests/integration/hwi_device_test.py`) is updated to point at the
  right file.

## Test plan

- [x] `uv run pre-commit run --all-files` (actionlint, zizmor, ruff,
      mypy, markdownlint, yamllint, check-manifest all pass)
- [x] `sphinx-build -W --keep-going -b html docs/source docs/build/html`
      succeeds
- [x] `uv run pytest tests/hwi_test.py` passes (the stand-in suite,
      unaffected by this change)
- [ ] a scheduled or dispatched run of `hwi-integration.yml` on GitHub,
      since nothing local can exercise its triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Split the HWI hardware wallet emulator integration checks into a dedicated workflow that no longer triggers on pull_request, keeping the Bitcoin Core regtest job as the sole integration check on PRs.

New Features:
- Introduce a standalone hwi-integration GitHub Actions workflow to run HWI integration tests against Trezor and Ledger emulators on schedule, main pushes, and manual dispatch.

Enhancements:
- Remove HWI emulator jobs from the integration workflow so they no longer appear as skipped checks on pull requests.
- Share the pinned bitcoind version and checksum between integration.yml and hwi-integration.yml via the existing composite install-bitcoind action.
- Update repository, contributing, and tests documentation to describe the new hwi-integration workflow and its triggers, and clarify required-check behavior.
- Adjust references in helper scripts and integration tests to point to hwi-integration.yml instead of integration.yml where appropriate.

CI:
- Reorganize CI so only the regtest against Bitcoin Core job remains in integration.yml for PR gating, with HWI emulator jobs moved to the new hwi-integration workflow.

Documentation:
- Document the HWI emulator workflow split and triggering behavior in CHANGELOG, REPOSITORY, CONTRIBUTING, and tests/README files.