### PR TITLE
Keep the generator's wNAF table, and hold it wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2165,6 +2165,39 @@ documented at release-notes length in the first place, and are still in
   applicable `mult` has returned before either -- what reaches this is
   every other curve, and secp256k1 with the dispatch patched off, which
   is what the suite holds the bindings against.
+- **A verification stops rebuilding the generator's table** (issue #803).
+  `_multi_mult_w_NAF` built one table per point per call, and one of the
+  points of a verification is the generator, which is the same on every
+  call. `Curve` now names its own fixed points -- the generator and its
+  opposite -- `_cached_odd_multiples_aff` memoizes their tables, and a
+  memoized table can be held at a width a per-call one could not pay for:
+  a wNAF has one nonzero digit in w+1, so the wide window is fewer
+  additions in the loop that indexes it. libsecp256k1 splits the two the
+  same way, `WINDOW_G` of 15 for the generator against `WINDOW_A` of 5
+  for the variable point.
+
+  Measured against `502d2789` on Python 3.14.6, best of seven alternating
+  rounds over 30 random 256-bit coefficient pairs:
+
+  | | per call | memoized | |
+  | --- | ---: | ---: | ---: |
+  | `_double_mult_endomorphism_secp256k1` | 715 us | 577 us | **1.24x** |
+  | `_double_mult_w_NAF`, secp256r1 | 1000 us | 878 us | **1.14x** |
+  | `_multi_mult_w_NAF`, 8 points, one fixed | 2160 us | 2048 us | **1.05x** |
+
+  The first row has four halves of which two are fixed, the endomorphism
+  splitting the generator into `±G` and `±beta*G`: those images are
+  formed by `_double_mult_endomorphism_secp256k1` and named fixed there,
+  which is the one place that knows them. The width is 10 by measurement
+  -- 1.07x at 4, 1.12x at 6, 1.15x at 8, 1.18x at 10, 1.20x at 12,
+  against a table that doubles at every step -- and capped at
+  `ec.scalar_len`, a window wider than the scalars buying nothing and
+  costing a table: uncapped it was the low-cardinality curves of the
+  suite that paid, 40 s of it against 17.
+
+  `_double_mult_w_NAF` is now `_multi_mult_w_NAF` of two points rather
+  than a second copy of the same loop. What it keeps is the two messages
+  its own coefficients answer with, and the name the algorithm has.
 
 ### The public API and the module layout
 

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -169,6 +169,12 @@ class Curve(CurveGroup):
 
         self.G = _generator_from_point(G, self)
         self.GJ = self.G[0], self.G[1], 1  # Jacobian coordinates
+        # the generator and its opposite are what a verification hands the
+        # same on every call, so their wNAF tables are memoized and held
+        # wide; _cached_odd_multiples_aff says what that buys. The
+        # endomorphism's images of the two are fixed as well and are added
+        # by _double_mult_endomorphism_secp256k1, which is what forms them
+        self._fixed_points = frozenset({self.GJ, self.negate_jac(self.GJ)})
 
         n = int_from_integer(n)
 

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -187,6 +187,11 @@ class CurveGroup:
         # these are zero, and nothing there is worth timing anyway
         self._stand_in_q = p // 3, p // 5, p // 7
         self._stand_in_r = p // 11, p // 13, p // 17
+        # the points whose wNAF table is worth memoizing rather than
+        # rebuilding per call: the ones the curve itself names, which a
+        # verification hands the same on every call. A CurveGroup names
+        # none -- it has no generator -- and Curve fills this in
+        self._fixed_points: frozenset[JacPoint] = frozenset()
 
     def __str__(self) -> str:
         # the class name, not the literal "Curve": the two classes hold
@@ -1006,6 +1011,30 @@ def _odd_multiples_aff(Q: JacPoint, ec: CurveGroup, w: int) -> list[Point]:
     return ec.aff_from_jac_batch(_odd_multiples(Q, ec, w))
 
 
