### PR TITLE
Floor every package the benchmark measures against

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -800,6 +800,37 @@ documented at release-notes length in the first place, and are still in
   allowlist, and `docs/source/package-content-policy.md` states it beside
   the rest.
 
+- **Every package the benchmark measures against has a floor** (issue
+  #837). The five names of the `bench` group -- what
+  `scripts/benchmark_libraries.py` times btclib against -- were bare, so
+  the comparison was against whatever a resolver happened to give. They
+  carry a floor at their latest release now: `buidl>=0.2.36`,
+  `ecdsa>=0.19.2`, `embit>=0.8.0`, `pycoin>=0.92718.20260405`,
+  `python-bitcoinlib>=0.12.2`.
+
+  A floor and not a pin, because the premise the bare names were for is
+  still right: the comparison is against whatever `pip install` currently
+  gives a user, so a new release is to be picked up and measured rather
+  than refused. What a bare name allowed is the other direction -- an
+  ancient release answering the comparison in silence, and a table saying
+  btclib is faster than a version nobody runs.
+
+  `ecdsa` is where that stopped being theoretical. GHSA-wj6h-64fc-37mp,
+  the Minerva timing attack on P-256, names every version of python-ecdsa
+  and no patched one: it is pure Python and says of itself that it is not
+  side-channel resistant, which is the property `SECURITY.md` publishes
+  about this library's own Python path. **The floor does not close that
+  alert and is not offered as closing it** -- every version is in range,
+  which is also why Dependabot has opened no pull request, there being
+  nothing to rise to. What it records is which release the advisory was
+  read against, and the same is now true of the other four.
+
+  Each floor is the version `uv.lock` already resolved to, so nothing
+  installed today moves and the lock changes by the five lines that carry
+  the specifiers. Raising one is what a measurement asks for and not what
+  a resolver does: the numbers the benchmark prints belong to the versions
+  the file names.
+
 ### Transactions, blocks and PSBT
 
 - **BIP375's Signer and Transaction Extractor** (#760, following #641).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,14 +108,37 @@ lint = ["mypy", "pre-commit", "ruff"]
 build = ["check-manifest", "check-wheel-contents", "pyroma", "twine"]
 mutation = ["cosmic-ray"]
 docs = ["myst-parser", "sphinx", "sphinx_rtd_theme"]
-# what scripts/benchmark_libraries.py times btclib against, at each
-# package's own latest release: no pin of its own, matching the
-# benchmark's premise that the comparison is against whatever `pip
-# install` currently gives a user. Not in `dev`, for the same reason
+# what scripts/benchmark_libraries.py times btclib against, each with a
+# floor at its latest release. Not in `dev`, for the same reason
 # btclib-secp256k1's own `bench` group is not: nothing else needs any of
-# these five, and a lint or type-check run that does not touch the
-# script should not have to resolve them
-bench = ["buidl", "ecdsa", "embit", "pycoin", "python-bitcoinlib"]
+# these five, and a lint or type-check run that does not touch the script
+# should not have to resolve them.
+#
+# A floor and not a pin: the benchmark's premise is that the comparison is
+# against whatever `pip install` currently gives a user, so a new release
+# is to be picked up and measured, not refused. What the bare names these
+# were let happen is the other direction -- an ancient release answering
+# the comparison in silence, and a table saying btclib is faster than a
+# version nobody runs.
+#
+# `ecdsa` is where that stopped being theoretical: GHSA-wj6h-64fc-37mp,
+# the Minerva timing attack on P-256, names every version of it and no
+# patched one, python-ecdsa being pure Python and saying of itself that it
+# is not side-channel resistant -- which is what SECURITY.md publishes
+# about this library's own Python path. The floor does not close that
+# alert and is not meant to; what it does is record which release the
+# advisory was read against, and the same is now true of the other four.
+#
+# Raising a floor is what a measurement asks for, not what a resolver
+# does: the numbers in the benchmark's own output belong to the versions
+# named here
+bench = [
+    "buidl>=0.2.36",
+    "ecdsa>=0.19.2",
+    "embit>=0.8.0",
+    "pycoin>=0.92718.20260405",
+    "python-bitcoinlib>=0.12.2",
+]
 dev = [
     { include-group = "test" },
     { include-group = "lint" },

--- a/uv.lock
+++ b/uv.lock
@@ -386,11 +386,11 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 bench = [
-    { name = "buidl" },
-    { name = "ecdsa" },
-    { name = "embit" },
-    { name = "pycoin" },
-    { name = "python-bitcoinlib" },
+    { name = "buidl", specifier = ">=0.2.36" },
+    { name = "ecdsa", specifier = ">=0.19.2" },
+    { name = "embit", specifier = ">=0.8.0" },
+    { name = "pycoin", specifier = ">=0.92718.20260405" },
+    { name = "python-bitcoinlib", specifier = ">=0.12.2" },
 ]
 build = [
     { name = "check-manifest" },


### PR DESCRIPTION
The five names of the bench group -- what scripts/benchmark_libraries.py
times btclib against -- were bare, so the comparison was against whatever
a resolver happened to give. They carry a floor at their latest release
now: buidl>=0.2.36, ecdsa>=0.19.2, embit>=0.8.0,
pycoin>=0.92718.20260405, python-bitcoinlib>=0.12.2.

A floor and not a pin, because the premise the bare names were for is
still right: the comparison is against whatever pip install currently
gives a user, so a new release is to be picked up and measured rather
than refused. What a bare name allowed is the other direction -- an
ancient release answering the comparison in silence, and a table saying
btclib is faster than a version nobody runs.

ecdsa is where that stopped being theoretical. GHSA-wj6h-64fc-37mp, the
Minerva timing attack on P-256, names every version of python-ecdsa and
no patched one: it is pure Python and says of itself that it is not
side-channel resistant, which is the property SECURITY.md publishes about
this library's own Python path. The floor does not close that alert and
is not offered as closing it -- every version is in range, which is also
why Dependabot has opened no pull request, there being nothing to rise
to. What it records is which release the advisory was read against, and
the same is now true of the other four.

Each floor is the version uv.lock already resolved to, so nothing
installed today moves and the lock changes by the five lines that carry
the specifiers.

Closes #837

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add minimum version constraints for benchmark dependency packages to ensure results are tied to current releases while still tracking future updates.

Enhancements:
- Set version floors for all libraries used in the benchmark group so comparisons are made against at least the latest known releases.

Documentation:
- Document the new benchmark dependency floors and their rationale, including the security advisory context for python-ecdsa, in the changelog.