### PR TITLE
Compare btclib, bindings enabled, against other Python bitcoin libraries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -493,14 +493,21 @@ repos:
   # and no test collects it: the smoke script needs a node, so a workflow
   # dispatch is the only thing that runs it, and strict mode is the whole of
   # what reads it in between. A bound method used as a truth value is what
-  # that buys -- in a script of checks, a check that cannot fail
+  # that buys -- in a script of checks, a check that cannot fail.
+  # scripts/ joins it for the same reason: nothing collects
+  # benchmark_libraries.py either, a manual run being the whole of what
+  # exercises it. It imports five untyped third-party packages the `bench`
+  # group installs and this command's `--group lint --group test` does
+  # not, so pyproject.toml's [[tool.mypy.overrides]] declares
+  # ignore_missing_imports for exactly those five -- unresolved either way,
+  # with or without the group, so the group is not what this command needs
   - repo: local
     hooks:
       - id: mypy
         name: mypy (strict, in the project environment)
         entry: >
           uv run --locked --no-default-groups --group lint --group test
-          mypy btclib tests .github/scripts
+          mypy btclib tests .github/scripts scripts
         language: system
         types: [python]
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3339,6 +3339,43 @@ documented at release-notes length in the first place, and are still in
   bindings hand back a point whose Z is 1 -- and 1.01x where the
   multiplication is Python's, an inverse being 8.8 us of 1148.
 