+# the width a point of ec._fixed_points has its table built at, against
+# the narrow one a point that arrives once is worth. The measurement is in
+# _multi_mult_w_NAF's docstring
+_FIXED_POINT_W = 10
+
+
+@functools.lru_cache  # a fixed point's table is the same on every call
+def _cached_odd_multiples_aff(Q: JacPoint, ec: CurveGroup, w: int) -> list[Point]:
+    """Return `_odd_multiples_aff` memoized, for a point known in advance.
+
+    What memoizing buys is not the building alone: a table that is not
+    rebuilt can be held at a width a per-call one could not pay for, and a
+    wNAF has one nonzero digit in w+1, so the wider window is fewer
+    additions in the loop that indexes it. libsecp256k1 splits the two the
+    same way, `WINDOW_A` of 5 for the variable point against a `WINDOW_G`
+    of 15 for the generator, whose table it generates at build time.
+
+    Only the points of `ec._fixed_points` may be handed here: a table
+    memoized on a public key is a table built once, used once and kept
+    for ever.
+    """
+    return _odd_multiples_aff(Q, ec, w)
+
+
 def _signed_odd_multiples_aff(Q: JacPoint, ec: CurveGroup, w: int) -> list[Point]:
     """Return the 2^w multiples a signed odd width-w digit names, affine.
 
@@ -1432,7 +1461,11 @@ _MULTI_MULT_W = 5
 
 
 def _multi_mult_w_NAF(
-    scalars: Sequence[int], jac_points: Sequence[JacPoint], ec: CurveGroup, w: int
+    scalars: Sequence[int],
+    jac_points: Sequence[JacPoint],
+    ec: CurveGroup,
+    w: int,
+    fixed: frozenset[JacPoint],
 ) -> JacPoint:
     """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
 
