### PR TITLE
Ask the wrong type and the wrong value separately (#814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2295,6 +2295,65 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **A wrong type and a wrong value are two questions, and the gate asks
+  them separately** (issue #814). `tests/input_validation_test.py` drove
+  one mixed vocabulary and asserted a `BTClibException` came out, which
+  is the weaker half of what the rule says: a value of a type the
+  signature does not declare is the caller's own mistake and leaves as a
+  `BTClibTypeError`, where a value of a declared type that no valid input
+  carries is a fact about the input -- refused, or answered `False` by a
+  function that answers a bool. `_WRONG_TYPE` and `_WRONG_VALUE` are the
+  two vocabularies now, and which dict a value belongs in is the
+  annotation's to decide.
+
+  Measured that way the type rule holds over every function the walk can
+  drive, with no exception -- which took one fix, `to_prv_key` having
+  flattened the two into one class as `to_pub_key` did before #818:
+  `_assert_prv_key_type` is its twin, so a `Point` passed as a private
+  key is a `BTClibTypeError` where it was a `NotAPrvKeyError` reporting
+  three formats tried against a value none of them could hold. The value
+  rule holds everywhere too, except the eleven that answer `False` --
+  nine script predicates, `b32.has_segwit_prefix` and
+  `dleq.verify_proof` -- which is the bool contract and is now stated as
+  one reason rather than as an exemption from the mixed rule.
+
+  `_OPEN` and `_EXCLUDED` are gone with it. Nothing needs excusing from
+  the type rule, and what `_EXCLUDED` held was the bool contract, so
+  `_ANSWERS_FALSE` states it once and ratchets: an entry that has started
+  refusing fails. `_classify` went too -- a hand-rolled three-way verdict
+  had a branch for a native exception that nothing reaches, where
+  `pytest.raises` names the class without one.
+
+- **The bool contract is gated over the verifications a fixture must
+  build** (issue #814). The automatic walk cannot drive `dsa.verify`:
+  it takes a valid message, key and signature, and a `Sig | Octets` no
+  vocabulary of wrong values can make. `tests/bool_contract_test.py` is
+  the hand-written table issue #776 asked for -- a call of each that
+  answers True, and a wrong value per position -- and it reaches twelve
+  functions the gate above never saw.
+
+  It found what #776 said a floor would find. Sixteen positions do not
+  hold the two rules, and each is a line in one of two ratcheted lists
+  naming what comes out instead. Three shapes, none of them a one-off: a
+  **sequence parameter** -- `ssa.batch_verify`'s three,
+  `merkle_proof.verify`'s branch -- is walked without being checked, so a
+  `None` is "not iterable" from underneath the library; a **signature
+  parameter** reaches `Sig.b64decode`, which strips before it decodes, so
+  a type with no `strip` is an `AttributeError` (`bms.verify`,
+  `bip322.verify`); and the **engine adapters** hand plain bytes to the
+  bindings, whose own message says "the message hash must be bytes" --
+  true, and not btclib saying it. `pedersen.verify` is the one that
+  answers instead of raising, reporting a commitment of no type at all as
+  one that does not open. The two value-rule entries are one shape:
+  `verify` reduces the message with `hf` before the `try`, so a message
+  that is no octets is refused where `verify_`, handed the hash, answers
+  False.
+
+  CONTRIBUTING.md says both rules are gated and that neither holds
+  everywhere yet, which is the shape `exceptions.py` already uses for the
+  exception contract: a rule with the ground it has not covered named
+  rather than implied.
+
 - **`check_` said four things, and therefore nothing** (issue #814).
   Thirteen public functions carried the prefix: nine refusals returning
   `None`, two bool verdicts, a converter returning bytes and a query

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -845,8 +845,25 @@ what issue #745 found and this replaces. The `assert_*` twin beside each
 of these is the spelling that says *why* a value was refused, and the two
 are how a caller chooses between an answer and a reason.
 
+**Both halves are gated, and neither holds everywhere yet.**
+`tests/input_validation_test.py` drives the two rules over every public
+function whose required parameters are all library input types, and there
+they hold with no exception. `tests/bool_contract_test.py` drives them
+from hand-written fixtures over the verifications that walk cannot reach
+— a signature verification needs a valid message, key and signature — and
+there some positions are still open, each in a ratcheted list naming what
+comes out instead: a sequence parameter walked without being checked, a
+signature reaching `Sig.b64decode`'s `strip`, the engine adapters handing
+plain bytes to the bindings, and `verify` reducing its message before the
+`try` where `verify_` answers False. A fix cannot land without deleting
+its line, and a line cannot outlive the defect.
+
 **Which of those a function is, its name says**, and the four prefixes
-are a closed vocabulary:
+below are a closed vocabulary *of prefixes*: a name carrying one promises
+that shape. It is not a requirement that every bool name carry one —
+`b32.has_segwit_prefix`, `Block.has_segwit_tx` and
+`Psbt.inputs_modifiable` are English predicates under the same contract.
+What the four buy is a promise read off the name:
 
 - `assert_*` refuses and returns `None`. There are eighty-odd of them
   and they are the reason half of the pair above.
@@ -867,6 +884,16 @@ two more while returning bytes and a pair of bools, which left the prefix
 saying four things and therefore nothing (issue #814). A converter is
 named for what it returns -- `bytes_from_octets`,
 `b32.bytes_from_witness_program` -- and a query for what it answers.
+
+**`check_validity` is a parameter and not one of those four**, which is
+worth saying now that the prefix means something: there `check` is a verb
+governing an object — "check the validity" — where a prefix on a function
+name classifies what the call answers, and a caller passes this one
+rather than reading a result off it. What it gates is `assert_valid`, a
+refusal, so the vocabulary above would name it after that if it named it
+at all. It keeps the name it has: `validate` says no more, and the
+alternative is renaming a keyword on eighty-odd public signatures for a
+reading nobody has to make twice.
 
 `check_validity=False` is not an exemption from this. It says "do not
 check *now*", not "this object is exempt from here on": these are mutable

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -54,9 +54,13 @@ full year, short month, short day (YYYY-M-D)
   on: `to_pub_key`'s `point_from_pub_key`, `pub_keyinfo_from_pub_key`,
   `point_from_key` and `pub_keyinfo_from_key` answer a `BTClibTypeError`
   for a type no spelling of a key has, where every refusal used to be a
-  `BTClibValueError`. Code catching `TypeError` or `BTClibException`
-  keeps working; code catching `BTClibValueError` alone around one of
-  those four has to widen.
+  `BTClibValueError`. `to_prv_key`'s `int_from_prv_key` and
+  `prv_keyinfo_from_prv_key` do the same, so a `Point` passed as a
+  private key is a `BTClibTypeError` where it was a `NotAPrvKeyError`
+  reporting three formats tried against a value none of them could hold.
+  Code catching `TypeError` or `BTClibException` keeps working; code
+  catching `BTClibValueError` — or `NotAPrvKeyError` — alone around one of
+  those six has to widen.
 
 - **a bad network name raises `BTClibValueError`, not `KeyError`.**
   Every function taking a `network: str` -- `b58.p2pkh`, `b32.p2wpkh`,

--- a/btclib/to_prv_key.py
+++ b/btclib/to_prv_key.py
@@ -11,6 +11,7 @@ from btclib.base58 import decode as b58decode
 from btclib.bip32.bip32 import BIP32Key, BIP32KeyData, _key_data_from_bip32_key
 from btclib.curves import Curve, secp256k1
 from btclib.exceptions import (
+    BTClibTypeError,
     BTClibValueError,
     InvalidPrvKeyError,
     NotAPrvKeyError,
@@ -39,6 +40,30 @@ __all__ = [
 # network and (un)compressed-pub_key-derivation
 PrvKey = int | bytes | str | BIP32KeyData
 
+# the union at run time, with the buffers bytes_from_octets accepts beside
+# bytes. `to_pub_key._PUB_KEY_TYPES` is the same list plus a Point and
+# minus nothing: a public key can be a point, a private key cannot
+_PRV_KEY_TYPES = (int, bytes, bytearray, memoryview, str, BIP32KeyData)
+
+
+def _assert_prv_key_type(prv_key: PrvKey) -> None:
+    """Refuse a type no spelling of a private key has.
+
+    `to_pub_key._assert_pub_key_type`'s twin, and asked for the same
+    reason: a type the union does not declare is the caller's own
+    mistake, where a value of a declared type that is no key is a
+    NotAPrvKeyError -- "wrong format, try the next one", which is what
+    the guessing below is for. Without this the two were one class: a
+    float was reported as "not a private key: not a WIF (...); not a
+    BIP32 xkey (...); not octets (...)", three formats tried against a
+    value no format could have held.
+
+    Never echo the input, every message in this module being about
+    candidate key material.
+    """
+    if not isinstance(prv_key, _PRV_KEY_TYPES):
+        raise BTClibTypeError("not a private key")
+
 
 def int_from_prv_key(prv_key: PrvKey, ec: Curve = secp256k1) -> int:
     """Return a verified-as-valid private key integer.
@@ -53,6 +78,8 @@ def int_from_prv_key(prv_key: PrvKey, ec: Curve = secp256k1) -> int:
     Network and compressed information from the input key
     are not used.
     """
+    _assert_prv_key_type(prv_key)
+
     if isinstance(prv_key, int):
         q = prv_key
     elif isinstance(prv_key, BIP32KeyData):
@@ -300,6 +327,8 @@ def prv_keyinfo_from_prv_key(
     or octets carry neither, so the arguments -- mainnet, compressed
     -- fill in.
     """
+    _assert_prv_key_type(prv_key)
+
     compr = True if compressed is None else compressed
     net = "mainnet" if network is None else network
     ec = network_from_name(net).curve

--- a/tests/bool_contract_test.py
+++ b/tests/bool_contract_test.py
@@ -1,0 +1,326 @@
+# Copyright (c) The btclib developers
+# Distributed under the MIT software license, see the accompanying
+# LICENSE file or https://opensource.org/license/mit for the full text.
+
+"""The gate for the bool contract, over what only a fixture can reach.
+
+CONTRIBUTING.md's "Every public function validates its inputs" states two
+rules about a function that answers a `bool`, and
+`input_validation_test.py` drives them automatically -- over the
+functions whose every required parameter is a library input type. That
+leaves out the ones this file is about, and they are the ones the rules
+were argued over: a signature verification takes a valid message, key and
+signature, and a `Sig | Octets` that no vocabulary of wrong values can
+build.
+
+So the calls here are hand-written, which is issue #776's own answer to
+what its walk cannot reach: "a hand-written table of name, and the
+shortest call that reaches the validator". Each case names a function, a
+call of it that answers True, and a wrong value for each position worth
+driving. Two rules, asked one position at a time with the others left
+valid:
+
+- a **wrong type** leaves as a `BTClibTypeError`. A bool is an answer
+  about a value, so a type the signature does not declare is not
+  something it answers about.
+- a **wrong value** of a declared type is `False`. That is what the bool
+  is for, and what a caller filtering signatures off the wire relies on.
+
+Issue #814 settled the second against issue #745's "total over everything
+it is handed", and this is where the decision is held to.
+
+## The two open lists, and which way they ratchet
+
+Reaching new ground found new findings, which is what issue #776 said its
+own floor of fifty-nine would do. `_TYPE_OPEN` and `_VALUE_OPEN` are
+those, one entry per position, each naming what comes out instead. They
+can only shrink: `test_what_is_open_is_still_open` fails on an entry that
+has come into line, as RUF100 fails an unused `noqa`, so a fix cannot
+land without deleting its line -- and a line cannot outlive the defect.
+
+Three shapes are in them. A **sequence parameter** -- `batch_verify`'s
+three, `merkle_proof.verify`'s branch -- is walked without being checked,
+so a `None` is "not iterable" from underneath the library. A **signature
+parameter** reaches `Sig.b64decode`, which strips before it decodes, so a
+type with no `strip` is an `AttributeError`. And the **engine adapters**
+take plain `bytes` and hand them to the bindings, whose own `TypeError`
+says "the message hash must be bytes" -- true, and not btclib saying it.
+The two `_VALUE_OPEN` shapes are one: `verify` reduces the message with
+`hf` *before* the `try`, so a message that is no octets is refused where
+`verify_`, handed the hash, answers False.
+
+What no fixture here reaches, and why: `musig2.partial_sig_verify_` and
+`partial_sig_verify` want a `SessionContext` and a signing round,
+`psbt.musig2.partial_sig_verify` a `Psbt` carrying one, and
+`dsa.anti_exfil_host_verify` a host-device exchange. Those are driven by
+the tests of their own modules, against fixtures those modules build.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from btclib import b58, bip322
+from btclib.block import merkle_proof
+from btclib.ecc import bms, dleq, dsa, pedersen, ssa
+from btclib.hashes import reduce_to_hlen
+from btclib.script.engine import script as engine_script
+from btclib.script.engine import tapscript as engine_tapscript
+from btclib.to_pub_key import pub_keyinfo_from_prv_key
+
+_Q = 12
+_PUB = pub_keyinfo_from_prv_key(_Q)[0]
+_X_ONLY = _PUB[1:]
+_MSG = b"Satoshi Nakamoto"
+_OTHER_MSG = b"another message"
+_MSG_HASH = reduce_to_hlen(_MSG)
+_ADDR = b58.p2pkh(_PUB)
+_DSA_SIG = dsa.sign(_MSG, _Q)
+_SSA_SIG = ssa.sign(_MSG, _Q)
+_BMS_SIG = bms.sign(_MSG, _Q)
+# BIP322 declares a `Sig` of its own, and it is not bms's: the two are
+# distinct classes, so each case is given the one its function takes
+_BIP322_SIG = bip322.sign(_MSG, _Q, _ADDR)
+_TX_ID = bytes.fromhex("01" * 32)
+# a DLEQ triple: A = a*G and C = a*B, so the proof holds for (A, B, C)
+_DLEQ_B = pub_keyinfo_from_prv_key(2)[0]
+_DLEQ_C = pub_keyinfo_from_prv_key(2 * _Q)[0]
+_DLEQ_PROOF = dleq.generate_proof(_Q, _DLEQ_B)
+# rG + vH for the very (r, v) its case opens it with
+_COMMITMENT = pedersen.commit(1, 2)
+
+# a value of a declared type that no valid input carries. The same split
+# `input_validation_test.py` makes, spelled per position because a
+# hand-written call knows which alias each of its arguments is
+_WRONG_OCTETS_VALUE = "not hex at all"
+_WRONG_KEY_VALUE = "not a key"
+_WRONG_STRING_VALUE = "not an address"
+
+# a value of no type any of these positions declares
+_WRONG_TYPES = (None, 1.5)
+
+
+@dataclass(frozen=True)
+class _Case:
+    """A bool function, a call that answers True, and what to drive."""
+
+    label: str
+    function: Any
+    args: tuple[Any, ...]
+    # position -> a wrong value of the type that position declares
+    wrong_values: dict[int, Any]
+
+
+_CASES = (
+    _Case(
+        "dsa.verify",
+        dsa.verify,
+        (_MSG, _PUB, _DSA_SIG),
+        {0: _WRONG_OCTETS_VALUE, 1: _WRONG_KEY_VALUE, 2: _WRONG_OCTETS_VALUE},
+    ),
+    _Case(
+        "dsa.verify_",
+        dsa.verify_,
+        (_MSG_HASH, _PUB, _DSA_SIG),
+        {0: _WRONG_OCTETS_VALUE, 1: _WRONG_KEY_VALUE, 2: _WRONG_OCTETS_VALUE},
+    ),
+    _Case(
+        "ssa.verify",
+        ssa.verify,
+        (_MSG, _X_ONLY, _SSA_SIG),
+        {0: _WRONG_OCTETS_VALUE, 1: _WRONG_KEY_VALUE, 2: _WRONG_OCTETS_VALUE},
+    ),
+    _Case(
+        "ssa.verify_",
+        ssa.verify_,
+        (_MSG_HASH, _X_ONLY, _SSA_SIG),
+        {0: _WRONG_OCTETS_VALUE, 1: _WRONG_KEY_VALUE, 2: _WRONG_OCTETS_VALUE},
+    ),
+    _Case(
+        "ssa.batch_verify",
+        ssa.batch_verify,
+        ([_MSG], [_X_ONLY], [_SSA_SIG]),
+        # a sequence whose element is the wrong value, the sequence being
+        # what the parameter declares
+        {0: [_WRONG_OCTETS_VALUE], 1: [_WRONG_KEY_VALUE]},
+    ),
+    _Case(
+        "bms.verify",
+        bms.verify,
+        (_MSG, _ADDR, _BMS_SIG),
+        {0: _WRONG_OCTETS_VALUE, 1: _WRONG_STRING_VALUE, 2: _WRONG_STRING_VALUE},
+    ),
+    _Case(
+        "bip322.verify",
+        bip322.verify,
+        (_MSG, _ADDR, _BIP322_SIG),
+        {0: _WRONG_OCTETS_VALUE, 1: _WRONG_STRING_VALUE, 2: _WRONG_STRING_VALUE},
+    ),
+    _Case(
+        "pedersen.verify",
+        pedersen.verify,
+        (1, 2, _COMMITMENT),
+        # every value of an int is one, so the wrong value here is a
+        # different number rather than a malformed one, and a commitment
+        # those two do not open
+        {0: 999, 1: 999, 2: pedersen.commit(9, 9)},
+    ),
+    _Case(
+        "merkle_proof.verify",
+        merkle_proof.verify,
+        # a one-transaction tree, where the coinbase *is* the root and the
+        # branch is empty: the shortest call that reaches the check
+        (_TX_ID, [], 0, _TX_ID),
+        # an index no branch places is the wrong value of an int, as
+        # merkle_proof's own tests put it
+        {0: _WRONG_OCTETS_VALUE, 2: 1, 3: _WRONG_OCTETS_VALUE},
+    ),
+    _Case(
+        "dleq.verify_proof",
+        dleq.verify_proof,
+        (_PUB, _DLEQ_B, _DLEQ_C, _DLEQ_PROOF),
+        {
+            0: _WRONG_KEY_VALUE,
+            1: _WRONG_KEY_VALUE,
+            2: _WRONG_KEY_VALUE,
+            3: _WRONG_OCTETS_VALUE,
+        },
+    ),
+    _Case(
+        "engine.script.dsa_verify",
+        engine_script.dsa_verify,
+        (_MSG_HASH, _PUB, _DSA_SIG.serialize()),
+        # plain bytes, so a wrong value is bytes that are not the thing: a
+        # DER signature of the right shape over another message
+        {2: dsa.sign(_OTHER_MSG, _Q).serialize()},
+    ),
+    _Case(
+        "engine.tapscript.ssa_verify",
+        engine_tapscript.ssa_verify,
+        (_MSG_HASH, _X_ONLY, _SSA_SIG.serialize()),
+        {2: ssa.sign(_OTHER_MSG, _Q).serialize()},
+    ),
+)
+
+_IDS = tuple(case.label for case in _CASES)
+
+# each entry names the class that comes out where a BTClibTypeError
+# belongs; the module docstring has the three shapes behind them
+_TYPE_OPEN: dict[str, str] = {
+    "bip322.verify[2]": "AttributeError",
+    "bms.verify[2]": "AttributeError",
+    "engine.script.dsa_verify[0]": "TypeError",
+    "engine.script.dsa_verify[1]": "TypeError",
+    "engine.script.dsa_verify[2]": "TypeError",
+    "engine.tapscript.ssa_verify[0]": "TypeError",
+    "engine.tapscript.ssa_verify[1]": "TypeError",
+    "engine.tapscript.ssa_verify[2]": "TypeError",
+    "merkle_proof.verify[1]": "TypeError",
+    # the one that answers rather than raising, which is the shape issue
+    # #776 put first because it is the only one that can cost money: a
+    # commitment of no type at all is reported as one that does not open
+    "pedersen.verify[2]": "answers False",
+    "ssa.batch_verify[0]": "TypeError",
+    "ssa.batch_verify[1]": "TypeError",
+    "ssa.batch_verify[2]": "TypeError",
+}
+
+# one shape, and `verify_` beside each of these is where it is not: the
+# message is reduced before the `try`, so a message that is no octets is
+# refused where the hash spelling answers False
+_VALUE_OPEN: dict[str, str] = {
+    "dsa.verify[0]": "BTClibValueError",
+    "ssa.batch_verify[0]": "BTClibValueError",
+    "ssa.verify[0]": "BTClibValueError",
+}
+
+
+def _at(label: str, position: int) -> str:
+    """Return the key both open lists are read by."""
+    return f"{label}[{position}]"
+
+
+def _case_of(at: str) -> tuple[_Case, int]:
+    """Return the case and the position an open entry names."""
+    label, _, rest = at.partition("[")
+    case = next(c for c in _CASES if c.label == label)
+    return case, int(rest.rstrip("]"))
+
+
+def _outcome(case: _Case, position: int, wrong: Any) -> str:
+    """Return what came out: the class raised, or the answer given."""
+    args = list(case.args)
+    args[position] = wrong
+    try:
+        return f"answers {case.function(*args)!r}"
+    # the class of what came out is the finding, so every one of them is
+    # named rather than let out of the walk
+    except Exception as e:  # noqa: BLE001
+        return type(e).__name__
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_IDS)
+def test_the_call_answers_true(case: _Case) -> None:
+    """The fixture is valid, which is what makes False an answer below.
+
+    Without this a case whose arguments had gone stale would pass every
+    test in the file by answering False to everything.
+    """
+    assert case.function(*case.args) is True
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_IDS)
+def test_a_wrong_type_leaves_as_a_btclib_type_error(case: _Case) -> None:
+    """The first rule, one position at a time, the others left valid."""
+    for position in range(len(case.args)):
+        if _at(case.label, position) in _TYPE_OPEN:
+            continue
+        for wrong in _WRONG_TYPES:
+            assert _outcome(case, position, wrong) == "BTClibTypeError"
+
+
+@pytest.mark.parametrize("case", _CASES, ids=_IDS)
+def test_a_wrong_value_answers_false(case: _Case) -> None:
+    """The second rule: a value of a declared type is answered, not refused."""
+    for position, wrong in sorted(case.wrong_values.items()):
+        if _at(case.label, position) in _VALUE_OPEN:
+            continue
+        assert _outcome(case, position, wrong) == "answers False"
+
+
+@pytest.mark.parametrize("at", sorted(_TYPE_OPEN))
+def test_what_the_type_rule_holds_open_is_still_open(at: str) -> None:
+    """A fix cannot land without deleting its line from `_TYPE_OPEN`."""
+    case, position = _case_of(at)
+    assert _outcome(case, position, _WRONG_TYPES[0]) == _TYPE_OPEN[at], (
+        f"{at} no longer answers a wrong type with {_TYPE_OPEN[at]}: delete"
+        " its line, or correct it to what it answers with now"
+    )
+
+
+@pytest.mark.parametrize("at", sorted(_VALUE_OPEN))
+def test_what_the_value_rule_holds_open_is_still_open(at: str) -> None:
+    """A fix cannot land without deleting its line from `_VALUE_OPEN`."""
+    case, position = _case_of(at)
+    wrong = case.wrong_values[position]
+    assert _outcome(case, position, wrong) == _VALUE_OPEN[at], (
+        f"{at} no longer answers a wrong value with {_VALUE_OPEN[at]}:"
+        " delete its line, or correct it to what it answers with now"
+    )
+
+
+def test_every_open_entry_names_a_driven_position() -> None:
+    """Neither list may name a position no case drives.
+
+    A renamed case, or a position dropped from `wrong_values`, would
+    otherwise leave an entry excusing something nothing runs.
+    """
+    for at in sorted(_TYPE_OPEN):
+        case, position = _case_of(at)
+        assert position < len(case.args), at
+    for at in sorted(_VALUE_OPEN):
+        case, position = _case_of(at)
+        assert position in case.wrong_values, at

--- a/tests/input_validation_test.py
+++ b/tests/input_validation_test.py
@@ -2,33 +2,45 @@
 # Distributed under the MIT software license, see the accompanying
 # LICENSE file or https://opensource.org/license/mit for the full text.
 
-"""The gate for the one rule about a public function's inputs.
+"""The gate for the two rules about a public function's inputs.
 
 > Every public function guarantees the validation of all its inputs,
 > directly or indirectly. A malformed argument leaves as
 > `BTClibTypeError` or `BTClibValueError`.
 
-Both are `BTClibException`, which is what makes this one predicate
-instead of a tuple that has to be kept in step with the hierarchy -- the
-reason issue #743 landed that base class before this test rather than
-after it.
+CONTRIBUTING.md's "Every public function validates its inputs" states it,
+and which of the two classes comes out is not a coin toss -- it is the
+distinction issue #814 settled, so this file drives the two separately:
+
+- **a value of a type the signature does not declare** is the caller's
+  own mistake, and leaves as a `BTClibTypeError`. Every function the walk
+  can drive, without exception.
+- **a value of a declared type that no valid input carries** is a fact
+  about the input, and leaves as a `BTClibException` -- unless the
+  function answers a `bool` about it, in which case the answer is
+  `False`. `_ANSWERS_FALSE` is that family, and it is a family: nine
+  script predicates, `b32.has_segwit_prefix` and `ecc.dleq.verify_proof`.
+
+Both are `BTClibException`, which is what makes the second rule one
+predicate instead of a tuple that has to be kept in step with the
+hierarchy -- the reason issue #743 landed that base class before this
+test rather than after it.
 
 ## How it calls what it calls
 
 The library's input types are few and well bounded, most of them named in
 `btclib/alias.py` and the key and path ones beside their converters.
-`_MALFORMED` gives each of them values that are not of it, and the walk
-finds every public module-level function whose *required* parameters are
-all of those types. Those it can call with no fixture and no knowledge of
-what the function does, and what it asserts is the rule as written:
-something is raised, and it is a `BTClibException`.
+`_WRONG_TYPE` and `_WRONG_VALUE` give each of them values of the two
+kinds, and the walk finds every public module-level function whose
+*required* parameters are all of those types. Those it can call with no
+fixture and no knowledge of what the function does.
 
-Every argument is malformed at once, which is not weaker than one
-malformed argument among valid ones: whichever the function refuses
-first, the rule says it must refuse it as a btclib error. And it needs no
-valid values, which is what makes the walk automatic -- a valid `Octets`
-is 20 bytes for one function, 32 for another and any length for a third,
-so the table of those is the hand-written thing this avoids.
+Every argument is wrong at once, which is not weaker than one wrong
+argument among valid ones: whichever the function refuses first, the rule
+says how it must refuse it. And it needs no valid values, which is what
+makes the walk automatic -- a valid `Octets` is 20 bytes for one
+function, 32 for another and any length for a third, so the table of
+those is the hand-written thing this avoids.
 
 ## What it does not reach, and why that is not a hole to plug here
 
@@ -39,108 +51,132 @@ instead, where their own checks live.
 
 A **method**, and a function taking a `Tx`, a `Psbt` or a callback, needs
 a valid instance the vocabulary cannot build. That is the part of issue
-#744 that stays hand-read. `test_the_walk_reaches_what_it_claims` pins
-what the walk does find, so a narrowing of it fails here rather than
-quietly running over less.
+#744 that stays hand-read, and `tests/bool_contract_test.py` is where the
+bool half of it is driven from fixtures instead.
+`test_the_walk_reaches_what_it_claims` pins what the walk does find, so a
+narrowing of it fails here rather than quietly running over less.
 
-## The two lists, and which way each ratchets
+## The three lists, and which way each ratchets
 
-- `_MALFORMED` is the vocabulary, and every name in it is a type this
-  tree still declares: a rename would otherwise shrink the walk in
-  silence, which `test_the_vocabulary_is_the_libraries_input_types` is
-  against.
-- `_EXCLUDED` is what must not be held to the rule this way, with the
-  reason. What is in it is two families, each stating its own design,
-  and it ratchets the way `_OPEN` used to:
-  `test_what_is_excluded_still_needs_to_be` fails on an entry that has
-  become compliant, as RUF100 fails an unused `noqa`, so a line cannot
-  outlive the reason for it.
+- `_WRONG_TYPE` and `_WRONG_VALUE` are the vocabulary, and every name in
+  them is a type this tree still declares: a rename would otherwise
+  shrink the walk in silence, which
+  `test_the_vocabulary_is_the_libraries_input_types` is against. Which
+  dict a value belongs in is the only judgement in this file, and it is
+  the annotation's to make: `1.5` is no `Octets`, `"not hex at all"` is
+  one that will not decode.
+- `_ANSWERS_FALSE` is what answers rather than refuses a wrong value,
+  with the reason. It can only shrink:
+  `test_what_answers_false_still_does` fails on an entry that has started
+  refusing, as RUF100 fails an unused `noqa`, so a line cannot outlive
+  the reason for it.
 
-There was a third, `_OPEN`, holding what issue #744's census left. It
-is empty and therefore gone: every function the walk drives now either
-holds the rule or is in `_EXCLUDED` with a reason. What the walk finds
-next is a red test above, to be fixed or to be excluded with a reason of
-its own -- a backlog is not a place a new finding goes to wait.
+There was a fourth, `_OPEN`, holding what issue #744's census left, and
+an `_EXCLUDED` that mixed the two kinds of wrong value into one
+exemption. Both are gone: with the vocabularies split, nothing needs
+excusing from the type rule, and what the old list held was the bool
+contract, which `_ANSWERS_FALSE` now states as one. `pytest.raises` went
+with them -- a hand-rolled verdict had a branch for a native exception
+that no function of the library reaches any more, and naming the class
+is what `pytest.raises` does without one.
 """
 
 from __future__ import annotations
 
 import ast
 import importlib
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from functools import partial
 from pathlib import Path
 from typing import Any
 
 import pytest
 
-from btclib.exceptions import BTClibException, BTClibValueError
+from btclib.exceptions import BTClibException, BTClibTypeError
 
 _LIBRARY = Path(__file__).parents[1] / "btclib"
 
-# a value of none of the library's input types is what each of these is,
-# and the tuples are read round-robin so that a function taking three
-# parameters of one type is called with three different wrong values.
-# Constants and not a strategy: what this gate reports has to be the same
-# on two runs, `_EXCLUDED` below being read as a statement about the tree
-_MALFORMED: dict[str, tuple[Any, ...]] = {
-    "BIP32Key": (None, 1.5, "not an xkey"),
-    "BinaryData": ("not hex at all", None, 1.5),
-    "DerPath": (-1, [2**32], "m/x", 1.5),
-    "Integer": ("not hex at all", None, 1.5),
-    "Key": (None, 1.5, "not a key"),
-    "Octets": ("not hex at all", "9", tuple(range(4)), None),
-    "Point": ((1,), "not a point", None),
-    "PrvKey": (None, 1.5, "not a key"),
-    "PubKey": (None, 1.5, "not a key"),
+# a value of no type the alias declares: the caller's own mistake, and a
+# call mypy refuses. The tuples are read round-robin so that a function
+# taking three parameters of one type is called with three different
+# wrong values. Constants and not a strategy: what this gate reports has
+# to be the same on two runs, the lists below being read as statements
+# about the tree
+_WRONG_TYPE: dict[str, tuple[Any, ...]] = {
+    "BIP32Key": (None, 1.5),
+    "BinaryData": (None, 1.5),
+    "DerPath": (None, 1.5),
+    "Integer": (None, 1.5),
+    "Key": (None, 1.5),
+    "Octets": (None, 1.5, tuple(range(4))),
+    "Point": (None, 1.5, "not a point"),
+    "PrvKey": (None, 1.5),
+    "PubKey": (None, 1.5),
     "ScriptList": (None, 1.5, "not a list"),
-    "String": (1, None, 1.5),
+    "String": (None, 1.5, 1),
 }
 
-# one reason for nine functions, and it is `script_pub_key._is_funct`'s
-# own: "these bool functions answer 'are these bytes a p2sh script', so
-# bytes that are not are False". A malformed hex string is bytes that are
-# not, and what `bytes.fromhex` raises for it is a ValueError, which that
-# `except ValueError` catches on purpose. A wrong *type* is not covered
-# by it and does raise, which is the half of those nine the rule reaches
-_A_PREDICATE_ANSWERS_FALSE = (
-    "a bool function about a script answers False for bytes that are not"
-    " one, and a malformed hex string is bytes that are not: the reason is"
-    " in script_pub_key._is_funct, which catches ValueError alone"
+# a value of a declared type that no valid input carries: a fact about
+# the input, and the half a bool function answers False about. Every one
+# of these type checks -- that is what puts it in this dict rather than
+# in the one above -- so a `# type: ignore` is never needed to build the
+# call, which is the same line drawn twice
+_WRONG_VALUE: dict[str, tuple[Any, ...]] = {
+    "BIP32Key": ("not an xkey",),
+    "BinaryData": ("not hex at all",),
+    # a string no path spelling reads, an index below zero, and one above
+    # the four bytes a BIP32 index has
+    "DerPath": ("m/x", -1, [2**32]),
+    "Integer": ("not hex at all",),
+    "Key": ("not a key",),
+    # a hex string that is not hex, and one of odd length
+    "Octets": ("not hex at all", "9"),
+    # a tuple of the wrong arity, and a pair of ints that is no point:
+    # run time cannot tell tuple[int] from tuple[int, int], so the arity
+    # is a value here and not a type
+    "Point": ((1,), (1, 2)),
+    "PrvKey": ("not a key",),
+    "PubKey": ("not a key",),
+    "ScriptList": (["OP_NOT_AN_OP_CODE"],),
+    "String": ("not an address",),
+}
+
+# one reason for eleven functions, nine of which are
+# `script_pub_key._is_funct`'s own: "these bool functions answer 'are
+# these bytes a p2sh script', so bytes that are not are False". The other
+# two answer the same shape of question one layer up -- does this string
+# start as a bech32 address, does this proof hold -- and CONTRIBUTING.md
+# states the rule for all of them beside the validation one.
+#
+# `taproot.check_output_pubkey` is deliberately *not* here, and is the
+# reason `check_` keeps its prefix: it answers a bool and refuses a
+# malformed control block, that being no proof rather than a disproof
+_A_BOOL_ANSWERS_FALSE = (
+    "a bool answers about a value of a declared type, so a value that is"
+    " not one is False rather than a refusal: issue #814 settled it, and"
+    " CONTRIBUTING.md's 'Every public function validates its inputs'"
+    " states it"
 )
 
-# the other family, and the same sentence one layer up: a verification
-# answers "does this proof hold", so a pub key of a declared type that
-# is no point is False, exactly as bytes that are no p2sh script are. A
-# wrong *type* does raise, `to_pub_key` refusing what is no spelling of
-# a key, which is the half of it the rule reaches. `dleq.verify_proof`
-# is the one of the family the walk can drive: the others take a
-# `Sig | Octets` the vocabulary has no wrong value for
-_A_VERIFICATION_ANSWERS_FALSE = (
-    "a boolean verification is total over the types it declares, so a pub"
-    " key that is no point is False: CONTRIBUTING.md's 'Every public"
-    " function validates its inputs' states the rule, ecc.dsa.verify_ the"
-    " reason, and issue #814 is where it was decided"
-)
-
-_EXCLUDED: dict[str, str] = {
-    "btclib.ecc.dleq.verify_proof": _A_VERIFICATION_ANSWERS_FALSE,
-    "btclib.script.script_pub_key.is_nulldata": _A_PREDICATE_ANSWERS_FALSE,
-    "btclib.script.script_pub_key.is_p2ms": _A_PREDICATE_ANSWERS_FALSE,
-    "btclib.script.script_pub_key.is_p2pk": _A_PREDICATE_ANSWERS_FALSE,
-    "btclib.script.script_pub_key.is_p2pkh": _A_PREDICATE_ANSWERS_FALSE,
-    "btclib.script.script_pub_key.is_p2sh": _A_PREDICATE_ANSWERS_FALSE,
-    "btclib.script.script_pub_key.is_p2tr": _A_PREDICATE_ANSWERS_FALSE,
-    "btclib.script.script_pub_key.is_p2wpkh": _A_PREDICATE_ANSWERS_FALSE,
-    "btclib.script.script_pub_key.is_p2wsh": _A_PREDICATE_ANSWERS_FALSE,
-    "btclib.script.script_pub_key.is_segwit": _A_PREDICATE_ANSWERS_FALSE,
+_ANSWERS_FALSE: dict[str, str] = {
+    "btclib.b32.has_segwit_prefix": _A_BOOL_ANSWERS_FALSE,
+    "btclib.ecc.dleq.verify_proof": _A_BOOL_ANSWERS_FALSE,
+    "btclib.script.script_pub_key.is_nulldata": _A_BOOL_ANSWERS_FALSE,
+    "btclib.script.script_pub_key.is_p2ms": _A_BOOL_ANSWERS_FALSE,
+    "btclib.script.script_pub_key.is_p2pk": _A_BOOL_ANSWERS_FALSE,
+    "btclib.script.script_pub_key.is_p2pkh": _A_BOOL_ANSWERS_FALSE,
+    "btclib.script.script_pub_key.is_p2sh": _A_BOOL_ANSWERS_FALSE,
+    "btclib.script.script_pub_key.is_p2tr": _A_BOOL_ANSWERS_FALSE,
+    "btclib.script.script_pub_key.is_p2wpkh": _A_BOOL_ANSWERS_FALSE,
+    "btclib.script.script_pub_key.is_p2wsh": _A_BOOL_ANSWERS_FALSE,
+    "btclib.script.script_pub_key.is_segwit": _A_BOOL_ANSWERS_FALSE,
 }
 
 
 def _alias_of(annotation: ast.expr) -> str | None:
     """Return the input type an annotation names, `X | None` included."""
     name = ast.unparse(annotation).replace(" | None", "").strip()
-    return name if name in _MALFORMED else None
+    return name if name in _WRONG_TYPE else None
 
 
 def _drivable() -> dict[str, list[str]]:
@@ -172,70 +208,78 @@ def _drivable() -> dict[str, list[str]]:
 _DRIVABLE = _drivable()
 
 
-def _classify(call: Callable[[], Any]) -> str | None:
-    """Return the class of what escapes the rule, or None if it holds.
+def _calls(
+    dotted: str, vocabulary: dict[str, tuple[Any, ...]]
+) -> Iterator[Callable[[], Any]]:
+    """Yield one prepared call per round, every argument wrong at once.
 
-    The whole of the verdict, on one call, and a function of its own so
-    that the three answers can be provoked here: the middle one names a
-    native exception, and no function of the library produces one any
-    more, so as a branch inside the walk it went uncovered -- and an
-    unrun branch is a poor thing to find out about on the day something
-    does leak. `test_the_walk_names_what_escapes` is what runs it.
+    The vocabulary is the parameter, and it is the whole of what tells the
+    two rules apart: the same walk, the same function, two kinds of wrong
+    value.
     """
-    try:
-        call()
-    except BTClibException:
-        return None
-    # the class of what came out is the finding, so every one of them is
-    # caught and named rather than let out of the walk
-    except Exception as e:  # noqa: BLE001
-        return type(e).__name__
-    return "no exception"
-
-
-def _leak(dotted: str) -> str | None:
-    """Return the class of what escapes the rule, or None if it holds."""
     module_name, _, name = dotted.rpartition(".")
     function = getattr(importlib.import_module(module_name), name)
     aliases = _DRIVABLE[dotted]
-    for round_ in range(max(len(_MALFORMED[a]) for a in aliases)):
-        args = [_MALFORMED[a][round_ % len(_MALFORMED[a])] for a in aliases]
+    for round_ in range(max(len(vocabulary[a]) for a in aliases)):
+        args = [vocabulary[a][round_ % len(vocabulary[a])] for a in aliases]
         # partial and not a lambda, which would close over the loop
         # variables and be read on a later round
-        found = _classify(partial(function, *args))
-        if found is not None:
-            return found
-    return None
+        yield partial(function, *args)
 
 
-_GATED = sorted(set(_DRIVABLE) - _EXCLUDED.keys())
+_DRIVEN = sorted(_DRIVABLE)
+_REFUSES_A_WRONG_VALUE = sorted(set(_DRIVABLE) - _ANSWERS_FALSE.keys())
 
 
-@pytest.mark.parametrize("dotted", _GATED)
-def test_a_malformed_argument_leaves_as_a_btclib_exception(dotted: str) -> None:
-    """The rule, over every public function the vocabulary can drive."""
-    leak = _leak(dotted)
-    assert leak is None, f"{dotted} answers a malformed argument with {leak}"
+@pytest.mark.parametrize("dotted", _DRIVEN)
+def test_a_wrong_type_leaves_as_a_btclib_type_error(dotted: str) -> None:
+    """The first rule, and it has no exceptions.
 
+    Every public function the walk can drive, `_ANSWERS_FALSE` included:
+    a bool is an answer about a value, so a type it does not declare is
+    not something it answers about either.
 
-@pytest.mark.parametrize("dotted", sorted(_EXCLUDED))
-def test_what_is_excluded_still_needs_to_be(dotted: str) -> None:
-    """A line of `_EXCLUDED` cannot outlive the reason for it.
-
-    The ratchet `_OPEN` used to carry, aimed at the list that is left:
-    an entry whose function has started refusing what its reason says it
-    answers is an exemption nothing needs any more, and it fails here
-    rather than quietly keeping a function out of the walk.
+    `BTClibTypeError` and not `BTClibException`: this is where the class
+    is the point. A bare `TypeError` fails here as a `BTClibValueError`
+    does -- the first is a leak from underneath the library, the second
+    is the library calling a caller's mistake a fact about the input.
     """
-    assert _leak(dotted) is not None, (
-        f"{dotted} now holds the rule: delete its line from _EXCLUDED"
-    )
+    for call in _calls(dotted, _WRONG_TYPE):
+        with pytest.raises(BTClibTypeError):
+            call()
+
+
+@pytest.mark.parametrize("dotted", _REFUSES_A_WRONG_VALUE)
+def test_a_wrong_value_leaves_as_a_btclib_exception(dotted: str) -> None:
+    """The second rule, over everything that does not answer False.
+
+    `BTClibException` and not one of the three: which of them a malformed
+    value deserves is the function's to decide -- a size is a
+    `BTClibValueError`, a bool where a number belongs is a
+    `BTClibTypeError` -- and the contract a caller is given is the base.
+    """
+    for call in _calls(dotted, _WRONG_VALUE):
+        with pytest.raises(BTClibException):
+            call()
+
+
+@pytest.mark.parametrize("dotted", sorted(_ANSWERS_FALSE))
+def test_what_answers_false_still_does(dotted: str) -> None:
+    """A line of `_ANSWERS_FALSE` cannot outlive the reason for it.
+
+    `is False` and not a falsy answer: these eleven return a bool, and an
+    empty string or a None passing for one is the shape issue #776 found
+    in `script_pub_key.address`, which answered "" for a None.
+    """
+    for call in _calls(dotted, _WRONG_VALUE):
+        assert call() is False
 
 
 def test_the_vocabulary_is_the_libraries_input_types() -> None:
     """A renamed type would narrow the walk without failing anything.
 
-    Every name in `_MALFORMED` is still declared under `btclib/`, and
+    Every name in the two vocabularies is still declared under
+    `btclib/`, and
     every type `alias.py` declares and a public parameter is annotated
     with is either in the vocabulary or named below with the reason no
     wrong value can be built for it.
@@ -266,7 +310,8 @@ def test_the_vocabulary_is_the_libraries_input_types() -> None:
                 if a.annotation is not None
             }
 
-    assert set(_MALFORMED) <= declared
+    assert set(_WRONG_TYPE) == set(_WRONG_VALUE)
+    assert set(_WRONG_TYPE) <= declared
 
     without_a_wrong_value = {
         # three Literals: a value outside them is what mypy refuses, and a
@@ -292,25 +337,7 @@ def test_the_vocabulary_is_the_libraries_input_types() -> None:
         # leaves are Octets and int
         "TaprootScriptTree",
     }
-    assert in_alias_py & annotated <= set(_MALFORMED) | without_a_wrong_value
-
-
-def test_the_walk_names_what_escapes() -> None:
-    """The three verdicts, on calls whose behaviour is stated here.
-
-    A walk that answered None to everything would pass every test above,
-    and the answer that says a native exception got out is the one no
-    function of the library provokes any more -- so this is where it is
-    provoked, rather than being a branch nothing runs until the day it
-    matters.
-    """
-
-    def raiser(e: Exception) -> None:
-        raise e
-
-    assert _classify(partial(raiser, BTClibValueError("refused"))) is None
-    assert _classify(partial(raiser, TypeError("from underneath"))) == "TypeError"
-    assert _classify(bool) == "no exception"
+    assert in_alias_py & annotated <= set(_WRONG_TYPE) | without_a_wrong_value
 
 
 def test_the_walk_reaches_what_it_claims() -> None:
@@ -334,7 +361,8 @@ def test_the_walk_reaches_what_it_claims() -> None:
     assert "btclib.psbt.psbt.finalize" not in _DRIVABLE
 
 
-def test_every_driven_function_is_gated_or_excluded() -> None:
+def test_every_driven_function_is_under_both_rules() -> None:
     """No function leaves the run without a line saying why."""
-    assert _EXCLUDED.keys() <= set(_DRIVABLE)
-    assert set(_GATED) | _EXCLUDED.keys() == set(_DRIVABLE)
+    assert _ANSWERS_FALSE.keys() <= set(_DRIVABLE)
+    assert set(_DRIVEN) == set(_DRIVABLE)
+    assert set(_REFUSES_A_WRONG_VALUE) | _ANSWERS_FALSE.keys() == set(_DRIVABLE)

--- a/tests/to_prv_key_test.py
+++ b/tests/to_prv_key_test.py
@@ -13,6 +13,7 @@ from btclib.b58 import wif_from_prv_key
 from btclib.base58 import encode as b58encode
 from btclib.curves.curve import CURVES
 from btclib.exceptions import (
+    BTClibTypeError,
     BTClibValueError,
     InvalidPrvKeyError,
     NotAPrvKeyError,
@@ -132,19 +133,27 @@ def test_from_prv_key() -> None:
         qn,
         xprv0_data,
         xprvn_data,
-        INF,
         INF_xpub_data,
         *not_a_prv_keys,
-        Q,
         *plain_pub_keys,
         xpub_data,
         *compressed_pub_keys,
         *uncompressed_pub_keys,
     ]:
         with pytest.raises(BTClibValueError):
-            int_from_prv_key(not_a_prv_key)  # type: ignore[arg-type]
+            int_from_prv_key(not_a_prv_key)
         with pytest.raises(BTClibValueError):
-            prv_keyinfo_from_prv_key(not_a_prv_key)  # type: ignore[arg-type]
+            prv_keyinfo_from_prv_key(not_a_prv_key)
+
+    # a Point is a public key spelling and no private one, so it is the
+    # type that is wrong and not the value: issue #814's rule, and the
+    # `type: ignore` these two need -- where none of the spellings above
+    # needs one -- is the same line drawn by the type checker
+    for a_point in [INF, Q]:
+        with pytest.raises(BTClibTypeError, match="not a private key"):
+            int_from_prv_key(a_point)  # type: ignore[arg-type]
+        with pytest.raises(BTClibTypeError, match="not a private key"):
+            prv_keyinfo_from_prv_key(a_point)  # type: ignore[arg-type]
 
 
 def test_no_key_material_in_exceptions() -> None:


### PR DESCRIPTION
The gate for the distinction https://github.com/btclib-org/btclib/issues/814
draws, which nothing checked: PR #818 put the rule in CONTRIBUTING.md and
PR #826 named the prefixes, but the walk still drove one mixed vocabulary
and asked only for a `BTClibException`.

## Two vocabularies, two rules

`_WRONG_TYPE` is a value of no type the alias declares; `_WRONG_VALUE` is
a value of a declared type that no valid input carries. Which dict a
value belongs in is the annotation's to decide — and every `_WRONG_VALUE`
entry type checks, which is the same line drawn twice.

- a **wrong type** leaves as a `BTClibTypeError`. Over every function the
  walk can drive, **with no exception** — which took one fix: `to_prv_key`
  flattened the two into one class, as `to_pub_key` did before #818, so a
  `Point` passed as a private key was a `NotAPrvKeyError` reporting three
  formats tried against a value none of them could hold.
  `_assert_prv_key_type` is `_assert_pub_key_type`'s twin.
- a **wrong value** leaves as a `BTClibException`, except the eleven that
  answer `False` — the nine script predicates, `b32.has_segwit_prefix`
  and `dleq.verify_proof`. That is the bool contract, and `_ANSWERS_FALSE`
  states it as one reason instead of as an exemption from a mixed rule.

`_OPEN` and `_EXCLUDED` go with it: nothing needs excusing from the type
rule, and what `_EXCLUDED` held *was* the bool contract. `_classify` goes
too — a hand-rolled three-way verdict had a branch for a native exception
nothing reaches, where `pytest.raises` names the class without one.

## The half a fixture must build

`tests/bool_contract_test.py` is the hand-written table
https://github.com/btclib-org/btclib/issues/776 §8 asked for. The
automatic walk cannot drive `dsa.verify`: it needs a valid message, key
and signature, and a `Sig | Octets` no vocabulary of wrong values can
make. Twelve functions the walk never saw, each with a call that answers
True — asserted, so a stale fixture cannot pass by answering False to
everything — and a wrong value per position.

**It found what #776 said a floor would find.** Sixteen positions do not
hold the two rules, each a line in one of two ratcheted lists naming what
comes out instead. Three shapes account for them, none a one-off:

| shape | where |
| --- | --- |
| a sequence parameter walked without being checked, so a `None` is "not iterable" | `ssa.batch_verify`'s three, `merkle_proof.verify`'s branch |
| a signature reaching `Sig.b64decode`, which strips before it decodes | `bms.verify`, `bip322.verify` |
| plain bytes handed to the bindings, whose own message says "the message hash must be bytes" | the two engine adapters |

`pedersen.verify` is the one that **answers** rather than raising —
reporting a commitment of no type at all as one that does not open, which
is the shape #776 put first. And the two value-rule entries are one:
`verify` reduces the message with `hf` *before* the `try`, so a message
that is no octets is refused where `verify_`, handed the hash, answers
False.

Fixing them is follow-up work and wants an issue of its own; this PR
makes them visible and unable to go stale.

## Two corrections to what these branches claimed

- **The four prefixes are a closed vocabulary *of prefixes***, not a
  requirement that every bool name carry one. Measured: fourteen public
  bool functions carry none — `b32.has_segwit_prefix`,
  `Block.has_segwit_tx`, `Psbt.inputs_modifiable`,
  `Miniscript.within_resource_limits` — and they are English predicates
  under the same contract. PR #826 said "closed vocabulary" flatly, which
  was wrong as written.
- **CONTRIBUTING.md now says both rules are gated and that neither holds
  everywhere yet**, naming where. That is the shape `exceptions.py`
  already uses for the exception contract: a rule with the ground it has
  not covered named rather than implied.

## And the question about `check_validity`

Answered in CONTRIBUTING.md rather than by a rename. It is a **parameter**,
where `check` is a verb governing an object — "check the validity" —
while a prefix on a function name classifies what the call answers; and
what it gates is `assert_valid`, a refusal. `validate` says no more, and
the alternative is renaming a keyword on eighty-odd public signatures for
a reading nobody has to make twice.

## Gates

- `uv run pytest` — 27093 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Split input validation into separate rules for wrong types and wrong values, enforce the bool/exception contracts across public APIs, and align private-key handling with the key-type error semantics.

New Features:
- Add a dedicated bool-contract test suite covering signature and proof verifications that require hand-built fixtures.

Bug Fixes:
- Ensure wrong-type inputs to private key converters raise BTClibTypeError instead of value/format-specific exceptions.
- Identify and track positions in verification functions that still return non-btclib errors or unexpected answers for malformed inputs.

Enhancements:
- Refine automated input validation tests to distinguish type errors from value errors and explicitly handle functions that legitimately answer False.
- Replace mixed exclusion lists with explicit vocabularies for wrong types, wrong values, and bool-returning functions, each ratcheting as coverage improves.
- Document the gated nature of the input-validation and bool contracts and clarify the naming and semantics of check_* prefixes and the check_validity parameter.

Documentation:
- Update CHANGELOG, HISTORY, and CONTRIBUTING to describe the separated input validation rules, bool contract coverage, and clarified naming conventions for check_* and check_validity.

Tests:
- Extend input validation tests with separate vocabularies for wrong types and wrong values and stricter expectations on BTClibTypeError vs BTClibException.
- Introduce tests/bool_contract_test.py to systematically exercise bool-returning verification APIs with valid fixtures and controlled wrong-type/wrong-value inputs.
- Tighten to_prv_key tests to assert BTClibTypeError for public-key types passed as private keys and remove unnecessary type-ignores.