### PR TITLE
Record two more libsecp256k1 ideas as measured and not taken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3661,6 +3661,29 @@ documented at release-notes length in the first place, and are still in
   arithmetic. The new `bench` dependency group installs the five
   comparands, and nothing else needs them.
 
+- **Two more libsecp256k1 ideas are recorded as measured and not taken**
+  (issue #835). `curve_group_2`'s list of them is there so that the same
+  idea does not arrive twice with the same measurement to make, and both
+  of these were measured while the `_var` census was being answered and
+  written down nowhere.
+
+  The lambda split's division, `secp256k1_scalar_mul_shift_var`:
+  `_multiplier_decomposer` rounds with `(_B2 * m + n // 2) // n`, 384 bits
+  by 256, where libsecp256k1 multiplies by a precomputed reciprocal. 0.24
+  us against 0.15, once per multiplication of some 700.
+
+  And the table built with no inversion at all, which is
+  `secp256k1_ecmult_odd_multiples_table` with
+  `secp256k1_ge_table_set_globalz`: the odd multiples formed on an
+  isomorphic curve where the doubled point is affine, the z-ratios kept as
+  they go, one common Z reached by products alone. The answer to that one
+  changed while it was being asked -- before issue #833 a call spent an
+  inversion per table and this would have removed all of them, and now it
+  spends one for the call, so what is left to remove is 7.4 us of a 700 us
+  `_mult` and of the 3667 us a 16-point `_multi_mult_var` takes. The rest
+  of that conversion is the three products an entry costs, which the
+  isomorphic construction pays in its own coin.
+
 ### Tests
 
 - **The input-validation gate's own verdict is exercised** (issue #776).

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -82,6 +82,23 @@ macOS arm64:
     - the masked table lookup of `secp256k1_ecmult_table_get_ge`, which
       reads every entry of a table under a cmov: a list index is a list
       index
+    - the lambda split's division by a multiply and a shift,
+      `secp256k1_scalar_mul_shift_var`: `_multiplier_decomposer` rounds
+      with `(_B2 * m + n // 2) // n`, 384 bits by 256, where libsecp256k1
+      multiplies by a precomputed reciprocal instead. 0.24 us against
+      0.15, once per multiplication of some 700
+    - the table built with no inversion at all,
+      `secp256k1_ecmult_odd_multiples_table` with
+      `secp256k1_ge_table_set_globalz`: the odd multiples are formed on an
+      isomorphic curve where the doubled point is affine, the z-ratios are
+      kept as they go, and the entries reach one common Z by products
+      alone. What it would remove is the single inversion a call now
+      spends, 7.4 us of a 700 us `_mult` and of the 3667 us a 16-point
+      `_multi_mult_var` takes; the rest of that conversion is the three
+      products an entry costs -- 21.9 us of the first, 253 of the second
+      -- and the isomorphic construction pays those in its own coin. An
+      accumulator that has to live in that frame and be rescaled out of it
+      at the end, for a ceiling of 1% and of 0.2%
     - the square root by an addition chain is the one of these that
       measures positive and is still not here: `pow(a, (p + 1) // 4, p)`
       is 73.6 us against the 63.6 of libsecp256k1's chain, which is 1.16x


### PR DESCRIPTION
curve_group_2's list of them is there so that the same idea does not
arrive twice with the same measurement to make. Both of these were
measured while the _var census was being answered, and written down
nowhere.

The lambda split's division, scalar_mul_shift_var:
_multiplier_decomposer rounds with (_B2 * m + n // 2) // n, 384 bits by
256, where libsecp256k1 multiplies by a precomputed reciprocal and
shifts. 0.24 us against 0.15, once per multiplication of some 700.

And the table built with no inversion at all, ecmult_odd_multiples_table
with ge_table_set_globalz: the odd multiples formed on an isomorphic
curve where the doubled point is affine, the z-ratios kept as they go,
one common Z reached by products alone.

The answer to the second changed while it was being asked. Before #833 a
call spent an inversion per table and this would have removed all of
them; now it spends one for the call, so what is left to remove is 7.4 us
of a 700 us _mult and of the 3667 us a 16-point _multi_mult_var takes.
The rest of that conversion is the three products an entry costs -- 21.9
us of the first and 253 of the second -- and the isomorphic construction
pays those in its own coin. An accumulator that has to live in that frame
and be rescaled out of it at the end, for a ceiling of 1% and of 0.2%.

Closes #835

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Document two additional evaluated libsecp256k1 optimization ideas as measured-but-not-adopted decisions and record their details alongside existing curve_group_2 notes.

Documentation:
- Expand CHANGELOG to describe two newly measured libsecp256k1 optimization ideas and why they were not taken.
- Extend curve_group_2 documentation to list these two optimization approaches with their performance characteristics and trade-offs.