### PR TITLE
Blind the ECDSA nonce inversion, and mark duration in the names

### DIFF
--- a/.github/mutation/curve_group.toml
+++ b/.github/mutation/curve_group.toml
@@ -13,7 +13,7 @@
 # of either module is reached without patching `curve.py`'s
 # `_libsecp256k1_applicable` off the way `curve_test.py`'s own
 # `no_bindings` fixture has to for the same code reached through `mult`,
-# `double_mult` and `multi_mult`.
+# `double_mult_var` and `multi_mult_var`.
 
 [cosmic-ray]
 module-path = [

--- a/.github/mutation/signatures.toml
+++ b/.github/mutation/signatures.toml
@@ -8,7 +8,7 @@
 # `dsa.Sig.parse`'s DER carries.
 #
 # CLAUDE.md's own warning about this pair applies to what a survivor here
-# can mean: `curves.curve.mult`/`double_mult`/`multi_mult` call the
+# can mean: `curves.curve.mult`/`double_mult_var`/`multi_mult_var` call the
 # libsecp256k1 bindings for secp256k1, so a mutant of the Python arithmetic
 # in `curves/curve_group.py` is invisible to a test running the default
 # curve -- it is not in this module-path and is not what this profile is
@@ -91,7 +91,7 @@ excluded-modules = []
 # - `assert_batch_as_valid_`'s `batch_size == 1` weakened to `< 1`: the
 #   shortcut it guards validates a lone `Sig` on its own account
 #   (`assert_as_valid_`, which runs `sig.assert_valid()`), where the
-#   general multi_mult sum below it does not; `< 1` never being true
+#   general multi_mult_var sum below it does not; `< 1` never being true
 #   once `batch_size == 0` has already raised two lines above, the
 #   widened guard sends every batch of one through the sum instead,
 #   silently dropping that check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1387,6 +1387,78 @@ documented at release-notes length in the first place, and are still in
 
 ### Curves, signatures and keys
 
+- **The ECDSA nonce is inverted blinded**, and `number_theory.mod_inv`
+  is now that blinded inverse, `dsa`'s signing being its one caller in
+  the library. The extended Euclid it used to be is `mod_inv_var`, under
+  the naming rule below. CPython's `long_invmod` takes the iterations its
+  operand asks for, so inverting the nonce with it timed the signature on
+  the nonce's bit-length: measured on
+  secp256k1's order over random scalars of each length, 8.8 us for a
+  256-bit one against 4.3 for a 128-bit one, falling at every step in
+  between. That correlation is what the Minerva attack (Jancar et al.,
+  CHES 2020) collects from signing times and hands to a lattice.
+
+  It was the only one of its shape left, which is what makes it worth
+  closing rather than adding to the list `SECURITY.md` publishes.
+  Measured the same way, with the bindings switched off so the Python
+  arithmetic answers a secp256k1 signature: `mult(k, G)` spreads 1.5%
+  across nonces from 256 bits down to 128 and `mult(k, Q)` 0.5%, against
+  a 2.2% noise floor and neither of them monotone — the regular
+  recodings of issue #254 and the projective blinding of issue #805
+  hold. The plain inverse spread 2.06x over the same range, monotone at
+  every step, and a census of the package found it the one place a
+  secret is inverted at all: `dsa`'s `r` and `s`, `ssa`'s challenge and
+  every Jacobian `Z` are public or already randomized.
+
+  `(b*a)^-1 * b` is `a^-1` for any invertible `b`, so a random factor
+  leaves the Euclid's iteration count following the factor: 1.02x across
+  the same operands, for 1.11x on the inverse — two multiplications, two
+  reductions and a draw from `secrets`, which is what costs. On the
+  signature that inverse sits in it is 1.5%, measured over 30 random
+  nonces on secp256k1 and secp256r1 with the bindings off. Fermat's
+  `pow(a, n - 2, n)` is the alternative and is flat for a different
+  reason, its ladder running on the fixed exponent, but costs 8.38x the
+  Euclid; the same figure is why `mod_inv_var` does not spell Fermat
+  either (issue #807).
+
+  A small modulus pays the draw against a Euclid of a few iterations, so
+  the ratio there is 4.8x on an order of 11 — the low-cardinality curves
+  of the test suite, which is the only place such an order signs.
+
+  Not a constant-time inverse, and `CONTRIBUTING.md` says what a name
+  here does promise: three tiers, of which only libsecp256k1's is
+  constant-time, with regular and blinded the second. What the blinding
+  does not touch is the rest of what `SECURITY.md` lists — a table is
+  still indexed by a secret digit, and that is out of reach from
+  bytecode.
+
+- **A `_var` suffix now marks any function whose operand decides the
+  work**, not only a scalar multiplication, and the plain name beside it
+  is the one a secret may be handed. It is libsecp256k1's own scope for
+  the convention — `secp256k1_scalar_inverse_var` sits beside
+  `secp256k1_scalar_inverse`, and even its Jacobi symbol is
+  `secp256k1_jacobi64_maybe_var` — where btclib had narrowed it to the
+  private multiplications and left a public surface that was
+  variable-time without saying so.
+
+  Renamed, each because it was measured to earn the suffix, over random
+  operands from 256 bits down to 64: `mod_inv_var` (4.21x),
+  `xgcd_var` (4.84x), `legendre_symbol_var` (4.26x),
+  `mod_inv_batch_var` (2.01x), `tonelli_var` (1.54x, spread within one
+  operand size rather than across sizes, Tonelli-Shanks iterating on the
+  value), `mod_sqrt_var`, `double_mult_var` and `multi_mult_var`.
+  `mod_sqrt_var` is the one that measures flat, 1.01x, for the `p` of 3
+  mod 4 every catalogued curve has — one exponentiation with a fixed
+  exponent — and carries the suffix because the caller picks the `p` and
+  a 1 mod 4 one reaches `tonelli_var`.
+
+  `mult` keeps its plain name: its two arms are the regular window and
+  the fixed-base ladder, whose additions are the same for every scalar,
+  which is what `double_mult_var` and `multi_mult_var` are not — those
+  are wNAF and Bos-Coster, whose shape is the coefficients. In every
+  btclib caller those coefficients are a signature and a message hash,
+  which is why the suffix is a label and not a defect.
+
 - **`mod_inv` delegates its extended Euclid to CPython** (issue #779).
   `pow(a, -1, m)` is `long_invmod`, the same algorithm `xgcd` runs with
   the second cofactor dropped -- CPython carries that loop as a comment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ the `btclib_secp256k1` cffi bindings — and delegated conditionally,
 which is the single most important thing to know before touching
 `btclib/curves/` or `btclib/ecc/`:
 
-- `curves.curve.mult`, `double_mult` and `multi_mult` call the bindings
+- `curves.curve.mult`, `double_mult_var` and `multi_mult_var` call the bindings
   for secp256k1 and any point of it, a zero scalar and the point at
   infinity excepted: libsecp256k1 has no scalar for the one and no public
   key for the other, so those two — and a sum landing on infinity — are

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -960,30 +960,75 @@ check is unreachable by design rather than missing. `btclib/utils.py`'s
 docstring is where that rule is written down, `OutPoint` and `TxIn` being
 the classes it holds for.
 
-#### A `_var` suffix means the scalar decides the work
+#### A `_var` suffix means the operand decides the work
 
-A private scalar multiplication whose number of point operations depends
-on the coefficient it is given ends in `_var`:
-`btclib.curves.curve_group._mult_jac_var` and
-`curve_group_2._double_mult_w_NAF_var` against `_mult_regular_window`,
-`_mult_fixed_base` and `_double_mult_regular_window`, which make the same
-number for every scalar of the curve. It is libsecp256k1's convention,
-where `secp256k1_gej_add_var` sits beside `secp256k1_gej_add_ge`, and it
-is there so that the question can be answered at the call site instead of
-in the docstring of the thing being called.
+A function whose duration follows the value it is given ends in `_var`,
+and the plain name beside it is the one a secret may be handed. It is
+libsecp256k1's convention and it is used there for the same two halves:
+`secp256k1_scalar_inverse_var` sits beside `secp256k1_scalar_inverse`,
+`secp256k1_gej_add_var` beside `secp256k1_gej_add_ge`. The point of it is
+that the question is answered at the call site rather than in the
+docstring of the thing being called.
 
-Two things it does not mean, and neither is a detail. **A name without
-`_var` is not a constant-time function**: `mod_inv` is an extended
-Euclid, a table is indexed by a secret digit, and `SECURITY.md` publishes
-the whole Python path as variable-time — what the absence of the suffix
-promises is one count of point operations, not one duration. And **the
-suffix is about the coefficient, not the point**: every table these build
-costs a modular inversion whose time follows the point, which is the
-caller's public key in the callers btclib has.
+What "the work" is depends on the function, and each of these was
+measured rather than assumed — on secp256k1's order or its `p`, over
+random operands of 256 bits down to 64, the ratio between the two ends:
 
-Add the suffix when adding such a function, and do not add it to the
-recodings, the tables or the group law: those take no scalar, and a
-suffix on everything says nothing about anything.
+- the count of point operations, for a scalar multiplication:
+    `curve_group._mult_jac_var` and `curve_group_2._double_mult_w_NAF_var`
+    against `_mult_regular_window`, `_mult_fixed_base` and
+    `_double_mult_regular_window`, which make the same number for every
+    scalar of the curve. `curves.double_mult_var` and
+    `curves.multi_mult_var` carry it for that reason and `curves.mult`
+    does not
+- the iteration count of an extended Euclid: `mod_inv_var` at 4.21x,
+    `xgcd_var` at 4.84x, `mod_inv_batch_var` at 2.01x
+- the length of a loop over the operand: `legendre_symbol_var` at 4.26x,
+    and `tonelli_var`, whose 1.54x is spread within one operand size
+    rather than across sizes — Tonelli-Shanks iterates on the value, not
+    on its length. `mod_sqrt_var` reaches that loop only for a `p` of 1
+    mod 4; for the 3 mod 4 of every catalogued curve it is one
+    exponentiation with a fixed exponent and measures 1.01x, and it
+    carries the suffix all the same, because the caller picks the `p`
+
+Three tiers of duration follow, of which only the first is constant-time:
+
+- **constant-time is libsecp256k1's alone.** Every claim of it in this
+    library is a claim about the C behind the bindings, which is why
+    `SECURITY.md` states argument by argument when a call crosses that
+    boundary. Nothing written in Python is constant-time, and no name
+    here should be read as promising it.
+- **regular, or blinded: the operand does not decide the duration, and
+    something else does.** `_mult_regular_window`, `_mult_fixed_base` and
+    `_double_mult_regular_window` make the same operations for every
+    scalar of the curve; `_blinded_jac` leaves the intermediate values a
+    function of a random factor rather than of the scalar alone; and
+    `mod_inv` leaves an extended Euclid's iteration count following a
+    random factor rather than the caller's operand, at 1.02x where
+    `mod_inv_var` is 2.06x over the same range. This is decorrelation and
+    not uniformity — the duration still varies, and what changes is what
+    it varies with.
+- **variable: the operand decides.** Everything suffixed above, and every
+    reduction whose cost is the size of what it reduces.
+
+So **a secret takes the plain name and a public value takes the `_var`
+one**, which is the opposite of an optimization default and is meant to
+be: the fail-safe direction is that forgetting to choose gives the slower
+and safer call. `dsa`'s signing inverts the nonce with `mod_inv` while
+its `r`, its `s` and a verification's `Z` take `mod_inv_var`, and those
+four sit within twenty lines of each other; a reviewer should be able to
+tell which is which without tracing where each value came from.
+
+Add the suffix when adding such a function, having measured that it earns
+one, and do not add it to the recodings, the tables or the group law:
+those take no operand whose size varies, and a suffix on everything says
+nothing about anything.
+
+What none of this does is make the Python path safe, and `SECURITY.md`'s
+limitations section is what says so at length: a table is still indexed
+by a secret digit, and that is out of reach from bytecode. A name in the
+second tier closes one measured channel, and the honest form of the claim
+is that one — which channel, measured how, and what is left.
 
 #### Documentation and comments
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -54,6 +54,24 @@ full year, short month, short day (YYYY-M-D)
   `AttributeError` around one of those two `verify` calls has to catch
   `TypeError` or `BTClibException`. `pedersen.verify` refuses a
   commitment of a type no point has, where it answered False.
+- **six functions gain a `_var` suffix, and `mod_inv` changes meaning.**
+  The suffix marks a duration that follows the operand, so the plain
+  name beside it is the one a secret may be handed:
+  `number_theory.mod_inv` is `mod_inv_var`, `xgcd` is `xgcd_var`,
+  `legendre_symbol` is `legendre_symbol_var`, `mod_sqrt` is
+  `mod_sqrt_var`, `tonelli` is `tonelli_var`, and `curves.double_mult`
+  and `curves.multi_mult` are `double_mult_var` and `multi_mult_var`.
+  `curves.mult` is unchanged, its two arms making the same additions for
+  every scalar.
+
+  An import of one of the six old spellings is an `ImportError`, and each
+  new name is a rename with no change of signature or behaviour.
+  `mod_inv` is the exception and does not raise: the name survives and
+  now returns the same inverse computed with a random blinding factor,
+  so a caller inverting a secret is protected without changing a line,
+  and one inverting public data should say `mod_inv_var` to keep the
+  1.11x. CHANGELOG.md has the measurement behind each suffix and
+  CONTRIBUTING.md the rule.
 
 - **eleven `check_*` functions are renamed, and the prefix means one
   thing.** It meant four at once: nine refusals returning `None`, two

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -106,8 +106,8 @@ used to teach and to prototype as much as to build:
     or xpub string handed to `derive` or `derive_from_account`: the
     decoded key stays reachable from that cache, bounded by its
     `maxsize`, past whatever reference the caller itself still holds
-- not every operation crosses that boundary. `mult`, `double_mult` and
-    `multi_mult` reach the bindings for secp256k1 and any point of it, a
+- not every operation crosses that boundary. `mult`, `double_mult_var` and
+    `multi_mult_var` reach the bindings for secp256k1 and any point of it, a
     zero scalar and the point at infinity excepted — libsecp256k1 has no
     scalar for the one and no public key for the other; `dsa.sign` for
     secp256k1 with sha256, the lower-s form, no caller-imposed nonce and
@@ -129,10 +129,16 @@ used to teach and to prototype as much as to build:
     A signature the bindings decline is not all Python for that:
     `dsa.gen_keys` and the nonce point of `dsa._sign_` go through `mult`,
     and the verification equation of both `dsa` and `ssa` through
-    `double_mult`, so those multiplications are delegated whatever else
+    `double_mult_var`, so those multiplications are delegated whatever else
     the signature asks for. The rest of that signature is not — the
     inversion of the nonce and the arithmetic on the key around it are
-    Python integers.
+    Python integers. That inversion is blinded, and is the one place in
+    the library where a secret is inverted at all: `mod_inv`
+    draws a random factor, so that the extended Euclid's iteration count
+    follows the factor rather than the nonce. Unblinded it followed the
+    nonce's bit-length — 8.8 us for a 256-bit scalar against 4.3 for a
+    128-bit one on secp256k1's order — which is the correlation the
+    Minerva attack turns into the private key.
     `bms.sign` is delegated outright, `recovery.sign` signing and naming
     the recovery flag in one call: message signing is defined for
     secp256k1 alone, so there is no argument that sends it down the
@@ -168,7 +174,7 @@ used to teach and to prototype as much as to build:
     interleaved wNAFs of the same decomposition make 51 to 64 and 124 to
     131. Those wNAFs add on a nonzero digit and so once per unit of the
     recoded weight of the coefficient, which is why they are not what
-    `mult` reaches for; they are what `double_mult` and signature
+    `mult` reaches for; they are what `double_mult_var` and signature
     verification reach, where the coefficients are a signature and a
     message hash rather than a secret.
 
@@ -177,10 +183,12 @@ used to teach and to prototype as much as to build:
     multiples with a secret digit, which is the memory access pattern the
     FLUSH+RELOAD recovery of OpenSSL's nonces read; every reduction and
     multiplication takes the time its operand sizes ask for, and a
-    residue is not always the full size; the affine group law and the
-    conversion back from Jacobian coordinates spend a modular inverse, an
-    extended Euclid whose iteration count follows its input; and
-    `multi_mult` is Bos-Coster, whose shape is the scalars themselves.
+    residue is not always the full size; the affine group law spends a
+    modular inverse, an extended Euclid whose iteration count follows its
+    input, and so does the conversion back from Jacobian coordinates —
+    that one on a Z coordinate `_blinded_jac` has randomized, which is
+    why it is named here as a cost and not as a channel; and `multi_mult_var`
+    is Bos-Coster, whose shape is the scalars themselves.
     Using it on key material that matters is a choice, and this is the
     notice of it
 - a sign-to-contract commitment is the signer's to open, and opening it

--- a/btclib/curves/__init__.py
+++ b/btclib/curves/__init__.py
@@ -54,7 +54,7 @@ not the faster alternative its name suggests.
 The underscore says the second thing too, which is what decided it: each
 takes a point it assumes to be on the curve and checks nothing, so a
 malformed one is answered with a point rather than refused. mult,
-double_mult and multi_mult are where require_on_curve runs, on every
+double_mult_var and multi_mult_var are where require_on_curve runs, on every
 argument and every path, and reaching past them is reaching past that. The
 test suite takes each variant from the module that defines it, which is
 what a private name is still good for.
@@ -68,9 +68,9 @@ materializing the point (issue #127).
 from btclib.curves.curve import (
     CURVES,
     Curve,
-    double_mult,
+    double_mult_var,
     mult,
-    multi_mult,
+    multi_mult_var,
     secp256k1,
 )
 from btclib.curves.curve_group import CurveGroup
@@ -87,11 +87,11 @@ __all__ = [
     "CurveGroup",
     "bytes_from_point",
     "bytes_from_prv_key_int",
-    "double_mult",
+    "double_mult_var",
     "find_all_points",
     "find_subgroup_points",
     "mult",
-    "multi_mult",
+    "multi_mult_var",
     "point_from_octets",
     "secp256k1",
 ]

--- a/btclib/curves/curve.py
+++ b/btclib/curves/curve.py
@@ -4,7 +4,7 @@
 
 """The prime-order Curve and the multiplications built on it.
 
-mult, double_mult and multi_mult dispatch secp256k1 to the
+mult, double_mult_var and multi_mult_var dispatch secp256k1 to the
 libsecp256k1 bindings and answer every other curve -- and the cases
 the bindings cannot express -- with curve_group's arithmetic.
 
@@ -55,7 +55,7 @@ from btclib.curves.curve_group_2 import (
     _mult_endomorphism_secp256k1,
 )
 from btclib.exceptions import BTClibValueError
-from btclib.number_theory import legendre_symbol
+from btclib.number_theory import legendre_symbol_var
 from btclib.utils import hex_string, int_from_integer
 
 __all__ = [
@@ -69,9 +69,9 @@ __all__ = [
     "SEC2v1_params2",
     "SEC2v2",
     "SEC2v2_params2",
-    "double_mult",
+    "double_mult_var",
     "mult",
-    "multi_mult",
+    "multi_mult_var",
     "secp256k1",
 ]
 
@@ -452,7 +452,7 @@ def _is_x_coordinate(x: int, ec: Curve) -> bool:
     # the symbol is 0 for a y^2 of zero, which is the two-torsion point:
     # its root is zero and it is on the curve, so -1 is the whole of what
     # says otherwise
-    return legendre_symbol(ec._y2(x), ec.p) != -1
+    return legendre_symbol_var(ec._y2(x), ec.p) != -1
 
 
 def _y_even(x: int, ec: Curve) -> int:
@@ -529,7 +529,7 @@ def _libsecp256k1_multi_mult_(
     one for all of them, a running total being what has an x to compare:
     measured on eight terms 112 us against 97, and on sixty-four 925
     against 774, where the Python arithmetic below takes 2.4 ms and 15 ms.
-    Two terms, which is double_mult and the shape most callers have, pay
+    Two terms, which is double_mult_var and the shape most callers have, pay
     nothing at all: one combine either way.
     """
     x_slice = slice(1, secp256k1.p_size + 1)
@@ -563,7 +563,7 @@ def _libsecp256k1_multi_mult(scalars: Sequence[int], points: Sequence[Point]) ->
     )
 
 
-# the widths mult and double_mult hand the variants below them; the
+# the widths mult and double_mult_var hand the variants below them; the
 # measurement behind each is in the docstring of the function it is passed
 # to, and they are two constants rather than one because what a window is
 # measured on is the length of the scalars in it: the GLV endomorphism's
@@ -640,7 +640,7 @@ def _double_mult_python(
 ) -> JacPoint:
     """Return u*HJ + v*QJ in Python, through the endomorphism if there is one.
 
-    The arm `double_mult` and `_jac_double_mult` share, so that one place
+    The arm `double_mult_var` and `_jac_double_mult` share, so that one place
     decides which double multiplication a curve gets and both reach the
     same one. On secp256k1 that is the GLV split of both coefficients,
     which is to `_double_mult_w_NAF_var` what `_mult_endomorphism_secp256k1`
@@ -672,7 +672,7 @@ def _double_mult_python(
     return _double_mult_w_NAF_var(u, HJ, v, QJ, ec, _DOUBLE_MULT_W)
 
 
-def double_mult(
+def double_mult_var(
     u: Integer, H: Point, v: Integer, Q: Point, ec: Curve = secp256k1
 ) -> Point:
     """Double scalar multiplication (u*H + v*Q)."""
@@ -698,12 +698,12 @@ def double_mult(
 def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> JacPoint:
     """Return u*HJ + v*QJ in Jacobian coordinates, delegated where it can be.
 
-    double_mult for a caller whose equation is written in projective
+    double_mult_var for a caller whose equation is written in projective
     coordinates: dsa's and ssa's _assert_as_valid_, which are the two
     verifications the bindings' own decline -- a hash function that is not
     sha256, a BIP340 message that is not 32 bytes (issue 169), a
     caller-imposed nonce, another curve -- and which paid a Python
-    double_mult underneath whatever the reason. 1.02 ms against 28 us on
+    double_mult_var underneath whatever the reason. 1.02 ms against 28 us on
     secp256k1.
 
     Jacobian in and Jacobian out, rather than those two rewritten in
@@ -720,17 +720,17 @@ def _jac_double_mult(u: int, HJ: JacPoint, v: int, QJ: JacPoint, ec: Curve) -> J
     case -- the affine point being the same pair of coordinates, no
     inversion at all -- saves both of them, 3% of the 28 us the call
     costs. Not worth a branch, and neither is the caller's own
-    mod_inv(1) on the way back out, the same inversion again on the
+    mod_inv_var(1) on the way back out, the same inversion again on the
     cheapest operand it has.
     """
     if not _libsecp256k1_applicable(ec, None):
         return _double_mult_python(u, HJ, v, QJ, ec)
 
-    R = double_mult(u, ec.aff_from_jac(HJ), v, ec.aff_from_jac(QJ), ec)
+    R = double_mult_var(u, ec.aff_from_jac(HJ), v, ec.aff_from_jac(QJ), ec)
     return _jac_from_aff(R)
 
 
-def multi_mult(
+def multi_mult_var(
     scalars: Sequence[Integer], points: Sequence[Point], ec: Curve = secp256k1
 ) -> Point:
     """Return the multi scalar multiplication u1*Q1 + ... + un*Qn.
@@ -750,7 +750,7 @@ def multi_mult(
     for Q in points:
         ec.require_on_curve(Q)
 
-    # as in double_mult; and fewer than two terms is not a multi_mult at
+    # as in double_mult_var; and fewer than two terms is not a multi_mult_var at
     # all, an error the Python path below is the one to raise
     if (
         len(points) > 1

--- a/btclib/curves/curve_group.py
+++ b/btclib/curves/curve_group.py
@@ -21,7 +21,7 @@ from math import ceil
 
 from btclib.alias import INF, INFJ, Integer, JacPoint, Point
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.number_theory import mod_inv, mod_inv_batch, mod_sqrt
+from btclib.number_theory import mod_inv_batch_var, mod_inv_var, mod_sqrt_var
 from btclib.utils import hex_string, int_from_integer
 
 __all__ = [
@@ -291,12 +291,12 @@ class CurveGroup:
         if Q[2] == 0:  # Infinity point in Jacobian coordinates
             return INF
 
-        return self._aff_from_z_inv(Q, mod_inv(Q[2], self.p))
+        return self._aff_from_z_inv(Q, mod_inv_var(Q[2], self.p))
 
     def aff_from_jac_batch(self, Qs: Sequence[JacPoint]) -> list[Point]:
         """Return the affine points: one modular inversion for all of them.
 
-        `aff_from_jac` over a sequence, with `mod_inv_batch` in place of
+        `aff_from_jac` over a sequence, with `mod_inv_batch_var` in place of
         the one inverse each: the conversion is two products a point once
         the inverse is in hand, so a caller holding several Jacobian
         points pays one extended Euclid instead of one per point.
@@ -305,7 +305,7 @@ class CurveGroup:
         in the batch, having no Z to invert, and comes back as INF where
         it stood.
         """
-        inverses = iter(mod_inv_batch([Q[2] for Q in Qs if Q[2]], self.p))
+        inverses = iter(mod_inv_batch_var([Q[2] for Q in Qs if Q[2]], self.p))
         return [
             INF if Q[2] == 0 else self._aff_from_z_inv(Q, next(inverses)) for Q in Qs
         ]
@@ -333,7 +333,7 @@ class CurveGroup:
             raise BTClibValueError("INF has no x-coordinate")
 
         Z2 = Q[2] * Q[2]
-        return (Q[0] * mod_inv(Z2, self.p)) % self.p
+        return (Q[0] * mod_inv_var(Z2, self.p)) % self.p
 
     def y_aff_from_jac(self, Q: JacPoint) -> int:
         """Return the affine y alone, without the product x costs.
@@ -347,7 +347,7 @@ class CurveGroup:
             raise BTClibValueError("INF has no y-coordinate")
 
         Z2 = Q[2] * Q[2]
-        return (Q[1] * mod_inv(Z2 * Q[2], self.p)) % self.p
+        return (Q[1] * mod_inv_var(Z2 * Q[2], self.p)) % self.p
 
     def is_jac_equal(self, QJ: JacPoint, PJ: JacPoint) -> bool:
         """Return True if Jacobian points are equal in affine coordinates.
@@ -601,7 +601,7 @@ class CurveGroup:
         # then doubling: two equal points make the chord a tangent and the
         # slope below 0/0. Branches, where add_jac computes every case and
         # selects, because there is nothing here for that to protect: the
-        # mod_inv this path exists to spend is an extended Euclid, whose
+        # mod_inv_var this path exists to spend is an extended Euclid, whose
         # iteration count follows the value it is inverting, so the affine
         # law cannot be made uniform whatever is done to these three tests
         if R[0] == Q[0]:
@@ -609,9 +609,10 @@ class CurveGroup:
 
         p = self.p
         # lam reduced before it is squared, as in add_jac, though here it
-        # is worth 6% of _mult_aff_var rather than a factor of two: mod_inv is
-        # what affine coordinates cost, and is why the ladders are not
-        lam = (R[1] - Q[1]) * mod_inv(R[0] - Q[0], p) % p
+        # is worth 6% of _mult_aff_var rather than a factor of two:
+        # mod_inv_var is what affine coordinates cost, and is why the
+        # ladders are not
+        lam = (R[1] - Q[1]) * mod_inv_var(R[0] - Q[0], p) % p
         x = (lam * lam - Q[0] - R[0]) % p
         y = (lam * (Q[0] - x) - Q[1]) % p
         return x, y
@@ -622,7 +623,7 @@ class CurveGroup:
             return INF
 
         p = self.p
-        lam = (3 * Q[0] * Q[0] + self._a) * mod_inv(2 * Q[1], p) % p
+        lam = (3 * Q[0] * Q[0] + self._a) * mod_inv_var(2 * Q[1], p) % p
         x = (lam * lam - Q[0] - Q[0]) % p
         y = (lam * (Q[0] - x) - Q[1]) % p
         return x, y
@@ -641,7 +642,7 @@ class CurveGroup:
             raise BTClibValueError(err_msg)
         y2 = self._y2(x)
         try:
-            return mod_sqrt(y2, self.p)
+            return mod_sqrt_var(y2, self.p)
         except BTClibValueError as e:
             err_msg = "invalid x-coordinate: "
             err_msg += f"{hex_string(x)}" if x > HEX_THRESHOLD else f"{x}"
@@ -693,7 +694,7 @@ class CurveGroup:
         # for a p of this form self.y answers the residue root already:
         # it is a ** ((p + 1) // 4), a power of the square a and so a
         # square itself, which leaves p - root the non-residue, -1 being
-        # one modulo such a p. Asking legendre_symbol which of the two
+        # one modulo such a p. Asking legendre_symbol_var which of the two
         # this is would spend a second exponentiation the size of the
         # first to be told what the exponent settles
         return self.y(x)
@@ -767,7 +768,7 @@ def _mult_aff_var(m: int, Q: Point, ec: CurveGroup) -> Point:
         Q = ec.double_aff(Q)
         # always perform the 'add', even if useless: one addition per bit
         # whatever the bit is, as in _mult_jac_var. It buys less here, add_aff
-        # branching on its own special cases and mod_inv taking the time
+        # branching on its own special cases and mod_inv_var taking the time
         # its input asks for, which is why the affine variants are the
         # readable ones rather than the ones to sign with
         R[1] = ec.add_aff(R[0], Q)
@@ -1446,7 +1447,7 @@ def _multi_mult_pairs(
         raise BTClibValueError(err_msg)
 
     if len(scalars) < 2:
-        raise BTClibValueError("not a multi_mult")
+        raise BTClibValueError("not a multi_mult_var")
 
     pairs: list[tuple[int, JacPoint]] = []
     for n, PJ in zip(scalars, jac_points, strict=True):
@@ -1604,8 +1605,8 @@ def _multi_mult_bos_coster_var(
     Bos-Coster is usually written with the q == 1 case of that identity,
     n1*P1 + n2*P2 = (n1-n2)*P1 + n2*(P1+P2), which is Euclid by repeated
     subtraction: n1/n2 steps to do what one divmod does (issue 175) --
-    multi_mult([10**6, 1], [G, H]) would take 10.6 s, and both
-    multi_mult([n-1, 1], [G, H]) and multi_mult([-1, 1], [G, H]) would
+    multi_mult_var([10**6, 1], [G, H]) would take 10.6 s, and both
+    multi_mult_var([n-1, 1], [G, H]) and multi_mult_var([-1, 1], [G, H]) would
     never finish, on scalars a caller has every right to pass. The whole
     of Euclid is what makes this a live path rather than a reading
     exercise: _multi_mult_var calls it above its threshold.

--- a/btclib/curves/curve_group_2.py
+++ b/btclib/curves/curve_group_2.py
@@ -65,7 +65,7 @@ macOS arm64:
       `pow(a, -1, p)` is 8.3 us, being CPython's extended Euclid in C,
       where 255 modular squarings in bytecode -- fewer than any chain
       needs -- are 61 us. `pow(a, p - 2, p)` is 74.7 us, which is why
-      `mod_inv` does not spell Fermat either:
+      `mod_inv_var` does not spell Fermat either:
 
         - https://briansmith.org/ecc-inversion-addition-chains-01
     - fast reduction for a pseudo-Mersenne p: `x % p` is 0.162 us and the
@@ -131,8 +131,8 @@ from btclib.exceptions import BTClibValueError
 # empty, and declared rather than omitted: every multiplication here is a
 # variant kept to be measured against the others, which is what the leading
 # underscore says, so this module has nothing public of its own.
-# `curve.py`'s mult, double_mult and multi_mult are what a caller reaches,
-# and they validate every point before dispatching to any of these
+# `curve.py`'s mult, double_mult_var and multi_mult_var are what a caller
+# reaches, and they validate every point before dispatching to any of these
 __all__: list[str] = []
 
 
@@ -275,7 +275,7 @@ def _double_mult_w_NAF_var(
     digits costing only an on-the-fly negation.
 
     This is the one the library calls on every curve without the GLV
-    endomorphism: `curves.double_mult`, `dsa` and `ssa` verification and
+    endomorphism: `curves.double_mult_var`, `dsa` and `ssa` verification and
     public key recovery all reach it through `curve`'s
     _double_mult_python, which sends secp256k1 to
     _double_mult_endomorphism_secp256k1_var instead -- four half-length
@@ -349,7 +349,7 @@ def _double_mult_regular_window(
     per coefficient, and their opposites, to make one addition per window
     per coefficient -- where the wNAF builds half as many points and adds
     on one digit in w+1. This function is therefore not what
-    `double_mult` runs -- verification's coefficients are public -- but
+    `double_mult_var` runs -- verification's coefficients are public -- but
     what _mult_endomorphism_secp256k1 runs, whose two are halves of a
     secret.
 
@@ -567,7 +567,7 @@ def _double_mult_endomorphism_secp256k1_var(
 
     The interleaved wNAF rather than the regular windows: the coefficients
     of a double multiplication are public, being a verification's, which is
-    the same reason `curve.double_mult` reaches `_double_mult_w_NAF_var`
+    the same reason `curve.double_mult_var` reaches `_double_mult_w_NAF_var`
     directly and not through the regular windows of
     `_mult_endomorphism_secp256k1`. A scalar that is a secret goes
     through `mult`.

--- a/btclib/ecc/bms.py
+++ b/btclib/ecc/bms.py
@@ -393,7 +393,7 @@ def assert_as_valid(msg: Octets, addr: String, sig: Sig | String) -> None:
     compressed = sig.rf > 30
     # signature is valid only if the provided address is matched, and an
     # address is a hash of the sec octets: no point is built here, the
-    # bindings answering the octets themselves -- which is the mod_inv of
+    # bindings answering the octets themselves -- which is the mod_inv_var of
     # an affine conversion not paid either. `verify` is 25 us against 2782,
     # the mean over 40 random keys, of which some 20 are the recovery
     # itself and 2.4 the r-congruence check of the Sig validation above

--- a/btclib/ecc/borromean.py
+++ b/btclib/ecc/borromean.py
@@ -20,7 +20,7 @@ from collections.abc import Sequence
 from hashlib import sha256
 
 from btclib.alias import HashF, Octets, Point
-from btclib.curves import Curve, bytes_from_point, double_mult, mult, secp256k1
+from btclib.curves import Curve, bytes_from_point, double_mult_var, mult, secp256k1
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.utils import bytes_from_octets, int_from_bits
 
@@ -37,9 +37,9 @@ __all__ = [
 # would mean rebinding an attribute of this module, which changes the
 # algorithm for every other caller in the process
 #
-# ec has to be passed to mult and double_mult too, and that is easy to
+# ec has to be passed to mult and double_mult_var too, and that is easy to
 # miss: both take the curve as their *last* argument and default it to
-# secp256k1, so `mult(k)` and `double_mult(-e, Q, s, ec.G)` type check,
+# secp256k1, so `mult(k)` and `double_mult_var(-e, Q, s, ec.G)` type check,
 # read as if they honoured ec, and compute on secp256k1 -- every point
 # then encoded against ec, so the first bytes_from_point rejects it and
 # no curve but secp256k1 can sign at all (issue 183)
@@ -141,7 +141,7 @@ def sign(
                 if not 0 < e[i][j] < ec.n:
                     err_msg = "implausible signature failure"
                     raise BTClibRuntimeError(err_msg)
-                t = double_mult(-e[i][j], pubk_ring[j], s[i][j], ec.G, ec)
+                t = double_mult_var(-e[i][j], pubk_ring[j], s[i][j], ec.G, ec)
                 r = bytes_from_point(t, ec)
         e0bytes += r
     hasher = hf()
@@ -157,7 +157,9 @@ def sign(
             raise BTClibRuntimeError(err_msg)
         for j in range(1, j_star + 1):
             s[i][j - 1] = secrets.randbits(256)
-            t = double_mult(-e[i][j - 1], pubk_rings[i][j - 1], s[i][j - 1], ec.G, ec)
+            t = double_mult_var(
+                -e[i][j - 1], pubk_rings[i][j - 1], s[i][j - 1], ec.G, ec
+            )
             r = bytes_from_point(t, ec)
             e[i][j] = int_from_bits(_hash(m, r, i, j, hf), ec.nlen) % ec.n
             # zero e again, and the one guard of the four that stays
@@ -227,7 +229,7 @@ def assert_as_valid(
             raise BTClibRuntimeError(err_msg)
         r = b"\0x00"
         for j in range(keys_size):
-            t = double_mult(-e[i][j], pubk_ring[j], s[i][j], ec.G, ec)
+            t = double_mult_var(-e[i][j], pubk_ring[j], s[i][j], ec.G, ec)
             r = bytes_from_point(t, ec)
             if j != keys_size - 1:
                 h = _hash(m, r, i, j + 1, hf)

--- a/btclib/ecc/commit_nonce.py
+++ b/btclib/ecc/commit_nonce.py
@@ -155,7 +155,7 @@ def commit_nonce_(
     # and not a rejection to loop over: a second candidate would be a
     # second tweak, and the tweak is what the verifier recomputes.
     # Refused here, because a nonce of zero has no point to sign with and
-    # mod_inv(0) is the error the caller would see instead
+    # mod_inv_var(0) is the error the caller would see instead
     if tweaked_nonce == 0:
         raise BTClibRuntimeError("failed to sign: zero tweaked nonce")
     return tweaked_nonce, receipt

--- a/btclib/ecc/dleq.py
+++ b/btclib/ecc/dleq.py
@@ -44,7 +44,7 @@ from __future__ import annotations
 import secrets
 
 from btclib.alias import Octets, Point
-from btclib.curves import bytes_from_point, double_mult, mult, secp256k1
+from btclib.curves import bytes_from_point, double_mult_var, mult, secp256k1
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import tagged_hash
 from btclib.to_prv_key import PrvKey, int_from_prv_key
@@ -204,10 +204,10 @@ def assert_proof_as_valid(
     if s >= secp256k1.n:
         raise BTClibValueError("s not in 0..n-1")
 
-    R1 = double_mult(s, G_point, -e, A_point)
+    R1 = double_mult_var(s, G_point, -e, A_point)
     if R1[1] == 0:
         raise BTClibValueError("invalid (INF) R1")
-    R2 = double_mult(s, B_point, -e, C_point)
+    R2 = double_mult_var(s, B_point, -e, C_point)
     if R2[1] == 0:
         raise BTClibValueError("invalid (INF) R2")
 

--- a/btclib/ecc/dsa.py
+++ b/btclib/ecc/dsa.py
@@ -57,7 +57,7 @@ from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point
 from btclib.ecc.rfc6979_nonce import _rfc6979_nonce_, challenge_
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.hashes import _assert_valid_hf, reduce_to_hlen
-from btclib.number_theory import mod_inv
+from btclib.number_theory import mod_inv, mod_inv_var
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import PubKey, point_from_pub_key, pub_keyinfo_from_pub_key
 from btclib.utils import bytes_from_octets, bytesio_from_binarydata, hex_string
@@ -353,9 +353,12 @@ def _sign_recoverable_(
     # generator to libsecp256k1 on secp256k1, which is where this
     # function is reached from whenever the bindings decline the whole
     # signature -- another hash function, another curve, a nonce the
-    # caller imposed, a sign-to-contract commitment. The nonce is secret
-    # and the Python fixed window is not constant time; the affine
-    # conversion the Jacobian form would have saved is one mod_inv
+    # caller imposed, a sign-to-contract commitment. The nonce is secret,
+    # and what multiplies it is regular in it either way: constant-time C
+    # on secp256k1, and `_mult_fixed_base` on every other curve, whose
+    # additions are the same for every scalar. The affine conversion the
+    # Jacobian form would have saved is one mod_inv_var, of a Z that
+    # `_blinded_jac` has randomized
     K = mult(nonce, ec=ec)  # 1
     x_K = K[0]
     # mod n makes it a scalar
@@ -363,6 +366,12 @@ def _sign_recoverable_(
     if r == 0:  # r≠0 required as it multiplies the public key
         raise BTClibRuntimeError("failed to sign: r = 0")
 
+    # blinded, and it is the one inverse in this module that has to be:
+    # the nonce is the secret here, an extended Euclid takes the
+    # iterations its input asks for, and a duration that follows a
+    # nonce's bit-length is what the Minerva attack turns into the key.
+    # Everything else dsa inverts -- a signature's s, its r, a
+    # verification's Z -- is public and takes the plain `mod_inv_var`
     s = mod_inv(nonce, ec.n) * (c + r * q) % ec.n  # 6
     if s == 0:  # s≠0 required as verify will need the inverse of s
         raise BTClibRuntimeError("failed to sign: s = 0")
@@ -769,11 +778,11 @@ def _assert_as_valid_(
     if lower_s and s > ec.n // 2:
         raise BTClibValueError("not a low s")
 
-    w = mod_inv(s, ec.n)
+    w = mod_inv_var(s, ec.n)
     u = c * w % ec.n
     v = r * w % ec.n  # 4
     # Let K = u*G + v*Q.
-    # the dispatching double_mult of curves.curve, not the Python
+    # the dispatching double_mult_var of curves.curve, not the Python
     # arithmetic under it: what reaches here is the verification the
     # bindings' own ecdsa_verify declined -- another hash function, a
     # commitment to check, a caller-imposed nonce, a curve of its own --
@@ -796,7 +805,7 @@ def _assert_as_valid_(
     # the bindings hand back a point whose Z is 1, so the inversion this
     # path pays is of one, and where the multiplication is Python's it is
     # 8.8 us of a verification that is 1148
-    x_K = (KJ[0] * mod_inv(KJ[2] * KJ[2], ec.p)) % ec.p
+    x_K = (KJ[0] * mod_inv_var(KJ[2] * KJ[2], ec.p)) % ec.p
     # Fail if r ≠ x_K %n.
     if r != x_K % ec.n:  # 6, 7, 8
         raise BTClibRuntimeError("signature verification failed")
@@ -1143,8 +1152,8 @@ def _recover_pub_keys_(
     # root first for bitcoin message signing compatibility. Which is the
     # order key_id numbers them in, so range() is the loop.
     #
-    # It costs a mod_inv per candidate rather than hoisting the
-    # precomputation out of the loop, and delegating the double_mult below
+    # It costs a mod_inv_var per candidate rather than hoisting the
+    # precomputation out of the loop, and delegating the double_mult_var below
     # is what made that measurable: 41 us of the 214 a candidate takes on
     # secp256k1 with the dispatch off, where the same 41 sat inside 2215.
     # Still not hoisted, because the plural is `_recover_pub_key_` over a
@@ -1230,7 +1239,7 @@ def _recover_pub_key_(
     # Private function provided for testing purposes only.
 
     # precomputations
-    r_1 = mod_inv(r, ec.n)
+    r_1 = mod_inv_var(r, ec.n)
     r1s = r_1 * s % ec.n
     r1e = -r_1 * c % ec.n
     # r is x_K reduced mod n, so it does not determine x_K:
@@ -1261,7 +1270,7 @@ def _recover_pub_key_(
     KJ = x_K, y_K, 1  # 1.2, 1.3, and 1.4
     # 1.5 has been performed in the recover_pub_keys calling function
     #
-    # delegated as the double_mult of _assert_as_valid_ below it is: this
+    # delegated as the double_mult_var of _assert_as_valid_ below it is: this
     # is the Python path of recovery -- the named candidate goes to
     # secp256k1_ecdsa_recover instead, and the enumeration has no
     # counterpart to go to at all -- but the arithmetic under it is
@@ -1440,8 +1449,8 @@ def crack_prv_key_(
     c_1 = challenge_(msg_hash1, ec, hf)
     c_2 = challenge_(msg_hash2, ec, hf)
 
-    nonce = (c_1 - c_2) * mod_inv(sig1.s - sig2.s, ec.n) % ec.n
-    q = (sig2.s * nonce - c_2) * mod_inv(sig1.r, ec.n) % ec.n
+    nonce = (c_1 - c_2) * mod_inv_var(sig1.s - sig2.s, ec.n) % ec.n
+    q = (sig2.s * nonce - c_2) * mod_inv_var(sig1.r, ec.n) % ec.n
     return q, nonce
 
 

--- a/btclib/ecc/ellswift.py
+++ b/btclib/ecc/ellswift.py
@@ -54,7 +54,7 @@ from btclib.curves.curve import (
 )
 from btclib.exceptions import BTClibRuntimeError, BTClibValueError
 from btclib.hashes import tagged_hash
-from btclib.number_theory import mod_inv, mod_sqrt
+from btclib.number_theory import mod_inv_var, mod_sqrt_var
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import PubKey, point_from_pub_key
 from btclib.utils import bytes_from_octets
@@ -91,25 +91,25 @@ def _constants(ec: Curve) -> tuple[int, int]:
             raise BTClibValueError(err_msg)
         # -3 is a square whenever p == 1 mod 3, which every a == 0 curve
         # fit to carry a key is: the others have p+1 points, x -> x^3
-        # being a bijection there, and mod_sqrt refuses them by itself
-        _CONSTANTS[ec] = mod_sqrt(-3 % ec.p, ec.p), mod_inv(2, ec.p)
+        # being a bijection there, and mod_sqrt_var refuses them by itself
+        _CONSTANTS[ec] = mod_sqrt_var(-3 % ec.p, ec.p), mod_inv_var(2, ec.p)
     return _CONSTANTS[ec]
 
 
 def _try_sqrt(a: int, p: int) -> int | None:
     """Return a square root of a mod p, or None when a is not a square.
 
-    mod_sqrt raises instead, which is the wrong shape for the map: a
+    mod_sqrt_var raises instead, which is the wrong shape for the map: a
     non-square is one of the branches, taken for about half the inputs,
     and not an error to phrase.
 
-    That refusal is the whole of the test, rather than a legendre_symbol
-    asked before it: mod_sqrt squares its candidate back to compare with
+    That refusal is the whole of the test, rather than a legendre_symbol_var
+    asked before it: mod_sqrt_var squares its candidate back to compare with
     a, which is the same question answered, and on a 256-bit prime the
     symbol is an exponentiation the size of the root's.
     """
     try:
-        return mod_sqrt(a, p)
+        return mod_sqrt_var(a, p)
     except BTClibValueError:
         return None
 
@@ -134,9 +134,9 @@ def _xswiftec(u: int, t: int, ec: Curve) -> int:
     # u^3 + t^2 + b == 0 would make X below zero, whose Y is not a point
     if (pow(u, 3, p) + t * t + ec._b) % p == 0:
         t = 2 * t % p
-    X = (pow(u, 3, p) + ec._b - t * t) * mod_inv(2 * t, p) % p
-    Y = (X + t) * mod_inv(minus_3_sqrt * u % p, p) % p
-    inv_Y = mod_inv(Y, p)
+    X = (pow(u, 3, p) + ec._b - t * t) * mod_inv_var(2 * t, p) % p
+    Y = (X + t) * mod_inv_var(minus_3_sqrt * u % p, p) % p
+    inv_Y = mod_inv_var(Y, p)
     # three candidates, in the order the specification gives them: the
     # first that is an x-coordinate is the answer, and one of them is
     for x in (
@@ -174,7 +174,7 @@ def _xswiftec_inv(x: int, u: int, case: int, ec: Curve) -> int | None:  # noqa: 
         if _is_x_coordinate((-x - u) % p, ec):
             return None
         v = x
-        s = -(pow(u, 3, p) + b) * mod_inv((u * u + u * v + v * v) % p, p) % p
+        s = -(pow(u, 3, p) + b) * mod_inv_var((u * u + u * v + v * v) % p, p) % p
     else:
         s = (x - u) % p
         if s == 0:
@@ -186,7 +186,7 @@ def _xswiftec_inv(x: int, u: int, case: int, ec: Curve) -> int | None:  # noqa: 
         # and only one of them is to return it
         if case & 1 and r == 0:
             return None
-        v = (-u + r * mod_inv(s, p)) * inv2 % p
+        v = (-u + r * mod_inv_var(s, p)) * inv2 % p
 
     w = _try_sqrt(s, p)
     if w is None:

--- a/btclib/ecc/pedersen.py
+++ b/btclib/ecc/pedersen.py
@@ -28,7 +28,7 @@ from functools import lru_cache
 from hashlib import sha256
 
 from btclib.alias import HashF, Point
-from btclib.curves import Curve, bytes_from_point, double_mult, secp256k1
+from btclib.curves import Curve, bytes_from_point, double_mult_var, secp256k1
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.utils import int_from_bits
 
@@ -91,7 +91,7 @@ def commit(r: int, v: int, ec: Curve = secp256k1, hf: HashF = sha256) -> Point:
     (NUMS) generator of the curve.
     """
     H = second_generator(ec, hf)
-    Q = double_mult(v, H, r, ec.G, ec)
+    Q = double_mult_var(v, H, r, ec.G, ec)
     # r and v both zero mod n commit here; anything else would need
     # the discrete log of H
     if Q[1] == 0:

--- a/btclib/ecc/ssa.py
+++ b/btclib/ecc/ssa.py
@@ -70,13 +70,13 @@ from btclib.curves.curve import (
     _libsecp256k1_applicable,
     _y_even,
     mult,
-    multi_mult,
+    multi_mult_var,
 )
 from btclib.ecc.bip340_nonce import bip340_nonce_
 from btclib.ecc.commit_nonce import commit_entropy_, commit_nonce_, commit_point_
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.hashes import _assert_valid_hf, reduce_to_hlen, tagged_hash
-from btclib.number_theory import mod_inv
+from btclib.number_theory import mod_inv_var
 from btclib.to_prv_key import PrvKey, int_from_prv_key
 from btclib.to_pub_key import point_from_pub_key
 from btclib.utils import (
@@ -507,7 +507,7 @@ def _assert_as_valid_(c: int, QJ: JacPoint, r: int, s: int, ec: Curve) -> None:
     # It raises Errors, while verify should always return True or False
 
     # Let K = sG - eQ.
-    # in Jacobian coordinates, and through the dispatching double_mult of
+    # in Jacobian coordinates, and through the dispatching double_mult_var of
     # curves.curve rather than the Python arithmetic under it: what
     # reaches here is the verification the bindings' own declined, which
     # is another curve or another hash function -- the size of the message
@@ -699,10 +699,10 @@ def _recover_pub_key_(c: int, r: int, s: int, ec: Curve) -> int:
 
     KJ = r, _y_even(r, ec), 1
 
-    e1 = mod_inv(c, ec.n)
+    e1 = mod_inv_var(c, ec.n)
     # libsecp256k1 recovers no x-only key -- its recovery module is ECDSA
     # ("recover(msg, signature, recid)") and its xonly module has no
-    # recovery in it -- so the delegated double_mult is the whole of what
+    # recovery in it -- so the delegated double_mult_var is the whole of what
     # there is to gain here, and it is all of the cost: 3540 us against
     # 109 for this function. Which is also why this stays private, with no
     # public spelling above it: BIP340 has no recovery flag to carry the
@@ -825,7 +825,7 @@ def assert_batch_as_valid_(
         points.append((x_Q, y_Q))
         t += rand * sig.s
 
-    # the public mult and multi_mult, in affine coordinates, rather than
+    # the public mult and multi_mult_var, in affine coordinates, rather than
     # the Jacobian functions of curve_group underneath them and an
     # equality of projective coordinates: those two are where the
     # libsecp256k1 dispatch lives, and this sum is the one place in btclib
@@ -836,8 +836,8 @@ def assert_batch_as_valid_(
     # left being two lifts and a challenge per signature, some 9 us of
     # which the lifts are libsecp256k1's. The two affine
     # conversions the equality costs on every other curve are one modular
-    # inversion each, next to a multi_mult of all the terms
-    if mult(t, ec=ec) != multi_mult(scalars, points, ec):
+    # inversion each, next to a multi_mult_var of all the terms
+    if mult(t, ec=ec) != multi_mult_var(scalars, points, ec):
         raise BTClibRuntimeError("signature verification failed")
     return
 

--- a/btclib/number_theory.py
+++ b/btclib/number_theory.py
@@ -7,7 +7,7 @@
 Implementations originally from
 https://en.wikibooks.org/wiki/Algorithm_Implementation/Mathematics/Extended_Euclidean_algorithm
 and
-https://codereview.stackexchange.com/questions/43210/tonelli-shanks-algorithm-implementation-of-prime-modular-square-root/43267
+https://codereview.stackexchange.com/questions/43210/tonelli_var-shanks-algorithm-implementation-of-prime-modular-square-root/43267
 with the following modifications:
 
 * type annotated Python3
@@ -17,18 +17,20 @@ with the following modifications:
 
 from __future__ import annotations
 
+import secrets
 from collections.abc import Sequence
 
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.utils import hex_string, is_integer
 
 __all__ = [
-    "legendre_symbol",
+    "legendre_symbol_var",
     "mod_inv",
-    "mod_inv_batch",
-    "mod_sqrt",
-    "tonelli",
-    "xgcd",
+    "mod_inv_batch_var",
+    "mod_inv_var",
+    "mod_sqrt_var",
+    "tonelli_var",
+    "xgcd_var",
 ]
 
 
@@ -37,7 +39,7 @@ def _assert_valid_operand(a: int) -> None:
 
     A float goes through every function here without complaint --
     `//`, `%` and `*` are all defined for it -- and comes back out of a
-    signature that says `int`: `mod_inv(3.0, 7)` answers `5.0`, which is
+    signature that says `int`: `mod_inv_var(3.0, 7)` answers `5.0`, which is
     not a residue and not an error either. `var_int.serialize` checks the
     same way and its docstring says why a bool is excluded.
     """
@@ -63,12 +65,12 @@ def _assert_valid_modulus(m: int) -> None:
 # private twins doing the work unchecked for the ones that call each
 # other: a pair of isinstance calls is a small fraction of the arithmetic
 # it stands in front of, an inverse modulo a 256-bit prime being an
-# extended Euclid even when C runs it, so the re-checking mod_sqrt does
-# through tonelli and legendre_symbol costs less than five more names
+# extended Euclid even when C runs it, so the re-checking mod_sqrt_var does
+# through tonelli_var and legendre_symbol_var costs less than five more names
 # would
 
 
-def xgcd(a: int, b: int) -> tuple[int, int, int]:
+def xgcd_var(a: int, b: int) -> tuple[int, int, int]:
     """Return (g, x, y) such that a*x + b*y = g = gcd(x, y).
 
     based on Extended Euclidean Algorithm, see
@@ -84,17 +86,21 @@ def xgcd(a: int, b: int) -> tuple[int, int, int]:
     return b, x0, y0
 
 
-def mod_inv(a: int, m: int) -> int:
+def mod_inv_var(a: int, m: int) -> int:
     """Return the inverse of a (mod m).
 
     m does not have to be a prime.
 
     `pow(a, -1, m)` is an Extended Euclidean Algorithm too -- CPython's
-    `long_invmod`, which is the loop `xgcd` runs with the second cofactor
+    `long_invmod`, which is the loop `xgcd_var` runs with the second cofactor
     dropped -- so this delegates the same algorithm to C rather than
     interpreting it, and that is the whole of why it is called. It is not
     a constant-time inverse and neither was the bytecode one; SECURITY.md
     publishes the Python path as variable-time.
+
+    Its duration follows the operand, so a secret one goes to
+    `mod_inv` instead: what that duration carries is measured
+    there, and it is enough to recover a private key from a signature.
 
     What `pow` does not carry is this module's contract, so the checks
     stay above it and the message below it: a non-invertible operand
@@ -114,17 +120,72 @@ def mod_inv(a: int, m: int) -> int:
         raise BTClibValueError(err_msg) from None
 
 
-def mod_inv_batch(a: Sequence[int], m: int) -> list[int]:
+def mod_inv(a: int, m: int) -> int:
+    """Return the inverse of a (mod m), timed on a random value instead.
+
+    What `mod_inv_var` is for an operand that is public, this is for one
+    that is secret. The extended Euclid under that one takes the
+    iterations its input asks for, and for an operand drawn uniformly
+    below m what its duration carries is the operand's bit-length: on
+    secp256k1's order, 8.8 us for a 256-bit scalar against 4.3 for a
+    128-bit one, falling at every step between them. That
+    correlation is what the Minerva attack collects -- an ECDSA nonce is
+    such a scalar, and a few thousand signing times sorted by it are a
+    lattice away from the private key.
+
+    (b*a)^-1 * b is a^-1 for every b invertible mod m, so drawing b at
+    random leaves an inverse whose iteration count follows b and tells an
+    observer nothing about a: 1.02x across the same range of operands,
+    where `mod_inv_var` is 2.06x. Two multiplications, two reductions
+    and a draw from `secrets`, which is 1.11x on a 256-bit operand and
+    1.5% of the whole Python signature it sits in. Fermat's
+    `pow(a, m - 2, m)` is the alternative and is flat for a different
+    reason, its ladder running on the fixed exponent rather than on a
+    random operand; it is not the one chosen, at 8.38x.
+
+    The draw is what costs, so a small modulus pays proportionally more
+    -- 4.8x on an order of 11, where the Euclid is a few iterations and
+    `secrets` is the same syscall. Nothing signs with such an order
+    outside the test suite.
+
+    Not a constant-time inverse, and no more claiming to be one than
+    `curve_group._blinded_jac` does: the duration is still an extended
+    Euclid's and still visible, and what the blinding changes is whose it
+    is. SECURITY.md publishes the Python path as variable-time, and
+    CONTRIBUTING.md has what a name in this library does and does not
+    promise about duration.
+    """
+    _assert_valid_operand(a)
+    _assert_valid_modulus(m)
+
+    # a nonzero b, and one the modulus leaves room to draw: m == 1 has
+    # only b = 1, every integer being zero modulo it
+    b = 1 + secrets.randbelow(m - 1) if m > 1 else 1
+    try:
+        return mod_inv_var(a * b % m, m) * b % m
+    except BTClibValueError:
+        # a product is invertible only if both factors are, so this is
+        # either the caller's own non-invertible a -- and the call below
+        # raises about the operand they passed, where the one above would
+        # name a product they never formed -- or a b that is a zero
+        # divisor, which only a composite m has. The blinding is lost in
+        # that second case and the answer is not; every modulus this is
+        # asked about in the library is the order of a group, which
+        # `curves.Curve` requires prime
+        return mod_inv_var(a, m)
+
+
+def mod_inv_batch_var(a: Sequence[int], m: int) -> list[int]:
     """Return the inverse of every element of a (mod m), in its order.
 
     m does not have to be a prime, and every element has to be invertible
-    modulo it, as `mod_inv` requires of its one operand.
+    modulo it, as `mod_inv_var` requires of its one operand.
 
     Montgomery's trick, which libsecp256k1 spells `secp256k1_fe_inv_all_var`:
     the running products a[0], a[0]*a[1], ..., a[0]*...*a[n-1] are formed,
     the last of them is inverted once, and the individual inverses are
     peeled back off it. So n inverses cost one inverse and 3(n-1)
-    products, where n calls to `mod_inv` are n extended Euclids -- an
+    products, where n calls to `mod_inv_var` are n extended Euclids -- an
     inverse modulo a 256-bit prime being some thirty times a product.
 
     An empty sequence has no inverses and is not an error: it is what a
@@ -149,9 +210,9 @@ def mod_inv_batch(a: Sequence[int], m: int) -> list[int]:
     except ValueError:
         # a product is invertible only if every factor is, so at least one
         # element is not: inverting them one at a time reaches it and
-        # answers `mod_inv`'s own message, naming the operand rather than
+        # answers `mod_inv_var`'s own message, naming the operand rather than
         # the product a caller never formed
-        return [mod_inv(x, m) for x in a]
+        return [mod_inv_var(x, m) for x in a]
 
     # and peeled back off it, from the last element to the first: the
     # inverse of the whole product times the product of everything before
@@ -164,7 +225,7 @@ def mod_inv_batch(a: Sequence[int], m: int) -> list[int]:
     return inverses
 
 
-def legendre_symbol(a: int, p: int) -> int:
+def legendre_symbol_var(a: int, p: int) -> int:
     """Compute the Legendre symbol a|p, as a binary Jacobi symbol.
 
     p is a prime, a is relatively prime to p (if p divides a, then a|p =
@@ -185,8 +246,11 @@ def legendre_symbol(a: int, p: int) -> int:
 
     The loop's length follows `a`, where an exponentiation's did not.
     SECURITY.md publishes the Python path as variable-time, and nothing
-    in the tree asks this about a value that has to stay hidden --
-    `curves.curve._is_x_coordinate` asks it about a signature's r.
+    in the tree asks this about a value that has to stay hidden:
+    `curves.curve._is_x_coordinate` is the one caller, and what reaches
+    it is a signature's r, the x-coordinate of a serialized xpub, or a
+    candidate x of an ElligatorSwift encoding -- each of them public, and
+    on secp256k1 each answered by the bindings before this is reached.
     """
     _assert_valid_operand(a)
     _assert_valid_modulus(p)
@@ -211,7 +275,7 @@ def legendre_symbol(a: int, p: int) -> int:
     return result if p == 1 else 0
 
 
-def mod_sqrt(a: int, p: int) -> int:
+def mod_sqrt_var(a: int, p: int) -> int:
     """Return a quadratic residue (mod p) of a; p must be a prime.
 
     Solve the equation:
@@ -222,7 +286,7 @@ def mod_sqrt(a: int, p: int) -> int:
     If a simple solution is not available for p,
     then the Tonelli-Shanks algorithm is used.
 
-    https://codereview.stackexchange.com/questions/43210/tonelli-shanks-algorithm-implementation-of-prime-modular-square-root/43267
+    https://codereview.stackexchange.com/questions/43210/tonelli_var-shanks-algorithm-implementation-of-prime-modular-square-root/43267
     """
     _assert_valid_operand(a)
     _assert_valid_modulus(p)
@@ -239,7 +303,7 @@ def mod_sqrt(a: int, p: int) -> int:
         # another inverse candidate
         r = r * pow(2, p >> 2, p) % p
     else:
-        return tonelli(a, p)
+        return tonelli_var(a, p)
 
     if r * r % p != a:
         err_msg = "no root for "
@@ -250,12 +314,12 @@ def mod_sqrt(a: int, p: int) -> int:
     return r
 
 
-def tonelli(a: int, p: int) -> int:
+def tonelli_var(a: int, p: int) -> int:
     """Return a quadratic residue (mod p) of a; p must be a prime.
 
     The Tonelli-Shanks algorithm is used.
 
-    https://codereview.stackexchange.com/questions/43210/tonelli-shanks-algorithm-implementation-of-prime-modular-square-root/43267
+    https://codereview.stackexchange.com/questions/43210/tonelli_var-shanks-algorithm-implementation-of-prime-modular-square-root/43267
     """
     _assert_valid_operand(a)
     _assert_valid_modulus(p)
@@ -264,7 +328,7 @@ def tonelli(a: int, p: int) -> int:
         return a
 
     # Check solution existence for an odd prime p
-    if legendre_symbol(a, p) != 1:
+    if legendre_symbol_var(a, p) != 1:
         err_msg = "no root for "
         err_msg += f"'{hex_string(a)}'" if a > 0xFFFFFFFF else f"{a}"
         err_msg += " mod "
@@ -283,7 +347,7 @@ def tonelli(a: int, p: int) -> int:
     # first value that can be one: 1 is a square modulo every prime, so
     # its symbol is known before the loop asks for it
     z = 2
-    while legendre_symbol(z, p) != -1:
+    while legendre_symbol_var(z, p) != -1:
         z += 1
     c = pow(z, q, p)
     r = pow(a, (q + 1) // 2, p)

--- a/btclib/silent_payments.py
+++ b/btclib/silent_payments.py
@@ -463,7 +463,7 @@ def pub_key_sum(pub_keys: Sequence[PubKey]) -> Point:
     sequence is the same answer, and is what a transaction of nothing but
     skipped inputs sums to.
 
-    Added one at a time rather than through `multi_mult`: an intermediate
+    Added one at a time rather than through `multi_mult_var`: an intermediate
     sum at infinity is a BIP352 vector, and infinity is exactly what
     libsecp256k1 has no public key for.
     """

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -333,11 +333,11 @@ def test_ec_exports_the_curve_api_not_the_benchmark() -> None:
         "CurveGroup",
         "bytes_from_point",
         "bytes_from_prv_key_int",
-        "double_mult",
+        "double_mult_var",
         "find_all_points",
         "find_subgroup_points",
         "mult",
-        "multi_mult",
+        "multi_mult_var",
         "point_from_octets",
         "secp256k1",
     ]

--- a/tests/bip32/bip32_test.py
+++ b/tests/bip32/bip32_test.py
@@ -279,7 +279,7 @@ def test_public_key_validation_does_not_lift(
     square root that found it was paid once per extended key -- so by
     every level of every derivation path (issue 615). What pins the
     predicate in place of the lift is reaching no square root at all,
-    not a stopwatch: mod_sqrt is patched to raise, and the accepted key
+    not a stopwatch: mod_sqrt_var is patched to raise, and the accepted key
     and the refused one both have to get their answer without it.
     """
 
@@ -290,7 +290,7 @@ def test_public_key_validation_does_not_lift(
             "the y of an extended public key was computed"
         )
 
-    monkeypatch.setattr(curve_group, "mod_sqrt", refuse)
+    monkeypatch.setattr(curve_group, "mod_sqrt_var", refuse)
 
     xpub = "xpub6H1LXWLaKsWFhvm6RVpEL9P4KfRZSW7abD2ttkWP3SSQvnyA8FSVqNTEcYFgJS2UaFcxupHiYkro49S8yGasTvXEYBVPamhGW6cFJodrTHy"
     assert BIP32KeyData.b58decode(xpub).b58encode() == xpub

--- a/tests/curves/curve_group_2_test.py
+++ b/tests/curves/curve_group_2_test.py
@@ -276,7 +276,7 @@ def test_double_mult_endomorphism_secp256k1() -> None:
             assert ec.is_jac_equal(dm(u, v, HJ, QJ, w), expected), (u, v, w)
 
     # infinity on either side, and the coefficient that contributes nothing:
-    # what `curves.double_mult` sends down this path on secp256k1, the
+    # what `curves.double_mult_var` sends down this path on secp256k1, the
     # bindings taking no zero scalar and no infinity
     for u, v in ((7, 5), (0, 5), (7, 0), (0, 0)):
         for H, Q in ((INFJ, QJ), (HJ, INFJ), (INFJ, INFJ)):

--- a/tests/curves/curve_group_test.py
+++ b/tests/curves/curve_group_test.py
@@ -14,7 +14,7 @@ from btclib.curves import Curve, CurveGroup, find_all_points, secp256k1
 
 # the mult_* variants under test, and the helpers they are built on, come
 # from the module that defines them: btclib.curves exports mult,
-# double_mult and multi_mult, not a menu of implementations
+# double_mult_var and multi_mult_var, not a menu of implementations
 from btclib.curves.curve_group import (
     _MULTI_MULT_W,
     BOS_COSTER_THRESHOLD,
@@ -858,7 +858,7 @@ def test_multi_mult_dispatch() -> None:
         with pytest.raises(BTClibValueError, match="negative coefficient: "):
             _multi_mult_var([-1, *scalars[1:]], points, ec)
 
-    with pytest.raises(BTClibValueError, match="not a multi_mult"):
+    with pytest.raises(BTClibValueError, match="not a multi_mult_var"):
         _multi_mult_var([1], [ec.GJ], ec)
 
 

--- a/tests/curves/curve_test.py
+++ b/tests/curves/curve_test.py
@@ -21,9 +21,9 @@ from btclib.curves import (
     # module attribute, and patching it off is how no_bindings below
     # reaches the Python arithmetic underneath
     curve,
-    double_mult,
+    double_mult_var,
     mult,
-    multi_mult,
+    multi_mult_var,
     secp256k1,
 )
 from btclib.curves.curve import (
@@ -49,7 +49,7 @@ from btclib.curves.curve import (
 from btclib.curves.curve_group import _cached_multiples, _jac_from_aff, _mult_jac_var
 from btclib.ecc import second_generator
 from btclib.exceptions import BTClibTypeError, BTClibValueError
-from btclib.number_theory import mod_inv, mod_sqrt
+from btclib.number_theory import mod_inv_var, mod_sqrt_var
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from tests import load, vector_id
 
@@ -397,9 +397,9 @@ def _textbook_add(ec: CurveGroup, P: Point | None, Q: Point | None) -> Point | N
     if P[0] == Q[0] and (P[1] + Q[1]) % ec.p == 0:
         return None
     if P == Q:
-        lam = (3 * P[0] * P[0] + ec._a) * mod_inv(2 * P[1], ec.p) % ec.p
+        lam = (3 * P[0] * P[0] + ec._a) * mod_inv_var(2 * P[1], ec.p) % ec.p
     else:
-        lam = (Q[1] - P[1]) * mod_inv(Q[0] - P[0], ec.p) % ec.p
+        lam = (Q[1] - P[1]) * mod_inv_var(Q[0] - P[0], ec.p) % ec.p
     x = (lam * lam - P[0] - Q[0]) % ec.p
     return x, (lam * (P[0] - x) - P[1]) % ec.p
 
@@ -822,14 +822,14 @@ def test_symmetry() -> None:
 
             # in this case only quad_res is a quadratic residue
             assert quad_res in hasRoot
-            root = mod_sqrt(quad_res, ec.p)
+            root = mod_sqrt_var(quad_res, ec.p)
             assert quad_res == (root * root) % ec.p
             root = ec.p - root
             assert quad_res == (root * root) % ec.p
 
             assert ec.p - quad_res not in hasRoot
             with pytest.raises(BTClibValueError, match="no root for "):
-                mod_sqrt(ec.p - quad_res, ec.p)
+                mod_sqrt_var(ec.p - quad_res, ec.p)
         else:
             assert ec.p % 4 == 1
             # cannot use y_quadratic_residue in this case
@@ -844,20 +844,20 @@ def test_symmetry() -> None:
             both = y_odd in hasRoot and y_even in hasRoot
             assert neither or both
             if y_odd in hasRoot:  # both have roots
-                root = mod_sqrt(y_odd, ec.p)
+                root = mod_sqrt_var(y_odd, ec.p)
                 assert y_odd == (root * root) % ec.p
                 root = ec.p - root
                 assert y_odd == (root * root) % ec.p
-                root = mod_sqrt(y_even, ec.p)
+                root = mod_sqrt_var(y_even, ec.p)
                 assert y_even == (root * root) % ec.p
                 root = ec.p - root
                 assert y_even == (root * root) % ec.p
             else:
                 err_msg = "no root for "
                 with pytest.raises(BTClibValueError, match=err_msg):
-                    mod_sqrt(y_odd, ec.p)
+                    mod_sqrt_var(y_odd, ec.p)
                 with pytest.raises(BTClibValueError, match=err_msg):
-                    mod_sqrt(y_even, ec.p)
+                    mod_sqrt_var(y_even, ec.p)
 
     with pytest.raises(BTClibValueError, match="invalid x-coordinate: "):
         secp256k1.y_even(INF[0])
@@ -868,7 +868,7 @@ def test_symmetry() -> None:
 
 
 def test_assorted_mult() -> None:
-    """Cross-check mult, double_mult and multi_mult on a tiny curve."""
+    """Cross-check mult, double_mult_var and multi_mult_var on a tiny curve."""
     ec = ec23_31
     H = second_generator(ec)
     for k1 in range(-2, ec.n):
@@ -876,18 +876,18 @@ def test_assorted_mult() -> None:
         for k2 in range(-2, ec.n):
             K2 = mult(k2, H, ec)
 
-            shamir = double_mult(k1, ec.G, k2, ec.G, ec)
+            shamir = double_mult_var(k1, ec.G, k2, ec.G, ec)
             assert shamir == mult(k1 + k2, None, ec)
 
-            shamir = double_mult(k1, INF, k2, H, ec)
+            shamir = double_mult_var(k1, INF, k2, H, ec)
             assert ec.is_on_curve(shamir)
             assert shamir == K2
 
-            shamir = double_mult(k1, ec.G, k2, INF, ec)
+            shamir = double_mult_var(k1, ec.G, k2, INF, ec)
             assert ec.is_on_curve(shamir)
             assert shamir == K1
 
-            shamir = double_mult(k1, ec.G, k2, H, ec)
+            shamir = double_mult_var(k1, ec.G, k2, H, ec)
             assert ec.is_on_curve(shamir)
             K1K2 = ec.add(K1, K2)
             assert shamir == K1K2
@@ -896,7 +896,7 @@ def test_assorted_mult() -> None:
             K3 = mult(k3, ec.G, ec)
             K1K2K3 = ec.add(K1K2, K3)
             assert ec.is_on_curve(K1K2K3)
-            boscoster = multi_mult([k1, k2, k3], [ec.G, H, ec.G], ec)
+            boscoster = multi_mult_var([k1, k2, k3], [ec.G, H, ec.G], ec)
             assert ec.is_on_curve(boscoster)
             assert boscoster == K1K2K3, k3
 
@@ -905,61 +905,61 @@ def test_assorted_mult() -> None:
             K1K2K3K4 = ec.add(K1K2K3, K4)
             assert ec.is_on_curve(K1K2K3K4)
             points = [ec.G, H, ec.G, H]
-            boscoster = multi_mult([k1, k2, k3, k4], points, ec)
+            boscoster = multi_mult_var([k1, k2, k3, k4], points, ec)
             assert ec.is_on_curve(boscoster)
             assert boscoster == K1K2K3K4, k4
-            assert multi_mult([k1, k2, k3, 0], points, ec) == K1K2K3
-            assert multi_mult([k1, k2, 0, 0], points, ec) == K1K2
-            assert multi_mult([k1, 0, 0, 0], points, ec) == K1
-            assert multi_mult([0, 0, 0, 0], points, ec) == INF
+            assert multi_mult_var([k1, k2, k3, 0], points, ec) == K1K2K3
+            assert multi_mult_var([k1, k2, 0, 0], points, ec) == K1K2
+            assert multi_mult_var([k1, 0, 0, 0], points, ec) == K1
+            assert multi_mult_var([0, 0, 0, 0], points, ec) == INF
 
             err_msg = "mismatch between number of scalars and points: "
             with pytest.raises(BTClibValueError, match=err_msg):
-                multi_mult([k1, k2, k3, k4], [ec.G, H, ec.G], ec)
+                multi_mult_var([k1, k2, k3, k4], [ec.G, H, ec.G], ec)
 
 
 def test_double_mult() -> None:
-    """Verify double_mult against add and mult over small scalars."""
+    """Verify double_mult_var against add and mult over small scalars."""
     H = second_generator(secp256k1)
     G = secp256k1.G
-    assert double_mult(0, G, 0, H) == INF
-    assert double_mult(1, G, 0, H) == G
-    assert double_mult(0, G, 1, H) == H
+    assert double_mult_var(0, G, 0, H) == INF
+    assert double_mult_var(1, G, 0, H) == G
+    assert double_mult_var(0, G, 1, H) == H
     for i, j in itertools.product(range(-1, 3), range(-1, 3)):
         exp = secp256k1.add(mult(i), mult(j, H))
-        assert exp == double_mult(i, G, j, H)
+        assert exp == double_mult_var(i, G, j, H)
 
 
 def test_multi_mult() -> None:
-    """Verify multi_mult against double_mult, issue 175's pairs too."""
-    with pytest.raises(BTClibValueError, match="not a multi_mult"):
-        multi_mult([1], [secp256k1.G])
+    """Verify multi_mult_var against double_mult_var, issue 175's pairs too."""
+    with pytest.raises(BTClibValueError, match="not a multi_mult_var"):
+        multi_mult_var([1], [secp256k1.G])
 
     H = second_generator(secp256k1)
     G = secp256k1.G
-    assert multi_mult([0, 0], [G, H]) == INF
-    assert multi_mult([1, 0], [G, H]) == G
-    assert multi_mult([0, 1], [G, H]) == H
+    assert multi_mult_var([0, 0], [G, H]) == INF
+    assert multi_mult_var([1, 0], [G, H]) == G
+    assert multi_mult_var([0, 1], [G, H]) == H
 
-    assert multi_mult([-1, 0], [G, H]) != INF
-    assert multi_mult([0, -1], [G, H]) != INF
+    assert multi_mult_var([-1, 0], [G, H]) != INF
+    assert multi_mult_var([0, -1], [G, H]) != INF
 
     for i, j in itertools.product(range(-1, 3), range(-1, 3)):
-        exp = double_mult(i, G, j, H)
-        assert exp == multi_mult([i, j], [G, H])
+        exp = double_mult_var(i, G, j, H)
+        assert exp == multi_mult_var([i, j], [G, H])
 
     # issue 175: a scalar pair of distant magnitude is what the
     # subtractive Bos-Coster step could not finish, and a mixed sign is
     # merely the worst instance of it -- -1 reduces to n-1, next to 1
     n = secp256k1.n
     for i, j in ((10**6, 1), (1, 10**6), (n - 1, 1), (n - 1, n - 2)):
-        assert double_mult(i, G, j, H) == multi_mult([i, j], [G, H])
+        assert double_mult_var(i, G, j, H) == multi_mult_var([i, j], [G, H])
 
 
 def no_bindings(monkeypatch: pytest.MonkeyPatch) -> None:
     """Patch the libsecp256k1 dispatch off, and the bindings out of reach.
 
-    The predicate is what mult, double_mult and multi_mult ask, and
+    The predicate is what mult, double_mult_var and multi_mult_var ask, and
     patching it is the pattern of tests/script_engine/python_path_test.py.
     Replacing the three bindings functions besides is what proves they
     were not asked anyway: a dispatch this does not cover raises here
@@ -991,7 +991,7 @@ def test_libsecp256k1_arbitrary_point() -> None:
     same call made again. The bindings are the authority on the answer --
     they are what bitcoin runs -- and the Python implementation is the one
     being held against them, `mult` reaching its GLV endomorphism there
-    and `multi_mult` its Bos-Coster.
+    and `multi_mult_var` its Bos-Coster.
 
     A spread of scalars and points rather than a random draw, so that a
     failure is the same failure tomorrow. G is among the points on
@@ -1012,18 +1012,18 @@ def test_libsecp256k1_arbitrary_point() -> None:
             assert mult(m, Q) == libsecp256k1_answer
 
     for (u, H), (v, Q) in itertools.product(pairs, repeat=2):
-        libsecp256k1_answer = double_mult(u, H, v, Q)
-        assert multi_mult([u, v], [H, Q]) == libsecp256k1_answer
+        libsecp256k1_answer = double_mult_var(u, H, v, Q)
+        assert multi_mult_var([u, v], [H, Q]) == libsecp256k1_answer
         with pytest.MonkeyPatch.context() as patch:
             no_bindings(patch)
-            assert double_mult(u, H, v, Q) == libsecp256k1_answer
-            assert multi_mult([u, v], [H, Q]) == libsecp256k1_answer
+            assert double_mult_var(u, H, v, Q) == libsecp256k1_answer
+            assert multi_mult_var([u, v], [H, Q]) == libsecp256k1_answer
 
     # and the many-scalar sum, which is what ssa's batch verification is
-    libsecp256k1_answer = multi_mult(scalars, points + points[:2])
+    libsecp256k1_answer = multi_mult_var(scalars, points + points[:2])
     with pytest.MonkeyPatch.context() as patch:
         no_bindings(patch)
-        assert multi_mult(scalars, points + points[:2]) == libsecp256k1_answer
+        assert multi_mult_var(scalars, points + points[:2]) == libsecp256k1_answer
 
 
 @pytest.mark.parametrize("bindings", [True, False], ids=["bindings", "python"])
@@ -1053,30 +1053,30 @@ def test_multiplications_the_bindings_decline(
     assert mult(0, INF) == INF
 
     # both of them again, as one term of a sum
-    assert double_mult(0, H, 0, G) == INF
-    assert double_mult(0, H, 3, G) == mult(3)
-    assert double_mult(3, INF, 5, H) == mult(5, H)
-    assert double_mult(3, H, 5, INF) == mult(3, H)
-    assert multi_mult([0, 0], [H, G]) == INF
-    assert multi_mult([3, 0], [H, G]) == mult(3, H)
-    assert multi_mult([3, 5], [INF, H]) == mult(5, H)
+    assert double_mult_var(0, H, 0, G) == INF
+    assert double_mult_var(0, H, 3, G) == mult(3)
+    assert double_mult_var(3, INF, 5, H) == mult(5, H)
+    assert double_mult_var(3, H, 5, INF) == mult(3, H)
+    assert multi_mult_var([0, 0], [H, G]) == INF
+    assert multi_mult_var([3, 0], [H, G]) == mult(3, H)
+    assert multi_mult_var([3, 5], [INF, H]) == mult(5, H)
 
     # and the sum that is infinity: v = n - u with the same point, the
-    # one-line case, then the same through multi_mult
-    assert double_mult(5, H, n - 5, H) == INF
-    assert multi_mult([5, n - 5], [H, H]) == INF
+    # one-line case, then the same through multi_mult_var
+    assert double_mult_var(5, H, n - 5, H) == INF
+    assert multi_mult_var([5, n - 5], [H, H]) == INF
 
     # an intermediate that is infinity and a total that is not: the
     # running total starts again from the term that follows it
-    assert multi_mult([5, n - 5, 3], [H, H, H]) == mult(3, H)
+    assert multi_mult_var([5, n - 5, 3], [H, H, H]) == mult(3, H)
 
     # a total that is infinity from three terms of which no two cancel:
     # 5 + (n-3) + 2*(n-1) is 2n
-    assert multi_mult([5, n - 3, n - 1], [H, H, mult(2, H)]) == INF
+    assert multi_mult_var([5, n - 3, n - 1], [H, H, mult(2, H)]) == INF
 
     # the same point twice is P + P, a doubling and not a cancellation
-    assert multi_mult([5, 5], [H, H]) == mult(10, H)
-    assert double_mult(5, H, 5, H) == mult(10, H)
+    assert multi_mult_var([5, 5], [H, H]) == mult(10, H)
+    assert double_mult_var(5, H, 5, H) == mult(10, H)
 
 
 def test_libsecp256k1_multi_mult_bytes() -> None:

--- a/tests/ecc/borromean_test.py
+++ b/tests/ecc/borromean_test.py
@@ -136,7 +136,7 @@ ROUND_TRIP_MSG = {
 def test_another_curve_signs_and_verifies(name: str) -> None:
     """The ec argument has to reach the arithmetic, not only the encodings.
 
-    It did not: `mult(k)` and `double_mult(-e, Q, s, ec.G)` were called
+    It did not: `mult(k)` and `double_mult_var(-e, Q, s, ec.G)` were called
     without ec, so every point was computed on secp256k1 -- ec.G being
     merely a *point* argument -- and then encoded against ec. The first
     bytes_from_point raised "y-coordinate not in 1..p-1" with a

--- a/tests/ecc/dsa_test.py
+++ b/tests/ecc/dsa_test.py
@@ -17,7 +17,7 @@ from btclib.curves import (
     Curve,
     bytes_from_point,
     curve,
-    double_mult,
+    double_mult_var,
     mult,
     point_from_octets,
     secp256k1,
@@ -28,7 +28,7 @@ from btclib.ecc import dsa
 from btclib.ecc.rfc6979_nonce import challenge_
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.hashes import reduce_to_hlen
-from btclib.number_theory import mod_inv
+from btclib.number_theory import mod_inv_var
 from btclib.to_pub_key import pub_keyinfo_from_prv_key
 from tests import load, vector_id
 from tests.curves.curve_test import low_card_curves, no_bindings, secp256k1_bis
@@ -227,7 +227,7 @@ def test_low_cardinality(name: str) -> None:
         for k in range(1, ec.n):  # all possible ephemeral keys
             RJ = _mult(k, ec.GJ, ec)
             r = ec.x_aff_from_jac(RJ) % ec.n
-            k_inv = mod_inv(k, ec.n)
+            k_inv = mod_inv_var(k, ec.n)
             for e in range(ec.n):  # all possible challenges
                 s = k_inv * (e + q * r) % ec.n
                 # bitcoin canonical 'low-s' encoding for ECDSA
@@ -291,7 +291,7 @@ def test_key_id_is_j_above_the_parity_bit() -> None:
                 if not ec.n < x_K < ec.p:  # else x_K is r itself
                     continue
                 r = x_K % ec.n
-                k_inv = mod_inv(k, ec.n)
+                k_inv = mod_inv_var(k, ec.n)
                 for e in range(ec.n):
                     s = k_inv * (e + q * r) % ec.n
                     if r == 0 or s == 0:
@@ -351,7 +351,7 @@ def test_key_id_is_the_j_zero_pair_when_n_is_above_p() -> None:
             # possibility this curve has, and a swapped curve would have
             # skipped silently where this says so
             assert r
-            k_inv = mod_inv(k, ec.n)
+            k_inv = mod_inv_var(k, ec.n)
             for e in range(ec.n):
                 s = k_inv * (e + q * r) % ec.n
                 if s == 0:
@@ -422,9 +422,9 @@ def test_forge_hash_sig() -> None:
     # pick u1 and u2 at will
     u1 = 1
     u2 = 2
-    R = double_mult(u2, Q, u1, ec.G, ec)
+    R = double_mult_var(u2, Q, u1, ec.G, ec)
     r = R[0] % ec.n
-    u2inv = mod_inv(u2, ec.n)
+    u2inv = mod_inv_var(u2, ec.n)
     s = r * u2inv % ec.n
     s = ec.n - s if s > ec.n / 2 else s
     e = s * u1 % ec.n
@@ -433,9 +433,9 @@ def test_forge_hash_sig() -> None:
     # pick u1 and u2 at will
     u1 = 1234567890
     u2 = 987654321
-    R = double_mult(u2, Q, u1, ec.G, ec)
+    R = double_mult_var(u2, Q, u1, ec.G, ec)
     r = R[0] % ec.n
-    u2inv = mod_inv(u2, ec.n)
+    u2inv = mod_inv_var(u2, ec.n)
     s = r * u2inv % ec.n
     s = ec.n - s if s > ec.n / 2 else s
     e = s * u1 % ec.n
@@ -1017,7 +1017,7 @@ def test_recovery_multiplies_in_libsecp256k1(
         assert [key for key in recovered if key is not None] == keys
 
         with monkeypatch.context() as patch:
-            # the Python enumeration, its double_mult still delegated
+            # the Python enumeration, its double_mult_var still delegated
             patch.setattr(dsa, "_libsecp256k1_applicable", lambda *_: False)
             assert dsa.recover_pub_keys(msg, sig) == keys
             assert [_recovered(key_id, msg, sig) for key_id in key_ids] == recovered

--- a/tests/ecc/ssa_test.py
+++ b/tests/ecc/ssa_test.py
@@ -14,14 +14,20 @@ from btclib_secp256k1 import ssa as libsecp256k1_ssa
 
 from btclib.alias import INF, Point, String
 from btclib.bip32 import BIP32KeyData
-from btclib.curves import bytes_from_point, curve_group, double_mult, mult, secp256k1
+from btclib.curves import (
+    bytes_from_point,
+    curve_group,
+    double_mult_var,
+    mult,
+    secp256k1,
+)
 from btclib.curves.curve import CURVES, Curve
 from btclib.curves.curve_group import _jac_from_aff
 from btclib.ecc import second_generator, ssa
 from btclib.ecc.bip340_nonce import bip340_nonce_
 from btclib.exceptions import BTClibRuntimeError, BTClibTypeError, BTClibValueError
 from btclib.hashes import reduce_to_hlen
-from btclib.number_theory import mod_inv
+from btclib.number_theory import mod_inv_var
 from btclib.utils import int_from_bits
 from tests import load_csv, replace_unchecked, vector_id
 from tests.curves.curve_test import low_card_curves, no_bindings, secp256k1_bis
@@ -216,7 +222,7 @@ def test_refusing_an_r_takes_no_square_root(
     x-coordinate and cost nothing to produce, so that was the expensive
     answer for the cheap input.
 
-    mod_sqrt is patched to raise rather than timed: what the change has
+    mod_sqrt_var is patched to raise rather than timed: what the change has
     to be is a refusal that reaches no square root, on this machine and
     on a loaded one alike.
 
@@ -231,7 +237,7 @@ def test_refusing_an_r_takes_no_square_root(
             "an r was lifted to a point in order to refuse it"
         )
 
-    monkeypatch.setattr(curve_group, "mod_sqrt", refuse)
+    monkeypatch.setattr(curve_group, "mod_sqrt_var", refuse)
     with pytest.raises(BTClibValueError, match="r is not a valid x-coordinate: "):
         ssa.Sig(r, 1)
 
@@ -601,7 +607,7 @@ def test_batch_validation_on_the_python_path(monkeypatch: pytest.MonkeyPatch) ->
     """The batch verification equation, on both point arithmetics.
 
     Batch verification is btclib's own: libsecp256k1 exposes no batch
-    verify, so what serves it is the multi_mult of curves.curve -- and on
+    verify, so what serves it is the multi_mult_var of curves.curve -- and on
     secp256k1 that is the bindings, which makes this the one caller
     handing them many scalars at once. Patching the dispatch off is the
     only way the Python arithmetic sees a batch, and what this catches is
@@ -671,7 +677,7 @@ def test_musig() -> None:
     Q1 = mult(q1)
     Q2 = mult(q2)
     Q3 = mult(q3)
-    Q = ec.add(double_mult(a1, Q1, a2, Q2), mult(a3, Q3))
+    Q = ec.add(double_mult_var(a1, Q1, a2, Q2), mult(a3, Q3))
     # the parity of the aggregated key is a coin flip on every run, so
     # the negation executes in half of them: the pragmas keep the
     # coverage gate deterministic. Keys pinned offline for an odd
@@ -724,7 +730,7 @@ def _share(f: list[int], x: int, ec: Curve) -> int:
     """Evaluate the sharing polynomial f at x, f(x) = sum_i f[i] x**i.
 
     Each term is reduced mod n and the sum is not: what every consumer
-    of a share needs is its value mod n, and mult, double_mult and the
+    of a share needs is its value mod n, and mult, double_mult_var and the
     Lagrange interpolation at the end each reduce again anyway.
     """
     return sum((f_i * pow(x, i)) % ec.n for i, f_i in enumerate(f))
@@ -766,16 +772,16 @@ def _deal(
     """
     f = [secret]
     f_prime = [secret_prime]
-    commits = [double_mult(secret_prime, H, secret, ec.G)]
+    commits = [double_mult_var(secret_prime, H, secret, ec.G)]
     for _ in range(1, m):
         f.append(ssa.gen_keys()[0])
         f_prime.append(ssa.gen_keys()[0])
-        commits.append(double_mult(f_prime[-1], H, f[-1], ec.G))
+        commits.append(double_mult_var(f_prime[-1], H, f[-1], ec.G))
 
     shares: list[int] = []
     for x in xs:
         alpha = _share(f, x, ec)
-        t = double_mult(_share(f_prime, x, ec), H, alpha, ec.G)
+        t = double_mult_var(_share(f_prime, x, ec), H, alpha, ec.G)
         assert t == _commitment(commits, x, ec), f"signer {dealer} is cheating"
         shares.append(alpha)
     return f, shares
@@ -793,7 +799,7 @@ def _partial_sig_point(
     """
     RHS = ec.add(K, mult(e, Q))
     for i in range(1, len(A)):
-        RHS = ec.add(RHS, double_mult(pow(x, i), B[i], e * pow(x, i), A[i]))
+        RHS = ec.add(RHS, double_mult_var(pow(x, i), B[i], e * pow(x, i), A[i]))
     return RHS
 
 
@@ -921,8 +927,8 @@ def test_threshold() -> None:
     assert mult(gamma1) == RHS1, "signer one is cheating"
 
     # PHASE FOUR: aggregating the signature ###
-    omega1 = 3 * mod_inv(3 - 1, ec.n) % ec.n
-    omega3 = 1 * mod_inv(1 - 3, ec.n) % ec.n
+    omega1 = 3 * mod_inv_var(3 - 1, ec.n) % ec.n
+    omega3 = 1 * mod_inv_var(1 - 3, ec.n) % ec.n
     sigma = (gamma1 * omega1 + gamma3 * omega3) % ec.n
 
     sig = ssa.Sig(K[0], sigma, ec)
@@ -1020,7 +1026,7 @@ def test_recover_infinity_pub_key(monkeypatch: pytest.MonkeyPatch) -> None:
     low-cardinality loop can never get here: its s comes from a real
     signature, hence s*G - K = c*q*G with c and q both nonzero.
 
-    Both arithmetics answer it, which is what the delegated double_mult of
+    Both arithmetics answer it, which is what the delegated double_mult_var of
     issue 286 turns on: a libsecp256k1 pubkey is never the identity, so
     the sum is recognized from the coordinates in curves.curve and handed
     back as the z == 0 this function tests -- u*H + v*Q with v*Q == -u*H
@@ -1042,7 +1048,7 @@ def test_recovery_multiplies_in_libsecp256k1(
 
     Nothing in libsecp256k1 recovers an x-only key: its recovery module is
     ECDSA -- `recover(msg, signature, recid)` -- and its xonly module has
-    no recovery in it, so the double_mult under this function is the whole
+    no recovery in it, so the double_mult_var under this function is the whole
     of what there is to delegate, and the Python arithmetic is reachable
     only by patching the dispatch off. What this catches is the two
     disagreeing about the recovered x_Q.

--- a/tests/integer_policy_test.py
+++ b/tests/integer_policy_test.py
@@ -40,7 +40,7 @@ from btclib.exceptions import BTClibTypeError
 from btclib.fee import FeeRate, fee_from_vsize
 from btclib.hashes import merkle_root_from_branch, sha256
 from btclib.mnemonic.entropy import bin_str_entropy_from_wordlist_indexes
-from btclib.number_theory import mod_inv, mod_inv_batch
+from btclib.number_theory import mod_inv, mod_inv_batch_var, mod_inv_var
 from btclib.script import input_script_sig, sig_hash
 from btclib.tx import OutPoint, Tx, TxIn, TxOut
 from btclib.utils import bytes_from_octets, encode_num, is_integer
@@ -118,10 +118,12 @@ _CASES: list[tuple[str, Callable[[Any], object]]] = [
     ("var_int max_size", lambda v: var_int.parse(b"\x01", max_size=v)),
     ("bech32 5-bit value", lambda v: bech32.encode("bc", [v])),
     ("word-list index", lambda v: bin_str_entropy_from_wordlist_indexes([v], 2048)),
-    ("modular operand", lambda v: mod_inv(v, 7)),
-    ("modulus", lambda v: mod_inv(3, v)),
-    ("modular operand in a batch", lambda v: mod_inv_batch([3, v], 7)),
-    ("modulus of a batch", lambda v: mod_inv_batch([3], v)),
+    ("modular operand", lambda v: mod_inv_var(v, 7)),
+    ("modulus", lambda v: mod_inv_var(3, v)),
+    ("blinded modular operand", lambda v: mod_inv(v, 7)),
+    ("blinded modulus", lambda v: mod_inv(3, v)),
+    ("modular operand in a batch", lambda v: mod_inv_batch_var([3, v], 7)),
+    ("modulus of a batch", lambda v: mod_inv_batch_var([3], v)),
     ("taproot leaf index", lambda v: input_script_sig(None, _SCRIPT_TREE, v)),
     (
         "sig_hash input index",
@@ -188,8 +190,9 @@ def test_the_integers_a_bool_refusal_must_not_take_with_it() -> None:
     assert var_int.parse(b"\x01", max_size=1) == 1
     assert bech32.encode("bc", [1]) == b"bc1pdg93mv"
     assert bin_str_entropy_from_wordlist_indexes([1], 2048) == "00000000001"
+    assert mod_inv_var(3, 7) == 5
     assert mod_inv(3, 7) == 5
-    assert mod_inv_batch([3, 2], 7) == [5, 4]
+    assert mod_inv_batch_var([3, 2], 7) == [5, 4]
     assert input_script_sig(None, _SCRIPT_TREE, 0)[0] == ["OP_1"]
     assert len(sig_hash.taproot(_tx(), 0, _PREVOUTS, 1, 0, b"", b"")) == 32
     assert encode_num(1) == b"\x01"

--- a/tests/number_theory_test.py
+++ b/tests/number_theory_test.py
@@ -5,19 +5,22 @@
 """Tests for the `btclib.number_theory` module."""
 
 import math
+import secrets
 
 import pytest
 from hypothesis import given
 from hypothesis import strategies as st
 
+from btclib import number_theory
 from btclib.exceptions import BTClibTypeError, BTClibValueError
 from btclib.number_theory import (
-    legendre_symbol,
+    legendre_symbol_var,
     mod_inv,
-    mod_inv_batch,
-    mod_sqrt,
-    tonelli,
-    xgcd,
+    mod_inv_batch_var,
+    mod_inv_var,
+    mod_sqrt_var,
+    tonelli_var,
+    xgcd_var,
 )
 
 primes = [
@@ -67,10 +70,10 @@ def test_a_float_is_no_operand_and_zero_is_no_modulus() -> None:
     """Modular arithmetic over what is not an integer answered anyway.
 
     Python defines `//`, `%` and `*` for a float, so every function here
-    ran to completion on one and returned it: `mod_inv(3.0, 7)` answered
-    `5.0` out of a signature that says `int`, and `xgcd(3.0, 7)` a
+    ran to completion on one and returned it: `mod_inv_var(3.0, 7)` answered
+    `5.0` out of a signature that says `int`, and `xgcd_var(3.0, 7)` a
     triple of floats -- no exception, and a residue that is not one.
-    `legendre_symbol` and its two callers reached `pow`'s own TypeError
+    `legendre_symbol_var` and its two callers reached `pow`'s own TypeError
     instead, which is no better for a caller filtering bad input.
 
     A modulus of zero is the other half: the `ZeroDivisionError` of
@@ -80,8 +83,8 @@ def test_a_float_is_no_operand_and_zero_is_no_modulus() -> None:
     """
     for a, m in ((3.0, 7), (3, 7.0), ("3", 7), (3, None)):
         with pytest.raises(BTClibTypeError, match="not an integer: "):
-            xgcd(a, m)  # type: ignore[arg-type]
-        for call in (mod_inv, legendre_symbol, mod_sqrt, tonelli):
+            xgcd_var(a, m)  # type: ignore[arg-type]
+        for call in (mod_inv_var, legendre_symbol_var, mod_sqrt_var, tonelli_var):
             with pytest.raises(BTClibTypeError, match="not an integer: "):
                 call(a, m)  # type: ignore[arg-type]
 
@@ -89,47 +92,47 @@ def test_a_float_is_no_operand_and_zero_is_no_modulus() -> None:
     # would otherwise make it the modulus one
     for value in (True, False):
         with pytest.raises(BTClibTypeError, match="not an integer: "):
-            mod_inv(value, 7)
+            mod_inv_var(value, 7)
         with pytest.raises(BTClibTypeError, match="not an integer: "):
-            mod_inv(3, value)
+            mod_inv_var(3, value)
 
     for m in (0, -7):
-        for call in (mod_inv, legendre_symbol, mod_sqrt, tonelli):
+        for call in (mod_inv_var, legendre_symbol_var, mod_sqrt_var, tonelli_var):
             with pytest.raises(BTClibValueError, match="non-positive modulus: "):
                 call(3, m)
-    # xgcd takes no modulus: zero is a legitimate operand there, whose
+    # xgcd_var takes no modulus: zero is a legitimate operand there, whose
     # greatest common divisor with three is three
-    assert xgcd(3, 0)[0] == 3
+    assert xgcd_var(3, 0)[0] == 3
 
 
 def test_mod_inv_prime() -> None:
     """Verify the inverse mod a prime, and refuse the zero residue."""
     for p in primes:
         with pytest.raises(BTClibValueError, match="no inverse for 0 mod"):
-            mod_inv(0, p)
+            mod_inv_var(0, p)
         for a in range(1, min(p, 500)):  # exhausted only for small p
-            inv = mod_inv(a, p)
+            inv = mod_inv_var(a, p)
             assert a * inv % p == 1
-            inv = mod_inv(a + p, p)
+            inv = mod_inv_var(a + p, p)
             assert a * inv % p == 1
 
 
 def test_mod_inv() -> None:
-    """Verify mod_inv over every residue of every modulus up to 100."""
+    """Verify mod_inv_var over every residue of every modulus up to 100."""
     max_m = 100
     for m in range(2, max_m):
         nums = list(range(m))
         for a in nums:
             mult = [a * i % m for i in nums]
             if 1 in mult:
-                inv = mod_inv(a, m)
+                inv = mod_inv_var(a, m)
                 assert a * inv % m == 1
-                inv = mod_inv(a + m, m)
+                inv = mod_inv_var(a + m, m)
                 assert a * inv % m == 1
             else:
                 err_msg = "no inverse for "
                 with pytest.raises(BTClibValueError, match=err_msg):
-                    mod_inv(a, m)
+                    mod_inv_var(a, m)
 
 
 def test_legendre_symbol_is_the_squares_of_the_field() -> None:
@@ -147,9 +150,9 @@ def test_legendre_symbol_is_the_squares_of_the_field() -> None:
         squares = {a * a % p for a in range(1, p)}
         for a in range(p):
             expected = 0 if a == 0 else 1 if a in squares else -1
-            assert legendre_symbol(a, p) == expected, (a, p)
-            assert legendre_symbol(a + p, p) == expected, (a, p)
-            assert legendre_symbol(a - p, p) == expected, (a, p)
+            assert legendre_symbol_var(a, p) == expected, (a, p)
+            assert legendre_symbol_var(a + p, p) == expected, (a, p)
+            assert legendre_symbol_var(a - p, p) == expected, (a, p)
 
 
 def test_mod_sqrt() -> None:
@@ -159,17 +162,17 @@ def test_mod_sqrt() -> None:
         has_root.update(i * i % p for i in range(2, p))
         for i in range(p):
             if i in has_root:
-                root1 = mod_sqrt(i, p)
+                root1 = mod_sqrt_var(i, p)
                 assert i == (root1 * root1) % p
                 root2 = p - root1
                 assert i == (root2 * root2) % p
-                root = mod_sqrt(i + p, p)
+                root = mod_sqrt_var(i + p, p)
                 assert i == (root * root) % p
                 if p % 4 == 3 or p % 8 == 5:
-                    assert tonelli(i, p) in {root1, root2}
+                    assert tonelli_var(i, p) in {root1, root2}
             else:
                 with pytest.raises(BTClibValueError, match="no root for "):
-                    mod_sqrt(i, p)
+                    mod_sqrt_var(i, p)
 
 
 def test_mod_sqrt2() -> None:
@@ -185,7 +188,7 @@ def test_mod_sqrt2() -> None:
         (41660815127637347468140745042827704103445750172002, 10**50 + 577),
     ]
     for i, p in test_vectors:
-        root = tonelli(i, p)
+        root = tonelli_var(i, p)
         assert i == (root * root) % p
 
 
@@ -194,10 +197,10 @@ def test_minus_one_quadr_res() -> None:
     for p in primes:
         if (p % 4) == 3:
             with pytest.raises(BTClibValueError, match="no root for "):
-                mod_sqrt(p - 1, p)
+                mod_sqrt_var(p - 1, p)
         else:
             assert p == 2 or p % 4 == 1, "something is badly broken"
-            root = mod_sqrt(p - 1, p)
+            root = mod_sqrt_var(p - 1, p)
             assert p - 1 == root * root % p
 
 
@@ -228,13 +231,13 @@ def test_legendre_symbol_agrees_with_euler(a: int, p: int) -> None:
     """
     euler = pow(a, p >> 1, p)
     expected = 0 if euler == 0 else 1 if euler == 1 else -1
-    assert legendre_symbol(a, p) == expected
+    assert legendre_symbol_var(a, p) == expected
 
 
 @given(a=st.integers(), b=st.integers())
 def test_xgcd_is_bezout(a: int, b: int) -> None:
-    """What xgcd returns is the identity it is named after."""
-    g, x, y = xgcd(a, b)
+    """What xgcd_var returns is the identity it is named after."""
+    g, x, y = xgcd_var(a, b)
     assert a * x + b * y == g
     assert g == math.gcd(a, b) or -g == math.gcd(a, b)
 
@@ -248,9 +251,9 @@ def test_mod_inv_inverts(a: int, m: int) -> None:
     """
     if math.gcd(a % m, m) != 1:
         with pytest.raises(BTClibValueError, match="no inverse"):
-            mod_inv(a, m)
+            mod_inv_var(a, m)
         return
-    inverse = mod_inv(a, m)
+    inverse = mod_inv_var(a, m)
     assert 0 <= inverse < m
     assert a * inverse % m == 1
 
@@ -259,17 +262,17 @@ def test_mod_inv_inverts(a: int, m: int) -> None:
 def test_mod_sqrt_squares_back(a: int, p: int) -> None:
     """A root squares back to what it is the root of, when there is one.
 
-    legendre_symbol is what says whether there is: 1 for a residue, -1
+    legendre_symbol_var is what says whether there is: 1 for a residue, -1
     for a non-residue, 0 for a multiple of p. The three cases together
     are the whole domain, which is the point of generating a.
     """
-    symbol = legendre_symbol(a, p)
+    symbol = legendre_symbol_var(a, p)
     assert symbol in {-1, 0, 1}
     if symbol == -1:
         with pytest.raises(BTClibValueError, match="no root for "):
-            mod_sqrt(a, p)
+            mod_sqrt_var(a, p)
         return
-    root = mod_sqrt(a, p)
+    root = mod_sqrt_var(a, p)
     assert root * root % p == a % p
     # the other root, p - root, is a root too: a square has two
     assert (p - root) * (p - root) % p == a % p
@@ -284,30 +287,30 @@ def test_mod_inv_batch_is_mod_inv_over_a_sequence() -> None:
     """
     for m in (7, 97, 2**521 - 1):
         values = [1, 2, m - 1, 3, m - 2]
-        assert mod_inv_batch(values, m) == [mod_inv(v, m) for v in values]
-        assert mod_inv_batch([2], m) == [mod_inv(2, m)]
-    assert mod_inv_batch([], 7) == []
+        assert mod_inv_batch_var(values, m) == [mod_inv_var(v, m) for v in values]
+        assert mod_inv_batch_var([2], m) == [mod_inv_var(2, m)]
+    assert mod_inv_batch_var([], 7) == []
 
 
 def test_mod_inv_batch_names_the_element_that_has_no_inverse() -> None:
     """A product is invertible only if every factor is.
 
     So the batch fails whenever one element does, and names that element
-    as `mod_inv` does rather than the product a caller never formed.
+    as `mod_inv_var` does rather than the product a caller never formed.
     """
     with pytest.raises(BTClibValueError, match="no inverse for 0 mod 7"):
-        mod_inv_batch([1, 2, 0, 3], 7)
+        mod_inv_batch_var([1, 2, 0, 3], 7)
     with pytest.raises(BTClibValueError, match="no inverse for 3 mod 9"):
-        mod_inv_batch([2, 3], 9)
+        mod_inv_batch_var([2, 3], 9)
 
     # the arguments are checked as every other function of the module
     # checks its own, a bool being no integer and zero no modulus
     for value in (2.0, True, None):
         with pytest.raises(BTClibTypeError, match="not an integer: "):
-            mod_inv_batch([1, value], 7)  # type: ignore[list-item]
+            mod_inv_batch_var([1, value], 7)  # type: ignore[list-item]
     for m in (0, -7, 3.0, False):
         with pytest.raises((BTClibTypeError, BTClibValueError)):
-            mod_inv_batch([1], m)  # type: ignore[arg-type]
+            mod_inv_batch_var([1], m)  # type: ignore[arg-type]
 
 
 @given(values=st.lists(st.integers(), max_size=8), m=st.integers(min_value=2))
@@ -315,10 +318,115 @@ def test_mod_inv_batch_inverts(values: list[int], m: int) -> None:
     """Every inverse multiplies its element back to one, or none does."""
     if any(math.gcd(v % m, m) != 1 for v in values):
         with pytest.raises(BTClibValueError, match="no inverse"):
-            mod_inv_batch(values, m)
+            mod_inv_batch_var(values, m)
         return
-    inverses = mod_inv_batch(values, m)
+    inverses = mod_inv_batch_var(values, m)
     assert len(inverses) == len(values)
     for v, inverse in zip(values, inverses, strict=True):
         assert 0 <= inverse < m
         assert v * inverse % m == 1
+
+
+def test_mod_inv_blinded_is_mod_inv() -> None:
+    """The blinding changes what is timed and not what is answered.
+
+    Over the primes above, which is what it is asked about in the
+    library -- a group order -- and over composite moduli, where an
+    element with no inverse still has none and is named as `mod_inv_var`
+    names it. A modulus of one is the degenerate case: every integer is
+    zero modulo it, so the only factor to draw with is one.
+    """
+    for m in primes:
+        for a in range(1, min(m, 200)):
+            assert mod_inv(a, m) == mod_inv_var(a, m)
+            assert mod_inv(a + m, m) == mod_inv_var(a, m)
+
+    for m in range(2, 60):
+        for a in range(m):
+            if math.gcd(a, m) == 1:
+                assert mod_inv(a, m) == mod_inv_var(a, m)
+            else:
+                with pytest.raises(BTClibValueError, match="no inverse for "):
+                    mod_inv(a, m)
+
+    assert mod_inv(7, 1) == mod_inv_var(7, 1) == 0
+
+    # the arguments are checked here rather than one call deeper: the
+    # factor is drawn before `mod_inv_var` is reached, and a modulus that is
+    # not an integer would fail in the draw instead
+    for value in (2.0, True, None):
+        with pytest.raises(BTClibTypeError, match="not an integer: "):
+            mod_inv(value, 7)  # type: ignore[arg-type]
+        with pytest.raises(BTClibTypeError, match="not an integer: "):
+            mod_inv(3, value)  # type: ignore[arg-type]
+    for m in (0, -7):
+        with pytest.raises(BTClibValueError, match="non-positive modulus: "):
+            mod_inv(3, m)
+
+
+def test_mod_inv_blinded_never_hands_the_operand_to_the_euclid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """What the extended Euclid is timed on is a fresh random value.
+
+    Which is the whole of what the blinding buys, `mod_inv_var`'s duration
+    following what it is handed: the same secret inverted twice reaches
+    it as two unrelated values, so the duration carries the factor and
+    not the caller's operand.
+    """
+    seen: list[int] = []
+    real_mod_inv = number_theory.mod_inv_var
+
+    def recording_mod_inv(a: int, m: int) -> int:
+        seen.append(a)
+        return real_mod_inv(a, m)
+
+    monkeypatch.setattr(number_theory, "mod_inv_var", recording_mod_inv)
+
+    n = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+    secret = 0x1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF
+    for _ in range(32):
+        assert number_theory.mod_inv(secret, n) == real_mod_inv(secret, n)
+
+    assert secret not in seen
+    # every call drew its own factor: a repeat would be a factor that is
+    # not fresh, and 32 draws below n repeat with probability 2^-246
+    assert len(set(seen)) == len(seen)
+
+
+def test_mod_inv_blinded_answers_a_factor_that_is_a_zero_divisor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A composite modulus can make the drawn factor non-invertible.
+
+    The product is then non-invertible while the operand is not, and the
+    answer still has to be the operand's inverse -- reached by inverting
+    it unblinded, which is the one case where the protection is lost and
+    the result is not. A prime modulus cannot take this path, and every
+    modulus the library blinds against is one: `curves.Curve` requires
+    the group order prime.
+    """
+    # 1 + randbelow(m - 1) == 2, a zero divisor mod 8
+    monkeypatch.setattr(secrets, "randbelow", lambda _: 1)
+    assert mod_inv(3, 8) == mod_inv_var(3, 8) == 3
+
+    # and an operand that has no inverse of its own still reports one,
+    # naming itself rather than the product the caller never formed
+    with pytest.raises(BTClibValueError, match="no inverse for 2 mod 8"):
+        mod_inv(2, 8)
+
+
+@given(a=st.integers(), m=st.integers(min_value=1))
+def test_mod_inv_blinded_inverts(a: int, m: int) -> None:
+    """`test_mod_inv_inverts`, of the blinded spelling.
+
+    m from one rather than from two: the degenerate modulus is a branch
+    here, where `mod_inv_var` has none.
+    """
+    if math.gcd(a % m, m) != 1 and m != 1:
+        with pytest.raises(BTClibValueError, match="no inverse"):
+            mod_inv(a, m)
+        return
+    inverse = mod_inv(a, m)
+    assert 0 <= inverse < m
+    assert a * inverse % m == 1 % m

--- a/tests/script/taproot_test.py
+++ b/tests/script/taproot_test.py
@@ -150,7 +150,7 @@ def test_the_python_prvkey_tweak_lifts_nothing(
     parity is a `%` and not a lift of the x back to the point it came
     from (issue 619). What pins that is reaching no modular square root
     at all, which is stronger than a stopwatch and does not depend on
-    the machine: mod_sqrt is patched to raise.
+    the machine: mod_sqrt_var is patched to raise.
 
     Both parities, because the branch this reads decides a negation:
     with only the even key the answer would be right for a run that
@@ -171,7 +171,7 @@ def test_the_python_prvkey_tweak_lifts_nothing(
 
     with monkeypatch.context() as no_bindings:
         no_bindings.setattr(taproot, "_libsecp256k1_applicable", lambda *_: False)
-        no_bindings.setattr(curve_group, "mod_sqrt", refuse)
+        no_bindings.setattr(curve_group, "mod_sqrt_var", refuse)
         for tree, expected in zip(SCRIPT_TREES, delegated, strict=True):
             assert output_prvkey(prv_key, tree) == expected
 

--- a/tests/script_engine/python_path_test.py
+++ b/tests/script_engine/python_path_test.py
@@ -80,7 +80,7 @@ def python_verification(monkeypatch: pytest.MonkeyPatch) -> None:
 
     The arithmetic under the verdict stays delegated: no third patch on
     `curves.curve`, whose dispatch is what `dsa._assert_as_valid_` and
-    `ssa._assert_as_valid_` reach for a `double_mult` and for the two
+    `ssa._assert_as_valid_` reach for a `double_mult_var` and for the two
     square roots that lift a key and answer for an r. Patching it off
     would send those down the Python path on every vector below, at the
     ratios `curves/curve.py` states beside each of them, and would buy a


### PR DESCRIPTION
## The channel

The pure-Python signing path leaked the nonce's bit-length through
`mod_inv`. CPython's `long_invmod` takes the iterations its operand asks
for, so on secp256k1's order a 256-bit nonce inverted in 8.8 us against a
128-bit one's 4.3, falling at every step between them. That is the
correlation [Minerva](https://minerva.crocs.fi.muni.cz/) (Jancar et al.,
CHES 2020) sorts signing times by and hands to a lattice.

**It was the only channel of that shape left**, which is what makes it
worth closing rather than adding to the list SECURITY.md publishes. With
the bindings switched off, measured over random nonces of each length in
alternating rounds:

| step | 256 bit | 128 bit | ratio |
| --- | --- | --- | --- |
| `mult(k, G)`, fixed-base ladder | 137833 ns | 136396 ns | 0.99 |
| `mult(k, Q)`, GLV regular window | 542334 ns | 542000 ns | 1.00 |
| `mod_inv(k, n)` | 8834 ns | 4291 ns | **2.06** |
| a constant, the noise floor | 1958 ns | 1958 ns | 1.00 |

Both multiplications are flat — spread 1.5% and 0.5% against a 2.2% noise
floor, neither monotone — so the regular recodings of #254 and the
projective blinding of #805 hold. A census of the package found the
inversion the one place a secret is inverted at all: `dsa`'s `r` and `s`,
`ssa`'s challenge and every Jacobian `Z` are public or already randomized.

## The fix

`(b*a)^-1 * b` is `a^-1` for any invertible `b`, so a random factor leaves
the Euclid's iteration count following the factor: **1.02x** across the
same operands where the plain inverse is 2.06x. It costs 1.11x on the
inverse and **1.5% on the whole signature**. Fermat's `pow(a, n-2, n)` is
flat too, for the different reason that its ladder runs on the fixed
exponent, and costs 8.38x — which is why it is not the one chosen, and is
the same figure behind #807.

## The naming

The suffix now marks **any** function whose operand decides the work, not
only a scalar multiplication, and the plain name beside it is the one a
secret may be handed. That is libsecp256k1's own scope for the
convention — `secp256k1_scalar_inverse_var` sits beside
`secp256k1_scalar_inverse`, and even its Jacobi symbol is
`secp256k1_jacobi64_maybe_var` — where btclib had narrowed it to the
private multiplications and left a public surface that was variable-time
without saying so.

Renamed, each because it was **measured** to earn the suffix:

| name | ratio | |
| --- | --- | --- |
| `mod_inv_var` | 4.21x | was `mod_inv`; `mod_inv` is now the blinded one |
| `xgcd_var` | 4.84x | |
| `legendre_symbol_var` | 4.26x | |
| `mod_inv_batch_var` | 2.01x | never released, so not a break |
| `tonelli_var` | 1.54x | spread within one operand size, not across |
| `mod_sqrt_var` | 1.01x | flat for p ≡ 3 mod 4; suffixed because the caller picks the p |
| `double_mult_var`, `multi_mult_var` | | wNAF and Bos-Coster |

`mult` keeps its plain name: its two arms make the same additions for
every scalar.

## Breaking

Six public spellings move, so an import of an old one is an `ImportError`;
HISTORY.md carries the bullet. `mod_inv` is the exception and does not
raise — the name survives and now returns the same inverse computed
blinded, so a caller inverting a secret is protected without changing a
line, and one inverting public data should say `mod_inv_var` to keep the
1.11x.

## Gates

`pytest` (27170 passed, coverage 100%), `pre-commit run --all-files` and
the `-W` sphinx build all exit 0, after the rebase onto f06ee1f9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Blind ECDSA nonce inversion to remove a timing side-channel and adopt a `_var` naming convention for variable-time operations across the curves and number theory APIs.

New Features:
- Introduce a blinded modular inverse `number_theory.mod_inv` for use with secret ECDSA nonces, keeping the existing inverse logic as `mod_inv_var` for public data.
- Add dedicated tests to verify the behaviour and blinding properties of the new `mod_inv` implementation, including edge cases with composite moduli.

Bug Fixes:
- Eliminate a timing channel in the pure-Python ECDSA signing path by ensuring nonce inversion no longer leaks its bit-length via the extended Euclid iteration count.

Enhancements:
- Standardize the `_var` suffix to denote variable-time behaviour for number theory and scalar multiplication functions, renaming affected APIs and updating call sites accordingly.
- Clarify and expand CONTRIBUTING, SECURITY, CHANGELOG, and HISTORY documentation around timing characteristics, blinding, and the meaning of `_var`-suffixed functions.
- Improve test coverage and naming to reflect the new `_var`-based API, including curve, signature, and integer policy tests that exercise both blinded and variable-time paths.

Documentation:
- Document the new blinding behaviour for ECDSA nonce inversion and its impact on side-channel resistance in CHANGELOG.md and SECURITY.md.
- Describe the broadened `_var` naming convention and timing tiers in CONTRIBUTING.md, and note the breaking renames and behavioural change of `mod_inv` in HISTORY.md.

Tests:
- Extend and adapt number theory, curve, DSA, SSA, and BIP32/taproot tests to cover the renamed `_var` functions and the new blinded `mod_inv`, including monkeypatched timing and correctness checks.
- Update mutation testing configuration to reflect the new function names and ensure mutants in timing-sensitive code paths remain observable.