+### Performance
+
+- **A benchmark compares btclib, bindings enabled, against other Python
+  bitcoin libraries** (issue #817), `scripts/benchmark_libraries.py`:
+  the `ecdsa` PyPI package, pycoin, buidl, embit and python-bitcoinlib,
+  each at its own latest release, on ECDSA sign/verify, BIP340
+  sign/verify and one BIP32 derivation -- never a feature a comparand
+  lacks, so `ecdsa` and python-bitcoinlib carry no BIP340 or BIP32 row,
+  and pycoin's own bare elliptic-curve `Generator` has no derivation of
+  its own either, which is why that row goes through
+  `pycoin.symbols.btc.network` instead. `bit`, the sixth candidate the
+  issue named, is not among them: its dependency `coincurve` has no
+  cp314 wheel yet, and its sdist fails to build on 3.14 with a
+  hatchling/cffi packaging defect this repository does not control.
+
+  Two comparands measure a moving target rather than a fixed one:
+  pycoin optimizes its pure-Python arithmetic with libsecp256k1 or
+  OpenSSL through ctypes when either is importable on the machine
+  running it, and python-bitcoinlib's OpenSSL wrapper can be pointed at
+  libsecp256k1 instead -- both machine-dependent, so the script checks
+  and prints which backend actually ran rather than assume the
+  pure-Python number a plain `pip install` usually gets. embit needs no
+  such check: it bundles a compiled libsecp256k1 for six platforms and
+  always calls it through ctypes, so its rows sit beside btclib's C
+  rather than beside the other four's Python. pycoin's `BIP32Node` also
+  caches every subkey it derives, keyed by index, which a benchmark
+  reusing one root object across many calls would have measured as a
+  dict lookup after the first; the script rebuilds each root from its
+  seed on every timed call instead, for all four BIP32 rows alike.
+
+  Not part of the test suite and not run by CI, matching issue #816's
+  bindings-against-Python benchmark inside btclib and
+  btclib-secp256k1#144's wrapper-against-wrapper one: none of the three
+  is gated, and each answers a different question about the same
+  arithmetic. The new `bench` dependency group installs the five
+  comparands, and nothing else needs them.
+
 ### Tests
 
 - **The input-validation gate's own verdict is exercised** (issue #776).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -156,7 +156,7 @@ These requirements are easily checked (and partially fixed) with:
 ```shell
 uv run ruff check --fix
 uv run ruff format
-uv run mypy btclib tests .github/scripts
+uv run mypy btclib tests .github/scripts scripts
 uv run pytest
 ```
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -32,6 +32,12 @@ recursive-include btclib *.txt
 recursive-include btclib *.bin
 recursive-include btclib *.typed
 
+# scripts/benchmark_libraries.py, not part of the btclib package
+# setuptools.packages.find installs but tracked and runnable from an
+# unpacked sdist all the same, as .github/scripts would be if
+# check-manifest did not ignore that directory outright
+recursive-include scripts *.py
+
 recursive-include tests *.bin
 recursive-include tests *.csv
 recursive-include tests *.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,14 @@ lint = ["mypy", "pre-commit", "ruff"]
 build = ["check-manifest", "check-wheel-contents", "pyroma", "twine"]
 mutation = ["cosmic-ray"]
 docs = ["myst-parser", "sphinx", "sphinx_rtd_theme"]
+# what scripts/benchmark_libraries.py times btclib against, at each
+# package's own latest release: no pin of its own, matching the
+# benchmark's premise that the comparison is against whatever `pip
+# install` currently gives a user. Not in `dev`, for the same reason
+# btclib-secp256k1's own `bench` group is not: nothing else needs any of
+# these five, and a lint or type-check run that does not touch the
+# script should not have to resolve them
+bench = ["buidl", "ecdsa", "embit", "pycoin", "python-bitcoinlib"]
 dev = [
     { include-group = "test" },
     { include-group = "lint" },
@@ -282,12 +290,14 @@ filterwarnings = ["error"]
 # which records where each of those files came from -- is still spell
 # checked, being prose about the data and not the data
 skip = "*/_data/*.json,*/_data/*.csv,*/_data/*.txt,*/_data/*.bin,*/_generated_files/*,.secrets.baseline,uv.lock"
-# identifiers, not misspellings: "wit" is a transaction's witness, and
-# "nd" is the Neutered Derivation the bip32 docstrings spell out. Both are
-# real words to codespell's dictionary, so neither can be fixed by writing
-# it differently -- unlike the rest of what this hook found, which was
+# identifiers, not misspellings: "wit" is a transaction's witness, "nd"
+# is the Neutered Derivation the bip32 docstrings spell out, and "buidl"
+# is scripts/benchmark_libraries.py's comparand, a PyPI package of that
+# exact name. All three are real words to codespell's dictionary (the
+# third by way of "build"), so none can be fixed by writing it
+# differently -- unlike the rest of what this hook found, which was
 # corrected instead of listed here
-ignore-words-list = "wit,nd"
+ignore-words-list = "wit,nd,buidl"
 # a misspelling written on purpose goes in backticks, and that is a
 # convention of this repository rather than a preference: prose that
 # documents a spell checker has to name what it catches, and the prose
@@ -386,6 +396,12 @@ ful = "ful"
 # ruff's own name for flake8-copyright, in the comment above
 # [tool.ruff.lint.flake8-copyright] explaining why it is selected
 CPY = "CPY"
+# the PyPI package scripts/benchmark_libraries.py compares btclib
+# against, not the "build" this hook offers to correct it to. Without
+# this line --write-changes turns every `buidl` in that script,
+# CHANGELOG.md and this file into a word that names a different package
+# on PyPI entirely
+buidl = "buidl"
 
 [tool.typos.type.verbatim]
 # the three files that quote misspellings on purpose: the #161 entry names
@@ -546,6 +562,17 @@ python_version = "3.10"
 exclude = [
     "build",
 ]
+
+# the comparands of scripts/benchmark_libraries.py, not dependencies of
+# the project: none ships py.typed or a stub on PyPI, and the `bench`
+# group that installs them is not part of the `--group lint --group
+# test` the mypy hook runs with, so the import is unresolved whether or
+# not the package happens to be installed. ignore_missing_imports
+# silences exactly that error; the script's own logic still gets strict
+# mode, and only what it receives back from one of these five is `Any`
+[[tool.mypy.overrides]]
+module = ["bitcoin.*", "buidl.*", "ecdsa.*", "embit.*", "pycoin.*"]
+ignore_missing_imports = true
 
 [tool.ruff]
 # target-version is inferred from project.requires-python
@@ -736,6 +763,13 @@ ignore = [
 # job that started an emulator: what it saw and how long it took, or the
 # ::error:: annotation naming what it saw instead
 ".github/scripts/wait_for_hwi_device.py" = ["T201"]
+# the benchmark script: its whole output is the table a manual run reads,
+# and it asserts every comparand agrees with btclib before timing any of
+# them, the same pattern btclib-secp256k1's own scripts/benchmark.py uses
+"scripts/benchmark_libraries.py" = [
+    "S101", # assert
+    "T201", # print
+]
 # the D rules are not here: a public test function, fixture or method
 # states what it verifies -- the property, the vector, the failure
 # mode -- under the same docstring gate as the library's public

--- a/scripts/benchmark_libraries.py
+++ b/scripts/benchmark_libraries.py
@@ -1,0 +1,447 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""Timings of btclib, bindings enabled, against other Python bitcoin libraries.
+
+btclib, with the `btclib_secp256k1` bindings it depends on and cannot be
+installed without, is what `pip install btclib` gives an end user -- so
+this times exactly that path, never the pure-Python fallback of
+`curves/curve_group.py`, which issue #816's benchmark covers instead.
+
+Every comparand is timed at its own latest PyPI release, on operations it
+actually offers: signing a message is compared against a package that
+signs, deriving a BIP32 child against one that has BIP32, and nothing
+is compared against a package that lacks the feature.
+
+## The candidates, and one that is not here
+
+The issue that asked for this script named six candidates: python-ecdsa,
+pycoin, bit, embit, python-bitcoinlib and buidl. `bit` is not among the
+rows below: its latest release, 0.8.0 from 2021-12-04, depends on
+`coincurve`, whose latest wheel set (21.0.0) stops at cp313 -- no cp314
+build exists yet -- and the sdist fails to build on 3.14 with
+"RuntimeError: Expected exactly one LICENSE file in cffi distribution",
+a coincurve/hatchling packaging defect this repository does not control.
+`uv sync --group bench` on `.python-version`'s 3.14 cannot install it, so
+it is left out rather than pinned around silently; revisit if a newer
+coincurve gains a 3.14 wheel.
+
+## What each comparand is actually running, and how that was checked
+
+A raw ctypes.util.find_library lookup answers "is a shared object
+findable on this machine", and that answer moves with what happens to be
+installed system-wide -- so two of the rows below are not always timing
+what they seem to:
+
+- pycoin optimizes its pure-Python arithmetic with libsecp256k1 or
+  OpenSSL through ctypes *if* either is importable at runtime
+  (`pycoin.ecdsa.native.secp256k1.libsecp256k1`,
+  `pycoin.ecdsa.native.openssl` through the same mechanism); with
+  neither found it falls back to the plain-Python `Generator` class.
+  `_pycoin_backend()` below reports which one actually ran, because
+  nothing here should claim a Python number without checking that it is
+  one.
+- python-bitcoinlib's `CECKey` defaults to OpenSSL's `EC_KEY` (loaded the
+  same way, `ctypes.util.find_library`) and only calls libsecp256k1 if a
+  caller opts in with `use_libsecp256k1_for_signing` -- not done here, so
+  this row is OpenSSL's C and not Python either way, and stays that on
+  every machine that has OpenSSL, which is to say every machine this
+  installs on.
+- embit does not probe the system at all: `embit/util/prebuilt/` ships a
+  compiled libsecp256k1 for six platforms, and `embit.ec` loads the one
+  matching `platform.machine()` through ctypes unconditionally. This row
+  is always C, and always a libsecp256k1 build embit vendors rather than
+  the one `btclib_secp256k1` vendors -- two different builds of the same
+  library, not the same binary measured twice.
+- buidl tries `buidl.cecc`, a compiled extension against Core's
+  secp256k1 that `pip install buidl` does not build (`libsec_build.py`
+  is a separate step this script does not run), and falls back to
+  `buidl.pecc`, pure Python -- deterministically, since nothing here
+  attempts the build. `ecdsa` (the PyPI package) has no native path to
+  fall back from: it is pure Python unconditionally.
+
+None of this makes a row invalid -- it is what `pip install <package>`
+actually gives a user on this machine, which is the same question this
+whole script asks of btclib. It does mean a pycoin row is not always
+comparable across two runs of this script on two machines, which is why
+the backend it picked is part of the output rather than a footnote.
+
+## What is measured
+
+Three operations, on secp256k1, sha256 where a digest is needed:
+
+- ECDSA sign and verify, over a fixed 32-byte digest -- every comparand
+  that exposes ECDSA takes a digest directly rather than a message, so
+  none of them hash it a second time on top of the `hashlib.sha256` call
+  below.
+- BIP340 (Schnorr) sign and verify, over a fixed 32-byte message --
+  BIP340 does not hash its message internally, so this is the value
+  every implementation signs and checks, byte for byte, and it doubles
+  as libsecp256k1's own fixed-size entry point, which is what keeps
+  btclib's row on the bindings path (`ecc.ssa.sign_`'s dispatch is
+  exactly this size or the arbitrary-size Python fallback, and this
+  script wants the former).
+- one BIP32 derivation, `m/0h/1` from a fixed 32-byte seed -- a hardened
+  step and a normal one, which is what every comparand's own derivation
+  function takes a path string or a chain of `child`/`subkey` calls for.
+  All four implementations below were checked to agree on the resulting
+  public key before any of this was timed.
+
+python-ecdsa and python-bitcoinlib carry neither BIP340 nor BIP32, so
+neither has a row in those two tables; pycoin's own `ecdsa.Generator` is
+a bare elliptic-curve object with no seed-derivation function either,
+which is why its BIP32 row goes through `pycoin.symbols.btc.network`
+instead, the layer above that actually has one. Nothing here compares a
+feature against a library that lacks it.
+
+Not part of the test suite and not run by CI: it needs five third-party
+packages this project does not depend on, declared in the `bench`
+dependency group and nowhere else.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import time
+from collections.abc import Callable
+from importlib.metadata import version
+
+import bitcoin.core.key as bitcoinlib_key
+import buidl.hd
+import buidl.libsec_status
+import buidl.pecc
+import ecdsa
+import embit.bip32
+import embit.ec
+import pycoin.symbols.btc
+
+from btclib.bip32 import bip32
+from btclib.ecc import dsa, ssa
+from btclib.to_pub_key import pub_keyinfo_from_prv_key
+
+PRVKEY = 1
+MSG_HASH = hashlib.sha256(b"Satoshi Nakamoto").digest()
+SEED = bytes(range(32))
+BIP32_PATH = "m/0h/1"
+
+
+def _pycoin_backend() -> str:
+    """Name the arithmetic pycoin's Generator actually runs, this machine.
+
+    `create_LibSECP256K1Optimizations`/`create_OpenSSLOptimizations` (in
+    `pycoin.ecdsa.native.*`) each resolve to a `noop` mixin class when
+    the shared library they probe for is not importable -- there is no
+    public flag to read instead, so this reads the MRO the generator
+    ended up with.
+    """
+    bases = type(pycoin.symbols.btc.network.generator).__mro__
+    names = [base.__name__ for base in bases]
+    if any("noop" not in name and "LibSECP256K1" in name for name in names):
+        return "libsecp256k1 (via ctypes)"
+    if any("noop" not in name and "OpenSSL" in name for name in names):
+        return "OpenSSL (via ctypes)"
+    return "pure Python"
+
+
+def report_setup() -> None:
+    """Print what is about to be timed, and on what.
+
+    A version number and a backend name, not a benchmark result, because
+    the numbers below mean something only next to what produced them.
+    """
+    print(f"btclib               : {version('btclib')} (bindings enabled)")
+    print(f"btclib_secp256k1     : {version('btclib_secp256k1')}")
+    print(f"ecdsa                : {version('ecdsa')} (pure Python, no native path)")
+    print(f"pycoin               : {version('pycoin')} ({_pycoin_backend()})")
+    buidl_backend = (
+        "libsecp256k1 (via cffi)"
+        if buidl.libsec_status.is_libsec_enabled()
+        else "pure Python"
+    )
+    print(f"buidl                : {version('buidl')} ({buidl_backend})")
+    print(
+        f"embit                : {version('embit')} "
+        "(bundled libsecp256k1, via ctypes, always)"
+    )
+    libsecp256k1_for_signing = bitcoinlib_key.is_libsec256k1_available()
+    print(
+        f"python-bitcoinlib    : {version('python-bitcoinlib')} "
+        f"(OpenSSL, via ctypes; libsecp256k1 available but unused: "
+        f"{libsecp256k1_for_signing})"
+    )
+    print()
+
+
+# --- ECDSA sign and verify, over MSG_HASH -----------------------------
+
+btclib_pubkey = pub_keyinfo_from_prv_key(PRVKEY)[0]
+btclib_dsa_sig = dsa.sign_(MSG_HASH, PRVKEY)
+
+ecdsa_signing_key = ecdsa.SigningKey.from_secret_exponent(PRVKEY, curve=ecdsa.SECP256k1)
+ecdsa_verifying_key = ecdsa_signing_key.verifying_key
+ecdsa_sig = ecdsa_signing_key.sign_digest_deterministic(
+    MSG_HASH, hashfunc=hashlib.sha256, sigencode=ecdsa.util.sigencode_der
+)
+
+pycoin_generator = pycoin.symbols.btc.network.generator
+pycoin_val = int.from_bytes(MSG_HASH, "big")
+pycoin_pubpoint = pycoin_generator * PRVKEY
+pycoin_public_pair = (pycoin_pubpoint[0], pycoin_pubpoint[1])
+pycoin_sig = pycoin_generator.sign(PRVKEY, pycoin_val)
+
+buidl_prvkey = buidl.pecc.PrivateKey(PRVKEY)
+buidl_z = int.from_bytes(MSG_HASH, "big")
+buidl_sig = buidl_prvkey.sign(buidl_z)
+
+bitcoinlib_key_ = bitcoinlib_key.CECKey()
+bitcoinlib_key_.set_secretbytes(PRVKEY.to_bytes(32, "big"))
+bitcoinlib_key_.set_compressed(True)
+bitcoinlib_pubkey = bitcoinlib_key.CPubKey(bitcoinlib_key_.get_pubkey())
+bitcoinlib_sig = bitcoinlib_key_.sign(MSG_HASH)
+
+embit_prvkey = embit.ec.PrivateKey(PRVKEY.to_bytes(32, "big"))
+embit_pubkey = embit_prvkey.get_public_key()
+embit_dsa_sig = embit_prvkey.sign(MSG_HASH)
+
+assert dsa.verify_(MSG_HASH, btclib_pubkey, btclib_dsa_sig)
+assert ecdsa_verifying_key.verify_digest(
+    ecdsa_sig, MSG_HASH, sigdecode=ecdsa.util.sigdecode_der
+)
+assert pycoin_generator.verify(pycoin_public_pair, pycoin_val, pycoin_sig)
+assert buidl_prvkey.point.verify(buidl_z, buidl_sig)
+assert bitcoinlib_pubkey.verify(MSG_HASH, bitcoinlib_sig)
+assert embit_pubkey.verify(embit_dsa_sig, MSG_HASH)
+
+
+def dsa_sign_btclib() -> None:
+    """Time ECDSA signing through btclib, bindings enabled."""
+    dsa.sign_(MSG_HASH, PRVKEY)
+
+
+def dsa_verify_btclib() -> None:
+    """Time ECDSA verification through btclib, bindings enabled."""
+    assert dsa.verify_(MSG_HASH, btclib_pubkey, btclib_dsa_sig)
+
+
+def dsa_sign_ecdsa() -> None:
+    """Time ECDSA signing through the `ecdsa` PyPI package."""
+    ecdsa_signing_key.sign_digest_deterministic(
+        MSG_HASH, hashfunc=hashlib.sha256, sigencode=ecdsa.util.sigencode_der
+    )
+
+
+def dsa_verify_ecdsa() -> None:
+    """Time ECDSA verification through the `ecdsa` PyPI package."""
+    assert ecdsa_verifying_key.verify_digest(
+        ecdsa_sig, MSG_HASH, sigdecode=ecdsa.util.sigdecode_der
+    )
+
+
+def dsa_sign_pycoin() -> None:
+    """Time ECDSA signing through pycoin's Generator, backend as reported."""
+    pycoin_generator.sign(PRVKEY, pycoin_val)
+
+
+def dsa_verify_pycoin() -> None:
+    """Time ECDSA verification through pycoin's Generator."""
+    assert pycoin_generator.verify(pycoin_public_pair, pycoin_val, pycoin_sig)
+
+
+def dsa_sign_buidl() -> None:
+    """Time ECDSA signing through buidl's pure-Python PrivateKey."""
+    buidl_prvkey.sign(buidl_z)
+
+
+def dsa_verify_buidl() -> None:
+    """Time ECDSA verification through buidl's pure-Python S256Point."""
+    assert buidl_prvkey.point.verify(buidl_z, buidl_sig)
+
+
+def dsa_sign_bitcoinlib() -> None:
+    """Time ECDSA signing through python-bitcoinlib's OpenSSL wrapper."""
+    bitcoinlib_key_.sign(MSG_HASH)
+
+
+def dsa_verify_bitcoinlib() -> None:
+    """Time ECDSA verification through python-bitcoinlib's OpenSSL wrapper."""
+    assert bitcoinlib_pubkey.verify(MSG_HASH, bitcoinlib_sig)
+
+
+def dsa_sign_embit() -> None:
+    """Time ECDSA signing through embit's bundled libsecp256k1."""
+    embit_prvkey.sign(MSG_HASH)
+
+
+def dsa_verify_embit() -> None:
+    """Time ECDSA verification through embit's bundled libsecp256k1."""
+    assert embit_pubkey.verify(embit_dsa_sig, MSG_HASH)
+
+
+# --- BIP340 (Schnorr) sign and verify, over MSG_HASH -------------------
+
+btclib_xonly_pubkey = btclib_pubkey[1:]
+btclib_ssa_sig = ssa.sign_(MSG_HASH, PRVKEY)
+
+buidl_aux = bytes(32)
+buidl_ssa_sig = buidl_prvkey.sign_schnorr(MSG_HASH, buidl_aux)
+
+embit_ssa_sig = embit_prvkey.schnorr_sign(MSG_HASH)
+
+assert ssa.verify_(MSG_HASH, btclib_xonly_pubkey, btclib_ssa_sig)
+assert buidl_prvkey.point.verify_schnorr(MSG_HASH, buidl_ssa_sig)
+assert embit_pubkey.schnorr_verify(embit_ssa_sig, MSG_HASH)
+
+
+def ssa_sign_btclib() -> None:
+    """Time BIP340 signing through btclib, bindings enabled."""
+    ssa.sign_(MSG_HASH, PRVKEY)
+
+
+def ssa_verify_btclib() -> None:
+    """Time BIP340 verification through btclib, bindings enabled."""
+    assert ssa.verify_(MSG_HASH, btclib_xonly_pubkey, btclib_ssa_sig)
+
+
+def ssa_sign_buidl() -> None:
+    """Time BIP340 signing through buidl's pure-Python PrivateKey."""
+    buidl_prvkey.sign_schnorr(MSG_HASH, buidl_aux)
+
+
+def ssa_verify_buidl() -> None:
+    """Time BIP340 verification through buidl's pure-Python S256Point."""
+    assert buidl_prvkey.point.verify_schnorr(MSG_HASH, buidl_ssa_sig)
+
+
+def ssa_sign_embit() -> None:
+    """Time BIP340 signing through embit's bundled libsecp256k1."""
+    embit_prvkey.schnorr_sign(MSG_HASH)
+
+
+def ssa_verify_embit() -> None:
+    """Time BIP340 verification through embit's bundled libsecp256k1."""
+    assert embit_pubkey.schnorr_verify(embit_ssa_sig, MSG_HASH)
+
+
+# --- BIP32 derivation, seed to "m/0h/1" child ---------------------------
+
+# the whole path from SEED, rebuilt inside every function below rather
+# than once here: pycoin's BIP32Node keeps a `_subkey_cache` dict keyed
+# by index, so a root reused across 1000 calls of the same path answers
+# the 999 after the first from that cache and times a dict lookup, not a
+# derivation. Rebuilding the root from the seed on every call is the one
+# methodology that measures the same thing for all four -- one HMAC-SHA512
+# to the root plus the path below it -- and none of the other three reads
+# any faster for it: none keeps a cross-call cache of its own
+
+
+def _btclib_child_pubkey(seed: bytes) -> bytes:
+    xprv = bip32.rootxprv_from_seed(seed)
+    child = bip32.derive(xprv, BIP32_PATH)
+    return bip32.BIP32KeyData.b58decode(bip32.xpub_from_xprv(child)).key
+
+
+def _pycoin_child_pubkey(seed: bytes) -> bytes:
+    root = pycoin.symbols.btc.network.keys.bip32_seed(seed)
+    return bytes(root.subkey_for_path("0H/1").sec())
+
+
+def _embit_child_pubkey(seed: bytes) -> bytes:
+    root = embit.bip32.HDKey.from_seed(seed)
+    return bytes(root.derive(BIP32_PATH).sec())
+
+
+def _buidl_child_pubkey(seed: bytes) -> bytes:
+    root = buidl.hd.HDPrivateKey.from_seed(seed)
+    return bytes(root.traverse(BIP32_PATH).pub.point.sec())
+
+
+assert (
+    _btclib_child_pubkey(SEED)
+    == _pycoin_child_pubkey(SEED)
+    == _embit_child_pubkey(SEED)
+    == _buidl_child_pubkey(SEED)
+)
+
+
+def bip32_derive_btclib() -> None:
+    """Time seed-to-child BIP32 derivation through btclib, bindings enabled."""
+    _btclib_child_pubkey(SEED)
+
+
+def bip32_derive_pycoin() -> None:
+    """Time seed-to-child BIP32 derivation through pycoin's BIP32Node."""
+    _pycoin_child_pubkey(SEED)
+
+
+def bip32_derive_embit() -> None:
+    """Time seed-to-child BIP32 derivation through embit's HDKey."""
+    _embit_child_pubkey(SEED)
+
+
+def bip32_derive_buidl() -> None:
+    """Time seed-to-child BIP32 derivation through buidl's HDPrivateKey."""
+    _buidl_child_pubkey(SEED)
+
+
+def benchmark(func: Callable[[], None], calls: int) -> None:
+    """Call `func` `calls` times and print microseconds per call.
+
+    `calls` is chosen per function rather than shared: pycoin's and
+    buidl's pure-Python rows are three to four orders of magnitude
+    slower than the C-backed ones, so one loop count for all of them
+    would either sit for minutes on the slowest or measure the fastest
+    against the resolution of the clock. Each count below was picked
+    from a first timed call to land near 1.5 seconds -- long enough that
+    Python's own call overhead is a rounding error next to it, short
+    enough that the whole script is a run to wait for, not start and
+    leave.
+    """
+    # perf_counter and not time(): the wall clock can step backwards
+    # under an NTP correction, and a benchmark is the one place that
+    # shows up as a negative duration
+    start = time.perf_counter()
+    for _ in range(calls):
+        func()
+    end = time.perf_counter()
+    us_per_call = (end - start) / calls * 1e6
+    print(f"{func.__name__:<22}: {us_per_call:10.2f} us/call ({calls} calls)")
+
+
+report_setup()
+
+print("ECDSA sign (32-byte digest, secp256k1)")
+benchmark(dsa_sign_btclib, 50_000)
+benchmark(dsa_sign_ecdsa, 5_000)
+benchmark(dsa_sign_pycoin, 200)
+benchmark(dsa_sign_buidl, 50)
+benchmark(dsa_sign_bitcoinlib, 8_000)
+benchmark(dsa_sign_embit, 50_000)
+print()
+
+print("ECDSA verify (32-byte digest, secp256k1)")
+benchmark(dsa_verify_btclib, 50_000)
+benchmark(dsa_verify_ecdsa, 3_000)
+benchmark(dsa_verify_pycoin, 80)
+benchmark(dsa_verify_buidl, 25)
+benchmark(dsa_verify_bitcoinlib, 7_000)
+benchmark(dsa_verify_embit, 50_000)
+print()
+
+print("BIP340 sign (32-byte message)")
+benchmark(ssa_sign_btclib, 50_000)
+benchmark(ssa_sign_buidl, 20)
+benchmark(ssa_sign_embit, 50_000)
+print()
+
+print("BIP340 verify (32-byte message)")
+benchmark(ssa_verify_btclib, 50_000)
+benchmark(ssa_verify_buidl, 25)
+benchmark(ssa_verify_embit, 50_000)
+print()
+
+print(f"BIP32 derive, seed to {BIP32_PATH} (32-byte seed)")
+benchmark(bip32_derive_btclib, 30_000)
+benchmark(bip32_derive_pycoin, 75)
+benchmark(bip32_derive_embit, 15_000)
+benchmark(bip32_derive_buidl, 12)

--- a/uv.lock
+++ b/uv.lock
@@ -318,6 +318,13 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
+bench = [
+    { name = "buidl" },
+    { name = "ecdsa" },
+    { name = "embit" },
+    { name = "pycoin" },
+    { name = "python-bitcoinlib" },
+]
 build = [
     { name = "check-manifest" },
     { name = "check-wheel-contents" },
@@ -378,6 +385,13 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
+bench = [
+    { name = "buidl" },
+    { name = "ecdsa" },
+    { name = "embit" },
+    { name = "pycoin" },
+    { name = "python-bitcoinlib" },
+]
 build = [
     { name = "check-manifest" },
     { name = "check-wheel-contents" },
@@ -504,6 +518,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/95/0e3172435a018a618f31830bfcd39505fb5ce46a35699b8e7b3b3b792a32/btclib_secp256k1-0.8.0.1-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f7aa577a0bc9a05a5dca2ed1032896ec3ad9a2b7a23c648d835f0fc048b31cad", size = 1329981, upload-time = "2026-08-13T19:06:30.832Z" },
     { url = "https://files.pythonhosted.org/packages/50/1a/1938af166ab4e4c84c506388cd304d221c60d733b558f5dd7c1cd144b9e7/btclib_secp256k1-0.8.0.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0d12c9c54c320faf465492ecce4a64e4e6fc8d9ff913f95c6ca43dbee5d80e23", size = 1310767, upload-time = "2026-08-13T19:06:32.484Z" },
     { url = "https://files.pythonhosted.org/packages/ff/0f/48a6a98cc735defbc58d260f71b132d428b9722053c350cb9c28168b4a06/btclib_secp256k1-0.8.0.1-py3-none-win_amd64.whl", hash = "sha256:9f077199d42f46bd4375783708eb81c7c396a47755d88750291af330ffd17a64", size = 1332872, upload-time = "2026-08-13T19:06:34.065Z" },
+]
+
+[[package]]
+name = "buidl"
+version = "0.2.36"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/a2/b311f04cd1ae0b6bdba797f836fa6dd070315eb37a1ce1cb7b84d37b86ed/buidl-0.2.36.tar.gz", hash = "sha256:e3537a33574154e7bce0ca7fbe45b8e512b4473189b0be3ce28e1d3ddf5303f9", size = 239081, upload-time = "2022-02-28T20:28:39.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/5b/f1c02f13043a83903c405a33e75cb1ff6a2d0c59299a84b0b894f764d5e8/buidl-0.2.36-py3-none-any.whl", hash = "sha256:89d00825bc286ae56da31ea3d12853d5cb1ad53c64ad6daa45d791af7df1186d", size = 253135, upload-time = "2022-02-28T20:28:36.575Z" },
 ]
 
 [[package]]
@@ -1111,6 +1134,24 @@ sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ff
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
 ]
+
+[[package]]
+name = "ecdsa"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
+]
+
+[[package]]
+name = "embit"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/88/b054b00ade6d2a41749e15976cdcec4b7ec4656ac1cb917ce3de395528d1/embit-0.8.0.tar.gz", hash = "sha256:8bf4b10073c67400370ce523fb16f035fe759f6fdd987c579bdcc268d75ed770", size = 763120, upload-time = "2024-05-30T10:56:48.944Z" }
 
 [[package]]
 name = "exceptiongroup"
