### PR TITLE
Give every public bool a name the vocabulary knows (#814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2382,6 +2382,40 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **Every public `bool` is named by the vocabulary now** (issue #814).
+  The four prefixes promised a shape to a caller who saw one and said
+  nothing about a bool carrying none, and seven carried none. Each is
+  renamed for what it answers:
+  `b32.has_segwit_prefix` is `is_segwit_prefixed`,
+  `BlockContext.bip34_active` is `is_bip34_active`,
+  `Miniscript.within_resource_limits` is `is_within_resource_limits`,
+  `hwi.available` is `is_available`,
+  `CurveGroup.jac_equality` is `is_jac_equal`,
+  `Block.has_segwit_tx` is `is_segwit`, and
+  `Miniscript.needs_signature` is `is_signature_required`.
+
+  Three of those are worth a word. `jac_equality` was a *noun*, so it read
+  as a thing rather than as a question, and it is the only one of the
+  seven that takes arguments. `Block.is_segwit` joins the
+  `Tx.is_segwit` its body is computed from -- `any(tx.is_segwit() for tx
+  in self.transactions)` -- so one property is one name at both levels.
+  And `is_signature_required` is what that docstring already said: "every
+  satisfaction requires a signature".
+
+  Six keep their names, and `tests/name_contract_test.py` says why one by
+  one: `Miniscript.mixes_timelocks` and `has_duplicate_keys` are BIP379's
+  own words, the three `Psbt` bits are named after
+  PSBT_GLOBAL_TX_MODIFIABLE, and `miniscript.reads_back` is the round
+  trip as a question -- `is_read_back` would ask who reads it. What closes
+  the vocabulary is not the renaming but the gate beside it: a public bool
+  that neither carries a prefix nor is named in that list fails, and an
+  entry that has gained a prefix fails too. `check_` drifted to four
+  meanings because nothing could notice; this is what noticing looks like.
+
+  `tests/_data/miniscript_fixed_tests.json` keeps its `needs_signature`
+  key, that file being upstream's, and the test maps the vendor's key to
+  btclib's property with a comment saying so.
+
 - **The sixteen positions the bool gate held open are closed** (issue
   #814). `tests/bool_contract_test.py` drove twelve verifications the
   automatic walk cannot reach and found sixteen positions where a wrong

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -864,11 +864,14 @@ argument handed **straight to the bindings**, whose own message names a C
 parameter; and a **reduction outside the `try`**, which refuses a message
 `verify_` would answer False about.
 
-**Which of those a function is, its name says**, and the four prefixes
-below are a closed vocabulary *of prefixes*: a name carrying one promises
-that shape. It is not a requirement that every bool name carry one —
-`b32.has_segwit_prefix`, `Block.has_segwit_tx` and
-`Psbt.inputs_modifiable` are English predicates under the same contract.
+**Which of those a function is, its name says**, and the vocabulary is
+closed: a public function that answers a `bool` carries one of the four
+prefixes below, or is one of the English predicates
+`tests/name_contract_test.py` names — `Psbt.inputs_modifiable` and
+`Miniscript.mixes_timelocks` among them, where the name is the standard's
+and `is_` would cost the reading. A bool that is neither fails that gate,
+so a new one is a prefix or a decision somebody wrote down.
+
 What the four buy is a promise read off the name:
 
 - `assert_*` refuses and returns `None`. There are eighty-odd of them

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,22 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **seven public `bool` names carry a prefix now.**
+  `b32.has_segwit_prefix` is `b32.is_segwit_prefixed`,
+  `BlockContext.bip34_active` is `is_bip34_active`,
+  `Block.has_segwit_tx` is `Block.is_segwit`,
+  `Miniscript.within_resource_limits` is `is_within_resource_limits`,
+  `Miniscript.needs_signature` is `is_signature_required`,
+  `CurveGroup.jac_equality` is `is_jac_equal`, and `hwi.available` is
+  `hwi.is_available`. Old name, `AttributeError` or `ImportError`; new
+  name, same answer, no change of signature or behaviour.
+
+  Six other bools keep an English name — `Psbt.inputs_modifiable`,
+  `Psbt.outputs_modifiable`, `Psbt.has_sig_hash_single`,
+  `Miniscript.mixes_timelocks`, `Miniscript.has_duplicate_keys` and
+  `miniscript.reads_back` — where the name is the standard's and a prefix
+  would cost the reading. Those are unchanged.
+
 - **`dsa.verify` answers False for a message that is not octets, where
   it raised.** It reduced the message with `hf` before the `try`, so a
   hex string that is not hex was a `BTClibValueError` where `verify_`,

--- a/btclib/b32.py
+++ b/btclib/b32.py
@@ -65,7 +65,7 @@ from btclib.utils import bytes_from_octets, str_from_string
 __all__ = [
     "address_from_witness",
     "bytes_from_witness_program",
-    "has_segwit_prefix",
+    "is_segwit_prefixed",
     "p2tr",
     "p2wpkh",
     "p2wsh",
@@ -76,7 +76,7 @@ __all__ = [
 # 0. bech32 facilities
 
 
-def has_segwit_prefix(addr: String) -> bool:
+def is_segwit_prefixed(addr: String) -> bool:
     """Answer whether the string starts as a bech32 address of any network.
 
     The prefix alone -- hrp and the 1 separator -- is read; whether the

--- a/btclib/bip21.py
+++ b/btclib/bip21.py
@@ -77,7 +77,7 @@ _MALFORMED_ESCAPE = re.compile(r"%(?![0-9A-Fa-f]{2})")
 
 def _network_from_address(address: str) -> str:
     """Return the network of an address, raising if it is not one."""
-    if b32.has_segwit_prefix(address):
+    if b32.is_segwit_prefixed(address):
         return b32.witness_from_address(address)[2]
     return b58.h160_from_address(address)[2]
 

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -244,7 +244,7 @@ class Block:
             check_validity=check_validity,
         )
 
-    def has_segwit_tx(self) -> bool:
+    def is_segwit(self) -> bool:
         """Answer whether any transaction carries a witness."""
         return any(tx.is_segwit() for tx in self.transactions)
 
@@ -386,7 +386,7 @@ class Block:
         witnesses of a block can be replaced wholesale, header and root
         untouched, and the signatures they carry are worth nothing.
         """
-        if not self.has_segwit_tx():
+        if not self.is_segwit():
             # Nothing to commit to, and nothing to check it against: this
             # is a block as a legacy node sees it, witnesses stripped by
             # the serialization, which btclib parses and this library
@@ -442,7 +442,7 @@ class Block:
         `bip34_commitment` is what the comparison is against.
 
         Which height, and whether BIP34 is in force at all, are the
-        caller's to say: the second is `BlockContext.bip34_active`, and
+        caller's to say: the second is `BlockContext.is_bip34_active`, and
         `assert_valid_contextual` is what applies it. Nothing is skipped
         here, so a caller that knows the rule binds can ask for it
         directly -- which is the only way to ask it of a block whose
@@ -487,7 +487,7 @@ class Block:
 
         self.header.assert_valid_time(context.now)
 
-        if context.bip34_active:
+        if context.is_bip34_active:
             self.assert_valid_coinbase_height(context.height)
 
     def assert_valid(self, pow_limit_bits: Octets = MAINNET_POW_LIMIT_BITS) -> None:

--- a/btclib/block/block_context.py
+++ b/btclib/block/block_context.py
@@ -70,7 +70,7 @@ class BlockContext:
     bip34_height: int = BIP34_HEIGHT
 
     @property
-    def bip34_active(self) -> bool:
+    def is_bip34_active(self) -> bool:
         """Whether the coinbase must commit to the height (BIP34).
 
         Core's `DeploymentActiveAfter(pindexPrev, DEPLOYMENT_HEIGHTINCB)`,

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -349,7 +349,7 @@ class CurveGroup:
         Z2 = Q[2] * Q[2]
         return (Q[1] * mod_inv(Z2 * Q[2], self.p)) % self.p
 
-    def jac_equality(self, QJ: JacPoint, PJ: JacPoint) -> bool:
+    def is_jac_equal(self, QJ: JacPoint, PJ: JacPoint) -> bool:
         """Return True if Jacobian points are equal in affine coordinates.
 
         The input points are assumed to be on curve.

--- a/btclib/descriptors/miniscript.py
+++ b/btclib/descriptors/miniscript.py
@@ -1146,7 +1146,7 @@ class Miniscript:
         return _has(self.properties, "m")
 
     @property
-    def needs_signature(self) -> bool:
+    def is_signature_required(self) -> bool:
         """Answer whether every satisfaction requires a signature."""
         return _has(self.properties, "s")
 
@@ -1266,7 +1266,7 @@ class Miniscript:
         return self.max_stack_items is not None
 
     @property
-    def within_resource_limits(self) -> bool:
+    def is_within_resource_limits(self) -> bool:
         """Answer whether a satisfaction is guaranteed to be spendable.
 
         The limits that depend on the satisfaction rather than on the
@@ -1289,7 +1289,7 @@ class Miniscript:
     def is_sane_subexpression(self) -> bool:
         """Answer whether the expression means what it says, as a part."""
         return (
-            self.within_resource_limits
+            self.is_within_resource_limits
             and self.is_non_malleable
             and not self.mixes_timelocks
             and not self.has_duplicate_keys
@@ -1308,7 +1308,7 @@ class Miniscript:
         return (
             self.is_valid_top_level
             and self.is_sane_subexpression
-            and self.needs_signature
+            and self.is_signature_required
         )
 
     @property
@@ -2725,7 +2725,7 @@ def _assert_sane(node: Miniscript) -> None:
         raise BTClibValueError(f"{node} is not satisfiable")
     if not insane.is_non_malleable:
         raise BTClibValueError(f"{insane} is not sane: malleable witnesses exist")
-    if insane is node and not insane.needs_signature:
+    if insane is node and not insane.is_signature_required:
         err_msg = f"{insane} is not sane: witnesses without signature exist"
         raise BTClibValueError(err_msg)
     if insane.mixes_timelocks:

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -116,7 +116,7 @@ from dataclasses import dataclass
 from hashlib import sha256
 
 from btclib.alias import BinaryData, Octets, String
-from btclib.b32 import has_segwit_prefix, p2wpkh, witness_from_address
+from btclib.b32 import is_segwit_prefixed, p2wpkh, witness_from_address
 from btclib.b58 import h160_from_address, p2pkh, p2wpkh_p2sh, wif_from_prv_key
 from btclib.curves import bytes_from_point, bytes_from_prv_key_int, secp256k1
 from btclib.curves.curve import _libsecp256k1_applicable
@@ -409,7 +409,7 @@ def assert_as_valid(msg: Octets, addr: String, sig: Sig | String) -> None:
     # carries the recovery-flag range that belongs to its type: the flag
     # is what the signer said the address was, so a flag outside the range
     # is a signature for a different address type
-    if has_segwit_prefix(addr):
+    if is_segwit_prefixed(addr):
         _assert_p2wpkh(addr, sig.rf, pub_key)
         return
 

--- a/btclib/hwi.py
+++ b/btclib/hwi.py
@@ -56,7 +56,7 @@ that is not about a device -- the executable is not installed -- is the
 `SignerNotFoundError` subclass, so that a caller which also offers
 signers of other kinds can tell "no hardware here" from "the hardware
 could not be reached" without matching on the text of a message.
-`available` is that one question asked *before* anything is run, which is
+`is_available` is that one question asked *before* anything is run, which is
 when a caller deciding what to offer at all has to have the answer: a
 refusal is the right answer to a question that was asked, and the wrong
 way to find out there was nothing to ask.
@@ -122,12 +122,12 @@ __all__ = [
     "NO_CAPABILITIES",
     "HwiDevice",
     "HwiSigner",
-    "available",
     "enumerate_devices",
+    "is_available",
 ]
 
 # the command HWI publishes, and the one name for it here: what
-# `available` looks for on the PATH and what every command runs are the
+# `is_available` looks for on the PATH and what every command runs are the
 # same string, so that "it is not installed" and "it is installed" cannot
 # be answers about two different executables
 DEFAULT_EXECUTABLE = "hwi"
@@ -204,7 +204,7 @@ def _executable(executable: str | Sequence[str]) -> list[str]:
     return [executable] if isinstance(executable, str) else list(executable)
 
 
-def available(executable: str | Sequence[str] = DEFAULT_EXECUTABLE) -> bool:
+def is_available(executable: str | Sequence[str] = DEFAULT_EXECUTABLE) -> bool:
     """Whether the command line this module runs is there to be run.
 
     Asked before running it, rather than read off a failure afterwards. A

--- a/btclib/script/script_pub_key.py
+++ b/btclib/script/script_pub_key.py
@@ -624,7 +624,7 @@ class ScriptPubKey(Script):
     @classmethod
     def from_address(cls, addr: String, *, check_validity: bool = True) -> ScriptPubKey:
         """Return the ScriptPubKey of the input bech32/base58 address."""
-        if b32.has_segwit_prefix(addr):
+        if b32.is_segwit_prefixed(addr):
             wit_ver, wit_prg, network = b32.witness_from_address(addr)
             return cls(
                 serialize([op_int(wit_ver), wit_prg]),

--- a/btclib/wallet/wallet.py
+++ b/btclib/wallet/wallet.py
@@ -90,7 +90,7 @@ def _address_str(address: String) -> str:
     """
     addr = address.decode("ascii") if isinstance(address, bytes) else address
     addr = addr.strip()
-    return addr.lower() if b32.has_segwit_prefix(addr) else addr
+    return addr.lower() if b32.is_segwit_prefixed(addr) else addr
 
 
 @dataclass(frozen=True)

--- a/tests/b32_test.py
+++ b/tests/b32_test.py
@@ -49,11 +49,11 @@ from btclib.script import op_int, output_pubkey, serialize
 def test_has_segwit_prefix() -> None:
     """Verify bc1 addresses are told from base58 ones, str or bytes."""
     addr = b"bc1q0hy024867ednvuhy9en4dggflt5w9unw4ztl5a"
-    assert b32.has_segwit_prefix(addr)
-    assert b32.has_segwit_prefix(addr.decode("ascii"))
+    assert b32.is_segwit_prefixed(addr)
+    assert b32.is_segwit_prefixed(addr.decode("ascii"))
     addr = b"1PMycacnJaSqwwJqjawXBErnLsZ7RkXUAs"
-    assert not b32.has_segwit_prefix(addr)
-    assert not b32.has_segwit_prefix(addr.decode("ascii"))
+    assert not b32.is_segwit_prefixed(addr)
+    assert not b32.is_segwit_prefixed(addr.decode("ascii"))
 
 
 def test_valid_address() -> None:

--- a/tests/block/block_context_test.py
+++ b/tests/block/block_context_test.py
@@ -59,11 +59,11 @@ def test_the_activation_height_is_cores() -> None:
         (_MAINNET_BIP34_HEIGHT, True),
         (_MAINNET_BIP34_HEIGHT + 1, True),
     ):
-        assert BlockContext(height=height, now=now).bip34_active is active
+        assert BlockContext(height=height, now=now).is_bip34_active is active
 
     # regtest has BIP34 in force from its first block, which is why the
     # one-byte encodings below are the mainline case and not an edge
-    assert BlockContext(height=1, now=now, bip34_height=1).bip34_active
+    assert BlockContext(height=1, now=now, bip34_height=1).is_bip34_active
 
 
 def test_a_context_is_a_height_and_an_instant() -> None:

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -58,7 +58,7 @@ def test_block_1() -> None:
     assert block.weight == 860
     assert block.sig_op_count == 1
     assert block.height is None
-    assert not block.has_segwit_tx()
+    assert not block.is_segwit()
     assert block == Block.parse(block.serialize())
     assert block == Block.from_dict(block.to_dict())
 
@@ -446,7 +446,7 @@ def test_block_170() -> None:
     # the p2pk it pays to and the p2pk it spends from
     assert block.sig_op_count == 3
     assert block.height is None
-    assert not block.has_segwit_tx()
+    assert not block.is_segwit()
     assert block == Block.parse(block.serialize())
     assert block == Block.from_dict(block.to_dict())
 
@@ -493,7 +493,7 @@ def test_block_200000() -> None:
     block.header.version = 0
     assert block.height == 200_000
     block.header.version = 2
-    assert not block.has_segwit_tx()
+    assert not block.is_segwit()
     assert block == Block.parse(block.serialize())
     assert block == Block.from_dict(block.to_dict())
 
@@ -585,13 +585,13 @@ def test_block_481824() -> None:
         assert block.sig_op_count == 3_409
 
         if i:  # segwit nodes see the witness data
-            assert block.has_segwit_tx()
+            assert block.is_segwit()
             assert block.size == 989_323
             assert block.stripped_size == 988_519
             assert block.weight == 3_954_880
             assert block.vsize == 988_720
         else:  # legacy nodes see NO witness data
-            assert not block.has_segwit_tx()
+            assert not block.is_segwit()
             assert block.size == 988_519
             assert block.stripped_size == 988_519
             assert block.weight == 3_954_076

--- a/tests/block/blockfilters_test.py
+++ b/tests/block/blockfilters_test.py
@@ -125,10 +125,10 @@ def test_blockfilters_coinbase_height(
         now=block.header.time,
         bip34_height=_TESTNET_BIP34_HEIGHT,
     )
-    assert context.bip34_active == (height >= _TESTNET_BIP34_HEIGHT)
+    assert context.is_bip34_active == (height >= _TESTNET_BIP34_HEIGHT)
     block.assert_valid_contextual(context)
 
-    if not context.bip34_active:
+    if not context.is_bip34_active:
         # the commitment is absent, so asking for it directly is what
         # measures that the gate above is doing the work
         with pytest.raises(BTClibValueError, match="invalid coinbase height: "):
@@ -182,5 +182,5 @@ def test_the_witness_row_commits_to_its_witnesses() -> None:
     what says the row was chosen for that and would be missed if it went.
     """
     block = block_at(1263442)
-    assert block.has_segwit_tx()
+    assert block.is_segwit()
     assert block.witness_commitment is not None

--- a/tests/curves/curve_group_2_test.py
+++ b/tests/curves/curve_group_2_test.py
@@ -38,23 +38,23 @@ def test_mult_sliding_window() -> None:
     """Check the sliding-window mult on boundary scalars and against _mult."""
     for w in range(1, 6):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(_mult_sliding_window_var(0, ec.GJ, ec, w), INFJ)
-            assert ec.jac_equality(_mult_sliding_window_var(0, INFJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_sliding_window_var(0, ec.GJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_sliding_window_var(0, INFJ, ec, w), INFJ)
 
-            assert ec.jac_equality(_mult_sliding_window_var(1, INFJ, ec, w), INFJ)
-            assert ec.jac_equality(_mult_sliding_window_var(1, ec.GJ, ec, w), ec.GJ)
+            assert ec.is_jac_equal(_mult_sliding_window_var(1, INFJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_sliding_window_var(1, ec.GJ, ec, w), ec.GJ)
 
             PJ = _mult_sliding_window_var(2, ec.GJ, ec, w)
-            assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
+            assert ec.is_jac_equal(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
             PJ = _mult_sliding_window_var(ec.n - 1, ec.GJ, ec, w)
-            assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
+            assert ec.is_jac_equal(ec.negate_jac(ec.GJ), PJ)
 
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(
                 _mult_sliding_window_var(ec.n - 1, INFJ, ec, w), INFJ
             )
-            assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(_mult_sliding_window_var(ec.n, ec.GJ, ec, w), INFJ)
+            assert ec.is_jac_equal(ec.add_jac(PJ, ec.GJ), INFJ)
+            assert ec.is_jac_equal(_mult_sliding_window_var(ec.n, ec.GJ, ec, w), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
                 _mult_sliding_window_var(-1, ec.GJ, ec, w)
@@ -66,28 +66,28 @@ def test_mult_sliding_window() -> None:
     for w in range(1, 10):
         for k1 in range(ec.n):
             K1 = _mult_sliding_window_var(k1, ec.GJ, ec, w)
-            assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
+            assert ec.is_jac_equal(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_mult_w_NAF() -> None:
     """Check the wNAF mult on boundary scalars and against _mult."""
     for w in range(1, 6):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(_mult_w_NAF_var(0, ec.GJ, ec, w), INFJ)
-            assert ec.jac_equality(_mult_w_NAF_var(0, INFJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_w_NAF_var(0, ec.GJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_w_NAF_var(0, INFJ, ec, w), INFJ)
 
-            assert ec.jac_equality(_mult_w_NAF_var(1, INFJ, ec, w), INFJ)
-            assert ec.jac_equality(_mult_w_NAF_var(1, ec.GJ, ec, w), ec.GJ)
+            assert ec.is_jac_equal(_mult_w_NAF_var(1, INFJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_w_NAF_var(1, ec.GJ, ec, w), ec.GJ)
 
             PJ = _mult_w_NAF_var(2, ec.GJ, ec, w)
-            assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
+            assert ec.is_jac_equal(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
             PJ = _mult_w_NAF_var(ec.n - 1, ec.GJ, ec, w)
-            assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
+            assert ec.is_jac_equal(ec.negate_jac(ec.GJ), PJ)
 
-            assert ec.jac_equality(_mult_w_NAF_var(ec.n - 1, INFJ, ec, w), INFJ)
-            assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(_mult_w_NAF_var(ec.n, ec.GJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_w_NAF_var(ec.n - 1, INFJ, ec, w), INFJ)
+            assert ec.is_jac_equal(ec.add_jac(PJ, ec.GJ), INFJ)
+            assert ec.is_jac_equal(_mult_w_NAF_var(ec.n, ec.GJ, ec, w), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
                 _mult_w_NAF_var(-1, ec.GJ, ec, w)
@@ -99,7 +99,7 @@ def test_mult_w_NAF() -> None:
     for w in range(1, 10):
         for k1 in range(ec.n):
             K1 = _mult_w_NAF_var(k1, ec.GJ, ec, w)
-            assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
+            assert ec.is_jac_equal(K1, _mult(k1, ec.GJ, ec))
 
 
 @pytest.mark.parametrize(
@@ -120,21 +120,21 @@ def test_mult_endomorphism_secp256k1(
         return mult_endo(m, QJ, secp256k1, 4)
 
     ec = secp256k1
-    assert ec.jac_equality(mult(0, ec.GJ), INFJ)
-    assert ec.jac_equality(mult(0, INFJ), INFJ)
+    assert ec.is_jac_equal(mult(0, ec.GJ), INFJ)
+    assert ec.is_jac_equal(mult(0, INFJ), INFJ)
 
-    assert ec.jac_equality(mult(1, INFJ), INFJ)
-    assert ec.jac_equality(mult(1, ec.GJ), ec.GJ)
+    assert ec.is_jac_equal(mult(1, INFJ), INFJ)
+    assert ec.is_jac_equal(mult(1, ec.GJ), ec.GJ)
 
     PJ = mult(2, ec.GJ)
-    assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
+    assert ec.is_jac_equal(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
     PJ = mult(ec.n - 1, ec.GJ)
-    assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
+    assert ec.is_jac_equal(ec.negate_jac(ec.GJ), PJ)
 
-    assert ec.jac_equality(mult(ec.n - 1, INFJ), INFJ)
-    assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-    assert ec.jac_equality(mult(ec.n, ec.GJ), INFJ)
+    assert ec.is_jac_equal(mult(ec.n - 1, INFJ), INFJ)
+    assert ec.is_jac_equal(ec.add_jac(PJ, ec.GJ), INFJ)
+    assert ec.is_jac_equal(mult(ec.n, ec.GJ), INFJ)
 
     with pytest.raises(BTClibValueError, match="negative m: "):
         mult(-1, ec.GJ)
@@ -169,7 +169,7 @@ def test_mult_endomorphism_agrees_with_mult_above_2_127() -> None:
             _mult_endomorphism_secp256k1_var,
         ):
             got = mult_endo(m, ec.GJ, ec, 4)
-            assert ec.jac_equality(got, expected), (m, mult_endo.__name__)
+            assert ec.is_jac_equal(got, expected), (m, mult_endo.__name__)
 
 
 def test_multiplier_decomposer() -> None:
@@ -222,10 +222,10 @@ def test_double_mult_w_NAF() -> None:
                 for v in range(ec.n):
                     expected = _double_mult_var(u, HJ, v, QJ, ec)
                     got = _double_mult_w_NAF_var(u, HJ, v, QJ, ec, w)
-                    assert ec.jac_equality(got, expected), (u, v, w)
+                    assert ec.is_jac_equal(got, expected), (u, v, w)
 
     ec = secp256k1
-    assert ec.jac_equality(_double_mult_w_NAF_var(0, ec.GJ, 0, ec.GJ, ec, w=4), INFJ)
+    assert ec.is_jac_equal(_double_mult_w_NAF_var(0, ec.GJ, 0, ec.GJ, ec, w=4), INFJ)
     with pytest.raises(BTClibValueError, match="negative first coefficient: "):
         _double_mult_w_NAF_var(-1, ec.GJ, 1, ec.GJ, ec, w=4)
     with pytest.raises(BTClibValueError, match="negative second coefficient: "):
@@ -273,21 +273,21 @@ def test_double_mult_endomorphism_secp256k1() -> None:
     for u, v in pairs:
         expected = _double_mult_var(u % _N, HJ, v % _N, QJ, ec)
         for w in (1, 2, 4, 5):
-            assert ec.jac_equality(dm(u, v, HJ, QJ, w), expected), (u, v, w)
+            assert ec.is_jac_equal(dm(u, v, HJ, QJ, w), expected), (u, v, w)
 
     # infinity on either side, and the coefficient that contributes nothing:
     # what `curves.double_mult` sends down this path on secp256k1, the
     # bindings taking no zero scalar and no infinity
     for u, v in ((7, 5), (0, 5), (7, 0), (0, 0)):
         for H, Q in ((INFJ, QJ), (HJ, INFJ), (INFJ, INFJ)):
-            assert ec.jac_equality(dm(u, v, H, Q), _double_mult_var(u, H, v, Q, ec)), (
+            assert ec.is_jac_equal(dm(u, v, H, Q), _double_mult_var(u, H, v, Q, ec)), (
                 u,
                 v,
             )
 
     # the same point twice, and a sum that lands on infinity
-    assert ec.jac_equality(dm(7, 5, HJ, HJ), _double_mult_var(7, HJ, 5, HJ, ec))
-    assert ec.jac_equality(dm(3, _N - 3, HJ, HJ), INFJ)
+    assert ec.is_jac_equal(dm(7, 5, HJ, HJ), _double_mult_var(7, HJ, 5, HJ, ec))
+    assert ec.is_jac_equal(dm(3, _N - 3, HJ, HJ), INFJ)
 
     with pytest.raises(BTClibValueError, match="negative first coefficient: "):
         dm(-1, 1, HJ, QJ)
@@ -313,7 +313,7 @@ def test_double_mult_regular_window() -> None:
                 for v in range(ec.n):
                     expected = _double_mult_var(u, HJ, v, QJ, ec)
                     got = _double_mult_regular_window(u, HJ, v, QJ, ec, w, scalar_len=0)
-                    assert ec.jac_equality(got, expected), (u, v, w)
+                    assert ec.is_jac_equal(got, expected), (u, v, w)
 
     ec = secp256k1
     # the scalar_len the endomorphism passes, and coefficients that need
@@ -322,7 +322,7 @@ def test_double_mult_regular_window() -> None:
         expected = _double_mult_var(u, ec.GJ, v, ec.GJ, ec)
         for scalar_len in (0, _HALF_LEN):
             got = _double_mult_regular_window(u, ec.GJ, v, ec.GJ, ec, 4, scalar_len)
-            assert ec.jac_equality(got, expected), (u, v, scalar_len)
+            assert ec.is_jac_equal(got, expected), (u, v, scalar_len)
 
     with pytest.raises(BTClibValueError, match="negative first coefficient: "):
         _double_mult_regular_window(-1, ec.GJ, 1, ec.GJ, ec, w=4, scalar_len=0)

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -79,28 +79,28 @@ def test_mult_recursive_aff() -> None:
             assert ec.is_on_curve(ec.aff_from_jac(QJ)), f"{q}, {ec}"
             assert ec.aff_from_jac(QJ) == Q, f"{q}, {ec}"
             assert _mult_recursive_aff_var(q, INF, ec) == INF, f"{q}, {ec}"
-            assert ec.jac_equality(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
+            assert ec.is_jac_equal(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
 
 
 def test_mult_recursive_jac() -> None:
     """Check the recursive Jacobian mult on boundary scalars, every curve."""
     for ec in all_curves.values():
-        assert ec.jac_equality(_mult_recursive_jac_var(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_recursive_jac_var(0, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_recursive_jac_var(0, ec.GJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_recursive_jac_var(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(_mult_recursive_jac_var(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(_mult_recursive_jac_var(1, ec.GJ, ec), ec.GJ)
+        assert ec.is_jac_equal(_mult_recursive_jac_var(1, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_recursive_jac_var(1, ec.GJ, ec), ec.GJ)
 
         PJ = ec.add_jac(ec.GJ, ec.GJ)
-        assert ec.jac_equality(PJ, _mult_recursive_jac_var(2, ec.GJ, ec))
+        assert ec.is_jac_equal(PJ, _mult_recursive_jac_var(2, ec.GJ, ec))
 
         PJ = _mult_recursive_jac_var(ec.n - 1, ec.GJ, ec)
-        assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(_mult_recursive_jac_var(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(ec.negate_jac(ec.GJ), PJ)
+        assert ec.is_jac_equal(_mult_recursive_jac_var(ec.n - 1, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(_mult_recursive_jac_var(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_recursive_jac_var(ec.n, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(ec.add_jac(PJ, ec.GJ), INFJ)
+        assert ec.is_jac_equal(_mult_recursive_jac_var(ec.n, ec.GJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_recursive_jac_var(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
             _mult_recursive_jac_var(-1, ec.GJ, ec)
@@ -108,7 +108,7 @@ def test_mult_recursive_jac() -> None:
     ec = ec23_31
     for k1 in range(ec.n):
         K1 = _mult_recursive_jac_var(k1, ec.GJ, ec)
-        assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
+        assert ec.is_jac_equal(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_mult_aff() -> None:
@@ -142,28 +142,28 @@ def test_mult_aff() -> None:
             assert ec.is_on_curve(ec.aff_from_jac(QJ)), f"{q}, {ec}"
             assert ec.aff_from_jac(QJ) == Q, f"{q}, {ec}"
             assert _mult_aff_var(q, INF, ec) == INF, f"{q}, {ec}"
-            assert ec.jac_equality(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
+            assert ec.is_jac_equal(INFJ, _mult(q, INFJ, ec)), f"{q}, {ec}"
 
 
 def test_mult_jac() -> None:
     """Check the Jacobian double-and-add on boundary scalars, every curve."""
     for ec in all_curves.values():
-        assert ec.jac_equality(_mult_jac_var(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_jac_var(0, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_jac_var(0, ec.GJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_jac_var(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(_mult_jac_var(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(_mult_jac_var(1, ec.GJ, ec), ec.GJ)
+        assert ec.is_jac_equal(_mult_jac_var(1, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_jac_var(1, ec.GJ, ec), ec.GJ)
 
         PJ = ec.add_jac(ec.GJ, ec.GJ)
-        assert ec.jac_equality(PJ, _mult_jac_var(2, ec.GJ, ec))
+        assert ec.is_jac_equal(PJ, _mult_jac_var(2, ec.GJ, ec))
 
         PJ = _mult_jac_var(ec.n - 1, ec.GJ, ec)
-        assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(_mult_jac_var(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(ec.negate_jac(ec.GJ), PJ)
+        assert ec.is_jac_equal(_mult_jac_var(ec.n - 1, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(_mult_jac_var(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_jac_var(ec.n, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(ec.add_jac(PJ, ec.GJ), INFJ)
+        assert ec.is_jac_equal(_mult_jac_var(ec.n, ec.GJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_jac_var(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
             _mult_jac_var(-1, ec.GJ, ec)
@@ -171,28 +171,28 @@ def test_mult_jac() -> None:
     ec = ec23_31
     for k1 in range(ec.n):
         K1 = _mult_jac_var(k1, ec.GJ, ec)
-        assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
+        assert ec.is_jac_equal(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_mont_ladder() -> None:
     """Check the Montgomery ladder on boundary scalars and against _mult."""
     for ec in low_card_curves.values():
-        assert ec.jac_equality(_mult_mont_ladder_var(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_mont_ladder_var(0, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_mont_ladder_var(0, ec.GJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_mont_ladder_var(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(_mult_mont_ladder_var(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(_mult_mont_ladder_var(1, ec.GJ, ec), ec.GJ)
+        assert ec.is_jac_equal(_mult_mont_ladder_var(1, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_mont_ladder_var(1, ec.GJ, ec), ec.GJ)
 
         PJ = _mult_mont_ladder_var(2, ec.GJ, ec)
-        assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
+        assert ec.is_jac_equal(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
         PJ = _mult_mont_ladder_var(ec.n - 1, ec.GJ, ec)
-        assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(_mult_mont_ladder_var(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(ec.negate_jac(ec.GJ), PJ)
+        assert ec.is_jac_equal(_mult_mont_ladder_var(ec.n - 1, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(_mult_mont_ladder_var(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(ec.add_jac(PJ, ec.GJ), INFJ)
+        assert ec.is_jac_equal(_mult_mont_ladder_var(ec.n, ec.GJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
             _mult_mont_ladder_var(-1, ec.GJ, ec)
@@ -200,28 +200,28 @@ def test_mont_ladder() -> None:
     ec = ec23_31
     for k1 in range(ec.n):
         K1 = _mult_mont_ladder_var(k1, ec.GJ, ec)
-        assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
+        assert ec.is_jac_equal(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_mult_base_3() -> None:
     """Check the base-3 mult on boundary scalars and against _mult."""
     for ec in low_card_curves.values():
-        assert ec.jac_equality(_mult_base_3_var(0, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_base_3_var(0, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_base_3_var(0, ec.GJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_base_3_var(0, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(_mult_base_3_var(1, INFJ, ec), INFJ)
-        assert ec.jac_equality(_mult_base_3_var(1, ec.GJ, ec), ec.GJ)
+        assert ec.is_jac_equal(_mult_base_3_var(1, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_base_3_var(1, ec.GJ, ec), ec.GJ)
 
         PJ = _mult_base_3_var(2, ec.GJ, ec)
-        assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
+        assert ec.is_jac_equal(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
         PJ = _mult_base_3_var(ec.n - 1, ec.GJ, ec)
-        assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-        assert ec.jac_equality(_mult_base_3_var(ec.n - 1, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(ec.negate_jac(ec.GJ), PJ)
+        assert ec.is_jac_equal(_mult_base_3_var(ec.n - 1, INFJ, ec), INFJ)
 
-        assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-        assert ec.jac_equality(_mult_base_3_var(ec.n, ec.GJ, ec), INFJ)
-        assert ec.jac_equality(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
+        assert ec.is_jac_equal(ec.add_jac(PJ, ec.GJ), INFJ)
+        assert ec.is_jac_equal(_mult_base_3_var(ec.n, ec.GJ, ec), INFJ)
+        assert ec.is_jac_equal(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
 
         with pytest.raises(BTClibValueError, match="negative m: "):
             _mult_base_3_var(-1, ec.GJ, ec)
@@ -229,7 +229,7 @@ def test_mult_base_3() -> None:
     ec = ec23_31
     for k1 in range(ec.n):
         K1 = _mult_base_3_var(k1, ec.GJ, ec)
-        assert ec.jac_equality(K1, _mult(k1, ec.GJ, ec))
+        assert ec.is_jac_equal(K1, _mult(k1, ec.GJ, ec))
 
 
 def test_cached_multiples() -> None:
@@ -295,34 +295,34 @@ def test_mult_fixed_window() -> None:
     """Check the fixed-window mult on boundary scalars, for every width."""
     for w in range(1, MAX_W):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(
                 _mult_fixed_window_var(0, ec.GJ, ec, w, cached=False), INFJ
             )
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(
                 _mult_fixed_window_var(0, INFJ, ec, w, cached=False), INFJ
             )
 
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(
                 _mult_fixed_window_var(1, INFJ, ec, w, cached=False), INFJ
             )
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(
                 _mult_fixed_window_var(1, ec.GJ, ec, w, cached=False), ec.GJ
             )
 
             PJ = _mult_fixed_window_var(2, ec.GJ, ec, w, cached=False)
-            assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
+            assert ec.is_jac_equal(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
             PJ = _mult_fixed_window_var(ec.n - 1, ec.GJ, ec, w, cached=False)
-            assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(ec.negate_jac(ec.GJ), PJ)
+            assert ec.is_jac_equal(
                 _mult_fixed_window_var(ec.n - 1, INFJ, ec, w, cached=False), INFJ
             )
 
-            assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(ec.add_jac(PJ, ec.GJ), INFJ)
+            assert ec.is_jac_equal(
                 _mult_fixed_window_var(ec.n, ec.GJ, ec, w, cached=False), INFJ
             )
-            assert ec.jac_equality(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
+            assert ec.is_jac_equal(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
                 _mult_fixed_window_var(-1, ec.GJ, ec, w, cached=False)
@@ -334,7 +334,7 @@ def test_mult_fixed_window() -> None:
     for w in range(1, 10):
         for k1 in range(ec.n):
             K1 = _mult_fixed_window_var(k1, ec.GJ, ec, w, cached=False)
-            assert ec.jac_equality(K1, _mult_jac_var(k1, ec.GJ, ec))
+            assert ec.is_jac_equal(K1, _mult_jac_var(k1, ec.GJ, ec))
 
 
 def test_signed_odd_digits() -> None:
@@ -419,7 +419,7 @@ def test_add_jac_aff_answers_add_jac_on_every_pair() -> None:
         for PJ in jac:
             for R in points:
                 mixed = ec.add_jac_aff(PJ, R)
-                assert ec.jac_equality(ec.add_jac(PJ, _jac_from_aff(R)), mixed)
+                assert ec.is_jac_equal(ec.add_jac(PJ, _jac_from_aff(R)), mixed)
 
 
 class _CountingGroup(CurveGroup):
@@ -495,11 +495,11 @@ def test_mult_fixed_base() -> None:
     for w in range(1, MAX_W):
         for ec in low_card_curves.values():
             for m in range(ec.n + 1):
-                assert ec.jac_equality(
+                assert ec.is_jac_equal(
                     _mult_fixed_base(m, ec.GJ, ec, w),
                     _mult_jac_var(m % ec.n, ec.GJ, ec),
                 ), (m, w, ec)
-            assert ec.jac_equality(_mult_fixed_base(1, INFJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_fixed_base(1, INFJ, ec, w), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
                 _mult_fixed_base(-1, ec.GJ, ec, w)
@@ -508,7 +508,7 @@ def test_mult_fixed_base() -> None:
 
     ec = secp256k1
     for m in (0, 1, 2, 3, ec.n - 1, ec.n, ec.n + 1):
-        assert ec.jac_equality(
+        assert ec.is_jac_equal(
             _mult_fixed_base(m, ec.GJ, ec, w=4), _mult_jac_var(m, ec.GJ, ec)
         ), m
 
@@ -520,21 +520,21 @@ def test_mult_regular_window() -> None:
     """Check the regular-window mult on boundaries and oversized scalars."""
     for w in range(1, MAX_W):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(_mult_regular_window(0, ec.GJ, ec, w), INFJ)
-            assert ec.jac_equality(_mult_regular_window(0, INFJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_regular_window(0, ec.GJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_regular_window(0, INFJ, ec, w), INFJ)
 
-            assert ec.jac_equality(_mult_regular_window(1, INFJ, ec, w), INFJ)
-            assert ec.jac_equality(_mult_regular_window(1, ec.GJ, ec, w), ec.GJ)
+            assert ec.is_jac_equal(_mult_regular_window(1, INFJ, ec, w), INFJ)
+            assert ec.is_jac_equal(_mult_regular_window(1, ec.GJ, ec, w), ec.GJ)
 
             PJ = _mult_regular_window(2, ec.GJ, ec, w)
-            assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
+            assert ec.is_jac_equal(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
             PJ = _mult_regular_window(ec.n - 1, ec.GJ, ec, w)
-            assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-            assert ec.jac_equality(_mult_regular_window(ec.n - 1, INFJ, ec, w), INFJ)
+            assert ec.is_jac_equal(ec.negate_jac(ec.GJ), PJ)
+            assert ec.is_jac_equal(_mult_regular_window(ec.n - 1, INFJ, ec, w), INFJ)
 
-            assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(_mult_regular_window(ec.n, ec.GJ, ec, w), INFJ)
+            assert ec.is_jac_equal(ec.add_jac(PJ, ec.GJ), INFJ)
+            assert ec.is_jac_equal(_mult_regular_window(ec.n, ec.GJ, ec, w), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
                 _mult_regular_window(-1, ec.GJ, ec, w)
@@ -546,14 +546,14 @@ def test_mult_regular_window() -> None:
     for w in range(1, 10):
         for k1 in range(ec.n):
             K1 = _mult_regular_window(k1, ec.GJ, ec, w)
-            assert ec.jac_equality(K1, _mult_jac_var(k1, ec.GJ, ec))
+            assert ec.is_jac_equal(K1, _mult_jac_var(k1, ec.GJ, ec))
 
     # a scalar of more bits than the group has, which is the one case where
     # the digit count is the scalar's own again: the answer is still the
     # multiplication, the recoding being asked for the digits it needs
     ec = secp256k1
     for m in (ec.n, ec.n + 1, 2 * ec.n, 1 << 300):
-        assert ec.jac_equality(
+        assert ec.is_jac_equal(
             _mult_regular_window(m, ec.GJ, ec, w=4), _mult_jac_var(m, ec.GJ, ec)
         ), m
 
@@ -562,34 +562,34 @@ def test_mult_fixed_window_cached() -> None:
     """Check the cached fixed-window mult on boundary scalars and widths."""
     for _ in range(1, MAX_W):
         for ec in low_card_curves.values():
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(
                 _mult_fixed_window_cached_var(0, ec.GJ, ec, w=4), INFJ
             )
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(
                 _mult_fixed_window_cached_var(0, INFJ, ec, w=4), INFJ
             )
 
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(
                 _mult_fixed_window_cached_var(1, INFJ, ec, w=4), INFJ
             )
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(
                 _mult_fixed_window_cached_var(1, ec.GJ, ec, w=4), ec.GJ
             )
 
             PJ = _mult_fixed_window_cached_var(2, ec.GJ, ec, w=4)
-            assert ec.jac_equality(PJ, ec.add_jac(ec.GJ, ec.GJ))
+            assert ec.is_jac_equal(PJ, ec.add_jac(ec.GJ, ec.GJ))
 
             PJ = _mult_fixed_window_cached_var(ec.n - 1, ec.GJ, ec, w=4)
-            assert ec.jac_equality(ec.negate_jac(ec.GJ), PJ)
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(ec.negate_jac(ec.GJ), PJ)
+            assert ec.is_jac_equal(
                 _mult_fixed_window_cached_var(ec.n - 1, INFJ, ec, w=4), INFJ
             )
 
-            assert ec.jac_equality(ec.add_jac(PJ, ec.GJ), INFJ)
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(ec.add_jac(PJ, ec.GJ), INFJ)
+            assert ec.is_jac_equal(
                 _mult_fixed_window_cached_var(ec.n, ec.GJ, ec, w=4), INFJ
             )
-            assert ec.jac_equality(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
+            assert ec.is_jac_equal(_mult_mont_ladder_var(ec.n, INFJ, ec), INFJ)
 
             with pytest.raises(BTClibValueError, match="negative m: "):
                 _mult_fixed_window_cached_var(-1, ec.GJ, ec, w=4)
@@ -601,7 +601,7 @@ def test_mult_fixed_window_cached() -> None:
     for w in range(1, 10):
         for k1 in range(ec.n):
             K1 = _mult_fixed_window_cached_var(k1, ec.GJ, ec, w)
-            assert ec.jac_equality(K1, _mult_jac_var(k1, ec.GJ, ec))
+            assert ec.is_jac_equal(K1, _mult_jac_var(k1, ec.GJ, ec))
 
 
 def test_assorted_jac_mult() -> None:
@@ -616,20 +616,20 @@ def test_assorted_jac_mult() -> None:
 
             shamir = _double_mult_var(k1, ec.GJ, k2, ec.GJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(shamir))
-            assert ec.jac_equality(shamir, _mult(k1 + k2, ec.GJ, ec))
+            assert ec.is_jac_equal(shamir, _mult(k1 + k2, ec.GJ, ec))
 
             shamir = _double_mult_var(k1, INFJ, k2, HJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(shamir))
-            assert ec.jac_equality(shamir, K2J)
+            assert ec.is_jac_equal(shamir, K2J)
 
             shamir = _double_mult_var(k1, ec.GJ, k2, INFJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(shamir))
-            assert ec.jac_equality(shamir, K1J)
+            assert ec.is_jac_equal(shamir, K1J)
 
             shamir = _double_mult_var(k1, ec.GJ, k2, HJ, ec)
             assert ec.is_on_curve(ec.aff_from_jac(shamir))
             K1JK2J = ec.add_jac(K1J, K2J)
-            assert ec.jac_equality(K1JK2J, shamir)
+            assert ec.is_jac_equal(K1JK2J, shamir)
 
             k3 = ec.n // 3  # just a point, not INF
             K3J = _mult(k3, ec.GJ, ec)
@@ -638,7 +638,7 @@ def test_assorted_jac_mult() -> None:
             boscoster = _multi_mult_var([k1, k2, k3], [ec.GJ, HJ, ec.GJ], ec)
             assert ec.is_on_curve(ec.aff_from_jac(boscoster))
             assert ec.aff_from_jac(K1JK2JK3J) == ec.aff_from_jac(boscoster), k3
-            assert ec.jac_equality(K1JK2JK3J, boscoster)
+            assert ec.is_jac_equal(K1JK2JK3J, boscoster)
 
             k4 = ec.n // 4  # just a point, not INF
             K4J = _mult(k4, HJ, ec)
@@ -648,13 +648,13 @@ def test_assorted_jac_mult() -> None:
             boscoster = _multi_mult_var([k1, k2, k3, k4], points, ec)
             assert ec.is_on_curve(ec.aff_from_jac(boscoster))
             assert ec.aff_from_jac(K1JK2JK3JK4J) == ec.aff_from_jac(boscoster), k4
-            assert ec.jac_equality(K1JK2JK3JK4J, boscoster)
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(K1JK2JK3JK4J, boscoster)
+            assert ec.is_jac_equal(
                 K1JK2JK3J, _multi_mult_var([k1, k2, k3, 0], points, ec)
             )
-            assert ec.jac_equality(K1JK2J, _multi_mult_var([k1, k2, 0, 0], points, ec))
-            assert ec.jac_equality(K1J, _multi_mult_var([k1, 0, 0, 0], points, ec))
-            assert ec.jac_equality(INFJ, _multi_mult_var([0, 0, 0, 0], points, ec))
+            assert ec.is_jac_equal(K1JK2J, _multi_mult_var([k1, k2, 0, 0], points, ec))
+            assert ec.is_jac_equal(K1J, _multi_mult_var([k1, 0, 0, 0], points, ec))
+            assert ec.is_jac_equal(INFJ, _multi_mult_var([0, 0, 0, 0], points, ec))
 
             err_msg = "mismatch between number of scalars and points: "
             with pytest.raises(BTClibValueError, match=err_msg):
@@ -746,13 +746,13 @@ def test_multi_mult_w_NAF() -> None:
                     got = _multi_mult_w_NAF_var(
                         scalars, points, ec, w, ec._fixed_points
                     )
-                    assert ec.jac_equality(got, expected), (k1, k2, w)
-                    assert ec.jac_equality(
+                    assert ec.is_jac_equal(got, expected), (k1, k2, w)
+                    assert ec.is_jac_equal(
                         got, _multi_mult_bos_coster_var(scalars, points, ec)
                     ), (k1, k2, w)
 
             # a zero scalar, an INF point, and scalars of distant lengths
-            assert ec.jac_equality(
+            assert ec.is_jac_equal(
                 _multi_mult_w_NAF_var([0, 0], [ec.GJ, HJ], ec, w, ec._fixed_points),
                 INFJ,
             )
@@ -762,7 +762,7 @@ def test_multi_mult_w_NAF() -> None:
                     got = _multi_mult_w_NAF_var(
                         scalars, points, ec, w, ec._fixed_points
                     )
-                    assert ec.jac_equality(got, expected), (scalars, w)
+                    assert ec.is_jac_equal(got, expected), (scalars, w)
 
         # a window wider than the order itself, where the table of odd
         # multiples wraps past n and holds the point at infinity among
@@ -775,7 +775,7 @@ def test_multi_mult_w_NAF() -> None:
                 points = [ec.GJ, HJ]
                 expected = _sum_of_mults(scalars, points, ec)
                 got = _multi_mult_w_NAF_var(scalars, points, ec, w, ec._fixed_points)
-                assert ec.jac_equality(got, expected), (scalars, w)
+                assert ec.is_jac_equal(got, expected), (scalars, w)
 
     ec = secp256k1
     with pytest.raises(BTClibValueError, match="non positive w: "):
@@ -795,11 +795,11 @@ def test_multi_mult_agrees_across_curves() -> None:
         points = [ec.GJ, HJ, _mult(3, ec.GJ, ec)]
         scalars = [rnd.randrange(ec.n) for _ in points]
         expected = _sum_of_mults(scalars, points, ec)
-        assert ec.jac_equality(
+        assert ec.is_jac_equal(
             _multi_mult_w_NAF_var(scalars, points, ec, _MULTI_MULT_W, ec._fixed_points),
             expected,
         )
-        assert ec.jac_equality(
+        assert ec.is_jac_equal(
             _multi_mult_bos_coster_var(scalars, points, ec), expected
         )
 
@@ -822,12 +822,12 @@ def test_multi_mult_dispatch() -> None:
         points = [ec.GJ if i % 2 else HJ for i in range(size)]
         scalars = [rnd.randrange(1, ec.n) for _ in range(size)]
         expected = _sum_of_mults(scalars, points, ec)
-        assert ec.jac_equality(_multi_mult_var(scalars, points, ec), expected)
-        assert ec.jac_equality(
+        assert ec.is_jac_equal(_multi_mult_var(scalars, points, ec), expected)
+        assert ec.is_jac_equal(
             _multi_mult_w_NAF_var(scalars, points, ec, _MULTI_MULT_W, ec._fixed_points),
             expected,
         )
-        assert ec.jac_equality(
+        assert ec.is_jac_equal(
             _multi_mult_bos_coster_var(scalars, points, ec), expected
         )
 
@@ -835,20 +835,20 @@ def test_multi_mult_dispatch() -> None:
         # both by name, the dispatch no longer being able to reach
         # Bos-Coster with it -- a batch of nothing but zeros is a batch
         # of no nonzero scalars, which is below any threshold
-        assert ec.jac_equality(_multi_mult_var([0] * size, points, ec), INFJ)
-        assert ec.jac_equality(
+        assert ec.is_jac_equal(_multi_mult_var([0] * size, points, ec), INFJ)
+        assert ec.is_jac_equal(
             _multi_mult_w_NAF_var(
                 [0] * size, points, ec, _MULTI_MULT_W, ec._fixed_points
             ),
             INFJ,
         )
-        assert ec.jac_equality(_multi_mult_bos_coster_var([0] * size, points, ec), INFJ)
+        assert ec.is_jac_equal(_multi_mult_bos_coster_var([0] * size, points, ec), INFJ)
 
         # a batch of this length whose *work* is two scalars: the zeros
         # are dropped downstream, so the count that dispatches counts
         # them out first and this goes to the interleaved wNAF
         sparse = [scalars[0], *([0] * (size - 2)), scalars[-1]]
-        assert ec.jac_equality(
+        assert ec.is_jac_equal(
             _multi_mult_var(sparse, points, ec), _sum_of_mults(sparse, points, ec)
         )
 
@@ -876,24 +876,24 @@ def test_multi_mult_distant_magnitudes() -> None:
     HJ = _jac_from_aff(second_generator(ec))
     for scalars in ([10**6, 1], [1, 10**6], [ec.n - 1, 1], [ec.n - 1, ec.n - 2]):
         expected = _sum_of_mults(scalars, [ec.GJ, HJ], ec)
-        assert ec.jac_equality(_multi_mult_var(scalars, [ec.GJ, HJ], ec), expected)
-        assert ec.jac_equality(
+        assert ec.is_jac_equal(_multi_mult_var(scalars, [ec.GJ, HJ], ec), expected)
+        assert ec.is_jac_equal(
             _multi_mult_bos_coster_var(scalars, [ec.GJ, HJ], ec), expected
         )
 
 
 def test_jac_equality() -> None:
-    """Check jac_equality on equal representations and on unequal points."""
+    """Check is_jac_equal on equal representations and on unequal points."""
     ec = ec23_31
-    assert ec.jac_equality(ec.GJ, _jac_from_aff(ec.G))
+    assert ec.is_jac_equal(ec.GJ, _jac_from_aff(ec.G))
 
     # q in [2, n-1], as the difference with ec.GJ is checked below
     q = 2
     Q = _mult_aff_var(q, ec.G, ec)
     QJ = _mult(q, ec.GJ, ec)
-    assert ec.jac_equality(QJ, _jac_from_aff(Q))
-    assert not ec.jac_equality(QJ, ec.negate_jac(QJ))
-    assert not ec.jac_equality(QJ, ec.GJ)
+    assert ec.is_jac_equal(QJ, _jac_from_aff(Q))
+    assert not ec.is_jac_equal(QJ, ec.negate_jac(QJ))
+    assert not ec.is_jac_equal(QJ, ec.GJ)
 
 
 def test_INF() -> None:
@@ -941,7 +941,7 @@ def test_blinding_changes_the_coordinates_and_not_the_point() -> None:
             blinded = [_blinded_jac(QJ, ec) for _ in range(8)]
             for B in blinded:
                 assert ec.aff_from_jac(B) == ec.aff_from_jac(QJ)
-                assert ec.jac_equality(B, QJ)
+                assert ec.is_jac_equal(B, QJ)
             # a curve of eleven points has eleven values of l to draw
             # from, so the Z's are only expected to differ where p is big
             if ec.p > 2**32:

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -344,22 +344,22 @@ def test_add_double_jac() -> None:
     """Test self-consistency of add and double in Jacobian coordinates."""
     for ec in all_curves.values():
         # add G and the infinity point
-        assert ec.jac_equality(ec.add_jac(ec.GJ, INFJ), ec.GJ)
-        assert ec.jac_equality(ec.add_jac(INFJ, ec.GJ), ec.GJ)
+        assert ec.is_jac_equal(ec.add_jac(ec.GJ, INFJ), ec.GJ)
+        assert ec.is_jac_equal(ec.add_jac(INFJ, ec.GJ), ec.GJ)
 
         # double G
         GJ2 = ec.add_jac(ec.GJ, ec.GJ)
-        assert ec.jac_equality(GJ2, ec.double_jac(ec.GJ))
+        assert ec.is_jac_equal(GJ2, ec.double_jac(ec.GJ))
 
         # double INF
-        assert ec.jac_equality(ec.add_jac(INFJ, INFJ), INFJ)
-        assert ec.jac_equality(ec.double_jac(INFJ), INFJ)
+        assert ec.is_jac_equal(ec.add_jac(INFJ, INFJ), INFJ)
+        assert ec.is_jac_equal(ec.double_jac(INFJ), INFJ)
 
         # add G and minus G
-        assert ec.jac_equality(ec.add_jac(ec.GJ, ec.negate_jac(ec.GJ)), INFJ)
+        assert ec.is_jac_equal(ec.add_jac(ec.GJ, ec.negate_jac(ec.GJ)), INFJ)
 
         # add INF and "minus" INF
-        assert ec.jac_equality(ec.add_jac(INFJ, ec.negate_jac(INFJ)), INFJ)
+        assert ec.is_jac_equal(ec.add_jac(INFJ, ec.negate_jac(INFJ)), INFJ)
 
 
 def test_add_double_aff_jac() -> None:
@@ -379,7 +379,7 @@ def test_add_double_aff_jac() -> None:
         RJ = ec.double_jac(QJ)
         assert ec.aff_from_jac(RJ) == R
         assert ec.add_aff(Q, Q) == R
-        assert ec.jac_equality(RJ, ec.add_jac(QJ, QJ))
+        assert ec.is_jac_equal(RJ, ec.add_jac(QJ, QJ))
 
 
 def _textbook_add(ec: CurveGroup, P: Point | None, Q: Point | None) -> Point | None:
@@ -411,7 +411,7 @@ def _jac_spellings(ec: CurveGroup, P: Point | None) -> list[JacPoint]:
     add_jac compares coordinates that only a common frame makes
     comparable, so one frame would not exercise the comparison. Infinity
     is any Z == 0 triple: the INFJ constant, what `_jac_from_aff` turns
-    the affine INF into, and the all-zero triple that `jac_equality`
+    the affine INF into, and the all-zero triple that `is_jac_equal`
     reads as equal to everything.
     """
     if P is None:
@@ -786,7 +786,7 @@ def test_negate() -> None:
         # Jacobian coordinates
         QJ = _jac_from_aff(Q)
         minus_QJ = ec.negate_jac(QJ)
-        assert ec.jac_equality(ec.add_jac(QJ, minus_QJ), INFJ)
+        assert ec.is_jac_equal(ec.add_jac(QJ, minus_QJ), INFJ)
 
         # negate of INF is INF
         minus_INF = ec.negate(INF)
@@ -794,7 +794,7 @@ def test_negate() -> None:
 
         # negate of INFJ is INFJ
         minus_INFJ = ec.negate_jac(INFJ)
-        assert ec.jac_equality(minus_INFJ, INFJ)
+        assert ec.is_jac_equal(minus_INFJ, INFJ)
 
         with pytest.raises(BTClibTypeError, match="not a point"):
             ec.negate(ec.GJ)  # type: ignore[arg-type]

--- a/tests/descriptors/miniscript_test.py
+++ b/tests/descriptors/miniscript_test.py
@@ -154,7 +154,10 @@ def test_core_fixed_vector(vector: dict[str, Any], context: str) -> None:
     if expected is not None:
         assert script.hex() == expected
     assert node.is_non_malleable == vector["non_malleable"]
-    assert node.needs_signature == vector["needs_signature"]
+    # the key is the vendor's and the property is btclib's: the vector
+    # file is upstream's and says `needs_signature`, which is what that
+    # property was called before issue #814 gave every bool a prefix
+    assert node.is_signature_required == vector["needs_signature"]
     assert node.mixes_timelocks == vector["mixed_timelocks"]
     witness = "witness_size" if context == P2WSH else "tapscript_witness_size"
     for name, bound in (
@@ -204,7 +207,7 @@ def test_a_tapscript_passes_the_p2wsh_limits(count: int) -> None:
     assert node.max_ops == count + (count - 1) * 3
     assert node.max_stack_items == count
     assert node.max_exec_stack_items == count + 1
-    assert node.within_resource_limits
+    assert node.is_within_resource_limits
     with pytest.raises(BTClibValueError, match="too large for P2WSH"):
         parse(expression, P2WSH)
 
@@ -225,10 +228,10 @@ def test_the_stack_limit_is_reached_during_execution() -> None:
     assert node.max_ops == 4 * 998 + 1
     assert node.max_stack_items == 1
     assert node.max_exec_stack_items == 1000
-    assert node.within_resource_limits
+    assert node.is_within_resource_limits
     deeper = parse(older_nesting(999), TAPSCRIPT)
     assert deeper.max_exec_stack_items == 1001
-    assert not deeper.within_resource_limits
+    assert not deeper.is_within_resource_limits
     # the script of a nesting no recursion could walk, read back
     assert from_script(deeper.script(), TAPSCRIPT).script() == deeper.script()
     assert str(parse(str(deeper), TAPSCRIPT)) == str(deeper)
@@ -538,10 +541,10 @@ def test_a_witness_of_a_hundred_elements_is_too_large_for_a_p2wsh() -> None:
     )
     node = parse(expression)
     assert node.is_valid_top_level
-    assert node.needs_signature
+    assert node.is_signature_required
     assert node.is_non_malleable
     assert node.max_stack_items == 105
-    assert not node.within_resource_limits
+    assert not node.is_within_resource_limits
     with pytest.raises(BTClibValueError, match="exceed the resource limits"):
         parse_descriptor(f"wsh({expression})")
 
@@ -550,7 +553,7 @@ def test_an_invalid_expression_is_within_no_limits() -> None:
     """Answer that nothing is guaranteed of a script the rules refuse."""
     node = Miniscript("and_b", subs=(Miniscript("1"), Miniscript("1")))
     assert not node.is_valid
-    assert not node.within_resource_limits
+    assert not node.is_within_resource_limits
 
 
 def test_an_unsatisfiable_expression_has_no_bounds() -> None:
@@ -562,7 +565,7 @@ def test_an_unsatisfiable_expression_has_no_bounds() -> None:
     assert node.max_ops is None
     assert node.max_witness_size is None
     # and a valid expression is still within the limits it cannot reach
-    assert node.within_resource_limits
+    assert node.is_within_resource_limits
 
 
 def test_a_repeated_key_is_not_sane() -> None:

--- a/tests/hwi_test.py
+++ b/tests/hwi_test.py
@@ -51,8 +51,8 @@ from btclib.hwi import (
     DEFAULT_TIMEOUT,
     HwiDevice,
     HwiSigner,
-    available,
     enumerate_devices,
+    is_available,
 )
 from btclib.psbt.psbt import Psbt
 from btclib.psbt_signer import (
@@ -619,7 +619,7 @@ def test_the_defaults_are_the_two_bounds(hwi: list[str]) -> None:
 def test_whether_the_command_line_is_there_is_asked_before_it_is_run(
     hwi: list[str], tmp_path: Path
 ) -> None:
-    """`available` looks for argv[0] of what would be run, and nothing else.
+    """`is_available` looks for argv[0] of what would be run, and nothing else.
 
     The stand-in is `[sys.executable, script]`, so what has to be on the
     PATH is the interpreter and not the script: which element that is is
@@ -629,14 +629,14 @@ def test_whether_the_command_line_is_there_is_asked_before_it_is_run(
     subprocess -- the same fact `enumerate_devices` reports afterwards,
     and by then it has run one.
     """
-    assert available(hwi)
-    assert available(sys.executable)
-    assert not available(str(tmp_path / "nowhere"))
-    assert not available([str(tmp_path / "nowhere"), "--flag"])
+    assert is_available(hwi)
+    assert is_available(sys.executable)
+    assert not is_available(str(tmp_path / "nowhere"))
+    assert not is_available([str(tmp_path / "nowhere"), "--flag"])
     # the default is the name every command here runs, so the two cannot
     # be answers about different executables
     assert DEFAULT_EXECUTABLE == "hwi"
-    assert available() == (shutil.which(DEFAULT_EXECUTABLE) is not None)
+    assert is_available() == (shutil.which(DEFAULT_EXECUTABLE) is not None)
 
 
 def test_btclib_runs_the_commands_hwi_publishes(tmp_path: Path) -> None:

--- a/tests/input_validation_test.py
+++ b/tests/input_validation_test.py
@@ -19,7 +19,7 @@ distinction issue #814 settled, so this file drives the two separately:
   about the input, and leaves as a `BTClibException` -- unless the
   function answers a `bool` about it, in which case the answer is
   `False`. `_ANSWERS_FALSE` is that family, and it is a family: nine
-  script predicates, `b32.has_segwit_prefix` and `ecc.dleq.verify_proof`.
+  script predicates, `b32.is_segwit_prefixed` and `ecc.dleq.verify_proof`.
 
 Both are `BTClibException`, which is what makes the second rule one
 predicate instead of a tuple that has to be kept in step with the
@@ -159,7 +159,7 @@ _A_BOOL_ANSWERS_FALSE = (
 )
 
 _ANSWERS_FALSE: dict[str, str] = {
-    "btclib.b32.has_segwit_prefix": _A_BOOL_ANSWERS_FALSE,
+    "btclib.b32.is_segwit_prefixed": _A_BOOL_ANSWERS_FALSE,
     "btclib.ecc.dleq.verify_proof": _A_BOOL_ANSWERS_FALSE,
     "btclib.script.script_pub_key.is_nulldata": _A_BOOL_ANSWERS_FALSE,
     "btclib.script.script_pub_key.is_p2ms": _A_BOOL_ANSWERS_FALSE,

--- a/tests/key_io_test.py
+++ b/tests/key_io_test.py
@@ -124,7 +124,7 @@ def test_address_payload(address: str, script_pub_key: str, network: str) -> Non
     payload rather than a script, and re-encoding that payload on the
     chain the metadata names is the round trip belonging to this layer.
     """
-    if b32.has_segwit_prefix(address):
+    if b32.is_segwit_prefixed(address):
         wit_ver, wit_prg, _ = b32.witness_from_address(address)
         assert b32.address_from_witness(wit_ver, wit_prg, network) == address
     else:

--- a/tests/name_contract_test.py
+++ b/tests/name_contract_test.py
@@ -80,6 +80,32 @@ _OTHER_CONTRACT: dict[str, str] = {
 }
 
 
+# A bool need not carry one of the four prefixes: an English predicate is
+# the same family and the same contract, and `is_` would cost the reading.
+# Six of them, each with the reason it keeps the name it has -- and the
+# ratchet below is what closes the vocabulary all the same, an entry that
+# has gained a prefix being one this list no longer excuses (issue #814)
+_ITS_STANDARD_SPELLING = (
+    "the name is the standard's: BIP379's malleability analysis says a"
+    " miniscript mixes timelocks and has duplicate keys, and the three"
+    " PSBT_GLOBAL_TX_MODIFIABLE bits are named after the field"
+)
+
+_A_PREDICATE_WITH_A_SUBJECT = (
+    "`reads_back` is the round trip as a question, and the subject is the"
+    " script: `is_read_back` would ask who reads it"
+)
+
+_ENGLISH_PREDICATE: dict[str, str] = {
+    "btclib.descriptors.miniscript.has_duplicate_keys": (_ITS_STANDARD_SPELLING),
+    "btclib.descriptors.miniscript.mixes_timelocks": (_ITS_STANDARD_SPELLING),
+    "btclib.descriptors.miniscript.reads_back": _A_PREDICATE_WITH_A_SUBJECT,
+    "btclib.psbt.psbt.has_sig_hash_single": _ITS_STANDARD_SPELLING,
+    "btclib.psbt.psbt.inputs_modifiable": _ITS_STANDARD_SPELLING,
+    "btclib.psbt.psbt.outputs_modifiable": _ITS_STANDARD_SPELLING,
+}
+
+
 def _promised_by(name: str) -> str | None:
     """Return the type the name promises, or None if it promises nothing."""
     if name.startswith(_AN_OP_CODE):
@@ -117,8 +143,28 @@ def _named() -> dict[str, str]:
     return found
 
 
+def _public_bools() -> list[str]:
+    """Return every public function that answers a bool, however named.
+
+    The dotted name drops the class, as `_named` above does: a method and
+    a module function of one name are one entry, which is the spelling
+    `input_validation_test.py` uses too.
+    """
+    found: list[str] = []
+    for path in sorted(_LIBRARY.rglob("*.py")):
+        module = ".".join(path.relative_to(_LIBRARY.parent).with_suffix("").parts)
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+                continue
+            if node.returns is not None and ast.unparse(node.returns) == "bool":
+                found.append(f"{module}.{node.name}")
+    return sorted(found)
+
+
 _NAMED = _named()
 _GATED = sorted(set(_NAMED) - _OTHER_CONTRACT.keys())
+_PUBLIC_BOOLS = _public_bools()
 
 
 @pytest.mark.parametrize("dotted", _GATED)
@@ -174,3 +220,36 @@ def test_check_says_one_thing() -> None:
         "btclib.script.engine.script.check_pub_key",
         "btclib.script.taproot.check_output_pubkey",
     }
+
+
+@pytest.mark.parametrize("dotted", _PUBLIC_BOOLS)
+def test_every_public_bool_is_named_by_the_vocabulary(dotted: str) -> None:
+    """A bool carries one of the four prefixes, or is named in the list.
+
+    What this closes is the gap the prefixes alone leave: they promise a
+    shape to a caller who sees one, and say nothing about a bool that
+    carries none. Seven did before issue #814 -- four were renamed and
+    three more were, `Block.is_segwit` joining the `Tx.is_segwit` it is
+    computed from -- and the six that are left keep their names for the
+    reason each entry gives.
+
+    So a bool added from here on either carries a prefix or is a decision
+    somebody wrote down, which is what `check_` drifting for four
+    meanings cost the tree.
+    """
+    name = dotted.rpartition(".")[2]
+    assert (
+        _promised_by(name) is not None
+        or name.startswith(_AN_OP_CODE)
+        or dotted in _ENGLISH_PREDICATE
+    ), f"{dotted} answers a bool and its name promises nothing"
+
+
+@pytest.mark.parametrize("dotted", sorted(_ENGLISH_PREDICATE))
+def test_what_keeps_its_english_name_still_needs_to(dotted: str) -> None:
+    """A line of `_ENGLISH_PREDICATE` cannot outlive the name it excuses."""
+    assert dotted in _PUBLIC_BOOLS, f"{dotted} is no longer a public bool"
+    name = dotted.rpartition(".")[2]
+    assert _promised_by(name) is None, (
+        f"{dotted} carries a prefix now: delete its line from _ENGLISH_PREDICATE"
+    )


### PR DESCRIPTION
Closes the last gap https://github.com/btclib-org/btclib/issues/814 left:
the four prefixes promised a shape to a caller who saw one and said
nothing about a bool carrying none. Seven carried none.

Source-breaking: seven public names change, no signature and no behaviour
with them.

## The seven, renamed for what they answer

| before | after |
| --- | --- |
| `b32.has_segwit_prefix` | `b32.is_segwit_prefixed` |
| `BlockContext.bip34_active` | `is_bip34_active` |
| `Block.has_segwit_tx` | `Block.is_segwit` |
| `Miniscript.within_resource_limits` | `is_within_resource_limits` |
| `Miniscript.needs_signature` | `is_signature_required` |
| `CurveGroup.jac_equality` | `is_jac_equal` |
| `hwi.available` | `hwi.is_available` |

Three are worth a word. **`jac_equality` was a noun** — it read as a
thing rather than as a question, and it is the only one of the seven that
takes arguments. **`Block.is_segwit` joins the `Tx.is_segwit` its body is
computed from** (`any(tx.is_segwit() for tx in self.transactions)`), so
one property is one name at both levels. And **`is_signature_required` is
what that docstring already said**: "every satisfaction requires a
signature".

## The six that keep an English name

`Miniscript.mixes_timelocks` and `has_duplicate_keys` are BIP379's own
words; `Psbt.inputs_modifiable`, `outputs_modifiable` and
`has_sig_hash_single` are named after the PSBT_GLOBAL_TX_MODIFIABLE bits
they read; and `miniscript.reads_back` is the round trip as a question —
`is_read_back` would ask who reads it. Forcing `is_` on those costs the
reading and moves the name away from its source.

## What actually closes the vocabulary

Not the renaming — the gate beside it. `tests/name_contract_test.py`
gained a second walk over **every** public bool, however named, and two
tests:

- one fails a bool that neither carries a prefix, nor is an `op_*` op code
  implementation, nor is named in `_ENGLISH_PREDICATE` with its reason
- one fails an `_ENGLISH_PREDICATE` entry that has *gained* a prefix, so a
  line cannot outlive the name it excuses

`check_` drifted to four meanings because nothing in the tree could
notice. This is what noticing looks like, and it is the difference between
a convention and a rule.

## One thing not renamed

`tests/_data/miniscript_fixed_tests.json` keeps its `needs_signature`
key: that file is upstream's, and `tests/_data/README.md` vendors it. The
test maps the vendor's key to btclib's property, with a comment saying
which is which — a blind rename would have silently stopped matching the
vectors.

## Gates

- `uv run pytest` — 27162 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Rename public boolean APIs and update tests and documentation to enforce a consistent predicate vocabulary and prefixes across the library.

New Features:
- Add a static analysis gate that walks the codebase to collect all public bool-returning functions and verifies their names adhere to the established predicate vocabulary or are explicitly whitelisted English predicates.

Enhancements:
- Rename several public boolean properties and helpers (e.g., segwit address/block predicates, miniscript resource/signature checks, Jacobian point equality, hardware wallet availability, BIP34 activation context) to carry clear `is_*`-style prefixes while preserving behavior.
- Align tests, input-validation metadata, and internal callers with the new boolean names to keep the suite and contracts in sync.
- Clarify contributor and user-facing documentation (CONTRIBUTING, CHANGELOG, HISTORY) around the boolean naming convention and the set of exceptions that keep their standard-derived English names.

Documentation:
- Document the boolean naming changes and the closure of the predicate vocabulary in CHANGELOG.md, HISTORY.md, and CONTRIBUTING.md, including the list of renamed identifiers and the rationale for preserved English names.

Tests:
- Extend name_contract_test to scan all public bool-returning functions and assert they either follow the prefix convention or are listed as justified English predicates, and add tests to ensure those exceptions remain necessary.
- Update curve, block, miniscript, HWI, address, and input-validation tests to use the renamed boolean APIs and to cover the new naming rules.