### PR TITLE
Read a bool off the object instead of calling it (#814)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2532,6 +2532,31 @@ documented at release-notes length in the first place, and are still in
 
 ### The public API and the module layout
 
+- **A bool about the object is a property, and six were not** (issue
+  #814). `Tx.is_segwit`, `Tx.is_coinbase`, `TxIn.is_segwit`,
+  `TxIn.is_coinbase`, `OutPoint.is_coinbase` and `Block.is_segwit` took
+  nothing but `self` and were called; the thirty other argument-less
+  bools in the library -- `BIP32KeyData.is_private`, `Miniscript.is_sane`,
+  every wallet's `is_watch_only` -- were read. Six against thirty is
+  which side is the exception, so the six are properties and the shape a
+  reader has to remember is one shape.
+
+  A bool *of an argument* is a function of it and cannot be a property:
+  `script_pub_key.is_p2sh(script)` and `is_on_curve(Q)` are untouched,
+  and `test_the_walk_reaches_both_shapes` pins that the filter tells the
+  two apart.
+
+  It spends the one hazard mypy's `truthy-function` covers rather than
+  relying on it. `if tx.is_segwit:` with the parentheses forgotten was a
+  bound method, and every bound method is true -- in code deciding
+  whether a transaction is segwit, which is the kind of place it costs
+  something. mypy names it and mypy is a gate here, so nothing in this
+  tree had made the mistake; a shape that cannot go wrong is still better
+  than a checker that catches it going wrong.
+
+  `tests/name_contract_test.py` gates it with no exemption list, which is
+  what "six against thirty" buys: there is no family left to excuse.
+
 - **Every public `bool` is named by the vocabulary now** (issue #814).
   The four prefixes promised a shape to a caller who saw one and said
   nothing about a bool carrying none, and seven carried none. Each is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -779,6 +779,26 @@ Work locally on your fork of btclib,
 until you are satisfied. Ensure that pre-commit and pytest
 have no issue with your modified codebase.
 
+#### Breaking a caller is not an argument
+
+**A refactoring that is reasonable gets made, however much it breaks.**
+Do not weigh "this renames something callers use" against it, and do not
+propose keeping an inconsistency and gating it going forward instead:
+consistency across a family — one naming shape, one contract per prefix,
+one way to read the same kind of answer — is itself the reason, and a
+release is where a break is reported rather than a reason not to make it.
+
+So a census that finds thirty names of one shape and six of another has
+found six to change, not a trade-off to price. What the measurement is
+for is knowing the blast radius and writing HISTORY.md's
+breaking-changes entry, which is how a user is told: read
+[HISTORY.md](./HISTORY.md) for what that entry looks like, and note that
+`v2026.9`'s list is long on purpose.
+
+The one thing this does not license is a break nobody can act on. An
+entry says the old spelling, the new one, and what a caller does about
+it; a rename with no note is the defect, not the rename.
+
 #### The public surface
 
 **Every module and every package declares `__all__`**, at every depth of
@@ -872,7 +892,16 @@ prefixes below, or is one of the English predicates
 and `is_` would cost the reading. A bool that is neither fails that gate,
 so a new one is a prefix or a decision somebody wrote down.
 
-What the four buy is a promise read off the name:
+**A bool that takes nothing but `self` is a `@property`**, and that is
+gated too: it is read off the object rather than called, so `tx.is_segwit`
+and not `tx.is_segwit()`. Thirty were properties and six were methods,
+which made the six the exception; they are properties now. It also makes
+the forgotten-parentheses bug unsayable — `if tx.is_segwit:` on a method
+is a bound method, and every bound method is true. mypy's
+`truthy-function` names that, and mypy is a gate here, but a shape that
+cannot go wrong beats a checker that catches it going wrong.
+
+What the four prefixes buy is a promise read off the name:
 
 - `assert_*` refuses and returns `None`. There are eighty-odd of them
   and they are the reason half of the pair above.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -20,6 +20,19 @@ full year, short month, short day (YYYY-M-D)
 
 ### Breaking changes
 
+- **six `bool` methods are properties: `tx.is_segwit`, not
+  `tx.is_segwit()`.** `Tx.is_segwit`, `Tx.is_coinbase`, `TxIn.is_segwit`,
+  `TxIn.is_coinbase`, `OutPoint.is_coinbase` and `Block.is_segwit` took
+  nothing but `self` and were the only argument-less bools in the library
+  that were not properties -- thirty others were. Drop the parentheses;
+  keeping them is `TypeError: 'bool' object is not callable`, which is a
+  loud failure and not a silent one.
+
+  It also makes a bug unsayable rather than merely caught: `if
+  tx.is_segwit:` with the parentheses forgotten was a bound method, and
+  every bound method is true. mypy's `truthy-function` reports it, so
+  anyone type-checking was already safe; anyone not type-checking was not.
+
 - **seven public `bool` names carry a prefix now.**
   `b32.has_segwit_prefix` is `b32.is_segwit_prefixed`,
   `BlockContext.bip34_active` is `is_bip34_active`,

--- a/btclib/block/block.py
+++ b/btclib/block/block.py
@@ -244,9 +244,10 @@ class Block:
             check_validity=check_validity,
         )
 
+    @property
     def is_segwit(self) -> bool:
         """Answer whether any transaction carries a witness."""
-        return any(tx.is_segwit() for tx in self.transactions)
+        return any(tx.is_segwit for tx in self.transactions)
 
     def _assert_coinbase(self) -> None:
         """Assert that there is a first transaction and that it is a coinbase.
@@ -264,7 +265,7 @@ class Block:
         if not self.transactions:
             raise BTClibValueError("block with no transactions")
 
-        if not self.transactions[0].is_coinbase():
+        if not self.transactions[0].is_coinbase:
             raise BTClibValueError("first transaction is not a coinbase")
 
     def assert_valid_length(self) -> None:
@@ -386,7 +387,7 @@ class Block:
         witnesses of a block can be replaced wholesale, header and root
         untouched, and the signatures they carry are worth nothing.
         """
-        if not self.is_segwit():
+        if not self.is_segwit:
             # Nothing to commit to, and nothing to check it against: this
             # is a block as a legacy node sees it, witnesses stripped by
             # the serialization, which btclib parses and this library
@@ -542,7 +543,7 @@ class Block:
             # block being assembled -- the toy mining of issue #188, and
             # any candidate-block path after it -- and that is exactly
             # where nothing else says no
-            if transaction.is_coinbase():
+            if transaction.is_coinbase:
                 raise BTClibValueError("more than one coinbase")
             transaction.assert_valid()
 

--- a/btclib/tx/out_point.py
+++ b/btclib/tx/out_point.py
@@ -71,6 +71,7 @@ class OutPoint:
         if check_validity:
             self.assert_valid()
 
+    @property
     def is_coinbase(self) -> bool:
         """Answer whether this is the coinbase marker, spending nothing."""
         return self.tx_id == b"\x00" * 32 and self.vout == 0xFFFFFFFF

--- a/btclib/tx/tx.py
+++ b/btclib/tx/tx.py
@@ -79,7 +79,7 @@ def _assert_valid_coinbase(vin: Sequence[TxIn], *, is_coinbase: bool) -> None:
         return
 
     for tx_in in vin:
-        if tx_in.is_coinbase():
+        if tx_in.is_coinbase:
             raise BTClibValueError("coinbase input in a non-coinbase transaction")
 
 
@@ -154,7 +154,7 @@ class Tx:  # noqa: PLW1641
         `test_the_size_and_the_serialization_agree` holds the two
         together over every vector the suite carries.
         """
-        segwit = include_witness and self.is_segwit()
+        segwit = include_witness and self.is_segwit
 
         size = 4 + 4  # version and lock_time
         if segwit:
@@ -207,17 +207,19 @@ class Tx:  # noqa: PLW1641
         """Return the witnesses, one per input and in input order."""
         return [tx_in.script_witness for tx_in in self.vin]
 
+    @property
     def is_segwit(self) -> bool:
         """Answer whether any input carries a witness.
 
         The inputs and not the outputs: paying to a segwit script does
         not make the paying transaction segwit, spending one does.
         """
-        return any(tx_in.is_segwit() for tx_in in self.vin)
+        return any(tx_in.is_segwit for tx_in in self.vin)
 
+    @property
     def is_coinbase(self) -> bool:
         """Answer whether this is a coinbase: one input, spending nothing."""
-        return len(self.vin) == 1 and self.vin[0].is_coinbase()
+        return len(self.vin) == 1 and self.vin[0].is_coinbase
 
     def __init__(
         self,
@@ -317,7 +319,7 @@ class Tx:  # noqa: PLW1641
         point of the format. BIP174 lists two zero-input PSBTs as valid
         and btclib refused both (issue 170).
         """
-        _assert_valid_coinbase(self.vin, is_coinbase=self.is_coinbase())
+        _assert_valid_coinbase(self.vin, is_coinbase=self.is_coinbase)
 
         # the type before the range, as BlockHeader.assert_valid checks its
         # own two int fields: a bool passes every comparison below as one or
@@ -373,7 +375,7 @@ class Tx:  # noqa: PLW1641
             _assert_valid_4_byte_field("version", self.version)
             _assert_valid_4_byte_field("lock time", self.lock_time)
 
-        segwit = include_witness and self.is_segwit()
+        segwit = include_witness and self.is_segwit
 
         return b"".join(
             [

--- a/btclib/tx/tx_in.py
+++ b/btclib/tx/tx_in.py
@@ -90,6 +90,7 @@ class TxIn:
         if check_validity:
             self.assert_valid()
 
+    @property
     def is_segwit(self) -> bool:
         """Answer whether the input carries a witness.
 
@@ -100,9 +101,10 @@ class TxIn:
         # self.prev_out has no segwit information
         return bool(self.script_witness.stack)
 
+    @property
     def is_coinbase(self) -> bool:
         """Answer whether the input is a coinbase, spending nothing."""
-        return self.prev_out.is_coinbase()
+        return self.prev_out.is_coinbase
 
     def assert_valid(self) -> None:
         """Refuse an invalid prev_out, sequence, or witness.

--- a/docs/source/guide.rst
+++ b/docs/source/guide.rst
@@ -434,7 +434,7 @@ Watch the parentheses here. ``id``, ``hash``, ``size``, ``vsize``,
 you a bound method, which is truthy, which is the sort of bug that
 passes review:
 
->>> tx.is_segwit()
+>>> tx.is_segwit
 False
 
 An input names the output it spends. The transaction id inside
@@ -575,7 +575,7 @@ DER signature with the hash type appended, then the public key.
 >>> from btclib.script.witness import Witness
 >>> signed = Tx(1, 0, [TxIn(funding, b"", 0xFFFFFFFF)], [tx_out])
 >>> signed.vin[0].script_witness = Witness([sig.serialize() + b"\x01", pub_key])
->>> signed.is_segwit()
+>>> signed.is_segwit
 True
 >>> signed.serialize(include_witness=True).hex()
 '01000000000101ef51e1b804cc89d182d279655c3aa89e815b1b309fe287d9b2b55d57b90ec68a0100000000ffffffff01c003b423000000001600141d0f172a0ecb48aee1be1f2687d2963ae33f71a10247304402207b7dffe084afa0d951726827d8469628e646349e9e6e1d60b76aa91d4a459ff2022003c3fd5ed4795126862efa7bc194d03c76af29741eb36c47659ac39506f2de100121025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee635700000000'

--- a/tests/block/block_test.py
+++ b/tests/block/block_test.py
@@ -58,7 +58,7 @@ def test_block_1() -> None:
     assert block.weight == 860
     assert block.sig_op_count == 1
     assert block.height is None
-    assert not block.is_segwit()
+    assert not block.is_segwit
     assert block == Block.parse(block.serialize())
     assert block == Block.from_dict(block.to_dict())
 
@@ -446,7 +446,7 @@ def test_block_170() -> None:
     # the p2pk it pays to and the p2pk it spends from
     assert block.sig_op_count == 3
     assert block.height is None
-    assert not block.is_segwit()
+    assert not block.is_segwit
     assert block == Block.parse(block.serialize())
     assert block == Block.from_dict(block.to_dict())
 
@@ -493,7 +493,7 @@ def test_block_200000() -> None:
     block.header.version = 0
     assert block.height == 200_000
     block.header.version = 2
-    assert not block.is_segwit()
+    assert not block.is_segwit
     assert block == Block.parse(block.serialize())
     assert block == Block.from_dict(block.to_dict())
 
@@ -585,13 +585,13 @@ def test_block_481824() -> None:
         assert block.sig_op_count == 3_409
 
         if i:  # segwit nodes see the witness data
-            assert block.is_segwit()
+            assert block.is_segwit
             assert block.size == 989_323
             assert block.stripped_size == 988_519
             assert block.weight == 3_954_880
             assert block.vsize == 988_720
         else:  # legacy nodes see NO witness data
-            assert not block.is_segwit()
+            assert not block.is_segwit
             assert block.size == 988_519
             assert block.stripped_size == 988_519
             assert block.weight == 3_954_076

--- a/tests/block/blockfilters_test.py
+++ b/tests/block/blockfilters_test.py
@@ -168,7 +168,7 @@ def test_a_coinbase_output_script_need_not_parse() -> None:
     where the opcodes stop making sense rather than raising.
     """
     coinbase = block_at(987876).transactions[0]
-    assert coinbase.is_coinbase()
+    assert coinbase.is_coinbase
     script_pub_key = coinbase.vout[0].script_pub_key
     assert script_pub_key.asm[-2:] == ["UNKNOWN_OP_CODE_216", "[error]"]
     assert script_pub_key.type == "unknown"
@@ -182,5 +182,5 @@ def test_the_witness_row_commits_to_its_witnesses() -> None:
     what says the row was chosen for that and would be missed if it went.
     """
     block = block_at(1263442)
-    assert block.is_segwit()
+    assert block.is_segwit
     assert block.witness_commitment is not None

--- a/tests/block/checkblock_test.py
+++ b/tests/block/checkblock_test.py
@@ -188,7 +188,7 @@ def test_the_bad_cb_multiple_vector_is_answered_by_the_work() -> None:
         if comment.startswith("More than one coinbase")
     )
     block = Block.parse(two_coinbases, check_validity=False)
-    assert [tx.is_coinbase() for tx in block.transactions] == [True, True]
+    assert [tx.is_coinbase for tx in block.transactions] == [True, True]
     block.assert_valid_merkle_root()
 
     with pytest.raises(BTClibValueError, match="invalid proof-of-work: "):

--- a/tests/name_contract_test.py
+++ b/tests/name_contract_test.py
@@ -143,6 +143,38 @@ def _named() -> dict[str, str]:
     return found
 
 
+def _argument_less_bools() -> dict[str, bool]:
+    """Return every public argument-less bool, and whether it is a property.
+
+    "No argument" means none besides `self`: a bool about the object it is
+    read off, which is the family the question applies to. One that takes
+    something is a function of it, and `@property` is not open to it.
+    """
+    found: dict[str, bool] = {}
+    for path in sorted(_LIBRARY.rglob("*.py")):
+        module = ".".join(path.relative_to(_LIBRARY.parent).with_suffix("").parts)
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or node.name.startswith("_"):
+                continue
+            if node.returns is None or ast.unparse(node.returns) != "bool":
+                continue
+            arguments = [
+                a.arg
+                for a in [
+                    *node.args.posonlyargs,
+                    *node.args.args,
+                    *node.args.kwonlyargs,
+                ]
+                if a.arg != "self"
+            ]
+            if arguments:
+                continue
+            decorated = {ast.unparse(d) for d in node.decorator_list}
+            found[f"{module}.{node.name}"] = "property" in decorated
+    return found
+
+
 def _public_bools() -> list[str]:
     """Return every public function that answers a bool, however named.
 
@@ -165,6 +197,7 @@ def _public_bools() -> list[str]:
 _NAMED = _named()
 _GATED = sorted(set(_NAMED) - _OTHER_CONTRACT.keys())
 _PUBLIC_BOOLS = _public_bools()
+_ARGUMENT_LESS_BOOLS = _argument_less_bools()
 
 
 @pytest.mark.parametrize("dotted", _GATED)
@@ -253,3 +286,33 @@ def test_what_keeps_its_english_name_still_needs_to(dotted: str) -> None:
     assert _promised_by(name) is None, (
         f"{dotted} carries a prefix now: delete its line from _ENGLISH_PREDICATE"
     )
+
+
+@pytest.mark.parametrize("dotted", sorted(_ARGUMENT_LESS_BOOLS))
+def test_a_bool_about_the_object_is_a_property(dotted: str) -> None:
+    """A bool taking nothing but `self` is read, not called.
+
+    Thirty were properties and six were methods -- `Tx.is_segwit`,
+    `Tx.is_coinbase` and their four siblings in `tx/` and `block/` -- so
+    the six were the exception and are properties now (issue #814). The
+    shape a reader has to remember is one shape.
+
+    It also spends the one hazard `truthy-function` covers rather than
+    relying on it: `if tx.is_segwit:` with the parentheses forgotten was a
+    bound method, and every bound method is true. mypy names that, and
+    mypy is a gate here; a property makes it unsayable, which is the
+    stronger of the two.
+    """
+    assert _ARGUMENT_LESS_BOOLS[dotted], (
+        f"{dotted} answers a bool about the object and takes nothing:"
+        " it is a @property, not a method"
+    )
+
+
+def test_the_walk_reaches_both_shapes() -> None:
+    """One of each shape, so the filter is doing work rather than nothing."""
+    assert _ARGUMENT_LESS_BOOLS["btclib.tx.tx.is_segwit"] is True
+    assert _ARGUMENT_LESS_BOOLS["btclib.bip32.bip32.is_private"] is True
+    # a bool of an argument is a function of it, and no property can be
+    assert "btclib.script.script_pub_key.is_p2sh" not in _ARGUMENT_LESS_BOOLS
+    assert "btclib.ecc.dsa.verify" not in _ARGUMENT_LESS_BOOLS

--- a/tests/psbt/psbt_size_test.py
+++ b/tests/psbt/psbt_size_test.py
@@ -376,7 +376,7 @@ def test_a_block_of_real_spends(
     checked = 0
     seen: set[str] = set()
     for tx in block.transactions[:first]:
-        if tx.is_coinbase():
+        if tx.is_coinbase:
             continue
         psbt = psbt_from_spend(tx)
         if psbt is None:

--- a/tests/tx/out_point_test.py
+++ b/tests/tx/out_point_test.py
@@ -21,7 +21,7 @@ def test_out_point() -> None:
     assert out_point.vout == 0xFFFFFFFF
     assert out_point.hash == int.from_bytes(out_point.tx_id, "big", signed=False)
     assert out_point.n == out_point.vout
-    assert out_point.is_coinbase()
+    assert out_point.is_coinbase
     assert out_point == OutPoint.parse(out_point.serialize())
     assert out_point == OutPoint.from_dict(out_point.to_dict())
 
@@ -32,7 +32,7 @@ def test_out_point() -> None:
     assert out_point.vout == vout
     assert out_point.hash == int.from_bytes(out_point.tx_id, "big", signed=False)
     assert out_point.n == out_point.vout
-    assert not out_point.is_coinbase()
+    assert not out_point.is_coinbase
     assert out_point == OutPoint.parse(out_point.serialize())
     assert out_point == OutPoint.from_dict(out_point.to_dict())
 
@@ -134,7 +134,7 @@ def test_a_coinbase_marker_is_both_fields_or_neither() -> None:
     to the coinbase script size or refuses it as a coinbase input in a
     transaction that is not one.
     """
-    assert OutPoint().is_coinbase()
+    assert OutPoint().is_coinbase
 
     for tx_id, vout in (
         (b"\x00" * 32, 0),  # the null tx_id, a real vout
@@ -143,4 +143,4 @@ def test_a_coinbase_marker_is_both_fields_or_neither() -> None:
         (b"\x00" * 32, 0xFFFFFFFF + 1),  # a vout no four bytes hold
         (b"\x01" * 32, 0),
     ):
-        assert not OutPoint(tx_id, vout, check_validity=False).is_coinbase()
+        assert not OutPoint(tx_id, vout, check_validity=False).is_coinbase

--- a/tests/tx/tx_in_test.py
+++ b/tests/tx/tx_in_test.py
@@ -24,13 +24,13 @@ def test_tx_in() -> None:
     assert tx_in.outpoint == tx_in.prev_out
     assert tx_in.scriptSig == tx_in.script_sig
     assert tx_in.nSequence == tx_in.sequence
-    assert tx_in.is_coinbase()
-    assert not tx_in.is_segwit()
+    assert tx_in.is_coinbase
+    assert not tx_in.is_segwit
     tx_in2 = TxIn.parse(tx_in.serialize())
-    assert not tx_in2.is_segwit()
+    assert not tx_in2.is_segwit
     assert tx_in == tx_in2
     tx_in2 = TxIn.from_dict(tx_in.to_dict())
-    assert not tx_in2.is_segwit()
+    assert not tx_in2.is_segwit
     assert tx_in == tx_in2
 
     tx_id = "d5b5982254eebca64e4b42a3092a10bfb76ab430455b2bf0cf7c4f7f32db1c2e"
@@ -45,13 +45,13 @@ def test_tx_in() -> None:
     assert tx_in.outpoint == tx_in.prev_out
     assert tx_in.scriptSig == tx_in.script_sig
     assert tx_in.nSequence == tx_in.sequence
-    assert not tx_in.is_coinbase()
-    assert not tx_in.is_segwit()
+    assert not tx_in.is_coinbase
+    assert not tx_in.is_segwit
     tx_in2 = TxIn.parse(tx_in.serialize())
-    assert not tx_in2.is_segwit()
+    assert not tx_in2.is_segwit
     assert tx_in == tx_in2
     tx_in2 = TxIn.from_dict(tx_in.to_dict())
-    assert not tx_in2.is_segwit()
+    assert not tx_in2.is_segwit
     assert tx_in == tx_in2
 
     prev_out = OutPoint(
@@ -73,10 +73,10 @@ def test_tx_in() -> None:
     assert tx_in.outpoint == tx_in.prev_out
     assert tx_in.scriptSig == tx_in.script_sig
     assert tx_in.nSequence == tx_in.sequence
-    assert not tx_in.is_coinbase()
-    assert tx_in.is_segwit()
+    assert not tx_in.is_coinbase
+    assert tx_in.is_segwit
     tx_in2 = TxIn.parse(tx_in.serialize())
-    assert not tx_in2.is_segwit()
+    assert not tx_in2.is_segwit
     # the witness is part of a TxIn comparison, so the input carrying one
     # differs from the input that comes back off the wire without it. Said
     # of the objects rather than of the flag behind them, and an
@@ -84,7 +84,7 @@ def test_tx_in() -> None:
     # way that flag is set
     assert tx_in != tx_in2
     tx_in2 = TxIn.from_dict(tx_in.to_dict())
-    assert tx_in2.is_segwit()
+    assert tx_in2.is_segwit
     assert tx_in == tx_in2
 
     # the sequence is a 4-byte unsigned integer, so both ends of the range
@@ -198,7 +198,7 @@ def test_script_sig_is_not_validated_and_that_is_the_answer() -> None:
     # the placeholder every builder starts from, which a coinbase-input
     # length check here would reject
     TxIn().assert_valid()
-    assert TxIn().is_coinbase()
+    assert TxIn().is_coinbase
     assert not TxIn().script_sig
 
     # and the coinbase rule is enforced where the transaction is known

--- a/tests/tx/tx_test.py
+++ b/tests/tx/tx_test.py
@@ -38,10 +38,10 @@ def test_tx() -> None:
     """Round-trip Tx through parse, serialize and dict, segwit included."""
     # default constructor
     tx = Tx(check_validity=False)
-    assert not tx.is_segwit()
+    assert not tx.is_segwit
     assert not any(bool(w) for w in tx.vwitness)
     assert not any(bool(tx_in.script_witness) for tx_in in tx.vin)
-    assert not tx.is_coinbase()
+    assert not tx.is_coinbase
     assert tx.version == 1
     assert tx.lock_time == 0
     assert not tx.vin
@@ -61,19 +61,19 @@ def test_tx() -> None:
         Tx(vin=[TxIn(script_sig="0000")])
 
     tx_2 = Tx.from_dict(tx.to_dict(check_validity=False), check_validity=False)
-    assert tx_2.is_segwit() == tx.is_segwit()
+    assert tx_2.is_segwit == tx.is_segwit
     assert tx_2 == tx
 
     tx_2 = Tx.parse(
         tx.serialize(include_witness=True, check_validity=False), check_validity=False
     )
-    assert tx_2.is_segwit() == tx.is_segwit()
+    assert tx_2.is_segwit == tx.is_segwit
     assert tx_2 == tx
 
     tx_2 = Tx.parse(
         tx.serialize(include_witness=False, check_validity=False), check_validity=False
     )
-    assert not tx_2.is_segwit()
+    assert not tx_2.is_segwit
     assert tx_2 == tx
 
     # non-default constructor, no segwit
@@ -95,10 +95,10 @@ def test_tx() -> None:
     version = 1
     lock_time = 0
     tx = Tx(version, lock_time, [tx_in], [tx_out1, tx_out2])
-    assert not tx.is_segwit()
+    assert not tx.is_segwit
     assert not any(bool(w) for w in tx.vwitness)
     assert not any(bool(tx_in.script_witness) for tx_in in tx.vin)
-    assert not tx.is_coinbase()
+    assert not tx.is_coinbase
     assert tx.version == 1
     assert tx.lock_time == 0
     assert len(tx.vin) == 1
@@ -113,15 +113,15 @@ def test_tx() -> None:
     assert tx.weight == tx.size * 4
 
     tx_2 = Tx.from_dict(tx.to_dict())
-    assert tx_2.is_segwit() == tx.is_segwit()
+    assert tx_2.is_segwit == tx.is_segwit
     assert tx_2 == tx
 
     tx_2 = Tx.parse(tx.serialize(include_witness=True))
-    assert tx_2.is_segwit() == tx.is_segwit()
+    assert tx_2.is_segwit == tx.is_segwit
     assert tx_2 == tx
 
     tx_2 = Tx.parse(tx.serialize(include_witness=False))
-    assert not tx_2.is_segwit()
+    assert not tx_2.is_segwit
     assert tx_2 == tx
 
     # non-default constructor, with segwit
@@ -135,10 +135,10 @@ def test_tx() -> None:
         "52210375e00eb72e29da82b89367947f29ef34afb75e8654f6ea368e0acdfd92976b7c2103a1b26313f430c4b15bb1fdce663207659d8cac749a0e53d70eff01874496feff2103c96d495bfdd5ba4145e3e046fee45e84a8a48ad05bd8dbb395c011a32cf9f88053ae",
     ]
     tx.vin[0].script_witness = Witness(stack)
-    assert tx.is_segwit()
+    assert tx.is_segwit
     assert any(bool(w) for w in tx.vwitness)
     assert any(bool(tx_in.script_witness) for tx_in in tx.vin)
-    assert not tx.is_coinbase()
+    assert not tx.is_coinbase
     assert tx.version == 1
     assert tx.lock_time == 0
     assert len(tx.vin) == 1
@@ -154,15 +154,15 @@ def test_tx() -> None:
     assert tx.weight == 758
 
     tx_2 = Tx.from_dict(tx.to_dict())
-    assert tx_2.is_segwit() == tx.is_segwit()
+    assert tx_2.is_segwit == tx.is_segwit
     assert tx_2 == tx
 
     tx_2 = Tx.parse(tx.serialize(include_witness=True))
-    assert tx_2.is_segwit() == tx.is_segwit()
+    assert tx_2.is_segwit == tx.is_segwit
     assert tx_2 == tx
 
     tx_2 = Tx.parse(tx.serialize(include_witness=False))
-    assert not tx_2.is_segwit()
+    assert not tx_2.is_segwit
     assert tx_2 != tx
 
     tx.version = 0
@@ -374,7 +374,7 @@ def test_coinbase_block_1() -> None:
     )
     tx_in = TxIn.parse(coinbase_inp)
     assert tx_in.serialize().hex() == coinbase_inp
-    assert tx_in.prev_out.is_coinbase()
+    assert tx_in.prev_out.is_coinbase
 
     coinbase = f"0100000001{coinbase_inp}01{coinbase_out}00000000"
     tx = Tx.parse(coinbase)
@@ -396,10 +396,10 @@ def test_coinbase_block_1() -> None:
     assert tx.size == 134
     assert tx.vsize == tx.size
     assert tx.weight == tx.size * 4
-    assert not tx.is_segwit()
+    assert not tx.is_segwit
     assert not any(bool(w) for w in tx.vwitness)
     assert not any(bool(tx_in.script_witness) for tx_in in tx.vin)
-    assert tx.is_coinbase()
+    assert tx.is_coinbase
 
     # the p2pk output announces one signature check; the coinbase
     # script_sig announces none, pushing the extranonce and nothing else
@@ -477,10 +477,10 @@ def test_wiki_transaction() -> None:
     assert tx.size == 258
     assert tx.vsize == tx.size
     assert tx.weight == tx.size * 4
-    assert not tx.is_segwit()
+    assert not tx.is_segwit
     assert not any(bool(w) for w in tx.vwitness)
     assert not any(bool(tx_in.script_witness) for tx_in in tx.vin)
-    assert not tx.is_coinbase()
+    assert not tx.is_coinbase
 
     # Core's GetLegacySigOpCount, which is the sum over both lists: the
     # two p2pkh outputs announce one check each, and the script_sig
@@ -522,9 +522,9 @@ def test_single_witness() -> None:
     assert tx.size == 380
     assert tx.vsize == 190
     assert tx.weight == 758
-    assert tx.is_segwit()
+    assert tx.is_segwit
     assert any(bool(w) for w in tx.vwitness)
-    assert not tx.is_coinbase()
+    assert not tx.is_coinbase
 
 
 def test_double_witness() -> None:
@@ -560,10 +560,10 @@ def test_double_witness() -> None:
     assert tx.size == 421
     assert tx.vsize == 259
     assert tx.weight == 1033
-    assert tx.is_segwit()
+    assert tx.is_segwit
     assert any(bool(w) for w in tx.vwitness)
     assert any(bool(tx_in.script_witness) for tx_in in tx.vin)
-    assert not tx.is_coinbase()
+    assert not tx.is_coinbase
 
 
 def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
@@ -583,7 +583,7 @@ def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
         "vin",
         "vout",
     ]
-    assert tx.is_segwit()
+    assert tx.is_segwit
     assert any(bool(w) for w in tx.vwitness)
     assert any(bool(tx_in.script_witness) for tx_in in tx.vin)
     assert tx.vin[0].script_witness
@@ -603,7 +603,7 @@ def test_dataclasses_json_dict(json_golden: JsonGolden) -> None:
     assert tx.vin[0] == tx2.vin[0]
     assert tx2.vin[0].script_witness
     assert tx2.vin[0].script_witness.stack
-    assert tx2.is_segwit()
+    assert tx2.is_segwit
     assert any(bool(w) for w in tx2.vwitness)
     assert any(bool(tx_in.script_witness) for tx_in in tx2.vin)
 
@@ -944,7 +944,7 @@ def test_the_size_and_the_serialization_agree() -> None:
     filename = Path(__file__).parent / "_data" / fname
     with filename.open("rb") as binary_file_:
         segwit = Tx.parse(binary_file_.read())
-    assert segwit.is_segwit()
+    assert segwit.is_segwit
 
     legacy = Tx(
         version=1,
@@ -952,7 +952,7 @@ def test_the_size_and_the_serialization_agree() -> None:
         vin=[TxIn(OutPoint(b"\x01" * 32, 0), b"\x02" * 253, 0xFFFFFFFF)],
         vout=[TxOut(1000, ScriptPubKey(b"\x03" * 25))],
     )
-    assert not legacy.is_segwit()
+    assert not legacy.is_segwit
 
     for tx in (segwit, legacy):
         for include_witness in (True, False):


### PR DESCRIPTION
The last inconsistency https://github.com/btclib-org/btclib/issues/814
turned up, and the one I wrongly recommended *against* fixing: six
argument-less bools were methods where thirty were properties.

Source-breaking, deliberately. CONTRIBUTING.md gains the policy this is
made under.

## Six against thirty

| | count | where |
| --- | ---: | --- |
| argument-less `bool`, **property** | 30 | bip32, block_context, descriptors, miniscript, hwi, psbt, wallet |
| argument-less `bool`, **method** | 6 | `Tx.is_segwit`, `Tx.is_coinbase`, `TxIn.is_segwit`, `TxIn.is_coinbase`, `OutPoint.is_coinbase`, `Block.is_segwit` |

Six against thirty is which side is the exception. `tx.is_segwit`, not
`tx.is_segwit()` — about 65 call sites, 8 of them in `btclib`.

A bool **of an argument** is a function of it and cannot be a property:
`script_pub_key.is_p2sh(script)`, `is_on_curve(Q)` and every `verify` are
untouched, and `test_the_walk_reaches_both_shapes` pins that the filter
tells the two shapes apart.

## What it buys beyond consistency

`if tx.is_segwit:` with the parentheses forgotten was a **bound method,
and every bound method is true** — in code deciding whether a transaction
is segwit, which is the kind of place that costs something.

mypy's `truthy-function` reports it (`Function "is_segwit" could always be
true in boolean context`), it is on by default under `--strict`, and mypy
is a gate here — so nothing in this tree had made the mistake, and I
originally argued that made the change not worth its breakage. That was
the wrong frame: a shape that cannot go wrong beats a checker that catches
it going wrong, and anyone not type-checking had no protection at all.

Keeping the parentheses now is `TypeError: 'bool' object is not callable`
— loud, not silent.

## The policy, written down

CONTRIBUTING.md gains **"Breaking a caller is not an argument"**: a
reasonable refactoring gets made however much it breaks, consistency
across a family being itself the reason; a measurement is for knowing the
blast radius and writing the HISTORY.md entry, not for pricing a
trade-off. The one thing it does not license is a break nobody can act
on, so the entry says the old spelling, the new one, and what a caller
does about it.

It also states the shape rule beside the four prefixes, and
`tests/name_contract_test.py` gates it **with no exemption list** — which
is what six against thirty buys: no family is left to excuse.

## Gates

- `uv run pytest` — 27205 passed, coverage 100.00%
- `uv run pre-commit run --all-files` — exit 0
- `sphinx-build -W --keep-going` — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Convert argument-less boolean helpers on transactions, inputs, outpoints, and blocks from methods to properties and formalize the project policy and tests enforcing this shape, updating documentation and changelogs accordingly.

Enhancements:
- Enforce that any public boolean taking only `self` is exposed as a property via a naming contract test and AST-based inspection.

Documentation:
- Document the policy that reasonable refactorings proceed even if caller-breaking, and that argument-less booleans on objects must be properties in CONTRIBUTING, HISTORY, and CHANGELOG entries.

Tests:
- Extend name-contract tests to verify argument-less booleans are properties and add coverage ensuring both property and function-shaped booleans are discovered by the test harness.