@@ -2339,6 +2380,12 @@ wheels = [
 ]
 
 [[package]]
+name = "pycoin"
+version = "0.92718.20260405"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/7f/7773215c24aa80e2932e2b770253f43fad36fc324772492f23a7808bdacb/pycoin-0.92718.20260405.tar.gz", hash = "sha256:5ea55aa17f0be2d4b78b559a88678ff6f4b007c256e08a4012d8c4090cf712f7", size = 380722, upload-time = "2026-04-05T22:55:19.941Z" }
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2573,6 +2620,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-bitcoinlib"
+version = "0.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/a1/ca9d770094a0bfd0f2ce66b7180f0a7729b1b646d90f37f6debf38b28fab/python-bitcoinlib-0.12.2.tar.gz", hash = "sha256:c65ab61427c77c38d397bfc431f71d86fd355b453a536496ec3fcb41bd10087d", size = 153798, upload-time = "2023-06-03T18:37:11.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/46/b388d0885cf799f5bc66ca9995c83e5b7e17cb737f812a7c2591aa789ea6/python_bitcoinlib-0.12.2-py3-none-any.whl", hash = "sha256:2f29a9f475f21c12169b3a6cc8820f34f11362d7ff1200a5703dce3e4e903a44", size = 106954, upload-time = "2023-06-03T18:37:08.524Z" },
+]
+
+[[package]]
 name = "python-discovery"
 version = "1.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2776,6 +2832,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `scripts/benchmark_libraries.py`, comparing btclib (bindings
  enabled) against the `ecdsa` PyPI package, pycoin, buidl, embit and
  python-bitcoinlib, each at its own latest release, on ECDSA
  sign/verify, BIP340 sign/verify and one BIP32 derivation — never a
  feature a comparand lacks.
