### PR TITLE
Say in the name whether the scalar decides the work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2212,6 +2212,36 @@ documented at release-notes length in the first place, and are still in
   `_double_mult_w_NAF` is now `_multi_mult_w_NAF` of two points rather
   than a second copy of the same loop. What it keeps is the two messages
   its own coefficients answer with, and the name the algorithm has.
+- **A multiplication says in its name whether the scalar decides its work**
+  (issue #806). Which of the private multiplications makes the same number
+  of point additions for every scalar and which makes a number the
+  coefficient decides is the distinction every dispatch in `curve.py`
+  turns on, and it was stated in the docstrings and nowhere else. It is in
+  the names now, as libsecp256k1 has it: `_mult_jac_var`,
+  `_mult_aff_var`, `_mult_base_3_var`, `_mult_mont_ladder_var`, the two
+  `_mult_recursive_*_var`, the two `_mult_fixed_window*_var`,
+  `_mult_sliding_window_var`, `_mult_w_NAF_var`, `_double_mult_var`,
+  `_double_mult_w_NAF_var`, `_double_mult_endomorphism_secp256k1_var`,
+  `_multi_mult_w_NAF_var`, `_multi_mult_bos_coster_var` and
+  `_multi_mult_var` -- against `_mult_regular_window`, `_mult_fixed_base`
+  and `_double_mult_regular_window`, which carry no suffix because they
+  make one count whatever the scalar.
+
+  `_mult_endomorphism_secp256k1` had a `regular` flag that decided which
+  of the two it was, so its name could only be half true: it is two
+  functions now, the regular windows `curves.mult` runs and
+  `_mult_endomorphism_secp256k1_var` beside it, which is algorithm 3.77 as
+  it is written and 16% faster at the cost of the count following the
+  scalar. Nothing signs with the second; it stays to be measured against
+  the first.
+
+  Every name is private and `curves/__init__.py` says so, so no caller's
+  code changes. CONTRIBUTING.md carries the rule for what comes next, with
+  the two things the absence of the suffix does not promise: not a
+  constant-time function -- `mod_inv` is an extended Euclid, a table is
+  indexed by a secret digit, and `SECURITY.md` publishes the Python path
+  as variable-time -- and nothing at all about the point, whose inversion
+  every table costs and whose value is the caller's public key.
 
 ### The public API and the module layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -901,6 +901,31 @@ check is unreachable by design rather than missing. `btclib/utils.py`'s
 docstring is where that rule is written down, `OutPoint` and `TxIn` being
 the classes it holds for.
 
+#### A `_var` suffix means the scalar decides the work
+
+A private scalar multiplication whose number of point operations depends
+on the coefficient it is given ends in `_var`:
+`btclib.curves.curve_group._mult_jac_var` and
+`curve_group_2._double_mult_w_NAF_var` against `_mult_regular_window`,
+`_mult_fixed_base` and `_double_mult_regular_window`, which make the same
+number for every scalar of the curve. It is libsecp256k1's convention,
+where `secp256k1_gej_add_var` sits beside `secp256k1_gej_add_ge`, and it
+is there so that the question can be answered at the call site instead of
+in the docstring of the thing being called.
+
+Two things it does not mean, and neither is a detail. **A name without
+`_var` is not a constant-time function**: `mod_inv` is an extended
+Euclid, a table is indexed by a secret digit, and `SECURITY.md` publishes
+the whole Python path as variable-time — what the absence of the suffix
+promises is one count of point operations, not one duration. And **the
+suffix is about the coefficient, not the point**: every table these build
+costs a modular inversion whose time follows the point, which is the
+caller's public key in the callers btclib has.
+
+Add the suffix when adding such a function, and do not add it to the
+recodings, the tables or the group law: those take no scalar, and a
+suffix on everything says nothing about anything.
+
 #### Documentation and comments
 
 What "satisfied" means for the prose — docstrings, comments, the

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -29,19 +29,27 @@ where they are defined: which standard a curve comes from is a question
 about a curve, not a way of finding one.
 
 The other multiplications of btclib.curves.curve_group and
-btclib.curves.curve_group_2 -- _mult_aff, _mult_jac, _mult_base_3,
-_mult_mont_ladder, the two _mult_recursive_*, the two _mult_fixed_window*,
-_mult_fixed_base, _mult_regular_window, _mult_sliding_window, _mult_w_NAF,
-the two _double_mult_* and _mult_endomorphism_secp256k1 -- are private, as
-are the _multiples, _cached_multiples, _cached_fixed_base_multiples,
-_odd_multiples and _jac_from_aff they are built on.
+btclib.curves.curve_group_2 -- _mult_aff_var, _mult_jac_var,
+_mult_base_3_var, _mult_mont_ladder_var, the two _mult_recursive_*_var, the
+two _mult_fixed_window*_var, _mult_fixed_base, _mult_regular_window,
+_mult_sliding_window_var, _mult_w_NAF_var, the three _double_mult_*, and the
+two _mult_endomorphism_secp256k1* -- are private, as are the _multiples,
+_cached_multiples, _cached_fixed_base_multiples, _odd_multiples and
+_jac_from_aff they are built on.
+
+The _var suffix on most of those is libsecp256k1's, and it says the same
+thing: the number of point operations such a multiplication makes depends
+on the coefficient it is given, where _mult_regular_window,
+_mult_fixed_base and _double_mult_regular_window make the same number for
+every scalar of the curve. CONTRIBUTING.md states the rule, and states
+what its absence does not promise: nothing here is constant-time.
 
 They are implementations of one operation, kept side by side to be measured
 against each other, and a menu of them is not an API: a caller reading them
 would find every way of multiplying a point this package implements and
 nothing to say that mult is the one to use, that it dispatches to
-libsecp256k1 for secp256k1 and the generator, and that _mult_jac is not the
-faster alternative its name suggests.
+libsecp256k1 for secp256k1 and the generator, and that _mult_jac_var is
+not the faster alternative its name suggests.
 
 The underscore says the second thing too, which is what decided it: each
 takes a point it assumes to be on the curve and checks nothing, so a

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -47,11 +47,11 @@ from btclib.curves.curve_group import (
     _jac_from_aff,
     _mult,
     _mult_fixed_base,
-    _multi_mult,
+    _multi_mult_var,
 )
 from btclib.curves.curve_group_2 import (
-    _double_mult_endomorphism_secp256k1,
-    _double_mult_w_NAF,
+    _double_mult_endomorphism_secp256k1_var,
+    _double_mult_w_NAF_var,
     _mult_endomorphism_secp256k1,
 )
 from btclib.exceptions import BTClibValueError
@@ -173,7 +173,7 @@ class Curve(CurveGroup):
         # same on every call, so their wNAF tables are memoized and held
         # wide; _cached_odd_multiples_aff says what that buys. The
         # endomorphism's images of the two are fixed as well and are added
-        # by _double_mult_endomorphism_secp256k1, which is what forms them
+        # by _double_mult_endomorphism_secp256k1_var, which is what forms them
         self._fixed_points = frozenset({self.GJ, self.negate_jac(self.GJ)})
 
         n = int_from_integer(n)
@@ -625,7 +625,7 @@ def mult(m_int: Integer, Q: Point | None = None, ec: Curve = secp256k1) -> Point
     QJ = _blinded_jac(QJ, ec)
 
     R = (
-        _mult_endomorphism_secp256k1(m, QJ, ec, _ENDOMORPHISM_W, regular=True)
+        _mult_endomorphism_secp256k1(m, QJ, ec, _ENDOMORPHISM_W)
         if ec == secp256k1
         else _mult(m, QJ, ec)
     )
@@ -640,7 +640,7 @@ def _double_mult_python(
     The arm `double_mult` and `_jac_double_mult` share, so that one place
     decides which double multiplication a curve gets and both reach the
     same one. On secp256k1 that is the GLV split of both coefficients,
-    which is to `_double_mult_w_NAF` what `_mult_endomorphism_secp256k1`
+    which is to `_double_mult_w_NAF_var` what `_mult_endomorphism_secp256k1`
     is to `_mult`: the same answer for ~128 doublings instead of ~256.
 
     Dispatched on the curve having the endomorphism, not on
@@ -657,14 +657,16 @@ def _double_mult_python(
     _eq_key tuples together, where the identical object short-circuits on
     identity. That is 8% of a low-cardinality double multiplication and
     two tenths of a second of the suite, spent for the same reason
-    _double_mult_w_NAF spends about 3 us a call there: what the saving
+    _double_mult_w_NAF_var spends about 3 us a call there: what the saving
     would buy is a fraction of a second, and what it would cost is a
     second copy of the dispatch, one per caller, free to drift. `mult`
     makes the same two comparisons for the same reason.
     """
     if ec == secp256k1:
-        return _double_mult_endomorphism_secp256k1(u, HJ, v, QJ, ec, _ENDOMORPHISM_W)
-    return _double_mult_w_NAF(u, HJ, v, QJ, ec, _DOUBLE_MULT_W)
+        return _double_mult_endomorphism_secp256k1_var(
+            u, HJ, v, QJ, ec, _ENDOMORPHISM_W
+        )
+    return _double_mult_w_NAF_var(u, HJ, v, QJ, ec, _DOUBLE_MULT_W)
 
 
 def double_mult(
@@ -731,7 +733,7 @@ def multi_mult(
     """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
 
     Interleaved wNAF on few scalars, Bos-Coster on many: curve_group's
-    _multi_mult dispatches on the count, at the size the two measure the
+    _multi_mult_var dispatches on the count, at the size the two measure the
     same. On secp256k1 the bindings serve the whole sum instead, and this
     is the one caller that hands them many scalars at once -- libsecp256k1
     exposing no batch verification, ssa's is built on this.
@@ -755,5 +757,5 @@ def multi_mult(
         return _libsecp256k1_multi_mult(ints, points)
 
     jac_points = [_jac_from_aff(Q) for Q in points]
-    R = _multi_mult(ints, jac_points, ec)
+    R = _multi_mult_var(ints, jac_points, ec)
     return ec.aff_from_jac(R)

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -394,7 +394,7 @@ class CurveGroup:
         # random -- over 2000 random scalars _mult reached it 3.98 times
         # on average and only 23 of them not at all, and the count *is*
         # the secret: exactly the number of zero base-16 digits of the
-        # scalar, or for _mult_jac the number of its low zero bits. An
+        # scalar, or for _mult_jac_var the number of its low zero bits. An
         # early return there put that on the clock, 0.03 us against the
         # 3.7 us of a generic addition, and _mult measured 0.93 ms with no
         # zero digit against 0.55 ms with 63.
@@ -405,12 +405,12 @@ class CurveGroup:
         # stand-in of full size takes its place, the table at the end
         # answers for it, and an addition with no infinity in it pays two
         # comparisons: 1.02x to 1.03x on every multiplication in the
-        # package, and 1.22x on _double_mult, whose Shamir-Strauss loop
+        # package, and 1.22x on _double_mult_var, whose Shamir-Strauss loop
         # adds the infinity of a zero digit pair a quarter of the time --
         # the additions an early return answers for free, at the price of
         # putting their count on the clock. Dropping the early return
         # without the stand-ins is not enough: P + INFJ still costs
-        # 1.8 us against 5.4, and _mult_jac is still 25% faster on a
+        # 1.8 us against 5.4, and _mult_jac_var is still 25% faster on a
         # scalar with 128 low zero bits
         QS = (Q, self._stand_in_q)[Q[2] == 0]
         RS = (R, self._stand_in_r)[R[2] == 0]
@@ -609,7 +609,7 @@ class CurveGroup:
 
         p = self.p
         # lam reduced before it is squared, as in add_jac, though here it
-        # is worth 6% of _mult_aff rather than a factor of two: mod_inv is
+        # is worth 6% of _mult_aff_var rather than a factor of two: mod_inv is
         # what affine coordinates cost, and is why the ladders are not
         lam = (R[1] - Q[1]) * mod_inv(R[0] - Q[0], p) % p
         x = (lam * lam - Q[0] - R[0]) % p
@@ -699,7 +699,7 @@ class CurveGroup:
         return self.y(x)
 
 
-def _mult_recursive_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
+def _mult_recursive_aff_var(m: int, Q: Point, ec: CurveGroup) -> Point:
     """Scalar multiplication of a curve point in affine coordinates.
 
     This implementation uses a recursive version of 'double & add',
@@ -716,12 +716,12 @@ def _mult_recursive_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
         return INF
 
     if m % 2 == 1:
-        return ec.add_aff(Q, _mult_recursive_aff((m - 1), Q, ec))
+        return ec.add_aff(Q, _mult_recursive_aff_var((m - 1), Q, ec))
 
-    return _mult_recursive_aff((m // 2), ec.double_aff(Q), ec)
+    return _mult_recursive_aff_var((m // 2), ec.double_aff(Q), ec)
 
 
-def _mult_recursive_jac(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
+def _mult_recursive_jac_var(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     """Scalar multiplication of a curve point in affine coordinates.
 
     This implementation uses a recursive version of 'double & add',
@@ -738,12 +738,12 @@ def _mult_recursive_jac(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
         return INFJ
 
     if m % 2 == 1:
-        return ec.add_jac(Q, _mult_recursive_jac((m - 1), Q, ec))
+        return ec.add_jac(Q, _mult_recursive_jac_var((m - 1), Q, ec))
 
-    return _mult_recursive_jac((m // 2), ec.double_jac(Q), ec)
+    return _mult_recursive_jac_var((m // 2), ec.double_jac(Q), ec)
 
 
-def _mult_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
+def _mult_aff_var(m: int, Q: Point, ec: CurveGroup) -> Point:
     """Scalar multiplication of a curve point in affine coordinates.
 
     This implementation uses 'double & add' algorithm, 'right-to-left'
@@ -766,7 +766,7 @@ def _mult_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
         # the doubling part of 'double & add'
         Q = ec.double_aff(Q)
         # always perform the 'add', even if useless: one addition per bit
-        # whatever the bit is, as in _mult_jac. It buys less here, add_aff
+        # whatever the bit is, as in _mult_jac_var. It buys less here, add_aff
         # branching on its own special cases and mod_inv taking the time
         # its input asks for, which is why the affine variants are the
         # readable ones rather than the ones to sign with
@@ -777,7 +777,7 @@ def _mult_aff(m: int, Q: Point, ec: CurveGroup) -> Point:
     return R[0]
 
 
-def _mult_jac(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
+def _mult_jac_var(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     """Scalar multiplication of a curve point in Jacobian coordinates.
 
     This implementation uses 'double & add' algorithm, 'right-to-left'
@@ -852,7 +852,7 @@ def _cached_multiples(Q: JacPoint, ec: CurveGroup) -> list[JacPoint]:
 def _cached_multiples_fixwind(
     Q: JacPoint, ec: CurveGroup, w: int
 ) -> list[list[JacPoint]]:
-    """Made to precompute values for _mult_fixed_window_cached.
+    """Made to precompute values for _mult_fixed_window_cached_var.
 
     Do not use it for other functions. Made to be used for w=4, do not
     use w.
@@ -901,7 +901,7 @@ def _wNAF_of_m(m: int, w: int) -> list[int]:
 
     This recoding sits here next to _convert_number_to_base, the same kind
     of integer-only helper, rather than with the wNAF multiplications of
-    curve_group_2: the interleaved _multi_mult_w_NAF below needs it, and
+    curve_group_2: the interleaved _multi_mult_w_NAF_var below needs it, and
     curve_group cannot import the module that imports it.
 
     For complete reference see:
@@ -1013,7 +1013,7 @@ def _odd_multiples_aff(Q: JacPoint, ec: CurveGroup, w: int) -> list[Point]:
 
 # the width a point of ec._fixed_points has its table built at, against
 # the narrow one a point that arrives once is worth. The measurement is in
-# _multi_mult_w_NAF's docstring
+# _multi_mult_w_NAF_var's docstring
 _FIXED_POINT_W = 10
 
 
@@ -1146,7 +1146,7 @@ def _mult_fixed_base(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     return ec.add_jac(R, (INFJ, ec.negate_jac(Q))[not m & 1])
 
 
-def _mult_mont_ladder(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
+def _mult_mont_ladder_var(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     """Scalar multiplication using 'Montgomery ladder' algorithm.
 
     This implementation uses
@@ -1179,7 +1179,7 @@ def _mult_mont_ladder(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     return R[0]
 
 
-def _mult_base_3(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
+def _mult_base_3_var(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     """Scalar multiplication using ternary decomposition of the scalar.
 
     This implementation uses 'triple & add' algorithm, 'left-to-right'
@@ -1207,7 +1207,7 @@ def _mult_base_3(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     return R
 
 
-def _mult_fixed_window(
+def _mult_fixed_window_var(
     m: int, Q: JacPoint, ec: CurveGroup, w: int, cached: bool
 ) -> JacPoint:
     """Scalar multiplication using "fixed window".
@@ -1244,7 +1244,9 @@ def _mult_fixed_window(
     return R
 
 
-def _mult_fixed_window_cached(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
+def _mult_fixed_window_cached_var(
+    m: int, Q: JacPoint, ec: CurveGroup, w: int
+) -> JacPoint:
     """Scalar multiplication using "fixed window" & cached values.
 
     This implementation uses 'multiple-double & add' algorithm, 'left-
@@ -1301,7 +1303,7 @@ def _mult_regular_window(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoin
     `_mult` the package reaches for rather than an option beside it. The
     fixed window stays as what it is didactically, the plain one, and the
     wNAF multiplications stay the fast irregular ones for coefficients
-    that are public: `_double_mult_w_NAF` is what verification runs.
+    that are public: `_double_mult_w_NAF_var` is what verification runs.
 
     w=4 by measurement, as for the fixed window: 0.803 ms at w=5 and 0.831
     at w=6, the window paying for a table twice the size of the NAF's at
@@ -1375,7 +1377,7 @@ def _mult(m: int, Q: JacPoint, ec: CurveGroup) -> JacPoint:
     return _mult_regular_window(m, Q, ec, _MULT_W)
 
 
-def _double_mult(
+def _double_mult_var(
     u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: CurveGroup
 ) -> JacPoint:
     """Double scalar multiplication (u*H + v*Q).
@@ -1431,7 +1433,7 @@ def _multi_mult_pairs(
     """Check the arguments of a multi multiplication and drop the zeros.
 
     Shared by the two implementations below so that they answer the same
-    errors to the same arguments: whichever of them _multi_mult calls is
+    errors to the same arguments: whichever of them _multi_mult_var calls is
     a performance decision, and a caller must not be able to tell which
     it got. A zero scalar contributes nothing to the sum and is dropped
     rather than carried, which Bos-Coster needs -- it would be a zero
@@ -1455,12 +1457,12 @@ def _multi_mult_pairs(
     return pairs
 
 
-# the width _multi_mult hands the interleaved wNAF; the measurement
+# the width _multi_mult_var hands the interleaved wNAF; the measurement
 # behind it is in the docstring of the function it is passed to
 _MULTI_MULT_W = 5
 
 
-def _multi_mult_w_NAF(
+def _multi_mult_w_NAF_var(
     scalars: Sequence[int],
     jac_points: Sequence[JacPoint],
     ec: CurveGroup,
@@ -1470,14 +1472,14 @@ def _multi_mult_w_NAF(
     """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
 
     Strauss' algorithm with interleaved wNAFs, the many-point form of
-    curve_group_2's _double_mult_w_NAF (HMV algorithm 3.51): each scalar
+    curve_group_2's _double_mult_w_NAF_var (HMV algorithm 3.51): each scalar
     gets its own width-w NAF and its own table of odd multiples, and a
     single left-to-right loop shares one doubling per bit position among
     all of them, adding a (possibly negated) table entry wherever a NAF
     has a nonzero digit.
 
     Sharing the doublings is the whole of the idea, and what the dispatch
-    of _multi_mult weighs: the ~256 doublings a 256-bit scalar needs are
+    of _multi_mult_var weighs: the ~256 doublings a 256-bit scalar needs are
     paid once for the batch instead of once per point, leaving some 50
     point operations per scalar of its own. Bos-Coster has no fixed cost
     to share and settles at 44.5 per scalar, so few scalars is where the
@@ -1498,7 +1500,7 @@ def _multi_mult_w_NAF(
     secp256k1: the split is curve-specific, this function serves every
     curve, and with many scalars the doublings it would halve are already
     shared. A caller that has only two of them has the opposite balance,
-    and curve_group_2's _double_mult_endomorphism_secp256k1 is that
+    and curve_group_2's _double_mult_endomorphism_secp256k1_var is that
     caller: it splits both coefficients itself and hands the four halves
     here, so the split lives with the curve that has it and the
     interleaving stays one implementation.
@@ -1514,8 +1516,8 @@ def _multi_mult_w_NAF(
 
     Measured over 30 random 256-bit coefficient pairs, best of seven
     alternating rounds, memoized against built per call: 1.24x on
-    `_double_mult_endomorphism_secp256k1`, whose four halves are two fixed
-    points and two of the caller's, and 1.14x on `_double_mult_w_NAF` over
+    `_double_mult_endomorphism_secp256k1_var`, whose four halves are two fixed
+    points and two of the caller's, and 1.14x on `_double_mult_w_NAF_var` over
     secp256r1, which has one of each. With eight points of which one is
     the generator it is 1.05x, the fixed point being an eighth of the
     work. `_FIXED_POINT_W` is 10 by measurement on the first of those:
@@ -1566,7 +1568,7 @@ def _multi_mult_w_NAF(
     return R
 
 
-def _multi_mult_bos_coster(
+def _multi_mult_bos_coster_var(
     scalars: Sequence[int], jac_points: Sequence[JacPoint], ec: CurveGroup
 ) -> JacPoint:
     """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
@@ -1590,7 +1592,7 @@ def _multi_mult_bos_coster(
     multi_mult([n-1, 1], [G, H]) and multi_mult([-1, 1], [G, H]) would
     never finish, on scalars a caller has every right to pass. The whole
     of Euclid is what makes this a live path rather than a reading
-    exercise: _multi_mult calls it above its threshold.
+    exercise: _multi_mult_var calls it above its threshold.
 
     Where the interleaved wNAF above shares one doubling per bit among
     all the points, this one has no fixed cost to amortize at all -- the
@@ -1617,15 +1619,15 @@ def _multi_mult_bos_coster(
         np2 = heapq.heappop(x)
         n_1, p_1 = -np1[0], np1[1]
         n_2, p_2 = -np2[0], np2[1]
-        # _mult_jac, not the faster _mult: the quotient is 1 about 40% of
+        # _mult_jac_var, not the faster _mult: the quotient is 1 about 40% of
         # the time (Gauss-Kuzmin), and _mult would rebuild its 16-entry
         # table of multiples for each of those -- 10x slower over 128
-        # random scalars. _mult_jac(1, P) is P at no cost, so this is the
+        # random scalars. _mult_jac_var(1, P) is P at no cost, so this is the
         # subtractive step precisely when the subtractive step is right;
         # measured, spelling that case out as a branch buys nothing, and
         # subtracting for q up to 4 or up to 16 costs 3% and 11%.
         q, n_1 = divmod(n_1, n_2)
-        p_2 = ec.add_jac(_mult_jac(q, p_1, ec), p_2)
+        p_2 = ec.add_jac(_mult_jac_var(q, p_1, ec), p_2)
         if n_1 > 0:
             heapq.heappush(x, (-n_1, p_1))
         heapq.heappush(x, (-n_2, p_2))
@@ -1649,7 +1651,7 @@ def _multi_mult_bos_coster(
 BOS_COSTER_THRESHOLD = 56
 
 
-def _multi_mult(
+def _multi_mult_var(
     scalars: Sequence[int], jac_points: Sequence[JacPoint], ec: CurveGroup
 ) -> JacPoint:
     """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
@@ -1682,7 +1684,7 @@ def _multi_mult(
     groups of order n).
     """
     if sum(1 for n in scalars if n) < BOS_COSTER_THRESHOLD:
-        return _multi_mult_w_NAF(
+        return _multi_mult_w_NAF_var(
             scalars, jac_points, ec, _MULTI_MULT_W, ec._fixed_points
         )
-    return _multi_mult_bos_coster(scalars, jac_points, ec)
+    return _multi_mult_bos_coster_var(scalars, jac_points, ec)

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -49,7 +49,7 @@ follow-ups; what is here is the rest:
         - 1-s_2.0-S1071579704000395-main (the file name it was saved as; the
           paper it refers to has not been identified)
     - Joint sparse form (JSF, HMV algorithm 3.50) for double mult: the
-      alternative to the interleaving _double_mult_w_NAF implements --
+      alternative to the interleaving _double_mult_w_NAF_var implements --
       one joint recoding of both scalars instead of one NAF each, fewer
       total additions in exchange for digit pairs that do not index a
       per-point table of odd multiples
@@ -98,13 +98,13 @@ from btclib.alias import INFJ, JacPoint
 
 # the wNAF recoding and the table of odd multiples it indexes live in
 # curve_group, next to _convert_number_to_base and for the same reason:
-# its interleaved _multi_mult_w_NAF needs them, and the dependency runs
+# its interleaved _multi_mult_w_NAF_var needs them, and the dependency runs
 # one way, this module importing that one
 from btclib.curves.curve_group import (
     CurveGroup,
     _convert_number_to_base,
     _jac_from_aff,
-    _multi_mult_w_NAF,
+    _multi_mult_w_NAF_var,
     _signed_odd_multiples_aff,
     _wNAF_of_m,
     signed_odd_digits,
@@ -147,7 +147,7 @@ def _double_and_add(
     return R
 
 
-def _mult_sliding_window(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
+def _mult_sliding_window_var(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     """Scalar multiplication using "sliding window".
 
     It has the benefit that the pre-computation stage is roughly half as
@@ -197,7 +197,7 @@ def _mult_sliding_window(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoin
     return R
 
 
-def _mult_w_NAF(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
+def _mult_w_NAF_var(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     """Scalar multiplication in Jacobian coordinates using wNAF.
 
     The "w-ary non-adjacent form": on a Weierstrass curve -P costs
@@ -243,7 +243,7 @@ def _mult_w_NAF(m: int, Q: JacPoint, ec: CurveGroup, w: int) -> JacPoint:
     return R
 
 
-def _double_mult_w_NAF(
+def _double_mult_w_NAF_var(
     u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: CurveGroup, w: int
 ) -> JacPoint:
     """Double scalar multiplication (u*H + v*Q), interleaved wNAFs.
@@ -252,7 +252,7 @@ def _double_mult_w_NAF(
     Cryptography': each coefficient gets its own width-w NAF and its own
     table of odd multiples, and one left-to-right loop shares the
     doublings, adding a (possibly negated) table entry wherever either
-    NAF has a nonzero digit. Against curve_group's _double_mult -- the
+    NAF has a nonzero digit. Against curve_group's _double_mult_var -- the
     Shamir-Strauss binary loop -- the doublings are the same and the
     additions drop from one per bit to ~2/(w+1) per bit, the negative
     digits costing only an on-the-fly negation.
@@ -261,22 +261,22 @@ def _double_mult_w_NAF(
     endomorphism: `curves.double_mult`, `dsa` and `ssa` verification and
     public key recovery all reach it through `curve`'s
     _double_mult_python, which sends secp256k1 to
-    _double_mult_endomorphism_secp256k1 instead -- four half-length
+    _double_mult_endomorphism_secp256k1_var instead -- four half-length
     coefficients where this takes two full-length ones, and 0.81 ms where
     this is 1.02. Measured over random 256-bit coefficients, best of
-    seven: 1.03 ms against the 1.53 ms of curve_group's _double_mult,
+    seven: 1.03 ms against the 1.53 ms of curve_group's _double_mult_var,
     which stays as the reference the tests compare this against. w=5
     measures 0.99 ms and w=3 1.10, so the w=4 `curve.py` passes is within
     4% of the best window and its table is half the size of w=5's.
 
-    The gap over _double_mult is the wider since add_jac stopped
+    The gap over _double_mult_var is the wider since add_jac stopped
     shortcutting infinity: fewer additions is worth the more when an
     addition of infinity costs what any other costs, and the
     Shamir-Strauss loop makes one for a quarter of its digit pairs.
 
     The tables are also why it is not faster everywhere: they are built
     per call and per point, so a coefficient too short to amortize them
-    pays for them. Against _double_mult, by coefficient size on
+    pays for them. Against _double_mult_var, by coefficient size on
     secp256k1: 8 bits 1.37x *slower*, 16 bits 0.98, 24 bits 0.85, 32 bits
     0.81, 64 bits 0.72, 128 bits 0.68, 256 bits 0.67. The crossover is
     around 16 bits, so every curve with a real order is on the winning
@@ -298,13 +298,13 @@ def _double_mult_w_NAF(
     if w <= 0:
         raise BTClibValueError(f"non positive w: {w}")
 
-    # curve_group's interleaved _multi_mult_w_NAF for two points, rather
+    # curve_group's interleaved _multi_mult_w_NAF_var for two points, rather
     # than a second copy of the same loop: it is what recodes each
     # coefficient, builds each table -- memoized and wide for a point the
     # curve names, per call and narrow for one it does not -- and shares
     # the doublings. What this function adds is the pair of messages its
     # own coefficients answer with, and the name the algorithm has
-    return _multi_mult_w_NAF([u, v], [HJ, QJ], ec, w, ec._fixed_points)
+    return _multi_mult_w_NAF_var([u, v], [HJ, QJ], ec, w, ec._fixed_points)
 
 
 def _double_mult_regular_window(
@@ -324,7 +324,7 @@ def _double_mult_regular_window(
     doublings and two additions per window, both of them made whatever the
     digits are. So the cost is the same for every pair (u, v) of a given
     scalar_len -- 143 additions and 254 doublings on secp256k1, over 200
-    random pairs -- where _double_mult_w_NAF's is the recoded weight of the
+    random pairs -- where _double_mult_w_NAF_var's is the recoded weight of the
     two coefficients and is 101 to 116 additions over the same pairs, and
     0.996 ms against 1.11.
 
@@ -417,7 +417,7 @@ def _multiplier_decomposer(m: int) -> tuple[int, int]:
     what makes c1, c2 the closest lattice point and m1, m2 short. The
     results stay signed, since a final mod-p reduction would throw away
     the sign that point negation is there to absorb, and hand
-    _double_mult two 256-bit multipliers for an 8-bit m.
+    _double_mult_var two 256-bit multipliers for an 8-bit m.
     """
     m %= _N
 
@@ -472,52 +472,63 @@ def _endomorphism_split_secp256k1(
 
 
 def _mult_endomorphism_secp256k1(
-    m: int, Q: JacPoint, ec: CurveGroup, w: int, regular: bool
+    m: int, Q: JacPoint, ec: CurveGroup, w: int
 ) -> JacPoint:
     """Scalar multiplication in Jacobian coordinates using endomorphism.
 
     Algorithm 3.77 of D. Hankerson, 'Guide to Elliptic Curve
     Cryptography': m*Q as m1*Q + m2*(lambda*Q), the halves coming from
     _multiplier_decomposer and a double multiplication sharing their
-    doublings. It is the fastest Python multiplication in the package and
-    what `curves.mult` runs for every secp256k1 point the bindings do not
-    take.
+    doublings. It is what `curves.mult` runs for a secp256k1 point that is
+    not the generator and that the bindings do not take.
 
-    Which double multiplication is `regular`, and the two answer the same
-    point at different costs. Measured over 30 random 256-bit scalars,
-    best of five, at w=4:
-
-    - the regular windows of _double_mult_regular_window, 0.589 ms, and 79
-      additions and 126 doublings for every one of 200 random scalars
-    - the interleaved wNAFs of _double_mult_w_NAF, 0.509 ms, which is
-      algorithm 3.77 as it is written, and 51 to 64 additions and 124 to
-      131 doublings over the same scalars: a quarter more work for the
-      worst scalar than for the best, and which it is is a property of
-      the secret (issue 254)
-
-    The regular one is what `curves.mult` asks for because the scalar of a
+    The regular windows of _double_mult_regular_window, so the number of
+    point additions is the same for every scalar: the scalar of a
     `curves.mult` is a private key or a nonce in every caller btclib has,
-    and 16% of a multiplication that libsecp256k1 answers in 13 us is not
-    what this path is for. Both stay: the wNAF is what verification wants,
-    its coefficients being public, and verification arrives at
-    `_double_mult_endomorphism_secp256k1` below, which splits two
-    coefficients rather than one and interleaves the four halves.
+    which is what issue 254 is about. _mult_endomorphism_secp256k1_var
+    below is algorithm 3.77 as it is written, and what it costs to be
+    regular is measured there.
 
-    w=4 by measurement for both: the regular windows give 0.610 ms at
-    w=5, and the wNAFs 0.527 at w=3 and 0.510 at w=5, which is w=4's own
-    noise.
+    w=4 by measurement: the regular windows give 0.589 ms at w=4 and
+    0.610 at w=5, over 30 random 256-bit scalars, best of five.
     """
     if m < 0:
         raise BTClibValueError(f"negative m: {hex(m)}")
 
     m1, P, m2, K = _endomorphism_split_secp256k1(m, Q, ec)
-
-    if regular:
-        return _double_mult_regular_window(m1, P, m2, K, ec, w, _HALF_LEN)
-    return _double_mult_w_NAF(m1, P, m2, K, ec, w)
+    return _double_mult_regular_window(m1, P, m2, K, ec, w, _HALF_LEN)
 
 
-def _double_mult_endomorphism_secp256k1(
+def _mult_endomorphism_secp256k1_var(
+    m: int, Q: JacPoint, ec: CurveGroup, w: int
+) -> JacPoint:
+    """Algorithm 3.77 as it is written: the interleaved wNAFs.
+
+    The same decomposition as `_mult_endomorphism_secp256k1`, over
+    `_double_mult_w_NAF_var` rather than the regular windows, and the
+    faster of the two: 0.509 ms against 0.589, over 30 random 256-bit
+    scalars, best of five, at w=4. What the 16% buys is 51 to 64 additions
+    and 124 to 131 doublings over 200 random scalars, where the regular
+    windows make 79 and 126 for every one of them -- a quarter more work
+    for the worst scalar than for the best, and which it is is a property
+    of the scalar.
+
+    So nothing signs with this one, and it is here to be measured against
+    the other. A verification's coefficients are public and go to
+    `_double_mult_endomorphism_secp256k1_var` below, which splits two of
+    them rather than one and interleaves the four halves.
+
+    w=4 by measurement here too: 0.527 ms at w=3 and 0.510 at w=5, which
+    is w=4's own noise.
+    """
+    if m < 0:
+        raise BTClibValueError(f"negative m: {hex(m)}")
+
+    m1, P, m2, K = _endomorphism_split_secp256k1(m, Q, ec)
+    return _double_mult_w_NAF_var(m1, P, m2, K, ec, w)
+
+
+def _double_mult_endomorphism_secp256k1_var(
     u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: CurveGroup, w: int
 ) -> JacPoint:
     """Double scalar multiplication (u*H + v*Q) through the endomorphism.
@@ -532,20 +543,21 @@ def _double_mult_endomorphism_secp256k1(
 
     That trade is the whole of the gain, and it is the same one
     `_mult_endomorphism_secp256k1` makes for a single coefficient: 0.81 ms
-    against `_double_mult_w_NAF`'s 1.02, measured over 30 random pairs of
+    against `_double_mult_w_NAF_var`'s 1.02, measured over 30 random pairs of
     256-bit coefficients, best of three, alternating the two so that
     neither is always warm. Both answer the same point on every pair the
     tests compare, boundary coefficients and infinities included.
 
     The interleaved wNAF rather than the regular windows: the coefficients
     of a double multiplication are public, being a verification's, which is
-    the same reason `curve.double_mult` reaches `_double_mult_w_NAF`
-    directly and not through `_mult_endomorphism_secp256k1`'s regular
-    default. A scalar that is a secret goes through `mult`.
+    the same reason `curve.double_mult` reaches `_double_mult_w_NAF_var`
+    directly and not through the regular windows of
+    `_mult_endomorphism_secp256k1`. A scalar that is a secret goes
+    through `mult`.
 
     w=4 by measurement over the same pairs: 0.88 ms at w=3, 0.81 at w=4,
     0.82 at w=5, 0.91 at w=6 -- so w=4 and w=5 measure the same and the
-    smaller table decides, as it does for `_double_mult_w_NAF`.
+    smaller table decides, as it does for `_double_mult_w_NAF_var`.
 
     The input points are assumed to be on curve. Either coefficient may be
     zero and either point may be infinity: the interleaved wNAF drops a
@@ -570,4 +582,4 @@ def _double_mult_endomorphism_secp256k1(
         fixed = fixed | {U1, U2}
     if QJ in fixed:
         fixed = fixed | {V1, V2}
-    return _multi_mult_w_NAF([u1, u2, v1, v2], [U1, U2, V1, V2], ec, w, fixed)
+    return _multi_mult_w_NAF_var([u1, u2, v1, v2], [U1, U2, V1, V2], ec, w, fixed)

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -324,7 +324,7 @@ def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
     """One multiplication, not fourteen ways to spell it.
 
     mult dispatches to libsecp256k1 for secp256k1 and the generator, which
-    is exactly what a caller choosing _mult_jac from the same namespace --
+    is exactly what a caller choosing _mult_jac_var from the same namespace --
     on the strength of its name -- gives up.
     """
     assert sorted(btclib.curves.__all__) == [
@@ -344,21 +344,22 @@ def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
 
     # the implementations are still there, in the module that defines them
     variants = [
-        (curve_group, "_mult_aff"),
-        (curve_group, "_mult_base_3"),
-        (curve_group, "_mult_fixed_window"),
-        (curve_group, "_mult_fixed_window_cached"),
-        (curve_group, "_mult_jac"),
-        (curve_group, "_mult_mont_ladder"),
-        (curve_group, "_mult_recursive_aff"),
-        (curve_group, "_mult_recursive_jac"),
+        (curve_group, "_mult_aff_var"),
+        (curve_group, "_mult_base_3_var"),
+        (curve_group, "_mult_fixed_window_var"),
+        (curve_group, "_mult_fixed_window_cached_var"),
+        (curve_group, "_mult_jac_var"),
+        (curve_group, "_mult_mont_ladder_var"),
+        (curve_group, "_mult_recursive_aff_var"),
+        (curve_group, "_mult_recursive_jac_var"),
         (curve_group, "_cached_multiples"),
         (curve_group, "_jac_from_aff"),
         (curve_group, "_multiples"),
-        (curve_group_2, "_double_mult_endomorphism_secp256k1"),
+        (curve_group_2, "_double_mult_endomorphism_secp256k1_var"),
         (curve_group_2, "_mult_endomorphism_secp256k1"),
-        (curve_group_2, "_mult_sliding_window"),
-        (curve_group_2, "_mult_w_NAF"),
+        (curve_group_2, "_mult_endomorphism_secp256k1_var"),
+        (curve_group_2, "_mult_sliding_window_var"),
+        (curve_group_2, "_mult_w_NAF_var"),
     ]
     for module, name in variants:
         assert hasattr(module, name), f"{module.__name__}.{name} went missing"

--- a/tests/curves/curve_group_2_test.py
+++ b/tests/curves/curve_group_2_test.py
@@ -5,12 +5,13 @@
 """Tests for the `btclib.curve_group_2` module."""
 
 import secrets
+from collections.abc import Callable
 
 import pytest
 
 from btclib.alias import INFJ, JacPoint
-from btclib.curves import secp256k1
-from btclib.curves.curve_group import _double_mult, _mult
+from btclib.curves import Curve, secp256k1
+from btclib.curves.curve_group import _double_mult_var, _mult
 
 # from the module that defines them: btclib.curves does not export the
 # individual multiplication implementations
@@ -18,12 +19,13 @@ from btclib.curves.curve_group_2 import (
     _HALF_LEN,
     _LAM,
     _N,
-    _double_mult_endomorphism_secp256k1,
+    _double_mult_endomorphism_secp256k1_var,
     _double_mult_regular_window,
-    _double_mult_w_NAF,
+    _double_mult_w_NAF_var,
     _mult_endomorphism_secp256k1,
-    _mult_sliding_window,
-    _mult_w_NAF,
+    _mult_endomorphism_secp256k1_var,
+    _mult_sliding_window_var,
+    _mult_w_NAF_var,
     _multiplier_decomposer,
 )
 from btclib.exceptions import BTClibValueError
@@ -36,32 +38,34 @@ def test_mult_sliding_window() -> None:
     """Check the sliding-window mult on boundary scalars and against _mult."""
     for w in range(1, 6):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(_mult_sliding_window(0, ec.GJ, ec, w), INFJ)
-            assert ec.jac_equality(_mult_sliding_window(0, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_sliding_window_var(0, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_sliding_window_var(0, INFJ, ec, w), INFJ)
 
-            assert ec.jac_equality(_mult_sliding_window(1, INFJ, ec, w), INFJ)
-            assert ec.jac_equality(_mult_sliding_window(1, ec.GJ, ec, w), ec.GJ)
+            assert ec.jac_equality(_mult_sliding_window_var(1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_sliding_window_var(1, ec.GJ, ec, w), ec.GJ)
 
-            PJ = _mult_sliding_window(2, ec.GJ, ec, w)
+            PJ = _mult_sliding_window_var(2, ec.GJ, ec, w)
             assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-            PJ = _mult_sliding_window(ec.n - 1, ec.GJ, ec, w)
+            PJ = _mult_sliding_window_var(ec.n - 1, ec.GJ, ec, w)
             assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
 
-            assert ec.jac_equality(_mult_sliding_window(ec.n - 1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(
+                _mult_sliding_window_var(ec.n - 1, INFJ, ec, w), INFJ
+            )
             assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(_mult_sliding_window(ec.n, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_sliding_window_var(ec.n, ec.GJ, ec, w), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
-                _mult_sliding_window(-1, ec.GJ, ec, w)
+                _mult_sliding_window_var(-1, ec.GJ, ec, w)
 
             with pytest.raises(BTClibValueError, match="non positive w: "):
-                _mult_sliding_window(1, ec.GJ, ec, -w)
+                _mult_sliding_window_var(1, ec.GJ, ec, -w)
 
     ec = ec23_31
     for w in range(1, 10):
         for k1 in range(ec.n):
-            K1 = _mult_sliding_window(k1, ec.GJ, ec, w)
+            K1 = _mult_sliding_window_var(k1, ec.GJ, ec, w)
             assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
@@ -69,46 +73,51 @@ def test_mult_w_NAF() -> None:
     """Check the wNAF mult on boundary scalars and against _mult."""
     for w in range(1, 6):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(_mult_w_NAF(0, ec.GJ, ec, w), INFJ)
-            assert ec.jac_equality(_mult_w_NAF(0, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_w_NAF_var(0, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_w_NAF_var(0, INFJ, ec, w), INFJ)
 
-            assert ec.jac_equality(_mult_w_NAF(1, INFJ, ec, w), INFJ)
-            assert ec.jac_equality(_mult_w_NAF(1, ec.GJ, ec, w), ec.GJ)
+            assert ec.jac_equality(_mult_w_NAF_var(1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_w_NAF_var(1, ec.GJ, ec, w), ec.GJ)
 
-            PJ = _mult_w_NAF(2, ec.GJ, ec, w)
+            PJ = _mult_w_NAF_var(2, ec.GJ, ec, w)
             assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-            PJ = _mult_w_NAF(ec.n - 1, ec.GJ, ec, w)
+            PJ = _mult_w_NAF_var(ec.n - 1, ec.GJ, ec, w)
             assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
 
-            assert ec.jac_equality(_mult_w_NAF(ec.n - 1, INFJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_w_NAF_var(ec.n - 1, INFJ, ec, w), INFJ)
             assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(_mult_w_NAF(ec.n, ec.GJ, ec, w), INFJ)
+            assert ec.jac_equality(_mult_w_NAF_var(ec.n, ec.GJ, ec, w), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
-                _mult_w_NAF(-1, ec.GJ, ec, w)
+                _mult_w_NAF_var(-1, ec.GJ, ec, w)
 
             with pytest.raises(BTClibValueError, match="non positive w: "):
-                _mult_w_NAF(1, ec.GJ, ec, -w)
+                _mult_w_NAF_var(1, ec.GJ, ec, -w)
 
     ec = ec23_31
     for w in range(1, 10):
         for k1 in range(ec.n):
-            K1 = _mult_w_NAF(k1, ec.GJ, ec, w)
+            K1 = _mult_w_NAF_var(k1, ec.GJ, ec, w)
             assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
-@pytest.mark.parametrize("regular", [True, False])
-def test_mult_endomorphism_secp256k1(regular: bool) -> None:
+@pytest.mark.parametrize(
+    "mult_endo", [_mult_endomorphism_secp256k1, _mult_endomorphism_secp256k1_var]
+)
+def test_mult_endomorphism_secp256k1(
+    mult_endo: Callable[[int, JacPoint, Curve, int], JacPoint],
+) -> None:
     """Both double multiplications the endomorphism can be built on.
 
-    The regular windows of the default and the interleaved wNAFs of
-    algorithm 3.77 as it is written: the same points, at the costs the
-    function's docstring measures, so both answer every case here.
+    The regular windows of the one `curves.mult` runs and the
+    interleaved wNAFs of algorithm 3.77 as it is written: the same
+    points, at the costs their docstrings measure, so both answer every
+    case here.
     """
 
     def mult(m: int, QJ: JacPoint) -> JacPoint:
-        return _mult_endomorphism_secp256k1(m, QJ, secp256k1, regular=regular, w=4)
+        return mult_endo(m, QJ, secp256k1, 4)
 
     ec = secp256k1
     assert ec.jac_equality(mult(0, ec.GJ), INFJ)
@@ -155,9 +164,12 @@ def test_mult_endomorphism_agrees_with_mult_above_2_127() -> None:
     ] + [secrets.randbelow(_N) for _ in range(8)]
     for m in scalars:
         expected = _mult(m, ec.GJ, ec)
-        for regular in (True, False):
-            got = _mult_endomorphism_secp256k1(m, ec.GJ, ec, regular=regular, w=4)
-            assert ec.jac_equality(got, expected), (m, regular)
+        for mult_endo in (
+            _mult_endomorphism_secp256k1,
+            _mult_endomorphism_secp256k1_var,
+        ):
+            got = mult_endo(m, ec.GJ, ec, 4)
+            assert ec.jac_equality(got, expected), (m, mult_endo.__name__)
 
 
 def test_multiplier_decomposer() -> None:
@@ -208,18 +220,18 @@ def test_double_mult_w_NAF() -> None:
         for w in (1, 2, 4):
             for u in range(ec.n):
                 for v in range(ec.n):
-                    expected = _double_mult(u, HJ, v, QJ, ec)
-                    got = _double_mult_w_NAF(u, HJ, v, QJ, ec, w)
+                    expected = _double_mult_var(u, HJ, v, QJ, ec)
+                    got = _double_mult_w_NAF_var(u, HJ, v, QJ, ec, w)
                     assert ec.jac_equality(got, expected), (u, v, w)
 
     ec = secp256k1
-    assert ec.jac_equality(_double_mult_w_NAF(0, ec.GJ, 0, ec.GJ, ec, w=4), INFJ)
+    assert ec.jac_equality(_double_mult_w_NAF_var(0, ec.GJ, 0, ec.GJ, ec, w=4), INFJ)
     with pytest.raises(BTClibValueError, match="negative first coefficient: "):
-        _double_mult_w_NAF(-1, ec.GJ, 1, ec.GJ, ec, w=4)
+        _double_mult_w_NAF_var(-1, ec.GJ, 1, ec.GJ, ec, w=4)
     with pytest.raises(BTClibValueError, match="negative second coefficient: "):
-        _double_mult_w_NAF(1, ec.GJ, -1, ec.GJ, ec, w=4)
+        _double_mult_w_NAF_var(1, ec.GJ, -1, ec.GJ, ec, w=4)
     with pytest.raises(BTClibValueError, match="non positive w: "):
-        _double_mult_w_NAF(1, ec.GJ, 1, ec.GJ, ec, 0)
+        _double_mult_w_NAF_var(1, ec.GJ, 1, ec.GJ, ec, 0)
 
 
 def test_double_mult_endomorphism_secp256k1() -> None:
@@ -242,7 +254,7 @@ def test_double_mult_endomorphism_secp256k1() -> None:
     QJ = _mult(3, ec.GJ, ec)
 
     def dm(u: int, v: int, H: JacPoint, Q: JacPoint, w: int = 4) -> JacPoint:
-        return _double_mult_endomorphism_secp256k1(u, H, v, Q, ec, w)
+        return _double_mult_endomorphism_secp256k1_var(u, H, v, Q, ec, w)
 
     pairs = [
         (0, 0),
@@ -259,7 +271,7 @@ def test_double_mult_endomorphism_secp256k1() -> None:
         (_N, _N + 42),  # reduced mod n before anything else
     ] + [(secrets.randbelow(_N), secrets.randbelow(_N)) for _ in range(8)]
     for u, v in pairs:
-        expected = _double_mult(u % _N, HJ, v % _N, QJ, ec)
+        expected = _double_mult_var(u % _N, HJ, v % _N, QJ, ec)
         for w in (1, 2, 4, 5):
             assert ec.jac_equality(dm(u, v, HJ, QJ, w), expected), (u, v, w)
 
@@ -268,10 +280,13 @@ def test_double_mult_endomorphism_secp256k1() -> None:
     # bindings taking no zero scalar and no infinity
     for u, v in ((7, 5), (0, 5), (7, 0), (0, 0)):
         for H, Q in ((INFJ, QJ), (HJ, INFJ), (INFJ, INFJ)):
-            assert ec.jac_equality(dm(u, v, H, Q), _double_mult(u, H, v, Q, ec)), (u, v)
+            assert ec.jac_equality(dm(u, v, H, Q), _double_mult_var(u, H, v, Q, ec)), (
+                u,
+                v,
+            )
 
     # the same point twice, and a sum that lands on infinity
-    assert ec.jac_equality(dm(7, 5, HJ, HJ), _double_mult(7, HJ, 5, HJ, ec))
+    assert ec.jac_equality(dm(7, 5, HJ, HJ), _double_mult_var(7, HJ, 5, HJ, ec))
     assert ec.jac_equality(dm(3, _N - 3, HJ, HJ), INFJ)
 
     with pytest.raises(BTClibValueError, match="negative first coefficient: "):
@@ -296,7 +311,7 @@ def test_double_mult_regular_window() -> None:
         for w in (1, 2, 4):
             for u in range(ec.n):
                 for v in range(ec.n):
-                    expected = _double_mult(u, HJ, v, QJ, ec)
+                    expected = _double_mult_var(u, HJ, v, QJ, ec)
                     got = _double_mult_regular_window(u, HJ, v, QJ, ec, w, scalar_len=0)
                     assert ec.jac_equality(got, expected), (u, v, w)
 
@@ -304,7 +319,7 @@ def test_double_mult_regular_window() -> None:
     # the scalar_len the endomorphism passes, and coefficients that need
     # more digits than it asks for: the count is fixed, not a limit
     for u, v in ((0, 0), (1, _N - 1), (_N - 1, 1), (_N - 1, _N - 2)):
-        expected = _double_mult(u, ec.GJ, v, ec.GJ, ec)
+        expected = _double_mult_var(u, ec.GJ, v, ec.GJ, ec)
         for scalar_len in (0, _HALF_LEN):
             got = _double_mult_regular_window(u, ec.GJ, v, ec.GJ, ec, 4, scalar_len)
             assert ec.jac_equality(got, expected), (u, v, scalar_len)

--- a/tests/curves/curve_group_f_test.py
+++ b/tests/curves/curve_group_f_test.py
@@ -7,7 +7,7 @@
 import pytest
 
 from btclib.curves import CurveGroup, find_all_points, find_subgroup_points
-from btclib.curves.curve_group import _mult_aff
+from btclib.curves.curve_group import _mult_aff_var
 from btclib.exceptions import BTClibValueError
 
 
@@ -36,9 +36,9 @@ def test_ecf() -> None:
 
     # Scalar Multiplication
     X = (5323, 5438)
-    assert _mult_aff(1337, X, ec) == (1089, 6931)
+    assert _mult_aff_var(1337, X, ec) == (1089, 6931)
     P = (2339, 2213)
-    S = _mult_aff(7863, P, ec)
+    S = _mult_aff_var(7863, P, ec)
     ec.require_on_curve(S)
     S_exp = (9467, 2742)
     assert S_exp == S

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -21,22 +21,22 @@ from btclib.curves.curve_group import (
     MAX_W,
     _blinded_jac,
     _cached_multiples,
-    _double_mult,
+    _double_mult_var,
     _jac_from_aff,
     _mult,
-    _mult_aff,
-    _mult_base_3,
+    _mult_aff_var,
+    _mult_base_3_var,
     _mult_fixed_base,
-    _mult_fixed_window,
-    _mult_fixed_window_cached,
-    _mult_jac,
-    _mult_mont_ladder,
-    _mult_recursive_aff,
-    _mult_recursive_jac,
+    _mult_fixed_window_cached_var,
+    _mult_fixed_window_var,
+    _mult_jac_var,
+    _mult_mont_ladder_var,
+    _mult_recursive_aff_var,
+    _mult_recursive_jac_var,
     _mult_regular_window,
-    _multi_mult,
-    _multi_mult_bos_coster,
-    _multi_mult_w_NAF,
+    _multi_mult_bos_coster_var,
+    _multi_mult_var,
+    _multi_mult_w_NAF_var,
     _multiples,
     _signed_odd_multiples_aff,
     signed_odd_digits,
@@ -51,184 +51,184 @@ ec23_31 = low_card_curves["ec23_31"]
 def test_mult_recursive_aff() -> None:
     """Check the recursive affine mult on boundary scalars, every curve."""
     for ec in all_curves.values():
-        assert _mult_recursive_aff(0, ec.G, ec) == INF
-        assert _mult_recursive_aff(0, INF, ec) == INF
+        assert _mult_recursive_aff_var(0, ec.G, ec) == INF
+        assert _mult_recursive_aff_var(0, INF, ec) == INF
 
-        assert _mult_recursive_aff(1, INF, ec) == INF
-        assert _mult_aff(1, ec.G, ec) == ec.G
+        assert _mult_recursive_aff_var(1, INF, ec) == INF
+        assert _mult_aff_var(1, ec.G, ec) == ec.G
 
         Q = ec.add_aff(ec.G, ec.G)
-        assert _mult_recursive_aff(2, ec.G, ec) == Q
+        assert _mult_recursive_aff_var(2, ec.G, ec) == Q
 
-        Q = _mult_recursive_aff(ec.n - 1, ec.G, ec)
+        Q = _mult_recursive_aff_var(ec.n - 1, ec.G, ec)
         assert ec.negate(ec.G) == Q
-        assert _mult_recursive_aff(ec.n - 1, INF, ec) == INF
+        assert _mult_recursive_aff_var(ec.n - 1, INF, ec) == INF
 
         assert ec.add_aff(Q, ec.G) == INF
-        assert _mult_recursive_aff(ec.n, ec.G, ec) == INF
-        assert _mult_recursive_aff(ec.n, INF, ec) == INF
+        assert _mult_recursive_aff_var(ec.n, ec.G, ec) == INF
+        assert _mult_recursive_aff_var(ec.n, INF, ec) == INF
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            _mult_recursive_aff(-1, ec.G, ec)
+            _mult_recursive_aff_var(-1, ec.G, ec)
 
     for ec in low_card_curves.values():
         for q in range(ec.n):
-            Q = _mult_recursive_aff(q, ec.G, ec)
+            Q = _mult_recursive_aff_var(q, ec.G, ec)
             assert ec.is_on_curve(Q), f"{q}, {ec}"
             QJ = _mult(q, ec.GJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(QJ)), f"{q}, {ec}"
             assert ec.aff_from_jac(QJ) == Q, f"{q}, {ec}"
-            assert _mult_recursive_aff(q, INF, ec) == INF, f"{q}, {ec}"
+            assert _mult_recursive_aff_var(q, INF, ec) == INF, f"{q}, {ec}"
             assert ec.jac_equality(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
 
 
 def test_mult_recursive_jac() -> None:
     """Check the recursive Jacobian mult on boundary scalars, every curve."""
     for ec in all_curves.values():
-        assert ec.jac_equality(_mult_recursive_jac(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_recursive_jac(0, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac_var(0, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac_var(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(_mult_recursive_jac(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(_mult_recursive_jac(1, ec.GJ, ec), ec.GJ)
+        assert ec.jac_equality(_mult_recursive_jac_var(1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac_var(1, ec.GJ, ec), ec.GJ)
 
         PJ = ec.add_jac(ec.GJ, ec.GJ)
-        assert ec.jac_equality(PJ, _mult_recursive_jac(2, ec.GJ, ec))
+        assert ec.jac_equality(PJ, _mult_recursive_jac_var(2, ec.GJ, ec))
 
-        PJ = _mult_recursive_jac(ec.n - 1, ec.GJ, ec)
+        PJ = _mult_recursive_jac_var(ec.n - 1, ec.GJ, ec)
         assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(_mult_recursive_jac(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac_var(ec.n - 1, INFJ, ec), INFJ)
 
         assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(_mult_recursive_jac(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_recursive_jac(ec.n, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac_var(ec.n, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_recursive_jac_var(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            _mult_recursive_jac(-1, ec.GJ, ec)
+            _mult_recursive_jac_var(-1, ec.GJ, ec)
 
     ec = ec23_31
     for k1 in range(ec.n):
-        K1 = _mult_recursive_jac(k1, ec.GJ, ec)
+        K1 = _mult_recursive_jac_var(k1, ec.GJ, ec)
         assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_mult_aff() -> None:
     """Check the affine double-and-add on boundary scalars, every curve."""
     for ec in all_curves.values():
-        assert _mult_aff(0, ec.G, ec) == INF
-        assert _mult_aff(0, INF, ec) == INF
+        assert _mult_aff_var(0, ec.G, ec) == INF
+        assert _mult_aff_var(0, INF, ec) == INF
 
-        assert _mult_aff(1, INF, ec) == INF
-        assert _mult_aff(1, ec.G, ec) == ec.G
+        assert _mult_aff_var(1, INF, ec) == INF
+        assert _mult_aff_var(1, ec.G, ec) == ec.G
 
         Q = ec.add_aff(ec.G, ec.G)
-        assert _mult_aff(2, ec.G, ec) == Q
+        assert _mult_aff_var(2, ec.G, ec) == Q
 
-        Q = _mult_aff(ec.n - 1, ec.G, ec)
+        Q = _mult_aff_var(ec.n - 1, ec.G, ec)
         assert ec.negate(ec.G) == Q
-        assert _mult_aff(ec.n - 1, INF, ec) == INF
+        assert _mult_aff_var(ec.n - 1, INF, ec) == INF
 
         assert ec.add_aff(Q, ec.G) == INF
-        assert _mult_aff(ec.n, ec.G, ec) == INF
-        assert _mult_aff(ec.n, INF, ec) == INF
+        assert _mult_aff_var(ec.n, ec.G, ec) == INF
+        assert _mult_aff_var(ec.n, INF, ec) == INF
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            _mult_aff(-1, ec.G, ec)
+            _mult_aff_var(-1, ec.G, ec)
 
     for ec in low_card_curves.values():
         for q in range(ec.n):
-            Q = _mult_aff(q, ec.G, ec)
+            Q = _mult_aff_var(q, ec.G, ec)
             assert ec.is_on_curve(Q), f"{q}, {ec}"
             QJ = _mult(q, ec.GJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(QJ)), f"{q}, {ec}"
             assert ec.aff_from_jac(QJ) == Q, f"{q}, {ec}"
-            assert _mult_aff(q, INF, ec) == INF, f"{q}, {ec}"
+            assert _mult_aff_var(q, INF, ec) == INF, f"{q}, {ec}"
             assert ec.jac_equality(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
 
 
 def test_mult_jac() -> None:
     """Check the Jacobian double-and-add on boundary scalars, every curve."""
     for ec in all_curves.values():
-        assert ec.jac_equality(_mult_jac(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_jac(0, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac_var(0, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac_var(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(_mult_jac(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(_mult_jac(1, ec.GJ, ec), ec.GJ)
+        assert ec.jac_equality(_mult_jac_var(1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac_var(1, ec.GJ, ec), ec.GJ)
 
         PJ = ec.add_jac(ec.GJ, ec.GJ)
-        assert ec.jac_equality(PJ, _mult_jac(2, ec.GJ, ec))
+        assert ec.jac_equality(PJ, _mult_jac_var(2, ec.GJ, ec))
 
-        PJ = _mult_jac(ec.n - 1, ec.GJ, ec)
+        PJ = _mult_jac_var(ec.n - 1, ec.GJ, ec)
         assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(_mult_jac(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac_var(ec.n - 1, INFJ, ec), INFJ)
 
         assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(_mult_jac(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_jac(ec.n, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac_var(ec.n, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_jac_var(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            _mult_jac(-1, ec.GJ, ec)
+            _mult_jac_var(-1, ec.GJ, ec)
 
     ec = ec23_31
     for k1 in range(ec.n):
-        K1 = _mult_jac(k1, ec.GJ, ec)
+        K1 = _mult_jac_var(k1, ec.GJ, ec)
         assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_mont_ladder() -> None:
     """Check the Montgomery ladder on boundary scalars and against _mult."""
     for ec in low_card_curves.values():
-        assert ec.jac_equality(_mult_mont_ladder(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_mont_ladder(0, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder_var(0, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder_var(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(_mult_mont_ladder(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(_mult_mont_ladder(1, ec.GJ, ec), ec.GJ)
+        assert ec.jac_equality(_mult_mont_ladder_var(1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder_var(1, ec.GJ, ec), ec.GJ)
 
-        PJ = _mult_mont_ladder(2, ec.GJ, ec)
+        PJ = _mult_mont_ladder_var(2, ec.GJ, ec)
         assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-        PJ = _mult_mont_ladder(ec.n - 1, ec.GJ, ec)
+        PJ = _mult_mont_ladder_var(ec.n - 1, ec.GJ, ec)
         assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(_mult_mont_ladder(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder_var(ec.n - 1, INFJ, ec), INFJ)
 
         assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(_mult_mont_ladder(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_mont_ladder(ec.n, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder_var(ec.n, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            _mult_mont_ladder(-1, ec.GJ, ec)
+            _mult_mont_ladder_var(-1, ec.GJ, ec)
 
     ec = ec23_31
     for k1 in range(ec.n):
-        K1 = _mult_mont_ladder(k1, ec.GJ, ec)
+        K1 = _mult_mont_ladder_var(k1, ec.GJ, ec)
         assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_mult_base_3() -> None:
     """Check the base-3 mult on boundary scalars and against _mult."""
     for ec in low_card_curves.values():
-        assert ec.jac_equality(_mult_base_3(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_base_3(0, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_base_3_var(0, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_base_3_var(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(_mult_base_3(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(_mult_base_3(1, ec.GJ, ec), ec.GJ)
+        assert ec.jac_equality(_mult_base_3_var(1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_base_3_var(1, ec.GJ, ec), ec.GJ)
 
-        PJ = _mult_base_3(2, ec.GJ, ec)
+        PJ = _mult_base_3_var(2, ec.GJ, ec)
         assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-        PJ = _mult_base_3(ec.n - 1, ec.GJ, ec)
+        PJ = _mult_base_3_var(ec.n - 1, ec.GJ, ec)
         assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(_mult_base_3(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_base_3_var(ec.n - 1, INFJ, ec), INFJ)
 
         assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(_mult_base_3(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_mont_ladder(ec.n, INFJ, ec), INFJ)
+        assert ec.jac_equality(_mult_base_3_var(ec.n, ec.GJ, ec), INFJ)
+        assert ec.jac_equality(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
-            _mult_base_3(-1, ec.GJ, ec)
+            _mult_base_3_var(-1, ec.GJ, ec)
 
     ec = ec23_31
     for k1 in range(ec.n):
-        K1 = _mult_base_3(k1, ec.GJ, ec)
+        K1 = _mult_base_3_var(k1, ec.GJ, ec)
         assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
 
 
@@ -296,45 +296,45 @@ def test_mult_fixed_window() -> None:
     for w in range(1, MAX_W):
         for ec in low_card_curves.values():
             assert ec.jac_equality(
-                _mult_fixed_window(0, ec.GJ, ec, w, cached=False), INFJ
+                _mult_fixed_window_var(0, ec.GJ, ec, w, cached=False), INFJ
             )
             assert ec.jac_equality(
-                _mult_fixed_window(0, INFJ, ec, w, cached=False), INFJ
+                _mult_fixed_window_var(0, INFJ, ec, w, cached=False), INFJ
             )
 
             assert ec.jac_equality(
-                _mult_fixed_window(1, INFJ, ec, w, cached=False), INFJ
+                _mult_fixed_window_var(1, INFJ, ec, w, cached=False), INFJ
             )
             assert ec.jac_equality(
-                _mult_fixed_window(1, ec.GJ, ec, w, cached=False), ec.GJ
+                _mult_fixed_window_var(1, ec.GJ, ec, w, cached=False), ec.GJ
             )
 
-            PJ = _mult_fixed_window(2, ec.GJ, ec, w, cached=False)
+            PJ = _mult_fixed_window_var(2, ec.GJ, ec, w, cached=False)
             assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-            PJ = _mult_fixed_window(ec.n - 1, ec.GJ, ec, w, cached=False)
+            PJ = _mult_fixed_window_var(ec.n - 1, ec.GJ, ec, w, cached=False)
             assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
             assert ec.jac_equality(
-                _mult_fixed_window(ec.n - 1, INFJ, ec, w, cached=False), INFJ
+                _mult_fixed_window_var(ec.n - 1, INFJ, ec, w, cached=False), INFJ
             )
 
             assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
             assert ec.jac_equality(
-                _mult_fixed_window(ec.n, ec.GJ, ec, w, cached=False), INFJ
+                _mult_fixed_window_var(ec.n, ec.GJ, ec, w, cached=False), INFJ
             )
-            assert ec.jac_equality(_mult_mont_ladder(ec.n, INFJ, ec), INFJ)
+            assert ec.jac_equality(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
-                _mult_fixed_window(-1, ec.GJ, ec, w, cached=False)
+                _mult_fixed_window_var(-1, ec.GJ, ec, w, cached=False)
 
             with pytest.raises(BTClibValueError, match="non positive w: "):
-                _mult_fixed_window(1, ec.GJ, ec, -w, cached=False)
+                _mult_fixed_window_var(1, ec.GJ, ec, -w, cached=False)
 
     ec = ec23_31
     for w in range(1, 10):
         for k1 in range(ec.n):
-            K1 = _mult_fixed_window(k1, ec.GJ, ec, w, cached=False)
-            assert ec.jac_equality(K1, _mult_jac(k1, ec.GJ, ec))
+            K1 = _mult_fixed_window_var(k1, ec.GJ, ec, w, cached=False)
+            assert ec.jac_equality(K1, _mult_jac_var(k1, ec.GJ, ec))
 
 
 def test_signed_odd_digits() -> None:
@@ -397,7 +397,7 @@ def test_signed_odd_multiples_aff() -> None:
             T = _signed_odd_multiples_aff(ec.GJ, ec, w)
             assert len(T) == 2**w
             for d in range(-(2**w - 1), 2**w, 2):
-                expected = ec.aff_from_jac(_mult_jac(d % ec.n, ec.GJ, ec))
+                expected = ec.aff_from_jac(_mult_jac_var(d % ec.n, ec.GJ, ec))
                 assert T[(d + 2**w - 1) // 2] == expected, (d, w)
 
 
@@ -415,7 +415,7 @@ def test_add_jac_aff_answers_add_jac_on_every_pair() -> None:
     for ec in low_card_curves.values():
         points = [*find_all_points(ec), INF]
         jac = [_jac_from_aff(P) for P in points]
-        jac += [_mult_jac(k, ec.GJ, ec) for k in range(ec.n)]
+        jac += [_mult_jac_var(k, ec.GJ, ec) for k in range(ec.n)]
         for PJ in jac:
             for R in points:
                 mixed = ec.add_jac_aff(PJ, R)
@@ -474,7 +474,7 @@ def test_regular_window_addition_count_is_the_same_for_every_scalar() -> None:
         _mult_regular_window(m, secp256k1.GJ, ec, w=4)
         regular.add(ec.additions)
         ec.additions = 0
-        _mult_fixed_window(m, secp256k1.GJ, ec, w=4, cached=False)
+        _mult_fixed_window_var(m, secp256k1.GJ, ec, w=4, cached=False)
         fixed.add(ec.additions)
 
     assert len(regular) == 1, regular
@@ -496,7 +496,8 @@ def test_mult_fixed_base() -> None:
         for ec in low_card_curves.values():
             for m in range(ec.n + 1):
                 assert ec.jac_equality(
-                    _mult_fixed_base(m, ec.GJ, ec, w), _mult_jac(m % ec.n, ec.GJ, ec)
+                    _mult_fixed_base(m, ec.GJ, ec, w),
+                    _mult_jac_var(m % ec.n, ec.GJ, ec),
                 ), (m, w, ec)
             assert ec.jac_equality(_mult_fixed_base(1, INFJ, ec, w), INFJ)
 
@@ -508,7 +509,7 @@ def test_mult_fixed_base() -> None:
     ec = secp256k1
     for m in (0, 1, 2, 3, ec.n - 1, ec.n, ec.n + 1):
         assert ec.jac_equality(
-            _mult_fixed_base(m, ec.GJ, ec, w=4), _mult_jac(m, ec.GJ, ec)
+            _mult_fixed_base(m, ec.GJ, ec, w=4), _mult_jac_var(m, ec.GJ, ec)
         ), m
 
     with pytest.raises(BTClibValueError, match="does not fit"):
@@ -545,7 +546,7 @@ def test_mult_regular_window() -> None:
     for w in range(1, 10):
         for k1 in range(ec.n):
             K1 = _mult_regular_window(k1, ec.GJ, ec, w)
-            assert ec.jac_equality(K1, _mult_jac(k1, ec.GJ, ec))
+            assert ec.jac_equality(K1, _mult_jac_var(k1, ec.GJ, ec))
 
     # a scalar of more bits than the group has, which is the one case where
     # the digit count is the scalar's own again: the answer is still the
@@ -553,7 +554,7 @@ def test_mult_regular_window() -> None:
     ec = secp256k1
     for m in (ec.n, ec.n + 1, 2 * ec.n, 1 << 300):
         assert ec.jac_equality(
-            _mult_regular_window(m, ec.GJ, ec, w=4), _mult_jac(m, ec.GJ, ec)
+            _mult_regular_window(m, ec.GJ, ec, w=4), _mult_jac_var(m, ec.GJ, ec)
         ), m
 
 
@@ -561,38 +562,46 @@ def test_mult_fixed_window_cached() -> None:
     """Check the cached fixed-window mult on boundary scalars and widths."""
     for _ in range(1, MAX_W):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(_mult_fixed_window_cached(0, ec.GJ, ec, w=4), INFJ)
-            assert ec.jac_equality(_mult_fixed_window_cached(0, INFJ, ec, w=4), INFJ)
+            assert ec.jac_equality(
+                _mult_fixed_window_cached_var(0, ec.GJ, ec, w=4), INFJ
+            )
+            assert ec.jac_equality(
+                _mult_fixed_window_cached_var(0, INFJ, ec, w=4), INFJ
+            )
 
-            assert ec.jac_equality(_mult_fixed_window_cached(1, INFJ, ec, w=4), INFJ)
-            assert ec.jac_equality(_mult_fixed_window_cached(1, ec.GJ, ec, w=4), ec.GJ)
+            assert ec.jac_equality(
+                _mult_fixed_window_cached_var(1, INFJ, ec, w=4), INFJ
+            )
+            assert ec.jac_equality(
+                _mult_fixed_window_cached_var(1, ec.GJ, ec, w=4), ec.GJ
+            )
 
-            PJ = _mult_fixed_window_cached(2, ec.GJ, ec, w=4)
+            PJ = _mult_fixed_window_cached_var(2, ec.GJ, ec, w=4)
             assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
-            PJ = _mult_fixed_window_cached(ec.n - 1, ec.GJ, ec, w=4)
+            PJ = _mult_fixed_window_cached_var(ec.n - 1, ec.GJ, ec, w=4)
             assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
             assert ec.jac_equality(
-                _mult_fixed_window_cached(ec.n - 1, INFJ, ec, w=4), INFJ
+                _mult_fixed_window_cached_var(ec.n - 1, INFJ, ec, w=4), INFJ
             )
 
             assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
             assert ec.jac_equality(
-                _mult_fixed_window_cached(ec.n, ec.GJ, ec, w=4), INFJ
+                _mult_fixed_window_cached_var(ec.n, ec.GJ, ec, w=4), INFJ
             )
-            assert ec.jac_equality(_mult_mont_ladder(ec.n, INFJ, ec), INFJ)
+            assert ec.jac_equality(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
-                _mult_fixed_window_cached(-1, ec.GJ, ec, w=4)
+                _mult_fixed_window_cached_var(-1, ec.GJ, ec, w=4)
 
             with pytest.raises(BTClibValueError, match="non positive w: "):
-                _mult_fixed_window_cached(1, ec.GJ, ec, -1)
+                _mult_fixed_window_cached_var(1, ec.GJ, ec, -1)
 
     ec = ec23_31
     for w in range(1, 10):
         for k1 in range(ec.n):
-            K1 = _mult_fixed_window_cached(k1, ec.GJ, ec, w)
-            assert ec.jac_equality(K1, _mult_jac(k1, ec.GJ, ec))
+            K1 = _mult_fixed_window_cached_var(k1, ec.GJ, ec, w)
+            assert ec.jac_equality(K1, _mult_jac_var(k1, ec.GJ, ec))
 
 
 def test_assorted_jac_mult() -> None:
@@ -605,19 +614,19 @@ def test_assorted_jac_mult() -> None:
         for k2 in range(ec.n):
             K2J = _mult(k2, HJ, ec)
 
-            shamir = _double_mult(k1, ec.GJ, k2, ec.GJ, ec)
+            shamir = _double_mult_var(k1, ec.GJ, k2, ec.GJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(shamir))
             assert ec.jac_equality(shamir, _mult(k1 + k2, ec.GJ, ec))
 
-            shamir = _double_mult(k1, INFJ, k2, HJ, ec)
+            shamir = _double_mult_var(k1, INFJ, k2, HJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(shamir))
             assert ec.jac_equality(shamir, K2J)
 
-            shamir = _double_mult(k1, ec.GJ, k2, INFJ, ec)
+            shamir = _double_mult_var(k1, ec.GJ, k2, INFJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(shamir))
             assert ec.jac_equality(shamir, K1J)
 
-            shamir = _double_mult(k1, ec.GJ, k2, HJ, ec)
+            shamir = _double_mult_var(k1, ec.GJ, k2, HJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(shamir))
             K1JK2J = ec.add_jac(K1J, K2J)
             assert ec.jac_equality(K1JK2J, shamir)
@@ -626,7 +635,7 @@ def test_assorted_jac_mult() -> None:
             K3J = _mult(k3, ec.GJ, ec)
             K1JK2JK3J = ec.add_jac(K1JK2J, K3J)
             assert ec.is_on_curve(ec.aff_from_jac(K1JK2JK3J))
-            boscoster = _multi_mult([k1, k2, k3], [ec.GJ, HJ, ec.GJ], ec)
+            boscoster = _multi_mult_var([k1, k2, k3], [ec.GJ, HJ, ec.GJ], ec)
             assert ec.is_on_curve(ec.aff_from_jac(boscoster))
             assert ec.aff_from_jac(K1JK2JK3J) == ec.aff_from_jac(boscoster), k3
             assert ec.jac_equality(K1JK2JK3J, boscoster)
@@ -636,27 +645,29 @@ def test_assorted_jac_mult() -> None:
             K1JK2JK3JK4J = ec.add_jac(K1JK2JK3J, K4J)
             assert ec.is_on_curve(ec.aff_from_jac(K1JK2JK3JK4J))
             points = [ec.GJ, HJ, ec.GJ, HJ]
-            boscoster = _multi_mult([k1, k2, k3, k4], points, ec)
+            boscoster = _multi_mult_var([k1, k2, k3, k4], points, ec)
             assert ec.is_on_curve(ec.aff_from_jac(boscoster))
             assert ec.aff_from_jac(K1JK2JK3JK4J) == ec.aff_from_jac(boscoster), k4
             assert ec.jac_equality(K1JK2JK3JK4J, boscoster)
-            assert ec.jac_equality(K1JK2JK3J, _multi_mult([k1, k2, k3, 0], points, ec))
-            assert ec.jac_equality(K1JK2J, _multi_mult([k1, k2, 0, 0], points, ec))
-            assert ec.jac_equality(K1J, _multi_mult([k1, 0, 0, 0], points, ec))
-            assert ec.jac_equality(INFJ, _multi_mult([0, 0, 0, 0], points, ec))
+            assert ec.jac_equality(
+                K1JK2JK3J, _multi_mult_var([k1, k2, k3, 0], points, ec)
+            )
+            assert ec.jac_equality(K1JK2J, _multi_mult_var([k1, k2, 0, 0], points, ec))
+            assert ec.jac_equality(K1J, _multi_mult_var([k1, 0, 0, 0], points, ec))
+            assert ec.jac_equality(INFJ, _multi_mult_var([0, 0, 0, 0], points, ec))
 
             err_msg = "mismatch between number of scalars and points: "
             with pytest.raises(BTClibValueError, match=err_msg):
-                _multi_mult([k1, k2, k3, k4], [ec.GJ, HJ, ec.GJ], ec)
+                _multi_mult_var([k1, k2, k3, k4], [ec.GJ, HJ, ec.GJ], ec)
 
             err_msg = "negative coefficient: "
             with pytest.raises(BTClibValueError, match=err_msg):
-                _multi_mult([k1, k2, -k3], [ec.GJ, HJ, ec.GJ], ec)
+                _multi_mult_var([k1, k2, -k3], [ec.GJ, HJ, ec.GJ], ec)
 
     with pytest.raises(BTClibValueError, match="negative first coefficient: "):
-        _double_mult(-5, HJ, 1, ec.GJ, ec)
+        _double_mult_var(-5, HJ, 1, ec.GJ, ec)
     with pytest.raises(BTClibValueError, match="negative second coefficient: "):
-        _double_mult(1, HJ, -5, ec.GJ, ec)
+        _double_mult_var(1, HJ, -5, ec.GJ, ec)
 
 
 def test_mult_on_a_characteristic_7_curve() -> None:
@@ -664,12 +675,12 @@ def test_mult_on_a_characteristic_7_curve() -> None:
 
     INFJ is (7, 0, 0), so p == 7 is where that arbitrary x reduces to
     zero and add_jac's doubling test can mistake the identity for the
-    other operand (issue 171). Before it was fixed, _mult_jac answered
-    wrong for 6 of the 13 scalars here, the ladder and _mult_recursive_jac
-    for 12 of 13, and _double_mult for 100 of the 169 coefficient pairs;
+    other operand (issue 171). Before it was fixed, _mult_jac_var answered
+    wrong for 6 of the 13 scalars here, the ladder and _mult_recursive_jac_var
+    for 12 of 13, and _double_mult_var for 100 of the 169 coefficient pairs;
     the two fixed windows happened not to, every scalar of a curve this
     small fitting in one base-16 digit -- which is why the reference here
-    is _mult_aff, the one multiplication that forms no Jacobian point at
+    is _mult_aff_var, the one multiplication that forms no Jacobian point at
     all.
     """
     ec = Curve(7, 0, 3, (1, 2), 13, 1, False)
@@ -678,21 +689,21 @@ def test_mult_on_a_characteristic_7_curve() -> None:
     # __name__ for the assertion to report
     variants = (
         ("_mult", _mult),
-        ("_mult_jac", _mult_jac),
-        ("_mult_recursive_jac", _mult_recursive_jac),
-        ("_mult_mont_ladder", _mult_mont_ladder),
-        ("_mult_base_3", _mult_base_3),
-        ("_mult_fixed_window", partial(_mult_fixed_window, w=4, cached=False)),
-        ("_mult_fixed_window_cached", partial(_mult_fixed_window_cached, w=4)),
+        ("_mult_jac_var", _mult_jac_var),
+        ("_mult_recursive_jac_var", _mult_recursive_jac_var),
+        ("_mult_mont_ladder_var", _mult_mont_ladder_var),
+        ("_mult_base_3_var", _mult_base_3_var),
+        ("_mult_fixed_window_var", partial(_mult_fixed_window_var, w=4, cached=False)),
+        ("_mult_fixed_window_cached_var", partial(_mult_fixed_window_cached_var, w=4)),
         ("_mult_regular_window", partial(_mult_regular_window, w=4)),
     )
     for k in range(ec.n):
-        expected = _mult_aff(k, ec.G, ec)
+        expected = _mult_aff_var(k, ec.G, ec)
         for name, mult_f in variants:
             assert ec.aff_from_jac(mult_f(k, ec.GJ, ec)) == expected, name
         for j in range(ec.n):
-            shamir = _double_mult(k, ec.GJ, j, ec.GJ, ec)
-            assert ec.aff_from_jac(shamir) == _mult_aff(k + j, ec.G, ec), (k, j)
+            shamir = _double_mult_var(k, ec.GJ, j, ec.GJ, ec)
+            assert ec.aff_from_jac(shamir) == _mult_aff_var(k + j, ec.G, ec), (k, j)
 
 
 def _sum_of_mults(
@@ -732,20 +743,25 @@ def test_multi_mult_w_NAF() -> None:
                     scalars = [k1, k2, ec.n // 3]
                     points = [ec.GJ, HJ, ec.GJ]
                     expected = _sum_of_mults(scalars, points, ec)
-                    got = _multi_mult_w_NAF(scalars, points, ec, w, ec._fixed_points)
+                    got = _multi_mult_w_NAF_var(
+                        scalars, points, ec, w, ec._fixed_points
+                    )
                     assert ec.jac_equality(got, expected), (k1, k2, w)
                     assert ec.jac_equality(
-                        got, _multi_mult_bos_coster(scalars, points, ec)
+                        got, _multi_mult_bos_coster_var(scalars, points, ec)
                     ), (k1, k2, w)
 
             # a zero scalar, an INF point, and scalars of distant lengths
             assert ec.jac_equality(
-                _multi_mult_w_NAF([0, 0], [ec.GJ, HJ], ec, w, ec._fixed_points), INFJ
+                _multi_mult_w_NAF_var([0, 0], [ec.GJ, HJ], ec, w, ec._fixed_points),
+                INFJ,
             )
             for scalars in ([0, 3], [3, 0], [1, ec.n - 1], [ec.n - 1, 1]):
                 for points in ([ec.GJ, HJ], [INFJ, HJ], [ec.GJ, INFJ]):
                     expected = _sum_of_mults(scalars, points, ec)
-                    got = _multi_mult_w_NAF(scalars, points, ec, w, ec._fixed_points)
+                    got = _multi_mult_w_NAF_var(
+                        scalars, points, ec, w, ec._fixed_points
+                    )
                     assert ec.jac_equality(got, expected), (scalars, w)
 
         # a window wider than the order itself, where the table of odd
@@ -758,12 +774,12 @@ def test_multi_mult_w_NAF() -> None:
             for scalars in ([1, ec.n - 1], [ec.n // 2, 3], [0, ec.n - 1]):
                 points = [ec.GJ, HJ]
                 expected = _sum_of_mults(scalars, points, ec)
-                got = _multi_mult_w_NAF(scalars, points, ec, w, ec._fixed_points)
+                got = _multi_mult_w_NAF_var(scalars, points, ec, w, ec._fixed_points)
                 assert ec.jac_equality(got, expected), (scalars, w)
 
     ec = secp256k1
     with pytest.raises(BTClibValueError, match="non positive w: "):
-        _multi_mult_w_NAF([1, 1], [ec.GJ, ec.GJ], ec, 0, ec._fixed_points)
+        _multi_mult_w_NAF_var([1, 1], [ec.GJ, ec.GJ], ec, 0, ec._fixed_points)
 
 
 def test_multi_mult_agrees_across_curves() -> None:
@@ -780,10 +796,12 @@ def test_multi_mult_agrees_across_curves() -> None:
         scalars = [rnd.randrange(ec.n) for _ in points]
         expected = _sum_of_mults(scalars, points, ec)
         assert ec.jac_equality(
-            _multi_mult_w_NAF(scalars, points, ec, _MULTI_MULT_W, ec._fixed_points),
+            _multi_mult_w_NAF_var(scalars, points, ec, _MULTI_MULT_W, ec._fixed_points),
             expected,
         )
-        assert ec.jac_equality(_multi_mult_bos_coster(scalars, points, ec), expected)
+        assert ec.jac_equality(
+            _multi_mult_bos_coster_var(scalars, points, ec), expected
+        )
 
 
 def test_multi_mult_dispatch() -> None:
@@ -804,46 +822,50 @@ def test_multi_mult_dispatch() -> None:
         points = [ec.GJ if i % 2 else HJ for i in range(size)]
         scalars = [rnd.randrange(1, ec.n) for _ in range(size)]
         expected = _sum_of_mults(scalars, points, ec)
-        assert ec.jac_equality(_multi_mult(scalars, points, ec), expected)
+        assert ec.jac_equality(_multi_mult_var(scalars, points, ec), expected)
         assert ec.jac_equality(
-            _multi_mult_w_NAF(scalars, points, ec, _MULTI_MULT_W, ec._fixed_points),
+            _multi_mult_w_NAF_var(scalars, points, ec, _MULTI_MULT_W, ec._fixed_points),
             expected,
         )
-        assert ec.jac_equality(_multi_mult_bos_coster(scalars, points, ec), expected)
+        assert ec.jac_equality(
+            _multi_mult_bos_coster_var(scalars, points, ec), expected
+        )
 
         # all zero, whatever the algorithm: nothing to sum. Asked of
         # both by name, the dispatch no longer being able to reach
         # Bos-Coster with it -- a batch of nothing but zeros is a batch
         # of no nonzero scalars, which is below any threshold
-        assert ec.jac_equality(_multi_mult([0] * size, points, ec), INFJ)
+        assert ec.jac_equality(_multi_mult_var([0] * size, points, ec), INFJ)
         assert ec.jac_equality(
-            _multi_mult_w_NAF([0] * size, points, ec, _MULTI_MULT_W, ec._fixed_points),
+            _multi_mult_w_NAF_var(
+                [0] * size, points, ec, _MULTI_MULT_W, ec._fixed_points
+            ),
             INFJ,
         )
-        assert ec.jac_equality(_multi_mult_bos_coster([0] * size, points, ec), INFJ)
+        assert ec.jac_equality(_multi_mult_bos_coster_var([0] * size, points, ec), INFJ)
 
         # a batch of this length whose *work* is two scalars: the zeros
         # are dropped downstream, so the count that dispatches counts
         # them out first and this goes to the interleaved wNAF
         sparse = [scalars[0], *([0] * (size - 2)), scalars[-1]]
         assert ec.jac_equality(
-            _multi_mult(sparse, points, ec), _sum_of_mults(sparse, points, ec)
+            _multi_mult_var(sparse, points, ec), _sum_of_mults(sparse, points, ec)
         )
 
         err_msg = "mismatch between number of scalars and points: "
         with pytest.raises(BTClibValueError, match=err_msg):
-            _multi_mult(scalars, points[1:], ec)
+            _multi_mult_var(scalars, points[1:], ec)
         with pytest.raises(BTClibValueError, match="negative coefficient: "):
-            _multi_mult([-1, *scalars[1:]], points, ec)
+            _multi_mult_var([-1, *scalars[1:]], points, ec)
 
     with pytest.raises(BTClibValueError, match="not a multi_mult"):
-        _multi_mult([1], [ec.GJ], ec)
+        _multi_mult_var([1], [ec.GJ], ec)
 
 
 def test_multi_mult_distant_magnitudes() -> None:
     """Issue 175, asked of the implementation that can still hang.
 
-    _multi_mult sends two scalars to the interleaved wNAF, which is
+    _multi_mult_var sends two scalars to the interleaved wNAF, which is
     indifferent to their magnitudes, so the pathological pairs reach
     Bos-Coster only inside a batch above the threshold -- where they are
     the whole of the batch's cost. Euclid's quotient is what bounds it:
@@ -854,9 +876,9 @@ def test_multi_mult_distant_magnitudes() -> None:
     HJ = _jac_from_aff(second_generator(ec))
     for scalars in ([10**6, 1], [1, 10**6], [ec.n - 1, 1], [ec.n - 1, ec.n - 2]):
         expected = _sum_of_mults(scalars, [ec.GJ, HJ], ec)
-        assert ec.jac_equality(_multi_mult(scalars, [ec.GJ, HJ], ec), expected)
+        assert ec.jac_equality(_multi_mult_var(scalars, [ec.GJ, HJ], ec), expected)
         assert ec.jac_equality(
-            _multi_mult_bos_coster(scalars, [ec.GJ, HJ], ec), expected
+            _multi_mult_bos_coster_var(scalars, [ec.GJ, HJ], ec), expected
         )
 
 
@@ -867,7 +889,7 @@ def test_jac_equality() -> None:
 
     # q in [2, n-1], as the difference with ec.GJ is checked below
     q = 2
-    Q = _mult_aff(q, ec.G, ec)
+    Q = _mult_aff_var(q, ec.G, ec)
     QJ = _mult(q, ec.GJ, ec)
     assert ec.jac_equality(QJ, _jac_from_aff(Q))
     assert not ec.jac_equality(QJ, ec.negate_jac(QJ))

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -46,7 +46,7 @@ from btclib.curves.curve import (
 # _cached_multiples and _jac_from_aff are implementation helpers of
 # curve_group, not part of what btclib.curves exports: they are taken from the
 # module that defines them
-from btclib.curves.curve_group import _cached_multiples, _jac_from_aff, _mult_jac
+from btclib.curves.curve_group import _cached_multiples, _jac_from_aff, _mult_jac_var
 from btclib.ecc import second_generator
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.number_theory import mod_inv, mod_sqrt
@@ -231,7 +231,7 @@ def test_curves_with_n_above_p() -> None:
         ec = low_card_curves[name]
         # every point of the curve, x below n, so nothing to reduce
         for q in range(1, ec.n):
-            x_K = ec.x_aff_from_jac(_mult_jac(q, ec.GJ, ec))
+            x_K = ec.x_aff_from_jac(_mult_jac_var(q, ec.GJ, ec))
             assert x_K < ec.n
             assert x_K % ec.n == x_K
 


### PR DESCRIPTION
Which of the private multiplications makes the same number of point
additions for every scalar, and which makes a number the coefficient
decides, is the distinction every dispatch in curve.py turns on. It was
stated in the docstrings and nowhere else.

It is in the names now, as libsecp256k1 has it -- gej_add_var beside
gej_add_ge: _mult_jac_var, _mult_aff_var, _mult_base_3_var,
_mult_mont_ladder_var, the two _mult_recursive_*_var, the two
_mult_fixed_window*_var, _mult_sliding_window_var, _mult_w_NAF_var,
_double_mult_var, _double_mult_w_NAF_var,
_double_mult_endomorphism_secp256k1_var, _multi_mult_w_NAF_var,
_multi_mult_bos_coster_var and _multi_mult_var, against
_mult_regular_window, _mult_fixed_base and _double_mult_regular_window,
which carry no suffix because they make one count whatever the scalar.

_mult_endomorphism_secp256k1 had a regular flag that decided which of the
two it was, so its name could only ever be half true: it is two functions
now, the regular windows curves.mult runs and
_mult_endomorphism_secp256k1_var beside it, which is algorithm 3.77 as it
is written and 16% faster at the cost of the count following the scalar.
Nothing signs with the second; it stays to be measured against the first.

Every name is private and curves/__init__.py says so, so no caller's code
changes. CONTRIBUTING.md carries the rule for what comes next, with the
two things the absence of the suffix does not promise: not a
constant-time function -- mod_inv is an extended Euclid, a table is
indexed by a secret digit, and SECURITY.md publishes the Python path as
variable-time -- and nothing at all about the point, whose inversion
every table costs and whose value is the caller's public key.

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Clarify which internal scalar multiplication routines have scalar-dependent work by renaming them with a `_var` suffix and adjusting dispatch to treat regular-window variants as the fixed-cost implementations.

New Features:
- Introduce `_mult_endomorphism_secp256k1_var` and `_double_mult_endomorphism_secp256k1_var` as explicit variable-cost endomorphism-based scalar multiplication variants used for benchmarking and verification, alongside the regular-window versions used for signing.

Enhancements:
- Rename existing private scalar multiplication and multi-multiplication helpers across curve_group and curve_group_2 to add a `_var` suffix for implementations whose point-operation count depends on the scalar, keeping regular-window and fixed-base variants unsuffixed as fixed-cost references.
- Update curve dispatch, endomorphism handling, and multi-multiplication flows to call the newly named `_var` variants while preserving behavior and performance characteristics.
- Extend tests to use the new `_var`-suffixed helpers, verify both endomorphism variants against the baseline multiplications, and ensure internal implementations remain discoverable but not exported in the public API.
- Document the `_var` naming convention and its semantics in CHANGELOG and CONTRIBUTING, emphasizing that it signals scalar-dependent work but does not imply constant-time behavior.

Documentation:
- Add documentation of the `_var` suffix convention for internal scalar multiplications in CONTRIBUTING.md and reference the change and its rationale in the CHANGELOG.

Tests:
- Adjust curve and curve_group test suites to exercise the renamed `_var`-suffixed multiplication variants, including characteristic-7 edge cases, multi-multiplication dispatch, and endomorphism-based double multiplication, ensuring parity with previous behavior.