### PR TITLE
Let the sdist ship scripts/, in the policy that checks it too

### DIFF
--- a/.github/scripts/verify_dist_contents.py
+++ b/.github/scripts/verify_dist_contents.py
@@ -115,9 +115,10 @@ WHEEL_METADATA_FILES = frozenset({"METADATA", "RECORD", "WHEEL", "top_level.txt"
 WHEEL_REQUIRED = frozenset({"btclib/__init__.py", "btclib/py.typed"})
 
 # the directories of the sdist, which is the development tree: the package,
-# its suite, the documentation sources, and the metadata setuptools
-# generates beside them
-SDIST_DIRECTORIES = frozenset({"btclib", "btclib.egg-info", "docs", "tests"})
+# its suite, the documentation sources, the developer scripts MANIFEST.in
+# ships so they stay runnable from an unpacked sdist, and the metadata
+# setuptools generates beside them
+SDIST_DIRECTORIES = frozenset({"btclib", "btclib.egg-info", "docs", "scripts", "tests"})
 
 # the files that may sit at the root of the sdist. MANIFEST.in ships these
 # by glob -- `include *.md`, `include *.yaml`, `include *.jsonc` -- so a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -791,6 +791,15 @@ documented at release-notes length in the first place, and are still in
   quality is a separate setting, which `code-scanning/default-setup` does
   not report.
 
+- **The `dist` job passes again with `scripts/` in the sdist.**
+  `MANIFEST.in` had shipped `scripts/benchmark_libraries.py` from the
+  start, on the same footing as `docs/` and `tests/`, but
+  `.github/scripts/verify_dist_contents.py`'s `SDIST_DIRECTORIES`
+  allowlist was never told: every build then failed on `scripts is a
+  directory the sdist does not ship`, main included. `scripts` joins the
+  allowlist, and `docs/source/package-content-policy.md` states it beside
+  the rest.
+
 ### Transactions, blocks and PSBT
 
 - **BIP375's Signer and Transaction Extractor** (#760, following #641).

--- a/docs/source/package-content-policy.md
+++ b/docs/source/package-content-policy.md
@@ -79,6 +79,9 @@ The directories, `SDIST_DIRECTORIES`:
 - `btclib` — the package
 - `tests` — its suite
 - `docs` — the documentation sources
+- `scripts` — the developer scripts `MANIFEST.in` ships so they stay
+    runnable from an unpacked sdist, as `.github/scripts` would be if
+    `check-manifest` did not ignore that directory outright
 - `btclib.egg-info` — the metadata setuptools generates beside them
 
 The files at that root, `SDIST_ROOT_SUFFIXES` and `SDIST_ROOT_NAMES`.


### PR DESCRIPTION
## Summary

- `main`, PR #819 and PR #826 all fail CI's `dist` job (`Build the
  distribution and install it` / `test: every job passed`) on
  `scripts is a directory the sdist does not ship`.
- `MANIFEST.in` has shipped `scripts/benchmark_libraries.py` in the
  sdist since it was added, on the same footing as `docs/` and
  `tests/`, but `.github/scripts/verify_dist_contents.py`'s
  `SDIST_DIRECTORIES` allowlist was never updated to match, so every
  build since fails the structural check.
- Adds `scripts` to `SDIST_DIRECTORIES`, states it in
  `docs/source/package-content-policy.md` beside the other allowed
  directories, and records the fix in CHANGELOG.md.

## Test plan

- [x] `uv build` then
      `uv run --no-project --python 3.14 .github/scripts/verify_dist_contents.py dist/`
      passes
- [x] `uv run pytest` — 26742 passed, 100.00% coverage
- [x] `uv run pre-commit run --all-files` — all hooks pass
- [x] `sphinx-build -W --keep-going` — docs build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Allow the sdist to include the scripts directory so distribution verification passes again.

Enhancements:
- Expand the sdist directory allowlist to include the scripts directory alongside package, tests, docs, and metadata.
- Clarify package content policy documentation to describe the scripts directory as part of the shipped sdist contents.

Documentation:
- Update package content policy docs to reflect that developer scripts are shipped in the sdist.

Chores:
- Record the sdist scripts directory fix in the changelog.