- `bit`, the sixth candidate the issue named, is left out: its
  `coincurve` dependency has no cp314 wheel yet and its sdist fails to
  build on 3.14 with a hatchling/cffi packaging defect this repository
  does not control.
- Adds the `bench` dependency group (the five comparands, nothing
  else needs them), a `[[tool.mypy.overrides]]` entry so the mypy hook
  (which does not install that group) still type-checks the script
  against `Any` for those five untyped imports, a ruff per-file-ignore
  for the script's asserts/prints, and `MANIFEST.in`/typos/codespell
  entries so the sdist ships the script and the linters stop
  "correcting" `buidl` to `build`.
- `.pre-commit-config.yaml` and `CONTRIBUTING.md`'s mypy command now
  both name `scripts` alongside `btclib tests .github/scripts`.

Two comparands' numbers depend on what's importable at runtime (pycoin's
optional libsecp256k1/OpenSSL ctypes optimization, python-bitcoinlib's
optional libsecp256k1 signing), so the script checks and prints which
backend actually ran instead of assuming the plain-`pip install` case.
pycoin's `BIP32Node` also caches subkeys by index, so every BIP32 row
rebuilds its root from the seed on each timed call rather than reusing
one object across calls.

Closes #817. Sibling of #816 (btclib's own bindings-vs-Python path) and
btclib-secp256k1#144 (wrapper-vs-wrapper).

