### PR TITLE
Give `check_` one meaning, and the other eleven their own (#814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2254,6 +2254,44 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **`check_` said four things, and therefore nothing** (issue #814).
+  Thirteen public functions carried the prefix: nine refusals returning
+  `None`, two bool verdicts, a converter returning bytes and a query
+  returning a pair of bools. Each of those shapes already had a name in
+  this library, so eleven of the thirteen were named for what they do
+  and the prefix keeps the one meaning that was left.
+
+  The nine refusals are `assert_*`, which is what their own docstrings
+  said all along -- "Reject a signature that failed to verify",
+  "Enforce Core's MAX_STACK_SIZE", "Reject an op code disabled by
+  CVE-2010-5137". `b32.check_witness` returned the witness program it
+  had validated, so it is `bytes_from_witness_program`, after
+  `bytes_from_octets` whose size rule it is;
+  `psbt_signer_contract.check_optional_protocols` answers which
+  protocols a signer offers, so it is `optional_protocols`.
+
+  What keeps `check_` is the two that answer a bool **and** refuse what
+  cannot be an answer, which is a fourth contract worth a name of its
+  own: it is the prefix that warns a caller an `except` is still needed.
+  `script.engine.script.check_pub_key` is False for a wrong length and
+  raises for a hybrid prefix under STRICTENC, which is how Core's
+  `CheckPubKeyEncoding` splits it; `taproot.check_output_pubkey` raises
+  for a malformed control block, that being no proof rather than a
+  disproof. Both said so in their docstrings already.
+
+  So the four prefixes are a closed vocabulary now, stated in
+  CONTRIBUTING.md beside the rule above -- and gated, which is the part
+  that keeps it: `tests/name_contract_test.py` reads the return
+  annotation of every public name carrying one of them. `check_` drifted
+  because the vocabulary was a habit, and nothing in the tree could
+  notice. Seven names answer something else and are listed with the
+  reason: the script engine's six `verify_*`, which refuse rather than
+  answer because a `ScriptError` carries the command index and the stack
+  depth that a bool would drop, and `bip322.assert_signed_message`,
+  which hands back the message whose five conditions it just checked.
+  The `op_*verify` op code implementations are not verifications in this
+  sense and are excluded by name.
+
 - **A `bool` is an answer about a value of a declared type** (issue
   #814). `script_pub_key.is_p2sh` already drew that line -- bytes that
   are not a p2sh script are `False`, a float is a `BTClibTypeError` --

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -845,6 +845,29 @@ what issue #745 found and this replaces. The `assert_*` twin beside each
 of these is the spelling that says *why* a value was refused, and the two
 are how a caller chooses between an answer and a reason.
 
+**Which of those a function is, its name says**, and the four prefixes
+are a closed vocabulary:
+
+- `assert_*` refuses and returns `None`. There are eighty-odd of them
+  and they are the reason half of the pair above.
+- `is_*` answers a `bool` about a value, and is total over the declared
+  types: `is_p2sh` is False for bytes that are not a p2sh script.
+- `verify*` answers a `bool` about a signature or a proof, on the same
+  terms. `assert_as_valid` beside it says why.
+- `check_*` answers a `bool` **and refuses what cannot be an answer** --
+  the one prefix that warns a caller it still needs an `except`. There
+  are two: `script.engine.script.check_pub_key`, where a wrong length is
+  False but a hybrid prefix under STRICTENC is the offence itself, which
+  is how Core's `CheckPubKeyEncoding` splits it; and
+  `script.taproot.check_output_pubkey`, where a malformed control block
+  is no proof rather than a disproof.
+
+Nine functions carried `check_` while refusing and returning `None`, and
+two more while returning bytes and a pair of bools, which left the prefix
+saying four things and therefore nothing (issue #814). A converter is
+named for what it returns -- `bytes_from_octets`,
+`b32.bytes_from_witness_program` -- and a query for what it answers.
+
 `check_validity=False` is not an exemption from this. It says "do not
 check *now*", not "this object is exempt from here on": these are mutable
 dataclasses whose fields are public and get reassigned in place, so

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,26 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **eleven `check_*` functions are renamed, and the prefix means one
+  thing.** It meant four at once: nine refusals returning `None`, two
+  bool verdicts, a converter returning bytes and a query returning a
+  pair of bools. The nine are `assert_*` now --
+  `assert_nullfail`, `assert_nulldummy`, `assert_pub_key_num`,
+  `assert_signature_num`, `assert_not_disabled`, `assert_stack_size`,
+  `assert_minimal_push`, `assert_balanced_if` and
+  `assert_psbt_signer` -- `b32.check_witness` is
+  `b32.bytes_from_witness_program`, and
+  `psbt_signer_contract.check_optional_protocols` is
+  `optional_protocols`. What keeps the prefix is the two that answer a
+  bool *and* refuse what cannot be an answer:
+  `script.engine.script.check_pub_key` and
+  `script.taproot.check_output_pubkey`.
+
+  An import of any of the eleven old names is an `ImportError`, and the
+  new name is a rename with no change of signature or behaviour.
+  `tests/name_contract_test.py` is the gate that keeps the four prefixes
+  meaning what CONTRIBUTING.md says they mean.
+
 - **a verification refuses a type it does not declare, where it used to
   answer `False`.** `dsa.verify` takes a `PubKey` -- bytes, a hex
   string, a `BIP32KeyData` or a `Point` -- and an int is none of those:

--- a/btclib/b32.py
+++ b/btclib/b32.py
@@ -36,8 +36,8 @@ The whole surface is exported, the two facilities below the addresses
 included: `power_of_2_base_conversion` is the `convertbits` of the
 reference implementation, which a caller reading or writing a witness
 program in five-bit groups needs as much as this module does, and
-`check_witness` is BIP141's length rule, which `btclib.b58` asks for the
-p2sh-wrapped forms.
+`bytes_from_witness_program` is BIP141's length rule, which `btclib.b58`
+asks for the p2sh-wrapped forms.
 
 Some of these functions are originally from
 https://github.com/sipa/bech32/tree/master/ref/python,
@@ -64,7 +64,7 @@ from btclib.utils import bytes_from_octets, str_from_string
 
 __all__ = [
     "address_from_witness",
-    "check_witness",
+    "bytes_from_witness_program",
     "has_segwit_prefix",
     "p2tr",
     "p2wpkh",
@@ -118,7 +118,7 @@ def power_of_2_base_conversion(
     return ret
 
 
-def check_witness(wit_ver: int, wit_prg: Octets) -> bytes:
+def bytes_from_witness_program(wit_ver: int, wit_prg: Octets) -> bytes:
     """Return the witness program, refusing what BIP141 does not define.
 
     A version outside 0..16, a program outside 2..40 bytes, or a v0
@@ -142,7 +142,7 @@ def check_witness(wit_ver: int, wit_prg: Octets) -> bytes:
 
 
 def _address_from_witness(wit_ver: int, wit_prg: Octets, hrp: str) -> str:
-    wit_prg = check_witness(wit_ver, wit_prg)
+    wit_prg = bytes_from_witness_program(wit_ver, wit_prg)
     data = [wit_ver, *power_of_2_base_conversion(wit_prg, 8, 5)]
     bytes_ = encode(hrp, data)
     return bytes_.decode("ascii")
@@ -175,7 +175,7 @@ def witness_from_address(b32addr: String) -> tuple[int, bytes, str]:
 
     wit_ver = data[0]
     wit_prog = bytes(power_of_2_base_conversion(data[1:], 5, 8, False))
-    wit_prog = check_witness(wit_ver, wit_prog)
+    wit_prog = bytes_from_witness_program(wit_ver, wit_prog)
 
     # check that it is a known segwit address type
     network = network_from_key_value("hrp", hrp)

--- a/btclib/b58.py
+++ b/btclib/b58.py
@@ -131,17 +131,16 @@ def p2sh(script_pub_key: Octets, network: str = "mainnet") -> str:
 
 def _address_from_v0_witness(wit_prg: Octets, network: str) -> str:
     """Return the legacy base58 p2sh-wrapped segwit v0 address."""
-    # check witness program
-    wit_prg = b32.check_witness(0, wit_prg)
+    wit_prg = b32.bytes_from_witness_program(0, wit_prg)
     # the redeem script is [OP_0, wit_prg], spelled out here instead of
     # asking script.serialize for it: this module must not import
     # btclib.script, because script.script_pub_key imports this one to
     # render an address, and importing any script submodule executes the
     # package __init__, which pulls script_pub_key in — so the import
     # would close a cycle (issue #147).
-    # check_witness has just restricted a v0 program to 20 or 32 bytes,
-    # and serialize pushes anything shorter than 76 bytes with a bare
-    # length byte, so no OP_PUSHDATA can be needed here
+    # bytes_from_witness_program has just restricted a v0 program to 20 or
+    # 32 bytes, and serialize pushes anything shorter than 76 bytes with a
+    # bare length byte, so no OP_PUSHDATA can be needed here
     redeem_script = b"\x00" + len(wit_prg).to_bytes(1, "big") + wit_prg
     return p2sh(redeem_script, network)
 

--- a/btclib/psbt_signer.py
+++ b/btclib/psbt_signer.py
@@ -273,7 +273,7 @@ class SignerDecorator:
         """Wrap a signer, carrying over the operations it offers.
 
         Whether what is passed is a signer at all is `psbt_signer_contract
-        .check_psbt_signer`'s question, asked of the signer itself and not
+        .assert_psbt_signer`'s question, asked of the signer itself and not
         of the wrapper around it: repeating a weaker form of it here would
         answer "it has five methods" to a caller who needs to know what
         they answer.

--- a/btclib/psbt_signer_contract.py
+++ b/btclib/psbt_signer_contract.py
@@ -13,7 +13,7 @@ first spend.
 btclib's own adapters are checked by btclib's tests, which is no help to
 the caller writing the next one: an implementer outside this repository
 had no way to ask the library whether their signer answers what callers
-of it will assume. `check_psbt_signer` is that question, and it takes any
+of it will assume. `assert_psbt_signer` is that question, and it takes any
 `PsbtSigner` -- a command line adapter, an in-process driver, a signing
 service, a signer that is not a device at all.
 
@@ -69,8 +69,8 @@ if TYPE_CHECKING:
     from btclib.bip32.der_path import DerPath
 
 __all__ = [
-    "check_optional_protocols",
-    "check_psbt_signer",
+    "assert_psbt_signer",
+    "optional_protocols",
     "unsignable_psbt",
 ]
 
@@ -193,7 +193,7 @@ def _check_signable(signer: PsbtSigner, signable: Psbt) -> None:
         _fail("sign_psbt added no signature to a psbt it was said to sign")
 
 
-def check_psbt_signer(
+def assert_psbt_signer(
     signer: object,
     *,
     der_path: DerPath | None = None,
@@ -235,7 +235,7 @@ def check_psbt_signer(
     signer.close()
 
 
-def check_optional_protocols(signer: object) -> tuple[bool, bool]:
+def optional_protocols(signer: object) -> tuple[bool, bool]:
     """Return which optional protocols the signer offers, as a caller asks.
 
     `isinstance` against the two runtime-checkable protocols, which is

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -39,13 +39,13 @@ __all__ = [
     "EVALUATED_WHEN_UNEXECUTED",
     "OPERATIONS",
     "STRICT_DER_FLAGS",
+    "assert_not_disabled",
+    "assert_nulldummy",
+    "assert_nullfail",
+    "assert_pub_key_num",
+    "assert_signature_num",
     "calculate_script_code",
-    "check_not_disabled",
-    "check_nulldummy",
-    "check_nullfail",
     "check_pub_key",
-    "check_pub_key_num",
-    "check_signature_num",
     "dsa_verify",
     "find_and_delete",
     "fix_signature",
@@ -294,7 +294,7 @@ def op_code_name(op_code: int) -> str:
     return OP_CODE_NAME_FROM_INT[op_code]
 
 
-def check_nullfail(
+def assert_nullfail(
     flags: ScriptFlag, verified: bool, signatures: list[bytes], op: str
 ) -> None:
     """Reject a signature that failed to verify and was not empty."""
@@ -302,13 +302,13 @@ def check_nullfail(
         raise BTClibValueError(f"non-empty signature for a failed {op}")
 
 
-def check_nulldummy(dummy: bytes, flags: ScriptFlag) -> None:
+def assert_nulldummy(dummy: bytes, flags: ScriptFlag) -> None:
     """Reject a non-empty dummy, the element OP_CHECKMULTISIG pops too many."""
     if dummy != b"" and ScriptFlag.NULLDUMMY in flags:
         raise BTClibValueError("non-empty OP_CHECKMULTISIG dummy element")
 
 
-def check_pub_key_num(pub_key_num: int) -> None:
+def assert_pub_key_num(pub_key_num: int) -> None:
     """Reject a public key count outside 0..20, before the keys are read.
 
     Core's SCRIPT_ERR_PUBKEY_COUNT, and the lower bound is the half that
@@ -322,7 +322,7 @@ def check_pub_key_num(pub_key_num: int) -> None:
         raise BTClibValueError(f"invalid number of public keys: {pub_key_num}")
 
 
-def check_signature_num(signature_num: int, pub_key_num: int) -> None:
+def assert_signature_num(signature_num: int, pub_key_num: int) -> None:
     """Reject a signature count outside 0..pub_key_num.
 
     Core's SCRIPT_ERR_SIG_COUNT, negative for the same reason as above.
@@ -393,7 +393,7 @@ DISABLED_OP_CODES = frozenset(
 )
 
 
-def check_not_disabled(op_code: int) -> None:
+def assert_not_disabled(op_code: int) -> None:
     """Reject an op code disabled by CVE-2010-5137, executed or not."""
     if op_code in DISABLED_OP_CODES:
         raise BTClibValueError(f"disabled op code: {op_code_name(op_code)}")
@@ -511,7 +511,7 @@ def _run_ops(  # noqa: C901, PLR0912
         script_index += 1
         script_index_ref[0] = script_index
 
-        script_op_codes.check_stack_size(stack, altstack)
+        script_op_codes.assert_stack_size(stack, altstack)
 
         skip_execution = not all(condition_stack)
 
@@ -528,7 +528,7 @@ def _run_ops(  # noqa: C901, PLR0912
         if t > 96:  # OP_16
             op_code_num = script_op_count(op_code_num, 1)
 
-        check_not_disabled(t)
+        assert_not_disabled(t)
 
         if skip_execution and t not in EVALUATED_WHEN_UNEXECUTED:
             continue
@@ -551,7 +551,7 @@ def _run_ops(  # noqa: C901, PLR0912
                 precomputed,
                 hash_types,
             )
-            check_nullfail(flags, result, [signature], "OP_CHECKSIG")
+            assert_nullfail(flags, result, [signature], "OP_CHECKSIG")
             stack.append(encode_num(int(result)))
 
         elif op == "OP_CHECKMULTISIG":
@@ -559,14 +559,14 @@ def _run_ops(  # noqa: C901, PLR0912
             # counts safe to build a `range` out of: each is bounded
             # before anything is popped with it
             pub_key_num = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-            check_pub_key_num(pub_key_num)
+            assert_pub_key_num(pub_key_num)
             op_code_num = script_op_count(op_code_num, pub_key_num)
             pub_keys = [stack.pop() for _ in range(pub_key_num)]
             signature_num = _to_num(stack.pop(), flags, _MAX_NUM_SIZE)
-            check_signature_num(signature_num, pub_key_num)
+            assert_signature_num(signature_num, pub_key_num)
             signatures = [stack.pop() for _ in range(signature_num)]
 
-            check_nulldummy(stack.pop(), flags)  # dummy value
+            assert_nulldummy(stack.pop(), flags)  # dummy value
             signature_index = 0
             for pub_key_index in range(pub_key_num):
                 if signature_index == signature_num:
@@ -593,7 +593,7 @@ def _run_ops(  # noqa: C901, PLR0912
             if signature_index == signature_num:
                 stack.append(b"\x01")
             else:
-                check_nullfail(flags, False, signatures, "OP_CHECKMULTISIG")
+                assert_nullfail(flags, False, signatures, "OP_CHECKMULTISIG")
                 stack.append(b"")
 
         elif op == "OP_CHECKLOCKTIMEVERIFY":
@@ -705,8 +705,8 @@ def verify_script(
         # exception is there for the cases in which it is not
         raise ScriptError("stack underflow", script_index_ref[0], len(stack)) from e
 
-    script_op_codes.check_stack_size(stack, altstack)
-    script_op_codes.check_balanced_if(condition_stack)
+    script_op_codes.assert_stack_size(stack, altstack)
+    script_op_codes.assert_balanced_if(condition_stack)
 
     if final:
         if not stack:

--- a/btclib/script/engine/script_op_codes.py
+++ b/btclib/script/engine/script_op_codes.py
@@ -36,9 +36,9 @@ from btclib.utils import decode_num, encode_num
 
 __all__ = [
     "ScriptOp",
-    "check_balanced_if",
-    "check_minimal_push",
-    "check_stack_size",
+    "assert_balanced_if",
+    "assert_minimal_push",
+    "assert_stack_size",
     "op_0notequal",
     "op_1add",
     "op_1negate",
@@ -150,7 +150,7 @@ ScriptOp = Callable[[list[bytes], list[bytes], ScriptFlag], ScriptList | None]
 # places and the minimal push in two, in identical words.
 
 
-def check_stack_size(stack: list[bytes], altstack: list[bytes]) -> None:
+def assert_stack_size(stack: list[bytes], altstack: list[bytes]) -> None:
     """Enforce Core's MAX_STACK_SIZE on the two stacks together."""
     if len(stack) + len(altstack) > MAX_STACK_SIZE:
         raise BTClibValueError(
@@ -158,7 +158,7 @@ def check_stack_size(stack: list[bytes], altstack: list[bytes]) -> None:
         )
 
 
-def check_minimal_push(
+def assert_minimal_push(
     data: bytes,
     op_code: int,
     flags: ScriptFlag,
@@ -196,7 +196,7 @@ def read_push_data(
     The read comes before the skip: the stream must advance past the
     data whether or not the branch executes, and only what executes is
     measured for minimality and pushed. The serializer is a parameter
-    for check_minimal_push's reason, each engine measuring a push
+    for assert_minimal_push's reason, each engine measuring a push
     against its own script language.
 
     The two refusals are Core's, at the top of its EvalScript loop and
@@ -231,7 +231,7 @@ def read_push_data(
         raise BTClibValueError(err_msg)
     if skip_execution:
         return
-    check_minimal_push(data, op_code, flags, serialize)
+    assert_minimal_push(data, op_code, flags, serialize)
     stack.append(data)
 
 
@@ -317,7 +317,7 @@ def op_endif(condition_stack: list[bool]) -> None:
     condition_stack.pop()
 
 
-def check_balanced_if(condition_stack: list[bool]) -> None:
+def assert_balanced_if(condition_stack: list[bool]) -> None:
     """Reject a conditional the script never closed.
 
     Core's `if (!vfExec.empty())` once the loop is over, and it is one of

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -277,7 +277,7 @@ def _run_ops(  # noqa: C901, PLR0912
 
         skip_execution = not all(condition_stack)
 
-        script_op_codes.check_stack_size(stack, altstack)
+        script_op_codes.assert_stack_size(stack, altstack)
 
         b = s.read(1)
         if not b:
@@ -414,7 +414,7 @@ def verify_script_path_vc0(
         # exception is there for the cases in which it is not
         raise ScriptError("stack underflow", script_index_ref[0], len(stack)) from e
 
-    script_op_codes.check_balanced_if(condition_stack)
+    script_op_codes.assert_balanced_if(condition_stack)
 
     if not stack:
         raise BTClibValueError("empty stack at the end of the script")

--- a/btclib/script/script.py
+++ b/btclib/script/script.py
@@ -392,7 +392,7 @@ def _serialize_bytes_command(command: bytes) -> bytes:
     code it names.
 
     Three readers depend on it, each measuring a push against what this
-    writes for its data: `engine.script_op_codes.check_minimal_push`,
+    writes for its data: `engine.script_op_codes.assert_minimal_push`,
     `miniscript._assert_minimal_push`, and -- differently --
     `engine.script.calculate_script_code`, which builds the needle
     FindAndDelete searches for as Core builds it, `CScript() << vchSig`.

--- a/tests/name_contract_test.py
+++ b/tests/name_contract_test.py
@@ -1,0 +1,176 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The gate for what a public function's name promises about its answer.
+
+CONTRIBUTING.md's "Every public function validates its inputs" states the
+vocabulary: `assert_*` refuses and returns None, `is_*` and `verify*`
+answer a bool about a value of a declared type, and `check_*` answers a
+bool *and* refuses what cannot be an answer -- the one prefix that warns
+a caller it still needs an `except`.
+
+This file is why the statement is worth making. `check_` had drifted to
+four meanings at once -- nine refusals returning None, two verdicts, a
+converter returning bytes and a query returning a pair of bools -- and a
+prefix that says four things says nothing, which is what issue #814
+found. Nothing in the tree noticed, because the vocabulary was a habit
+and not a rule.
+
+So it is a rule now, read off the annotations rather than off a list of
+names somebody keeps in step. What it cannot see is the *contract*: that
+`is_p2sh` is total over its values where `check_pub_key` is not is a
+promise in prose, and only the return type is here.
+
+`_OTHER_CONTRACT` is what the rule does not cover, one entry per reason.
+It ratchets the way every list in `input_validation_test.py` does:
+`test_what_is_excepted_still_needs_to_be` fails on an entry that has come
+into line, so a name cannot keep an exemption it has stopped needing.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_LIBRARY = Path(__file__).parents[1] / "btclib"
+
+# what each prefix promises the return type is. `verify` is matched
+# anywhere in the name and not only at the front: `batch_verify_`,
+# `partial_sig_verify` and `anti_exfil_host_verify` are verifications,
+# and reading the front alone is what left them out of issue #814's first
+# census
+_PROMISED: dict[str, str] = {
+    "assert_": "None",
+    "check_": "bool",
+    "is_": "bool",
+    "verify": "bool",
+}
+
+# an op code implementation is named for the op code, and OP_VERIFY,
+# OP_EQUALVERIFY and their kind carry the word: they answer with the
+# stack, or with nothing, and are no more verifications in this sense
+# than OP_CHECKSIG is a `check_`
+_AN_OP_CODE = "op_"
+
+_A_SCRIPT_FAILURE_SAYS_WHERE = (
+    "the script engine refuses instead of answering: a ScriptError carries"
+    " the command index and the stack depth, which is the whole of what an"
+    " engine is asked for, and a bool would drop it"
+)
+
+_AN_ASSERT_WITH_A_PAYLOAD = (
+    "it is the Signer's own question -- five conditions on the psbt, and"
+    " the message they prove it commits to -- so refusing and handing back"
+    " what was validated are one answer, not two"
+)
+
+_OTHER_CONTRACT: dict[str, str] = {
+    "btclib.bip322.assert_signed_message": _AN_ASSERT_WITH_A_PAYLOAD,
+    "btclib.script.engine.__init__.verify_amounts": _A_SCRIPT_FAILURE_SAYS_WHERE,
+    "btclib.script.engine.__init__.verify_input": _A_SCRIPT_FAILURE_SAYS_WHERE,
+    "btclib.script.engine.__init__.verify_transaction": _A_SCRIPT_FAILURE_SAYS_WHERE,
+    "btclib.script.engine.script.verify_script": _A_SCRIPT_FAILURE_SAYS_WHERE,
+    "btclib.script.engine.tapscript.verify_key_path": _A_SCRIPT_FAILURE_SAYS_WHERE,
+    "btclib.script.engine.tapscript.verify_script_path_vc0": (
+        _A_SCRIPT_FAILURE_SAYS_WHERE
+    ),
+}
+
+
+def _promised_by(name: str) -> str | None:
+    """Return the type the name promises, or None if it promises nothing."""
+    if name.startswith(_AN_OP_CODE):
+        return None
+    for prefix, promised in _PROMISED.items():
+        if name.startswith(prefix) or (prefix == "verify" and prefix in name):
+            return promised
+    return None
+
+
+def _named() -> dict[str, str]:
+    """Return every public function whose name promises a return type.
+
+    Methods included, a property being one: `BIP32KeyData.is_private`
+    promises a bool as much as `script_pub_key.is_p2sh` does.
+
+    The dotted name is the file's path and keeps the `__init__` of a
+    package module, which is what `input_validation_test.py`'s walk does
+    and is importable either way: one spelling across the two gates.
+    """
+    found: dict[str, str] = {}
+    for path in sorted(_LIBRARY.rglob("*.py")):
+        module = ".".join(path.relative_to(_LIBRARY.parent).with_suffix("").parts)
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+                continue
+            if _promised_by(node.name) is None:
+                continue
+            # every function of this package is annotated, mypy running
+            # strict over it, so an unannotated one is a state the tree
+            # does not reach
+            assert node.returns is not None
+            found[f"{module}.{node.name}"] = ast.unparse(node.returns)
+    return found
+
+
+_NAMED = _named()
+_GATED = sorted(set(_NAMED) - _OTHER_CONTRACT.keys())
+
+
+@pytest.mark.parametrize("dotted", _GATED)
+def test_the_name_says_what_the_answer_is(dotted: str) -> None:
+    """The rule, over every public name that carries one of the prefixes."""
+    promised = _promised_by(dotted.rpartition(".")[2])
+    assert _NAMED[dotted] == promised, (
+        f"{dotted} returns {_NAMED[dotted]} where its name promises {promised}"
+    )
+
+
+@pytest.mark.parametrize("dotted", sorted(_OTHER_CONTRACT))
+def test_what_is_excepted_still_needs_to_be(dotted: str) -> None:
+    """An entry of `_OTHER_CONTRACT` cannot outlive the reason for it."""
+    promised = _promised_by(dotted.rpartition(".")[2])
+    assert _NAMED[dotted] != promised, (
+        f"{dotted} now returns {promised}: delete its line from _OTHER_CONTRACT"
+    )
+
+
+def test_the_walk_reaches_what_it_claims() -> None:
+    """One name per prefix it must find, and the two kinds it must not.
+
+    A walk that found nothing would pass the test above.
+    """
+    assert _NAMED["btclib.script.script_pub_key.is_p2sh"] == "bool"
+    assert _NAMED["btclib.script.engine.script.check_pub_key"] == "bool"
+    assert _NAMED["btclib.script.taproot.check_output_pubkey"] == "bool"
+    assert _NAMED["btclib.ecc.dsa.verify_"] == "bool"
+    assert _NAMED["btclib.ecc.ssa.batch_verify"] == "bool"
+    assert _NAMED["btclib.ecc.dsa.assert_as_valid"] == "None"
+    # a method, and a property among them
+    assert _NAMED["btclib.bip32.bip32.is_private"] == "bool"
+
+    # an op code is named for the op code
+    assert "btclib.script.engine.script_op_codes.op_verify" not in _NAMED
+    assert "btclib.script.engine.script_op_codes.op_equalverify" not in _NAMED
+    # a private name, and a name that promises nothing
+    assert "btclib.hashes._assert_valid_hf" not in _NAMED
+    assert "btclib.utils.bytes_from_octets" not in _NAMED
+
+
+def test_check_says_one_thing() -> None:
+    """`check_` is two functions, and issue #814 is why they are named.
+
+    The prefix meant four things at once. Pinning what is left keeps a
+    tenth `check_` from being added without the question being asked
+    again: a refusal is an `assert_`, a converter is named for what it
+    returns, and a query for what it answers.
+    """
+    checks = {d for d in _NAMED if d.rpartition(".")[2].startswith("check_")}
+    assert checks == {
+        "btclib.script.engine.script.check_pub_key",
+        "btclib.script.taproot.check_output_pubkey",
+    }

--- a/tests/psbt_signer_contract_test.py
+++ b/tests/psbt_signer_contract_test.py
@@ -26,8 +26,8 @@ from btclib.psbt.psbt import Psbt
 from btclib.psbt_signer import PsbtSigner, SignerCapabilities, SoftwareSigner
 from btclib.psbt_signer_contract import (
     _SOMEBODY_ELSES_KEY,
-    check_optional_protocols,
-    check_psbt_signer,
+    assert_psbt_signer,
+    optional_protocols,
     unsignable_psbt,
 )
 from btclib.script import serialize, sig_hash
@@ -97,19 +97,19 @@ def _signable() -> Psbt:
 
 def test_the_reference_signer_conforms() -> None:
     """What the checks are calibrated against."""
-    check_psbt_signer(_signer(), der_path=_ACCOUNT, signable=_signable())
+    assert_psbt_signer(_signer(), der_path=_ACCOUNT, signable=_signable())
 
 
 def test_the_optional_protocols_are_reported() -> None:
     """SoftwareSigner offers both; a signer of the four methods, neither."""
-    assert check_optional_protocols(_signer()) == (True, True)
-    assert check_optional_protocols(_Wrapper()) == (False, False)
+    assert optional_protocols(_signer()) == (True, True)
+    assert optional_protocols(_Wrapper()) == (False, False)
 
 
 def test_something_that_is_not_a_signer_is_refused() -> None:
     """The one check a caller cannot make with a type annotation."""
     with pytest.raises(BTClibValueError, match="does not implement PsbtSigner"):
-        check_psbt_signer(object())
+        assert_psbt_signer(object())
 
 
 def test_a_fingerprint_of_the_wrong_width_is_refused() -> None:
@@ -120,7 +120,7 @@ def test_a_fingerprint_of_the_wrong_width_is_refused() -> None:
             return b"\x00" * 5
 
     with pytest.raises(BTClibValueError, match="is 5 bytes, not 4"):
-        check_psbt_signer(_TooLong())
+        assert_psbt_signer(_TooLong())
 
     # and short of it, which a width checked as a ceiling would accept: a
     # three-byte fingerprint is what a key origin would then be written to
@@ -129,7 +129,7 @@ def test_a_fingerprint_of_the_wrong_width_is_refused() -> None:
             return b"\x00" * 3
 
     with pytest.raises(BTClibValueError, match="is 3 bytes, not 4"):
-        check_psbt_signer(_TooShort())
+        assert_psbt_signer(_TooShort())
 
 
 def test_a_fingerprint_that_changes_is_refused() -> None:
@@ -145,7 +145,7 @@ def test_a_fingerprint_that_changes_is_refused() -> None:
             return bytes([self._asked, 0, 0, 0])
 
     with pytest.raises(BTClibValueError, match="two different values"):
-        check_psbt_signer(_Drifting())
+        assert_psbt_signer(_Drifting())
 
     # drifting the other way, which is the same disagreement: what the
     # check asks is whether the two answers are one answer, and an
@@ -160,7 +160,7 @@ def test_a_fingerprint_that_changes_is_refused() -> None:
             return bytes([self._asked, 0, 0, 0])
 
     with pytest.raises(BTClibValueError, match="two different values"):
-        check_psbt_signer(_Receding())
+        assert_psbt_signer(_Receding())
 
 
 def test_an_xpub_that_is_not_an_extended_key_is_refused() -> None:
@@ -171,7 +171,7 @@ def test_an_xpub_that_is_not_an_extended_key_is_refused() -> None:
             return "not a key at all"
 
     with pytest.raises(BTClibValueError, match="not an extended key"):
-        check_psbt_signer(_Nonsense(), der_path=_ACCOUNT)
+        assert_psbt_signer(_Nonsense(), der_path=_ACCOUNT)
 
 
 def test_an_xpub_that_is_private_is_refused() -> None:
@@ -182,7 +182,7 @@ def test_an_xpub_that_is_private_is_refused() -> None:
             return derive(bip39.mxprv_from_mnemonic(_MNEMONIC, "", "mainnet"), der_path)
 
     with pytest.raises(BTClibValueError, match="answered a private key"):
-        check_psbt_signer(_Leaking(), der_path=_ACCOUNT)
+        assert_psbt_signer(_Leaking(), der_path=_ACCOUNT)
 
 
 def test_an_xpub_that_changes_is_refused() -> None:
@@ -198,7 +198,7 @@ def test_an_xpub_that_changes_is_refused() -> None:
             return self._signer.xpub(f"m/84h/0h/{self._asked}h")
 
     with pytest.raises(BTClibValueError, match="two different keys"):
-        check_psbt_signer(_Drifting(), der_path=_ACCOUNT)
+        assert_psbt_signer(_Drifting(), der_path=_ACCOUNT)
 
     # and the two keys the other way round: whichever of the two base58
     # strings sorts first, they are two keys for one path
@@ -212,7 +212,7 @@ def test_an_xpub_that_changes_is_refused() -> None:
             return self._signer.xpub(f"m/84h/0h/{self._asked}h")
 
     with pytest.raises(BTClibValueError, match="two different keys"):
-        check_psbt_signer(_Receding(), der_path=_ACCOUNT)
+        assert_psbt_signer(_Receding(), der_path=_ACCOUNT)
 
 
 def test_signing_an_input_of_another_master_is_refused() -> None:
@@ -238,7 +238,7 @@ def test_signing_an_input_of_another_master_is_refused() -> None:
             return answer
 
     with pytest.raises(BTClibValueError, match="names another master"):
-        check_psbt_signer(_Rogue())
+        assert_psbt_signer(_Rogue())
 
 
 def test_a_signer_that_signs_nothing_it_was_said_to_sign_is_refused() -> None:
@@ -249,7 +249,7 @@ def test_a_signer_that_signs_nothing_it_was_said_to_sign_is_refused() -> None:
             return deepcopy(psbt)
 
     with pytest.raises(BTClibValueError, match="added no signature"):
-        check_psbt_signer(_Idle(), signable=_signable())
+        assert_psbt_signer(_Idle(), signable=_signable())
 
 
 def test_the_unsignable_psbt_names_another_master() -> None:
@@ -273,7 +273,7 @@ def test_a_conforming_signer_is_closed_twice() -> None:
 
     # the forwarding wrapper answers every question here, which is what
     # says the checks pass for a signer that is not SoftwareSigner itself
-    check_psbt_signer(_Counting(), der_path=_ACCOUNT)
+    assert_psbt_signer(_Counting(), der_path=_ACCOUNT)
     assert closed == 2
 
 
@@ -285,7 +285,7 @@ def test_the_wrapper_is_a_signer() -> None:
 def test_something_that_is_not_a_psbt_is_refused() -> None:
     """`signable` is checked rather than assumed, being typed `object`."""
     with pytest.raises(BTClibValueError, match="is str, not a Psbt"):
-        check_psbt_signer(_signer(), signable="not a psbt")
+        assert_psbt_signer(_signer(), signable="not a psbt")
 
 
 def test_capabilities_that_change_are_refused() -> None:
@@ -301,7 +301,7 @@ def test_capabilities_that_change_are_refused() -> None:
             return SignerCapabilities(taproot=self._asked % 2 == 0)
 
     with pytest.raises(BTClibValueError, match="capabilities answered two"):
-        check_psbt_signer(_Drifting())
+        assert_psbt_signer(_Drifting())
 
 
 # two more seeds, so a quorum can hold a signature that is not the
@@ -357,7 +357,7 @@ def test_a_quorum_the_signer_adds_one_signature_to_is_accepted() -> None:
     nothing -- and a sum that is right for the second is not necessarily
     right for the first.
     """
-    check_psbt_signer(_signer(), der_path=_ACCOUNT, signable=_partly_signed_quorum())
+    assert_psbt_signer(_signer(), der_path=_ACCOUNT, signable=_partly_signed_quorum())
 
 
 def test_a_signer_that_adds_nothing_to_a_signed_quorum_is_refused() -> None:
@@ -374,4 +374,4 @@ def test_a_signer_that_adds_nothing_to_a_signed_quorum_is_refused() -> None:
             return deepcopy(psbt)
 
     with pytest.raises(BTClibValueError, match="added no signature"):
-        check_psbt_signer(_Idle(), signable=_partly_signed_quorum())
+        assert_psbt_signer(_Idle(), signable=_partly_signed_quorum())


### PR DESCRIPTION
Implements §7 of https://github.com/btclib-org/btclib/issues/814, the
half left out of https://github.com/btclib-org/btclib/pull/818. Source-
breaking: eleven public names change.

## What the prefix said

Thirteen public functions carried `check_`, and it meant four things at
once — which is to say nothing:

| what it was | return | how many |
| --- | --- | ---: |
| a refusal | `None` | 9 |
| a bool verdict | `bool` | 2 |
| a validating conversion | `bytes` | 1 |
| a query | `tuple[bool, bool]` | 1 |

## The rename

The nine refusals are `assert_*`, which is what their own docstrings said
all along — "Reject a signature that failed to verify", "Enforce Core's
MAX_STACK_SIZE", "Reject an op code disabled by CVE-2010-5137":
`assert_nullfail`, `assert_nulldummy`, `assert_pub_key_num`,
`assert_signature_num`, `assert_not_disabled`, `assert_stack_size`,
`assert_minimal_push`, `assert_balanced_if`, `assert_psbt_signer`.

`b32.check_witness` returned the witness program it had validated, so it
is `b32.bytes_from_witness_program`, after the `bytes_from_octets` whose
size rule it is. `psbt_signer_contract.check_optional_protocols` answers
which protocols a signer offers, so it is `optional_protocols`.

## Where I changed my mind, and why

§7 of the issue proposed **abolishing** the prefix. Reading the two
`-> bool` ones changed that: both refuse a malformed value *deliberately*,
and both say so in their own docstrings.

- `engine.script.check_pub_key` is False for a wrong length or prefix and
  raises for a hybrid `0x06`/`0x07` under STRICTENC — which is how Core's
  `CheckPubKeyEncoding` splits it.
- `taproot.check_output_pubkey` raises for a malformed control block,
  that being no proof rather than a disproof.

So neither is an `is_*` nor a `verify*` in #818's sense — those are total
over their declared values — and forcing them into either family would
make the name a lie. `check_` earns exactly that meaning instead: **a
bool that also refuses what cannot be an answer**, the one prefix that
warns a caller an `except` is still needed. Four meanings become one.

## The part that keeps it

`check_` drifted because the vocabulary was a habit and nothing in the
tree could notice. `tests/name_contract_test.py` reads the return
annotation of every public name carrying one of the four prefixes, so it
is a rule now.

Seven names answer something else and are listed with the reason, each
ratcheted the way `input_validation_test.py`'s lists are:

- the script engine's six `verify_*`, which refuse rather than answer,
  because a `ScriptError` carries the command index and the stack depth
  that a bool would drop
- `bip322.assert_signed_message`, which hands back the message whose five
  conditions it just checked

The `op_*verify` implementations are named for their op codes, not for a
verification, and are excluded by name.

CONTRIBUTING.md states the four prefixes beside #818's bool rule.

## Gates

- `uv run pytest` — 26901 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

No signature and no behaviour changes with any name; an import of one of
the eleven old ones is an `ImportError`. HISTORY.md carries the
breaking-changes bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Standardize the meaning of the check_ prefix by renaming misaligned functions to assert_* or more descriptive names, updating documentation and tests, and adding a gate that enforces the naming/return-type contract across the public API.

New Features:
- Introduce a naming contract test that enforces return-type conventions for public functions with assert_ / is_ / verify* / check_ prefixes.

Enhancements:
- Rename eleven check_* functions to assert_* or more descriptive names, reserving check_ for bool-returning validators that also refuse malformed inputs.
- Align script engine and tapscript code with new assert_* helpers and updated witness program conversion naming.

Documentation:
- Document the closed vocabulary for function prefixes and their return-type contracts in CONTRIBUTING.md.
- Record the breaking check_* renames and the preserved meaning of check_ in CHANGELOG.md and HISTORY.md.

Tests:
- Add name_contract_test to gate that public function names match their annotated return types and that check_* is only used for its specific contract.
- Update psbt_signer_contract tests to use assert_psbt_signer and optional_protocols.