@@ -1470,6 +1503,26 @@ def _multi_mult_w_NAF(
     here, so the split lives with the curve that has it and the
     interleaving stays one implementation.
 
+    `fixed` is the points whose table is worth memoizing rather than
+    building here: `ec._fixed_points`, or that set with the endomorphism's
+    images added by the caller that forms them. A memoized table can be
+    held at a width a per-call one could not pay for, `_FIXED_POINT_W`
+    against the `w` every other point gets, and a wNAF has one nonzero
+    digit in w+1, so the wide window is fewer additions in the loop. That
+    is libsecp256k1's `WINDOW_G` of 15 beside its `WINDOW_A` of 5, on a
+    table it generates at build time.
+
+    Measured over 30 random 256-bit coefficient pairs, best of seven
+    alternating rounds, memoized against built per call: 1.24x on
+    `_double_mult_endomorphism_secp256k1`, whose four halves are two fixed
+    points and two of the caller's, and 1.14x on `_double_mult_w_NAF` over
+    secp256r1, which has one of each. With eight points of which one is
+    the generator it is 1.05x, the fixed point being an eighth of the
+    work. `_FIXED_POINT_W` is 10 by measurement on the first of those:
+    1.07x at 4, 1.12x at 6, 1.15x at 8, 1.18x at 10, 1.20x at 12, against
+    a table that doubles at every step -- and capped at `ec.scalar_len`,
+    a window wider than the scalars buying nothing and costing a table.
+
     The input points are assumed to be on curve, the scalar coefficients
     are assumed to have been reduced mod n if appropriate (e.g. cyclic
     groups of order n).
@@ -1482,8 +1535,24 @@ def _multi_mult_w_NAF(
     if not pairs:
         return INFJ
 
-    nafs = [_wNAF_of_m(n, w) for n, _ in pairs]
-    tables = [_odd_multiples_aff(PJ, ec, w) for _, PJ in pairs]
+    # a point the caller hands the same on every call gets the memoized
+    # table of _cached_odd_multiples_aff, at the wider window that only a
+    # memoized table can pay for; every other point gets its own, built
+    # here and dropped with the call
+    # a window wider than the scalars themselves buys nothing and costs a
+    # table, which is what the cap is for: the low-cardinality curves of
+    # the test suite have a scalar_len of a handful of bits
+    fixed_w = min(_FIXED_POINT_W, ec.scalar_len)
+    nafs = []
+    tables = []
+    for n, PJ in pairs:
+        width = fixed_w if PJ in fixed else w
+        nafs.append(_wNAF_of_m(n, width))
+        tables.append(
+            _cached_odd_multiples_aff(PJ, ec, width)
+            if PJ in fixed
+            else _odd_multiples_aff(PJ, ec, width)
+        )
 
     R = INFJ
     for j in range(max(len(naf) for naf in nafs) - 1, -1, -1):
@@ -1613,5 +1682,7 @@ def _multi_mult(
     groups of order n).
     """
     if sum(1 for n in scalars if n) < BOS_COSTER_THRESHOLD:
-        return _multi_mult_w_NAF(scalars, jac_points, ec, _MULTI_MULT_W)
+        return _multi_mult_w_NAF(
+            scalars, jac_points, ec, _MULTI_MULT_W, ec._fixed_points
+        )
     return _multi_mult_bos_coster(scalars, jac_points, ec)

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -105,7 +105,6 @@ from btclib.curves.curve_group import (
     _convert_number_to_base,
     _jac_from_aff,
     _multi_mult_w_NAF,
-    _odd_multiples_aff,
     _signed_odd_multiples_aff,
     _wNAF_of_m,
     signed_odd_digits,
@@ -299,28 +298,13 @@ def _double_mult_w_NAF(
     if w <= 0:
         raise BTClibValueError(f"non positive w: {w}")
 
-    us = _wNAF_of_m(u, w)
-    vs = _wNAF_of_m(v, w)
-
-    # one table of odd multiples per point, the same curve_group's
-    # interleaved _multi_mult_w_NAF builds for each of its own, and in
-    # affine coordinates for the same reason: one inversion a table
-    # against five products on every addition that indexes it
-    TH = _odd_multiples_aff(HJ, ec, w)
-    TQ = _odd_multiples_aff(QJ, ec, w)
-
-    R = INFJ
-    for j in range(max(len(us), len(vs)) - 1, -1, -1):
-        R = ec.double_jac(R)
-        if j < len(us) and us[j] != 0:
-            d = us[j]
-            T = TH[(d - 1) // 2] if d > 0 else ec.negate(TH[(-d - 1) // 2])
-            R = ec.add_jac_aff(R, T)
-        if j < len(vs) and vs[j] != 0:
-            d = vs[j]
-            T = TQ[(d - 1) // 2] if d > 0 else ec.negate(TQ[(-d - 1) // 2])
-            R = ec.add_jac_aff(R, T)
-    return R
+    # curve_group's interleaved _multi_mult_w_NAF for two points, rather
+    # than a second copy of the same loop: it is what recodes each
+    # coefficient, builds each table -- memoized and wide for a point the
+    # curve names, per call and narrow for one it does not -- and shares
+    # the doublings. What this function adds is the pair of messages its
+    # own coefficients answer with, and the name the algorithm has
+    return _multi_mult_w_NAF([u, v], [HJ, QJ], ec, w, ec._fixed_points)
 
 
 def _double_mult_regular_window(
@@ -576,4 +560,14 @@ def _double_mult_endomorphism_secp256k1(
 
     u1, U1, u2, U2 = _endomorphism_split_secp256k1(u, HJ, ec)
     v1, V1, v2, V2 = _endomorphism_split_secp256k1(v, QJ, ec)
-    return _multi_mult_w_NAF([u1, u2, v1, v2], [U1, U2, V1, V2], ec, w)
+    # the split of a fixed point is fixed: the halves are +-H and
+    # +-lambda*H, determined by H alone and by which of the two signs the
+    # coefficient asked for, so both are worth a memoized table whenever H
+    # is one of the points the curve names. The images are formed here and
+    # nowhere else, which is why they are added here rather than in Curve
+    fixed = ec._fixed_points
+    if HJ in fixed:
+        fixed = fixed | {U1, U2}
+    if QJ in fixed:
+        fixed = fixed | {V1, V2}
+    return _multi_mult_w_NAF([u1, u2, v1, v2], [U1, U2, V1, V2], ec, w, fixed)

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -732,18 +732,20 @@ def test_multi_mult_w_NAF() -> None:
                     scalars = [k1, k2, ec.n // 3]
                     points = [ec.GJ, HJ, ec.GJ]
                     expected = _sum_of_mults(scalars, points, ec)
-                    got = _multi_mult_w_NAF(scalars, points, ec, w)
+                    got = _multi_mult_w_NAF(scalars, points, ec, w, ec._fixed_points)
                     assert ec.jac_equality(got, expected), (k1, k2, w)
                     assert ec.jac_equality(
                         got, _multi_mult_bos_coster(scalars, points, ec)
                     ), (k1, k2, w)
 
             # a zero scalar, an INF point, and scalars of distant lengths
-            assert ec.jac_equality(_multi_mult_w_NAF([0, 0], [ec.GJ, HJ], ec, w), INFJ)
+            assert ec.jac_equality(
+                _multi_mult_w_NAF([0, 0], [ec.GJ, HJ], ec, w, ec._fixed_points), INFJ
+            )
             for scalars in ([0, 3], [3, 0], [1, ec.n - 1], [ec.n - 1, 1]):
                 for points in ([ec.GJ, HJ], [INFJ, HJ], [ec.GJ, INFJ]):
                     expected = _sum_of_mults(scalars, points, ec)
-                    got = _multi_mult_w_NAF(scalars, points, ec, w)
+                    got = _multi_mult_w_NAF(scalars, points, ec, w, ec._fixed_points)
                     assert ec.jac_equality(got, expected), (scalars, w)
 
         # a window wider than the order itself, where the table of odd
@@ -756,12 +758,12 @@ def test_multi_mult_w_NAF() -> None:
             for scalars in ([1, ec.n - 1], [ec.n // 2, 3], [0, ec.n - 1]):
                 points = [ec.GJ, HJ]
                 expected = _sum_of_mults(scalars, points, ec)
-                got = _multi_mult_w_NAF(scalars, points, ec, w)
+                got = _multi_mult_w_NAF(scalars, points, ec, w, ec._fixed_points)
                 assert ec.jac_equality(got, expected), (scalars, w)
 
     ec = secp256k1
     with pytest.raises(BTClibValueError, match="non positive w: "):
-        _multi_mult_w_NAF([1, 1], [ec.GJ, ec.GJ], ec, 0)
+        _multi_mult_w_NAF([1, 1], [ec.GJ, ec.GJ], ec, 0, ec._fixed_points)
 
 
 def test_multi_mult_agrees_across_curves() -> None:
@@ -778,7 +780,8 @@ def test_multi_mult_agrees_across_curves() -> None:
         scalars = [rnd.randrange(ec.n) for _ in points]
         expected = _sum_of_mults(scalars, points, ec)
         assert ec.jac_equality(
-            _multi_mult_w_NAF(scalars, points, ec, _MULTI_MULT_W), expected
+            _multi_mult_w_NAF(scalars, points, ec, _MULTI_MULT_W, ec._fixed_points),
+            expected,
         )
         assert ec.jac_equality(_multi_mult_bos_coster(scalars, points, ec), expected)
 
@@ -803,7 +806,8 @@ def test_multi_mult_dispatch() -> None:
         expected = _sum_of_mults(scalars, points, ec)
         assert ec.jac_equality(_multi_mult(scalars, points, ec), expected)
         assert ec.jac_equality(
-            _multi_mult_w_NAF(scalars, points, ec, _MULTI_MULT_W), expected
+            _multi_mult_w_NAF(scalars, points, ec, _MULTI_MULT_W, ec._fixed_points),
+            expected,
         )
         assert ec.jac_equality(_multi_mult_bos_coster(scalars, points, ec), expected)
 
@@ -813,7 +817,8 @@ def test_multi_mult_dispatch() -> None:
         # of no nonzero scalars, which is below any threshold
         assert ec.jac_equality(_multi_mult([0] * size, points, ec), INFJ)
         assert ec.jac_equality(
-            _multi_mult_w_NAF([0] * size, points, ec, _MULTI_MULT_W), INFJ
+            _multi_mult_w_NAF([0] * size, points, ec, _MULTI_MULT_W, ec._fixed_points),
+            INFJ,
         )
         assert ec.jac_equality(_multi_mult_bos_coster([0] * size, points, ec), INFJ)
 


### PR DESCRIPTION
_multi_mult_w_NAF built one table per point per call, and one of the
points of a verification is the generator, which is the same on every
call. Curve now names its own fixed points -- the generator and its
opposite -- _cached_odd_multiples_aff memoizes their tables, and a
memoized table can be held at a width a per-call one could not pay for: a
wNAF has one nonzero digit in w+1, so the wide window is fewer additions
in the loop that indexes it. libsecp256k1 splits the two the same way,
WINDOW_G of 15 for the generator against WINDOW_A of 5 for the variable
point.

Measured against 502d2789 on Python 3.14.6, best of seven alternating
rounds over 30 random 256-bit coefficient pairs:

                                            per call   memoized
  _double_mult_endomorphism_secp256k1          715 us     577 us   1.24x
  _double_mult_w_NAF, secp256r1               1000 us     878 us   1.14x
  _multi_mult_w_NAF, 8 points, one fixed      2160 us    2048 us   1.05x

The first row has four halves of which two are fixed, the endomorphism
splitting the generator into +-G and +-beta*G: those images are formed by
_double_mult_endomorphism_secp256k1 and named fixed there, which is the
one place that knows them.

The width is 10 by measurement -- 1.07x at 4, 1.12x at 6, 1.15x at 8,
1.18x at 10, 1.20x at 12, against a table that doubles at every step --
and capped at ec.scalar_len, a window wider than the scalars buying
nothing and costing a table: uncapped it was the low-cardinality curves
of the suite that paid, 40 s of it against 17.

_double_mult_w_NAF is now _multi_mult_w_NAF of two points rather than a
second copy of the same loop. What it keeps is the two messages its own
coefficients answer with, and the name the algorithm has.

Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize wNAF-based multi-scalar multiplication by caching wide-window tables for curve-fixed points and reusing the generic routine for double multiplications.

New Features:
- Introduce curve-level tracking of fixed points (generator and its opposite) for use in scalar multiplication routines.
- Add memoized odd-multiples tables for fixed points with a wider window than per-call tables, capped by the scalar bit length.

Enhancements:
- Extend `_multi_mult_w_NAF` to accept a set of fixed points and to use memoized wide-window tables when available, improving performance of verification paths.
- Refactor `_double_mult_w_NAF` to delegate to `_multi_mult_w_NAF` with two points instead of maintaining a separate loop, and update the endomorphism-based double multiplication to mark its derived images as fixed.

Documentation:
- Document the new fixed-point caching behavior, window-width choice, and measured performance improvements in the changelog.

Tests:
- Update multi-mult and dispatch tests to use the new `_multi_mult_w_NAF` signature with fixed points, ensuring correctness across curves and edge cases.