## Test plan

- [x] `uv run pre-commit run --all-files` (ruff, mypy, codespell, typos,
      check-manifest, etc.) — all passed
- [x] `uv run pytest` — 26733 passed, 100.00% coverage
- [x] `uv run --group docs sphinx-build -W --keep-going -b html
      docs/source docs/build/html` — build succeeded
- [x] `uv sync --group bench && uv run python
      scripts/benchmark_libraries.py` — runs end to end in ~30s,
      correctness asserted for every comparand before any timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a standalone benchmarking script that compares btclib (with secp256k1 bindings) against several other Python Bitcoin libraries on core cryptographic operations, and wire it into tooling without affecting CI or tests.

New Features:
- Introduce scripts/benchmark_libraries.py to time btclib against ecdsa, pycoin, buidl, embit and python-bitcoinlib on ECDSA, BIP340 and BIP32 operations, reporting backend details and ensuring result correctness before timing.

Enhancements:
- Define a dedicated bench dependency group for benchmark comparand libraries and keep it separate from dev, lint and test environments.
- Update mypy configuration and pre-commit setup so the new benchmark script is type-checked (with missing imports ignored for untyped comparand packages) and covered by local mypy commands.
- Extend linting and packaging configuration (ruff, codespell, typos, MANIFEST) to account for the new benchmark script and the buidl package name, ensuring the script ships in sdists and linters do not auto-correct identifiers.
- Document the new performance benchmark and its methodology in the changelog, clarifying scope, comparands, and non-CI nature of the benchmark.

Documentation:
- Add changelog documentation for the new btclib-vs-other-libraries performance benchmark, including comparands, measurement details, and execution constraints.

Tests:
- Clarify that the new benchmarking script is not part of the automated test suite or CI and is intended for manual performance comparisons only.