### PR TITLE
Recognize a square by a gcd, not by an exponentiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2251,6 +2251,47 @@ documented at release-notes length in the first place, and are still in
   indexed by a secret digit, and `SECURITY.md` publishes the Python path
   as variable-time -- and nothing at all about the point, whose inversion
   every table costs and whose value is the caller's public key.
+- **The Legendre symbol asks a gcd instead of an exponentiation** (issue
+  #827). `legendre_symbol` was Euler's criterion, `pow(a, (p - 1) // 2,
+  p)`: an exponentiation the size of the square root the caller is asking
+  about. It is the binary Jacobi symbol now, which for a prime modulus is
+  the same number -- the reciprocity recursion, with every factor of two
+  coming out at once through `a & -a`. That is libsecp256k1's
+  `secp256k1_ctz64_var`, and asking a gcd rather than an exponent is what
+  its `secp256k1_fe_is_square_var` does, through
+  `secp256k1_jacobi64_maybe_var` and never through a power; its own
+  recursion is the safegcd one, which in bytecode loses as every safegcd
+  does.
+
+  `curves.curve._is_x_coordinate` is where that lands: it asks whether an
+  x is on the curve and answered with `ec.y(x)`, a modular square root,
+  where libsecp256k1's `secp256k1_ge_x_on_curve_var` is
+  `fe_is_square_var` of `x^3 + ax + b` and nothing else. It is what
+  `dsa.Sig`'s congruence check runs on the Python path. Measured against
+  `4afc13ce` on Python 3.14.6, best of seven alternating rounds:
+
+  | | Euler | Jacobi | |
+  | --- | ---: | ---: | ---: |
+  | `legendre_symbol`, secp256k1's p | 74.9 us | 13.7 us | **5.45x** |
+  | `_is_x_coordinate`, secp256r1 | 67.9 us | 14.8 us | **4.58x** |
+
+  `mod_sqrt` does not change and must not: there the root is what is
+  wanted and asking for the symbol first is the work twice, which is what
+  issue #783 measured. `tonelli` gains with it, its search for a
+  non-residue calling the symbol once per candidate.
+
+  **`legendre_symbol(1, 2)` answered -1 and now answers 1.** The old line
+  was `return -1 if ls == p - 1 else ls`, which reads `ls == p - 1` as
+  "non-residue" -- and at p = 2 that is `ls == 1`, where every residue of
+  the field of two elements is a square, 1 among them. No caller in the
+  tree reached it, `tonelli` returning before it for p == 2, and the
+  function is public. A test now asserts the symbol against the squares
+  themselves, exhaustively, over every small prime including 2.
+
+  The symbol is variable-time in `a` where the exponentiation was not, a
+  gcd's length following its operand. `SECURITY.md` publishes the Python
+  path as variable-time, and no caller here hands it a secret:
+  `_is_x_coordinate` asks it about a signature's r.
 
 ### The public API and the module layout
 

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -55,6 +55,7 @@ from btclib.curves.curve_group_2 import (
     _mult_endomorphism_secp256k1,
 )
 from btclib.exceptions import BTClibValueError
+from btclib.number_theory import legendre_symbol
 from btclib.utils import hex_string, int_from_integer
 
 __all__ = [
@@ -424,18 +425,19 @@ def _is_x_coordinate(x: int, ec: Curve) -> bool:
     """Return True if x is the x-coordinate of a point of the curve.
 
     Existence and nothing else, which is what a caller with no use for
-    the y has to ask: ec.y computes the modular square root to find out,
-    75 us on secp256k1, while ec_pubkey_parse answers the same question
-    of the compressed key 0x02 || x in 2.4 -- and it is the same answer,
-    both implementations refusing the same x.
+    the y has to ask, and it is a question the Legendre symbol answers
+    without ever forming a root: 14 us on secp256k1 against the 75 of
+    ec.y, and ec_pubkey_parse answers the same of the compressed key
+    0x02 || x in 2.4 -- the same answer three ways, all three refusing
+    the same x. It is libsecp256k1's own shape, `secp256k1_ge_x_on_curve_var`
+    being `secp256k1_fe_is_square_var` of x^3 + ax + b and nothing else.
 
     A bool rather than an exception, because the value that names itself
     in an error message is the caller's and not this x: dsa.Sig's
     congruence check tries every x congruent to r and reports r. That is
     also what keeps the refusal cheap, where _y_even below cannot: half
-    of the field elements are not x-coordinates, so falling back to ec.y
-    to phrase an error would pay, on half of the candidates, the very
-    square root this replaces.
+    of the field elements are not x-coordinates, and the symbol costs the
+    same for those as for the others.
     """
     sec = _compressed_sec(x, ec)
     if sec is not None:
@@ -445,11 +447,12 @@ def _is_x_coordinate(x: int, ec: Curve) -> bool:
             return False
         return True
 
-    try:
-        ec.y(x)
-    except BTClibValueError:
+    if not 0 <= x < ec.p:
         return False
-    return True
+    # the symbol is 0 for a y^2 of zero, which is the two-torsion point:
+    # its root is zero and it is on the curve, so -1 is the whole of what
+    # says otherwise
+    return legendre_symbol(ec._y2(x), ec.p) != -1
 
 
 def _y_even(x: int, ec: Curve) -> int:

--- a/btclib/number_theory.py
+++ b/btclib/number_theory.py
@@ -165,17 +165,50 @@ def mod_inv_batch(a: Sequence[int], m: int) -> list[int]:
 
 
 def legendre_symbol(a: int, p: int) -> int:
-    """Compute the Legendre symbol a|p using Euler's criterion.
+    """Compute the Legendre symbol a|p, as a binary Jacobi symbol.
 
     p is a prime, a is relatively prime to p (if p divides a, then a|p =
-    0). It returns 1 if a has a square root modulo p, -1 otherwise.
+    0). It returns 1 if a has a square root modulo p, -1 otherwise. The
+    Jacobi symbol is what is computed, and for a prime modulus the two
+    are the same number.
 
-    https://codereview.stackexchange.com/questions/43210/tonelli-shanks-algorithm-implementation-of-prime-modular-square-root/43267
+    By the reciprocity recursion rather than by Euler's criterion, which
+    is `pow(a, (p - 1) // 2, p)` -- an exponentiation the size of the
+    square root the caller is asking about, where this is a gcd: 13.3 us
+    against 74.7 on secp256k1's p, over 3000 calls, best of seven. The
+    factors of two come out all at once, `a & -a` being the lowest set
+    bit, which is libsecp256k1's `secp256k1_ctz64_var`; asking a gcd
+    rather than an exponent is what its `secp256k1_fe_is_square_var`
+    does, through `secp256k1_jacobi64_maybe_var` and never through a
+    power. Its own recursion is the safegcd one, which in bytecode loses
+    as every safegcd does -- `curves.curve_group_2` keeps the list.
+
+    The loop's length follows `a`, where an exponentiation's did not.
+    SECURITY.md publishes the Python path as variable-time, and nothing
+    in the tree asks this about a value that has to stay hidden --
+    `curves.curve._is_x_coordinate` asks it about a signature's r.
     """
     _assert_valid_operand(a)
     _assert_valid_modulus(p)
-    ls = pow(a, p >> 1, p)
-    return -1 if ls == p - 1 else ls
+
+    a %= p
+    result = 1
+    while a:
+        # every factor of two at once, and the symbol 2|p is -1 for a p
+        # of 3 or 5 mod 8, so only an odd count of them turns the sign
+        twos = (a & -a).bit_length() - 1
+        a >>= twos
+        if twos & 1 and p & 7 in {3, 5}:
+            result = -result
+        # quadratic reciprocity: the operands swap, and the sign turns
+        # when both of them are 3 mod 4
+        if a & 3 == 3 and p & 3 == 3:
+            result = -result
+        a, p = p % a, a
+    # what is left is the gcd, and a symbol is zero when it is not one:
+    # for a prime p that is a multiple of p, which has no square root
+    # and is not a non-residue either
+    return result if p == 1 else 0
 
 
 def mod_sqrt(a: int, p: int) -> int:

--- a/tests/number_theory_test.py
+++ b/tests/number_theory_test.py
@@ -132,6 +132,26 @@ def test_mod_inv() -> None:
                     mod_inv(a, m)
 
 
+def test_legendre_symbol_is_the_squares_of_the_field() -> None:
+    """The symbol against the squares themselves, exhaustively.
+
+    For a prime p the residues are exactly the squares of 1..p-1 and zero
+    is neither, so brute force is the oracle: the symbol is 1 on a square,
+    -1 on anything else, 0 on a multiple of p, and it reads a negative or
+    oversized operand as its residue.
+
+    p = 2 is the case worth naming: every residue there is a square, so
+    the symbol of 1 is 1.
+    """
+    for p in primes[:30]:  # exhaustable only for small p
+        squares = {a * a % p for a in range(1, p)}
+        for a in range(p):
+            expected = 0 if a == 0 else 1 if a in squares else -1
+            assert legendre_symbol(a, p) == expected, (a, p)
+            assert legendre_symbol(a + p, p) == expected, (a, p)
+            assert legendre_symbol(a - p, p) == expected, (a, p)
+
+
 def test_mod_sqrt() -> None:
     """Verify both roots of every residue, exhaustively on small primes."""
     for p in primes[:30]:  # exhaustable only for small p
@@ -195,6 +215,20 @@ FIELD_PRIMES = st.sampled_from(
         0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141,
     ]
 )
+
+
+@given(a=st.integers(), p=FIELD_PRIMES)
+def test_legendre_symbol_agrees_with_euler(a: int, p: int) -> None:
+    """Euler's criterion is the definition, the recursion is what runs.
+
+    Over the fields the library computes in, which are too large to
+    enumerate. p = 2 is not among them and could not be: the criterion is
+    `pow(a, (p - 1) // 2, p)` compared with p - 1, and at p = 2 that is a
+    comparison with 1, which reads every residue as a non-residue.
+    """
+    euler = pow(a, p >> 1, p)
+    expected = 0 if euler == 0 else 1 if euler == 1 else -1
+    assert legendre_symbol(a, p) == expected
 
 
 @given(a=st.integers(), b=st.integers())


### PR DESCRIPTION
legendre_symbol was Euler's criterion, pow(a, (p - 1) // 2, p): an
exponentiation the size of the square root the caller is asking about. It
is the binary Jacobi symbol now, which for a prime modulus is the same
number -- the reciprocity recursion, with every factor of two coming out
at once through a & -a. That is libsecp256k1's ctz64_var, and asking a
gcd rather than an exponent is what its fe_is_square_var does, through
jacobi64_maybe_var and never through a power; its own recursion is the
safegcd one, which in bytecode loses as every safegcd does.

curves.curve._is_x_coordinate is where that lands: it asks whether an x
is on the curve and answered with ec.y(x), a modular square root, where
libsecp256k1's ge_x_on_curve_var is fe_is_square_var of x^3 + ax + b and
nothing else. It is what dsa.Sig's congruence check runs on the Python
path.

Measured against 4afc13ce on Python 3.14.6, best of seven alternating
rounds:

                                          Euler     Jacobi
  legendre_symbol, secp256k1's p         74.9 us    13.7 us   5.45x
  _is_x_coordinate, secp256r1            67.9 us    14.8 us   4.58x

mod_sqrt does not change and must not: there the root is what is wanted,
and asking for the symbol first is the work twice, which is what #783
measured. tonelli gains with it, its search for a non-residue calling the
symbol once per candidate.

legendre_symbol(1, 2) answered -1 and now answers 1. The old line was
`return -1 if ls == p - 1 else ls`, which reads ls == p - 1 as "non
residue" -- and at p = 2 that is ls == 1, where every residue of the
field of two elements is a square, 1 among them. No caller in the tree
reached it, tonelli returning before it for p == 2, and the function is
public. A test now asserts the symbol against the squares themselves,
exhaustively, over every small prime including 2.

The symbol is variable-time in a where the exponentiation was not, a
gcd's length following its operand. SECURITY.md publishes the Python path
as variable-time, and nothing in the tree asks it about a value that has
to stay hidden.

Closes #827

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Replace Legendre symbol computation with a binary Jacobi symbol–based GCD recursion for performance and correctness, and use it to check curve x-coordinates instead of computing modular square roots.

New Features:
- Use the Legendre/Jacobi symbol to determine whether an x-coordinate lies on an elliptic curve without computing a modular square root.

Bug Fixes:
- Correct legendre_symbol(1, 2) to return 1 by aligning behavior with the mathematical definition of the Legendre symbol over small primes, including 2.

Enhancements:
- Reimplement legendre_symbol as a binary Jacobi symbol using a GCD-based recursion for significant performance improvements over Euler’s criterion.
- Adjust _is_x_coordinate to rely on legendre_symbol over the curve’s y² value instead of ec.y(x), reducing the cost of rejecting non-curve x-coordinates.
- Document the new Legendre/Jacobi symbol implementation, its performance characteristics, and its impact on curve checks in the changelog.

Tests:
- Add exhaustive tests over small primes to validate legendre_symbol against the set of quadratic residues and multiples of the modulus.
- Add property-based tests to verify that legendre_symbol agrees with Euler’s criterion over supported field primes.