### PR TITLE
Close the sixteen positions the bool gate held open (#814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2321,6 +2321,56 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **The sixteen positions the bool gate held open are closed** (issue
+  #814). `tests/bool_contract_test.py` drove twelve verifications the
+  automatic walk cannot reach and found sixteen positions where a wrong
+  type was not a `BTClibTypeError` or a wrong value was not `False`.
+  Four shapes accounted for all of them, and each is a way of being
+  handed an argument without looking at it:
+
+  A **sequence parameter** walked before it is checked, so a `None` left
+  the walk as "not iterable" -- `ssa.batch_verify`'s three and
+  `merkle_proof.verify`'s branch. `ssa._assert_batch_sequences` is asked
+  by both batch spellings, the reduction of `assert_batch_as_valid` being
+  ahead of the prepared one's zip, and `merkle_proof.assert_as_valid`
+  asks the same of its branch. A `str` stays a `Sequence` on purpose: run
+  time cannot tell `Sequence[Octets]` from `Sequence[str]`, so the
+  elements answer for their own values.
+
+  A **signature reaching `Sig.b64decode`**, which strips before it
+  decodes, so a type with no `strip` was an `AttributeError` --
+  `bms.verify` and `bip322.verify`. Both now coerce with
+  `utils.str_from_string`, which is what that function is for, and the
+  stripping still covers what came as bytes as well as what came as text.
+
+  An argument handed **straight to the bindings**, whose own `TypeError`
+  says "the message hash must be bytes" -- true, and not btclib saying
+  it. The two engine adapters ask `_assert_bytes_arguments` first, which
+  names the parameter that was wrong; they are called with stack
+  elements, so it is a few nanoseconds of a microsecond-scale
+  verification.
+
+  And a **reduction outside the `try`**: `dsa.verify`, `ssa.verify` and
+  `ssa.batch_verify` reduced the message with `hf` before entering it, so
+  a message that is no octets was refused where `verify_`, handed the
+  hash, answered False about it. All three wrap their own
+  `assert_as_valid` now instead of delegating past the reduction, which
+  makes the pair symmetric: the same question, the same answer, whichever
+  spelling a caller reaches for.
+
+  `pedersen.verify` is the one that answered rather than raising, a
+  `None` comparing unequal to every point, so a commitment of no type at
+  all was reported as one that does not open. `assert_as_valid` checks
+  the type and deliberately not `is_on_curve`: a pair of ints that is no
+  commitment is exactly what False is for.
+
+  **What moves for a caller**: `TypeError` and `BTClibException` catch
+  everything they caught. `dsa.verify(non_hex_str, key, sig)` is False
+  where it raised, and a `None` or a float in any of those positions is a
+  `BTClibTypeError` where it was a native `TypeError` or
+  `AttributeError` -- code catching those two builtins keeps working,
+  `BTClibTypeError` being a `TypeError`.
+
 - **A wrong type and a wrong value are two questions, and the gate asks
   them separately** (issue #814). `tests/input_validation_test.py` drove
   one mixed vocabulary and asserted a `BTClibException` came out, which

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -845,18 +845,24 @@ what issue #745 found and this replaces. The `assert_*` twin beside each
 of these is the spelling that says *why* a value was refused, and the two
 are how a caller chooses between an answer and a reason.
 
-**Both halves are gated, and neither holds everywhere yet.**
+**Both halves are gated, and both hold.**
 `tests/input_validation_test.py` drives the two rules over every public
-function whose required parameters are all library input types, and there
-they hold with no exception. `tests/bool_contract_test.py` drives them
-from hand-written fixtures over the verifications that walk cannot reach
-— a signature verification needs a valid message, key and signature — and
-there some positions are still open, each in a ratcheted list naming what
-comes out instead: a sequence parameter walked without being checked, a
-signature reaching `Sig.b64decode`'s `strip`, the engine adapters handing
-plain bytes to the bindings, and `verify` reducing its message before the
-`try` where `verify_` answers False. A fix cannot land without deleting
-its line, and a line cannot outlive the defect.
+function whose required parameters are all library input types.
+`tests/bool_contract_test.py` drives them from hand-written fixtures over
+the verifications that walk cannot reach — a signature verification needs
+a valid message, key and signature, and a `Sig | Octets` no vocabulary of
+wrong values can build. Neither has an exemption list, which is the state
+to keep: a finding is a red test, to be fixed or to be given a reason of
+its own beside the two families that have one.
+
+Four shapes were what the second gate found when it was written, and they
+are worth knowing because each is a way of being handed an argument
+without looking at it: a **sequence parameter** walked before it is
+checked, so a `None` is "not iterable" from underneath the library; a
+**signature** reaching `Sig.b64decode`, which strips before it decodes; an
+argument handed **straight to the bindings**, whose own message names a C
+parameter; and a **reduction outside the `try`**, which refuses a message
+`verify_` would answer False about.
 
 **Which of those a function is, its name says**, and the four prefixes
 below are a closed vocabulary *of prefixes*: a name carrying one promises

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,25 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **`dsa.verify` answers False for a message that is not octets, where
+  it raised.** It reduced the message with `hf` before the `try`, so a
+  hex string that is not hex was a `BTClibValueError` where `verify_`,
+  handed the hash, answered False about the same input. `ssa.verify` and
+  `ssa.batch_verify` did the same and move with it. Code that relied on
+  the refusal — a `try` around `verify` to catch a malformed message —
+  has to read the bool instead; `assert_as_valid` is the spelling that
+  still says why.
+
+  The other way round, a `None` or a float in a verification is a
+  `BTClibTypeError` now where it was a native `TypeError` or
+  `AttributeError`: `ssa.batch_verify`'s three sequences,
+  `merkle_proof.verify`'s branch, `bms.verify`'s and `bip322.verify`'s
+  signature, and both engine signature adapters. Code catching
+  `TypeError` keeps working, `BTClibTypeError` being one; code catching
+  `AttributeError` around one of those two `verify` calls has to catch
+  `TypeError` or `BTClibException`. `pedersen.verify` refuses a
+  commitment of a type no point has, where it answered False.
+
 - **eleven `check_*` functions are renamed, and the prefix means one
   thing.** It meant four at once: nine refusals returning `None`, two
   bool verdicts, a converter returning bytes and a query returning a

--- a/btclib/bip322.py
+++ b/btclib/bip322.py
@@ -111,7 +111,7 @@ from btclib.script.taproot import output_prvkey_from_merkle_root, output_pubkey
 from btclib.script.witness import Witness
 from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
-from btclib.utils import bytes_from_octets
+from btclib.utils import bytes_from_octets, str_from_string
 
 __all__ = [
     "FULL",
@@ -326,8 +326,11 @@ class Sig:
         what BIP322 says a verifier may assume of the implementations
         that predate them.
         """
-        text = data.decode("ascii") if isinstance(data, bytes) else data
-        text = text.strip()
+        # the coercion before the strip, as in `ecc.bms.Sig.b64decode`
+        # and for its reason: what is neither text nor bytes left
+        # `bip322.verify` as an AttributeError about a missing method
+        # rather than as a refusal of the argument (issue #814)
+        text = str_from_string(data, "base64 signature").strip()
         prefix = text[:_PREFIX_SIZE]
         if prefix not in _PREFIXES:
             prefix = SIMPLE

--- a/btclib/block/merkle_proof.py
+++ b/btclib/block/merkle_proof.py
@@ -88,6 +88,12 @@ def assert_as_valid(
     displayed in, which is what `Tx.id` and `BlockHeader.merkle_root`
     hold.
     """
+    # the branch before it is walked: what is not a sequence went to the
+    # comprehension below untouched, so a None left it as "not iterable"
+    # -- a complaint about iteration and not about a branch (issue #814)
+    if not isinstance(branch, Sequence):
+        raise BTClibTypeError(f"invalid branch type: {type(branch).__name__}")
+
     root = bytes_from_octets(merkle_root, 32)
     computed = merkle_root_from_branch(
         bytes_from_octets(txid, 32)[::-1],

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -126,7 +126,7 @@ from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import hash160, magic_message, reduce_to_hlen
 from btclib.network import network_from_name
 from btclib.to_prv_key import PrvKey, prv_keyinfo_from_prv_key
-from btclib.utils import assert_no_trailing, bytesio_from_binarydata
+from btclib.utils import assert_no_trailing, bytesio_from_binarydata, str_from_string
 
 __all__ = [
     "Sig",
@@ -241,11 +241,15 @@ class Sig:
         # take -- and every version discards the bits a non-final group
         # leaves over. What settles it everywhere is requiring the
         # canonical encoding, the one b64encode gives back.
-        # Stripping covers bytes as well as str: the whitespace around a
-        # copied and pasted signature is the one laxity worth tolerating
-        data = data.strip()
+        # the coercion before the strip, which is str's and bytes': what
+        # is neither reached it untouched, so `bms.verify` handed a type
+        # of its own choosing left as an AttributeError about a missing
+        # method (issue #814). Stripping then covers what came as bytes
+        # as well as what came as text: the whitespace around a copied
+        # and pasted signature is the one laxity worth tolerating
+        text = str_from_string(data, "base64 signature").strip()
         try:
-            data_bin = data.encode("ascii") if isinstance(data, str) else data
+            data_bin = text.encode("ascii")
             data_decoded = base64.b64decode(data_bin, validate=True)
         except ValueError as e:  # binascii.Error and UnicodeEncodeError
             raise BTClibValueError(f"invalid base64 encoding: {e}") from e

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -971,9 +971,17 @@ def verify(
     commit is reduced by hf as msg is; `verify_` is the spelling that
     takes the two hashes.
     """
-    msg_hash = reduce_to_hlen(msg, hf)
-    commit_hash = None if commit is None else reduce_to_hlen(commit, hf)
-    return verify_(msg_hash, key, sig, hf, commit_hash=commit_hash, receipt=receipt)
+    # ValueError and BTClibRuntimeError, as `ecc.dsa.verify_` catches them
+    # and for its reasons, which it states. `assert_as_valid` and not a
+    # delegation to the prepared spelling: the reduction has to be inside
+    # the try, or a message that is no octets is refused here where the
+    # hash spelling answers False about it (issue #814)
+    try:
+        assert_as_valid(msg, key, sig, hf, commit=commit, receipt=receipt)
+    except (ValueError, BTClibRuntimeError):
+        return False
+
+    return True
 
 
 def anti_exfil_host_commit(rho: Octets, hf: HashF = sha256) -> bytes:

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -29,7 +29,7 @@ from hashlib import sha256
 
 from btclib.alias import HashF, Point
 from btclib.curves import Curve, bytes_from_point, double_mult, secp256k1
-from btclib.exceptions import BTClibRuntimeError, BTClibValueError
+from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.utils import int_from_bits
 
 __all__ = [
@@ -107,7 +107,18 @@ def assert_as_valid(
 
     The commitment is recomputed and compared; verify is the boolean
     answer.
+
+    The type of the commitment is checked and its *value* is not: a
+    `None` compares unequal to every point, so `verify` reported a
+    commitment of no type at all as one that does not open, where a pair
+    of ints that is no commitment is exactly what False is for (issue
+    #814). `is_on_curve` is deliberately not asked -- that would refuse a
+    wrong value too.
     """
+    if not isinstance(commitment, tuple):
+        err_msg = f"invalid commitment type: {type(commitment).__name__}"  # type: ignore[unreachable]
+        raise BTClibTypeError(err_msg)
+
     if commitment != commit(r, v, ec, hf):
         raise BTClibRuntimeError("commitment verification failed")
 

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -679,10 +679,17 @@ def verify(
     commit is reduced by hf as msg is; `verify_` is the spelling that
     takes the two hashes.
     """
-    commit_hash = None if commit is None else reduce_to_hlen(commit, hf)
-    return verify_(
-        reduce_to_hlen(msg, hf), Q, sig, hf, commit_hash=commit_hash, receipt=receipt
-    )
+    # ValueError and BTClibRuntimeError, as `ecc.dsa.verify_` catches them
+    # and for its reasons, which it states. `assert_as_valid` and not a
+    # delegation to the prepared spelling: the reduction has to be inside
+    # the try, or a message that is no octets is refused here where the
+    # hash spelling answers False about it (issue #814)
+    try:
+        assert_as_valid(msg, Q, sig, hf, commit=commit, receipt=receipt)
+    except (ValueError, BTClibRuntimeError):
+        return False
+
+    return True
 
 
 def _recover_pub_key_(c: int, r: int, s: int, ec: Curve) -> int:
@@ -716,6 +723,26 @@ def _err_msg(size: int, msgs_or_sigs: str, arg2: Sequence[Octets | Sig]) -> str:
     return f"{err_msg} and number of {msgs_or_sigs} ({len(arg2)})"
 
 
+def _assert_batch_sequences(
+    msgs: Sequence[Octets], Qs: Sequence[BIP340PubKey], sigs: Sequence[Sig]
+) -> None:
+    """Refuse a batch parameter that is no sequence, naming which.
+
+    What is not one was walked untouched, so a None left the zip of
+    `assert_batch_as_valid_`, or the reduction of `assert_batch_as_valid`,
+    as "not iterable" -- a complaint about iteration, from underneath the
+    library, about a batch (issue #814). Both spellings ask it, the
+    reduction being ahead of the prepared one.
+
+    A `str` is a Sequence and stays one: run time cannot tell
+    Sequence[Octets] from Sequence[str], so the elements are what answer
+    for their own values.
+    """
+    for value, what in ((msgs, "msgs"), (Qs, "Qs"), (sigs, "sigs")):
+        if not isinstance(value, Sequence):
+            raise BTClibTypeError(f"invalid {what} type: {type(value).__name__}")
+
+
 def assert_batch_as_valid_(
     msgs: Sequence[Octets],
     Qs: Sequence[BIP340PubKey],
@@ -738,6 +765,9 @@ def assert_batch_as_valid_(
     # ahead of everything, as in assert_as_valid_ and for the same reason:
     # batch_verify_ turns a ValueError into False
     _assert_valid_hf(hf)
+
+    # and the three sequences, for that reason again
+    _assert_batch_sequences(msgs, Qs, sigs)
 
     batch_size = len(Qs)
     if batch_size == 0:
@@ -819,6 +849,10 @@ def assert_batch_as_valid(
     hf: HashF = sha256,
 ) -> None:
     """Refuse an invalid signature in a batch, reducing each message."""
+    # ahead of the reduction, which walks `ms`: the prepared spelling asks
+    # the same thing, and neither can rely on the other having asked
+    _assert_batch_sequences(ms, Qs, sigs)
+
     msgs = [reduce_to_hlen(msg, hf) for msg in ms]
     return assert_batch_as_valid_(msgs, Qs, sigs, hf)
 
@@ -854,5 +888,14 @@ def batch_verify(
     hf: HashF = sha256,
 ) -> bool:
     """Batch verification of BIP340 signatures."""
-    msgs = [reduce_to_hlen(msg, hf) for msg in ms]
-    return batch_verify_(msgs, Qs, sigs, hf)
+    # ValueError and BTClibRuntimeError, as `ecc.dsa.verify_` catches them
+    # and for its reasons, which it states. `assert_batch_as_valid` and not a
+    # delegation to the prepared spelling: the reduction has to be inside
+    # the try, or a message that is no octets is refused here where the
+    # hash spelling answers False about it (issue #814)
+    try:
+        assert_batch_as_valid(ms, Qs, sigs, hf)
+    except (ValueError, BTClibRuntimeError):
+        return False
+
+    return True

--- a/btclib/script/engine/script.py
+++ b/btclib/script/engine/script.py
@@ -12,7 +12,12 @@ from btclib_secp256k1.dsa import verify as _libsecp256k1_dsa_verify
 
 from btclib.alias import ScriptList
 from btclib.ecc.dsa import Sig
-from btclib.exceptions import BTClibRuntimeError, BTClibValueError, ScriptError
+from btclib.exceptions import (
+    BTClibRuntimeError,
+    BTClibTypeError,
+    BTClibValueError,
+    ScriptError,
+)
 from btclib.script import sig_hash
 from btclib.script.engine import script_op_codes
 from btclib.script.engine.flags import ScriptFlag
@@ -57,6 +62,20 @@ __all__ = [
 ]
 
 
+def _assert_bytes_arguments(**arguments: object) -> None:
+    """Refuse an argument that is not `bytes`, naming the parameter.
+
+    The two signature adapters of this package declare `bytes` exactly
+    and hand it straight to the bindings, whose own message would name a
+    C parameter -- "the message hash must be bytes" is true and is not
+    btclib saying it (issue #814). Keyword arguments, so that what comes
+    out names the one that was wrong.
+    """
+    for what, value in arguments.items():
+        if not isinstance(value, bytes):
+            raise BTClibTypeError(f"invalid {what} type: {type(value).__name__}")
+
+
 def dsa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:
     """Verify an ECDSA signature, returning False if it is malformed.
 
@@ -64,7 +83,15 @@ def dsa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:
     libsecp256k1 refuses to parse, while the engine treats it as a failed
     verification: DER strictness is enforced upstream, by fix_signature,
     under the STRICT_DER_FLAGS below.
+
+    `bytes` and nothing wider, which is what the three declare: the
+    bindings would answer a float with "the message hash must be bytes",
+    which is true and is not btclib saying it. Every caller here hands
+    stack elements, so the check costs a few nanoseconds of a
+    microsecond-scale verification (issue #814).
     """
+    _assert_bytes_arguments(msg_hash=msg_hash, pub_key=pub_key, sig=sig)
+
     try:
         return bool(_libsecp256k1_dsa_verify(msg_hash, pub_key, sig))
     except ValueError:

--- a/btclib/script/engine/tapscript.py
+++ b/btclib/script/engine/tapscript.py
@@ -17,7 +17,10 @@ from btclib.hashes import tagged_hash
 from btclib.script import sig_hash
 from btclib.script.engine import script_op_codes
 from btclib.script.engine.flags import ScriptFlag
-from btclib.script.engine.script import EVALUATED_WHEN_UNEXECUTED
+from btclib.script.engine.script import (
+    EVALUATED_WHEN_UNEXECUTED,
+    _assert_bytes_arguments,
+)
 from btclib.script.engine.script_op_codes import ScriptOp
 from btclib.script.limits import MAX_SCRIPT_ELEMENT_SIZE
 from btclib.script.op_codes_tapscript import OP_CODE_NAMES
@@ -46,7 +49,12 @@ def ssa_verify(msg_hash: bytes, pub_key: bytes, sig: bytes) -> bool:
     The bindings raise a ValueError on a signature or x-only public key
     that libsecp256k1 refuses to parse, while the caller treats it as a
     failed verification and raises BTClibValueError itself.
+
+    `bytes` and nothing wider, as in `engine.script.dsa_verify` and for
+    its reason.
     """
+    _assert_bytes_arguments(msg_hash=msg_hash, pub_key=pub_key, sig=sig)
+
     try:
         return bool(_libsecp256k1_ssa_verify(msg_hash, pub_key, sig))
     except ValueError:

--- a/tests/bool_contract_test.py
+++ b/tests/bool_contract_test.py
@@ -29,25 +29,23 @@ valid:
 Issue #814 settled the second against issue #745's "total over everything
 it is handed", and this is where the decision is held to.
 
-## The two open lists, and which way they ratchet
+## Both rules hold, and they did not when this file was written
 
-Reaching new ground found new findings, which is what issue #776 said its
-own floor of fifty-nine would do. `_TYPE_OPEN` and `_VALUE_OPEN` are
-those, one entry per position, each naming what comes out instead. They
-can only shrink: `test_what_is_open_is_still_open` fails on an entry that
-has come into line, as RUF100 fails an unused `noqa`, so a fix cannot
-land without deleting its line -- and a line cannot outlive the defect.
+Reaching ground the automatic walk cannot touch found sixteen positions
+open, which is what issue #776 said a floor would do, and they were held
+in two ratcheted lists until they were closed. Three shapes accounted for
+them, so the fixes are where the shapes are: a sequence parameter checked
+before it is walked (`ssa._assert_batch_sequences`,
+`merkle_proof.assert_as_valid`), a signature coerced by `str_from_string`
+before `Sig.b64decode` strips it, and the engine adapters asking
+`_assert_bytes_arguments` before the bindings would. The two value-rule
+entries were one shape as well: `verify` reduced the message *before* its
+`try`, so a message that is no octets was refused where `verify_`, handed
+the hash, answered False; both spellings wrap `assert_as_valid` now
+instead of delegating past the reduction.
 
-Three shapes are in them. A **sequence parameter** -- `batch_verify`'s
-three, `merkle_proof.verify`'s branch -- is walked without being checked,
-so a `None` is "not iterable" from underneath the library. A **signature
-parameter** reaches `Sig.b64decode`, which strips before it decodes, so a
-type with no `strip` is an `AttributeError`. And the **engine adapters**
-take plain `bytes` and hand them to the bindings, whose own `TypeError`
-says "the message hash must be bytes" -- true, and not btclib saying it.
-The two `_VALUE_OPEN` shapes are one: `verify` reduces the message with
-`hf` *before* the `try`, so a message that is no octets is refused where
-`verify_`, handed the hash, answers False.
+No list is left, and that is deliberate: a finding this file makes next is
+a red test above, to be fixed or to be given a reason of its own.
 
 What no fixture here reaches, and why: `musig2.partial_sig_verify_` and
 `partial_sig_verify` want a `SessionContext` and a signing round,
@@ -207,48 +205,6 @@ _CASES = (
 
 _IDS = tuple(case.label for case in _CASES)
 
-# each entry names the class that comes out where a BTClibTypeError
-# belongs; the module docstring has the three shapes behind them
-_TYPE_OPEN: dict[str, str] = {
-    "bip322.verify[2]": "AttributeError",
-    "bms.verify[2]": "AttributeError",
-    "engine.script.dsa_verify[0]": "TypeError",
-    "engine.script.dsa_verify[1]": "TypeError",
-    "engine.script.dsa_verify[2]": "TypeError",
-    "engine.tapscript.ssa_verify[0]": "TypeError",
-    "engine.tapscript.ssa_verify[1]": "TypeError",
-    "engine.tapscript.ssa_verify[2]": "TypeError",
-    "merkle_proof.verify[1]": "TypeError",
-    # the one that answers rather than raising, which is the shape issue
-    # #776 put first because it is the only one that can cost money: a
-    # commitment of no type at all is reported as one that does not open
-    "pedersen.verify[2]": "answers False",
-    "ssa.batch_verify[0]": "TypeError",
-    "ssa.batch_verify[1]": "TypeError",
-    "ssa.batch_verify[2]": "TypeError",
-}
-
-# one shape, and `verify_` beside each of these is where it is not: the
-# message is reduced before the `try`, so a message that is no octets is
-# refused where the hash spelling answers False
-_VALUE_OPEN: dict[str, str] = {
-    "dsa.verify[0]": "BTClibValueError",
-    "ssa.batch_verify[0]": "BTClibValueError",
-    "ssa.verify[0]": "BTClibValueError",
-}
-
-
-def _at(label: str, position: int) -> str:
-    """Return the key both open lists are read by."""
-    return f"{label}[{position}]"
-
-
-def _case_of(at: str) -> tuple[_Case, int]:
-    """Return the case and the position an open entry names."""
-    label, _, rest = at.partition("[")
-    case = next(c for c in _CASES if c.label == label)
-    return case, int(rest.rstrip("]"))
-
 
 def _outcome(case: _Case, position: int, wrong: Any) -> str:
     """Return what came out: the class raised, or the answer given."""
@@ -276,8 +232,6 @@ def test_the_call_answers_true(case: _Case) -> None:
 def test_a_wrong_type_leaves_as_a_btclib_type_error(case: _Case) -> None:
     """The first rule, one position at a time, the others left valid."""
     for position in range(len(case.args)):
-        if _at(case.label, position) in _TYPE_OPEN:
-            continue
         for wrong in _WRONG_TYPES:
             assert _outcome(case, position, wrong) == "BTClibTypeError"
 
@@ -286,41 +240,4 @@ def test_a_wrong_type_leaves_as_a_btclib_type_error(case: _Case) -> None:
 def test_a_wrong_value_answers_false(case: _Case) -> None:
     """The second rule: a value of a declared type is answered, not refused."""
     for position, wrong in sorted(case.wrong_values.items()):
-        if _at(case.label, position) in _VALUE_OPEN:
-            continue
         assert _outcome(case, position, wrong) == "answers False"
-
-
-@pytest.mark.parametrize("at", sorted(_TYPE_OPEN))
-def test_what_the_type_rule_holds_open_is_still_open(at: str) -> None:
-    """A fix cannot land without deleting its line from `_TYPE_OPEN`."""
-    case, position = _case_of(at)
-    assert _outcome(case, position, _WRONG_TYPES[0]) == _TYPE_OPEN[at], (
-        f"{at} no longer answers a wrong type with {_TYPE_OPEN[at]}: delete"
-        " its line, or correct it to what it answers with now"
-    )
-
-
-@pytest.mark.parametrize("at", sorted(_VALUE_OPEN))
-def test_what_the_value_rule_holds_open_is_still_open(at: str) -> None:
-    """A fix cannot land without deleting its line from `_VALUE_OPEN`."""
-    case, position = _case_of(at)
-    wrong = case.wrong_values[position]
-    assert _outcome(case, position, wrong) == _VALUE_OPEN[at], (
-        f"{at} no longer answers a wrong value with {_VALUE_OPEN[at]}:"
-        " delete its line, or correct it to what it answers with now"
-    )
-
-
-def test_every_open_entry_names_a_driven_position() -> None:
-    """Neither list may name a position no case drives.
-
-    A renamed case, or a position dropped from `wrong_values`, would
-    otherwise leave an entry excusing something nothing runs.
-    """
-    for at in sorted(_TYPE_OPEN):
-        case, position = _case_of(at)
-        assert position < len(case.args), at
-    for at in sorted(_VALUE_OPEN):
-        case, position = _case_of(at)
-        assert position in case.wrong_values, at


### PR DESCRIPTION
`tests/bool_contract_test.py`, landed in
https://github.com/btclib-org/btclib/pull/832, drove twelve verifications
the automatic walk cannot reach and found sixteen positions where a wrong
type was not a `BTClibTypeError` or a wrong value was not `False`. This
closes all sixteen, so **neither gate has an exemption list any more**.

Four shapes accounted for every one of them, and each is a way of being
handed an argument without looking at it — which is why they are worth
naming rather than patching one by one.

| shape | where | fix |
| --- | --- | --- |
| a **sequence** walked before it is checked, so a `None` is "not iterable" | `ssa.batch_verify`'s three, `merkle_proof.verify`'s branch | `ssa._assert_batch_sequences`, asked by *both* batch spellings; `merkle_proof.assert_as_valid` asks it of its branch |
| a **signature** reaching `Sig.b64decode`, which strips before it decodes | `bms.verify`, `bip322.verify` | both coerce with `utils.str_from_string`, which is what it is for |
| an argument handed **straight to the bindings**, whose `TypeError` names a C parameter | the two engine adapters | `_assert_bytes_arguments`, naming the parameter that was wrong |
| a **reduction outside the `try`** | `dsa.verify`, `ssa.verify`, `ssa.batch_verify` | each wraps its own `assert_as_valid` instead of delegating past the reduction |

A `str` stays a `Sequence` on purpose: run time cannot tell
`Sequence[Octets]` from `Sequence[str]`, so the elements answer for their
own values.

`pedersen.verify` is the one that **answered** rather than raising — a
`None` compares unequal to every point, so a commitment of no type at all
was reported as one that does not open. `assert_as_valid` checks the type
and deliberately *not* `is_on_curve`: a pair of ints that is no commitment
is exactly what False is for, and checking the curve would refuse a wrong
value too.

## The reduction fix is worth a second look

`verify` reduced the message with `hf` *before* entering the `try`, so
`dsa.verify("not hex at all", key, sig)` raised where
`dsa.verify_(hash, key, sig)` answered False about the same input. All
three now wrap their own `assert_as_valid`, which puts the reduction
inside the `try` and makes the pair symmetric — the same question, the
same answer, whichever spelling a caller reaches for. A bad `hf` still
raises: `_assert_valid_hf` gives a `BTClibTypeError`, and no `TypeError`
is in the `except`.

It is the one change here a caller can be relying on, so it has a
HISTORY.md bullet of its own.

## Gates

- `uv run pytest` — 27076 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

Coverage staying at 100% is worth noting: every refusal added here is
exercised by the two gates, not by a test written to cover it.

CONTRIBUTING.md drops "neither holds everywhere yet" and keeps the four
shapes — they are what to look for the next time a public function takes
an argument it does not check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Align verification APIs with the bool contract by closing all remaining exceptions where invalid inputs previously raised non-BTClibTypeError exceptions or returned True, and by ensuring malformed but typed inputs yield False consistently across verify/verify_ pairs.

Bug Fixes:
- Normalize error handling in dsa/ssa verify and batch_verify so that message reduction occurs inside try blocks and malformed messages produce False instead of propagating ValueError/BTClibRuntimeError.
- Ensure Pedersen commitments of invalid types raise BTClibTypeError instead of silently failing verification as False.
- Validate sequence-typed batch verification inputs in SSA and Merkle proof branches to raise BTClibTypeError rather than low-level TypeError on iteration.
- Harden BMS and BIP322 signature base64 decoding to coerce inputs via str_from_string, avoiding AttributeError from unexpected types.
- Ensure script and tapscript engine adapters validate bytes arguments explicitly, surfacing BTClibTypeError instead of libsecp256k1 C-layer TypeError messages.

Enhancements:
- Remove bool_contract_test exemption lists now that all covered verification positions comply with the type/value bool gate rules.
- Document the closure of the sixteen open bool-gate positions and the behavioral change to dsa/ssa verify semantics in CHANGELOG and HISTORY.
- Clarify CONTRIBUTING guidance on the two input-validation gates and the four anti-pattern “shapes” to watch for in new public APIs.

Tests:
- Tighten bool_contract_test to enforce that all driven positions now satisfy the BTClibTypeError/False contract without exemptions.